### PR TITLE
v1.4.3 - Railway Deploy Auth + GitHub Deployment Status Stability

### DIFF
--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -38,7 +38,7 @@ jobs:
         run: npm install -g @railway/cli
 
       - name: Deploy to Railway via CLI
-        run: railway up --ci --project "$RAILWAY_PROJECT_ID" --environment "$RAILWAY_ENVIRONMENT"
+        run: railway up --ci --project "$RAILWAY_PROJECT_ID" --environment "$RAILWAY_ENVIRONMENT" --service ClashCookies
 
   pr-check:
     if: github.event_name == 'pull_request'


### PR DESCRIPTION
# ClashCookies v1.4.3 - Railway Deploy Auth + GitHub Deployment Status Stability

## Release scope
- Base: `v1.4.2 (98edb97)`
- Target: `origin/dev (8f6b51f)` for PR into `main`
- Compare: `v1.4.2...origin/dev`
- Commits in range: `4`

## Highlights

### 1. Environment-specific Railway deploy tokens
- Deploy workflow now uses branch-based token secrets instead of one shared token.
- `main` uses production token and `dev` uses staging token, reducing unauthorized deploy failures.

### 2. Deployment detection/status is now working end-to-end
- GitHub Actions to Railway deployment linkage is now stable and correctly reported.
- PR/branch deployment signal in GitHub UI now reflects actual deployment behavior.

### 3. Branch synchronization cleanup
- Merged `main` changes back into `dev` to keep release history aligned.
- Release branch state is now clean for `dev -> main` promotion.

## Full changelog (commits)
- `8f6b51f` merge(main): sync main into dev
- `9dc7cea` Merge pull request #95 from tonykslee/dev (#95)
- `f209a83` Merge pull request #94 from tonykslee/fix/railway-env-specific-tokens (#94)
- `d746139` ci(deploy): use branch-based Railway token secrets for staging and production

## Operational note(s)
- Ensure GitHub repository secrets exist and are current: `RAILWAY_TOKEN_STAGING`, `RAILWAY_TOKEN_PRODUCTION`.
- No database migration required for this release; rollback is safe via release PR revert.