### PR TITLE
feat(war-events): refine event embeds, add war-test triggers, and persist clan-level war history with warId lookup

### DIFF
--- a/prisma/migrations/20260227113000_add_war_clan_history_and_lookup/migration.sql
+++ b/prisma/migrations/20260227113000_add_war_clan_history_and_lookup/migration.sql
@@ -1,0 +1,50 @@
+CREATE SEQUENCE IF NOT EXISTS "WarClanHistory_warId_seq"
+    START WITH 1000000
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+CREATE TABLE "WarClanHistory" (
+  "warId" INTEGER NOT NULL DEFAULT nextval('"WarClanHistory_warId_seq"'),
+  "syncNumber" INTEGER,
+  "matchType" "WarMatchType",
+  "clanStars" INTEGER,
+  "clanDestruction" DOUBLE PRECISION,
+  "opponentStars" INTEGER,
+  "opponentDestruction" DOUBLE PRECISION,
+  "fwaPointsGained" INTEGER,
+  "expectedOutcome" TEXT,
+  "actualOutcome" TEXT,
+  "enemyPoints" INTEGER,
+  "warStartTime" TIMESTAMP(3) NOT NULL,
+  "warEndTime" TIMESTAMP(3),
+  "clanName" TEXT,
+  "clanTag" TEXT NOT NULL,
+  "opponentName" TEXT,
+  "opponentTag" TEXT,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "WarClanHistory_pkey" PRIMARY KEY ("warId")
+);
+
+CREATE UNIQUE INDEX "WarClanHistory_clanTag_warStartTime_key"
+ON "WarClanHistory"("clanTag", "warStartTime");
+
+CREATE INDEX "WarClanHistory_clanTag_warEndTime_idx"
+ON "WarClanHistory"("clanTag", "warEndTime");
+
+CREATE TABLE "WarLookup" (
+  "warId" INTEGER NOT NULL,
+  "payload" JSONB NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+  CONSTRAINT "WarLookup_pkey" PRIMARY KEY ("warId")
+);
+
+ALTER TABLE "WarLookup"
+ADD CONSTRAINT "WarLookup_warId_fkey"
+FOREIGN KEY ("warId") REFERENCES "WarClanHistory"("warId")
+ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -192,3 +192,37 @@ model WarEventLogSubscription {
   @@unique([guildId, clanTag])
   @@index([guildId, notify])
 }
+
+model WarClanHistory {
+  warId               Int           @id @default(autoincrement())
+  syncNumber          Int?
+  matchType           WarMatchType?
+  clanStars           Int?
+  clanDestruction     Float?
+  opponentStars       Int?
+  opponentDestruction Float?
+  fwaPointsGained     Int?
+  expectedOutcome     String?
+  actualOutcome       String?
+  enemyPoints         Int?
+  warStartTime        DateTime
+  warEndTime          DateTime?
+  clanName            String?
+  clanTag             String
+  opponentName        String?
+  opponentTag         String?
+  createdAt           DateTime      @default(now())
+  updatedAt           DateTime      @updatedAt
+  lookup              WarLookup?
+
+  @@unique([clanTag, warStartTime])
+  @@index([clanTag, warEndTime])
+}
+
+model WarLookup {
+  warId      Int            @id
+  payload    Json
+  createdAt  DateTime       @default(now())
+  updatedAt  DateTime       @updatedAt
+  warHistory WarClanHistory @relation(fields: [warId], references: [warId], onDelete: Cascade)
+}

--- a/src/commands/Post.ts
+++ b/src/commands/Post.ts
@@ -14,6 +14,11 @@ import {
 } from "discord.js";
 import { Command } from "../Command";
 import { formatError } from "../helper/formatError";
+import {
+  getSyncBadgeEmojis,
+  getSyncBadgeEmojiIdentifiers,
+  type SyncBadgeEmoji as BadgeEmoji,
+} from "../helper/syncBadgeEmoji";
 import { safeReply } from "../helper/safeReply";
 import { CoCService } from "../services/CoCService";
 import {
@@ -31,44 +36,6 @@ const TIMEZONE_INPUT_ID = "timezone";
 const ROLE_INPUT_ID = "role";
 const IANA_TIMEZONE_HELP_URL =
   "https://en.wikipedia.org/wiki/List_of_tz_database_time_zones";
-const PROD_BOT_ID = "1131335782016237749";
-const STAGING_BOT_ID = "1474193888146358393";
-
-type BadgeEmoji = { code: string; label: string; name: string; id: string };
-
-const SYNC_BADGE_EMOJIS_BY_BOT: Record<string, BadgeEmoji[]> = {
-  [STAGING_BOT_ID]: [
-    { code: "ZG", label: "ZERO GRAVITY", name: "zg", id: "1476279645174366449" },
-    { code: "TWC", label: "TheWiseCowboys", name: "twc", id: "1476279643660091452" },
-    { code: "SE", label: "Steel Empire 2", name: "se", id: "1476279635208573009" },
-    { code: "RR", label: "Rocky Road", name: "rr", id: "1476279632729866242" },
-    { code: "RD", label: "RISING DAWN", name: "rd", id: "1476279631345614902" },
-    { code: "MV", label: "MARVELS", name: "mv", id: "1476279630129528986" },
-    { code: "DE", label: "DARK EMPIRE™!", name: "de", id: "1476279629106118676" },
-    { code: "AK", label: "ＡＫＡＴＳＵＫＩ", name: "ak", id: "1476279627839307836" },
-  ],
-  [PROD_BOT_ID]: [
-    { code: "ZG", label: "ZERO GRAVITY", name: "zg", id: "1476279778670673930" },
-    { code: "TWC", label: "TheWiseCowboys", name: "twc", id: "1476279777466908755" },
-    { code: "SE", label: "Steel Empire 2", name: "se", id: "1476279774241493104" },
-    { code: "RR", label: "Rocky Road", name: "rr", id: "1476279773243379762" },
-    { code: "RD", label: "RISING DAWN", name: "rd", id: "1476279771884290100" },
-    { code: "MV", label: "MARVELS", name: "mv", id: "1476279770667814932" },
-    { code: "DE", label: "DARK EMPIRE™!", name: "de", id: "1476279769552392427" },
-    { code: "AK", label: "ＡＫＡＴＳＵＫＩ", name: "ak", id: "1476279768608411874" },
-  ],
-};
-
-function getSyncBadgeEmojis(botUserId: string | undefined): BadgeEmoji[] {
-  if (!botUserId) return [];
-  return SYNC_BADGE_EMOJIS_BY_BOT[botUserId] ?? [];
-}
-
-function getSyncBadgeEmojiIdentifiers(botUserId: string | undefined): string[] {
-  const badges = getSyncBadgeEmojis(botUserId);
-  return badges.map((e) => `${e.name}:${e.id}`);
-}
-
 function parseAllowedRoleIds(raw: string | null): string[] {
   if (!raw) return [];
   return [...new Set(raw.split(",").map((s) => s.trim()).filter((s) => /^\d+$/.test(s)))];
@@ -850,3 +817,4 @@ export const Post: Command = {
     await interaction.showModal(modal);
   },
 };
+

--- a/src/helper/syncBadgeEmoji.ts
+++ b/src/helper/syncBadgeEmoji.ts
@@ -1,0 +1,76 @@
+const PROD_BOT_ID = "1131335782016237749";
+const STAGING_BOT_ID = "1474193888146358393";
+
+export type SyncBadgeEmoji = { code: string; label: string; name: string; id: string };
+
+const SYNC_BADGE_EMOJIS_BY_BOT: Record<string, SyncBadgeEmoji[]> = {
+  [STAGING_BOT_ID]: [
+    { code: "ZG", label: "ZERO GRAVITY", name: "zg", id: "1476279645174366449" },
+    { code: "TWC", label: "TheWiseCowboys", name: "twc", id: "1476279643660091452" },
+    { code: "SE", label: "Steel Empire 2", name: "se", id: "1476279635208573009" },
+    { code: "RR", label: "Rocky Road", name: "rr", id: "1476279632729866242" },
+    { code: "RD", label: "RISING DAWN", name: "rd", id: "1476279631345614902" },
+    { code: "MV", label: "MARVELS", name: "mv", id: "1476279630129528986" },
+    { code: "DE", label: "DARK EMPIRE™!", name: "de", id: "1476279629106118676" },
+    { code: "AK", label: "ＡＫＡＴＳＵＫＩ", name: "ak", id: "1476279627839307836" },
+  ],
+  [PROD_BOT_ID]: [
+    { code: "ZG", label: "ZERO GRAVITY", name: "zg", id: "1476279778670673930" },
+    { code: "TWC", label: "TheWiseCowboys", name: "twc", id: "1476279777466908755" },
+    { code: "SE", label: "Steel Empire 2", name: "se", id: "1476279774241493104" },
+    { code: "RR", label: "Rocky Road", name: "rr", id: "1476279773243379762" },
+    { code: "RD", label: "RISING DAWN", name: "rd", id: "1476279771884290100" },
+    { code: "MV", label: "MARVELS", name: "mv", id: "1476279770667814932" },
+    { code: "DE", label: "DARK EMPIRE™!", name: "de", id: "1476279769552392427" },
+    { code: "AK", label: "ＡＫＡＴＳＵＫＩ", name: "ak", id: "1476279768608411874" },
+  ],
+};
+
+function normalizeClanName(value: string): string {
+  return value
+    .normalize("NFKC")
+    .replace(/["'`]/g, "")
+    .replace(/[^A-Za-z0-9 ]/g, "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .toUpperCase();
+}
+
+function getClanCodeFromName(value: string): string {
+  const normalized = normalizeClanName(value);
+  const map: Record<string, string> = {
+    "RISING DAWN": "RD",
+    "ZERO GRAVITY": "ZG",
+    "DARK EMPIRE": "DE",
+    "STEEL EMPIRE 2": "SE",
+    "THEWISECOWBOYS": "TWC",
+    MARVELS: "MV",
+    "ROCKY ROAD": "RR",
+    AKATSUKI: "AK",
+  };
+  return map[normalized] ?? normalized;
+}
+
+export function getSyncBadgeEmojis(botUserId: string | undefined): SyncBadgeEmoji[] {
+  if (!botUserId) return [];
+  return SYNC_BADGE_EMOJIS_BY_BOT[botUserId] ?? [];
+}
+
+export function getSyncBadgeEmojiIdentifiers(botUserId: string | undefined): string[] {
+  return getSyncBadgeEmojis(botUserId).map((e) => `${e.name}:${e.id}`);
+}
+
+export function findSyncBadgeEmojiForClan(
+  botUserId: string | undefined,
+  clanName: string
+): SyncBadgeEmoji | null {
+  const badges = getSyncBadgeEmojis(botUserId);
+  if (badges.length === 0) return null;
+  const normalized = normalizeClanName(clanName);
+  const code = getClanCodeFromName(clanName);
+  return (
+    badges.find((b) => normalizeClanName(b.label) === normalized) ??
+    badges.find((b) => b.code.toUpperCase() === code.toUpperCase()) ??
+    null
+  );
+}

--- a/src/services/CoCService.ts
+++ b/src/services/CoCService.ts
@@ -1,5 +1,6 @@
 import { AxiosError } from "axios";
 import {
+  ClanWarLogEntry,
   ClanWar,
   ClansApi,
   Configuration,
@@ -89,6 +90,29 @@ export class CoCService {
       });
       if (status) throw new Error(`CoC API error ${status}`);
       throw err;
+    }
+  }
+
+  async getClanWarLog(tag: string, limit = 10): Promise<ClanWarLogEntry[]> {
+    const clanTag = tag.startsWith("#") ? tag : `#${tag}`;
+    try {
+      const { data } = await this.clansApi.getClanWarLog(clanTag, limit);
+      recordFetchEvent({
+        namespace: "coc",
+        operation: "getClanWarLog",
+        source: "api",
+        detail: `tag=${clanTag} limit=${limit}`,
+      });
+      return Array.isArray(data.items) ? data.items : [];
+    } catch (err) {
+      const status = (err as AxiosError)?.response?.status;
+      recordFetchEvent({
+        namespace: "coc",
+        operation: "getClanWarLog",
+        source: "api",
+        detail: `tag=${clanTag} status=${status ?? "unknown"} result=error`,
+      });
+      return [];
     }
   }
 

--- a/src/services/WarEventLogService.ts
+++ b/src/services/WarEventLogService.ts
@@ -8,6 +8,7 @@ import {
 } from "discord.js";
 import { Prisma } from "@prisma/client";
 import { formatError } from "../helper/formatError";
+import { findSyncBadgeEmojiForClan } from "../helper/syncBadgeEmoji";
 import { prisma } from "../prisma";
 import { CoCService } from "./CoCService";
 import { PointsProjectionService } from "./PointsProjectionService";
@@ -632,6 +633,14 @@ export class WarEventLogService {
   ): string {
     const mapped = this.badgeEmojiByTag[normalizeTag(clanTag)];
     if (mapped) return mapped;
+
+    const fromSyncBadgeMap = findSyncBadgeEmojiForClan(this.client.user?.id, clanName);
+    if (fromSyncBadgeMap) {
+      return formatBadgeEmojiInline({
+        id: fromSyncBadgeMap.id,
+        name: fromSyncBadgeMap.name,
+      });
+    }
 
     const guild = "guild" in channel ? channel.guild : null;
     if (!guild) return "Unavailable";

--- a/src/services/WarEventLogService.ts
+++ b/src/services/WarEventLogService.ts
@@ -569,8 +569,6 @@ export class WarEventLogService {
     }
 
     const opponentTag = normalizeTag(payload.opponentTag);
-    const badgeEmoji = this.resolveTrackedClanBadgeEmoji(channel, payload.clanTag, payload.clanName);
-
     const embed = new EmbedBuilder()
       .setTitle(`Event: ${eventTitle(payload.eventType)} - ${payload.clanName}`)
       .setColor(
@@ -594,11 +592,6 @@ export class WarEventLogService {
     });
 
     if (payload.eventType === "battle_day") {
-      embed.addFields({
-        name: "Clan Badge",
-        value: badgeEmoji,
-        inline: true,
-      });
       embed.addFields({
         name: "Match Type",
         value: payload.matchType ?? "unknown",
@@ -631,11 +624,6 @@ export class WarEventLogService {
     }
 
     if (payload.eventType === "war_started") {
-      embed.addFields({
-        name: "Clan Badge",
-        value: badgeEmoji,
-        inline: true,
-      });
       embed.addFields({
         name: "Prep Day Remaining",
         value: toDiscordRelativeTime(payload.warStartTime),

--- a/src/services/WarEventLogService.ts
+++ b/src/services/WarEventLogService.ts
@@ -1,4 +1,11 @@
-import { ChannelType, Client, EmbedBuilder } from "discord.js";
+import {
+  ChannelType,
+  Client,
+  EmbedBuilder,
+  GuildBasedChannel,
+  PublicThreadChannel,
+  PrivateThreadChannel,
+} from "discord.js";
 import { Prisma } from "@prisma/client";
 import { formatError } from "../helper/formatError";
 import { prisma } from "../prisma";
@@ -8,6 +15,44 @@ import { SettingsService } from "./SettingsService";
 
 type WarState = "notInWar" | "preparation" | "inWar";
 type EventType = "war_started" | "battle_day" | "war_ended";
+type MatchType = "FWA" | "BL" | "MM" | null;
+type TestSource = "current" | "last";
+
+type SubscriptionRow = {
+  id: number;
+  guildId: string;
+  clanTag: string;
+  channelId: string;
+  notify: boolean;
+  inferredMatchType: boolean;
+  notifyRole: string | null;
+  fwaPoints: number | null;
+  opponentFwaPoints: number | null;
+  outcome: string | null;
+  matchType: MatchType;
+  warStartFwaPoints: number | null;
+  warEndFwaPoints: number | null;
+  lastClanStars: number | null;
+  lastOpponentStars: number | null;
+  lastState: string | null;
+  lastWarStartTime: Date | null;
+  lastOpponentTag: string | null;
+  lastOpponentName: string | null;
+  clanName: string | null;
+};
+
+type WarEndResultSnapshot = {
+  clanStars: number | null;
+  opponentStars: number | null;
+  clanDestruction: number | null;
+  opponentDestruction: number | null;
+  resultLabel: "WIN" | "LOSE" | "TIE" | "UNKNOWN";
+};
+
+type WarComplianceSnapshot = {
+  missedBoth: string[];
+  notFollowingPlan: string[];
+};
 
 function normalizeTag(input: string | null | undefined): string {
   const raw = String(input ?? "").trim().toUpperCase();
@@ -15,6 +60,9 @@ function normalizeTag(input: string | null | undefined): string {
   return raw.startsWith("#") ? raw : `#${raw}`;
 }
 
+function normalizeTagBare(input: string | null | undefined): string {
+  return normalizeTag(input).replace(/^#/, "");
+}
 
 function deriveState(rawState: string | null | undefined): WarState {
   const state = String(rawState ?? "").toLowerCase();
@@ -73,15 +121,66 @@ function deriveExpectedOutcome(
   return wins ? "WIN" : "LOSE";
 }
 
+function parseCocTime(input: string | null | undefined): Date | null {
+  if (!input) return null;
+  const m = input.match(/^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})\.\d{3}Z$/);
+  if (!m) return null;
+  const [, y, mo, d, h, mi, s] = m;
+  return new Date(Date.UTC(Number(y), Number(mo) - 1, Number(d), Number(h), Number(mi), Number(s)));
+}
+
+function normalizeOutcome(input: string | null | undefined): "WIN" | "LOSE" | null {
+  const normalized = String(input ?? "").trim().toUpperCase();
+  if (normalized === "WIN" || normalized === "LOSE") return normalized;
+  return null;
+}
+
+function formatPercent(value: number | null): string {
+  if (value === null || !Number.isFinite(value)) return "unknown";
+  return `${value.toFixed(2)}%`;
+}
+
+function formatList(items: string[]): string {
+  if (items.length === 0) return "None";
+  const capped = items.slice(0, 15);
+  const extra = items.length - capped.length;
+  return extra > 0 ? `${capped.join(", ")} (+${extra} more)` : capped.join(", ");
+}
+
+function formatBadgeEmojiInline(emoji: { id: string; name: string; animated?: boolean } | null): string {
+  if (!emoji) return "Unavailable";
+  return emoji.animated ? `<a:${emoji.name}:${emoji.id}>` : `<:${emoji.name}:${emoji.id}>`;
+}
+
+function parseBadgeEmojiMap(): Record<string, string> {
+  const raw = (process.env.WAR_EVENT_BADGE_EMOJI_BY_TAG ?? "").trim();
+  if (!raw) return {};
+  try {
+    const parsed = JSON.parse(raw) as Record<string, string>;
+    const out: Record<string, string> = {};
+    for (const [key, value] of Object.entries(parsed)) {
+      const tag = normalizeTag(key);
+      const emoji = String(value ?? "").trim();
+      if (!tag || !emoji) continue;
+      out[tag] = emoji;
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
 export class WarEventLogService {
   private readonly points: PointsProjectionService;
   private readonly settings: SettingsService;
+  private readonly badgeEmojiByTag: Record<string, string>;
   private static readonly PREVIOUS_SYNC_KEY = "previousSyncNum";
   private static readonly PREVIOUS_SYNC_DEFAULT = 469;
 
   constructor(private readonly client: Client, private readonly coc: CoCService) {
     this.points = new PointsProjectionService(coc);
     this.settings = new SettingsService();
+    this.badgeEmojiByTag = parseBadgeEmojiMap();
   }
 
   private static getDefaultPreviousSyncNum(): number {
@@ -113,30 +212,7 @@ export class WarEventLogService {
   }
 
   async poll(): Promise<void> {
-    type SubRow = {
-      id: number;
-      guildId: string;
-      clanTag: string;
-      channelId: string;
-      notify: boolean;
-      inferredMatchType: boolean;
-      notifyRole: string | null;
-      fwaPoints: number | null;
-      opponentFwaPoints: number | null;
-      outcome: string | null;
-      matchType: "FWA" | "BL" | "MM" | null;
-      warStartFwaPoints: number | null;
-      warEndFwaPoints: number | null;
-      lastClanStars: number | null;
-      lastOpponentStars: number | null;
-      lastState: string | null;
-      lastWarStartTime: Date | null;
-      lastOpponentTag: string | null;
-      lastOpponentName: string | null;
-      clanName: string | null;
-    };
-
-    const subs = await prisma.$queryRaw<SubRow[]>(
+    const subs = await prisma.$queryRaw<SubscriptionRow[]>(
       Prisma.sql`
         SELECT
           "id","guildId","clanTag","channelId","notify","inferredMatchType","notifyRole","fwaPoints","opponentFwaPoints","outcome","matchType","warStartFwaPoints","warEndFwaPoints","lastClanStars","lastOpponentStars","lastState","lastWarStartTime","lastOpponentTag","lastOpponentName","clanName"
@@ -156,30 +232,102 @@ export class WarEventLogService {
     }
   }
 
+  async emitTestEventForClan(params: {
+    guildId: string;
+    clanTag: string;
+    eventType: EventType;
+    source: TestSource;
+  }): Promise<{ ok: boolean; reason?: string }> {
+    const sub = await this.findSubscriptionByGuildAndTag(params.guildId, params.clanTag);
+    if (!sub) return { ok: false, reason: "No war event subscription found for that guild+clan." };
+    if (!sub.channelId) return { ok: false, reason: "Subscription has no configured channel." };
+
+    const previousSync = await this.getPreviousSyncNum();
+    const activeSync = previousSync + 1;
+    const syncNumber = params.eventType === "war_ended" ? activeSync : activeSync;
+
+    const currentWar = params.source === "current" ? await this.coc.getCurrentWar(sub.clanTag).catch(() => null) : null;
+    const lastWarRow =
+      params.source === "last"
+        ? await prisma.warHistoryParticipant.findFirst({
+            where: { clanTag: normalizeTag(sub.clanTag), warEndTime: { not: null } },
+            orderBy: { warStartTime: "desc" },
+            select: {
+              clanName: true,
+              opponentClanTag: true,
+              opponentClanName: true,
+              warStartTime: true,
+            },
+          })
+        : null;
+
+    const clanTag = normalizeTag(sub.clanTag);
+    const opponentTag = normalizeTag(
+      currentWar?.opponent?.tag ?? lastWarRow?.opponentClanTag ?? sub.lastOpponentTag ?? ""
+    );
+    const clanName =
+      String(currentWar?.clan?.name ?? lastWarRow?.clanName ?? sub.clanName ?? clanTag).trim() || clanTag;
+    const opponentName =
+      String(currentWar?.opponent?.name ?? lastWarRow?.opponentClanName ?? sub.lastOpponentName ?? "Unknown").trim() ||
+      "Unknown";
+
+    let fwaPoints = sub.fwaPoints;
+    let opponentFwaPoints = sub.opponentFwaPoints;
+    let outcome = normalizeOutcome(sub.outcome);
+    if (opponentTag) {
+      const [a, b] = await Promise.all([
+        this.points.fetchSnapshot(clanTag),
+        this.points.fetchSnapshot(opponentTag),
+      ]);
+      fwaPoints = a.balance;
+      opponentFwaPoints = b.balance;
+      outcome = deriveExpectedOutcome(clanTag, opponentTag, a.balance, b.balance, syncNumber);
+    }
+
+    await this.emitEvent(sub.channelId, {
+      eventType: params.eventType,
+      clanTag,
+      clanName,
+      opponentTag,
+      opponentName,
+      syncNumber,
+      notifyRole: sub.notifyRole,
+      fwaPoints,
+      opponentFwaPoints,
+      outcome,
+      matchType: sub.matchType,
+      warStartFwaPoints: sub.warStartFwaPoints,
+      warEndFwaPoints: sub.warEndFwaPoints,
+      lastClanStars: Number.isFinite(Number(currentWar?.clan?.stars))
+        ? Number(currentWar?.clan?.stars)
+        : sub.lastClanStars,
+      lastOpponentStars: Number.isFinite(Number(currentWar?.opponent?.stars))
+        ? Number(currentWar?.opponent?.stars)
+        : sub.lastOpponentStars,
+      warStartTime: lastWarRow?.warStartTime ?? sub.lastWarStartTime ?? parseCocTime(currentWar?.startTime ?? null),
+    });
+
+    return { ok: true };
+  }
+
+  private async findSubscriptionByGuildAndTag(
+    guildId: string,
+    clanTag: string
+  ): Promise<SubscriptionRow | null> {
+    const rows = await prisma.$queryRaw<SubscriptionRow[]>(
+      Prisma.sql`
+        SELECT
+          "id","guildId","clanTag","channelId","notify","inferredMatchType","notifyRole","fwaPoints","opponentFwaPoints","outcome","matchType","warStartFwaPoints","warEndFwaPoints","lastClanStars","lastOpponentStars","lastState","lastWarStartTime","lastOpponentTag","lastOpponentName","clanName"
+        FROM "WarEventLogSubscription"
+        WHERE "guildId" = ${guildId} AND UPPER(REPLACE("clanTag",'#','')) = ${normalizeTagBare(clanTag)}
+        LIMIT 1
+      `
+    );
+    return rows[0] ?? null;
+  }
+
   private async processSubscription(subscriptionId: number): Promise<void> {
-    type SubRow = {
-      id: number;
-      guildId: string;
-      clanTag: string;
-      channelId: string;
-      notify: boolean;
-      inferredMatchType: boolean;
-      notifyRole: string | null;
-      fwaPoints: number | null;
-      opponentFwaPoints: number | null;
-      outcome: string | null;
-      matchType: "FWA" | "BL" | "MM" | null;
-      warStartFwaPoints: number | null;
-      warEndFwaPoints: number | null;
-      lastClanStars: number | null;
-      lastOpponentStars: number | null;
-      lastState: string | null;
-      lastWarStartTime: Date | null;
-      lastOpponentTag: string | null;
-      lastOpponentName: string | null;
-      clanName: string | null;
-    };
-    const rows = await prisma.$queryRaw<SubRow[]>(
+    const rows = await prisma.$queryRaw<SubscriptionRow[]>(
       Prisma.sql`
         SELECT
           "id","guildId","clanTag","channelId","notify","inferredMatchType","notifyRole","fwaPoints","opponentFwaPoints","outcome","matchType","warStartFwaPoints","warEndFwaPoints","lastClanStars","lastOpponentStars","lastState","lastWarStartTime","lastOpponentTag","lastOpponentName","clanName"
@@ -286,7 +434,13 @@ export class WarEventLogService {
         notifyRole: sub.notifyRole,
         fwaPoints: nextFwaPoints,
         opponentFwaPoints: nextOpponentFwaPoints,
-        outcome: nextOutcome,
+        outcome: normalizeOutcome(nextOutcome),
+        matchType: nextMatchType,
+        warStartFwaPoints: nextWarStartFwaPoints,
+        warEndFwaPoints: nextWarEndFwaPoints,
+        lastClanStars: nextClanStars,
+        lastOpponentStars: nextOpponentStars,
+        warStartTime: nextWarStartTime,
       });
     }
 
@@ -324,7 +478,13 @@ export class WarEventLogService {
       notifyRole: string | null;
       fwaPoints: number | null;
       opponentFwaPoints: number | null;
-      outcome: string | null;
+      outcome: "WIN" | "LOSE" | null;
+      matchType: MatchType;
+      warStartFwaPoints: number | null;
+      warEndFwaPoints: number | null;
+      lastClanStars: number | null;
+      lastOpponentStars: number | null;
+      warStartTime: Date | null;
     }
   ): Promise<void> {
     const channel = await this.client.channels.fetch(channelId).catch(() => null);
@@ -338,13 +498,8 @@ export class WarEventLogService {
       return;
     }
 
-    const clanTag = normalizeTag(payload.clanTag);
     const opponentTag = normalizeTag(payload.opponentTag);
-    const pointsLine =
-      payload.fwaPoints !== null && payload.opponentFwaPoints !== null
-        ? `Points: ${payload.clanName}: ${payload.fwaPoints} | ${payload.opponentName}: ${payload.opponentFwaPoints}`
-        : "Points: unavailable";
-    const projection = payload.outcome ? `Projection: ${payload.outcome}` : "Projection: unavailable";
+    const badgeEmoji = this.resolveTrackedClanBadgeEmoji(channel, payload.clanTag, payload.clanName);
 
     const embed = new EmbedBuilder()
       .setTitle(`Event: ${eventTitle(payload.eventType)} - ${payload.clanName}`)
@@ -355,34 +510,80 @@ export class WarEventLogService {
             ? 0xf1c40f
             : 0x2ecc71
       )
-      .addFields(
-        {
-          name: "Clan",
-          value: `${payload.clanName} (${normalizeTag(payload.clanTag) ? `#${normalizeTag(payload.clanTag)}` : payload.clanTag})`,
-          inline: false,
-        },
-        {
-          name: "Opponent",
-          value: `${payload.opponentName} (${opponentTag ? `#${opponentTag}` : "unknown"})`,
-          inline: false,
-        },
-        {
-          name: "Sync #",
-          value: payload.syncNumber ? `#${payload.syncNumber}` : "unknown",
-          inline: true,
-        },
-        {
-          name: "FWA Points",
-          value: pointsLine,
-          inline: false,
-        },
-        {
-          name: "Which Clan Should Win",
-          value: projection,
-          inline: false,
-        }
-      )
       .setTimestamp(new Date());
+
+    embed.addFields({
+      name: "Opponent",
+      value: `${payload.opponentName} (${opponentTag ? `#${opponentTag}` : "unknown"})`,
+      inline: false,
+    });
+    embed.addFields({
+      name: "Sync #",
+      value: payload.syncNumber ? `#${payload.syncNumber}` : "unknown",
+      inline: true,
+    });
+
+    if (payload.eventType === "battle_day") {
+      embed.addFields({
+        name: "Clan Badge",
+        value: badgeEmoji,
+        inline: true,
+      });
+      if (payload.matchType !== "BL" && payload.matchType !== "MM") {
+        const outcome = payload.outcome ? payload.outcome[0] + payload.outcome.slice(1).toLowerCase() : "Unknown";
+        embed.addFields({
+          name: "Outcome",
+          value:
+            payload.outcome === null
+              ? `Unknown war outcome against ${payload.opponentName}`
+              : `${outcome} war against ${payload.opponentName}`,
+          inline: false,
+        });
+      }
+    }
+
+    if (payload.eventType === "war_started") {
+      embed.addFields({
+        name: "Clan Badge",
+        value: badgeEmoji,
+        inline: true,
+      });
+    }
+
+    if (payload.eventType === "war_ended") {
+      const finalResult = await this.getWarEndResultSnapshot({
+        clanTag: payload.clanTag,
+        opponentTag: payload.opponentTag,
+        fallbackClanStars: payload.lastClanStars,
+        fallbackOpponentStars: payload.lastOpponentStars,
+        warStartTime: payload.warStartTime,
+      });
+      const compliance = await this.getWarComplianceSnapshot(payload.clanTag, payload.warStartTime);
+      embed.addFields({
+        name: "Result",
+        value: [
+          `Outcome: **${finalResult.resultLabel}**`,
+          `Stars: ${payload.clanName} ${finalResult.clanStars ?? "unknown"} - ${payload.opponentName} ${finalResult.opponentStars ?? "unknown"}`,
+          `Destruction: ${payload.clanName} ${formatPercent(finalResult.clanDestruction)} - ${payload.opponentName} ${formatPercent(finalResult.opponentDestruction)}`,
+        ].join("\n"),
+        inline: false,
+      });
+      embed.addFields({
+        name: "FWA Points",
+        value: this.buildWarEndPointsLine(payload, finalResult),
+        inline: false,
+      });
+      embed.addFields({
+        name: "Missed Both Attacks",
+        value: formatList(compliance.missedBoth),
+        inline: false,
+      });
+      embed.addFields({
+        name: "Didn't Follow War Plan",
+        value: formatList(compliance.notFollowingPlan),
+        inline: false,
+      });
+    }
 
     const roleMention = payload.notifyRole ? `<@&${payload.notifyRole}>` : null;
     await channel.send({
@@ -394,5 +595,179 @@ export class WarEventLogService {
         `[war-events] send failed channel=${channelId} clan=${payload.clanTag} error=${formatError(err)}`
       );
     });
+  }
+
+  private resolveTrackedClanBadgeEmoji(
+    channel: GuildBasedChannel | PublicThreadChannel<boolean> | PrivateThreadChannel,
+    clanTag: string,
+    clanName: string
+  ): string {
+    const mapped = this.badgeEmojiByTag[normalizeTag(clanTag)];
+    if (mapped) return mapped;
+
+    const guild = "guild" in channel ? channel.guild : null;
+    if (!guild) return "Unavailable";
+    const emojis = [...guild.emojis.cache.values()];
+    if (emojis.length === 0) return "Unavailable";
+
+    const normalizedName = clanName.toLowerCase().replace(/[^a-z0-9]+/g, "");
+    const initials = clanName
+      .split(/[^a-zA-Z0-9]+/)
+      .filter(Boolean)
+      .map((w) => w[0]?.toLowerCase() ?? "")
+      .join("");
+    const candidates = new Set<string>([
+      normalizeTagBare(clanTag).toLowerCase(),
+      normalizedName,
+      initials,
+    ]);
+
+    for (const emoji of emojis) {
+      const rawName = String(emoji.name ?? "").trim();
+      if (!rawName) continue;
+      const name = rawName.toLowerCase();
+      if ([...candidates].some((candidate) => candidate && (name === candidate || name.includes(candidate)))) {
+        return formatBadgeEmojiInline({
+          id: emoji.id,
+          name: rawName,
+          animated: emoji.animated === true,
+        });
+      }
+    }
+    return "Unavailable";
+  }
+
+  private buildWarEndPointsLine(
+    payload: {
+      clanName: string;
+      matchType: MatchType;
+      warStartFwaPoints: number | null;
+      warEndFwaPoints: number | null;
+    },
+    finalResult: WarEndResultSnapshot
+  ): string {
+    const before = payload.warStartFwaPoints;
+
+    if (payload.matchType === "BL") {
+      const gained =
+        finalResult.resultLabel === "WIN"
+          ? 3
+          : (finalResult.clanDestruction ?? 0) >= 60
+            ? 2
+            : 1;
+      const after = before !== null && Number.isFinite(before) ? before + gained : null;
+      return `${payload.clanName}: ${before ?? "unknown"} -> ${after ?? "unknown"} (${gained >= 0 ? `+${gained}` : String(gained)}) [BL]`;
+    }
+
+    const after = payload.warEndFwaPoints;
+    if (
+      before !== null &&
+      Number.isFinite(before) &&
+      after !== null &&
+      Number.isFinite(after)
+    ) {
+      const delta = after - before;
+      return `${payload.clanName}: ${before} -> ${after} (${delta >= 0 ? `+${delta}` : String(delta)})`;
+    }
+    return `${payload.clanName}: ${before ?? "unknown"} -> ${after ?? "unknown"}`;
+  }
+
+  private async getWarEndResultSnapshot(input: {
+    clanTag: string;
+    opponentTag: string;
+    fallbackClanStars: number | null;
+    fallbackOpponentStars: number | null;
+    warStartTime: Date | null;
+  }): Promise<WarEndResultSnapshot> {
+    const log = await this.coc.getClanWarLog(input.clanTag, 10);
+    const normalizedOpponentTag = normalizeTag(input.opponentTag);
+
+    const matched =
+      log.find((entry) => normalizeTag(entry.opponent?.tag ?? "") === normalizedOpponentTag) ??
+      log[0] ??
+      null;
+
+    const clanStars =
+      Number.isFinite(Number(matched?.clan?.stars))
+        ? Number(matched?.clan?.stars)
+        : input.fallbackClanStars;
+    const opponentStars =
+      Number.isFinite(Number(matched?.opponent?.stars))
+        ? Number(matched?.opponent?.stars)
+        : input.fallbackOpponentStars;
+    const clanDestruction = Number.isFinite(Number(matched?.clan?.destructionPercentage))
+      ? Number(matched?.clan?.destructionPercentage)
+      : null;
+    const opponentDestruction = Number.isFinite(Number(matched?.opponent?.destructionPercentage))
+      ? Number(matched?.opponent?.destructionPercentage)
+      : null;
+
+    let resultLabel: "WIN" | "LOSE" | "TIE" | "UNKNOWN" = "UNKNOWN";
+    if (clanStars !== null && opponentStars !== null) {
+      resultLabel = clanStars > opponentStars ? "WIN" : clanStars < opponentStars ? "LOSE" : "TIE";
+    } else if (matched?.result) {
+      const result = String(matched.result).toLowerCase();
+      if (result.includes("win")) resultLabel = "WIN";
+      else if (result.includes("lose")) resultLabel = "LOSE";
+      else if (result.includes("tie")) resultLabel = "TIE";
+    }
+
+    return {
+      clanStars,
+      opponentStars,
+      clanDestruction,
+      opponentDestruction,
+      resultLabel,
+    };
+  }
+
+  private async getWarComplianceSnapshot(
+    clanTagInput: string,
+    preferredWarStartTime: Date | null
+  ): Promise<WarComplianceSnapshot> {
+    const clanTag = normalizeTag(clanTagInput);
+    const warStartTime = preferredWarStartTime
+      ? preferredWarStartTime
+      : (
+          await prisma.warHistoryParticipant.findFirst({
+            where: { clanTag, warEndTime: { not: null } },
+            orderBy: { warStartTime: "desc" },
+            select: { warStartTime: true },
+          })
+        )?.warStartTime ?? null;
+    if (!warStartTime) {
+      return { missedBoth: [], notFollowingPlan: [] };
+    }
+
+    const participants = await prisma.warHistoryParticipant.findMany({
+      where: { clanTag, warStartTime },
+      select: { playerName: true, playerTag: true, attacksUsed: true, playerPosition: true },
+      orderBy: [{ playerPosition: "asc" }, { playerName: "asc" }],
+    });
+    const attacks = await prisma.warHistoryAttack.findMany({
+      where: { clanTag, warStartTime },
+      select: { playerTag: true, playerName: true, playerPosition: true, defenderPosition: true },
+    });
+
+    const missedBoth = participants
+      .filter((p) => Number(p.attacksUsed ?? 0) <= 0)
+      .map((p) => String(p.playerName ?? p.playerTag).trim())
+      .filter(Boolean);
+
+    const notFollowing = new Set<string>();
+    for (const attack of attacks) {
+      const playerPos = attack.playerPosition ?? null;
+      const defenderPos = attack.defenderPosition ?? null;
+      if (playerPos === null || defenderPos === null) continue;
+      if (playerPos !== defenderPos) {
+        const label = String(attack.playerName ?? attack.playerTag).trim();
+        if (label) notFollowing.add(label);
+      }
+    }
+
+    return {
+      missedBoth,
+      notFollowingPlan: [...notFollowing].sort((a, b) => a.localeCompare(b)),
+    };
   }
 }


### PR DESCRIPTION
### Summary
This PR upgrades war event logging, adds test triggers, and introduces long-term war archive storage for clan-level lookup and drill-down.

### Main Changes

1. War event embed refinements
- **War Started**
  - Shows opponent, sync #, prep-day remaining (`<t:...:R>`), match type.
  - If `FWA`: includes expected outcome and war plan text.
- **Battle Day Started**
  - Shows opponent, sync #, match type.
  - If `FWA`: includes expected outcome and war plan text.
  - If `BL`: includes BL reminder message to swap back to FWA bases.
- **War Ended**
  - Shows final stars/destruction for both sides.
  - Shows before/after points and delta.
  - BL delta logic:
    - win = `+3`
    - else if destruction >= 60% = `+2`
    - else `+1`
  - Shows missed-both-attacks list.
  - `Didn't Follow War Plan`:
    - `N/A` for `BL/MM`
    - computed for `FWA`.

2. Test trigger support
- Added `/notify war-test`:
  - event selection: prep/battle/end
  - data source: `current` or `last`
- `source=last` now uses only previous-war data (no mixing with current war), including sync behavior.

3. War history persistence (new archive design)
- Added **`WarClanHistory`** table (clan-level war summary).
- Added **`WarLookup`** table (`warId` PK + JSON blob of war attack data).
- `warId` starts at **1000000** via DB sequence.
- On war end, service upserts:
  - clan-level summary into `WarClanHistory`
  - attack blob into `WarLookup`.

4. Badge handling
- Clan badge display was removed from event embeds per latest request.
- Sync badge mapping was centralized in helper code for reuse.

### DB / Migration
- New migration:
  - `20260227113000_add_war_clan_history_and_lookup`
- Includes:
  - sequence for `WarClanHistory.warId` starting at `1000000`
  - `WarClanHistory` + indexes/unique key
  - `WarLookup` + FK to `WarClanHistory`.

### Operational Notes
- No automatic cleanup of `WarHistoryAttack` was added.
- Recommended: retention policy/archival job instead of immediate deletion.

### Validation
- Typecheck passed (`npx tsc --noEmit`) after changes.