### PR TITLE
Refine FWA sync consistency and war-start behavior in /fwa match

### DIFF
--- a/prisma/migrations/20260228173000_add_tracked_clan_points_scrape/migration.sql
+++ b/prisma/migrations/20260228173000_add_tracked_clan_points_scrape/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "TrackedClan"
+ADD COLUMN "pointsScrape" JSONB;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -32,6 +32,7 @@ model TrackedClan {
   tag       String    @unique
   name      String?
   loseStyle LoseStyle @default(TRIPLE_TOP_30)
+  pointsScrape Json?
   createdAt DateTime  @default(now())
 }
 

--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -35,6 +35,7 @@ const FWA_MATCH_COPY_BUTTON_PREFIX = "fwa-match-copy";
 const FWA_MATCH_TYPE_ACTION_PREFIX = "fwa-match-type-action";
 const FWA_MATCH_TYPE_EDIT_PREFIX = "fwa-match-type-edit";
 const FWA_OUTCOME_ACTION_PREFIX = "fwa-outcome-action";
+const FWA_MATCH_SYNC_ACTION_PREFIX = "fwa-match-sync-action";
 const FWA_MATCH_SELECT_PREFIX = "fwa-match-select";
 const FWA_MATCH_ALLIANCE_PREFIX = "fwa-match-alliance";
 const POINTS_REQUEST_HEADERS = {
@@ -128,6 +129,13 @@ type MatchView = {
   matchTypeCurrent?: "FWA" | "BL" | "MM" | null;
   inferredMatchType?: boolean;
   outcomeAction?: { tag: string; currentOutcome: "WIN" | "LOSE" } | null;
+  syncAction?: {
+    tag: string;
+    siteMatchType: "FWA" | "MM" | null;
+    siteFwaPoints: number | null;
+    siteOpponentFwaPoints: number | null;
+    siteOutcome: "WIN" | "LOSE" | null;
+  } | null;
   clanName?: string;
   clanTag?: string;
 };
@@ -260,6 +268,30 @@ export function isFwaOutcomeActionButtonCustomId(customId: string): boolean {
   return customId.startsWith(`${FWA_OUTCOME_ACTION_PREFIX}:`);
 }
 
+type MatchSyncActionParams = {
+  userId: string;
+  key: string;
+  tag: string;
+};
+
+function buildMatchSyncActionCustomId(params: MatchSyncActionParams): string {
+  return `${FWA_MATCH_SYNC_ACTION_PREFIX}:${params.userId}:${params.key}:${normalizeTag(params.tag)}`;
+}
+
+function parseMatchSyncActionCustomId(customId: string): MatchSyncActionParams | null {
+  const parts = customId.split(":");
+  if (parts.length !== 4 || parts[0] !== FWA_MATCH_SYNC_ACTION_PREFIX) return null;
+  const userId = parts[1]?.trim() ?? "";
+  const key = parts[2]?.trim() ?? "";
+  const tag = normalizeTag(parts[3] ?? "");
+  if (!userId || !key || !tag) return null;
+  return { userId, key, tag };
+}
+
+export function isFwaMatchSyncActionButtonCustomId(customId: string): boolean {
+  return customId.startsWith(`${FWA_MATCH_SYNC_ACTION_PREFIX}:`);
+}
+
 export function isFwaMatchSelectCustomId(customId: string): boolean {
   return customId.startsWith(`${FWA_MATCH_SELECT_PREFIX}:`);
 }
@@ -386,6 +418,7 @@ function buildFwaMatchCopyComponents(
       : payload.singleViews[payload.currentTag] ?? payload.allianceView;
   const matchTypeAction = view.matchTypeAction ?? null;
   const outcomeAction = view.outcomeAction ?? null;
+  const syncAction = view.syncAction ?? null;
   const toggleMode = showMode === "embed" ? "copy" : "embed";
   const toggleLabel = showMode === "embed" ? "Copy/Paste View" : "Embed View";
   const baseRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
@@ -471,6 +504,22 @@ function buildFwaMatchCopyComponents(
         .setStyle(ButtonStyle.Primary)
     );
     rows.push(outcomeRow);
+  }
+  if (syncAction) {
+    rows.push(
+      new ActionRowBuilder<ButtonBuilder>().addComponents(
+        new ButtonBuilder()
+          .setCustomId(
+            buildMatchSyncActionCustomId({
+              userId,
+              key,
+              tag: syncAction.tag,
+            })
+          )
+          .setLabel("Sync Data")
+          .setStyle(ButtonStyle.Danger)
+      )
+    );
   }
   if (payload.currentScope === "alliance") {
     const entries = Object.keys(payload.singleViews).slice(0, 25);
@@ -837,6 +886,102 @@ export async function handleFwaOutcomeActionButton(interaction: ButtonInteractio
   });
 }
 
+export async function handleFwaMatchSyncActionButton(
+  interaction: ButtonInteraction
+): Promise<void> {
+  const parsed = parseMatchSyncActionCustomId(interaction.customId);
+  if (!parsed) return;
+
+  if (interaction.user.id !== parsed.userId) {
+    await interaction.reply({
+      ephemeral: true,
+      content: "Only the command requester can use this button.",
+    });
+    return;
+  }
+  if (!interaction.guildId) {
+    await interaction.reply({
+      ephemeral: true,
+      content: "This action can only be used in a server.",
+    });
+    return;
+  }
+
+  const payload = fwaMatchCopyPayloads.get(parsed.key);
+  if (!payload) {
+    await interaction.reply({
+      ephemeral: true,
+      content: "This match view expired. Please run /fwa match again.",
+    });
+    return;
+  }
+  const view = payload.singleViews[parsed.tag];
+  const syncAction = view?.syncAction ?? null;
+  if (!view || !syncAction) {
+    await interaction.reply({
+      ephemeral: true,
+      content: "No out-of-sync data found for this clan.",
+    });
+    return;
+  }
+
+  await prisma.warEventLogSubscription.upsert({
+    where: {
+      guildId_clanTag: {
+        guildId: interaction.guildId,
+        clanTag: `#${parsed.tag}`,
+      },
+    },
+    create: {
+      guildId: interaction.guildId,
+      clanTag: `#${parsed.tag}`,
+      channelId: interaction.channelId,
+      notify: false,
+      fwaPoints: syncAction.siteFwaPoints,
+      opponentFwaPoints: syncAction.siteOpponentFwaPoints,
+      matchType: syncAction.siteMatchType ?? undefined,
+      inferredMatchType: syncAction.siteMatchType !== null,
+      outcome: syncAction.siteOutcome,
+    },
+    update: {
+      fwaPoints: syncAction.siteFwaPoints,
+      opponentFwaPoints: syncAction.siteOpponentFwaPoints,
+      matchType: syncAction.siteMatchType ?? undefined,
+      inferredMatchType: syncAction.siteMatchType !== null,
+      outcome: syncAction.siteOutcome,
+      updatedAt: new Date(),
+    },
+  });
+
+  const refreshed = await rebuildTrackedPayloadForTag(
+    payload,
+    interaction.guildId,
+    parsed.tag
+  );
+  if (!refreshed) {
+    await interaction.reply({
+      ephemeral: true,
+      content: "Data synced, but this view could not be refreshed.",
+    });
+    return;
+  }
+  fwaMatchCopyPayloads.set(parsed.key, refreshed);
+  const showMode = interaction.message.embeds.length > 0 ? "embed" : "copy";
+  const nextView = refreshed.singleViews[parsed.tag];
+  if (!nextView) {
+    await interaction.reply({
+      ephemeral: true,
+      content: "Data synced, but clan view is unavailable now.",
+    });
+    return;
+  }
+  await interaction.update({
+    content: showMode === "copy" ? limitDiscordContent(nextView.copyText) : undefined,
+    embeds: showMode === "embed" ? [nextView.embed] : [],
+    components: buildFwaMatchCopyComponents(refreshed, refreshed.userId, parsed.key, showMode),
+  });
+}
+
 export async function handlePointsPostButton(interaction: ButtonInteraction): Promise<void> {
   const parsed = parsePointsPostButtonCustomId(interaction.customId);
   if (!parsed) return;
@@ -1081,6 +1226,16 @@ function buildPointsMismatchWarning(
   }
   if (expected === actual) return null;
   return `\u26A0\uFE0F ${label} points mismatch: expected ${expected}, site ${actual}.`;
+}
+
+function buildPointsSyncStatusLine(siteUpdated: boolean, hasMismatch: boolean): string {
+  if (!siteUpdated) {
+    return ":hourglass_flowing_sand: points.fwafarm is not updated for this matchup yet.";
+  }
+  if (hasMismatch) {
+    return ":broken_chain: out of sync with points site";
+  }
+  return ":white_check_mark: data in sync with points.fwafarm";
 }
 
 function getWarStateRemaining(
@@ -2016,12 +2171,15 @@ async function buildTrackedMatchOverview(
         )
       : null;
     const mismatchLines = [primaryMismatch, opponentMismatch].filter(Boolean).join("\n");
+    const hasMismatch = Boolean(primaryMismatch || opponentMismatch);
+    const pointsSyncStatus = buildPointsSyncStatusLine(siteUpdatedForAlert, hasMismatch);
+    const siteMatchType = hasOpponentPoints ? "FWA" : "MM";
 
     if (matchType === "FWA") {
       const warnSuffix = inferredMatchType ? ` :warning: ${verifyLink}` : "";
       embed.addFields({
         name: `${clanName} (#${clanTag}) vs ${opponentName} (#${opponentTag})`,
-        value: `${pointsLine}\nMatch Type: **FWA${warnSuffix}**\nOutcome: **${effectiveOutcome ?? "UNKNOWN"}**${mismatchLines ? `\n${mismatchLines}` : ""}`,
+        value: `${pointsLine}\n${pointsSyncStatus}\nMatch Type: **FWA${warnSuffix}**\nOutcome: **${effectiveOutcome ?? "UNKNOWN"}**${mismatchLines ? `\n${mismatchLines}` : ""}`,
         inline: false,
       });
       copyLines.push(
@@ -2031,6 +2189,7 @@ async function buildTrackedMatchOverview(
         `### Opponent Tag`,
         `\`${opponentTag}\``,
         `${pointsLine}`,
+        pointsSyncStatus,
         `Match Type: FWA${inferredMatchType ? " :warning:" : ""}`,
         inferredMatchType ? `Verify: ${buildCcVerifyUrl(opponentTag)}` : "",
         `Outcome: ${effectiveOutcome ?? "UNKNOWN"}`,
@@ -2040,7 +2199,7 @@ async function buildTrackedMatchOverview(
       const warnSuffix = inferredMatchType ? ` :warning: ${verifyLink}` : "";
       embed.addFields({
         name: `${clanName} (#${clanTag}) vs ${opponentName} (#${opponentTag})`,
-        value: `Match Type: **${matchType}${warnSuffix}**${mismatchLines ? `\n${mismatchLines}` : ""}`,
+        value: `${pointsSyncStatus}\nMatch Type: **${matchType}${warnSuffix}**${mismatchLines ? `\n${mismatchLines}` : ""}`,
         inline: false,
       });
       copyLines.push(
@@ -2049,6 +2208,7 @@ async function buildTrackedMatchOverview(
         `\`${opponentName}\``,
         `### Opponent Tag`,
         `\`${opponentTag}\``,
+        pointsSyncStatus,
         `Match Type: ${matchType}${inferredMatchType ? " :warning:" : ""}`,
         inferredMatchType ? `Verify: ${buildCcVerifyUrl(opponentTag)}` : "",
         mismatchLines
@@ -2063,6 +2223,7 @@ async function buildTrackedMatchOverview(
           }).split("\n")[1] ?? "Projection unavailable.")
         : `This is a ${matchType} match.`;
     const singleDescription = [
+      pointsSyncStatus,
       inferredMatchType ? MATCHTYPE_WARNING_LEGEND : "",
       inferredMatchType ? "\u200B" : "",
       `${projectionLineSingle}`,
@@ -2077,9 +2238,9 @@ async function buildTrackedMatchOverview(
     ]
       .filter(Boolean)
       .join("\n");
-      singleViews[clanTag] = {
-        embed: new EmbedBuilder()
-          .setTitle(`${clanName} (#${clanTag}) vs ${opponentName} (#${opponentTag})`)
+    singleViews[clanTag] = {
+      embed: new EmbedBuilder()
+        .setTitle(`${clanName} (#${clanTag}) vs ${opponentName} (#${opponentTag})`)
         .setDescription(singleDescription)
         .addFields({
           name: "Points",
@@ -2097,6 +2258,7 @@ async function buildTrackedMatchOverview(
         [
           `# ${clanName} (#${clanTag}) vs ${opponentName} (#${opponentTag})`,
           inferredMatchType ? MATCHTYPE_WARNING_LEGEND : "",
+          pointsSyncStatus,
           `Sync: ${withSyncModeLabel(getSyncDisplay(sourceSync, warState), sourceSync)}`,
           `War State: ${formatWarStateLabel(warState)}`,
           `Time Remaining: ${getWarStateRemaining(war, warState)}`,
@@ -2127,6 +2289,16 @@ async function buildTrackedMatchOverview(
       outcomeAction:
         matchType === "FWA" && (effectiveOutcome === "WIN" || effectiveOutcome === "LOSE")
           ? { tag: clanTag, currentOutcome: effectiveOutcome }
+          : null,
+      syncAction:
+        siteUpdatedForAlert && hasMismatch
+          ? {
+              tag: clanTag,
+              siteMatchType,
+              siteFwaPoints: primaryPoints?.balance ?? null,
+              siteOpponentFwaPoints: opponentPoints?.balance ?? null,
+              siteOutcome: matchType === "FWA" ? derivedOutcome : null,
+            }
           : null,
       clanName,
       clanTag,
@@ -2674,8 +2846,6 @@ export const Fwa: Command = {
         const syncDisplay = withSyncModeLabel(getSyncDisplay(sourceSync, warState), sourceSync);
         const leftName = resolvedPrimaryName ?? primaryNameFromApi ?? tag;
         const rightName = resolvedOpponentName ?? opponentNameFromApi ?? opponentTag;
-        const staleSite = !siteUpdated;
-        const siteStatusLine = staleSite ? "Note: points.fwafarm site is not updated yet." : null;
         const trackedMismatch = siteUpdated
           ? buildPointsMismatchWarning(
               leftName,
@@ -2693,6 +2863,8 @@ export const Fwa: Command = {
         const mismatchLines = [trackedMismatch, opponentMismatch]
           .filter(Boolean)
           .join("\n");
+        const hasMismatch = Boolean(trackedMismatch || opponentMismatch);
+        const siteStatusLine = buildPointsSyncStatusLine(siteUpdated, hasMismatch);
         const outcomeLine =
           matchType === "FWA"
             ? `${effectiveOutcome ?? "UNKNOWN"}`
@@ -2708,9 +2880,7 @@ export const Fwa: Command = {
               verifyLink ? ` ${verifyLink}` : ""
             }${
               outcomeLine ? `\nExpected outcome: **${outcomeLine}**` : ""
-            }\nWar state: **${formatWarStateLabel(warState)}**\nTime remaining: **${warRemaining}**\nSync: **${syncDisplay}**${
-              siteStatusLine ? `\n${siteStatusLine}` : ""
-            }${
+            }\n${siteStatusLine}\nWar state: **${formatWarStateLabel(warState)}**\nTime remaining: **${warRemaining}**\nSync: **${syncDisplay}**${
               mismatchLines ? `\n${mismatchLines}` : ""
             }`
           )
@@ -2730,6 +2900,7 @@ export const Fwa: Command = {
           [
             `# ${leftName} (#${tag}) vs ${rightName} (#${opponentTag})`,
             inferredMatchType ? MATCHTYPE_WARNING_LEGEND : "",
+            siteStatusLine,
             `Sync: ${syncDisplay}`,
             `War State: ${formatWarStateLabel(warState)}`,
             `Time Remaining: ${warRemaining}`,
@@ -2748,7 +2919,6 @@ export const Fwa: Command = {
             verifyLink ? `Verify: ${buildCcVerifyUrl(opponentTag)}` : "",
             outcomeLine ? `Expected outcome: ${outcomeLine}` : "",
             mismatchLines,
-            siteStatusLine ?? "",
           ]
             .filter(Boolean)
             .join("\n")
@@ -2766,6 +2936,16 @@ export const Fwa: Command = {
           outcomeAction:
             matchType === "FWA" && (effectiveOutcome === "WIN" || effectiveOutcome === "LOSE")
               ? { tag, currentOutcome: effectiveOutcome }
+              : null,
+          syncAction:
+            siteUpdated && hasMismatch
+              ? {
+                  tag,
+                  siteMatchType: hasOpponentPoints ? "FWA" : "MM",
+                  siteFwaPoints: primary.balance,
+                  siteOpponentFwaPoints: opponent.balance,
+                  siteOutcome: matchType === "FWA" ? derivedOutcome : null,
+                }
               : null,
         };
         alliance = {
@@ -2868,10 +3048,13 @@ export const Fwa: Command = {
             })
           : null;
       const trueOpponentTag = normalizeTag(String(war?.opponent?.tag ?? ""));
+      const siteUpdatedForCurrentWar =
+        trueOpponentTag ? isPointsSiteUpdatedForOpponent(result, trueOpponentTag, sourceSync) : false;
       const mismatch =
-        trueOpponentTag && isPointsSiteUpdatedForOpponent(result, trueOpponentTag, sourceSync)
+        siteUpdatedForCurrentWar
           ? buildPointsMismatchWarning(displayName, subscription?.fwaPoints ?? null, balance)
           : null;
+      const syncStatusLine = buildPointsSyncStatusLine(siteUpdatedForCurrentWar, Boolean(mismatch));
 
       await editReplySafe(
         `Clan Name: **${displayName}**\nTag: #${tag}\nPoint Balance: **${formatPoints(
@@ -2879,7 +3062,7 @@ export const Fwa: Command = {
         )}**\nWar state: ${formatWarStateLabel(warState)}\nTime remaining: ${warRemaining}\nSync: ${getSyncDisplay(
           sourceSync,
           warState
-        )}${mismatch ? `\n${mismatch}` : ""}\n${buildOfficialPointsUrl(tag)}`
+        )}\n${syncStatusLine}${mismatch ? `\n${mismatch}` : ""}\n${buildOfficialPointsUrl(tag)}`
       );
     } catch (err) {
       console.error(`[points] request failed tag=${tag} error=${formatError(err)}`);

--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -135,6 +135,7 @@ type MatchView = {
     siteFwaPoints: number | null;
     siteOpponentFwaPoints: number | null;
     siteOutcome: "WIN" | "LOSE" | null;
+    siteSyncNumber: number | null;
   } | null;
   clanName?: string;
   clanTag?: string;
@@ -952,6 +953,15 @@ export async function handleFwaMatchSyncActionButton(
       updatedAt: new Date(),
     },
   });
+  if (
+    syncAction.siteSyncNumber !== null &&
+    syncAction.siteSyncNumber !== undefined &&
+    Number.isFinite(syncAction.siteSyncNumber)
+  ) {
+    const settings = new SettingsService();
+    const nextPrevious = Math.max(0, Math.trunc(syncAction.siteSyncNumber) - 1);
+    await settings.set(PREVIOUS_SYNC_KEY, String(nextPrevious));
+  }
 
   const refreshed = await rebuildTrackedPayloadForTag(
     payload,
@@ -2452,6 +2462,7 @@ async function buildTrackedMatchOverview(
               siteFwaPoints: primaryPoints?.balance ?? null,
               siteOpponentFwaPoints: opponentPoints?.balance ?? null,
               siteOutcome: matchType === "FWA" ? derivedOutcome : null,
+              siteSyncNumber: siteSyncObserved,
             }
           : null,
       clanName,
@@ -3322,6 +3333,7 @@ export const Fwa: Command = {
                   siteFwaPoints: primary.balance,
                   siteOpponentFwaPoints: opponent.balance,
                   siteOutcome: matchType === "FWA" ? derivedOutcome : null,
+                  siteSyncNumber: siteSyncObserved,
                 }
               : null,
         };

--- a/src/listeners/interactionCreate.ts
+++ b/src/listeners/interactionCreate.ts
@@ -25,7 +25,9 @@ import {
   handleFwaMatchTypeEditButton,
   handleFwaOutcomeActionButton,
   handleFwaMatchTypeActionButton,
+  handleFwaMatchSyncActionButton,
   isFwaMatchAllianceButtonCustomId,
+  isFwaMatchSyncActionButtonCustomId,
   isFwaMatchTypeEditButtonCustomId,
   isFwaOutcomeActionButtonCustomId,
   isFwaMatchSelectCustomId,
@@ -317,6 +319,20 @@ const handleButtonInteraction = async (interaction: Interaction): Promise<void> 
         await interaction.reply({
           ephemeral: true,
           content: "Failed to open alliance view.",
+        });
+      }
+    }
+  }
+
+  if (isFwaMatchSyncActionButtonCustomId(interaction.customId)) {
+    try {
+      await handleFwaMatchSyncActionButton(interaction);
+    } catch (err) {
+      console.error(`FWA match sync action button failed: ${formatError(err)}`);
+      if (!interaction.replied && !interaction.deferred) {
+        await interaction.reply({
+          ephemeral: true,
+          content: "Failed to sync points-site data.",
         });
       }
     }

--- a/src/services/PointsProjectionService.ts
+++ b/src/services/PointsProjectionService.ts
@@ -18,6 +18,8 @@ type Snapshot = {
   balance: number | null;
   effectiveSync: number | null;
   syncMode: "low" | "high" | null;
+  winnerBoxSync: number | null;
+  winnerBoxTags: string[];
 };
 
 function normalizeTag(input: string): string {
@@ -137,6 +139,8 @@ export class PointsProjectionService {
         balance: null,
         effectiveSync: null,
         syncMode: null,
+        winnerBoxSync: null,
+        winnerBoxTags: [],
       };
     }
 
@@ -159,6 +163,8 @@ export class PointsProjectionService {
       balance: extractPointBalance(html),
       effectiveSync,
       syncMode: getSyncMode(effectiveSync),
+      winnerBoxSync,
+      winnerBoxTags,
     };
   }
 


### PR DESCRIPTION
**Summary**
- Adds `TrackedClan.pointsScrape` persistence and uses it as the preferred points-site reference.
- Introduces `/fwa sync force <tag> [datapoint]` for targeted overwrite (`points` or `syncNum`).
- Tightens in-sync validation to require alignment on points, sync number, and outcome.
- Fixes Sync Data button to also update global sync source (`previousSyncNum`).
- Updates `/fwa match` no-war behavior to show `:face_palm: failed to start war` and suppress match metadata.
- Adds war-start points-site retry job state (30 min interval, max 10 attempts) with one-time opponent inference fetch.

**What changed**
- `prisma/schema.prisma`
  - Added `TrackedClan.pointsScrape Json?`
- `prisma/migrations/20260228173000_add_tracked_clan_points_scrape/migration.sql`
  - Adds `pointsScrape` JSONB column
- `src/services/WarEventLogService.ts`
  - War-start points check job persistence/retry logic
  - Persists key points-site snapshot into `TrackedClan.pointsScrape` when site is up-to-date
- `src/commands/Fwa.ts`
  - New `/fwa sync force` subcommand group + `datapoint` selector
  - Sync status uses `pointsScrape` preferentially
  - In-sync check now includes points + sync# + outcome
  - Sync Data button now updates `previousSyncNum`
  - No-war match rendering now outputs `:face_palm: failed to start war`
- `src/listeners/interactionCreate.ts`
  - Wires new FWA sync action button handler

**Validation**
- `npx prisma generate` succeeded
- `npm run build` succeeded

**Deploy notes**
1. Run DB migration:
   - `npx prisma migrate deploy`
2. Redeploy bot service
3. Optionally verify with:
   - `/fwa sync force <tracked-tag> datapoint:syncNum`
   - `/fwa match` alliance and single clan views