### PR TITLE
v1.4.2 - Inactive Accuracy + Deployment Workflow Detection

### DIFF
--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -4,6 +4,10 @@ on:
     branches:
       - main
       - dev
+  pull_request:
+    branches:
+      - dev
+      - main
 
 jobs:
   deploy:
@@ -16,5 +20,5 @@ jobs:
         uses: ayungavis/railway-preview-deploy@v1.0.2
         with:
           railway_api_token: ${{ secrets.RAILWAY_API_TOKEN }}
-          project_id: ${{ github.ref_name == 'main' && '4e5afdf5-8892-4f40-b50f-76f6b5dd81f0' || '4e5afdf5-8892-4f40-b50f-76f6b5dd81f0' }}
-          environment_name: ${{ github.ref_name == 'main' && 'production' || 'staging' }}
+          project_id: 4e5afdf5-8892-4f40-b50f-76f6b5dd81f0
+          environment_name: ${{ (github.ref_name == 'main' || github.base_ref == 'main') && 'production' || 'staging' }}

--- a/src/commands/Inactive.ts
+++ b/src/commands/Inactive.ts
@@ -4,6 +4,8 @@ import { prisma } from "../prisma";
 import { CoCService } from "../services/CoCService";
 import { formatError } from "../helper/formatError";
 
+const DEFAULT_STALE_HOURS = 6;
+
 export const Inactive: Command = {
   name: "inactive",
   description: "List players inactive for N days",
@@ -24,33 +26,33 @@ export const Inactive: Command = {
     await interaction.deferReply({ ephemeral: true });
 
     const days = interaction.options.get("days", true).value as number;
-
     if (days <= 0) {
-      await interaction.editReply("⚠️ Days must be greater than 0.");
+      await interaction.editReply("Days must be greater than 0.");
       return;
     }
 
-    const cutoff = new Date(
-      Date.now() - days * 24 * 60 * 60 * 1000
-    );
+    const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
 
     const dbTracked = await prisma.trackedClan.findMany({
       orderBy: { createdAt: "asc" },
       select: { tag: true },
     });
-
     const trackedTags = dbTracked.map((c) => c.tag);
 
-    const liveMemberTags = new Set<string>();
+    if (trackedTags.length === 0) {
+      await interaction.editReply(
+        "No tracked clans configured. Configure at least one clan with `/tracked-clan add` before using `/inactive`."
+      );
+      return;
+    }
 
+    const liveMemberTags = new Set<string>();
     for (const trackedTag of trackedTags) {
       try {
         const clan = await cocService.getClan(trackedTag);
         for (const member of clan.members ?? []) {
           const memberTag = String(member?.tag ?? "").trim();
-          if (memberTag) {
-            liveMemberTags.add(memberTag);
-          }
+          if (memberTag) liveMemberTags.add(memberTag);
         }
       } catch (err) {
         console.error(
@@ -59,64 +61,67 @@ export const Inactive: Command = {
       }
     }
 
-    if (trackedTags.length > 0 && liveMemberTags.size === 0) {
+    if (liveMemberTags.size === 0) {
       await interaction.editReply(
-        "⚠️ Tracked clans are configured, but live rosters could not be read from CoC API. Try again shortly."
+        "Tracked clans are configured, but live rosters could not be read from CoC API. Try again shortly."
+      );
+      return;
+    }
+
+    const activitySnapshot = await prisma.playerActivity.aggregate({
+      where: {
+        tag: { in: [...liveMemberTags] },
+      },
+      _max: { updatedAt: true },
+      _count: { tag: true },
+    });
+
+    const staleHoursRaw = Number(process.env.INACTIVE_STALE_HOURS ?? DEFAULT_STALE_HOURS);
+    const staleHours =
+      Number.isFinite(staleHoursRaw) && staleHoursRaw > 0
+        ? staleHoursRaw
+        : DEFAULT_STALE_HOURS;
+    const latestObservedAt = activitySnapshot._max.updatedAt ?? null;
+    const staleCutoff = new Date(Date.now() - staleHours * 60 * 60 * 1000);
+
+    if (!latestObservedAt || latestObservedAt < staleCutoff) {
+      const snapshotAge = latestObservedAt
+        ? `<t:${Math.floor(latestObservedAt.getTime() / 1000)}:R>`
+        : "unavailable";
+      await interaction.editReply(
+        `Inactive data is stale (latest observation: ${snapshotAge}). Wait for observation refresh and retry.`
       );
       return;
     }
 
     const inactivePlayers = await prisma.playerActivity.findMany({
       where: {
-        lastSeenAt: {
-          lt: cutoff,
-        },
-        ...(liveMemberTags.size > 0
-          ? {
-              tag: {
-                in: [...liveMemberTags],
-              },
-            }
-          : {}),
+        lastSeenAt: { lt: cutoff },
+        tag: { in: [...liveMemberTags] },
       },
-      orderBy: {
-        lastSeenAt: "asc",
-      },
+      orderBy: { lastSeenAt: "asc" },
     });
 
     if (inactivePlayers.length === 0) {
-      await interaction.editReply(
-        `✅ No inactive players for ${days}+ days.`
-      );
+      await interaction.editReply(`No inactive players for ${days}+ days.`);
       return;
     }
 
-    // Discord message safety (keep it readable)
     const lines = inactivePlayers.slice(0, 25).map((p) => {
-      const daysAgo = Math.floor(
-        (Date.now() - p.lastSeenAt.getTime()) /
-          (24 * 60 * 60 * 1000)
-      );
-
-      return `• **${p.name}** (${p.tag}) — ${daysAgo}d`;
+      const daysAgo = Math.floor((Date.now() - p.lastSeenAt.getTime()) / (24 * 60 * 60 * 1000));
+      return `- **${p.name}** (${p.tag}) - ${daysAgo}d`;
     });
 
     let message =
-      `⚠️ **Inactive for ${days}+ days (${inactivePlayers.length})**\n\n` +
-      lines.join("\n");
+      `**Inactive for ${days}+ days (${inactivePlayers.length})**\n\n` + lines.join("\n");
 
-    if (trackedTags.length > 0) {
-      message +=
-        `\n\nScope: ${trackedTags.length} tracked clan(s), ` +
-        `${liveMemberTags.size} live member tag(s).`;
-    } else {
-      message += "\n\nScope: no tracked clans configured.";
-    }
+    message +=
+      `\n\nScope: ${trackedTags.length} tracked clan(s), ` +
+      `${liveMemberTags.size} live member tag(s), ` +
+      `${activitySnapshot._count.tag} observed player record(s).`;
 
     if (inactivePlayers.length > 25) {
-      message += `\n\n…and ${
-        inactivePlayers.length - 25
-      } more.`;
+      message += `\n\n...and ${inactivePlayers.length - 25} more.`;
     }
 
     await interaction.editReply(message);


### PR DESCRIPTION
# ClashCookies v1.4.2 - Inactive Accuracy + Deployment Workflow Detection

## Release scope
- Base: `v1.4.1 (ac5c783)`
- Target: `dev (d931435)` for PR into `main`
- Compare: `v1.4.1...dev`
- Commits in range: `11`

## Highlights

### 1. `/inactive` now avoids inflated false positives
- Added stricter tracked-clan scoping so inactivity checks are based on live tracked clan members.
- Added stale observation-data guardrails to prevent historical/stale records from inflating inactive counts.

### 2. GitHub deployment detection workflow improved
- Unified Railway deployment workflow across branches to reduce branch drift.
- Added PR triggers for both `dev` and `main` so deployment checks/detection appear in PR flows for both staging and production paths.

### 3. Branch/workflow alignment cleanup
- Synced previously diverged workflow history between `main` and `dev`.
- Standardized deployment logic with branch-aware environment handling.

## Full changelog (commits)
- `d931435` Merge pull request #85 from `fix/deployment_detection_workflow` (#85)
- `3fd2c7b` `ci(workflows): trigger railway deploy workflow for pull requests to main and dev`
- `1c16dcd` Merge pull request #84 from `fix/inactive_stale_guard` (#84)
- `1877fd7` `fix(inactive): require tracked-clan scope and block stale observation data from inflating inactivity counts`
- `fbfbb72` `merge(dev): align branches and unify railway workflow`
- `3a837e5` `ci(workflows): unify main/dev railway deploy into single branch-aware workflow`
- `bcaf42a` `merge(main): sync workflow changes into dev`
- `e74ac54` `Update project ID for Railway deployment`
- `d07abb2` `Update Railway project ID for staging deployment`
- `a71c0ed` `Add GitHub Actions workflow for Railway deployment`
- `25ef907` `Add GitHub Actions workflow for staging deployment`

## Operational note(s)
- No database migration required for this release.
- Verify GitHub Actions secrets (especially `RAILWAY_API_TOKEN`) and confirm deployment events appear in PR UI for both `dev` and `main`.