### PR TITLE
Trying to fix GitHub <-> Railway deployment handshake

### DIFF
--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -22,7 +22,7 @@ jobs:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     env:
-      RAILWAY_TOKEN: ${{ secrets.RAILWAY_API_TOKEN }}
+      RAILWAY_TOKEN: ${{ github.ref_name == 'main' && secrets.RAILWAY_TOKEN_PRODUCTION || secrets.RAILWAY_TOKEN_STAGING }}
       RAILWAY_PROJECT_ID: 4e5afdf5-8892-4f40-b50f-76f6b5dd81f0
       RAILWAY_ENVIRONMENT: ${{ github.ref_name == 'main' && 'production' || 'staging' }}
     steps:


### PR DESCRIPTION
## Summary
Update Railway GitHub Actions deploy workflow to use environment-specific tokens by branch.

## Changes
- File changed: `.github/workflows/deploy-railway.yml`
- `RAILWAY_TOKEN` now resolves by branch:
  - `main` -> `secrets.RAILWAY_TOKEN_PRODUCTION`
  - `dev` -> `secrets.RAILWAY_TOKEN_STAGING`
- No application code changes.

## Why
- Ensures deploy auth uses the correct environment-scoped Railway token.
- Reduces unauthorized deploy failures caused by token scope mismatch.

## Validation
- Workflow syntax reviewed.
- Branch-to-environment mapping remains:
  - `main` -> `production`
  - `dev` -> `staging`

## Ops / Notes
- Requires both GitHub repository secrets to be set:
  - `RAILWAY_TOKEN_STAGING`
  - `RAILWAY_TOKEN_PRODUCTION`