### PR TITLE
v1.4.2 - Inactive Accuracy + Deployment Workflow Stabilization

### DIFF
--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -5,6 +5,10 @@ on:
       - main
       - dev
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
     branches:
       - dev
       - main

--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -9,6 +9,10 @@ on:
       - dev
       - main
 
+permissions:
+  contents: read
+  deployments: write
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -5,20 +5,44 @@ on:
       - main
       - dev
   pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
     branches:
       - dev
       - main
 
+permissions:
+  contents: read
+  deployments: write
+
 jobs:
   deploy:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
+    env:
+      RAILWAY_TOKEN: ${{ secrets.RAILWAY_API_TOKEN }}
+      RAILWAY_PROJECT_ID: 4e5afdf5-8892-4f40-b50f-76f6b5dd81f0
+      RAILWAY_ENVIRONMENT: ${{ github.ref_name == 'main' && 'production' || 'staging' }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
 
-      - name: Deploy to Railway
-        uses: ayungavis/railway-preview-deploy@v1.0.2
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
         with:
-          railway_api_token: ${{ secrets.RAILWAY_API_TOKEN }}
-          project_id: 4e5afdf5-8892-4f40-b50f-76f6b5dd81f0
-          environment_name: ${{ (github.ref_name == 'main' || github.base_ref == 'main') && 'production' || 'staging' }}
+          node-version: 20
+
+      - name: Install Railway CLI
+        run: npm install -g @railway/cli
+
+      - name: Deploy to Railway via CLI
+        run: railway up --ci --project "$RAILWAY_PROJECT_ID" --environment "$RAILWAY_ENVIRONMENT"
+
+  pr-check:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - name: PR deployment check
+        run: echo "PR event detected. Railway deploy runs on push to dev/main."

--- a/src/commands/Inactive.ts
+++ b/src/commands/Inactive.ts
@@ -1,4 +1,12 @@
-import { Client, CommandInteraction } from "discord.js";
+import {
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  Client,
+  CommandInteraction,
+  ComponentType,
+  EmbedBuilder,
+} from "discord.js";
 import { Command } from "../Command";
 import { prisma } from "../prisma";
 import { CoCService } from "../services/CoCService";
@@ -6,6 +14,23 @@ import { formatError } from "../helper/formatError";
 
 const DEFAULT_STALE_HOURS = 6;
 const DEFAULT_MIN_COVERAGE = 0.8;
+const MAX_LINES_PER_PAGE = 24;
+const MAX_DESCRIPTION_LENGTH = 3900;
+
+function buildPaginationRow(customIdPrefix: string, page: number, totalPages: number) {
+  return new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder()
+      .setCustomId(`${customIdPrefix}:prev`)
+      .setLabel("Prev")
+      .setStyle(ButtonStyle.Secondary)
+      .setDisabled(page <= 0),
+    new ButtonBuilder()
+      .setCustomId(`${customIdPrefix}:next`)
+      .setLabel("Next")
+      .setStyle(ButtonStyle.Secondary)
+      .setDisabled(page >= totalPages - 1)
+  );
+}
 
 export const Inactive: Command = {
   name: "inactive",
@@ -48,12 +73,17 @@ export const Inactive: Command = {
     }
 
     const liveMemberTags = new Set<string>();
+    const liveMemberClanByTag = new Map<string, string>();
     for (const trackedTag of trackedTags) {
       try {
         const clan = await cocService.getClan(trackedTag);
+        const clanName = String(clan.name ?? trackedTag).trim() || trackedTag;
         for (const member of clan.members ?? []) {
           const memberTag = String(member?.tag ?? "").trim();
-          if (memberTag) liveMemberTags.add(memberTag);
+          if (memberTag) {
+            liveMemberTags.add(memberTag);
+            liveMemberClanByTag.set(memberTag, clanName);
+          }
         }
       } catch (err) {
         console.error(
@@ -136,24 +166,141 @@ export const Inactive: Command = {
       return;
     }
 
-    const lines = inactivePlayers.slice(0, 25).map((p) => {
-      const daysAgo = Math.floor((Date.now() - p.lastSeenAt.getTime()) / (24 * 60 * 60 * 1000));
-      return `- **${p.name}** (${p.tag}) - ${daysAgo}d`;
+    const inactiveWithClan = inactivePlayers.map((p) => ({
+      player: p,
+      clan: liveMemberClanByTag.get(p.tag) ?? p.clanTag ?? "Unknown Clan",
+    }));
+
+    const clanCounts = new Map<string, number>();
+    for (const entry of inactiveWithClan) {
+      clanCounts.set(entry.clan, (clanCounts.get(entry.clan) ?? 0) + 1);
+    }
+
+    const clanOrder = new Map<string, number>();
+    let index = 0;
+    for (const tag of trackedTags) {
+      const clanName =
+        inactiveWithClan.find((entry) => entry.player.clanTag === tag)?.clan ??
+        tag;
+      if (!clanOrder.has(clanName)) {
+        clanOrder.set(clanName, index++);
+      }
+    }
+
+    inactiveWithClan.sort((a, b) => {
+      const orderA = clanOrder.get(a.clan) ?? Number.MAX_SAFE_INTEGER;
+      const orderB = clanOrder.get(b.clan) ?? Number.MAX_SAFE_INTEGER;
+      if (orderA !== orderB) return orderA - orderB;
+      if (a.clan !== b.clan) return a.clan.localeCompare(b.clan);
+      return a.player.lastSeenAt.getTime() - b.player.lastSeenAt.getTime();
     });
 
-    let message =
-      `**Inactive for ${days}+ days (${inactivePlayers.length})**\n\n` + lines.join("\n");
+    const pages: string[] = [];
+    let currentLines: string[] = [];
+    let currentClan: string | null = null;
+    const clanPageCounts = new Map<string, number>();
 
-    message +=
-      `\n\nScope: ${trackedTags.length} tracked clan(s), ` +
+    for (const entry of inactiveWithClan) {
+      const isNewClan = currentClan !== entry.clan;
+      if (isNewClan) {
+        const continuationCount = clanPageCounts.get(entry.clan) ?? 0;
+        const header =
+          continuationCount === 0
+            ? `**${entry.clan} (${clanCounts.get(entry.clan) ?? 0})**`
+            : `**${entry.clan} (${clanCounts.get(entry.clan) ?? 0}) (cont.)**`;
+        const projectedLines = currentLines.length + (currentLines.length > 0 ? 2 : 1);
+        if (projectedLines > MAX_LINES_PER_PAGE) {
+          pages.push(currentLines.join("\n"));
+          currentLines = [];
+        }
+        if (currentLines.length > 0) currentLines.push("");
+        currentLines.push(header);
+        currentClan = entry.clan;
+        clanPageCounts.set(entry.clan, continuationCount + 1);
+      }
+
+      const daysAgo = Math.floor(
+        (Date.now() - entry.player.lastSeenAt.getTime()) / (24 * 60 * 60 * 1000)
+      );
+      const playerLine = `- **${entry.player.name}** (${entry.player.tag}) - ${daysAgo}d`;
+
+      if (currentLines.length + 1 > MAX_LINES_PER_PAGE) {
+        pages.push(currentLines.join("\n"));
+        currentLines = [
+          `**${entry.clan} (${clanCounts.get(entry.clan) ?? 0}) (cont.)**`,
+          playerLine,
+        ];
+        currentClan = entry.clan;
+        clanPageCounts.set(entry.clan, (clanPageCounts.get(entry.clan) ?? 0) + 1);
+      } else {
+        currentLines.push(playerLine);
+      }
+    }
+
+    if (currentLines.length > 0) {
+      pages.push(currentLines.join("\n"));
+    }
+
+    const summary =
+      `Scope: ${trackedTags.length} tracked clan(s), ` +
       `${liveMemberTags.size} live member tag(s), ` +
       `${activitySnapshot._count.tag} observed player record(s), ` +
       `${freshObservedCount} fresh in last ${staleHours}h.`;
 
-    if (inactivePlayers.length > 25) {
-      message += `\n\n...and ${inactivePlayers.length - 25} more.`;
+    const embeds = pages.map((content, pageIdx) => {
+      let description = content;
+      if (description.length > MAX_DESCRIPTION_LENGTH) {
+        description = `${description.slice(0, MAX_DESCRIPTION_LENGTH - 20)}\n...truncated`;
+      }
+
+      return new EmbedBuilder()
+        .setTitle(`Inactive for ${days}+ days (${inactivePlayers.length})`)
+        .setDescription(description)
+        .setFooter({
+          text: `Page ${pageIdx + 1}/${pages.length} • ${summary}`,
+        });
+    });
+
+    let page = 0;
+    const customIdPrefix = `inactive:${interaction.id}`;
+    const usePagination = embeds.length > 1;
+    const reply = await interaction.editReply({
+      embeds: [embeds[page]],
+      components: usePagination ? [buildPaginationRow(customIdPrefix, page, embeds.length)] : [],
+    });
+
+    if (!usePagination) {
+      return;
     }
 
-    await interaction.editReply(message);
+    const collector = reply.createMessageComponentCollector({
+      componentType: ComponentType.Button,
+      time: 5 * 60 * 1000,
+      filter: (btn) =>
+        btn.user.id === interaction.user.id &&
+        (btn.customId === `${customIdPrefix}:prev` || btn.customId === `${customIdPrefix}:next`),
+    });
+
+    collector.on("collect", async (btn) => {
+      if (btn.customId.endsWith(":prev")) {
+        page = Math.max(0, page - 1);
+      } else if (btn.customId.endsWith(":next")) {
+        page = Math.min(embeds.length - 1, page + 1);
+      }
+
+      await btn.update({
+        embeds: [embeds[page]],
+        components: [buildPaginationRow(customIdPrefix, page, embeds.length)],
+      });
+    });
+
+    collector.on("end", async () => {
+      await interaction
+        .editReply({
+          embeds: [embeds[page]],
+          components: [],
+        })
+        .catch(() => undefined);
+    });
   },
 };

--- a/src/listeners/ready.ts
+++ b/src/listeners/ready.ts
@@ -17,14 +17,17 @@ export default (client: Client, cocService: CoCService): void => {
     const guild = await client.guilds.fetch(guildId);
     const me = await guild.members.fetch(client.user!.id);
     const guildPerms = me.permissions;
+    const maybePinMessagesBit = (PermissionFlagsBits as Record<string, bigint>).PinMessages;
     const requiredGuildPerms: Array<[bigint, string]> = [
       [PermissionFlagsBits.ViewChannel, "View Channels"],
       [PermissionFlagsBits.SendMessages, "Send Messages"],
       [PermissionFlagsBits.EmbedLinks, "Embed Links"],
       [PermissionFlagsBits.ReadMessageHistory, "Read Message History"],
-      [PermissionFlagsBits.ManageMessages, "Manage Messages (for pin/unpin)"],
       [PermissionFlagsBits.MentionEveryone, "Mention Everyone (for non-mentionable role pings)"],
     ];
+    if (maybePinMessagesBit) {
+      requiredGuildPerms.push([maybePinMessagesBit, "Pin Messages (for pin/unpin)"]);
+    }
     const missingGuildPerms = requiredGuildPerms
       .filter(([bit]) => !guildPerms.has(bit))
       .map(([, label]) => label);


### PR DESCRIPTION
# ClashCookies v1.4.2 - Inactive Accuracy + Deployment Workflow Stabilization

## Release scope
- Base: `v1.4.1 (ac5c783)`
- Target: `origin/dev (697eb51)` for PR into `main`
- Compare: `v1.4.1...origin/dev`
- Commits in range: `21`

## Highlights

### 1. `/inactive` reliability and usability overhaul
- Added stricter freshness/coverage safeguards so stale partial observations do not inflate inactive counts.
- Added grouped output by current clan plus paginated embed navigation for large result sets.

### 2. Railway deployment workflow hardening
- Added PR-trigger coverage for `dev`/`main` and deployment-status permissions.
- Replaced third-party preview deploy action with Railway CLI push-based deploy flow to reduce preview-environment edge-case failures.

### 3. Branch/workflow alignment and rollout cleanup
- Unified/realigned workflow history between `dev` and `main` after direct-branch workflow edits.
- Included follow-up fixes for PR closed-event deploy behavior and token/permissions handling path.

## Full changelog (commits)
- `697eb51` Merge pull request #91 from `feat/inactive-grouped-paginated` (#91)
- `71143d4` feat(inactive): group inactive results by clan and add paginated embed navigation
- `83535b6` Merge pull request #90 from `fix/inactive-observation-coverage` (#90)
- `1c30fbf` ci(deploy): replace railway-preview action with Railway CLI and run deploys on push only
- `6666b5e` Merge pull request #89 from `fix/inactive-observation-coverage` (#89)
- `eb5033b` fix(inactive): require fresh observation coverage before reporting inactivity
- `efff970` Merge pull request #88 from `fix/railway-pr-closed-trigger` (#88)
- `0cbc8b4` fix(ci): prevent railway preview deploy on pull_request closed events
- `5198792` Merge pull request #87 from `fix/deployment_detection_workflow_2` (#87)
- `97d4902` ci(workflows): grant deployments write permission for railway deploy status reporting
- `d931435` Merge pull request #85 from `fix/deployment_detection_workflow` (#85)
- `3fd2c7b` ci(workflows): trigger railway deploy workflow for pull requests to main and dev
- `1c16dcd` Merge pull request #84 from `fix/inactive_stale_guard` (#84)
- `1877fd7` fix(inactive): require tracked-clan scope and block stale observation data from inflating inactivity counts
- `fbfbb72` merge(dev): align branches and unify railway workflow
- `3a837e5` ci(workflows): unify main/dev railway deploy into single branch-aware workflow
- `bcaf42a` merge(main): sync workflow changes into dev
- `e74ac54` Update project ID for Railway deployment
- `d07abb2` Update Railway project ID for staging deployment
- `a71c0ed` Add GitHub Actions workflow for Railway deployment
- `25ef907` Add GitHub Actions workflow for staging deployment

## Operational note(s)
- Verify GitHub secret `RAILWAY_API_TOKEN` is valid for project `4e5afdf5-8892-4f40-b50f-76f6b5dd81f0`; Railway CLI deploy now depends on this directly.
- No Prisma migration required; rollback can be done by reverting the release PR from `dev` to `main`.