### PR TITLE
feat(war): add history commands, tracked-clan lose-style config, and notify subscription management

### DIFF
--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -139,12 +139,15 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
     details: [
       "`war` enables war-state event embeds for a clan in a selected channel.",
       "`show` lists notify routing (channel/role/status) for tracked clans, optionally filtered by tag.",
+      "`war-remove` removes a clan's war event subscription for this server.",
       "Optional `role` pings that role whenever a war event embed is posted.",
       "Works with clans outside tracked-clans table (tag must still be valid in CoC API).",
       "Posts at war start, battle day, and war end with opponent + points projection.",
     ],
     examples: [
       "/notify war clan-tag:2QG2C08UP target-channel:#war-events role:@Leaders",
+      "/notify war clan-tag:2QG2C08UP target-channel:#new-war-events",
+      "/notify war-remove clan-tag:2QG2C08UP",
       "/notify show",
       "/notify show clan-tag:2QG2C08UP",
     ],

--- a/src/commands/Notify.ts
+++ b/src/commands/Notify.ts
@@ -107,6 +107,20 @@ export const Notify: Command = {
         },
       ],
     },
+    {
+      name: "war-remove",
+      description: "Remove war event log subscription for a clan",
+      type: ApplicationCommandOptionType.Subcommand,
+      options: [
+        {
+          name: "clan-tag",
+          description: "Clan tag to remove from notify routing",
+          type: ApplicationCommandOptionType.String,
+          required: true,
+          autocomplete: true,
+        },
+      ],
+    },
   ],
   run: async (
     _client: Client,
@@ -120,6 +134,27 @@ export const Notify: Command = {
     }
 
     const sub = interaction.options.getSubcommand(true);
+    if (sub === "war-remove") {
+      const clanTag = normalizeClanTag(interaction.options.getString("clan-tag", true));
+      if (!clanTag) {
+        await interaction.editReply("Invalid clan tag.");
+        return;
+      }
+
+      const deleted = await prisma.warEventLogSubscription.deleteMany({
+        where: {
+          guildId: interaction.guildId,
+          clanTag,
+        },
+      });
+      if (deleted.count === 0) {
+        await interaction.editReply(`No /notify war subscription found for ${clanTag}.`);
+        return;
+      }
+      await interaction.editReply(`Removed /notify war subscription for ${clanTag}.`);
+      return;
+    }
+
     if (sub === "show") {
       const rawTag = interaction.options.getString("clan-tag", false);
       const normalizedFilter = rawTag ? normalizeClanTag(rawTag) : "";


### PR DESCRIPTION
**PR Title**  
`feat(war): add history lookup commands, tracked-clan lose-style config, and notify subscription management`

**PR Notes**  
## Summary
Adds war history retrieval commands, tracked-clan lose-style persistence/configuration, and notify subscription visibility/removal.

## Included
- New `/war` commands:
  - `/war history clan-tag:<tag> [limit]`
  - `/war war-id war-id:<id>` (CSV export from `WarLookup.payload`)
- Notify management improvements:
  - `/notify show` and `/notify show clan-tag:<tag>`
  - `/notify war-remove clan-tag:<tag>`
  - Reconfigure existing routing via `/notify war ...` (upsert behavior)
- Tracked clan lose-style in DB:
  - Added `TrackedClan.loseStyle` (default `TRIPLE_TOP_30`)
  - `/tracked-clan add <tag> [lose-style]` now upserts and can update style
  - War lose-plan logic now reads lose-style from `TrackedClan` instead of env mapping
- War-event reliability fixes:
  - War-end dedupe (emit once per clan/war)
  - Sync increments once per poll cycle (not per clan)
  - BL points updates persist to stored points values
  - Improved war-end stars/destruction readability

## DB / Deploy
- Migrations to apply:
  - `20260227113000_add_war_clan_history_and_lookup`
  - `20260228113000_add_tracked_clan_lose_style`
- Commands:
  - `npx prisma migrate deploy`
  - `npx prisma generate`

## Validation
- `npx tsc --noEmit` passed.