### PR TITLE
Release `v1.2.0` from `dev` to `main`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Optional fallback auth (not required for your current setup):
 - `/help` - List available commands.
 - `/permission add command:<name> role:<discordRole>` - Allow a role to use a command.
 - `/permission remove command:<name> role:<discordRole>` - Remove a role from a command whitelist.
-- `/permission list command:<name>` - List roles whitelisted for one command.
+- `/permission list [command:<name>]` - List whitelisted roles for one command, or all commands if omitted.
 - `/clan-name tag:<tag>` - Get clan name by tag.
 - `/lastseen tag:<playerTag>` - Show a player's last seen activity.
 - `/inactive days:<number>` - List players inactive for N days.

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ Optional fallback auth (not required for your current setup):
 
 ## Commands
 - `/help` - List available commands.
+- `/permission add command:<name> role:<discordRole>` - Allow a role to use a command.
+- `/permission remove command:<name> role:<discordRole>` - Remove a role from a command whitelist.
+- `/permission list command:<name>` - List roles whitelisted for one command.
 - `/clan-name tag:<tag>` - Get clan name by tag.
 - `/lastseen tag:<playerTag>` - Show a player's last seen activity.
 - `/inactive days:<number>` - List players inactive for N days.
@@ -53,6 +56,15 @@ Optional fallback auth (not required for your current setup):
 - `/sheet unlink [mode:actual|war]` - Remove one mode link or all links.
 - `/compo advice clan:<tracked-clan> [mode:actual|war]` - Pull advice using mode-specific sheet link.
 - `/compo state [mode:actual|war]` - Render AllianceDashboard state as an attached PNG image with mode label.
+- `/post sync time [role:<discordRole>]` - Open modal, compose sync-time message, post it, and pin it.
+
+## Command Access Control
+- By default, commands are usable by everyone.
+- Exception: `/permission` is Administrator-only by default.
+- You can whitelist roles per command with `/permission add`.
+- Administrator users can always use commands regardless of role whitelist.
+- To lock `/post` to role X, run:
+  - `/permission add command:post role:@RoleX`
 
 ## Deployment Notes
 - Commands are registered as guild commands using `GUILD_ID` on startup.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Optional fallback auth (not required for your current setup):
 - `/help` - List available commands.
 - `/permission add command:<name> role:<discordRole>` - Allow a role to use a command.
 - `/permission remove command:<name> role:<discordRole>` - Remove a role from a command whitelist.
-- `/permission list [command:<name>]` - List whitelisted roles for one command, or all commands if omitted.
+- `/permission list [command:<name>]` - List role policy for one command target, or all if omitted.
 - `/clan-name tag:<tag>` - Get clan name by tag.
 - `/lastseen tag:<playerTag>` - Show a player's last seen activity.
 - `/inactive days:<number>` - List players inactive for N days.
@@ -60,7 +60,11 @@ Optional fallback auth (not required for your current setup):
 
 ## Command Access Control
 - By default, commands are usable by everyone.
-- Exception: `/permission` is Administrator-only by default.
+- Default Administrator-only targets:
+  - `/tracked-clan add`, `/tracked-clan remove`
+  - `/permission add`, `/permission remove`
+  - `/sheet link`, `/sheet unlink`, `/sheet show`
+  - `/post sync time`
 - You can whitelist roles per command with `/permission add`.
 - Administrator users can always use commands regardless of role whitelist.
 - To lock `/post` to role X, run:

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Optional fallback auth (not required for your current setup):
 - `/sheet unlink [mode:actual|war]` - Remove one mode link or all links.
 - `/compo advice clan:<tracked-clan> [mode:actual|war]` - Pull advice using mode-specific sheet link.
 - `/compo state [mode:actual|war]` - Render AllianceDashboard state as an attached PNG image with mode label.
+- `/compo place weight:<value>` - Suggest placement options from ACTUAL state (vacancy + composition fit). Accepts formats like `145000`, `145,000`, or `145k` and maps to TH weight buckets.
 - `/post sync time [role:<discordRole>]` - Open modal, compose sync-time message, post it, and pin it.
 
 ## Command Access Control

--- a/src/Commands.ts
+++ b/src/Commands.ts
@@ -7,6 +7,7 @@ import { TrackedClan } from "./commands/TrackedClan";
 import { Sheet } from "./commands/Sheet";
 import { Compo } from "./commands/Compo";
 import { Post } from "./commands/Post";
+import { CommandRole } from "./commands/CommandRole";
 
 // ...existing code...
 export const Commands = [
@@ -19,4 +20,5 @@ export const Commands = [
   Sheet,
   Compo,
   Post,
+  CommandRole,
 ];

--- a/src/commands/CommandRole.ts
+++ b/src/commands/CommandRole.ts
@@ -117,12 +117,12 @@ export const CommandRole: Command = {
     },
     {
       name: "list",
-      description: "List roles whitelisted for one command",
+      description: "List role policy for one or all commands",
       type: ApplicationCommandOptionType.Subcommand,
       options: [
         {
           name: "command",
-          description: "Command to inspect (omit to list all)",
+          description: "Command or subcommand target (omit to list all)",
           type: ApplicationCommandOptionType.String,
           required: false,
           choices: COMMAND_CHOICES,
@@ -160,10 +160,9 @@ export const CommandRole: Command = {
 
       if (commandInput) {
         const roleIds = await permissionService.getAllowedRoleIds(commandInput);
-        const summary =
-          roleIds.length === 0
-            ? "No whitelisted roles. Default access applies."
-            : `Whitelisted roles: ${formatRoleList(roleIds)}`;
+        const summary = roleIds.length
+          ? `Whitelisted roles: ${formatRoleList(roleIds)}`
+          : await permissionService.getPolicySummary(commandInput);
         await safeReply(interaction, {
           ephemeral: true,
           content: `\`/${commandInput}\` roles:\n${summary}`,
@@ -173,8 +172,8 @@ export const CommandRole: Command = {
 
       const allLines: string[] = [];
       for (const target of COMMAND_PERMISSION_TARGETS) {
-        const roleIds = await permissionService.getAllowedRoleIds(target);
-        allLines.push(`- \`/${target}\`: ${formatRoleList(roleIds)}`);
+        const summary = await permissionService.getPolicySummary(target);
+        allLines.push(`- \`/${target}\`: ${summary}`);
       }
 
       if (allLines.length === 0) {

--- a/src/commands/CommandRole.ts
+++ b/src/commands/CommandRole.ts
@@ -1,9 +1,16 @@
 import {
+  ActionRowBuilder,
   ApplicationCommandOptionType,
+  ButtonBuilder,
+  ButtonInteraction,
+  ButtonStyle,
   ChatInputCommandInteraction,
   Client,
+  ComponentType,
+  EmbedBuilder,
 } from "discord.js";
 import { Command } from "../Command";
+import { formatError } from "../helper/formatError";
 import { safeReply } from "../helper/safeReply";
 import { CoCService } from "../services/CoCService";
 import {
@@ -16,6 +23,9 @@ const COMMAND_CHOICES = COMMAND_PERMISSION_TARGETS.map((name) => ({
   name,
   value: name,
 }));
+const LIST_PAGE_SIZE = 8;
+const LIST_PREV_ID = "permission-list-prev";
+const LIST_NEXT_ID = "permission-list-next";
 
 function isPermissionTarget(value: string): value is (typeof COMMAND_PERMISSION_TARGETS)[number] {
   return (COMMAND_PERMISSION_TARGETS as readonly string[]).includes(value);
@@ -24,6 +34,41 @@ function isPermissionTarget(value: string): value is (typeof COMMAND_PERMISSION_
 function formatRoleList(roleIds: string[]): string {
   if (roleIds.length === 0) return "(none)";
   return roleIds.map((id) => `<@&${id}>`).join(", ");
+}
+
+function getListRow(page: number, pageCount: number) {
+  return new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder()
+      .setCustomId(LIST_PREV_ID)
+      .setLabel("Previous")
+      .setStyle(ButtonStyle.Secondary)
+      .setDisabled(page <= 0),
+    new ButtonBuilder()
+      .setCustomId(LIST_NEXT_ID)
+      .setLabel("Next")
+      .setStyle(ButtonStyle.Secondary)
+      .setDisabled(page >= pageCount - 1)
+  );
+}
+
+function getListEmbed(
+  interaction: ChatInputCommandInteraction,
+  lines: string[],
+  page: number,
+  pageCount: number
+) {
+  const embed = new EmbedBuilder()
+    .setTitle("Command Role Permissions")
+    .setDescription(lines.join("\n"))
+    .setColor(0x5865f2)
+    .setFooter({ text: `Page ${page + 1}/${pageCount}` });
+
+  const guildIcon = interaction.guild?.iconURL();
+  if (guildIcon) {
+    embed.setThumbnail(guildIcon);
+  }
+
+  return embed;
 }
 
 export const CommandRole: Command = {
@@ -77,9 +122,9 @@ export const CommandRole: Command = {
       options: [
         {
           name: "command",
-          description: "Command to inspect",
+          description: "Command to inspect (omit to list all)",
           type: ApplicationCommandOptionType.String,
-          required: true,
+          required: false,
           choices: COMMAND_CHOICES,
         },
       ],
@@ -103,24 +148,112 @@ export const CommandRole: Command = {
     const permissionService = new CommandPermissionService();
     const subcommand = interaction.options.getSubcommand(true);
 
+    if (subcommand === "list") {
+      const commandInput = interaction.options.getString("command", false);
+      if (commandInput && !isPermissionTarget(commandInput)) {
+        await safeReply(interaction, {
+          ephemeral: true,
+          content: "Unknown command target.",
+        });
+        return;
+      }
+
+      if (commandInput) {
+        const roleIds = await permissionService.getAllowedRoleIds(commandInput);
+        const summary =
+          roleIds.length === 0
+            ? "No whitelisted roles. Default access applies."
+            : `Whitelisted roles: ${formatRoleList(roleIds)}`;
+        await safeReply(interaction, {
+          ephemeral: true,
+          content: `\`/${commandInput}\` roles:\n${summary}`,
+        });
+        return;
+      }
+
+      const allLines: string[] = [];
+      for (const target of COMMAND_PERMISSION_TARGETS) {
+        const roleIds = await permissionService.getAllowedRoleIds(target);
+        allLines.push(`- \`/${target}\`: ${formatRoleList(roleIds)}`);
+      }
+
+      if (allLines.length === 0) {
+        await safeReply(interaction, {
+          ephemeral: true,
+          content: "No commands found.",
+        });
+        return;
+      }
+
+      const pages: string[][] = [];
+      for (let i = 0; i < allLines.length; i += LIST_PAGE_SIZE) {
+        pages.push(allLines.slice(i, i + LIST_PAGE_SIZE));
+      }
+
+      let page = 0;
+      await interaction.editReply({
+        embeds: [getListEmbed(interaction, pages[page], page, pages.length)],
+        components: pages.length > 1 ? [getListRow(page, pages.length)] : [],
+      });
+
+      if (pages.length <= 1) return;
+
+      const message = await interaction.fetchReply();
+      const collector = message.createMessageComponentCollector({
+        componentType: ComponentType.Button,
+        time: 10 * 60 * 1000,
+      });
+
+      collector.on("collect", async (button: ButtonInteraction) => {
+        try {
+          if (button.user.id !== interaction.user.id) {
+            await button.reply({
+              content: "Only the command user can control this paginator.",
+              ephemeral: true,
+            });
+            return;
+          }
+
+          if (button.customId === LIST_PREV_ID && page > 0) {
+            page -= 1;
+          } else if (button.customId === LIST_NEXT_ID && page < pages.length - 1) {
+            page += 1;
+          }
+
+          await button.update({
+            embeds: [getListEmbed(interaction, pages[page], page, pages.length)],
+            components: [getListRow(page, pages.length)],
+          });
+        } catch (err) {
+          console.error(`permission list paginator failed: ${formatError(err)}`);
+          try {
+            if (!button.replied && !button.deferred) {
+              await button.reply({
+                content: "Failed to update paginator.",
+                ephemeral: true,
+              });
+            }
+          } catch {
+            // no-op
+          }
+        }
+      });
+
+      collector.on("end", async () => {
+        try {
+          await interaction.editReply({ components: [] });
+        } catch {
+          // no-op
+        }
+      });
+      return;
+    }
+
     const commandInput = interaction.options.getString("command", true);
     if (!isPermissionTarget(commandInput)) {
       await safeReply(interaction, {
         ephemeral: true,
         content: "Unknown command target.",
-      });
-      return;
-    }
-
-    if (subcommand === "list") {
-      const roleIds = await permissionService.getAllowedRoleIds(commandInput);
-      const summary =
-        roleIds.length === 0
-          ? "No whitelisted roles. Default access applies."
-          : `Whitelisted roles: ${formatRoleList(roleIds)}`;
-      await safeReply(interaction, {
-        ephemeral: true,
-        content: `\`/${commandInput}\` roles:\n${summary}`,
       });
       return;
     }

--- a/src/commands/CommandRole.ts
+++ b/src/commands/CommandRole.ts
@@ -1,0 +1,167 @@
+import {
+  ApplicationCommandOptionType,
+  ChatInputCommandInteraction,
+  Client,
+} from "discord.js";
+import { Command } from "../Command";
+import { safeReply } from "../helper/safeReply";
+import { CoCService } from "../services/CoCService";
+import {
+  COMMAND_PERMISSION_TARGETS,
+  CommandPermissionService,
+  MANAGE_COMMAND_ROLES_COMMAND,
+} from "../services/CommandPermissionService";
+
+const COMMAND_CHOICES = COMMAND_PERMISSION_TARGETS.map((name) => ({
+  name,
+  value: name,
+}));
+
+function isPermissionTarget(value: string): value is (typeof COMMAND_PERMISSION_TARGETS)[number] {
+  return (COMMAND_PERMISSION_TARGETS as readonly string[]).includes(value);
+}
+
+function formatRoleList(roleIds: string[]): string {
+  if (roleIds.length === 0) return "(none)";
+  return roleIds.map((id) => `<@&${id}>`).join(", ");
+}
+
+export const CommandRole: Command = {
+  name: MANAGE_COMMAND_ROLES_COMMAND,
+  description: "Set which roles can use each command",
+  options: [
+    {
+      name: "add",
+      description: "Allow a role to use a command",
+      type: ApplicationCommandOptionType.Subcommand,
+      options: [
+        {
+          name: "command",
+          description: "Command to restrict",
+          type: ApplicationCommandOptionType.String,
+          required: true,
+          choices: COMMAND_CHOICES,
+        },
+        {
+          name: "role",
+          description: "Role to allow",
+          type: ApplicationCommandOptionType.Role,
+          required: true,
+        },
+      ],
+    },
+    {
+      name: "remove",
+      description: "Remove a role from a command whitelist",
+      type: ApplicationCommandOptionType.Subcommand,
+      options: [
+        {
+          name: "command",
+          description: "Command to update",
+          type: ApplicationCommandOptionType.String,
+          required: true,
+          choices: COMMAND_CHOICES,
+        },
+        {
+          name: "role",
+          description: "Role to remove",
+          type: ApplicationCommandOptionType.Role,
+          required: true,
+        },
+      ],
+    },
+    {
+      name: "list",
+      description: "List roles whitelisted for one command",
+      type: ApplicationCommandOptionType.Subcommand,
+      options: [
+        {
+          name: "command",
+          description: "Command to inspect",
+          type: ApplicationCommandOptionType.String,
+          required: true,
+          choices: COMMAND_CHOICES,
+        },
+      ],
+    },
+  ],
+  run: async (
+    _client: Client,
+    interaction: ChatInputCommandInteraction,
+    _cocService: CoCService
+  ) => {
+    if (!interaction.inGuild()) {
+      await safeReply(interaction, {
+        ephemeral: true,
+        content: "This command can only be used in a server.",
+      });
+      return;
+    }
+
+    await interaction.deferReply({ ephemeral: true });
+
+    const permissionService = new CommandPermissionService();
+    const subcommand = interaction.options.getSubcommand(true);
+
+    const commandInput = interaction.options.getString("command", true);
+    if (!isPermissionTarget(commandInput)) {
+      await safeReply(interaction, {
+        ephemeral: true,
+        content: "Unknown command target.",
+      });
+      return;
+    }
+
+    if (subcommand === "list") {
+      const roleIds = await permissionService.getAllowedRoleIds(commandInput);
+      const summary =
+        roleIds.length === 0
+          ? "No whitelisted roles. Default access applies."
+          : `Whitelisted roles: ${formatRoleList(roleIds)}`;
+      await safeReply(interaction, {
+        ephemeral: true,
+        content: `\`/${commandInput}\` roles:\n${summary}`,
+      });
+      return;
+    }
+
+    const role = interaction.options.getRole("role", true);
+    if (!("id" in role)) {
+      await safeReply(interaction, {
+        ephemeral: true,
+        content: "Invalid role selected.",
+      });
+      return;
+    }
+
+    if (subcommand === "add") {
+      const next = await permissionService.addAllowedRoleId(commandInput, role.id);
+      await safeReply(interaction, {
+        ephemeral: true,
+        content:
+          `Added <@&${role.id}> to \`/${commandInput}\`.\n` +
+          `Allowed roles: ${formatRoleList(next)}`,
+      });
+      return;
+    }
+
+    if (subcommand === "remove") {
+      const next = await permissionService.removeAllowedRoleId(commandInput, role.id);
+      const summary = next.length
+        ? `Allowed roles: ${formatRoleList(next)}`
+        : await permissionService.getPolicySummary(commandInput);
+      await safeReply(interaction, {
+        ephemeral: true,
+        content:
+          `Removed <@&${role.id}> from \`/${commandInput}\`.\n` +
+          summary,
+      });
+      return;
+    }
+
+    await safeReply(interaction, {
+      ephemeral: true,
+      content: "Unknown subcommand.",
+    });
+  },
+};

--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -13,7 +13,8 @@ export const Help: Command = {
     const permissionNotes = [
       "**Permission notes:**",
       "- `/sheet` subcommands require Administrator.",
-      "- `/post sync time` requires Administrator.",
+      "- `/permission` is Administrator-only by default (or role-whitelisted).",
+      "- Other commands default to everyone unless restricted with `/permission`.",
       "- `/tracked-clan add` and `/tracked-clan remove` require Administrator.",
       "- `/tracked-clan list` is available to non-admin users.",
     ].join("\n");

--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -12,11 +12,8 @@ export const Help: Command = {
 
     const permissionNotes = [
       "**Permission notes:**",
-      "- `/sheet` subcommands require Administrator.",
-      "- `/permission` is Administrator-only by default (or role-whitelisted).",
+      "- Administrator-only by default: `/tracked-clan add|remove`, `/permission add|remove`, `/sheet link|unlink|show`, `/post sync time`.",
       "- Other commands default to everyone unless restricted with `/permission`.",
-      "- `/tracked-clan add` and `/tracked-clan remove` require Administrator.",
-      "- `/tracked-clan list` is available to non-admin users.",
     ].join("\n");
 
     await interaction.reply({

--- a/src/commands/Post.ts
+++ b/src/commands/Post.ts
@@ -5,7 +5,6 @@ import {
   Client,
   ModalBuilder,
   ModalSubmitInteraction,
-  PermissionFlagsBits,
   TextInputBuilder,
   TextInputStyle,
 } from "discord.js";
@@ -239,16 +238,6 @@ export async function handlePostModalSubmit(
     return;
   }
 
-  if (
-    !interaction.memberPermissions?.has(PermissionFlagsBits.Administrator)
-  ) {
-    await interaction.reply({
-      ephemeral: true,
-      content: "You need Administrator permission to use /post commands.",
-    });
-    return;
-  }
-
   await interaction.deferReply({ ephemeral: true });
 
   const settings = new SettingsService();
@@ -385,16 +374,6 @@ export const Post: Command = {
       await safeReply(interaction, {
         ephemeral: true,
         content: "This command can only be used in a server.",
-      });
-      return;
-    }
-
-    if (
-      !interaction.memberPermissions?.has(PermissionFlagsBits.Administrator)
-    ) {
-      await safeReply(interaction, {
-        ephemeral: true,
-        content: "You need Administrator permission to use /post commands.",
       });
       return;
     }

--- a/src/commands/Sheet.ts
+++ b/src/commands/Sheet.ts
@@ -2,7 +2,6 @@ import {
   ApplicationCommandOptionType,
   ChatInputCommandInteraction,
   Client,
-  PermissionFlagsBits,
 } from "discord.js";
 import { Command } from "../Command";
 import { formatError } from "../helper/formatError";
@@ -132,17 +131,6 @@ export const Sheet: Command = {
     _cocService: CoCService
   ) => {
     try {
-      if (
-        interaction.inGuild() &&
-        !interaction.memberPermissions?.has(PermissionFlagsBits.ManageGuild)
-      ) {
-        await safeReply(interaction, {
-          ephemeral: true,
-          content: "You need Manage Server permission to manage sheet settings.",
-        });
-        return;
-      }
-
       await interaction.deferReply({ ephemeral: true });
 
       const subcommand = interaction.options.getSubcommand(true);

--- a/src/listeners/interactionCreate.ts
+++ b/src/listeners/interactionCreate.ts
@@ -9,6 +9,9 @@ import { Commands } from "../Commands";
 import { formatError } from "../helper/formatError";
 import { CoCService } from "../services/CoCService";
 import { handlePostModalSubmit, isPostModalCustomId } from "../commands/Post";
+import { CommandPermissionService } from "../services/CommandPermissionService";
+
+const commandPermissionService = new CommandPermissionService();
 
 let isRegistered = false;
 
@@ -56,6 +59,15 @@ const handleModalSubmit = async (
   if (!isPostModalCustomId(interaction.customId)) return;
 
   try {
+    const allowed = await commandPermissionService.canUseCommand("post", interaction);
+    if (!allowed) {
+      await interaction.reply({
+        content: "You do not have permission to use /post.",
+        ephemeral: true,
+      });
+      return;
+    }
+
     await handlePostModalSubmit(interaction);
   } catch (err) {
     console.error(`Modal submit failed: ${formatError(err)}`);
@@ -118,6 +130,18 @@ const handleSlashCommand = async (
   }
 
   try {
+    const allowed = await commandPermissionService.canUseCommand(
+      interaction.commandName,
+      interaction
+    );
+    if (!allowed) {
+      await interaction.reply({
+        content: `You do not have permission to use /${interaction.commandName}.`,
+        ephemeral: true,
+      });
+      return;
+    }
+
     await slashCommand.run(client, interaction, cocService);
   } catch (err) {
     console.error(`Command failed: ${formatError(err)}`);

--- a/src/listeners/interactionCreate.ts
+++ b/src/listeners/interactionCreate.ts
@@ -9,7 +9,10 @@ import { Commands } from "../Commands";
 import { formatError } from "../helper/formatError";
 import { CoCService } from "../services/CoCService";
 import { handlePostModalSubmit, isPostModalCustomId } from "../commands/Post";
-import { CommandPermissionService } from "../services/CommandPermissionService";
+import {
+  CommandPermissionService,
+  getCommandTargetsFromInteraction,
+} from "../services/CommandPermissionService";
 
 const commandPermissionService = new CommandPermissionService();
 
@@ -59,7 +62,10 @@ const handleModalSubmit = async (
   if (!isPostModalCustomId(interaction.customId)) return;
 
   try {
-    const allowed = await commandPermissionService.canUseCommand("post", interaction);
+    const allowed = await commandPermissionService.canUseAnyTarget(
+      ["post:sync:time", "post"],
+      interaction
+    );
     if (!allowed) {
       await interaction.reply({
         content: "You do not have permission to use /post.",
@@ -130,8 +136,9 @@ const handleSlashCommand = async (
   }
 
   try {
-    const allowed = await commandPermissionService.canUseCommand(
-      interaction.commandName,
+    const targets = getCommandTargetsFromInteraction(interaction);
+    const allowed = await commandPermissionService.canUseAnyTarget(
+      targets,
       interaction
     );
     if (!allowed) {

--- a/src/services/CommandPermissionService.ts
+++ b/src/services/CommandPermissionService.ts
@@ -1,0 +1,128 @@
+import {
+  ChatInputCommandInteraction,
+  ModalSubmitInteraction,
+  PermissionFlagsBits,
+} from "discord.js";
+import { SettingsService } from "./SettingsService";
+
+export const MANAGE_COMMAND_ROLES_COMMAND = "permission";
+
+export const COMMAND_PERMISSION_TARGETS = [
+  "help",
+  "clan-name",
+  "lastseen",
+  "inactive",
+  "role-users",
+  "tracked-clan",
+  "sheet",
+  "compo",
+  "post",
+  MANAGE_COMMAND_ROLES_COMMAND,
+] as const;
+
+export type CommandPermissionTarget = (typeof COMMAND_PERMISSION_TARGETS)[number];
+
+type GuildInteraction = ChatInputCommandInteraction | ModalSubmitInteraction;
+
+function commandRolesKey(commandName: string): string {
+  return `command_roles:${commandName}`;
+}
+
+function parseRoleIds(input: string | null): string[] {
+  if (!input) return [];
+  const parts = input
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => /^\d+$/.test(s));
+  return [...new Set(parts)];
+}
+
+function stringifyRoleIds(roleIds: string[]): string {
+  return [...new Set(roleIds)].join(",");
+}
+
+async function getInteractionRoleIds(interaction: GuildInteraction): Promise<string[]> {
+  if (!interaction.inGuild()) return [];
+
+  const member = interaction.member;
+  if (member && "roles" in member) {
+    const roles = member.roles;
+    if (Array.isArray(roles)) {
+      return roles;
+    }
+    if (roles && "cache" in roles) {
+      return [...roles.cache.keys()];
+    }
+  }
+
+  const guild = interaction.guild;
+  if (!guild) return [];
+
+  const fetched = await guild.members.fetch(interaction.user.id);
+  return [...fetched.roles.cache.keys()];
+}
+
+export class CommandPermissionService {
+  constructor(private readonly settings = new SettingsService()) {}
+
+  async getAllowedRoleIds(commandName: string): Promise<string[]> {
+    const raw = await this.settings.get(commandRolesKey(commandName));
+    return parseRoleIds(raw);
+  }
+
+  async setAllowedRoleIds(commandName: string, roleIds: string[]): Promise<void> {
+    const serialized = stringifyRoleIds(roleIds);
+    if (!serialized) {
+      await this.settings.delete(commandRolesKey(commandName));
+      return;
+    }
+    await this.settings.set(commandRolesKey(commandName), serialized);
+  }
+
+  async addAllowedRoleId(commandName: string, roleId: string): Promise<string[]> {
+    const existing = await this.getAllowedRoleIds(commandName);
+    const next = [...new Set([...existing, roleId])];
+    await this.setAllowedRoleIds(commandName, next);
+    return next;
+  }
+
+  async removeAllowedRoleId(commandName: string, roleId: string): Promise<string[]> {
+    const existing = await this.getAllowedRoleIds(commandName);
+    const next = existing.filter((id) => id !== roleId);
+    await this.setAllowedRoleIds(commandName, next);
+    return next;
+  }
+
+  async clearAllowedRoles(commandName: string): Promise<void> {
+    await this.settings.delete(commandRolesKey(commandName));
+  }
+
+  async canUseCommand(
+    commandName: string,
+    interaction: GuildInteraction
+  ): Promise<boolean> {
+    if (!interaction.inGuild()) return true;
+
+    if (interaction.memberPermissions?.has(PermissionFlagsBits.Administrator)) {
+      return true;
+    }
+
+    const allowedRoles = await this.getAllowedRoleIds(commandName);
+    if (allowedRoles.length === 0) {
+      return commandName === MANAGE_COMMAND_ROLES_COMMAND ? false : true;
+    }
+
+    const userRoles = await getInteractionRoleIds(interaction);
+    return allowedRoles.some((id) => userRoles.includes(id));
+  }
+
+  async getPolicySummary(commandName: string): Promise<string> {
+    const roles = await this.getAllowedRoleIds(commandName);
+    if (roles.length === 0) {
+      return commandName === MANAGE_COMMAND_ROLES_COMMAND
+        ? "Default: Administrator only."
+        : "Default: Everyone can use this command.";
+    }
+    return `Allowed roles: ${roles.map((id) => `<@&${id}>`).join(", ")}`;
+  }
+}


### PR DESCRIPTION
## Summary
Release `v1.2.0` from `dev` to `main`.

This release adds a new sync-time posting workflow, centralized role-based command permissions, restores `/compo place`, and improves `/compo state` with data-refresh timestamp context.

## What’s Included

### New `/post sync time` workflow
- Added `/post sync time` command with modal-based input.
- Posts standardized sync message with localized Discord timestamp formatting.
- Supports role ping and auto-pins the new sync post.
- Automatically unpins prior pinned sync-time post from the bot in the same channel.
- Remembers:
  - user timezone
  - guild sync role

### New centralized permissions model
- Added `CommandPermissionService` and centralized enforcement in interaction handling.
- Added `/permission` command with:
  - `add`
  - `remove`
  - `list [command]`
- `/permission list` supports:
  - single-command policy output
  - full policy listing with paginated embed when listing all.
- Default admin-only targets:
  - `/tracked-clan add`, `/tracked-clan remove`
  - `/permission add`, `/permission remove`
  - `/sheet link`, `/sheet unlink`, `/sheet show`
  - `/post sync time`
- All other commands default to everyone unless whitelisted.

### `/compo` updates
- Restored `/compo place` and its follow-up improvements:
  - bucketed weight parsing
  - recommendation formatting (`Recommended / Vacancy / Composition`)
- `/compo state` now includes:
  - `RAW Data last refreshed: <t:{Lookup!B10}:F>`
  - reads unix refresh timestamp from `Lookup!B10`

### Docs/help updates
- README updated with:
  - `/post sync time`
  - `/permission` command usage
  - default permission policy
  - `/compo place` command details
- `/help` permission notes updated to reflect centralized policy behavior.

## Validation
- TypeScript build passes (`npm run build`).
- Features validated on `dev` prior to release PR.

## Release Type
- **Minor release** (`v1.2.0`) from `v1.1.0`.