### PR TITLE
feat(war-events): enforce exact war-start and battle-day message word…

### DIFF
--- a/src/services/WarEventLogService.ts
+++ b/src/services/WarEventLogService.ts
@@ -611,12 +611,14 @@ export class WarEventLogService {
         embed.addFields({
           name: "Message",
           value: [
-            `⚫️ BLACKLIST WAR 🆚 ${payload.opponentName} 🏴‍☠️`,
+            `**⚫️ BLACKLIST WAR 🆚 ${payload.opponentName} 🏴‍☠️**`,
             "Everyone switch to WAR BASES!!",
             "This is our opportunity to gain some extra FWA points!",
             "➕ 30+ people switch to war base = +1 point",
             "➕ 60% total destruction = +1 point",
             "➕ win war = +1 point",
+            "---",
+            "If you need war base, check https://clashofclans-layouts.com/ or ⁠bases",
           ].join("\n"),
           inline: false,
         });

--- a/src/services/war-events/history.ts
+++ b/src/services/war-events/history.ts
@@ -70,25 +70,35 @@ export class WarEventHistoryService {
     matchType: MatchType,
     expectedOutcome: "WIN" | "LOSE" | null,
     clanTag: string,
-    _opponentNameInput?: string | null
+    opponentNameInput?: string | null
   ): Promise<string | null> {
     if (matchType !== "FWA") return null;
+    const opponentName = String(opponentNameInput ?? "").trim() || "Unknown";
     if (expectedOutcome === "WIN") {
       return [
-        "Win plan: if clan stars are under 100 and time remaining is over 12h,",
-        "one attack must be a 3-star on mirror. Other attack can be 3-star on already-tripled base,",
-        "or 2-star/1-star any base. Outside that window, free hit plan applies.",
-      ].join(" ");
+        `**💚 WIN WAR 🆚 ${opponentName} 🟢 **`,
+        "🗡️ 1st Attack: ★ ★ ★ -> Mirror",
+        "🗡️ 2nd Attack: ★ ★ ☆ -> any",
+        "⌛️ Only after 101+ stars -> Attack ANY base",
+      ].join("\n");
     }
     if (expectedOutcome === "LOSE") {
       const loseStyle = await this.getLoseStyleForClan(normalizeTag(clanTag));
       if (loseStyle === "TRIPLE_TOP_30") {
-        return "Lose plan (Triple Top 30): hit only top 30 bases with both attacks; do not hit bottom 20.";
+        return [
+          `**❤️ LOSE WAR 🆚 ${opponentName} 🔴**`,
+          "🗡️ Attack any of the top 30 bases for 1-3 stars",
+          "🚫 Do NOT attack the bottom 20 bases",
+          "🎯 Goal is 90 stars (do not cross)",
+        ].join("\n");
       }
       return [
-        "Lose plan (Traditional): when under 12h remaining, do mirror 2-star plus non-mirror 1-star.",
-        "Before that, do 1-star/2-star hits while keeping clan stars at or under 100.",
-      ].join(" ");
+        `**❤️ LOSE WAR 🆚 ${opponentName} 🔴**`,
+        "🗡️ 1st Attack: ★ ★ ☆ -> Mirror",
+        "🗡️ 2nd Attack: ★ ☆ ☆ -> any",
+        "⏳ Last 12hrs: ★ ★ ☆ -> any",
+        "🎯 Do NOT surpass 100 ★",
+      ].join("\n");
     }
     return "FWA plan unavailable (expected outcome unknown).";
   }

--- a/tests/warPlanText.test.ts
+++ b/tests/warPlanText.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+import { WarEventHistoryService } from "../src/services/war-events/history";
+
+describe("WarEventHistoryService.buildWarPlanText", () => {
+  it("returns exact WIN plan lines", async () => {
+    const svc = new WarEventHistoryService({} as never);
+    const out = await svc.buildWarPlanText("FWA", "WIN", "ABC123", "OPPONENT_NAME");
+    expect(out).toBe(
+      [
+        "**💚 WIN WAR 🆚 OPPONENT_NAME 🟢 **",
+        "🗡️ 1st Attack: ★ ★ ★ -> Mirror",
+        "🗡️ 2nd Attack: ★ ★ ☆ -> any",
+        "⌛️ Only after 101+ stars -> Attack ANY base",
+      ].join("\n")
+    );
+  });
+
+  it("returns exact LOSE TRIPLE_TOP_30 plan lines", async () => {
+    const svc = new WarEventHistoryService({} as never);
+    (svc as any).getLoseStyleForClan = vi.fn().mockResolvedValue("TRIPLE_TOP_30");
+    const out = await svc.buildWarPlanText("FWA", "LOSE", "ABC123", "OPPONENT_NAME");
+    expect(out).toBe(
+      [
+        "**❤️ LOSE WAR 🆚 OPPONENT_NAME 🔴**",
+        "🗡️ Attack any of the top 30 bases for 1-3 stars",
+        "🚫 Do NOT attack the bottom 20 bases",
+        "🎯 Goal is 90 stars (do not cross)",
+      ].join("\n")
+    );
+  });
+
+  it("returns exact LOSE TRADITIONAL plan lines", async () => {
+    const svc = new WarEventHistoryService({} as never);
+    (svc as any).getLoseStyleForClan = vi.fn().mockResolvedValue("TRADITIONAL");
+    const out = await svc.buildWarPlanText("FWA", "LOSE", "ABC123", "OPPONENT_NAME");
+    expect(out).toBe(
+      [
+        "**❤️ LOSE WAR 🆚 OPPONENT_NAME 🔴**",
+        "🗡️ 1st Attack: ★ ★ ☆ -> Mirror",
+        "🗡️ 2nd Attack: ★ ☆ ☆ -> any",
+        "⏳ Last 12hrs: ★ ★ ☆ -> any",
+        "🎯 Do NOT surpass 100 ★",
+      ].join("\n")
+    );
+  });
+});


### PR DESCRIPTION
…ing by scenario

- update FWA war plan text (WIN / LOSE TRIPLE_TOP_30 / LOSE TRADITIONAL) to exact line-by-line wording with emojis and formatting
- include opponent name in FWA plan header line for both war_started and battle_day embeds
- update war_started BL message to exact requested wording and add base-resource guidance lines
- keep war_started MM and battle_day BL/MM messages aligned to exact requested text
- add unit tests validating exact FWA plan output strings