### PR TITLE
fix(fwa): resolve live embed refresh bugs and improve inferred warning rendering

### DIFF
--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -482,7 +482,7 @@ function buildFwaMatchCopyComponents(
           entries.map((tag) => {
             const viewForTag = payload.singleViews[tag];
             const clanName = (viewForTag?.clanName ?? `#${tag}`).trim();
-            const warningSuffix = viewForTag?.inferredMatchType ? " :warning:" : "";
+            const warningSuffix = viewForTag?.inferredMatchType ? " ⚠️" : "";
             return {
               label: `${clanName}${warningSuffix}`.slice(0, 100),
               description: `#${tag}`.slice(0, 100),


### PR DESCRIPTION
**Summary**  
Small follow-up fix after the prior PRs.

**Changes**  
1. Replaced dropdown inferred marker from `:warning:` to `⚠️` in `/fwa match` clan select menu labels.

**Why**  
Discord select menu labels do not reliably render `:warning:` shortcode; Unicode renders correctly.