### PR TITLE
fix(permissions): make sync target rename fully canonical

### DIFF
--- a/src/commands/Post.ts
+++ b/src/commands/Post.ts
@@ -47,12 +47,9 @@ async function getLeaderRoleIds(settings: SettingsService, guildId: string): Pro
     return [preferredRole.trim()];
   }
   // Preferred: guild-scoped fwa leader role (new default permission model).
-  // Fallback: legacy command role whitelist for backwards compatibility.
+  // Fallback: command role whitelist for backwards compatibility.
   const syncRoles = parseAllowedRoleIds(await settings.get("command_roles:sync:time:post"));
   if (syncRoles.length > 0) return syncRoles;
-  // Backward compatibility for older permission-target key naming.
-  const legacySyncRoles = parseAllowedRoleIds(await settings.get("command_roles:post:sync:time"));
-  if (legacySyncRoles.length > 0) return legacySyncRoles;
   return parseAllowedRoleIds(await settings.get("command_roles:post"));
 }
 

--- a/src/services/CommandPermissionService.ts
+++ b/src/services/CommandPermissionService.ts
@@ -89,11 +89,6 @@ const FWA_LEADER_DEFAULT_TARGETS = new Set<string>([
   "inactive",
 ]);
 
-const COMMAND_TARGET_ALIASES: Record<string, string> = {
-  "post:sync:time": "sync:time:post",
-  "post:sync:status": "sync:post:status",
-};
-
 /** Purpose: command roles key. */
 function commandRolesKey(commandName: string): string {
   return `command_roles:${commandName}`;
@@ -194,7 +189,11 @@ export function getCommandTargetsFromInteraction(
   const sub = interaction.options.getSubcommand(false);
 
   const raw: string[] = [];
-  if (group && sub) {
+  if (command === "post" && group === "sync" && sub === "time") {
+    raw.push("sync:time:post");
+  } else if (command === "post" && group === "sync" && sub === "status") {
+    raw.push("sync:post:status");
+  } else if (group && sub) {
     raw.push(`${command}:${group}:${sub}`);
   }
   if (sub) {
@@ -202,9 +201,7 @@ export function getCommandTargetsFromInteraction(
   }
   raw.push(command);
 
-  return raw
-    .map((target) => COMMAND_TARGET_ALIASES[target] ?? target)
-    .filter((target) => isKnownTarget(target));
+  return raw.filter((target) => isKnownTarget(target));
 }
 
 export class CommandPermissionService {


### PR DESCRIPTION
- remove remaining legacy `post:sync:time` / `post:sync:status` alias mapping
- resolve `/post sync time` and `/post sync status` directly to `sync:time:post` and `sync:post:status` in target extraction
- remove legacy settings-key fallback for `command_roles:post:sync:time` in post leader-role lookup
- keep `command_roles:sync:time:post` and `command_roles:post` as active lookup keys