### PR TITLE
feat(auth): require Administrator permission for /sheet and /tracked-…

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,12 @@ Optional fallback auth (not required for your current setup):
 - `/lastseen tag:<playerTag>` - Show a player's last seen activity.
 - `/inactive days:<number>` - List players inactive for N days.
 - `/role-users role:<discordRole>` - List users in a role with pagination.
-- `/tracked-clan add tag:<tag>` - Add tracked clan.
-- `/tracked-clan remove tag:<tag>` - Remove tracked clan.
-- `/tracked-clan list` - List tracked clans.
-- `/sheet link sheet_id_or_url:<id-or-url> [tab:<tab-name>] [mode:actual|war]` - Link or relink sheet; mode is optional.
-- `/sheet show [mode:actual|war]` - Show linked sheet settings (single mode or all).
-- `/sheet unlink [mode:actual|war]` - Remove one mode link or all links.
+- `/tracked-clan add tag:<tag>` - Add tracked clan (Administrator only).
+- `/tracked-clan remove tag:<tag>` - Remove tracked clan (Administrator only).
+- `/tracked-clan list` - List tracked clans (available to non-admin users).
+- `/sheet link sheet_id_or_url:<id-or-url> [tab:<tab-name>] [mode:actual|war]` - Link or relink sheet; mode is optional (Administrator only).
+- `/sheet show [mode:actual|war]` - Show linked sheet settings (single mode or all, Administrator only).
+- `/sheet unlink [mode:actual|war]` - Remove one mode link or all links (Administrator only).
 - `/compo advice clan:<tracked-clan> [mode:actual|war]` - Pull advice using mode-specific sheet link.
 - `/compo state [mode:actual|war]` - Render AllianceDashboard state as an attached PNG image with mode label.
 

--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -1,20 +1,28 @@
-
 import { CommandInteraction, Client } from "discord.js";
 import { Command } from "../Command";
 import { Commands } from "../Commands";
-
 
 export const Help: Command = {
   name: "help",
   description: "List all available commands",
   run: async (
-    client: Client,
+    _client: Client,
     interaction: CommandInteraction
   ) => {
-    const commandList = Commands.map(cmd => `• **/${cmd.name}**: ${cmd.description}`).join("\n");
+    const commandList = Commands.map(
+      (cmd) => `- **/${cmd.name}**: ${cmd.description}`
+    ).join("\n");
+
+    const permissionNotes = [
+      "**Permission notes:**",
+      "- `/sheet` subcommands require Administrator.",
+      "- `/tracked-clan add` and `/tracked-clan remove` require Administrator.",
+      "- `/tracked-clan list` is available to non-admin users.",
+    ].join("\n");
+
     await interaction.reply({
       ephemeral: true,
-      content: `Here are all available commands:\n\n${commandList}`,
+      content: `Here are all available commands:\n\n${commandList}\n\n${permissionNotes}`,
     });
   },
 };

--- a/src/commands/Sheet.ts
+++ b/src/commands/Sheet.ts
@@ -134,11 +134,11 @@ export const Sheet: Command = {
     try {
       if (
         interaction.inGuild() &&
-        !interaction.memberPermissions?.has(PermissionFlagsBits.ManageGuild)
+        !interaction.memberPermissions?.has(PermissionFlagsBits.Administrator)
       ) {
         await safeReply(interaction, {
           ephemeral: true,
-          content: "You need Manage Server permission to manage sheet settings.",
+          content: "You need Administrator permission to use /sheet commands.",
         });
         return;
       }

--- a/src/commands/TrackedClan.ts
+++ b/src/commands/TrackedClan.ts
@@ -2,6 +2,7 @@ import {
   ApplicationCommandOptionType,
   ChatInputCommandInteraction,
   Client,
+  PermissionFlagsBits,
 } from "discord.js";
 import { Command } from "../Command";
 import { formatError } from "../helper/formatError";
@@ -57,8 +58,22 @@ export const TrackedClan: Command = {
     cocService: CoCService
   ) => {
     try {
-      await interaction.deferReply({ ephemeral: true });
       const subcommand = interaction.options.getSubcommand(true);
+
+      if (
+        interaction.inGuild() &&
+        (subcommand === "add" || subcommand === "remove") &&
+        !interaction.memberPermissions?.has(PermissionFlagsBits.Administrator)
+      ) {
+        await safeReply(interaction, {
+          ephemeral: true,
+          content:
+            "You need Administrator permission to use /tracked-clan add or /tracked-clan remove.",
+        });
+        return;
+      }
+
+      await interaction.deferReply({ ephemeral: true });
 
       if (subcommand === "list") {
         const tracked = await prisma.trackedClan.findMany({


### PR DESCRIPTION
…clan commands

feat(auth): allow /tracked-clan list for all users while keeping add/remove admin-only
docs(help,readme): document admin-only sheet/tracked-clan actions and open tracked-clan list access