### PR TITLE
v1.4.1 - Permission + Reliability Hotfixes

### DIFF
--- a/src/commands/Inactive.ts
+++ b/src/commands/Inactive.ts
@@ -1,6 +1,8 @@
 import { Client, CommandInteraction } from "discord.js";
 import { Command } from "../Command";
 import { prisma } from "../prisma";
+import { CoCService } from "../services/CoCService";
+import { formatError } from "../helper/formatError";
 
 export const Inactive: Command = {
   name: "inactive",
@@ -14,7 +16,11 @@ export const Inactive: Command = {
     },
   ],
 
-  run: async (_client: Client, interaction: CommandInteraction) => {
+  run: async (
+    _client: Client,
+    interaction: CommandInteraction,
+    cocService: CoCService
+  ) => {
     await interaction.deferReply({ ephemeral: true });
 
     const days = interaction.options.get("days", true).value as number;
@@ -35,15 +41,40 @@ export const Inactive: Command = {
 
     const trackedTags = dbTracked.map((c) => c.tag);
 
+    const liveMemberTags = new Set<string>();
+
+    for (const trackedTag of trackedTags) {
+      try {
+        const clan = await cocService.getClan(trackedTag);
+        for (const member of clan.members ?? []) {
+          const memberTag = String(member?.tag ?? "").trim();
+          if (memberTag) {
+            liveMemberTags.add(memberTag);
+          }
+        }
+      } catch (err) {
+        console.error(
+          `inactive: failed to fetch live roster for ${trackedTag}: ${formatError(err)}`
+        );
+      }
+    }
+
+    if (trackedTags.length > 0 && liveMemberTags.size === 0) {
+      await interaction.editReply(
+        "⚠️ Tracked clans are configured, but live rosters could not be read from CoC API. Try again shortly."
+      );
+      return;
+    }
+
     const inactivePlayers = await prisma.playerActivity.findMany({
       where: {
         lastSeenAt: {
           lt: cutoff,
         },
-        ...(trackedTags.length > 0
+        ...(liveMemberTags.size > 0
           ? {
-              clanTag: {
-                in: trackedTags,
+              tag: {
+                in: [...liveMemberTags],
               },
             }
           : {}),
@@ -75,7 +106,9 @@ export const Inactive: Command = {
       lines.join("\n");
 
     if (trackedTags.length > 0) {
-      message += `\n\nScope: ${trackedTags.length} tracked clan(s).`;
+      message +=
+        `\n\nScope: ${trackedTags.length} tracked clan(s), ` +
+        `${liveMemberTags.size} live member tag(s).`;
     } else {
       message += "\n\nScope: no tracked clans configured.";
     }

--- a/src/commands/Post.ts
+++ b/src/commands/Post.ts
@@ -5,6 +5,7 @@ import {
   Client,
   ModalBuilder,
   ModalSubmitInteraction,
+  PermissionFlagsBits,
   TextInputBuilder,
   TextInputStyle,
 } from "discord.js";
@@ -167,6 +168,14 @@ function buildSyncMessage(epochSeconds: number, roleId: string): string {
 <@&${roleId}>`;
 }
 
+function summarizePermissionIssue(err: unknown, action: string): string {
+  const code = (err as { code?: number } | null | undefined)?.code;
+  if (code === 50013 || code === 50001) {
+    return `${action} failed due to missing bot permissions in this channel.`;
+  }
+  return `${action} failed. Check bot permissions and logs.`;
+}
+
 function isBotSyncTimeMessage(content: string): boolean {
   return content.startsWith("# Sync time :gem:");
 }
@@ -311,32 +320,83 @@ export async function handlePostModalSubmit(
     return;
   }
 
-  const content = buildSyncMessage(epochSeconds, role.id);
-  const postedMessage = await channel.send({
-    content,
-    allowedMentions: { roles: [role.id] },
-  });
-
-  let pinNote = "";
-  try {
-    const pinned = await channel.messages.fetchPinned();
-    for (const pinnedMessage of pinned.values()) {
-      if (pinnedMessage.id === postedMessage.id) continue;
-      if (!pinnedMessage.author.bot) continue;
-      if (!isBotSyncTimeMessage(pinnedMessage.content)) continue;
-      await pinnedMessage.unpin().catch(() => undefined);
-    }
-
-    await postedMessage.pin();
-  } catch {
-    pinNote = " Posted, but I could not pin it (missing permission).";
+  if (!("permissionsFor" in channel)) {
+    await interaction.editReply("This command can only post in guild text channels.");
+    return;
   }
 
+  const me = guild.members.me ?? (await guild.members.fetchMe().catch(() => null));
+  if (!me) {
+    await interaction.editReply("Could not verify bot permissions in this channel.");
+    return;
+  }
+
+  const permissions = channel.permissionsFor(me);
+  if (!permissions?.has(PermissionFlagsBits.SendMessages)) {
+    await interaction.editReply(
+      "Could not post sync time: bot is missing `Send Messages` in this channel."
+    );
+    return;
+  }
+
+  const canManageMessages = permissions.has(PermissionFlagsBits.ManageMessages);
+  const canMentionEveryone = permissions.has(PermissionFlagsBits.MentionEveryone);
+  const mentionWillNotify = role.mentionable || canMentionEveryone;
+  const notices: string[] = [];
+
+  const content = buildSyncMessage(epochSeconds, role.id);
+  const postedMessage = await channel
+    .send({
+      content,
+      allowedMentions: {
+        parse: ["roles"],
+        roles: [role.id],
+      },
+    })
+    .catch(async (err) => {
+      await interaction.editReply(summarizePermissionIssue(err, "Posting sync time"));
+      return null;
+    });
+  if (!postedMessage) {
+    return;
+  }
+
+  if (!mentionWillNotify) {
+    notices.push(
+      `Role mention was included but may not notify members because \`${role.name}\` is not mentionable and bot lacks \`Mention Everyone\`.`
+    );
+  }
+
+  if (canManageMessages) {
+    try {
+      const pinned = await channel.messages.fetchPinned();
+      for (const pinnedMessage of pinned.values()) {
+        if (pinnedMessage.id === postedMessage.id) continue;
+        if (!pinnedMessage.author.bot) continue;
+        if (!isBotSyncTimeMessage(pinnedMessage.content)) continue;
+        await pinnedMessage.unpin().catch(() => undefined);
+      }
+    } catch (err) {
+      notices.push(summarizePermissionIssue(err, "Cleaning previous sync pins"));
+    }
+
+    try {
+      await postedMessage.pin();
+    } catch (err) {
+      notices.push(summarizePermissionIssue(err, "Pinning message"));
+    }
+  } else {
+    notices.push("Message posted, but bot is missing `Manage Messages` so it could not pin.");
+  }
+
+  const noticeBlock =
+    notices.length > 0 ? `\n${notices.map((n) => `- ${n}`).join("\n")}` : "";
+
   await interaction.editReply(
-    `Sync time message posted${pinNote}\nUsed: ${dateInput} ${timeInput} (${to12HourLabel(
+    `Sync time message posted.\nUsed: ${dateInput} ${timeInput} (${to12HourLabel(
       time.hour,
       time.minute
-    )}, ${timezoneInput}).`
+    )}, ${timezoneInput}).${noticeBlock}`
   );
 }
 

--- a/src/commands/Post.ts
+++ b/src/commands/Post.ts
@@ -3,6 +3,7 @@ import {
   ApplicationCommandOptionType,
   ChatInputCommandInteraction,
   Client,
+  type MessageMentionOptions,
   ModalBuilder,
   ModalSubmitInteraction,
   PermissionFlagsBits,
@@ -347,15 +348,15 @@ export async function handlePostModalSubmit(
   const canMentionEveryone = permissions.has(PermissionFlagsBits.MentionEveryone);
   const mentionWillNotify = role.mentionable || canMentionEveryone;
   const notices: string[] = [];
+  const allowedMentions: MessageMentionOptions = mentionWillNotify
+    ? { roles: [role.id] }
+    : { parse: [] };
 
   const content = buildSyncMessage(epochSeconds, role.id);
   const postedMessage = await channel
     .send({
       content,
-      allowedMentions: {
-        parse: ["roles"],
-        roles: [role.id],
-      },
+      allowedMentions,
     })
     .catch(async (err) => {
       console.error(


### PR DESCRIPTION
# ClashCookies v1.4.1 - Permission + Reliability Hotfixes

## Release scope
- Base: `main@48d1421`
- Target: `dev@fb7c14c`
- Compare: `main...dev` (`48d1421..fb7c14c`)
- Commits in range: `6`

## Highlights

### 1. `/post sync time` reliability and permission feedback
- Improved `/post sync time` behavior around role mention/pin workflows.
- Added explicit user-facing feedback when bot permissions cause partial/failed actions.

### 2. Better diagnostics for staging/prod incidents
- Added detailed logging for `/post sync time` send/pin failure paths (guild/channel/role/user + Discord error).
- Improved operator visibility so Railway logs now show actionable failure context.

### 3. Inactive tracking accuracy fix
- `/inactive` now filters using the live tracked-clan roster.
- Prevents stale historical members from inflating inactive/member counts.

## Full changelog (commits)
- `fb7c14c` merge: fix/perm_check_2 (#81)
- `e3cdcd2` chore(logging): add detailed /post sync time failure logs and include Discord error codes in user feedback
- `7294d70` merge: fix/perm_check (#80)
- `83e5a72` fix(post): ensure sync-time role pings, pin feedback, and permission-aware errors
- `722fceb` merge: fix/inactive_tracking_3 (#79)
- `d880a5c` fix(inactive): filter by live tracked-clan roster to avoid stale historical member counts

## Operational note(s)
- Ensure bot has channel-level `Send Messages`, `Manage Messages` (pin/unpin), and role-mention capability (`Mention Everyone` if pinging non-mentionable roles).
- No DB migration required for this release; rollback is safe by reverting the release PR.