### PR TITLE
feat(fwa): ignore missed-sync clans in match overview

### DIFF
--- a/tests/fwaMissedSync.logic.test.ts
+++ b/tests/fwaMissedSync.logic.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { isMissedSyncClanForTest } from "../src/commands/Fwa";
+
+describe("isMissedSyncClanForTest", () => {
+  const baseline = Date.UTC(2026, 2, 1, 8, 0, 0);
+  const twoHoursMs = 2 * 60 * 60 * 1000;
+
+  it("returns false when baseline is unknown", () => {
+    expect(
+      isMissedSyncClanForTest({
+        baselineWarStartMs: null,
+        clanWarState: "notInWar",
+        clanWarStartMs: null,
+        nowMs: baseline + twoHoursMs + 1,
+      })
+    ).toBe(false);
+  });
+
+  it("marks notInWar clan as missed sync after 2h from baseline", () => {
+    expect(
+      isMissedSyncClanForTest({
+        baselineWarStartMs: baseline,
+        clanWarState: "notInWar",
+        clanWarStartMs: null,
+        nowMs: baseline + twoHoursMs + 1,
+      })
+    ).toBe(true);
+  });
+
+  it("marks late-started clan as missed sync when start is >2h after baseline", () => {
+    expect(
+      isMissedSyncClanForTest({
+        baselineWarStartMs: baseline,
+        clanWarState: "preparation",
+        clanWarStartMs: baseline + twoHoursMs + 60 * 1000,
+        nowMs: baseline + twoHoursMs + 60 * 1000,
+      })
+    ).toBe(true);
+  });
+
+  it("does not mark clan as missed sync when start is within 2h window", () => {
+    expect(
+      isMissedSyncClanForTest({
+        baselineWarStartMs: baseline,
+        clanWarState: "inWar",
+        clanWarStartMs: baseline + twoHoursMs - 1,
+        nowMs: baseline + twoHoursMs + 1,
+      })
+    ).toBe(false);
+  });
+});


### PR DESCRIPTION
- add missed-sync detection using a 2-hour war-start window from alliance baseline start time
- exclude missed-sync clans from `/fwa match` alliance overview rows and counts
- include per-clan Sync, War State, and Time Remaining lines for non-missed-sync overview entries
- show ignored missed-sync clan count in overview embed/copy header
- add focused unit tests for missed-sync detection logic