### PR TITLE
v1.5.0 - Points Reliability and Telemetry Efficiency

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/dev-to-main-release.md
+++ b/.github/PULL_REQUEST_TEMPLATE/dev-to-main-release.md
@@ -1,0 +1,31 @@
+## Release Summary
+- Release version: `vX.Y.Z`
+- Base: `dev` -> `main`
+- Objective: Promote vetted staging changes to production
+
+## Included Changes
+- Link this section to the release notes format in `docs/release-notes-template.md`.
+- Keep entries user-facing and grouped by theme.
+
+## Validation Evidence
+- [ ] Changes were tested in staging Discord server
+- [ ] Required CI checks passed
+- [ ] Railway deployment status is healthy for staging path
+
+## Operational Notes
+- Required env var updates in production:
+  - `None` or list keys only (no secret values)
+- Migration or data changes:
+  - `None` or describe
+
+## Post-Merge Steps
+- [ ] Sync `dev` to `main` to keep branch history aligned:
+  1. `git fetch origin`
+  2. `git switch dev`
+  3. `git merge --ff-only origin/main`
+  4. `git push origin dev`
+- [ ] Verify alignment:
+  - `git rev-list --left-right --count origin/main...origin/dev`
+  - Expected: `0    0`
+- [ ] Create GitHub release tag with same notes
+

--- a/.github/PULL_REQUEST_TEMPLATE/feature-or-fix-to-dev.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature-or-fix-to-dev.md
@@ -1,0 +1,32 @@
+## Summary
+- What was implemented or fixed?
+- Why was this needed?
+
+## Scope
+- Branch: `<feature-branch>` -> `dev`
+- Type: `feature` | `fix` | `docs` | `chore`
+
+## Changes
+- List key code changes.
+- List key behavior changes.
+
+## Validation
+- [ ] Ran `npx tsc --noEmit`
+- [ ] Ran lint (if available)
+- [ ] Verified command behavior in staging Discord server
+- [ ] Confirmed bot replies stay within Discord 2000-char limit
+
+## Risks / Notes
+- Any known risks, edge cases, or follow-up work.
+
+## Deployment / Ops
+- Railway environment impacted: `staging` | `production` | `none`
+- Any required env var changes:
+  - `None` or list keys only (no secret values)
+
+## Checklist
+- [ ] I did not commit directly to `dev` or `main`
+- [ ] Branch was created from `origin/dev`
+- [ ] First push used upstream tracking (`git push -u origin <branch>`)
+- [ ] Documentation updated when behavior changed
+

--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -38,7 +38,7 @@ jobs:
         run: npm install -g @railway/cli
 
       - name: Deploy to Railway via CLI
-        run: railway up --ci --project "$RAILWAY_PROJECT_ID" --environment "$RAILWAY_ENVIRONMENT" --service ClashCookies --detach
+        run: railway up --ci --detach --message "${{ github.event.head_commit.message }}" --project "$RAILWAY_PROJECT_ID" --environment "$RAILWAY_ENVIRONMENT" --service ClashCookies
 
   pr-check:
     if: github.event_name == 'pull_request'

--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -38,7 +38,7 @@ jobs:
         run: npm install -g @railway/cli
 
       - name: Deploy to Railway via CLI
-        run: railway up --ci --project "$RAILWAY_PROJECT_ID" --environment "$RAILWAY_ENVIRONMENT" --service ClashCookies
+        run: railway up --ci --project "$RAILWAY_PROJECT_ID" --environment "$RAILWAY_ENVIRONMENT" --service ClashCookies --detach
 
   pr-check:
     if: github.event_name == 'pull_request'

--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,6 @@ dist
 # Prisma
 dev.db
 dev.db-journal
+
+# Local AI workflow instructions (do not commit)
+AGENTS.local.md

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Discord bot for Clash of Clans activity tooling.
 - Manages tracked clans at runtime (`/tracked-clan ...`).
 - Links to a Google Sheet at runtime (`/sheet ...`).
 - Supports mode-specific sheet links for `actual` and `war` roster workflows.
+- Fetches FWA points balances for one clan or all tracked clans (`/points`).
 
 ## Setup
 1. Create a `.env` with required Discord, CoC API, and database values.
@@ -64,6 +65,7 @@ Optional fallback auth (not required for your current setup):
 - `/compo place weight:<value>` - Suggest placement options from ACTUAL state (vacancy + composition fit). Accepts formats like `145000`, `145,000`, or `145k` and maps to TH weight buckets.
 - `/cc player tag:<tag>` - Build `https://cc.fwafarm.com/cc_n/member.php?tag=<tag>`.
 - `/cc clan tag:<tag>` - Build `https://cc.fwafarm.com/cc_n/clan.php?tag=<tag>`.
+- `/points [tag:<tag>]` - Fetch current point balance from `https://points.fwafarm.com/clan?tag=<tag-without-#>`. If `tag` is omitted, fetches all tracked clans.
 - `/post sync time [role:<discordRole>]` - Open modal, compose sync-time message, post it, and pin it.
 
 ## Command Access Control

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Optional fallback auth (not required for your current setup):
 - `/compo place weight:<value>` - Suggest placement options from ACTUAL state (vacancy + composition fit). Accepts formats like `145000`, `145,000`, or `145k` and maps to TH weight buckets.
 - `/cc player tag:<tag>` - Build `https://cc.fwafarm.com/cc_n/member.php?tag=<tag>`.
 - `/cc clan tag:<tag>` - Build `https://cc.fwafarm.com/cc_n/clan.php?tag=<tag>`.
-- `/points [tag:<tag>]` - Fetch current point balance from `https://points.fwafarm.com/clan?tag=<tag-without-#>`. If `tag` is omitted, fetches all tracked clans.
+- `/points [tag:<tag>] [opponent-tag:<tag>]` - Fetch current point balance from `https://points.fwafarm.com/clan?tag=<tag-without-#>`. If `tag` is omitted, fetches all tracked clans. If both tags are provided, returns projected winner/loser by points, or sync-based tiebreak when points are tied.
 - `/post sync time [role:<discordRole>]` - Open modal, compose sync-time message, post it, and pin it.
 
 ## Command Access Control

--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ Optional fallback auth (not required for your current setup):
 - Administrator users can always use commands regardless of role whitelist.
 - To lock `/post` to role X, run:
   - `/permission add command:post role:@RoleX`
+- To lock `/points` to role X, run:
+  - `/permission add command:points role:@RoleX`
 
 ## Deployment Notes
 - Commands are registered as guild commands using `GUILD_ID` on startup.

--- a/docs/GIT_ALIASES.md
+++ b/docs/GIT_ALIASES.md
@@ -1,0 +1,46 @@
+# Git Aliases for This Repo Workflow
+
+Add these aliases once on your machine to reduce repeated commands.
+
+## Setup
+
+Run:
+
+```powershell
+git config --global alias.new-from-dev "!f() { git fetch origin && git switch -c \"$1\" origin/dev; }; f"
+git config --global alias.sync-dev-main "!git fetch origin && git switch dev && git merge --ff-only origin/main && git push origin dev"
+git config --global alias.aheadbehind "!git fetch origin && git rev-list --left-right --count origin/main...origin/dev"
+```
+
+## Usage
+
+Create a new feature/fix branch from latest `origin/dev`:
+
+```powershell
+git new-from-dev fix/short-description
+```
+
+Then set upstream on first push:
+
+```powershell
+git push -u origin fix/short-description
+```
+
+Sync `dev` to `main` after a release merge:
+
+```powershell
+git sync-dev-main
+```
+
+Check if `main` and `dev` are aligned:
+
+```powershell
+git aheadbehind
+```
+
+Expected aligned output:
+
+```text
+0    0
+```
+

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -1,0 +1,36 @@
+# Release Checklist
+
+Use this for each release promotion from `dev` to `main`.
+
+## 1. Pre-PR Gate (dev is ready)
+- [ ] Feature/fix PRs into `dev` are merged
+- [ ] Staging behavior is validated
+- [ ] Any required docs updates are merged in `dev`
+- [ ] Release notes drafted using `docs/release-notes-template.md`
+
+## 2. Create PR (`dev` -> `main`)
+- [ ] Open PR from `dev` to `main`
+- [ ] Choose template: `dev-to-main-release.md`
+- [ ] Paste final release notes content
+- [ ] Confirm CI checks are passing
+
+## 3. Merge and Tag
+- [ ] Merge PR to `main`
+- [ ] Create release tag (example: `v1.4.3`)
+- [ ] Use the same release notes as PR
+
+## 4. Keep Branches Aligned (target: 0 0)
+- [ ] Run:
+  1. `git fetch origin`
+  2. `git switch dev`
+  3. `git merge --ff-only origin/main`
+  4. `git push origin dev`
+- [ ] Verify:
+  - `git rev-list --left-right --count origin/main...origin/dev`
+  - Expected: `0    0`
+
+## 5. Post-Release Quick Audit
+- [ ] Production deploy status is green
+- [ ] Bot health checks look normal
+- [ ] No permission warnings/regressions in logs
+

--- a/src/Commands.ts
+++ b/src/Commands.ts
@@ -9,6 +9,7 @@ import { Compo } from "./commands/Compo";
 import { Post } from "./commands/Post";
 import { CommandRole } from "./commands/CommandRole";
 import { CC } from "./commands/CC";
+import { Points } from "./commands/Points";
 
 // ...existing code...
 export const Commands = [
@@ -21,6 +22,7 @@ export const Commands = [
   Sheet,
   Compo,
   CC,
+  Points,
   Post,
   CommandRole,
 ];

--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -155,6 +155,7 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
     ],
     examples: [
       "/permission add command:post role:@Leaders",
+      "/permission add command:points role:@Leaders",
       "/permission remove command:post role:@Leaders",
       "/permission list",
     ],

--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -129,6 +129,14 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
     ],
     examples: ["/cc player tag:ABCD1234", "/cc clan tag:2QG2C08UP"],
   },
+  points: {
+    summary: "Fetch FWA points balance from points.fwafarm.com.",
+    details: [
+      "Provide a clan tag, or omit tag to fetch all tracked clan balances.",
+      "Tag supports autocomplete from tracked clans.",
+    ],
+    examples: ["/points tag:2QG2C08UP", "/points"],
+  },
   post: {
     summary: "Post structured messages such as sync time announcements.",
     details: [

--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -130,12 +130,13 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
     examples: ["/cc player tag:ABCD1234", "/cc clan tag:2QG2C08UP"],
   },
   points: {
-    summary: "Fetch FWA points balance from points.fwafarm.com.",
+    summary: "Fetch FWA points balance and optional matchup projection.",
     details: [
       "Provide a clan tag, or omit tag to fetch all tracked clan balances.",
+      "Optionally provide `opponent-tag` to compare points and apply sync-based tiebreak logic.",
       "Tag supports autocomplete from tracked clans.",
     ],
-    examples: ["/points tag:2QG2C08UP", "/points"],
+    examples: ["/points tag:2QG2C08UP", "/points", "/points tag:2QG2C08UP opponent-tag:ABC12345"],
   },
   post: {
     summary: "Post structured messages such as sync time announcements.",

--- a/src/commands/Points.ts
+++ b/src/commands/Points.ts
@@ -1,0 +1,146 @@
+import axios from "axios";
+import {
+  ApplicationCommandOptionType,
+  AutocompleteInteraction,
+  ChatInputCommandInteraction,
+  Client,
+} from "discord.js";
+import { Command } from "../Command";
+import { formatError } from "../helper/formatError";
+import { safeReply } from "../helper/safeReply";
+import { prisma } from "../prisma";
+import { CoCService } from "../services/CoCService";
+
+const POINTS_BASE_URL = "https://points.fwafarm.com/clan?tag=";
+
+function normalizeTag(input: string): string {
+  return input.trim().toUpperCase().replace(/^#/, "");
+}
+
+function toPlainText(html: string): string {
+  return html
+    .replace(/<script[\s\S]*?<\/script>/gi, " ")
+    .replace(/<style[\s\S]*?<\/style>/gi, " ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/gi, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function extractField(text: string, label: string): string | null {
+  const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const regex = new RegExp(`${escaped}\\s*:\\s*([^\\n\\r]+)`, "i");
+  const match = text.match(regex);
+  if (!match?.[1]) return null;
+  return match[1].trim();
+}
+
+function extractPointBalance(html: string): number | null {
+  const directMatch = html.match(/(?:Point Balance|Current Point Balance)\s*:\s*([+-]?\d+)/i);
+  if (directMatch?.[1]) return Number(directMatch[1]);
+
+  const plain = toPlainText(html);
+  const textMatch = plain.match(/(?:Point Balance|Current Point Balance)\s*:\s*([+-]?\d+)/i);
+  if (!textMatch?.[1]) return null;
+  return Number(textMatch[1]);
+}
+
+export const Points: Command = {
+  name: "points",
+  description: "Get FWA points balance for a clan tag",
+  options: [
+    {
+      name: "tag",
+      description: "Clan tag (with or without #)",
+      type: ApplicationCommandOptionType.String,
+      required: true,
+      autocomplete: true,
+    },
+  ],
+  run: async (
+    _client: Client,
+    interaction: ChatInputCommandInteraction,
+    _cocService: CoCService
+  ) => {
+    const rawTag = interaction.options.getString("tag", true);
+    const tag = normalizeTag(rawTag);
+    if (!tag) {
+      await safeReply(interaction, {
+        ephemeral: true,
+        content: "Please provide a valid clan tag.",
+      });
+      return;
+    }
+
+    await interaction.deferReply({ ephemeral: true });
+
+    const url = `${POINTS_BASE_URL}${tag}`;
+    try {
+      const response = await axios.get<string>(url, {
+        timeout: 15000,
+        responseType: "text",
+        headers: {
+          "User-Agent": "ClashCookiesBot/1.0 (+https://github.com/tonykslee/ClashCookies)",
+        },
+      });
+
+      const html = String(response.data ?? "");
+      const balance = extractPointBalance(html);
+      if (balance === null || Number.isNaN(balance)) {
+        const plain = toPlainText(html);
+        if (/not found|unknown clan|no clan/i.test(plain)) {
+          await interaction.editReply(
+            `No points data found for #${tag}. Check the clan tag and try again.`
+          );
+          return;
+        }
+
+        console.error(`[points] could not parse point balance for tag=${tag} url=${url}`);
+        await interaction.editReply(
+          "Could not parse point balance from points.fwafarm.com right now. Try again later."
+        );
+        return;
+      }
+
+      const plain = toPlainText(html);
+      const clanName = extractField(plain, "Clan Name");
+      const clanTag = extractField(plain, "Clan Tag") ?? tag;
+      await interaction.editReply(
+        `${clanName ? `**${clanName}**\n` : ""}Tag: #${normalizeTag(clanTag)}\nPoint Balance: **${balance}**\n${url}`
+      );
+    } catch (err) {
+      console.error(`[points] request failed tag=${tag} error=${formatError(err)}`);
+      await interaction.editReply(
+        "Failed to fetch points. Check the tag and try again."
+      );
+    }
+  },
+  autocomplete: async (interaction: AutocompleteInteraction) => {
+    const focused = interaction.options.getFocused(true);
+    if (focused.name !== "tag") {
+      await interaction.respond([]);
+      return;
+    }
+
+    const query = String(focused.value ?? "").trim().toLowerCase();
+    const tracked = await prisma.trackedClan.findMany({
+      orderBy: { createdAt: "asc" },
+      select: { name: true, tag: true },
+    });
+
+    const choices = tracked
+      .map((c) => {
+        const normalized = normalizeTag(c.tag);
+        const label = c.name?.trim() ? `${c.name.trim()} (#${normalized})` : `#${normalized}`;
+        return { name: label.slice(0, 100), value: normalized };
+      })
+      .filter(
+        (c) =>
+          c.name.toLowerCase().includes(query) ||
+          c.value.toLowerCase().includes(query)
+      )
+      .slice(0, 25);
+
+    await interaction.respond(choices);
+  },
+};

--- a/src/commands/Points.ts
+++ b/src/commands/Points.ts
@@ -26,6 +26,18 @@ function normalizeTag(input: string): string {
   return input.trim().toUpperCase().replace(/^#/, "");
 }
 
+function buildPointsUrl(tag: string): string {
+  const normalizedTag = normalizeTag(tag);
+  const proxyBase = (process.env.POINTS_PROXY_URL ?? "").trim();
+  if (!proxyBase) {
+    return `${POINTS_BASE_URL}${normalizedTag}`;
+  }
+
+  const proxyUrl = new URL(proxyBase);
+  proxyUrl.searchParams.set("tag", normalizedTag);
+  return proxyUrl.toString();
+}
+
 function toPlainText(html: string): string {
   return html
     .replace(/<script[\s\S]*?<\/script>/gi, " ")
@@ -128,7 +140,7 @@ async function fetchClanPoints(tag: string): Promise<{
   winnerBoxHasTag: boolean;
 }> {
   const normalizedTag = normalizeTag(tag);
-  const url = `${POINTS_BASE_URL}${normalizedTag}`;
+  const url = buildPointsUrl(normalizedTag);
   const response = await axios.get<string>(url, {
     timeout: 15000,
     responseType: "text",

--- a/src/commands/Points.ts
+++ b/src/commands/Points.ts
@@ -72,6 +72,10 @@ function buildPointsUrl(tag: string): string {
   return proxyUrl.toString();
 }
 
+function buildOfficialPointsUrl(tag: string): string {
+  return `${POINTS_BASE_URL}${normalizeTag(tag)}`;
+}
+
 function toPlainText(html: string): string {
   return html
     .replace(/<script[\s\S]*?<\/script>/gi, " ")
@@ -783,7 +787,7 @@ export const Points: Command = {
         "Unknown Clan";
 
       await editReplySafe(
-        `Clan Name: **${displayName}**\nTag: #${tag}\nPoint Balance: **${formatPoints(balance)}**\n${result.url}`
+        `Clan Name: **${displayName}**\nTag: #${tag}\nPoint Balance: **${formatPoints(balance)}**\n${buildOfficialPointsUrl(tag)}`
       );
     } catch (err) {
       console.error(`[points] request failed tag=${tag} error=${formatError(err)}`);

--- a/src/commands/Points.ts
+++ b/src/commands/Points.ts
@@ -10,9 +10,11 @@ import { formatError } from "../helper/formatError";
 import { safeReply } from "../helper/safeReply";
 import { prisma } from "../prisma";
 import { CoCService } from "../services/CoCService";
+import { SettingsService } from "../services/SettingsService";
 
 const POINTS_BASE_URL = "https://points.fwafarm.com/clan?tag=";
 const TIEBREAK_ORDER = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+const CACHE_REFRESH_DELAY_MS = 30 * 60 * 1000;
 const POINTS_REQUEST_HEADERS = {
   "User-Agent":
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36",
@@ -20,6 +22,28 @@ const POINTS_REQUEST_HEADERS = {
   "Accept-Language": "en-US,en;q=0.9",
   Referer: "https://points.fwafarm.com/",
   Origin: "https://points.fwafarm.com",
+};
+
+type PointsSnapshot = {
+  tag: string;
+  url: string;
+  balance: number | null;
+  clanName: string | null;
+  notFound: boolean;
+  winnerBoxText: string | null;
+  winnerBoxTags: string[];
+  winnerBoxSync: number | null;
+  effectiveSync: number | null;
+  syncMode: "low" | "high" | null;
+  winnerBoxHasTag: boolean;
+  fetchedAtMs: number;
+  refreshedForWarEndMs: number | null;
+};
+
+type MatchupCacheEntry = {
+  cycleKey: string;
+  message: string;
+  createdAtMs: number;
 };
 
 function normalizeTag(input: string): string {
@@ -126,19 +150,76 @@ function getHttpStatus(err: unknown): number | null {
   return typeof status === "number" ? status : null;
 }
 
-async function fetchClanPoints(tag: string): Promise<{
-  tag: string;
-  url: string;
-  balance: number | null;
-  clanName: string | null;
-  notFound: boolean;
-  winnerBoxText: string | null;
-  winnerBoxTags: string[];
-  winnerBoxSync: number | null;
-  effectiveSync: number | null;
-  syncMode: "low" | "high" | null;
-  winnerBoxHasTag: boolean;
-}> {
+function parseCocApiTime(input: string | null | undefined): number | null {
+  if (!input) return null;
+  const match = input.match(
+    /^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})\.\d{3}Z$/
+  );
+  if (!match) return null;
+  const [, y, m, d, hh, mm, ss] = match;
+  return Date.UTC(Number(y), Number(m) - 1, Number(d), Number(hh), Number(mm), Number(ss));
+}
+
+function clanCacheKey(tag: string): string {
+  return `points_cache:${normalizeTag(tag)}`;
+}
+
+function matchupCacheKey(tag: string, opponentTag: string): string {
+  return `points_matchup_cache:${normalizeTag(tag)}:${normalizeTag(opponentTag)}`;
+}
+
+async function getClanWarEndMs(cocService: CoCService, tag: string): Promise<number | null> {
+  const war = await cocService.getCurrentWar(`#${normalizeTag(tag)}`);
+  return parseCocApiTime(war?.endTime);
+}
+
+async function readPointsCache(
+  settings: SettingsService,
+  tag: string
+): Promise<PointsSnapshot | null> {
+  const raw = await settings.get(clanCacheKey(tag));
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as PointsSnapshot;
+    return parsed && typeof parsed === "object" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+async function writePointsCache(
+  settings: SettingsService,
+  tag: string,
+  snapshot: PointsSnapshot
+): Promise<void> {
+  await settings.set(clanCacheKey(tag), JSON.stringify(snapshot));
+}
+
+async function readMatchupCache(
+  settings: SettingsService,
+  tag: string,
+  opponentTag: string
+): Promise<MatchupCacheEntry | null> {
+  const raw = await settings.get(matchupCacheKey(tag, opponentTag));
+  if (!raw) return null;
+  try {
+    const parsed = JSON.parse(raw) as MatchupCacheEntry;
+    return parsed && typeof parsed === "object" ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+async function writeMatchupCache(
+  settings: SettingsService,
+  tag: string,
+  opponentTag: string,
+  data: MatchupCacheEntry
+): Promise<void> {
+  await settings.set(matchupCacheKey(tag, opponentTag), JSON.stringify(data));
+}
+
+async function scrapeClanPoints(tag: string, refreshedForWarEndMs: number | null): Promise<PointsSnapshot> {
   const normalizedTag = normalizeTag(tag);
   const url = buildPointsUrl(normalizedTag);
   const response = await axios.get<string>(url, {
@@ -179,7 +260,97 @@ async function fetchClanPoints(tag: string): Promise<{
     effectiveSync,
     syncMode,
     winnerBoxHasTag,
+    fetchedAtMs: Date.now(),
+    refreshedForWarEndMs,
   };
+}
+
+async function getClanPointsCached(
+  settings: SettingsService,
+  cocService: CoCService,
+  tag: string
+): Promise<PointsSnapshot> {
+  const normalizedTag = normalizeTag(tag);
+  const cached = await readPointsCache(settings, normalizedTag);
+  const warEndMs = await getClanWarEndMs(cocService, normalizedTag);
+  const refreshAfterMs = warEndMs === null ? null : warEndMs + CACHE_REFRESH_DELAY_MS;
+  const now = Date.now();
+
+  const needsRefreshByCycle =
+    warEndMs !== null &&
+    refreshAfterMs !== null &&
+    now >= refreshAfterMs &&
+    cached?.refreshedForWarEndMs !== warEndMs;
+
+  if (cached && !needsRefreshByCycle) {
+    return cached;
+  }
+
+  try {
+    const snapshot = await scrapeClanPoints(
+      normalizedTag,
+      warEndMs !== null && refreshAfterMs !== null && now >= refreshAfterMs ? warEndMs : null
+    );
+    await writePointsCache(settings, normalizedTag, snapshot);
+    return snapshot;
+  } catch (err) {
+    if (cached) {
+      console.warn(
+        `[points] using cached value after scrape error tag=${normalizedTag} error=${formatError(err)}`
+      );
+      return cached;
+    }
+    throw err;
+  }
+}
+
+function buildMatchupMessage(primary: PointsSnapshot, opponent: PointsSnapshot): string {
+  const primaryTag = normalizeTag(primary.tag);
+  const opponentTag = normalizeTag(opponent.tag);
+  const primaryName = primary.clanName ?? `#${primaryTag}`;
+  const opponentName = opponent.clanName ?? `#${opponentTag}`;
+  const primaryBalance = primary.balance ?? 0;
+  const opponentBalance = opponent.balance ?? 0;
+
+  let outcome = "";
+  if (primaryBalance > opponentBalance) {
+    outcome = `**${primaryName}** should win by points (${primaryBalance} > ${opponentBalance})`;
+  } else if (primaryBalance < opponentBalance) {
+    outcome = `**${primaryName}** should lose by points (${opponentBalance} > ${primaryBalance})`;
+  } else {
+    const syncMode = primary.syncMode ?? opponent.syncMode;
+    if (!syncMode) {
+      outcome = `Points are tied (${primaryBalance} = ${opponentBalance}) but sync number was not found, so tiebreak cannot be determined.`;
+    } else {
+      const tiebreakCmp = compareTagsForTiebreak(primaryTag, opponentTag);
+      if (tiebreakCmp === 0) {
+        outcome = `Points are tied (${primaryBalance} = ${opponentBalance}) and tags are identical for tiebreak ordering.`;
+      } else {
+        const primaryWinsTiebreak = syncMode === "low" ? tiebreakCmp < 0 : tiebreakCmp > 0;
+        outcome = primaryWinsTiebreak
+          ? `**${primaryName}** should win by tiebreak (${primaryBalance} = ${opponentBalance}, ${syncMode} sync)`
+          : `**${primaryName}** should lose by tiebreak (${primaryBalance} = ${opponentBalance}, ${syncMode} sync)`;
+      }
+    }
+  }
+
+  const matchupVerified =
+    primary.winnerBoxTags.includes(opponentTag) || opponent.winnerBoxTags.includes(primaryTag);
+  const verificationNote = matchupVerified
+    ? "Matchup verified in winner-box."
+    : "Matchup not verified in winner-box yet (site delay possible).";
+  const syncNote =
+    primary.effectiveSync !== null
+      ? `Sync #${primary.effectiveSync} (${primary.syncMode ?? "unknown"} sync)${
+          primary.winnerBoxHasTag ? "" : " [adjusted +1 due to stale winner-box tag]"
+        }`
+      : "Sync not found in winner-box.";
+
+  return (
+    `${primaryName} points: **${formatPoints(primaryBalance)}**\n` +
+    `${opponentName} points: **${formatPoints(opponentBalance)}**\n\n` +
+    `${outcome}\n\n${syncNote}\n${verificationNote}`
+  );
 }
 
 export const Points: Command = {
@@ -204,8 +375,9 @@ export const Points: Command = {
   run: async (
     _client: Client,
     interaction: ChatInputCommandInteraction,
-    _cocService: CoCService
+    cocService: CoCService
   ) => {
+    const settings = new SettingsService();
     await interaction.deferReply({ ephemeral: true });
     const rawTag = interaction.options.getString("tag", false);
     const rawOpponentTag = interaction.options.getString("opponent-tag", false);
@@ -213,9 +385,7 @@ export const Points: Command = {
     const opponentTag = normalizeTag(rawOpponentTag ?? "");
 
     if (!tag && opponentTag) {
-      await interaction.editReply(
-        "Please provide `tag` when using `opponent-tag`."
-      );
+      await interaction.editReply("Please provide `tag` when using `opponent-tag`.");
       return;
     }
 
@@ -238,25 +408,22 @@ export const Points: Command = {
       for (const clan of tracked) {
         const trackedTag = normalizeTag(clan.tag);
         try {
-          const result = await fetchClanPoints(trackedTag);
+          const result = await getClanPointsCached(settings, cocService, trackedTag);
           if (result.balance === null || Number.isNaN(result.balance)) {
             failedCount += 1;
             lines.push(`- ${clan.name ?? `#${trackedTag}`}: unavailable`);
             continue;
           }
           const label = result.clanName ?? clan.name ?? `#${trackedTag}`;
-          lines.push(`- ${label} (#${trackedTag}): **${result.balance}**`);
+          lines.push(`- ${label} (#${trackedTag}): **${formatPoints(result.balance)}**`);
         } catch (err) {
           failedCount += 1;
-          if (getHttpStatus(err) === 403) {
-            forbiddenCount += 1;
-          }
+          if (getHttpStatus(err) === 403) forbiddenCount += 1;
           console.error(
             `[points] bulk request failed tag=${trackedTag} error=${formatError(err)}`
           );
           lines.push(`- ${clan.name ?? `#${trackedTag}`}: unavailable`);
         }
-        await new Promise((resolve) => setTimeout(resolve, 250));
       }
 
       const header = `Tracked clan points (${tracked.length})`;
@@ -280,8 +447,8 @@ export const Points: Command = {
 
       try {
         const [primary, opponent] = await Promise.all([
-          fetchClanPoints(tag),
-          fetchClanPoints(opponentTag),
+          getClanPointsCached(settings, cocService, tag),
+          getClanPointsCached(settings, cocService, opponentTag),
         ]);
 
         if (primary.balance === null || Number.isNaN(primary.balance)) {
@@ -293,50 +460,21 @@ export const Points: Command = {
           return;
         }
 
-        const primaryName = primary.clanName ?? `#${tag}`;
-        const opponentName = opponent.clanName ?? `#${opponentTag}`;
-
-        let outcome = "";
-        if (primary.balance > opponent.balance) {
-          outcome = `**${primaryName}** should win by points (${primary.balance} > ${opponent.balance})`;
-        } else if (primary.balance < opponent.balance) {
-          outcome = `**${primaryName}** should lose by points (${opponent.balance} > ${primary.balance})`;
-        } else {
-          const syncMode = primary.syncMode ?? opponent.syncMode;
-          if (!syncMode) {
-            outcome = `Points are tied (${primary.balance} = ${opponent.balance}) but sync number was not found, so tiebreak cannot be determined.`;
-          } else {
-            const tiebreakCmp = compareTagsForTiebreak(tag, opponentTag);
-            if (tiebreakCmp === 0) {
-              outcome = `Points are tied (${primary.balance} = ${opponent.balance}) and tags are identical for tiebreak ordering.`;
-            } else {
-              const primaryWinsTiebreak =
-                syncMode === "low" ? tiebreakCmp < 0 : tiebreakCmp > 0;
-              outcome = primaryWinsTiebreak
-                ? `**${primaryName}** should win by tiebreak (${primary.balance} = ${opponent.balance}, ${syncMode} sync)`
-                : `**${primaryName}** should lose by tiebreak (${primary.balance} = ${opponent.balance}, ${syncMode} sync)`;
-            }
-          }
+        const cycleKey = `${primary.refreshedForWarEndMs ?? "none"}:${opponent.refreshedForWarEndMs ?? "none"}`;
+        const cachedMatchup = await readMatchupCache(settings, tag, opponentTag);
+        if (cachedMatchup && cachedMatchup.cycleKey === cycleKey) {
+          await interaction.editReply(cachedMatchup.message);
+          return;
         }
 
-        const matchupVerified =
-          primary.winnerBoxTags.includes(opponentTag) ||
-          opponent.winnerBoxTags.includes(tag);
-        const verificationNote = matchupVerified
-          ? "Matchup verified in winner-box."
-          : "Matchup not verified in winner-box yet (site delay possible).";
-        const syncNote =
-          primary.effectiveSync !== null
-            ? `Sync #${primary.effectiveSync} (${primary.syncMode ?? "unknown"} sync)${
-                primary.winnerBoxHasTag ? "" : " [adjusted +1 due to stale winner-box tag]"
-              }`
-            : "Sync not found in winner-box.";
+        const message = buildMatchupMessage(primary, opponent);
+        await writeMatchupCache(settings, tag, opponentTag, {
+          cycleKey,
+          message,
+          createdAtMs: Date.now(),
+        });
 
-        await interaction.editReply(
-          `${primaryName} points: **${formatPoints(primary.balance)}**\n` +
-            `${opponentName} points: **${formatPoints(opponent.balance)}**\n\n` +
-            `${outcome}\n\n${syncNote}\n${verificationNote}`
-        );
+        await interaction.editReply(message);
         return;
       } catch (err) {
         console.error(
@@ -344,19 +482,17 @@ export const Points: Command = {
         );
         if (getHttpStatus(err) === 403) {
           await interaction.editReply(
-            "points.fwafarm.com blocked this request (HTTP 403). Try again later or fetch one clan at a time."
+            "points.fwafarm.com blocked this request (HTTP 403). Try again later."
           );
           return;
         }
-        await interaction.editReply(
-          "Failed to fetch points matchup. Check both tags and try again."
-        );
+        await interaction.editReply("Failed to fetch points matchup. Check both tags and try again.");
         return;
       }
     }
 
     try {
-      const result = await fetchClanPoints(tag);
+      const result = await getClanPointsCached(settings, cocService, tag);
       const balance = result.balance;
       if (balance === null || Number.isNaN(balance)) {
         if (result.notFound) {
@@ -374,7 +510,7 @@ export const Points: Command = {
       }
 
       await interaction.editReply(
-        `${result.clanName ? `**${result.clanName}**\n` : ""}Tag: #${tag}\nPoint Balance: **${balance}**\n${result.url}`
+        `${result.clanName ? `**${result.clanName}**\n` : ""}Tag: #${tag}\nPoint Balance: **${formatPoints(balance)}**\n${result.url}`
       );
     } catch (err) {
       console.error(`[points] request failed tag=${tag} error=${formatError(err)}`);
@@ -384,9 +520,7 @@ export const Points: Command = {
         );
         return;
       }
-      await interaction.editReply(
-        "Failed to fetch points. Check the tag and try again."
-      );
+      await interaction.editReply("Failed to fetch points. Check the tag and try again.");
     }
   },
   autocomplete: async (interaction: AutocompleteInteraction) => {

--- a/src/commands/Points.ts
+++ b/src/commands/Points.ts
@@ -147,6 +147,15 @@ function formatPoints(value: number): string {
   return Intl.NumberFormat("en-US").format(value);
 }
 
+function sanitizeClanName(input: string | null | undefined): string | null {
+  if (!input) return null;
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+  if (trimmed.length > 80) return null;
+  if (/Clan Tag|Point Balance|Sync #|Winner|War State/i.test(trimmed)) return null;
+  return trimmed;
+}
+
 function buildLimitedMessage(header: string, lines: string[], summary: string): string {
   let message = `${header}\n\n`;
   let included = 0;
@@ -459,7 +468,10 @@ export const Points: Command = {
             lines.push(`- ${clan.name ?? `#${trackedTag}`}: unavailable`);
             continue;
           }
-          const label = result.clanName ?? clan.name ?? `#${trackedTag}`;
+          const label =
+            sanitizeClanName(clan.name) ??
+            sanitizeClanName(result.clanName) ??
+            `#${trackedTag}`;
           lines.push(`- ${label} (#${trackedTag}): **${formatPoints(result.balance)}**`);
         } catch (err) {
           failedCount += 1;
@@ -555,7 +567,9 @@ export const Points: Command = {
       }
 
       await interaction.editReply(
-        `${result.clanName ? `**${result.clanName}**\n` : ""}Tag: #${tag}\nPoint Balance: **${formatPoints(balance)}**\n${result.url}`
+        `${
+          sanitizeClanName(result.clanName) ? `**${sanitizeClanName(result.clanName)}**\n` : ""
+        }Tag: #${tag}\nPoint Balance: **${formatPoints(balance)}**\n${result.url}`
       );
     } catch (err) {
       console.error(`[points] request failed tag=${tag} error=${formatError(err)}`);

--- a/src/commands/Points.ts
+++ b/src/commands/Points.ts
@@ -664,10 +664,22 @@ export const Points: Command = {
         return;
       }
 
+      const trackedClan = await prisma.trackedClan.findFirst({
+        where: { tag: { equals: `#${tag}`, mode: "insensitive" } },
+        select: { name: true },
+      });
+      const apiName = await cocService
+        .getClanName(tag)
+        .then((name) => sanitizeClanName(name))
+        .catch(() => null);
+      const displayName =
+        sanitizeClanName(trackedClan?.name) ??
+        sanitizeClanName(result.clanName) ??
+        apiName ??
+        "Unknown Clan";
+
       await editReplySafe(
-        `${
-          sanitizeClanName(result.clanName) ? `**${sanitizeClanName(result.clanName)}**\n` : ""
-        }Tag: #${tag}\nPoint Balance: **${formatPoints(balance)}**\n${result.url}`
+        `Clan Name: **${displayName}**\nTag: #${tag}\nPoint Balance: **${formatPoints(balance)}**\n${result.url}`
       );
     } catch (err) {
       console.error(`[points] request failed tag=${tag} error=${formatError(err)}`);

--- a/src/helper/discordContent.ts
+++ b/src/helper/discordContent.ts
@@ -1,0 +1,11 @@
+export const DISCORD_CONTENT_LIMIT = 2000;
+
+export function truncateDiscordContent(
+  content: string,
+  limit = DISCORD_CONTENT_LIMIT
+): string {
+  if (content.length <= limit) return content;
+  const suffix = "\n...truncated";
+  if (suffix.length >= limit) return content.slice(0, limit);
+  return `${content.slice(0, limit - suffix.length)}${suffix}`;
+}

--- a/src/helper/fetchTelemetry.ts
+++ b/src/helper/fetchTelemetry.ts
@@ -5,6 +5,7 @@ type FetchEvent = {
   operation: string;
   source: FetchSource;
   detail?: string;
+  incrementBy?: number;
 };
 
 type Totals = Record<FetchSource, number>;
@@ -23,20 +24,20 @@ function makeEmptyTotals(): Totals {
 }
 
 export function recordFetchEvent(event: FetchEvent): void {
+  const incrementBy = Math.max(1, Math.trunc(event.incrementBy ?? 1));
   const eventKey = `${event.namespace}:${event.operation}:${event.source}`;
   const opKey = `${event.namespace}:${event.operation}`;
 
-  const nextEventCount = (eventCounts.get(eventKey) ?? 0) + 1;
+  const nextEventCount = (eventCounts.get(eventKey) ?? 0) + incrementBy;
   eventCounts.set(eventKey, nextEventCount);
 
   const totals = operationTotals.get(opKey) ?? makeEmptyTotals();
-  totals[event.source] += 1;
+  totals[event.source] += incrementBy;
   operationTotals.set(opKey, totals);
 
   const savedCalls = totals.cache_hit + totals.fallback_cache;
   const suffix = event.detail ? ` ${event.detail}` : "";
   console.info(
-    `[telemetry] ns=${event.namespace} op=${event.operation} source=${event.source} count=${nextEventCount} totals(api=${totals.api}, web=${totals.web}, cache_hit=${totals.cache_hit}, cache_miss=${totals.cache_miss}, fallback_cache=${totals.fallback_cache}, saved=${savedCalls})${suffix}`
+    `[telemetry] ns=${event.namespace} op=${event.operation} source=${event.source} count=${nextEventCount} +${incrementBy} totals(api=${totals.api}, web=${totals.web}, cache_hit=${totals.cache_hit}, cache_miss=${totals.cache_miss}, fallback_cache=${totals.fallback_cache}, saved=${savedCalls})${suffix}`
   );
 }
-

--- a/src/helper/fetchTelemetry.ts
+++ b/src/helper/fetchTelemetry.ts
@@ -1,0 +1,42 @@
+type FetchSource = "api" | "web" | "cache_hit" | "cache_miss" | "fallback_cache";
+
+type FetchEvent = {
+  namespace: string;
+  operation: string;
+  source: FetchSource;
+  detail?: string;
+};
+
+type Totals = Record<FetchSource, number>;
+
+const eventCounts = new Map<string, number>();
+const operationTotals = new Map<string, Totals>();
+
+function makeEmptyTotals(): Totals {
+  return {
+    api: 0,
+    web: 0,
+    cache_hit: 0,
+    cache_miss: 0,
+    fallback_cache: 0,
+  };
+}
+
+export function recordFetchEvent(event: FetchEvent): void {
+  const eventKey = `${event.namespace}:${event.operation}:${event.source}`;
+  const opKey = `${event.namespace}:${event.operation}`;
+
+  const nextEventCount = (eventCounts.get(eventKey) ?? 0) + 1;
+  eventCounts.set(eventKey, nextEventCount);
+
+  const totals = operationTotals.get(opKey) ?? makeEmptyTotals();
+  totals[event.source] += 1;
+  operationTotals.set(opKey, totals);
+
+  const savedCalls = totals.cache_hit + totals.fallback_cache;
+  const suffix = event.detail ? ` ${event.detail}` : "";
+  console.info(
+    `[telemetry] ns=${event.namespace} op=${event.operation} source=${event.source} count=${nextEventCount} totals(api=${totals.api}, web=${totals.web}, cache_hit=${totals.cache_hit}, cache_miss=${totals.cache_miss}, fallback_cache=${totals.fallback_cache}, saved=${savedCalls})${suffix}`
+  );
+}
+

--- a/src/helper/safeReply.ts
+++ b/src/helper/safeReply.ts
@@ -1,15 +1,17 @@
 import { ChatInputCommandInteraction, DiscordAPIError } from "discord.js";
 import { formatError } from "./formatError";
+import { truncateDiscordContent } from "./discordContent";
 
 export async function safeReply(
   interaction: ChatInputCommandInteraction,
   options: { content: string; ephemeral?: boolean }
 ): Promise<void> {
+  const safeOptions = { ...options, content: truncateDiscordContent(options.content) };
   try {
     if (interaction.deferred) {
-      await interaction.editReply(options);
+      await interaction.editReply(safeOptions);
     } else if (!interaction.replied) {
-      await interaction.reply(options);
+      await interaction.reply(safeOptions);
     }
   } catch (err: any) {
     if (

--- a/src/listeners/interactionCreate.ts
+++ b/src/listeners/interactionCreate.ts
@@ -6,6 +6,7 @@ import {
   ModalSubmitInteraction,
 } from "discord.js";
 import { Commands } from "../Commands";
+import { truncateDiscordContent } from "../helper/discordContent";
 import { formatError } from "../helper/formatError";
 import { CoCService } from "../services/CoCService";
 import { handlePostModalSubmit, isPostModalCustomId } from "../commands/Post";
@@ -92,14 +93,14 @@ const handleModalSubmit = async (
 
     if (!interaction.replied && !interaction.deferred) {
       await interaction.reply({
-        content: message,
+        content: truncateDiscordContent(message),
         ephemeral: true,
       });
       return;
     }
 
     if (interaction.deferred) {
-      await interaction.editReply(message);
+      await interaction.editReply(truncateDiscordContent(message));
     }
   }
 };
@@ -140,7 +141,7 @@ const handleSlashCommand = async (
     try {
       await interaction.reply({
         ephemeral: true,
-        content: "An error has occurred",
+        content: truncateDiscordContent("An error has occurred"),
       });
     } catch {
       // no-op
@@ -170,13 +171,13 @@ const handleSlashCommand = async (
       : "Something went wrong.";
 
     if (interaction.deferred) {
-      await interaction.editReply(message).catch(() => undefined);
+      await interaction.editReply(truncateDiscordContent(message)).catch(() => undefined);
       return;
     }
 
     if (!interaction.replied) {
       await interaction.reply({
-        content: message,
+        content: truncateDiscordContent(message),
         ephemeral: true,
       });
     }

--- a/src/services/CoCService.ts
+++ b/src/services/CoCService.ts
@@ -1,5 +1,6 @@
 import { AxiosError } from "axios";
 import {
+  ClanWar,
   ClansApi,
   Configuration,
   Player,
@@ -39,6 +40,19 @@ export class CoCService {
   async getClanName(tag: string): Promise<string> {
     const clan = await this.getClan(tag);
     return clan.name ?? "Unknown Clan";
+  }
+
+  async getCurrentWar(tag: string): Promise<ClanWar | null> {
+    const clanTag = tag.startsWith("#") ? tag : `#${tag}`;
+    try {
+      const { data } = await this.clansApi.getCurrentWar(clanTag);
+      return data;
+    } catch (err) {
+      const status = (err as AxiosError)?.response?.status;
+      if (status === 404) return null;
+      if (status) throw new Error(`CoC API error ${status}`);
+      throw err;
+    }
   }
 
   async getPlayerRaw(tag: string | undefined): Promise<any> {

--- a/src/services/CommandPermissionService.ts
+++ b/src/services/CommandPermissionService.ts
@@ -29,6 +29,7 @@ export const COMMAND_PERMISSION_TARGETS = [
   "cc",
   "cc:player",
   "cc:clan",
+  "points",
   "post",
   "post:sync:time",
   MANAGE_COMMAND_ROLES_COMMAND,


### PR DESCRIPTION
# ClashCookies v1.5.0 - Points Reliability and Telemetry Efficiency

## Release scope
- Base: `v1.4.3`
- Target: `origin/dev`
- Compare: `v1.4.3...origin/dev`
- Commits in range: `43`

## Highlights

### 1. `/points` output and matchup reliability improvements
- Fixed oversized and noisy `/points` responses; matchup output is now compact and consistent.
- Improved sync/opponent parsing, cache invalidation behavior, and single-tag output clarity (including clan name and official FWA link).

### 2. Reduced external call volume with smarter cache behavior
- Added war-check throttling and conditional refresh logic to reduce repeated CoC API and points web calls on frequent command usage.
- Reworked name lookup flow to avoid unnecessary API calls when tracked/scraped names are already available.

### 3. Added telemetry for API/web/cache source tracking
- Introduced telemetry logs for `api`, `web`, `cache_hit`, `cache_miss`, and `fallback_cache` to quantify savings.
- Batched loop-heavy `getPlayerRaw` logging into summarized count-based telemetry entries.

## Full changelog (commits)
- `9edab74` `fix(points): show official fwafarm URL in single-tag response instead of proxy URL` (#116)
- `47f2156` `perf(points): reduce repeated war/name api calls with war-check throttling and conditional clan-name lookups` (#115)
- `0d007e0` `fix(telemetry): batch looped getPlayerRaw logs into single summary with call count increment` (#114)
- `c45c084` `feat(telemetry): log coc api and points web/cache call sources with running savings totals` (#113)
- `be520d9` `fix(points): always include clan name in single-tag response with tracked/api fallback` (#112)
- `5a29cf0` `fix(points): invalidate stale caches and use Clash API clan names for matchup output` (#111)
- `8690ad3` `fix(points): parse sync and clan matchup from top section before war-state block` (#110)
- `43d661f` `docs(workflow): add PR templates, release checklist, and git alias guide` (#109)
- `66f2770` `fix(points): force compact matchup output and invalidate legacy verbose matchup cache` (#108)
- `413359a` `fix(discord): enforce 2000-char content limit via shared truncation helper and safe reply paths` (#107)
- `b042dc7` `fix(points): sanitize cached clan names and prefer tracked-clan names in bulk output` (#106)
- `e113033` `deploy: use head commit message instead of generic railway up deployment name` (#105)

## Operational note(s)
- No database migration required for this release scope.
- Validate `POINTS_PROXY_URL` configuration in environment if proxy mode is enabled; user-facing `/points tag` output now always links to the official FWA points page.