### PR TITLE
release: merge dev into main (prod) - fwa permissions, sync bootstrap, and match persistence

### DIFF
--- a/src/Commands.ts
+++ b/src/Commands.ts
@@ -13,6 +13,7 @@ import { KickList } from "./commands/KickList";
 import { Recruitment } from "./commands/Recruitment";
 import { Accounts } from "./commands/Accounts";
 import { Notify } from "./commands/Notify";
+import { SetCommand } from "./commands/Set";
 
 // ...existing code...
 export const Commands = [
@@ -27,6 +28,7 @@ export const Commands = [
   Accounts,
   Fwa,
   Notify,
+  SetCommand,
   Recruitment,
   KickList,
   Post,

--- a/src/commands/CommandRole.ts
+++ b/src/commands/CommandRole.ts
@@ -208,6 +208,7 @@ export const CommandRole: Command = {
         allLines.push(
           "⚠️ `fwa-leader-role` is not set. Leader-default commands currently require Administrator. Use `/set fwa-leader-role`."
         );
+        allLines.push("");
       }
       for (const target of COMMAND_PERMISSION_TARGETS) {
         const summary = await permissionService.getPolicySummary(target, interaction.guildId);

--- a/src/commands/CommandRole.ts
+++ b/src/commands/CommandRole.ts
@@ -194,7 +194,7 @@ export const CommandRole: Command = {
         const roleIds = await permissionService.getAllowedRoleIds(commandInput);
         const summary = roleIds.length
           ? `Whitelisted roles: ${formatRoleList(roleIds)}`
-          : await permissionService.getPolicySummary(commandInput);
+          : await permissionService.getPolicySummary(commandInput, interaction.guildId);
         await safeReply(interaction, {
           ephemeral: true,
           content: `\`/${commandInput}\` roles:\n${summary}`,
@@ -203,8 +203,14 @@ export const CommandRole: Command = {
       }
 
       const allLines: string[] = [];
+      const fwaLeaderRoleId = await permissionService.getFwaLeaderRoleId(interaction.guildId);
+      if (!fwaLeaderRoleId) {
+        allLines.push(
+          "⚠️ `fwa-leader-role` is not set. Leader-default commands currently require Administrator. Use `/set fwa-leader-role`."
+        );
+      }
       for (const target of COMMAND_PERMISSION_TARGETS) {
-        const summary = await permissionService.getPolicySummary(target);
+        const summary = await permissionService.getPolicySummary(target, interaction.guildId);
         allLines.push(`- \`/${target}\`: ${summary}`);
       }
 
@@ -327,7 +333,7 @@ export const CommandRole: Command = {
       const next = await permissionService.removeAllowedRoleId(commandInput, role.id);
       const summary = next.length
         ? `Allowed roles: ${formatRoleList(next)}`
-        : await permissionService.getPolicySummary(commandInput);
+        : await permissionService.getPolicySummary(commandInput, interaction.guildId);
       await safeReply(interaction, {
         ephemeral: true,
         content:

--- a/src/commands/Set.ts
+++ b/src/commands/Set.ts
@@ -1,0 +1,78 @@
+import {
+  ApplicationCommandOptionType,
+  ChatInputCommandInteraction,
+  Client,
+  PermissionFlagsBits,
+} from "discord.js";
+import { Command } from "../Command";
+import { safeReply } from "../helper/safeReply";
+import { CoCService } from "../services/CoCService";
+import { CommandPermissionService, SET_COMMAND } from "../services/CommandPermissionService";
+
+export const SetCommand: Command = {
+  name: SET_COMMAND,
+  description: "Set bot configuration values",
+  options: [
+    {
+      name: "fwa-leader-role",
+      description: "Set the default FWA leader role used for leader-only commands",
+      type: ApplicationCommandOptionType.Subcommand,
+      options: [
+        {
+          name: "role",
+          description: "Role to set as the FWA leader role",
+          type: ApplicationCommandOptionType.Role,
+          required: true,
+        },
+      ],
+    },
+  ],
+  run: async (
+    _client: Client,
+    interaction: ChatInputCommandInteraction,
+    _cocService: CoCService
+  ) => {
+    if (!interaction.inGuild()) {
+      await safeReply(interaction, {
+        ephemeral: true,
+        content: "This command can only be used in a server.",
+      });
+      return;
+    }
+
+    if (!interaction.memberPermissions?.has(PermissionFlagsBits.Administrator)) {
+      await safeReply(interaction, {
+        ephemeral: true,
+        content: "Only administrators can use this command.",
+      });
+      return;
+    }
+
+    const subcommand = interaction.options.getSubcommand(true);
+    if (subcommand !== "fwa-leader-role") {
+      await safeReply(interaction, {
+        ephemeral: true,
+        content: "Unknown subcommand.",
+      });
+      return;
+    }
+
+    const role = interaction.options.getRole("role", true);
+    if (!("id" in role)) {
+      await safeReply(interaction, {
+        ephemeral: true,
+        content: "Invalid role selected.",
+      });
+      return;
+    }
+
+    const permissionService = new CommandPermissionService();
+    await permissionService.setFwaLeaderRoleId(interaction.guildId, role.id);
+
+    await safeReply(interaction, {
+      ephemeral: true,
+      content: `FWA leader role set to <@&${role.id}>.`,
+    });
+  },
+};
+


### PR DESCRIPTION
## Summary
Promote `dev` into `main` (production) with updates to FWA command behavior, permission targeting, and sync/outcome reliability.

## Key changes
- Added `/set fwa-leader-role` and leader-default permission behavior for leader-scoped commands.
- Cleaned `/permission list` targets to remove non-functional/root entries.
- Added warning in `/permission list` when `fwa-leader-role` is not set.
- Updated `/post sync status` to resolve the active sync post guild-wide (not channel-limited).
- Bootstrapped missing `previousSyncNum` from `DEFAULT_PREVIOUS_SYNC_NUM`.
- Improved `/fwa match` persistence:
  - derives missing expected outcome when possible
  - persists `fwaPoints`, `opponentFwaPoints`, `warStartFwaPoints`, `warEndFwaPoints`, and outcome.

## Why
- Prevent unknown sync/outcome states caused by missing bootstrap data.
- Reduce permission confusion by exposing only actionable targets.
- Ensure points/outcome data computed during commands is saved for reuse.

## Validation
- `npx tsc --noEmit` passes.
- Manually verified:
  - `/permission list` warning/spacing behavior
  - `/fwa match` output and persistence behavior
  - `/post sync status` from non-sync channels

## Config note
- Ensure `DEFAULT_PREVIOUS_SYNC_NUM` is set in production/staging envs (already configured).