### PR TITLE
Release: Sync Source-of-Truth Fixes, FWA Overview Cleanup, and War Event Embed Updates

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,5 @@
+dist/
+node_modules/
+src/generated/
+prisma/generated/
+

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -1,0 +1,28 @@
+module.exports = {
+  root: true,
+  env: {
+    node: true,
+    es2022: true,
+  },
+  parser: "@typescript-eslint/parser",
+  parserOptions: {
+    sourceType: "module",
+  },
+  plugins: ["@typescript-eslint"],
+  extends: ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
+  ignorePatterns: ["dist/", "node_modules/", "src/generated/", "prisma/generated/"],
+  rules: {
+    "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/no-var-requires": "off",
+    "@typescript-eslint/no-unused-vars": [
+      "warn",
+      {
+        argsIgnorePattern: "^_",
+        varsIgnorePattern: "^_",
+      },
+    ],
+    "no-console": "off",
+    "no-unsafe-finally": "off",
+    "prefer-const": "off",
+  },
+};

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - dev
+      - main
+  pull_request:
+    branches:
+      - dev
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm run test
+
+      - name: Build
+        run: npm run build
+

--- a/.github/workflows/discord-releases.yml
+++ b/.github/workflows/discord-releases.yml
@@ -12,26 +12,26 @@ jobs:
         run: |
           curl -H "Content-Type: application/json" \
           -X POST \
-          -d "{
-            \"content\": \"<@&1477488801478869196>\",
-            \"allowed_mentions\": {
-              \"roles\": [\"1477488801478869196\"]
+          -d '{
+            "content": "<@&1477488801478869196>",
+            "allowed_mentions": {
+              "roles": ["1477488801478869196"]
             },
-            \"username\": \"ClashCookies\",
-            \"embeds\": [{
-              \"title\": \"🚀 New Release: ${{ github.event.release.name }}\",
-              \"description\": \"Click the button below to view the full changelog.\",
-              \"color\": 5814783,
-              \"footer\": { \"text\": \"Version ${{ github.event.release.tag_name }}\" }
+            "username": "ClashCookies",
+            "embeds": [{
+              "title": "🚀 New Release: ${{ github.event.release.name }}",
+              "description": "Click the button below to view the full changelog.",
+              "color": 5814783,
+              "footer": { "text": "Version ${{ github.event.release.tag_name }}" }
             }],
-            \"components\": [{
-              \"type\": 1,
-              \"components\": [{
-                \"type\": 2,
-                \"style\": 5,
-                \"label\": \"View Release\",
-                \"url\": \"${{ github.event.release.html_url }}\"
+            "components": [{
+              "type": 1,
+              "components": [{
+                "type": 2,
+                "style": 5,
+                "label": "View Release",
+                "url": "${{ github.event.release.html_url }}"
               }]
             }]
-          }" \
+          }' \
           ${{ secrets.DISCORD_WEBHOOK_URL }}

--- a/.github/workflows/discord-releases.yml
+++ b/.github/workflows/discord-releases.yml
@@ -12,14 +12,23 @@ jobs:
         run: |
           curl -H "Content-Type: application/json" \
           -X POST \
-          -d '{
-            "username": "ClashCookies",
-            "embeds": [{
-              "title": "🚀 New Release: ${{ github.event.release.name }}",
-              "url": "${{ github.event.release.html_url }}",
-              "description": "Click below to view full changelog.",
-              "color": 5814783,
-              "footer": { "text": "Version ${{ github.event.release.tag_name }}" }
+          -d "{
+            \"content\": \"<@&1477488801478869196>\",
+            \"username\": \"ClashCookies\",
+            \"embeds\": [{
+              \"title\": \"🚀 New Release: ${{ github.event.release.name }}\",
+              \"description\": \"Click the button below to view the full changelog.\",
+              \"color\": 5814783,
+              \"footer\": { \"text\": \"Version ${{ github.event.release.tag_name }}\" }
+            }],
+            \"components\": [{
+              \"type\": 1,
+              \"components\": [{
+                \"type\": 2,
+                \"style\": 5,
+                \"label\": \"View Release\",
+                \"url\": \"${{ github.event.release.html_url }}\"
+              }]
             }]
-          }' \
+          }" \
           ${{ secrets.DISCORD_WEBHOOK_URL }}

--- a/.github/workflows/discord-releases.yml
+++ b/.github/workflows/discord-releases.yml
@@ -1,0 +1,24 @@
+name: Discord Release Notification
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  notify-discord:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Release to Discord
+        run: |
+          curl -H "Content-Type: application/json" \
+          -X POST \
+          -d "{
+            \"username\": \"ClashCookies\",
+            \"embeds\": [{
+              \"title\": \"🚀 New Release: ${{ github.event.release.name }}\",
+              \"url\": \"${{ github.event.release.html_url }}\",
+              \"description\": \"${{ github.event.release.body }}\",
+              \"color\": 5814783
+            }]
+          }" \
+          ${{ secrets.DISCORD_WEBHOOK_URL }}

--- a/.github/workflows/discord-releases.yml
+++ b/.github/workflows/discord-releases.yml
@@ -12,13 +12,14 @@ jobs:
         run: |
           curl -H "Content-Type: application/json" \
           -X POST \
-          -d "{
-            \"username\": \"ClashCookies\",
-            \"embeds\": [{
-              \"title\": \"🚀 New Release: ${{ github.event.release.name }}\",
-              \"url\": \"${{ github.event.release.html_url }}\",
-              \"description\": \"${{ github.event.release.body }}\",
-              \"color\": 5814783
+          -d '{
+            "username": "ClashCookies",
+            "embeds": [{
+              "title": "🚀 New Release: ${{ github.event.release.name }}",
+              "url": "${{ github.event.release.html_url }}",
+              "description": "Click below to view full changelog.",
+              "color": 5814783,
+              "footer": { "text": "Version ${{ github.event.release.tag_name }}" }
             }]
-          }" \
+          }' \
           ${{ secrets.DISCORD_WEBHOOK_URL }}

--- a/.github/workflows/discord-releases.yml
+++ b/.github/workflows/discord-releases.yml
@@ -14,6 +14,9 @@ jobs:
           -X POST \
           -d "{
             \"content\": \"<@&1477488801478869196>\",
+            \"allowed_mentions\": {
+              \"roles\": [\"1477488801478869196\"]
+            },
             \"username\": \"ClashCookies\",
             \"embeds\": [{
               \"title\": \"🚀 New Release: ${{ github.event.release.name }}\",

--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,9 @@ dev.db-journal
 
 # Local AI workflow instructions (do not commit)
 AGENTS.local.md
+
+# VSCode
+.vscode/
+
+# Local scripts not meant for repo (if applicable)
+scripts/

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ Optional fallback auth (not required for your current setup):
 - `/cc player tag:<tag>` - Build `https://cc.fwafarm.com/cc_n/member.php?tag=<tag>`.
 - `/cc clan tag:<tag>` - Build `https://cc.fwafarm.com/cc_n/clan.php?tag=<tag>`.
 - `/notify war clan-tag:<tag> target-channel:<channel> [role:<discordRole>]` - Enable war-state event logs (war start, battle day, war end) for a clan in a selected channel. Optional role is pinged when event logs are posted.
+- `/war history clan-tag:<tag> [limit:<number>]` - Show recent clan-level war history from stored war records.
+- `/war war-id war-id:<number>` - Export stored war lookup payload for one war ID as CSV.
 - `/accounts [visibility:private|public] [tag:<playerTag>] [discord-id:<snowflake>]` - List linked player accounts grouped by current clan. Default is your own account; provide exactly one of `tag` or `discord-id` to inspect a different linked user.
 - `/fwa points [visibility:private|public] [tag:<tag>]` - Fetch current point balance from `https://points.fwafarm.com/clan?tag=<tag-without-#>`. If `tag` is omitted, fetches all tracked clans.
 - `/fwa match [visibility:private|public] tag:<tag>` - Resolve current war opponent from CoC API, then return projected win/lose by points (or sync-based tiebreak on tie).
@@ -109,6 +111,7 @@ Optional fallback auth (not required for your current setup):
 - Administrator users can always use commands regardless of role whitelist.
 - To lock `/post` to role X, run:
   - `/permission add command:post role:@RoleX`
+  - Fine-grained targets for `/post sync ...` are `sync:time:post` and `sync:post:status`.
 - To lock `/fwa` to role X, run:
   - `/permission add command:fwa role:@RoleX`
 - `/fwa match-type` is Administrator-only by default.

--- a/README.md
+++ b/README.md
@@ -4,17 +4,10 @@ Discord bot for Clash of Clans activity tooling.
 ## What It Does
 - Tracks configured clans and updates player activity records.
 - Supports last seen and inactivity queries.
-- Manages tracked clans at runtime (`/tracked-clan ...`).
-- Links to a Google Sheet at runtime (`/sheet ...`).
-- Supports mode-specific sheet links for `actual` and `war` roster workflows.
-- Fetches FWA points balances and matchup projections (`/fwa ...`).
+- Manages tracked clans and roster/sheet integrations.
+- Provides FWA points and matchup tooling.
 
-## Setup
-1. Create a `.env` with required Discord, CoC API, and database values.
-2. Install dependencies.
-3. Run migrations.
-4. Build and start.
-
+## Quick Start
 ```bash
 npm install
 npx prisma migrate deploy
@@ -22,117 +15,8 @@ npm run build
 npm start
 ```
 
-Optional owner bypass:
-- `OWNER_DISCORD_USER_ID` - single Discord user ID with full command access override in all guilds.
-- `OWNER_DISCORD_USER_IDS` - comma-separated list of Discord user IDs with full override.
-
-Optional ClashKing link lookup (kick-list fallback when local links are missing):
-- `CLASHKING_LINKS_URL_TEMPLATE` - ClashKing links endpoint URL (supports either fixed `POST /discord_links` or a `{tag}` URL template).
-- `CLASHKING_API_TOKEN` - bearer token for private ClashKing API (if required).
-- Bot behavior:
-  - `/accounts` backfills `PlayerLink` from ClashKing when local links are missing for the target user.
-  - Activity observe loop checks unresolved tracked-member links via ClashKing at most once every 6 hours and caches matches in `PlayerLink`.
-
-Optional war event log poll setting:
-- `WAR_EVENT_LOG_POLL_INTERVAL_MINUTES` - interval for war-state event listener polling (default: `5` minutes).
-
-## Google Sheets (OAuth)
-This project is currently set up to use OAuth refresh token auth.
-
-Required env vars:
-- `GOOGLE_OAUTH_CLIENT_ID`
-- `GOOGLE_OAUTH_CLIENT_SECRET`
-- `GOOGLE_OAUTH_REFRESH_TOKEN`
-
-Notes:
-- The refresh token should be minted with scope: `https://www.googleapis.com/auth/spreadsheets.readonly`.
-- The Google account tied to the refresh token must have access to the sheet.
-- Viewer access is enough.
-
-Optional fallback auth (not required for your current setup):
-- `GOOGLE_SERVICE_ACCOUNT_JSON`
-- `GOOGLE_SERVICE_ACCOUNT_JSON_BASE64`
-- `GOOGLE_SERVICE_ACCOUNT_EMAIL` + `GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY`
-
-## Commands
-- `/help [command:<name>] [visibility:private|public]` - List command docs/examples. Default visibility is private.
-- `/permission add command:<name> role:<discordRole> [role2] [role3] [role4] [role5]` - Allow one or more roles to use a command.
-- `/permission remove command:<name> role:<discordRole>` - Remove a role from a command whitelist.
-- `/permission list [command:<name>]` - List role policy for one command target, or all if omitted.
-- `/lastseen tag:<playerTag>` - Show a player's last seen activity, with drill-down button for tracked signal timestamps.
-- `/inactive days:<number>` - List players inactive for N days.
-- `/inactive wars:<number>` - List tracked-clan members who used 0/2 attacks in each of the last N ended wars (requires war-history tracking window).
-- `/role-users role:<discordRole>` - List users in a role with pagination.
-- `/tracked-clan add tag:<tag>` - Add tracked clan.
-- `/tracked-clan remove tag:<tag>` - Remove tracked clan.
-- `/tracked-clan list` - List tracked clans.
-- `/sheet link sheet_id_or_url:<id-or-url> [tab:<tab-name>] [mode:actual|war]` - Link or relink sheet; mode is optional.
-- `/sheet show [mode:actual|war]` - Show linked sheet settings (single mode or all).
-- `/sheet unlink [mode:actual|war]` - Remove one mode link or all links.
-- `/sheet refresh mode:actual|war` - Trigger mode-specific Apps Script raw feed refresh.
-- `/compo advice clan:<tracked-clan> [mode:actual|war]` - Pull advice using mode-specific sheet link.
-- `/compo state [mode:actual|war]` - Render AllianceDashboard state as an attached PNG image with mode label.
-- `/compo place weight:<value>` - Suggest placement options from ACTUAL state (vacancy + composition fit). Accepts formats like `145000`, `145,000`, or `145k` and maps to TH weight buckets.
-- `/cc player tag:<tag>` - Build `https://cc.fwafarm.com/cc_n/member.php?tag=<tag>`.
-- `/cc clan tag:<tag>` - Build `https://cc.fwafarm.com/cc_n/clan.php?tag=<tag>`.
-- `/notify war clan-tag:<tag> target-channel:<channel> [role:<discordRole>]` - Enable war-state event logs (war start, battle day, war end) for a clan in a selected channel. Optional role is pinged when event logs are posted.
-- `/war history clan-tag:<tag> [limit:<number>]` - Show recent clan-level war history from stored war records.
-- `/war war-id war-id:<number>` - Export stored war lookup payload for one war ID as CSV.
-- `/accounts [visibility:private|public] [tag:<playerTag>] [discord-id:<snowflake>]` - List linked player accounts grouped by current clan. Default is your own account; provide exactly one of `tag` or `discord-id` to inspect a different linked user.
-- `/fwa points [visibility:private|public] [tag:<tag>]` - Fetch current point balance from `https://points.fwafarm.com/clan?tag=<tag-without-#>`. If `tag` is omitted, fetches all tracked clans.
-- `/fwa match [visibility:private|public] tag:<tag>` - Resolve current war opponent from CoC API, then return projected win/lose by points (or sync-based tiebreak on tie).
-- `/fwa match-type [visibility:private|public] [tag:<trackedClanTag>] [type:FWA|BL|MM]` - Manually set or view per-clan match type override used by matchup output. If no args, lists overrides for all tracked clans.
-- `/recruitment show platform:discord|reddit|band clan:<tag>` - Render platform-specific recruitment template output for a tracked clan.
-- `/recruitment edit platform:discord|reddit|band clan:<tag>` - Open platform-specific modal:
-  - Discord: clan tag, body (max 1024), optional image URL(s)
-  - Band: body, optional image URL(s)
-  - Reddit: subject (`[Recruiting] Name of Clan | #ClanTag | Required TH/Level | Clan Level | FWA | Discord`) auto-prefilled from in-game TH minimum and clan level, body (markdown), optional image URL(s)
-- `/recruitment countdown start platform:discord|reddit|band clan:<tag>` - Start exact cooldown timer for your account on that platform+clan pair.
-- `/recruitment countdown status` - Show your current recruitment cooldown timers.
-- `/recruitment dashboard` - Show readiness across all tracked clans/platforms for your account.
-- `/kick-list build [days:<number>]` - Auto-build kick-list candidates from tracked-clan members who are inactive (`days` threshold, default `3`), unlinked, or linked to users not in this server. Players matching both inactivity and link issues are shown first.
-- `/kick-list add tag:<playerTag> reason:<text>` - Manually add a kick-list candidate with reason.
-- `/kick-list remove tag:<playerTag>` - Remove a player from kick list.
-- `/kick-list show` - Show current kick-list with reasons.
-- `/kick-list clear [mode:all|auto|manual]` - Clear kick-list entries.
-- `/post sync time [role:<discordRole>]` - Open modal, compose sync-time message, post it, and pin it.
-- `/post sync status [message-id:<id>]` - Show claimed vs unclaimed clan badge reactions for the active sync-time post, or for a specific message in the channel.
-
-## Command Access Control
-- By default, commands are usable by everyone.
-- Default Administrator-only targets:
-  - `/tracked-clan add`, `/tracked-clan remove`
-  - `/permission add`, `/permission remove`
-  - `/sheet link`, `/sheet unlink`, `/sheet show`, `/sheet refresh`
-  - `/kick-list build`, `/kick-list add`, `/kick-list remove`, `/kick-list show`, `/kick-list clear`
-  - `/post sync time`
-  - `/notify war`
-- You can whitelist roles per command with `/permission add`.
-- Administrator users can always use commands regardless of role whitelist.
-- To lock `/post` to role X, run:
-  - `/permission add command:post role:@RoleX`
-  - Fine-grained targets for `/post sync ...` are `sync:time:post` and `sync:post:status`.
-- To lock `/fwa` to role X, run:
-  - `/permission add command:fwa role:@RoleX`
-- `/fwa match-type` is Administrator-only by default.
-- To lock `/recruitment` to role X, run:
-  - `/permission add command:recruitment role:@RoleX`
-- To lock `/notify` to role X, run:
-  - `/permission add command:notify role:@RoleX`
-
-## Deployment Notes
-- Commands are registered as guild commands using `GUILD_ID` on startup.
-- If commands are missing, verify environment (`DISCORD_TOKEN`, `GUILD_ID`) and restart.
-
-## Install Links
-Prod guild install:
-https://discord.com/oauth2/authorize?client_id=1131335782016237749&permissions=8&integration_type=0&scope=bot+applications.commands
-
-Prod user install:
-https://discord.com/oauth2/authorize?client_id=1131335782016237749&permissions=8&integration_type=1&scope=bot+applications.commands
-
-Staging guild install:
-https://discord.com/oauth2/authorize?client_id=1474193888146358393&permissions=8&integration_type=0&scope=bot+applications.commands
-
-Staging user install:
-https://discord.com/oauth2/authorize?client_id=1474193888146358393&permissions=8&integration_type=1&scope=bot+applications.commands
+## Documentation
+- [Setup and Environment](docs/setup.md)
+- [Commands Reference](docs/commands.md)
+- [Command Access and Permissions](docs/permissions.md)
+- [Deployment and Install Links](docs/deployment.md)

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -40,5 +40,5 @@
 - `/kick-list remove tag:<playerTag>` - Remove a player from kick list.
 - `/kick-list show` - Show current kick-list with reasons.
 - `/kick-list clear [mode:all|auto|manual]` - Clear kick-list entries.
-- `/post sync time [role:<discordRole>]` - Open modal, compose sync-time message, post it, and pin it.
-- `/post sync status [message-id:<id>]` - Show claimed vs unclaimed clan badge reactions for the active sync-time post, or for a specific message in the channel.
+- `/sync time post [role:<discordRole>]` - Open modal, compose sync-time message, post it, and pin it.
+- `/sync post status [message-id:<id>]` - Show claimed vs unclaimed clan badge reactions for the active sync-time post, or for a specific message in the channel.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,0 +1,44 @@
+# Commands Reference
+
+- `/help [command:<name>] [visibility:private|public]` - List command docs/examples. Default visibility is private.
+- `/permission add command:<name> role:<discordRole> [role2] [role3] [role4] [role5]` - Allow one or more roles to use a command.
+- `/permission remove command:<name> role:<discordRole>` - Remove a role from a command whitelist.
+- `/permission list [command:<name>]` - List role policy for one command target, or all if omitted.
+- `/lastseen tag:<playerTag>` - Show a player's last seen activity, with drill-down button for tracked signal timestamps.
+- `/inactive days:<number>` - List players inactive for N days.
+- `/inactive wars:<number>` - List tracked-clan members who used 0/2 attacks in each of the last N ended wars (requires war-history tracking window).
+- `/role-users role:<discordRole>` - List users in a role with pagination.
+- `/tracked-clan add tag:<tag>` - Add tracked clan.
+- `/tracked-clan remove tag:<tag>` - Remove tracked clan.
+- `/tracked-clan list` - List tracked clans.
+- `/sheet link sheet_id_or_url:<id-or-url> [tab:<tab-name>] [mode:actual|war]` - Link or relink sheet; mode is optional.
+- `/sheet show [mode:actual|war]` - Show linked sheet settings (single mode or all).
+- `/sheet unlink [mode:actual|war]` - Remove one mode link or all links.
+- `/sheet refresh mode:actual|war` - Trigger mode-specific Apps Script raw feed refresh.
+- `/compo advice clan:<tracked-clan> [mode:actual|war]` - Pull advice using mode-specific sheet link.
+- `/compo state [mode:actual|war]` - Render AllianceDashboard state as an attached PNG image with mode label.
+- `/compo place weight:<value>` - Suggest placement options from ACTUAL state (vacancy + composition fit). Accepts formats like `145000`, `145,000`, or `145k` and maps to TH weight buckets.
+- `/cc player tag:<tag>` - Build `https://cc.fwafarm.com/cc_n/member.php?tag=<tag>`.
+- `/cc clan tag:<tag>` - Build `https://cc.fwafarm.com/cc_n/clan.php?tag=<tag>`.
+- `/notify war clan-tag:<tag> target-channel:<channel> [role:<discordRole>]` - Enable war-state event logs (war start, battle day, war end) for a clan in a selected channel. Optional role is pinged when event logs are posted.
+- `/war history clan-tag:<tag> [limit:<number>]` - Show recent clan-level war history from stored war records.
+- `/war war-id war-id:<number>` - Export stored war lookup payload for one war ID as CSV.
+- `/accounts [visibility:private|public] [tag:<playerTag>] [discord-id:<snowflake>]` - List linked player accounts grouped by current clan. Default is your own account; provide exactly one of `tag` or `discord-id` to inspect a different linked user.
+- `/fwa points [visibility:private|public] [tag:<tag>]` - Fetch current point balance from `https://points.fwafarm.com/clan?tag=<tag-without-#>`. If `tag` is omitted, fetches all tracked clans.
+- `/fwa match [visibility:private|public] tag:<tag>` - Resolve current war opponent from CoC API, then return projected win/lose by points (or sync-based tiebreak on tie).
+- `/fwa match-type [visibility:private|public] [tag:<trackedClanTag>] [type:FWA|BL|MM]` - Manually set or view per-clan match type override used by matchup output. If no args, lists overrides for all tracked clans.
+- `/recruitment show platform:discord|reddit|band clan:<tag>` - Render platform-specific recruitment template output for a tracked clan.
+- `/recruitment edit platform:discord|reddit|band clan:<tag>` - Open platform-specific modal:
+  - Discord: clan tag, body (max 1024), optional image URL(s)
+  - Band: body, optional image URL(s)
+  - Reddit: subject (`[Recruiting] Name of Clan | #ClanTag | Required TH/Level | Clan Level | FWA | Discord`) auto-prefilled from in-game TH minimum and clan level, body (markdown), optional image URL(s)
+- `/recruitment countdown start platform:discord|reddit|band clan:<tag>` - Start exact cooldown timer for your account on that platform+clan pair.
+- `/recruitment countdown status` - Show your current recruitment cooldown timers.
+- `/recruitment dashboard` - Show readiness across all tracked clans/platforms for your account.
+- `/kick-list build [days:<number>]` - Auto-build kick-list candidates from tracked-clan members who are inactive (`days` threshold, default `3`), unlinked, or linked to users not in this server. Players matching both inactivity and link issues are shown first.
+- `/kick-list add tag:<playerTag> reason:<text>` - Manually add a kick-list candidate with reason.
+- `/kick-list remove tag:<playerTag>` - Remove a player from kick list.
+- `/kick-list show` - Show current kick-list with reasons.
+- `/kick-list clear [mode:all|auto|manual]` - Clear kick-list entries.
+- `/post sync time [role:<discordRole>]` - Open modal, compose sync-time message, post it, and pin it.
+- `/post sync status [message-id:<id>]` - Show claimed vs unclaimed clan badge reactions for the active sync-time post, or for a specific message in the channel.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,0 +1,18 @@
+# Deployment and Install Links
+
+## Deployment Notes
+- Commands are registered as guild commands using `GUILD_ID` on startup.
+- If commands are missing, verify environment (`DISCORD_TOKEN`, `GUILD_ID`) and restart.
+
+## Install Links
+Prod guild install:
+https://discord.com/oauth2/authorize?client_id=1131335782016237749&permissions=8&integration_type=0&scope=bot+applications.commands
+
+Prod user install:
+https://discord.com/oauth2/authorize?client_id=1131335782016237749&permissions=8&integration_type=1&scope=bot+applications.commands
+
+Staging guild install:
+https://discord.com/oauth2/authorize?client_id=1474193888146358393&permissions=8&integration_type=0&scope=bot+applications.commands
+
+Staging user install:
+https://discord.com/oauth2/authorize?client_id=1474193888146358393&permissions=8&integration_type=1&scope=bot+applications.commands

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -1,0 +1,34 @@
+# Command Access and Permissions
+
+## Defaults
+- By default, commands are usable by everyone.
+- Administrator users can always use commands regardless of role whitelist.
+
+## Default Administrator-Only Targets
+- `/tracked-clan add`, `/tracked-clan remove`
+- `/permission add`, `/permission remove`
+- `/sheet link`, `/sheet unlink`, `/sheet show`, `/sheet refresh`
+- `/kick-list build`, `/kick-list add`, `/kick-list remove`, `/kick-list show`, `/kick-list clear`
+- `/post sync time`
+- `/notify war`
+
+## Role Whitelisting
+- Use `/permission add` to whitelist roles per command target.
+- Use `/permission remove` to remove role access.
+- Use `/permission list` to inspect current policy.
+
+Examples:
+- Lock `/post` to role `@RoleX`:
+  - `/permission add command:post role:@RoleX`
+- Fine-grained `/post sync ...` targets:
+  - `sync:time:post`
+  - `sync:post:status`
+- Lock `/fwa` to role `@RoleX`:
+  - `/permission add command:fwa role:@RoleX`
+- Lock `/recruitment` to role `@RoleX`:
+  - `/permission add command:recruitment role:@RoleX`
+- Lock `/notify` to role `@RoleX`:
+  - `/permission add command:notify role:@RoleX`
+
+## Notes
+- `/fwa match-type` is Administrator-only by default.

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -9,7 +9,7 @@
 - `/permission add`, `/permission remove`
 - `/sheet link`, `/sheet unlink`, `/sheet show`, `/sheet refresh`
 - `/kick-list build`, `/kick-list add`, `/kick-list remove`, `/kick-list show`, `/kick-list clear`
-- `/post sync time`
+- `/sync time post`
 - `/notify war`
 
 ## Role Whitelisting
@@ -18,11 +18,13 @@
 - Use `/permission list` to inspect current policy.
 
 Examples:
-- Lock `/post` to role `@RoleX`:
-  - `/permission add command:post role:@RoleX`
-- Fine-grained `/post sync ...` targets:
+- Lock `/sync` to role `@RoleX`:
+  - `/permission add command:sync role:@RoleX`
+- Fine-grained `/sync ...` targets:
   - `sync:time:post`
   - `sync:post:status`
+  - Example: `/permission add command:sync:time:post role:@RoleX`
+  - Example: `/permission add command:sync:post:status role:@RoleX`
 - Lock `/fwa` to role `@RoleX`:
   - `/permission add command:fwa role:@RoleX`
 - Lock `/recruitment` to role `@RoleX`:

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -1,0 +1,48 @@
+# Setup
+
+## Base Setup
+1. Create a `.env` with required Discord, CoC API, and database values.
+2. Install dependencies.
+3. Run migrations.
+4. Build and start.
+
+```bash
+npm install
+npx prisma migrate deploy
+npm run build
+npm start
+```
+
+## Optional Owner Bypass
+- `OWNER_DISCORD_USER_ID` - single Discord user ID with full command access override in all guilds.
+- `OWNER_DISCORD_USER_IDS` - comma-separated list of Discord user IDs with full override.
+
+## Optional ClashKing Link Lookup
+- `CLASHKING_LINKS_URL_TEMPLATE` - ClashKing links endpoint URL (supports either fixed `POST /discord_links` or a `{tag}` URL template).
+- `CLASHKING_API_TOKEN` - bearer token for private ClashKing API (if required).
+
+Behavior:
+- `/accounts` backfills `PlayerLink` from ClashKing when local links are missing for the target user.
+- Activity observe loop checks unresolved tracked-member links via ClashKing at most once every 6 hours and caches matches in `PlayerLink`.
+
+## Optional War Event Poll Setting
+- `WAR_EVENT_LOG_POLL_INTERVAL_MINUTES` - interval for war-state event listener polling (default: `5` minutes).
+
+## Google Sheets (OAuth)
+This project is currently set up to use OAuth refresh token auth.
+
+Required env vars:
+- `GOOGLE_OAUTH_CLIENT_ID`
+- `GOOGLE_OAUTH_CLIENT_SECRET`
+- `GOOGLE_OAUTH_REFRESH_TOKEN`
+
+Notes:
+- Refresh token scope: `https://www.googleapis.com/auth/spreadsheets.readonly`.
+- The Google account tied to the refresh token must have access to the sheet.
+- Viewer access is enough.
+
+Optional fallback auth (not required for current setup):
+- `GOOGLE_SERVICE_ACCOUNT_JSON`
+- `GOOGLE_SERVICE_ACCOUNT_JSON_BASE64`
+- `GOOGLE_SERVICE_ACCOUNT_EMAIL`
+- `GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY`

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,12 +20,42 @@
         "@types/node": "^20.4.2",
         "@typescript-eslint/eslint-plugin": "^6.21.0",
         "@typescript-eslint/parser": "^6.21.0",
+        "@vitest/coverage-v8": "^0.34.6",
         "eslint": "^8.57.1",
         "nodemon": "^3.1.11",
         "prisma": "^5.22.0",
         "ts-node": "^10.9.2",
         "vitest": "^0.34.6"
       }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@ampproject/remapping/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -589,6 +619,15 @@
       "deprecated": "Use @eslint/object-schema instead",
       "dev": true
     },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
+      "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@jest/schemas": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
@@ -599,6 +638,26 @@
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -684,13 +743,13 @@
       "version": "5.22.0",
       "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-5.22.0.tgz",
       "integrity": "sha512-AUt44v3YJeggO2ZU5BkXI7M4hu9BF2zzH2iF2V5pyXT/lRTyWiElZ7It+bRH1EshoMRxHgpYg4VB6rCM+mG5jQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@prisma/engines": {
       "version": "5.22.0",
       "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.22.0.tgz",
       "integrity": "sha512-UNjfslWhAt06kVL3CjkuYpHAWSO6L4kDCVPegV6itt7nD1kSJavd3vhgAEhjglLJJKEdJ7oIqDJ+yHk6qO8gPA==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "dependencies": {
         "@prisma/debug": "5.22.0",
@@ -703,13 +762,13 @@
       "version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2",
       "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2.tgz",
       "integrity": "sha512-2PTmxFR2yHW/eB3uqWtcgRcgAbG1rwG9ZriSvQw+nnb7c4uCr3RAcGMb6/zfE88SKlC1Nj2ziUvc96Z379mHgQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@prisma/fetch-engine": {
       "version": "5.22.0",
       "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-5.22.0.tgz",
       "integrity": "sha512-bkrD/Mc2fSvkQBV5EpoFcZ87AvOgDxbG99488a5cexp5Ccny+UM6MAe/UFkUC0wLYD9+9befNOqGiIJhhq+HbA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@prisma/debug": "5.22.0",
         "@prisma/engines-version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2",
@@ -720,7 +779,7 @@
       "version": "5.22.0",
       "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-5.22.0.tgz",
       "integrity": "sha512-pHhpQdr1UPFpt+zFfnPazhulaZYCUqeIcPpJViYoq9R+D/yw4fjE+CtnsnKzPYm0ddUbeXUzjGVGIRVgPDCk4Q==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@prisma/debug": "5.22.0"
       }
@@ -1143,6 +1202,12 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true
+    },
+    "node_modules/@types/istanbul-lib-coverage": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz",
+      "integrity": "sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==",
       "dev": true
     },
     "node_modules/@types/json-schema": {
@@ -1651,6 +1716,31 @@
       "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
       "dev": true
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "0.34.6",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-0.34.6.tgz",
+      "integrity": "sha512-fivy/OK2d/EsJFoEoxHFEnNGTg+MmdZBAVK9Ka4qhXR2K3J0DS08vcGVwzDtXSuUMabLv4KtPcpSKkcMXFDViw==",
+      "dev": true,
+      "dependencies": {
+        "@ampproject/remapping": "^2.2.1",
+        "@bcoe/v8-coverage": "^0.2.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^4.0.1",
+        "istanbul-reports": "^3.1.5",
+        "magic-string": "^0.30.1",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.3.3",
+        "test-exclude": "^6.0.0",
+        "v8-to-istanbul": "^9.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "vitest": ">=0.32.0 <1"
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "0.34.6",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-0.34.6.tgz",
@@ -2108,6 +2198,12 @@
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
       "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true
     },
     "node_modules/create-require": {
@@ -2874,6 +2970,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
+    },
     "node_modules/ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -3008,6 +3110,77 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/js-yaml": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
@@ -3126,6 +3299,21 @@
       "dev": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/make-error": {
@@ -3542,7 +3730,7 @@
       "version": "5.22.0",
       "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.22.0.tgz",
       "integrity": "sha512-vtpjW3XuYCSnMsNVBjLMNkTj6OZbudcPPTPYHqX0CJfpcdWciI1dM8uHETwmDxxiqEwCIE6WvXucWUetJgfu/A==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "dependencies": {
         "@prisma/engines": "5.22.0"
@@ -3837,6 +4025,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3938,6 +4135,20 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "dev": true,
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/text-table": {
@@ -4158,6 +4369,30 @@
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
+    "node_modules/v8-to-istanbul/node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "node_modules/vite": {
       "version": "5.4.21",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,23 +1,30 @@
 {
-  "name": "ClashCookies",
+  "name": "Dusk bot",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
+      "hasInstallScript": true,
       "dependencies": {
         "@prisma/client": "^5.22.0",
+        "axios": "^1.13.5",
         "clashofclans.js": "^3.1.0",
         "discord.js": "^14.11.0",
         "dotenv": "^16.3.1",
         "knockout": "^3.5.1",
-        "q": "^1.5.1"
+        "pngjs": "^7.0.0",
+        "q": "^1.5.1",
+        "typescript": "^5.9.3"
       },
       "devDependencies": {
         "@types/node": "^20.4.2",
+        "@typescript-eslint/eslint-plugin": "^6.21.0",
+        "@typescript-eslint/parser": "^6.21.0",
+        "eslint": "^8.57.1",
         "nodemon": "^3.1.11",
         "prisma": "^5.22.0",
         "ts-node": "^10.9.2",
-        "typescript": "^5.9.3"
+        "vitest": "^0.34.6"
       }
     },
     "node_modules/@cspotcode/source-map-support": {
@@ -120,6 +127,480 @@
         "node": ">=16.9.0"
       }
     },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@eslint-community/eslint-utils": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "dev": true,
+      "dependencies": {
+        "eslint-visitor-keys": "^3.4.3"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
+      }
+    },
+    "node_modules/@eslint-community/regexpp": {
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
+      "dev": true,
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@eslint/eslintrc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^6.12.4",
+        "debug": "^4.3.2",
+        "espree": "^9.6.0",
+        "globals": "^13.19.0",
+        "ignore": "^5.2.0",
+        "import-fresh": "^3.2.1",
+        "js-yaml": "^4.1.0",
+        "minimatch": "^3.1.2",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/@eslint/js": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
+      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@humanwhocodes/config-array": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
+      "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
+      "deprecated": "Use @eslint/config-array instead",
+      "dev": true,
+      "dependencies": {
+        "@humanwhocodes/object-schema": "^2.0.3",
+        "debug": "^4.3.1",
+        "minimatch": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=10.10.0"
+      }
+    },
+    "node_modules/@humanwhocodes/module-importer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+      "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.22"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/nzakas"
+      }
+    },
+    "node_modules/@humanwhocodes/object-schema": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
+      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
+      "deprecated": "Use @eslint/object-schema instead",
+      "dev": true
+    },
+    "node_modules/@jest/schemas": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
+      "integrity": "sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==",
+      "dev": true,
+      "dependencies": {
+        "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
@@ -131,11 +612,10 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.15",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-      "dev": true,
-      "license": "MIT"
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.9",
@@ -146,6 +626,41 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/@prisma/client": {
@@ -169,13 +684,13 @@
       "version": "5.22.0",
       "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-5.22.0.tgz",
       "integrity": "sha512-AUt44v3YJeggO2ZU5BkXI7M4hu9BF2zzH2iF2V5pyXT/lRTyWiElZ7It+bRH1EshoMRxHgpYg4VB6rCM+mG5jQ==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/@prisma/engines": {
       "version": "5.22.0",
       "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.22.0.tgz",
       "integrity": "sha512-UNjfslWhAt06kVL3CjkuYpHAWSO6L4kDCVPegV6itt7nD1kSJavd3vhgAEhjglLJJKEdJ7oIqDJ+yHk6qO8gPA==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@prisma/debug": "5.22.0",
@@ -188,13 +703,13 @@
       "version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2",
       "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2.tgz",
       "integrity": "sha512-2PTmxFR2yHW/eB3uqWtcgRcgAbG1rwG9ZriSvQw+nnb7c4uCr3RAcGMb6/zfE88SKlC1Nj2ziUvc96Z379mHgQ==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/@prisma/fetch-engine": {
       "version": "5.22.0",
       "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-5.22.0.tgz",
       "integrity": "sha512-bkrD/Mc2fSvkQBV5EpoFcZ87AvOgDxbG99488a5cexp5Ccny+UM6MAe/UFkUC0wLYD9+9befNOqGiIJhhq+HbA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@prisma/debug": "5.22.0",
         "@prisma/engines-version": "5.22.0-44.605197351a3c8bdd595af2d2a9bc3025bca48ea2",
@@ -205,10 +720,335 @@
       "version": "5.22.0",
       "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-5.22.0.tgz",
       "integrity": "sha512-pHhpQdr1UPFpt+zFfnPazhulaZYCUqeIcPpJViYoq9R+D/yw4fjE+CtnsnKzPYm0ddUbeXUzjGVGIRVgPDCk4Q==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@prisma/debug": "5.22.0"
       }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
+      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
+      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
+      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
+      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
+      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
+      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
+      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
+      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
+      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
+      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
+      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
+      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
+      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
+      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
+      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
+      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
+      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
+      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
+      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
+      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
+      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
+      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
+      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@sapphire/async-queue": {
       "version": "1.5.0",
@@ -244,6 +1084,12 @@
         "npm": ">=7.0.0"
       }
     },
+    "node_modules/@sinclair/typebox": {
+      "version": "0.27.10",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
+      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
+      "dev": true
+    },
     "node_modules/@tokenizer/token": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
@@ -278,11 +1124,44 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/chai": {
+      "version": "4.3.20",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.20.tgz",
+      "integrity": "sha512-/pC9HAB5I/xMlc5FP77qjCnI16ChlJfW0tGa0IUcFn38VJrTV6DeZ60NU5KZBtaOZqjdpwTWohz5HU1RrhiYxQ==",
+      "dev": true
+    },
+    "node_modules/@types/chai-subset": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@types/chai-subset/-/chai-subset-1.3.6.tgz",
+      "integrity": "sha512-m8lERkkQj+uek18hXOZuec3W/fCRTrU4hrnXjH3qhHy96ytuPaPiWGgu7sJb7tZxZonO75vYAjCvpe/e4VUwRw==",
+      "dev": true,
+      "peerDependencies": {
+        "@types/chai": "<5.2.0"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true
+    },
+    "node_modules/@types/json-schema": {
+      "version": "7.0.15",
+      "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true
+    },
     "node_modules/@types/node": {
       "version": "20.4.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.4.2.tgz",
       "integrity": "sha512-Dd0BYtWgnWJKwO1jkmTrzofjK2QXXcai0dmtzvIBhcA+RsG5h8R3xlyta0kGOZRNfL9GuRtb1knmPEhQrePCEw==",
       "license": "MIT"
+    },
+    "node_modules/@types/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==",
+      "dev": true
     },
     "node_modules/@types/ws": {
       "version": "8.5.5",
@@ -291,6 +1170,580 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.21.0.tgz",
+      "integrity": "sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.5.1",
+        "@typescript-eslint/scope-manager": "6.21.0",
+        "@typescript-eslint/type-utils": "6.21.0",
+        "@typescript-eslint/utils": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0",
+        "debug": "^4.3.4",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.4",
+        "natural-compare": "^1.4.0",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
+        "eslint": "^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/scope-manager": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
+      "integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
+      "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+      "dev": true,
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
+      "integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "9.0.3",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.21.0.tgz",
+      "integrity": "sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@types/json-schema": "^7.0.12",
+        "@types/semver": "^7.5.0",
+        "@typescript-eslint/scope-manager": "6.21.0",
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/typescript-estree": "6.21.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
+      "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ts-api-utils": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
+      "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.2.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
+      "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "6.21.0",
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/typescript-estree": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
+      "integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
+      "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+      "dev": true,
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
+      "integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "9.0.3",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
+      "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/parser/node_modules/ts-api-utils": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
+      "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.2.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.21.0.tgz",
+      "integrity": "sha512-rZQI7wHfao8qMX3Rd3xqeYSMCL3SoiSQLBATSiVKARdFGCYSRvmViieZjqc58jKgs8Y8i9YvVVhRbHSTA4VBag==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/typescript-estree": "6.21.0",
+        "@typescript-eslint/utils": "6.21.0",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/scope-manager": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
+      "integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
+      "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+      "dev": true,
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
+      "integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "9.0.3",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/utils": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.21.0.tgz",
+      "integrity": "sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0",
+        "@types/json-schema": "^7.0.12",
+        "@types/semver": "^7.5.0",
+        "@typescript-eslint/scope-manager": "6.21.0",
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/typescript-estree": "6.21.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
+      "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+      "dev": true,
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/brace-expansion": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils/node_modules/ts-api-utils": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
+      "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
+      "dev": true,
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.2.0"
+      }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "dev": true
+    },
+    "node_modules/@vitest/expect": {
+      "version": "0.34.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-0.34.6.tgz",
+      "integrity": "sha512-QUzKpUQRc1qC7qdGo7rMK3AkETI7w18gTCUrsNnyjjJKYiuUB9+TQK3QnR1unhCnWRC0AbKv2omLGQDF/mIjOw==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "0.34.6",
+        "@vitest/utils": "0.34.6",
+        "chai": "^4.3.10"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "0.34.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-0.34.6.tgz",
+      "integrity": "sha512-1CUQgtJSLF47NnhN+F9X2ycxUP0kLHQ/JWvNHbeBfwW8CzEGgeskzNnHDyv1ieKTltuR6sdIHV+nmR6kPxQqzQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "0.34.6",
+        "p-limit": "^4.0.0",
+        "pathe": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/p-limit": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
+      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@vitest/runner/node_modules/yocto-queue": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "0.34.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-0.34.6.tgz",
+      "integrity": "sha512-B3OZqYn6k4VaN011D+ve+AA4whM4QkcwcrwaKwAbyyvS/NB1hCWjFIBQxAQQSQir9/RtyAAGuq+4RJmbn2dH4w==",
+      "dev": true,
+      "dependencies": {
+        "magic-string": "^0.30.1",
+        "pathe": "^1.1.1",
+        "pretty-format": "^29.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "0.34.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-0.34.6.tgz",
+      "integrity": "sha512-xaCvneSaeBw/cz8ySmF7ZwGvL0lBjfvqc1LpQ/vcdHEvpLn3Ff1vAvjw+CoGn0802l++5L/pxb7whwcWAw+DUQ==",
+      "dev": true,
+      "dependencies": {
+        "tinyspy": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "0.34.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-0.34.6.tgz",
+      "integrity": "sha512-IG5aDD8S6zlvloDsnzHw0Ut5xczlF+kv2BOTo+iXfPr54Yhi5qbVOgGB1hZaVq4iJ4C/MZ2J0y15IlsV/ZcI0A==",
+      "dev": true,
+      "dependencies": {
+        "diff-sequences": "^29.4.3",
+        "loupe": "^2.3.6",
+        "pretty-format": "^29.5.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vladfrangu/async_event_emitter": {
@@ -304,16 +1757,24 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.10.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
-      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/acorn-jsx": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+      "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
+      "dev": true,
+      "peerDependencies": {
+        "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
     "node_modules/acorn-walk": {
@@ -324,6 +1785,46 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/anymatch": {
@@ -345,6 +1846,45 @@
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
+      "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/axios": {
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
+      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^1.1.0"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.2",
@@ -397,6 +1937,103 @@
         "node": ">=10.16.0"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/chai": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz",
+      "integrity": "sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^1.1.0",
+        "check-error": "^1.0.3",
+        "deep-eql": "^4.1.3",
+        "get-func-name": "^2.0.2",
+        "loupe": "^2.3.6",
+        "pathval": "^1.1.1",
+        "type-detect": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/chalk/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
+      "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+      "dev": true,
+      "dependencies": {
+        "get-func-name": "^2.0.2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -432,10 +2069,45 @@
         "node": ">=14.x"
       }
     },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
       "dev": true
     },
     "node_modules/create-require": {
@@ -444,6 +2116,20 @@
       "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -462,6 +2148,32 @@
         }
       }
     },
+    "node_modules/deep-eql": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz",
+      "integrity": "sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/deep-is": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+      "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
+      "dev": true
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/diff": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
@@ -470,6 +2182,27 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "dev": true,
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/discord-api-types": {
@@ -503,6 +2236,18 @@
         "node": ">=16.9.0"
       }
     },
+    "node_modules/doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "dependencies": {
+        "esutils": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/dotenv": {
       "version": "16.3.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
@@ -514,11 +2259,319 @@
         "url": "https://github.com/motdotla/dotenv?sponsor=1"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint": {
+      "version": "8.57.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
+      "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
+      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+      "dev": true,
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/regexpp": "^4.6.1",
+        "@eslint/eslintrc": "^2.1.4",
+        "@eslint/js": "8.57.1",
+        "@humanwhocodes/config-array": "^0.13.0",
+        "@humanwhocodes/module-importer": "^1.0.1",
+        "@nodelib/fs.walk": "^1.2.8",
+        "@ungap/structured-clone": "^1.2.0",
+        "ajv": "^6.12.4",
+        "chalk": "^4.0.0",
+        "cross-spawn": "^7.0.2",
+        "debug": "^4.3.2",
+        "doctrine": "^3.0.0",
+        "escape-string-regexp": "^4.0.0",
+        "eslint-scope": "^7.2.2",
+        "eslint-visitor-keys": "^3.4.3",
+        "espree": "^9.6.1",
+        "esquery": "^1.4.2",
+        "esutils": "^2.0.2",
+        "fast-deep-equal": "^3.1.3",
+        "file-entry-cache": "^6.0.1",
+        "find-up": "^5.0.0",
+        "glob-parent": "^6.0.2",
+        "globals": "^13.19.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^5.2.0",
+        "imurmurhash": "^0.1.4",
+        "is-glob": "^4.0.0",
+        "is-path-inside": "^3.0.3",
+        "js-yaml": "^4.1.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.4.1",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^3.1.2",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.9.3",
+        "strip-ansi": "^6.0.1",
+        "text-table": "^0.2.0"
+      },
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-scope": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
+      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+      "dev": true,
+      "dependencies": {
+        "esrecurse": "^4.3.0",
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-visitor-keys": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+      "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
+      "dev": true,
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/glob-parent": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+      "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/espree": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
+      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.9.0",
+        "acorn-jsx": "^5.3.2",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esquery": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
+      "dev": true,
+      "dependencies": {
+        "estraverse": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/esrecurse": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+      "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+      "dev": true,
+      "dependencies": {
+        "estraverse": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/estraverse": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+      "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/esutils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-json-stable-stringify": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+      "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+      "dev": true
+    },
+    "node_modules/fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
+      "dev": true
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "dev": true,
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/file-entry-cache": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+      "dev": true,
+      "dependencies": {
+        "flat-cache": "^3.0.4"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
     },
     "node_modules/file-type": {
       "version": "18.5.0",
@@ -549,6 +2602,82 @@
         "node": ">=8"
       }
     },
+    "node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/flat-cache": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
+      "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
+      "dev": true,
+      "dependencies": {
+        "flatted": "^3.2.9",
+        "keyv": "^4.5.3",
+        "rimraf": "^3.0.2"
+      },
+      "engines": {
+        "node": "^10.12.0 || >=12.0.0"
+      }
+    },
+    "node_modules/flatted": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "dev": true
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -563,6 +2692,79 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-func-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
@@ -575,6 +2777,58 @@
         "node": ">= 6"
       }
     },
+    "node_modules/globals": {
+      "version": "13.24.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
+      "dev": true,
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graphemer": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
+      "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
+      "dev": true
+    },
     "node_modules/has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -582,6 +2836,42 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/ieee754": {
@@ -604,11 +2894,56 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
     "node_modules/ignore-by-default": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
       "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
       "dev": true
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dev": true,
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.19"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
     },
     "node_modules/inherits": {
       "version": "2.0.4",
@@ -658,10 +2993,104 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/is-path-inside": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
+      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+      "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+      "dev": true
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true
+    },
+    "node_modules/keyv": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+      "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
+      "dev": true,
+      "dependencies": {
+        "json-buffer": "3.0.1"
+      }
+    },
     "node_modules/knockout": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/knockout/-/knockout-3.5.1.tgz",
       "integrity": "sha512-wRJ9I4az0QcsH7A4v4l0enUpkS++MBx0BnL/68KaLzJg7x1qmbjSlwEoCNol7KTYZ+pmtI7Eh2J0Nu6/2Z5J/Q=="
+    },
+    "node_modules/levn": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+      "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "^1.2.1",
+        "type-check": "~0.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/local-pkg": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.4.3.tgz",
+      "integrity": "sha512-SFppqq5p42fe2qcZQqqEOiVRXl+WCP1MdT6k7BDEW1j++sp5fIY+/fdRQitvKgB5BrBcmrs5m/L0v2FrU5MY1g==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/lodash": {
       "version": "4.17.21",
@@ -669,11 +3098,35 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "license": "MIT"
     },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true
+    },
     "node_modules/lodash.snakecase": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
       "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
       "license": "MIT"
+    },
+    "node_modules/loupe": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
+      "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+      "dev": true,
+      "dependencies": {
+        "get-func-name": "^2.0.1"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
     },
     "node_modules/make-error": {
       "version": "1.3.6",
@@ -682,10 +3135,59 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dev": true,
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -694,10 +3196,52 @@
         "node": "*"
       }
     },
+    "node_modules/mlly": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz",
+      "integrity": "sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.15.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.1"
+      }
+    },
+    "node_modules/mlly/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
     },
     "node_modules/node-fetch": {
@@ -756,6 +3300,125 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/optionator": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+      "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
+      "dev": true,
+      "dependencies": {
+        "deep-is": "^0.1.3",
+        "fast-levenshtein": "^2.0.6",
+        "levn": "^0.4.1",
+        "prelude-ls": "^1.2.1",
+        "type-check": "^0.4.0",
+        "word-wrap": "^1.2.5"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dev": true,
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true
+    },
+    "node_modules/pathval": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
+      "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/peek-readable": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-5.0.0.tgz",
@@ -769,6 +3432,12 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
+    },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -781,11 +3450,99 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/pkg-types/node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true
+    },
+    "node_modules/pngjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+      "engines": {
+        "node": ">=14.19.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prelude-ls": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+      "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
+      "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+      "dev": true,
+      "dependencies": {
+        "@jest/schemas": "^29.6.3",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^18.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/prisma": {
       "version": "5.22.0",
       "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.22.0.tgz",
       "integrity": "sha512-vtpjW3XuYCSnMsNVBjLMNkTj6OZbudcPPTPYHqX0CJfpcdWciI1dM8uHETwmDxxiqEwCIE6WvXucWUetJgfu/A==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "@prisma/engines": "5.22.0"
@@ -800,11 +3557,25 @@
         "fsevents": "2.3.3"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
     "node_modules/pstree.remy": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
       "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
       "dev": true
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/q": {
       "version": "1.5.1",
@@ -815,6 +3586,32 @@
         "node": ">=0.6.0",
         "teleport": ">=0.2.0"
       }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/react-is": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "dev": true
     },
     "node_modules/readable-stream": {
       "version": "3.6.2",
@@ -858,6 +3655,108 @@
         "node": ">=8.10.0"
       }
     },
+    "node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rimraf": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
+      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
+      "deprecated": "Rimraf versions prior to v4 are no longer supported",
+      "dev": true,
+      "dependencies": {
+        "glob": "^7.1.3"
+      },
+      "bin": {
+        "rimraf": "bin.js"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
+      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.59.0",
+        "@rollup/rollup-android-arm64": "4.59.0",
+        "@rollup/rollup-darwin-arm64": "4.59.0",
+        "@rollup/rollup-darwin-x64": "4.59.0",
+        "@rollup/rollup-freebsd-arm64": "4.59.0",
+        "@rollup/rollup-freebsd-x64": "4.59.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
+        "@rollup/rollup-linux-arm64-musl": "4.59.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
+        "@rollup/rollup-linux-loong64-musl": "4.59.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-musl": "4.59.0",
+        "@rollup/rollup-openbsd-x64": "4.59.0",
+        "@rollup/rollup-openharmony-arm64": "4.59.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
+        "@rollup/rollup-win32-x64-gnu": "4.59.0",
+        "@rollup/rollup-win32-x64-msvc": "4.59.0",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -890,6 +3789,33 @@
         "node": ">=10"
       }
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
     "node_modules/simple-update-notifier": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
@@ -901,6 +3827,36 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true
     },
     "node_modules/streamsearch": {
       "version": "1.1.0",
@@ -917,6 +3873,42 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-1.3.0.tgz",
+      "integrity": "sha512-PugKzOsyXpArk0yWmUwqOZecSO0GH0bPoctLcqNDH9J04pVW3lflYE0ujElBGTloevcxF5MofAOZ7C5l2b+wLg==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/strtok3": {
@@ -946,6 +3938,36 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
+      "dev": true
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
+    "node_modules/tinypool": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-0.7.0.tgz",
+      "integrity": "sha512-zSYNUlYSMhJ6Zdou4cJwo/p7w5nmAH17GRfU/ui3ctvjXFErXXkruT4MWW6poDeXgCaIBlGLrfU6TbTXxyGMww==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.1.tgz",
+      "integrity": "sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -1046,11 +4068,43 @@
       "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
       "license": "0BSD"
     },
+    "node_modules/type-check": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+      "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
+      "dev": true,
+      "dependencies": {
+        "prelude-ls": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz",
+      "integrity": "sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -1058,6 +4112,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
+      "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
+      "dev": true
     },
     "node_modules/undefsafe": {
       "version": "2.0.5",
@@ -1077,6 +4137,15 @@
         "node": ">=14.0"
       }
     },
+    "node_modules/uri-js": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+      "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.1.0"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -1089,6 +4158,165 @@
       "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "0.34.6",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.34.6.tgz",
+      "integrity": "sha512-nlBMJ9x6n7/Amaz6F3zJ97EBwR2FkzhBRxF5e+jE6LA3yi6Wtc2lyTij1OnDMIr34v5g/tVQtsVAzhT0jc5ygA==",
+      "dev": true,
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.4",
+        "mlly": "^1.4.0",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "vite": "^3.0.0 || ^4.0.0 || ^5.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": ">=v14.18.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "0.34.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.34.6.tgz",
+      "integrity": "sha512-+5CALsOvbNKnS+ZHMXtuUC7nL8/7F1F2DnHGjSsszX8zCjWSSviphCb/NuS9Nzf4Q03KyyDRBAXhF/8lffME4Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/chai": "^4.3.5",
+        "@types/chai-subset": "^1.3.3",
+        "@types/node": "*",
+        "@vitest/expect": "0.34.6",
+        "@vitest/runner": "0.34.6",
+        "@vitest/snapshot": "0.34.6",
+        "@vitest/spy": "0.34.6",
+        "@vitest/utils": "0.34.6",
+        "acorn": "^8.9.0",
+        "acorn-walk": "^8.2.0",
+        "cac": "^6.7.14",
+        "chai": "^4.3.10",
+        "debug": "^4.3.4",
+        "local-pkg": "^0.4.3",
+        "magic-string": "^0.30.1",
+        "pathe": "^1.1.1",
+        "picocolors": "^1.0.0",
+        "std-env": "^3.3.3",
+        "strip-literal": "^1.0.1",
+        "tinybench": "^2.5.0",
+        "tinypool": "^0.7.0",
+        "vite": "^3.1.0 || ^4.0.0 || ^5.0.0-0",
+        "vite-node": "0.34.6",
+        "why-is-node-running": "^2.2.2"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": ">=v14.18.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@vitest/browser": "*",
+        "@vitest/ui": "*",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "playwright": "*",
+        "safaridriver": "*",
+        "webdriverio": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "playwright": {
+          "optional": true
+        },
+        "safaridriver": {
+          "optional": true
+        },
+        "webdriverio": {
+          "optional": true
+        }
+      }
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
@@ -1103,6 +4331,52 @@
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
       }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/word-wrap": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+      "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
     },
     "node_modules/ws": {
       "version": "8.13.0",
@@ -1133,6 +4407,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@types/node": "^20.4.2",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",
+    "@vitest/coverage-v8": "^0.34.6",
     "eslint": "^8.57.1",
     "nodemon": "^3.1.11",
     "prisma": "^5.22.0",

--- a/package.json
+++ b/package.json
@@ -12,13 +12,21 @@
   },
   "devDependencies": {
     "@types/node": "^20.4.2",
+    "@typescript-eslint/eslint-plugin": "^6.21.0",
+    "@typescript-eslint/parser": "^6.21.0",
+    "eslint": "^8.57.1",
     "nodemon": "^3.1.11",
     "prisma": "^5.22.0",
-    "ts-node": "^10.9.2"
+    "ts-node": "^10.9.2",
+    "vitest": "^0.34.6"
   },
   "scripts": {
     "build": "tsc",
+    "lint": "eslint \"src/**/*.ts\" \"tests/**/*.ts\"",
+    "lint:fix": "eslint \"src/**/*.ts\" \"tests/**/*.ts\" --fix",
     "start": "prisma migrate deploy && node dist/ClashCookies.js",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "dev": "ts-node-dev dist/ClashCookies.ts",
     "postinstall": "prisma generate"
   }

--- a/prisma/migrations/20260228190000_add_war_event_ping_role_flag/migration.sql
+++ b/prisma/migrations/20260228190000_add_war_event_ping_role_flag/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "WarEventLogSubscription"
+ADD COLUMN "pingRole" BOOLEAN NOT NULL DEFAULT true;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -178,6 +178,7 @@ model WarEventLogSubscription {
   clanTag          String
   channelId        String
   notify           Boolean  @default(true)
+  pingRole         Boolean  @default(true)
   inferredMatchType Boolean @default(true)
   notifyRole       String?
   fwaPoints        Int?

--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -1845,6 +1845,11 @@ async function buildTrackedMatchOverview(
   const copyLines: string[] = [];
   const singleViews: Record<string, MatchView> = {};
   let hasAnyInferredMatchType = false;
+  const sourceOfTruthSyncLine = `Sync#: ${
+    sourceSync !== null && Number.isFinite(sourceSync)
+      ? `#${Math.trunc(sourceSync) + 1}`
+      : "unknown"
+  }`;
 
   for (const clan of includedTracked) {
     const clanTag = normalizeTag(clan.tag);
@@ -1859,7 +1864,6 @@ async function buildTrackedMatchOverview(
         name: `${clanName} (#${clanTag})`,
         value: [
           ":face_palm: failed to start war",
-          `Sync: **${clanSyncLine}**`,
           `War State: **${clanWarStateLine}**`,
           `Time Remaining: **${clanTimeRemainingLine}**`,
         ].join("\n"),
@@ -1868,7 +1872,6 @@ async function buildTrackedMatchOverview(
       copyLines.push(
         `## ${clanName} (#${clanTag})`,
         ":face_palm: failed to start war",
-        `Sync: ${clanSyncLine}`,
         `War State: ${clanWarStateLine}`,
         `Time Remaining: ${clanTimeRemainingLine}`
       );
@@ -1891,7 +1894,6 @@ async function buildTrackedMatchOverview(
         name: `${clanName} (#${clanTag}) vs Unknown`,
         value: [
           "No active war opponent",
-          `Sync: **${clanSyncLine}**`,
           `War State: **${clanWarStateLine}**`,
           `Time Remaining: **${clanTimeRemainingLine}**`,
         ].join("\n"),
@@ -1900,7 +1902,6 @@ async function buildTrackedMatchOverview(
       copyLines.push(
         `## ${clanName} (#${clanTag})`,
         "No active war opponent",
-        `Sync: ${clanSyncLine}`,
         `War State: ${clanWarStateLine}`,
         `Time Remaining: ${clanTimeRemainingLine}`
       );
@@ -2124,7 +2125,6 @@ async function buildTrackedMatchOverview(
           pointsSyncStatus,
           `Match Type: **FWA${warnSuffix}**`,
           `Outcome: **${effectiveOutcome ?? "UNKNOWN"}**`,
-          `Sync: **${clanSyncLine}**`,
           `War State: **${clanWarStateLine}**`,
           `Time Remaining: **${clanTimeRemainingLine}**`,
           mismatchLines,
@@ -2144,7 +2144,6 @@ async function buildTrackedMatchOverview(
         `Match Type: FWA${inferredMatchType ? " :warning:" : ""}`,
         inferredMatchType ? `Verify: ${buildCcVerifyUrl(opponentTag)}` : "",
         `Outcome: ${effectiveOutcome ?? "UNKNOWN"}`,
-        `Sync: ${clanSyncLine}`,
         `War State: ${clanWarStateLine}`,
         `Time Remaining: ${clanTimeRemainingLine}`,
         mismatchLines
@@ -2156,7 +2155,6 @@ async function buildTrackedMatchOverview(
         value: [
           pointsSyncStatus,
           `Match Type: **${matchType}${warnSuffix}**`,
-          `Sync: **${clanSyncLine}**`,
           `War State: **${clanWarStateLine}**`,
           `Time Remaining: **${clanTimeRemainingLine}**`,
           mismatchLines,
@@ -2174,7 +2172,6 @@ async function buildTrackedMatchOverview(
         pointsSyncStatus,
         `Match Type: ${matchType}${inferredMatchType ? " :warning:" : ""}`,
         inferredMatchType ? `Verify: ${buildCcVerifyUrl(opponentTag)}` : "",
-        `Sync: ${clanSyncLine}`,
         `War State: ${clanWarStateLine}`,
         `Time Remaining: ${clanTimeRemainingLine}`,
         mismatchLines
@@ -2273,6 +2270,7 @@ async function buildTrackedMatchOverview(
   }
 
   const overviewNotes: string[] = [];
+  overviewNotes.push(`Source of truth ${sourceOfTruthSyncLine}`);
   if (hasAnyInferredMatchType) {
     overviewNotes.push(MATCHTYPE_WARNING_LEGEND);
   }
@@ -2286,6 +2284,7 @@ async function buildTrackedMatchOverview(
   }
 
   const copyHeaderLines = [`# FWA Match Overview (${includedTracked.length})`];
+  copyHeaderLines.push(`Source of truth ${sourceOfTruthSyncLine}`);
   if (hasAnyInferredMatchType) {
     copyHeaderLines.push(MATCHTYPE_WARNING_LEGEND);
   }

--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -2499,11 +2499,17 @@ export const Fwa: Command = {
       const fresh = await scrapeClanPoints(tag);
 
       const siteSync = fresh.winnerBoxSync;
-      const siteUpdatedForOpponent =
-        opponentTag && isPointsSiteUpdatedForOpponent(fresh, opponentTag, null);
+      const siteUpdatedForOpponent = Boolean(
+        opponentTag && isPointsSiteUpdatedForOpponent(fresh, opponentTag, null)
+      );
       let previousSyncSet: number | null = null;
-      if (shouldOverwriteSyncNum && siteSync !== null && Number.isFinite(siteSync)) {
-        const recoveredPrevious = siteUpdatedForOpponent ? siteSync - 1 : siteSync;
+      if (
+        shouldOverwriteSyncNum &&
+        siteUpdatedForOpponent &&
+        siteSync !== null &&
+        Number.isFinite(siteSync)
+      ) {
+        const recoveredPrevious = siteSync - 1;
         if (Number.isFinite(recoveredPrevious) && recoveredPrevious >= 0) {
           previousSyncSet = Math.trunc(recoveredPrevious);
           await settings.set(PREVIOUS_SYNC_KEY, String(previousSyncSet));

--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -31,7 +31,7 @@ const ADMIN_DEFAULT_TARGETS = new Set<string>([
   "kick-list:remove",
   "kick-list:show",
   "kick-list:clear",
-  "post:sync:time",
+  "sync:time:post",
   "notify:war",
   "permission:add",
   "permission:remove",
@@ -257,6 +257,10 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
     ],
   },
 };
+
+export function getHelpDocumentedCommandNames(): string[] {
+  return Object.keys(COMMAND_DOCS).sort((a, b) => a.localeCompare(b));
+}
 
 type RenderState = {
   page: number;

--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -232,15 +232,15 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
       "/kick-list show",
     ],
   },
-  post: {
+  sync: {
     summary: "Post structured messages such as sync time announcements.",
     details: [
-      "`/post sync time` opens a modal to capture date/time/timezone and role ping.",
+      "`/sync time post` opens a modal to capture date/time/timezone and role ping.",
       "Creates and pins a sync-time message in the active channel, then adds clan badge reactions.",
-      "`/post sync status` shows claimed vs unclaimed clans from the stored active sync post, or a provided message ID.",
+      "`/sync post status` shows claimed vs unclaimed clans from the stored active sync post, or a provided message ID.",
       "`sync time` is admin-only by default.",
     ],
-    examples: ["/post sync time role:@War", "/post sync status", "/post sync status message-id:123456789012345678"],
+    examples: ["/sync time post role:@War", "/sync post status", "/sync post status message-id:123456789012345678"],
   },
   permission: {
     summary: "Control which roles can run each command target.",
@@ -250,9 +250,9 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
       "`add` and `remove` are admin-only by default.",
     ],
     examples: [
-      "/permission add command:post role:@Leaders",
+      "/permission add command:sync role:@Leaders",
       "/permission add command:fwa role:@Leaders",
-      "/permission remove command:post role:@Leaders",
+      "/permission remove command:sync role:@Leaders",
       "/permission list",
     ],
   },

--- a/src/commands/Post.ts
+++ b/src/commands/Post.ts
@@ -48,8 +48,11 @@ async function getLeaderRoleIds(settings: SettingsService, guildId: string): Pro
   }
   // Preferred: guild-scoped fwa leader role (new default permission model).
   // Fallback: legacy command role whitelist for backwards compatibility.
-  const syncRoles = parseAllowedRoleIds(await settings.get("command_roles:post:sync:time"));
+  const syncRoles = parseAllowedRoleIds(await settings.get("command_roles:sync:time:post"));
   if (syncRoles.length > 0) return syncRoles;
+  // Backward compatibility for older permission-target key naming.
+  const legacySyncRoles = parseAllowedRoleIds(await settings.get("command_roles:post:sync:time"));
+  if (legacySyncRoles.length > 0) return legacySyncRoles;
   return parseAllowedRoleIds(await settings.get("command_roles:post"));
 }
 

--- a/src/commands/Post.ts
+++ b/src/commands/Post.ts
@@ -50,7 +50,7 @@ async function getLeaderRoleIds(settings: SettingsService, guildId: string): Pro
   // Fallback: command role whitelist for backwards compatibility.
   const syncRoles = parseAllowedRoleIds(await settings.get("command_roles:sync:time:post"));
   if (syncRoles.length > 0) return syncRoles;
-  return parseAllowedRoleIds(await settings.get("command_roles:post"));
+  return parseAllowedRoleIds(await settings.get("command_roles:sync"));
 }
 
 function activeSyncPostKey(guildId: string): string {
@@ -144,7 +144,7 @@ async function handleSyncStatusSubcommand(
     await interaction.editReply(
       explicitMessageId
         ? "Could not find that message ID in this channel."
-        : "Could not find an active sync-time message. Post one with `/post sync time` first."
+        : "Could not find an active sync-time message. Post one with `/sync time post` first."
     );
     return;
   }
@@ -241,8 +241,8 @@ async function handleSyncStatusSubcommand(
     .setFooter({
       text:
         leaderRoleIds.length > 0
-          ? "Leader eligibility: Administrator or role allowed for /post sync time"
-          : "Leader eligibility: Administrator only (no /post sync time role whitelist configured)",
+          ? "Leader eligibility: Administrator or role allowed for /sync time post"
+          : "Leader eligibility: Administrator only (no /sync time post role whitelist configured)",
     });
 
   await interaction.editReply({ embeds: [embed] });
@@ -687,16 +687,16 @@ export async function handlePostModalSubmit(
 }
 
 export const Post: Command = {
-  name: "post",
-  description: "Post formatted messages",
+  name: "sync",
+  description: "Sync posting and status commands",
   options: [
     {
-      name: "sync",
-      description: "Sync related posting commands",
+      name: "time",
+      description: "Sync time related commands",
       type: ApplicationCommandOptionType.SubcommandGroup,
       options: [
         {
-          name: "time",
+          name: "post",
           description: "Post a localized sync time with role ping",
           type: ApplicationCommandOptionType.Subcommand,
           options: [
@@ -708,6 +708,13 @@ export const Post: Command = {
             },
           ],
         },
+      ],
+    },
+    {
+      name: "post",
+      description: "Sync post related commands",
+      type: ApplicationCommandOptionType.SubcommandGroup,
+      options: [
         {
           name: "status",
           description: "Show claimed/unclaimed clan badges for a sync-time post",
@@ -740,7 +747,7 @@ export const Post: Command = {
 
     const subcommandGroup = interaction.options.getSubcommandGroup(false);
     const subcommand = interaction.options.getSubcommand(true);
-    if (subcommandGroup !== "sync") {
+    if (!subcommandGroup) {
       await safeReply(interaction, {
         ephemeral: true,
         content: "Unknown subcommand.",
@@ -748,12 +755,12 @@ export const Post: Command = {
       return;
     }
 
-    if (subcommand === "status") {
+    if (subcommandGroup === "post" && subcommand === "status") {
       await handleSyncStatusSubcommand(interaction);
       return;
     }
 
-    if (subcommand !== "time") {
+    if (!(subcommandGroup === "time" && subcommand === "post")) {
       await safeReply(interaction, {
         ephemeral: true,
         content: "Unknown subcommand.",

--- a/src/commands/Post.ts
+++ b/src/commands/Post.ts
@@ -47,12 +47,9 @@ async function getLeaderRoleIds(settings: SettingsService, guildId: string): Pro
     return [preferredRole.trim()];
   }
   // Preferred: guild-scoped fwa leader role (new default permission model).
-  // Fallback: legacy command role whitelist for backwards compatibility.
+  // Fallback: command role whitelist for backwards compatibility.
   const syncRoles = parseAllowedRoleIds(await settings.get("command_roles:sync:time:post"));
   if (syncRoles.length > 0) return syncRoles;
-  // Backward compatibility for older permission-target key naming.
-  const legacySyncRoles = parseAllowedRoleIds(await settings.get("command_roles:post:sync:time"));
-  if (legacySyncRoles.length > 0) return legacySyncRoles;
   return parseAllowedRoleIds(await settings.get("command_roles:post"));
 }
 

--- a/src/commands/fwa/matchState.ts
+++ b/src/commands/fwa/matchState.ts
@@ -1,0 +1,213 @@
+export type WarStateForSync = "preparation" | "inWar" | "notInWar";
+
+export const MISSED_SYNC_WINDOW_MS = 2 * 60 * 60 * 1000;
+
+type PointsSnapshotLike = {
+  winnerBoxTags: string[];
+  winnerBoxSync: number | null;
+  headerPrimaryTag: string | null;
+  headerOpponentTag: string | null;
+  headerPrimaryBalance: number | null;
+  headerOpponentBalance: number | null;
+};
+
+function normalizeTag(input: string): string {
+  return input.trim().toUpperCase().replace(/^#/, "");
+}
+
+function parseCocApiTime(input: string | null | undefined): number | null {
+  if (!input) return null;
+  const match = input.match(
+    /^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})\.\d{3}Z$/
+  );
+  if (!match) return null;
+  const [, y, m, d, hh, mm, ss] = match;
+  return Date.UTC(Number(y), Number(m) - 1, Number(d), Number(hh), Number(mm), Number(ss));
+}
+
+function getSyncModeFromPrevious(previousSync: number | null): "high" | "low" | null {
+  if (previousSync === null) return null;
+  return (previousSync + 1) % 2 === 0 ? "high" : "low";
+}
+
+export function deriveWarState(rawState: string | null | undefined): WarStateForSync {
+  const state = String(rawState ?? "").toLowerCase();
+  if (state.includes("preparation")) return "preparation";
+  if (state.includes("inwar")) return "inWar";
+  return "notInWar";
+}
+
+export function getCurrentSyncFromPrevious(
+  previousSync: number | null,
+  warState: WarStateForSync
+): number | null {
+  if (previousSync === null) return null;
+  if (warState === "notInWar") return null;
+  return previousSync + 1;
+}
+
+export function getSyncDisplay(
+  previousSync: number | null,
+  warState: WarStateForSync
+): string {
+  if (previousSync === null) return "unknown";
+  const current = previousSync + 1;
+  if (warState === "notInWar") {
+    return `between #${previousSync} and #${current}`;
+  }
+  return `#${current}`;
+}
+
+export function withSyncModeLabel(syncText: string, previousSync: number | null): string {
+  const mode = getSyncModeFromPrevious(previousSync);
+  if (!mode) return syncText;
+  return `${syncText} (${mode === "high" ? "High Sync" : "Low Sync"})`;
+}
+
+export function formatWarStateLabel(warState: WarStateForSync): string {
+  if (warState === "preparation") return "preparation";
+  if (warState === "inWar") return "battle day";
+  return "no war";
+}
+
+export function formatMatchTypeLabel(
+  matchType: "FWA" | "BL" | "MM" | "UNKNOWN",
+  inferred: boolean
+): string {
+  if (!inferred) return matchType;
+  return `${matchType} \u26A0\uFE0F`;
+}
+
+export function isPointsSiteUpdatedForOpponent(
+  primary: PointsSnapshotLike,
+  opponentTag: string,
+  previousSync: number | null
+): boolean {
+  const normalizedOpponent = normalizeTag(opponentTag);
+  const hasOpponent = primary.winnerBoxTags.map((t) => normalizeTag(t)).includes(normalizedOpponent);
+  if (!hasOpponent) return false;
+  if (
+    previousSync !== null &&
+    primary.winnerBoxSync !== null &&
+    Number.isFinite(primary.winnerBoxSync) &&
+    primary.winnerBoxSync <= previousSync
+  ) {
+    return false;
+  }
+  return true;
+}
+
+export function deriveOpponentBalanceFromPrimarySnapshot(
+  primary: PointsSnapshotLike,
+  primaryTag: string,
+  opponentTag: string
+): number | null {
+  const normalizedPrimary = normalizeTag(primaryTag);
+  const normalizedOpponent = normalizeTag(opponentTag);
+  if (
+    primary.headerPrimaryTag === normalizedPrimary &&
+    primary.headerOpponentTag === normalizedOpponent
+  ) {
+    return primary.headerOpponentBalance;
+  }
+  if (
+    primary.headerPrimaryTag === normalizedOpponent &&
+    primary.headerOpponentTag === normalizedPrimary
+  ) {
+    return primary.headerPrimaryBalance;
+  }
+  return null;
+}
+
+export function buildPointsMismatchWarning(
+  label: string,
+  expected: number | null | undefined,
+  actual: number | null | undefined
+): string | null {
+  if (
+    expected === null ||
+    expected === undefined ||
+    actual === null ||
+    actual === undefined ||
+    Number.isNaN(expected) ||
+    Number.isNaN(actual)
+  ) {
+    return null;
+  }
+  if (expected === actual) return null;
+  return `\u26A0\uFE0F ${label} points mismatch: expected ${expected}, site ${actual}.`;
+}
+
+export function buildSyncMismatchWarning(
+  expectedSync: number | null | undefined,
+  siteSync: number | null | undefined
+): string | null {
+  if (
+    expectedSync === null ||
+    expectedSync === undefined ||
+    siteSync === null ||
+    siteSync === undefined ||
+    Number.isNaN(expectedSync) ||
+    Number.isNaN(siteSync)
+  ) {
+    return null;
+  }
+  if (expectedSync === siteSync) return null;
+  return `\u26A0\uFE0F Sync # mismatch: expected #${expectedSync}, site #${siteSync}.`;
+}
+
+export function buildOutcomeMismatchWarning(
+  expectedOutcome: "WIN" | "LOSE" | null | undefined,
+  siteOutcome: "WIN" | "LOSE" | null | undefined
+): string | null {
+  if (!siteOutcome) return null;
+  if (expectedOutcome === siteOutcome) return null;
+  return `\u26A0\uFE0F Outcome mismatch: expected ${expectedOutcome ?? "UNKNOWN"}, site ${siteOutcome}.`;
+}
+
+export function buildPointsSyncStatusLine(siteUpdated: boolean, hasMismatch: boolean): string {
+  if (!siteUpdated) {
+    return ":hourglass_flowing_sand: points.fwafarm is not updated for this matchup yet.";
+  }
+  if (hasMismatch) {
+    return ":broken_chain: out of sync with points site";
+  }
+  return ":white_check_mark: data in sync with points.fwafarm";
+}
+
+export function getWarStateRemaining(
+  war: { startTime?: string | null; endTime?: string | null } | null | undefined,
+  warState: WarStateForSync
+): string {
+  if (warState === "notInWar") return "n/a";
+  const startMs = parseCocApiTime(war?.startTime);
+  const endMs = parseCocApiTime(war?.endTime);
+  const targetMs = warState === "preparation" ? startMs : endMs;
+  if (targetMs === null || !Number.isFinite(targetMs)) return "unknown";
+  return `<t:${Math.floor(targetMs / 1000)}:R>`;
+}
+
+export function isMissedSyncClan(input: {
+  baselineWarStartMs: number | null;
+  clanWarState: WarStateForSync;
+  clanWarStartMs: number | null;
+  nowMs: number;
+}): boolean {
+  const { baselineWarStartMs, clanWarState, clanWarStartMs, nowMs } = input;
+  if (baselineWarStartMs === null || !Number.isFinite(baselineWarStartMs)) return false;
+  const deadlineMs = baselineWarStartMs + MISSED_SYNC_WINDOW_MS;
+  if (clanWarState === "notInWar") {
+    return nowMs >= deadlineMs;
+  }
+  if (clanWarStartMs === null || !Number.isFinite(clanWarStartMs)) return false;
+  return clanWarStartMs > deadlineMs;
+}
+
+export function isMissedSyncClanForTest(input: {
+  baselineWarStartMs: number | null;
+  clanWarState: WarStateForSync;
+  clanWarStartMs: number | null;
+  nowMs: number;
+}): boolean {
+  return isMissedSyncClan(input);
+}

--- a/src/listeners/interactionCreate.ts
+++ b/src/listeners/interactionCreate.ts
@@ -348,13 +348,13 @@ const handleModalSubmit = async (
 
   try {
     const targets = isPostModal
-      ? ["sync:time:post", "post"]
+      ? ["sync:time:post", "sync"]
       : ["recruitment:edit", "recruitment"];
     const allowed = await commandPermissionService.canUseAnyTarget(targets, interaction);
     if (!allowed) {
       await interaction.reply({
         content: isPostModal
-          ? "You do not have permission to use /post."
+          ? "You do not have permission to use /sync."
           : "You do not have permission to use /recruitment.",
         ephemeral: true,
       });

--- a/src/listeners/interactionCreate.ts
+++ b/src/listeners/interactionCreate.ts
@@ -348,7 +348,7 @@ const handleModalSubmit = async (
 
   try {
     const targets = isPostModal
-      ? ["post:sync:time", "post"]
+      ? ["sync:time:post", "post"]
       : ["recruitment:edit", "recruitment"];
     const allowed = await commandPermissionService.canUseAnyTarget(targets, interaction);
     if (!allowed) {

--- a/src/services/ActivityService.ts
+++ b/src/services/ActivityService.ts
@@ -6,6 +6,7 @@ import { ActivitySignalService } from "./ActivitySignalService";
 export class ActivityService {
   private readonly signalService = new ActivitySignalService();
 
+  /** Purpose: initialize service dependencies. */
   constructor(private coc: CoCService) {}
 
   /**

--- a/src/services/ActivitySignalService.ts
+++ b/src/services/ActivitySignalService.ts
@@ -76,10 +76,12 @@ type ProcessedSignals = {
   lastSeenAtMs: number | null;
 };
 
+/** Purpose: signal state key. */
 function signalStateKey(tag: string): string {
   return `player_signal_state:${tag.toUpperCase()}`;
 }
 
+/** Purpose: to finite number. */
 function toFiniteNumber(value: unknown): number {
   const num = Number(value ?? 0);
   if (!Number.isFinite(num)) return 0;
@@ -91,6 +93,7 @@ function normalizeArray<T = unknown>(value: unknown): T[] {
   return value as T[];
 }
 
+/** Purpose: stable hash from array. */
 function stableHashFromArray(items: unknown[]): string {
   const normalized = items
     .map((item) => {
@@ -104,6 +107,7 @@ function stableHashFromArray(items: unknown[]): string {
   return normalized.join("|");
 }
 
+/** Purpose: get default state. */
 function getDefaultState(input: PlayerSignalInput): PlayerSignalState {
   return {
     version: PLAYER_SIGNAL_STATE_VERSION,
@@ -136,6 +140,7 @@ function getDefaultState(input: PlayerSignalInput): PlayerSignalState {
   };
 }
 
+/** Purpose: parse state. */
 function parseState(raw: string | null): PlayerSignalState | null {
   if (!raw) return null;
   try {
@@ -148,6 +153,7 @@ function parseState(raw: string | null): PlayerSignalState | null {
   }
 }
 
+/** Purpose: should count counter change as activity. */
 function shouldCountCounterChangeAsActivity(
   key: CounterKey,
   previous: number,
@@ -166,12 +172,15 @@ function shouldCountCounterChangeAsActivity(
 }
 
 export class ActivitySignalService {
+  /** Purpose: initialize service dependencies. */
   constructor(private readonly settings = new SettingsService()) {}
 
+  /** Purpose: get state. */
   async getState(tag: string): Promise<PlayerSignalState | null> {
     return parseState(await this.settings.get(signalStateKey(tag)));
   }
 
+  /** Purpose: process player. */
   async processPlayer(input: PlayerSignalInput): Promise<ProcessedSignals> {
     const existing = await this.getState(input.tag);
     const nowMs = input.nowMs;
@@ -259,6 +268,7 @@ export class ActivitySignalService {
   }
 }
 
+/** Purpose: signal key label. */
 export function signalKeyLabel(key: SignalKey): string {
   const map: Record<SignalKey, string> = {
     name: "Name Change",

--- a/src/services/ClashKingService.ts
+++ b/src/services/ClashKingService.ts
@@ -2,10 +2,12 @@ import axios from "axios";
 import { recordFetchEvent } from "../helper/fetchTelemetry";
 import { formatError } from "../helper/formatError";
 
+/** Purpose: normalize tag. */
 function normalizeTag(tag: string): string {
   return tag.trim().toUpperCase().replace(/^#/, "");
 }
 
+/** Purpose: get lookup url. */
 function getLookupUrl(tag: string): string | null {
   const template = (process.env.CLASHKING_LINKS_URL_TEMPLATE ?? "").trim();
   if (!template) return null;
@@ -15,27 +17,32 @@ function getLookupUrl(tag: string): string | null {
     : template;
 }
 
+/** Purpose: normalize discord user id. */
 function normalizeDiscordUserId(input: string): string | null {
   const trimmed = String(input ?? "").trim();
   if (!/^\d{15,22}$/.test(trimmed)) return null;
   return trimmed;
 }
 
+/** Purpose: is discord user id input. */
 function isDiscordUserIdInput(input: string): boolean {
   return normalizeDiscordUserId(input) !== null;
 }
 
+/** Purpose: is likely player tag. */
 function isLikelyPlayerTag(input: string): boolean {
   const normalized = normalizeTag(input);
   return /^[0-9A-Z]{4,15}$/.test(normalized);
 }
 
+/** Purpose: as discord user id. */
 function asDiscordUserId(value: unknown): string | null {
   const id = String(value ?? "").trim();
   if (!/^\d{15,22}$/.test(id)) return null;
   return id;
 }
 
+/** Purpose: parse discord links payload. */
 function parseDiscordLinksPayload(raw: string): Map<string, string | null> {
   const result = new Map<string, string | null>();
   const pairRegex = /"([^"]+)"\s*:\s*(null|"(\d{15,22})"|(\d{15,22}))/g;
@@ -53,6 +60,7 @@ function parseDiscordLinksPayload(raw: string): Map<string, string | null> {
   return result;
 }
 
+/** Purpose: extract discord user id. */
 function extractDiscordUserId(data: unknown): string | null {
   if (data === null || data === undefined) return null;
 
@@ -88,6 +96,7 @@ function extractDiscordUserId(data: unknown): string | null {
 }
 
 export class ClashKingService {
+  /** Purpose: lookup links. */
   async lookupLinks(inputs: string[]): Promise<Map<string, string | null>> {
     const cleaned = [...new Set(inputs.map((i) => String(i ?? "").trim()).filter(Boolean))];
     if (cleaned.length === 0) return new Map();
@@ -141,6 +150,7 @@ export class ClashKingService {
     }
   }
 
+  /** Purpose: get linked discord user id. */
   async getLinkedDiscordUserId(playerTag: string): Promise<string | null> {
     const url = getLookupUrl(playerTag);
     if (!url) return null;

--- a/src/services/CoCService.ts
+++ b/src/services/CoCService.ts
@@ -13,6 +13,7 @@ export class CoCService {
   private clansApi: ClansApi;
   private playersApi: PlayersApi;
 
+  /** Purpose: initialize service dependencies. */
   constructor() {
     const token = process.env.COC_API_TOKEN?.trim();
     if (!token) throw new Error("COC_API_TOKEN missing");
@@ -26,6 +27,7 @@ export class CoCService {
     this.playersApi = new PlayersApi(config);
   }
 
+  /** Purpose: get clan. */
   async getClan(tag: string): Promise<any> {
     const clanTag = tag.startsWith("#") ? tag : `#${tag}`;
     try {
@@ -55,11 +57,13 @@ export class CoCService {
     }
   }
 
+  /** Purpose: get clan name. */
   async getClanName(tag: string): Promise<string> {
     const clan = await this.getClan(tag);
     return clan.name ?? "Unknown Clan";
   }
 
+  /** Purpose: get current war. */
   async getCurrentWar(tag: string): Promise<ClanWar | null> {
     const clanTag = tag.startsWith("#") ? tag : `#${tag}`;
     try {
@@ -93,6 +97,7 @@ export class CoCService {
     }
   }
 
+  /** Purpose: get clan war log. */
   async getClanWarLog(tag: string, limit = 10): Promise<ClanWarLogEntry[]> {
     const clanTag = tag.startsWith("#") ? tag : `#${tag}`;
     try {
@@ -160,6 +165,7 @@ export class CoCService {
     }
   }
 
+  /** Purpose: normalize player. */
   private normalizePlayer(player: Player): any {
     return {
       ...player,

--- a/src/services/CommandPermissionService.ts
+++ b/src/services/CommandPermissionService.ts
@@ -89,11 +89,6 @@ const FWA_LEADER_DEFAULT_TARGETS = new Set<string>([
   "inactive",
 ]);
 
-const COMMAND_TARGET_ALIASES: Record<string, string> = {
-  "post:sync:time": "sync:time:post",
-  "post:sync:status": "sync:post:status",
-};
-
 /** Purpose: command roles key. */
 function commandRolesKey(commandName: string): string {
   return `command_roles:${commandName}`;
@@ -194,7 +189,11 @@ export function getCommandTargetsFromInteraction(
   const sub = interaction.options.getSubcommand(false);
 
   const raw: string[] = [];
-  if (group && sub) {
+  if (command === "post" && group === "sync" && sub === "time") {
+    raw.push("sync:time:post");
+  } else if (command === "post" && group === "sync" && sub === "status") {
+    raw.push("sync:post:status");
+  } else if (group && sub) {
     raw.push(`${command}:${group}:${sub}`);
   }
   if (sub) {
@@ -202,9 +201,7 @@ export function getCommandTargetsFromInteraction(
   }
   raw.push(command);
 
-  return raw
-    .map((target) => COMMAND_TARGET_ALIASES[target] ?? target)
-    .filter((target) => isKnownTarget(target));
+  return raw.filter((target) => isKnownTarget(target));
 }
 
 export class CommandPermissionService {

--- a/src/services/CommandPermissionService.ts
+++ b/src/services/CommandPermissionService.ts
@@ -85,14 +85,17 @@ const FWA_LEADER_DEFAULT_TARGETS = new Set<string>([
   "inactive",
 ]);
 
+/** Purpose: command roles key. */
 function commandRolesKey(commandName: string): string {
   return `command_roles:${commandName}`;
 }
 
+/** Purpose: fwa leader role key. */
 function fwaLeaderRoleKey(guildId: string): string {
   return `${FWA_LEADER_ROLE_SETTING_KEY}:${guildId}`;
 }
 
+/** Purpose: parse role ids. */
 function parseRoleIds(input: string | null): string[] {
   if (!input) return [];
   const parts = input
@@ -102,10 +105,12 @@ function parseRoleIds(input: string | null): string[] {
   return [...new Set(parts)];
 }
 
+/** Purpose: stringify role ids. */
 function stringifyRoleIds(roleIds: string[]): string {
   return [...new Set(roleIds)].join(",");
 }
 
+/** Purpose: get interaction role ids. */
 async function getInteractionRoleIds(interaction: GuildInteraction): Promise<string[]> {
   if (!interaction.inGuild()) return [];
 
@@ -127,18 +132,22 @@ async function getInteractionRoleIds(interaction: GuildInteraction): Promise<str
   return [...fetched.roles.cache.keys()];
 }
 
+/** Purpose: is admin default target. */
 function isAdminDefaultTarget(target: string): boolean {
   return ADMIN_DEFAULT_TARGETS.has(target);
 }
 
+/** Purpose: is fwa leader default target. */
 function isFwaLeaderDefaultTarget(target: string): boolean {
   return FWA_LEADER_DEFAULT_TARGETS.has(target);
 }
 
+/** Purpose: is known target. */
 function isKnownTarget(target: string): target is CommandPermissionTarget {
   return (COMMAND_PERMISSION_TARGETS as readonly string[]).includes(target);
 }
 
+/** Purpose: get owner bypass ids. */
 function getOwnerBypassIds(): Set<string> {
   const raw = process.env.OWNER_DISCORD_USER_IDS ?? process.env.OWNER_DISCORD_USER_ID;
   if (!raw) return new Set();
@@ -149,12 +158,14 @@ function getOwnerBypassIds(): Set<string> {
   return new Set(ids);
 }
 
+/** Purpose: has owner bypass. */
 function hasOwnerBypass(interaction: GuildInteraction): boolean {
   const owners = getOwnerBypassIds();
   if (owners.size === 0) return false;
   return owners.has(interaction.user.id);
 }
 
+/** Purpose: get command targets from interaction. */
 export function getCommandTargetsFromInteraction(
   interaction: ChatInputCommandInteraction
 ): string[] {
@@ -175,23 +186,28 @@ export function getCommandTargetsFromInteraction(
 }
 
 export class CommandPermissionService {
+  /** Purpose: initialize service dependencies. */
   constructor(private readonly settings = new SettingsService()) {}
 
+  /** Purpose: get fwa leader role id. */
   async getFwaLeaderRoleId(guildId: string): Promise<string | null> {
     const raw = await this.settings.get(fwaLeaderRoleKey(guildId));
     if (!raw || !/^\d+$/.test(raw.trim())) return null;
     return raw.trim();
   }
 
+  /** Purpose: set fwa leader role id. */
   async setFwaLeaderRoleId(guildId: string, roleId: string): Promise<void> {
     await this.settings.set(fwaLeaderRoleKey(guildId), roleId);
   }
 
+  /** Purpose: get allowed role ids. */
   async getAllowedRoleIds(commandName: string): Promise<string[]> {
     const raw = await this.settings.get(commandRolesKey(commandName));
     return parseRoleIds(raw);
   }
 
+  /** Purpose: set allowed role ids. */
   async setAllowedRoleIds(commandName: string, roleIds: string[]): Promise<void> {
     const serialized = stringifyRoleIds(roleIds);
     if (!serialized) {
@@ -201,6 +217,7 @@ export class CommandPermissionService {
     await this.settings.set(commandRolesKey(commandName), serialized);
   }
 
+  /** Purpose: add allowed role id. */
   async addAllowedRoleId(commandName: string, roleId: string): Promise<string[]> {
     const existing = await this.getAllowedRoleIds(commandName);
     const next = [...new Set([...existing, roleId])];
@@ -208,6 +225,7 @@ export class CommandPermissionService {
     return next;
   }
 
+  /** Purpose: remove allowed role id. */
   async removeAllowedRoleId(commandName: string, roleId: string): Promise<string[]> {
     const existing = await this.getAllowedRoleIds(commandName);
     const next = existing.filter((id) => id !== roleId);
@@ -215,6 +233,7 @@ export class CommandPermissionService {
     return next;
   }
 
+  /** Purpose: clear allowed roles. */
   async clearAllowedRoles(commandName: string): Promise<void> {
     await this.settings.delete(commandRolesKey(commandName));
   }
@@ -293,6 +312,7 @@ export class CommandPermissionService {
     return true;
   }
 
+  /** Purpose: get policy summary. */
   async getPolicySummary(commandName: string, guildId?: string | null): Promise<string> {
     const roles = await this.getAllowedRoleIds(commandName);
     if (roles.length === 0) {

--- a/src/services/CommandPermissionService.ts
+++ b/src/services/CommandPermissionService.ts
@@ -42,7 +42,7 @@ export const COMMAND_PERMISSION_TARGETS = [
   "kick-list:remove",
   "kick-list:show",
   "kick-list:clear",
-  "post",
+  "sync",
   "sync:time:post",
   "sync:post:status",
   `${MANAGE_COMMAND_ROLES_COMMAND}:add`,

--- a/src/services/GoogleSheetsService.ts
+++ b/src/services/GoogleSheetsService.ts
@@ -20,6 +20,7 @@ type AccessTokenCache = {
 export class GoogleSheetsService {
   private static accessTokenCache: AccessTokenCache | null = null;
 
+  /** Purpose: initialize service dependencies. */
   constructor(private settings: SettingsService) {}
 
   async getLinkedSheet(
@@ -68,6 +69,7 @@ export class GoogleSheetsService {
     }
   }
 
+  /** Purpose: clear linked sheet. */
   async clearLinkedSheet(mode?: GoogleSheetMode): Promise<void> {
     if (mode) {
       const modeKeys = this.getModeKeys(mode);
@@ -80,6 +82,7 @@ export class GoogleSheetsService {
     await this.settings.delete(SHEET_SETTING_TAB_KEY);
   }
 
+  /** Purpose: test access. */
   async testAccess(sheetId: string, tabName?: string): Promise<void> {
     const range = tabName?.trim()
       ? `${tabName.trim()}!A1:A1`
@@ -103,6 +106,7 @@ export class GoogleSheetsService {
     return this.readValues(sheetId, effectiveRange);
   }
 
+  /** Purpose: read values. */
   async readValues(sheetId: string, range: string): Promise<string[][]> {
     const token = await this.getAccessToken();
     const encodedRange = encodeURIComponent(range);
@@ -119,6 +123,7 @@ export class GoogleSheetsService {
     return response.data.values ?? [];
   }
 
+  /** Purpose: get access token. */
   private async getAccessToken(): Promise<string> {
     const cache = GoogleSheetsService.accessTokenCache;
     const now = Date.now();
@@ -138,6 +143,7 @@ export class GoogleSheetsService {
     return token;
   }
 
+  /** Purpose: request access token. */
   private async requestAccessToken(): Promise<{
     data: {
       access_token: string;
@@ -187,6 +193,7 @@ export class GoogleSheetsService {
     );
   }
 
+  /** Purpose: build service account assertion. */
   private buildServiceAccountAssertion(): string {
     const { clientEmail, privateKey } = this.readServiceAccountFromEnv();
     const nowSeconds = Math.floor(Date.now() / 1000);
@@ -211,6 +218,7 @@ export class GoogleSheetsService {
     return `${body}.${this.base64url(signature)}`;
   }
 
+  /** Purpose: read service account from env. */
   private readServiceAccountFromEnv(): {
     clientEmail: string;
     privateKey: string;
@@ -252,6 +260,7 @@ export class GoogleSheetsService {
     return { clientEmail, privateKey };
   }
 
+  /** Purpose: base64url. */
   private base64url(input: string | Buffer): string {
     const raw = typeof input === "string" ? Buffer.from(input, "utf8") : input;
     return raw
@@ -261,6 +270,7 @@ export class GoogleSheetsService {
       .replace(/=+$/g, "");
   }
 
+  /** Purpose: get mode keys. */
   private getModeKeys(mode: GoogleSheetMode): { idKey: string; tabKey: string } {
     if (mode === "actual") {
       return {

--- a/src/services/PlayerLinkSyncService.ts
+++ b/src/services/PlayerLinkSyncService.ts
@@ -7,12 +7,14 @@ import { SettingsService } from "./SettingsService";
 const UNRESOLVED_SYNC_INTERVAL_MS = 6 * 60 * 60 * 1000;
 const UNRESOLVED_LAST_SYNC_KEY = "clashking:unresolved_last_sync_ms";
 
+/** Purpose: normalize tag. */
 function normalizeTag(input: string): string {
   const trimmed = String(input ?? "").trim().toUpperCase();
   if (!trimmed) return "";
   return trimmed.startsWith("#") ? trimmed : `#${trimmed}`;
 }
 
+/** Purpose: normalize discord user id. */
 function normalizeDiscordUserId(input: string): string | null {
   const trimmed = String(input ?? "").trim();
   if (!/^\d{15,22}$/.test(trimmed)) return null;
@@ -20,11 +22,13 @@ function normalizeDiscordUserId(input: string): string | null {
 }
 
 export class PlayerLinkSyncService {
+  /** Purpose: initialize service dependencies. */
   constructor(
     private readonly clashKing = new ClashKingService(),
     private readonly settings = new SettingsService()
   ) {}
 
+  /** Purpose: sync by discord user id. */
   async syncByDiscordUserId(discordUserId: string): Promise<number> {
     const normalizedId = normalizeDiscordUserId(discordUserId);
     if (!normalizedId) return 0;
@@ -50,6 +54,7 @@ export class PlayerLinkSyncService {
     return upserted;
   }
 
+  /** Purpose: sync missing tags if due. */
   async syncMissingTagsIfDue(tags: string[]): Promise<void> {
     const normalizedTags = [...new Set(tags.map(normalizeTag).filter(Boolean))];
     if (normalizedTags.length === 0) return;

--- a/src/services/RecruitmentService.ts
+++ b/src/services/RecruitmentService.ts
@@ -30,19 +30,23 @@ const PLATFORM_DURATION_MS: Record<RecruitmentPlatform, number> = {
   reddit: 7 * 24 * 60 * 60 * 1000,
 };
 
+/** Purpose: normalize clan tag. */
 export function normalizeClanTag(input: string): string {
   return input.trim().toUpperCase().replace(/^#/, "");
 }
 
+/** Purpose: format clan tag. */
 export function formatClanTag(tag: string): string {
   const normalized = normalizeClanTag(tag);
   return `#${normalized}`;
 }
 
+/** Purpose: get recruitment cooldown duration ms. */
 export function getRecruitmentCooldownDurationMs(platform: RecruitmentPlatform): number {
   return PLATFORM_DURATION_MS[platform];
 }
 
+/** Purpose: parse recruitment platform. */
 export function parseRecruitmentPlatform(input: string): RecruitmentPlatform | null {
   const value = input.trim().toLowerCase();
   if (value === "discord" || value === "reddit" || value === "band") {
@@ -51,15 +55,18 @@ export function parseRecruitmentPlatform(input: string): RecruitmentPlatform | n
   return null;
 }
 
+/** Purpose: parse image urls csv. */
 export function parseImageUrlsCsv(input: string): string[] {
   if (!input.trim()) return [];
   return [...new Set(input.split(",").map((v) => v.trim()).filter(Boolean))];
 }
 
+/** Purpose: to image urls csv. */
 export function toImageUrlsCsv(imageUrls: string[]): string {
   return imageUrls.join(", ");
 }
 
+/** Purpose: get recruitment template. */
 export async function getRecruitmentTemplate(
   clanTag: string,
   platform: RecruitmentPlatform
@@ -84,6 +91,7 @@ export async function getRecruitmentTemplate(
   return rows[0] ?? null;
 }
 
+/** Purpose: upsert recruitment template. */
 export async function upsertRecruitmentTemplate(input: {
   clanTag: string;
   platform: RecruitmentPlatform;
@@ -108,6 +116,7 @@ export async function upsertRecruitmentTemplate(input: {
   );
 }
 
+/** Purpose: get recruitment cooldown. */
 export async function getRecruitmentCooldown(
   userId: string,
   clanTag: string,
@@ -135,6 +144,7 @@ export async function getRecruitmentCooldown(
   return rows[0] ?? null;
 }
 
+/** Purpose: start or reset recruitment cooldown. */
 export async function startOrResetRecruitmentCooldown(input: {
   userId: string;
   clanTag: string;
@@ -159,6 +169,7 @@ export async function startOrResetRecruitmentCooldown(input: {
   );
 }
 
+/** Purpose: list recruitment cooldowns for user. */
 export async function listRecruitmentCooldownsForUser(
   userId: string
 ): Promise<RecruitmentCooldownRecord[]> {
@@ -179,6 +190,7 @@ export async function listRecruitmentCooldownsForUser(
   );
 }
 
+/** Purpose: list recruitment cooldowns for user by clan tags. */
 export async function listRecruitmentCooldownsForUserByClanTags(
   userId: string,
   clanTags: string[]
@@ -205,6 +217,7 @@ export async function listRecruitmentCooldownsForUserByClanTags(
   );
 }
 
+/** Purpose: get tracked clan name map by tags. */
 export async function getTrackedClanNameMapByTags(
   clanTags: string[]
 ): Promise<Map<string, string>> {
@@ -225,6 +238,7 @@ export async function getTrackedClanNameMapByTags(
   );
 }
 
+/** Purpose: process recruitment cooldown reminders. */
 export async function processRecruitmentCooldownReminders(client: Client): Promise<void> {
   const now = new Date();
   const dueRows = await prisma.$queryRaw<RecruitmentCooldownRecord[]>(

--- a/src/services/SettingsService.ts
+++ b/src/services/SettingsService.ts
@@ -2,6 +2,7 @@ import { prisma } from "../prisma";
 import { Prisma } from "@prisma/client";
 
 export class SettingsService {
+  /** Purpose: get. */
   async get(key: string): Promise<string | null> {
     const rows = await prisma.$queryRaw<Array<{ value: string }>>(
       Prisma.sql`SELECT "value" FROM "BotSetting" WHERE "key" = ${key} LIMIT 1`
@@ -9,6 +10,7 @@ export class SettingsService {
     return rows[0]?.value ?? null;
   }
 
+  /** Purpose: set. */
   async set(key: string, value: string): Promise<void> {
     await prisma.$executeRaw(
       Prisma.sql`
@@ -20,6 +22,7 @@ export class SettingsService {
     );
   }
 
+  /** Purpose: delete. */
   async delete(key: string): Promise<void> {
     await prisma.$executeRaw(
       Prisma.sql`DELETE FROM "BotSetting" WHERE "key" = ${key}`

--- a/src/services/WarEventLogService.ts
+++ b/src/services/WarEventLogService.ts
@@ -13,12 +13,35 @@ import { prisma } from "../prisma";
 import { CoCService } from "./CoCService";
 import { PointsProjectionService } from "./PointsProjectionService";
 import { SettingsService } from "./SettingsService";
+import {
+  type EventType,
+  type FwaLoseStyle,
+  type MatchType,
+  type WarComplianceSnapshot,
+  type WarEndResultSnapshot,
+  type WarState,
+  compareTagsForTiebreak,
+  computeWarComplianceForTest,
+  computeWarPointsDeltaForTest,
+  deriveExpectedOutcome,
+  deriveState,
+  eventTitle,
+  formatList,
+  formatPercent,
+  normalizeOutcome,
+  normalizeTag,
+  normalizeTagBare,
+  parseCocTime,
+  sanitizeClanName,
+  shouldEmit,
+  toDiscordRelativeTime,
+} from "./war-events/core";
+export {
+  computeWarComplianceForTest,
+  computeWarPointsDeltaForTest,
+} from "./war-events/core";
 
-type WarState = "notInWar" | "preparation" | "inWar";
-type EventType = "war_started" | "battle_day" | "war_ended";
-type MatchType = "FWA" | "BL" | "MM" | null;
 type TestSource = "current" | "last";
-type FwaLoseStyle = "TRIPLE_TOP_30" | "TRADITIONAL";
 
 type SubscriptionRow = {
   id: number;
@@ -43,38 +66,6 @@ type SubscriptionRow = {
   clanName: string | null;
 };
 
-type WarEndResultSnapshot = {
-  clanStars: number | null;
-  opponentStars: number | null;
-  clanDestruction: number | null;
-  opponentDestruction: number | null;
-  warEndTime: Date | null;
-  resultLabel: "WIN" | "LOSE" | "TIE" | "UNKNOWN";
-};
-
-type WarComplianceSnapshot = {
-  missedBoth: string[];
-  notFollowingPlan: string[];
-};
-
-type WarComplianceParticipant = {
-  playerName: string | null;
-  playerTag: string;
-  attacksUsed: number | null;
-  playerPosition: number | null;
-};
-
-type WarComplianceAttack = {
-  playerTag: string;
-  playerName: string | null;
-  playerPosition: number | null;
-  defenderPosition: number | null;
-  stars: number | null;
-  trueStars: number | null;
-  attackSeenAt: Date;
-  warEndTime: Date | null;
-  attackOrder: number;
-};
 
 type PollSyncContext = {
   previousSync: number | null;
@@ -115,127 +106,10 @@ type TrackedClanPointsScrape = {
   pointsSiteUpToDate: boolean;
 };
 
-/** Purpose: normalize tag. */
-function normalizeTag(input: string | null | undefined): string {
-  const raw = String(input ?? "").trim().toUpperCase();
-  if (!raw) return "";
-  return raw.startsWith("#") ? raw : `#${raw}`;
-}
-
-/** Purpose: normalize tag bare. */
-function normalizeTagBare(input: string | null | undefined): string {
-  return normalizeTag(input).replace(/^#/, "");
-}
-
-/** Purpose: derive state. */
-function deriveState(rawState: string | null | undefined): WarState {
-  const state = String(rawState ?? "").toLowerCase();
-  if (state.includes("preparation")) return "preparation";
-  if (state.includes("inwar")) return "inWar";
-  return "notInWar";
-}
-
-/** Purpose: event title. */
-function eventTitle(eventType: EventType): string {
-  if (eventType === "war_started") return "War Started";
-  if (eventType === "battle_day") return "Battle Day";
-  return "War Ended";
-}
-
-/** Purpose: should emit. */
-function shouldEmit(prev: WarState, next: WarState): EventType | null {
-  if (prev === "notInWar" && next === "preparation") return "war_started";
-  if ((prev === "preparation" || prev === "notInWar") && next === "inWar") return "battle_day";
-  if ((prev === "inWar" || prev === "preparation") && next === "notInWar") return "war_ended";
-  return null;
-}
-
-/** Purpose: rank char. */
-function rankChar(ch: string): number {
-  const order = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-  const idx = order.indexOf(ch);
-  return idx >= 0 ? idx : Number.MAX_SAFE_INTEGER;
-}
-
-/** Purpose: compare tags for tiebreak. */
-function compareTagsForTiebreak(primaryTag: string, opponentTag: string): number {
-  const a = normalizeTag(primaryTag);
-  const b = normalizeTag(opponentTag);
-  const maxLen = Math.max(a.length, b.length);
-  for (let i = 0; i < maxLen; i += 1) {
-    const ra = rankChar(a[i] ?? "");
-    const rb = rankChar(b[i] ?? "");
-    if (ra === rb) continue;
-    return ra - rb;
-  }
-  return 0;
-}
-
-/** Purpose: derive expected outcome. */
-function deriveExpectedOutcome(
-  clanTag: string,
-  opponentTag: string,
-  clanPoints: number | null,
-  opponentPoints: number | null,
-  syncNumber: number | null
-): "WIN" | "LOSE" | null {
-  if (clanPoints === null || opponentPoints === null) return null;
-  if (clanPoints > opponentPoints) return "WIN";
-  if (clanPoints < opponentPoints) return "LOSE";
-  if (syncNumber === null) return null;
-  const mode = syncNumber % 2 === 0 ? "high" : "low";
-  const cmp = compareTagsForTiebreak(clanTag, opponentTag);
-  if (cmp === 0) return null;
-  const wins = mode === "low" ? cmp < 0 : cmp > 0;
-  return wins ? "WIN" : "LOSE";
-}
-
-/** Purpose: parse coc time. */
-function parseCocTime(input: string | null | undefined): Date | null {
-  if (!input) return null;
-  const m = input.match(/^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})\.\d{3}Z$/);
-  if (!m) return null;
-  const [, y, mo, d, h, mi, s] = m;
-  return new Date(Date.UTC(Number(y), Number(mo) - 1, Number(d), Number(h), Number(mi), Number(s)));
-}
-
-/** Purpose: normalize outcome. */
-function normalizeOutcome(input: string | null | undefined): "WIN" | "LOSE" | null {
-  const normalized = String(input ?? "").trim().toUpperCase();
-  if (normalized === "WIN" || normalized === "LOSE") return normalized;
-  return null;
-}
-
-/** Purpose: sanitize clan name. */
-function sanitizeClanName(input: string | null | undefined): string | null {
-  const value = String(input ?? "").trim();
-  return value ? value : null;
-}
-
-/** Purpose: format percent. */
-function formatPercent(value: number | null): string {
-  if (value === null || !Number.isFinite(value)) return "unknown";
-  return `${value.toFixed(2)}%`;
-}
-
-/** Purpose: format list. */
-function formatList(items: string[]): string {
-  if (items.length === 0) return "None";
-  const capped = items.slice(0, 15);
-  const extra = items.length - capped.length;
-  return extra > 0 ? `${capped.join(", ")} (+${extra} more)` : capped.join(", ");
-}
-
 /** Purpose: format badge emoji inline. */
 function formatBadgeEmojiInline(emoji: { id: string; name: string; animated?: boolean } | null): string {
   if (!emoji) return "Unavailable";
   return emoji.animated ? `<a:${emoji.name}:${emoji.id}>` : `<:${emoji.name}:${emoji.id}>`;
-}
-
-/** Purpose: to discord relative time. */
-function toDiscordRelativeTime(value: Date | null): string {
-  if (!(value instanceof Date) || Number.isNaN(value.getTime())) return "unknown";
-  return `<t:${Math.floor(value.getTime() / 1000)}:R>`;
 }
 
 /** Purpose: parse badge emoji map. */
@@ -257,167 +131,6 @@ function parseBadgeEmojiMap(): Record<string, string> {
   }
 }
 
-/** Purpose: compute war points delta for test. */
-export function computeWarPointsDeltaForTest(input: {
-  matchType: MatchType;
-  before: number | null;
-  after: number | null;
-  finalResult: WarEndResultSnapshot;
-}): number | null {
-  if (input.matchType === "BL") {
-    if (input.finalResult.resultLabel === "WIN") return 3;
-    if ((input.finalResult.clanDestruction ?? 0) >= 60) return 2;
-    return 1;
-  }
-  if (
-    input.before !== null &&
-    Number.isFinite(input.before) &&
-    input.after !== null &&
-    Number.isFinite(input.after)
-  ) {
-    return input.after - input.before;
-  }
-  return null;
-}
-
-/** Purpose: compute war compliance for test. */
-export function computeWarComplianceForTest(input: {
-  clanTag: string;
-  participants: WarComplianceParticipant[];
-  attacks: WarComplianceAttack[];
-  matchType: MatchType;
-  expectedOutcome: "WIN" | "LOSE" | null;
-  loseStyle: FwaLoseStyle;
-}): WarComplianceSnapshot {
-  if (input.matchType === "BL" || input.matchType === "MM") {
-    return { missedBoth: [], notFollowingPlan: [] };
-  }
-
-  const participants = [...input.participants].sort((a, b) => {
-    const posA = a.playerPosition ?? Number.MAX_SAFE_INTEGER;
-    const posB = b.playerPosition ?? Number.MAX_SAFE_INTEGER;
-    if (posA !== posB) return posA - posB;
-    return String(a.playerName ?? "").localeCompare(String(b.playerName ?? ""));
-  });
-  const attacks = [...input.attacks].sort((a, b) => {
-    const t = a.attackSeenAt.getTime() - b.attackSeenAt.getTime();
-    if (t !== 0) return t;
-    const o = (a.attackOrder ?? 0) - (b.attackOrder ?? 0);
-    if (o !== 0) return o;
-    return normalizeTag(a.playerTag).localeCompare(normalizeTag(b.playerTag));
-  });
-
-  const missedBoth = participants
-    .filter((p) => Number(p.attacksUsed ?? 0) <= 0)
-    .map((p) => String(p.playerName ?? p.playerTag).trim())
-    .filter(Boolean);
-
-  const labelForTag = new Map<string, string>();
-  for (const p of participants) {
-    const playerTag = normalizeTag(p.playerTag);
-    const label = String(p.playerName ?? p.playerTag).trim();
-    if (playerTag && label) labelForTag.set(playerTag, label);
-  }
-  const notFollowing = new Set<string>();
-  const addViolation = (playerTagRaw: string | null | undefined, fallbackName: string | null | undefined) => {
-    const playerTag = normalizeTag(playerTagRaw);
-    const label = labelForTag.get(playerTag) ?? String(fallbackName ?? playerTagRaw ?? "").trim();
-    if (label) notFollowing.add(label);
-  };
-
-  if (input.matchType === "FWA" && input.expectedOutcome) {
-    let cumulativeClanStars = 0;
-    const starsBeforeAttack = new Map<number, number>();
-    const starsAfterAttack = new Map<number, number>();
-    for (let i = 0; i < attacks.length; i += 1) {
-      const attack = attacks[i];
-      const before = cumulativeClanStars;
-      const gain = Math.max(0, Number(attack.trueStars ?? 0));
-      cumulativeClanStars += gain;
-      starsBeforeAttack.set(i, before);
-      starsAfterAttack.set(i, cumulativeClanStars);
-    }
-
-    if (input.expectedOutcome === "WIN") {
-      const mirrorTripleByPlayer = new Map<string, boolean>();
-      const strictWindowSeenByPlayer = new Map<string, boolean>();
-      for (let i = 0; i < attacks.length; i += 1) {
-        const attack = attacks[i];
-        const playerTag = normalizeTag(attack.playerTag);
-        const playerPos = attack.playerPosition ?? null;
-        const defenderPos = attack.defenderPosition ?? null;
-        const stars = Number(attack.stars ?? 0);
-        const trueStars = Number(attack.trueStars ?? 0);
-        const hoursRemaining =
-          attack.warEndTime instanceof Date
-            ? (attack.warEndTime.getTime() - attack.attackSeenAt.getTime()) / (60 * 60 * 1000)
-            : null;
-        const isStrictWindow =
-          hoursRemaining !== null &&
-          Number.isFinite(hoursRemaining) &&
-          hoursRemaining > 12 &&
-          (starsBeforeAttack.get(i) ?? 0) < 100;
-        if (isStrictWindow) {
-          strictWindowSeenByPlayer.set(playerTag, true);
-          const isMirror = playerPos !== null && defenderPos !== null && playerPos === defenderPos;
-          if (isMirror && stars >= 3) {
-            mirrorTripleByPlayer.set(playerTag, true);
-          }
-          if (!isMirror) {
-            if (stars === 3 && trueStars > 0) addViolation(attack.playerTag, attack.playerName);
-            if (stars <= 0) addViolation(attack.playerTag, attack.playerName);
-          }
-        }
-      }
-      for (const [playerTag, seenStrict] of strictWindowSeenByPlayer.entries()) {
-        if (!seenStrict) continue;
-        if (!mirrorTripleByPlayer.get(playerTag)) {
-          addViolation(playerTag, labelForTag.get(playerTag) ?? playerTag);
-        }
-      }
-    } else if (input.loseStyle === "TRIPLE_TOP_30") {
-      for (const attack of attacks) {
-        const defenderPos = attack.defenderPosition ?? null;
-        if (defenderPos !== null && defenderPos > 30) {
-          addViolation(attack.playerTag, attack.playerName);
-        }
-      }
-    } else {
-      for (let i = 0; i < attacks.length; i += 1) {
-        const attack = attacks[i];
-        const hoursRemaining =
-          attack.warEndTime instanceof Date
-            ? (attack.warEndTime.getTime() - attack.attackSeenAt.getTime()) / (60 * 60 * 1000)
-            : null;
-        const stars = Number(attack.stars ?? 0);
-        if (hoursRemaining !== null && Number.isFinite(hoursRemaining) && hoursRemaining < 12) {
-          const playerPos = attack.playerPosition ?? null;
-          const defenderPos = attack.defenderPosition ?? null;
-          const isMirror = playerPos !== null && defenderPos !== null && playerPos === defenderPos;
-          const validLate = (isMirror && stars === 2) || (!isMirror && stars === 1);
-          if (!validLate) addViolation(attack.playerTag, attack.playerName);
-          continue;
-        }
-        if (!(stars === 1 || stars === 2)) addViolation(attack.playerTag, attack.playerName);
-        if ((starsAfterAttack.get(i) ?? 0) > 100) addViolation(attack.playerTag, attack.playerName);
-      }
-    }
-  } else {
-    for (const attack of attacks) {
-      const playerPos = attack.playerPosition ?? null;
-      const defenderPos = attack.defenderPosition ?? null;
-      if (playerPos === null || defenderPos === null) continue;
-      if (playerPos !== defenderPos) {
-        addViolation(attack.playerTag, attack.playerName);
-      }
-    }
-  }
-
-  return {
-    missedBoth,
-    notFollowingPlan: [...notFollowing].sort((a, b) => a.localeCompare(b)),
-  };
-}
 
 export class WarEventLogService {
   private readonly points: PointsProjectionService;

--- a/src/services/WarEventLogService.ts
+++ b/src/services/WarEventLogService.ts
@@ -551,7 +551,13 @@ export class WarEventLogService {
         });
         embed.addFields({
           name: "War Plan",
-          value: (await this.history.buildWarPlanText(payload.matchType, payload.outcome, payload.clanTag)) ?? "N/A",
+          value:
+            (await this.history.buildWarPlanText(
+              payload.matchType,
+              payload.outcome,
+              payload.clanTag,
+              payload.opponentName
+            )) ?? "N/A",
           inline: false,
         });
       }
@@ -559,7 +565,14 @@ export class WarEventLogService {
         embed.addFields({
           name: "Message",
           value:
-            "Battle day has started! Thank you for your help swapping to war bases, please swap back to FWA bases asap!",
+            "**Battle day has started! Thank you for your help swapping to war bases, please swap back to FWA bases asap!**",
+          inline: false,
+        });
+      }
+      if (payload.matchType === "MM") {
+        embed.addFields({
+          name: "Message",
+          value: "Attack whatever you want! Free for all! ⚔️",
           inline: false,
         });
       }
@@ -584,7 +597,37 @@ export class WarEventLogService {
         });
         embed.addFields({
           name: "War Plan",
-          value: (await this.history.buildWarPlanText(payload.matchType, payload.outcome, payload.clanTag)) ?? "N/A",
+          value:
+            (await this.history.buildWarPlanText(
+              payload.matchType,
+              payload.outcome,
+              payload.clanTag,
+              payload.opponentName
+            )) ?? "N/A",
+          inline: false,
+        });
+      }
+      if (payload.matchType === "BL") {
+        embed.addFields({
+          name: "Message",
+          value: [
+            `⚫️ BLACKLIST WAR 🆚 ${payload.opponentName} 🏴‍☠️`,
+            "Everyone switch to WAR BASES!!",
+            "This is our opportunity to gain some extra FWA points!",
+            "➕ 30+ people switch to war base = +1 point",
+            "➕ 60% total destruction = +1 point",
+            "➕ win war = +1 point",
+          ].join("\n"),
+          inline: false,
+        });
+      }
+      if (payload.matchType === "MM") {
+        embed.addFields({
+          name: "Message",
+          value: [
+            `⚪️ MISMATCHED WAR 🆚 ${payload.opponentName} :sob:`,
+            "Keep WA base active, attack what you can!",
+          ].join("\n"),
           inline: false,
         });
       }

--- a/src/services/WarEventLogService.ts
+++ b/src/services/WarEventLogService.ts
@@ -611,12 +611,14 @@ export class WarEventLogService {
         embed.addFields({
           name: "Message",
           value: [
-            `⚫️ BLACKLIST WAR 🆚 ${payload.opponentName} 🏴‍☠️`,
+            `**⚫️ BLACKLIST WAR 🆚 ${payload.opponentName} 🏴‍☠️**`,
             "Everyone switch to WAR BASES!!",
             "This is our opportunity to gain some extra FWA points!",
             "➕ 30+ people switch to war base = +1 point",
             "➕ 60% total destruction = +1 point",
             "➕ win war = +1 point",
+            "---",
+            "If you need war base, check https://clashofclans-layouts.com/ or ⁠bases",
           ].join("\n"),
           inline: false,
         });

--- a/src/services/WarEventLogService.ts
+++ b/src/services/WarEventLogService.ts
@@ -26,6 +26,7 @@ type SubscriptionRow = {
   clanTag: string;
   channelId: string;
   notify: boolean;
+  pingRole: boolean;
   inferredMatchType: boolean;
   notifyRole: string | null;
   fwaPoints: number | null;
@@ -726,7 +727,7 @@ export class WarEventLogService {
     const subs = await prisma.$queryRaw<SubscriptionRow[]>(
       Prisma.sql`
         SELECT
-          "id","guildId","clanTag","channelId","notify","inferredMatchType","notifyRole","fwaPoints","opponentFwaPoints","outcome","matchType","warStartFwaPoints","warEndFwaPoints","lastClanStars","lastOpponentStars","lastState","lastWarStartTime","lastOpponentTag","lastOpponentName","clanName"
+          "id","guildId","clanTag","channelId","notify","pingRole","inferredMatchType","notifyRole","fwaPoints","opponentFwaPoints","outcome","matchType","warStartFwaPoints","warEndFwaPoints","lastClanStars","lastOpponentStars","lastState","lastWarStartTime","lastOpponentTag","lastOpponentName","clanName"
         FROM "WarEventLogSubscription"
         WHERE "notify" = true
         ORDER BY "updatedAt" ASC
@@ -835,6 +836,7 @@ export class WarEventLogService {
       opponentName,
       syncNumber,
       notifyRole: sub.notifyRole,
+      pingRole: sub.pingRole,
       fwaPoints,
       opponentFwaPoints,
       outcome,
@@ -870,7 +872,7 @@ export class WarEventLogService {
     const rows = await prisma.$queryRaw<SubscriptionRow[]>(
       Prisma.sql`
         SELECT
-          "id","guildId","clanTag","channelId","notify","inferredMatchType","notifyRole","fwaPoints","opponentFwaPoints","outcome","matchType","warStartFwaPoints","warEndFwaPoints","lastClanStars","lastOpponentStars","lastState","lastWarStartTime","lastOpponentTag","lastOpponentName","clanName"
+          "id","guildId","clanTag","channelId","notify","pingRole","inferredMatchType","notifyRole","fwaPoints","opponentFwaPoints","outcome","matchType","warStartFwaPoints","warEndFwaPoints","lastClanStars","lastOpponentStars","lastState","lastWarStartTime","lastOpponentTag","lastOpponentName","clanName"
         FROM "WarEventLogSubscription"
         WHERE "guildId" = ${guildId} AND UPPER(REPLACE("clanTag",'#','')) = ${normalizeTagBare(clanTag)}
         LIMIT 1
@@ -903,7 +905,7 @@ export class WarEventLogService {
     const rows = await prisma.$queryRaw<SubscriptionRow[]>(
       Prisma.sql`
         SELECT
-          "id","guildId","clanTag","channelId","notify","inferredMatchType","notifyRole","fwaPoints","opponentFwaPoints","outcome","matchType","warStartFwaPoints","warEndFwaPoints","lastClanStars","lastOpponentStars","lastState","lastWarStartTime","lastOpponentTag","lastOpponentName","clanName"
+          "id","guildId","clanTag","channelId","notify","pingRole","inferredMatchType","notifyRole","fwaPoints","opponentFwaPoints","outcome","matchType","warStartFwaPoints","warEndFwaPoints","lastClanStars","lastOpponentStars","lastState","lastWarStartTime","lastOpponentTag","lastOpponentName","clanName"
         FROM "WarEventLogSubscription"
         WHERE "id" = ${subscriptionId}
         LIMIT 1
@@ -1051,6 +1053,7 @@ export class WarEventLogService {
         opponentName: nextOpponentName || sub.lastOpponentName || "Unknown",
         syncNumber: syncNumberForEvent,
         notifyRole: sub.notifyRole,
+        pingRole: sub.pingRole,
         fwaPoints: nextFwaPoints,
         opponentFwaPoints: nextOpponentFwaPoints,
         outcome: normalizeOutcome(nextOutcome),
@@ -1105,6 +1108,7 @@ export class WarEventLogService {
       opponentName: string;
       syncNumber: number | null;
       notifyRole: string | null;
+      pingRole: boolean;
       fwaPoints: number | null;
       opponentFwaPoints: number | null;
       outcome: "WIN" | "LOSE" | null;
@@ -1250,7 +1254,8 @@ export class WarEventLogService {
       });
     }
 
-    const roleMention = payload.notifyRole ? `<@&${payload.notifyRole}>` : null;
+    const roleMention =
+      payload.pingRole && payload.notifyRole ? `<@&${payload.notifyRole}>` : null;
     await channel.send({
       content: roleMention ?? undefined,
       embeds: [embed],

--- a/src/services/WarEventLogService.ts
+++ b/src/services/WarEventLogService.ts
@@ -2,27 +2,20 @@ import {
   ChannelType,
   Client,
   EmbedBuilder,
-  GuildBasedChannel,
-  PublicThreadChannel,
-  PrivateThreadChannel,
 } from "discord.js";
 import { Prisma } from "@prisma/client";
 import { formatError } from "../helper/formatError";
-import { findSyncBadgeEmojiForClan } from "../helper/syncBadgeEmoji";
 import { prisma } from "../prisma";
 import { CoCService } from "./CoCService";
 import { PointsProjectionService } from "./PointsProjectionService";
 import { SettingsService } from "./SettingsService";
+import { WarEventHistoryService } from "./war-events/history";
+import { WarStartPointsSyncService } from "./war-events/pointsSync";
 import {
   type EventType,
-  type FwaLoseStyle,
   type MatchType,
-  type WarComplianceSnapshot,
   type WarEndResultSnapshot,
   type WarState,
-  compareTagsForTiebreak,
-  computeWarComplianceForTest,
-  computeWarPointsDeltaForTest,
   deriveExpectedOutcome,
   deriveState,
   eventTitle,
@@ -32,7 +25,6 @@ import {
   normalizeTag,
   normalizeTagBare,
   parseCocTime,
-  sanitizeClanName,
   shouldEmit,
   toDiscordRelativeTime,
 } from "./war-events/core";
@@ -72,366 +64,24 @@ type PollSyncContext = {
   activeSync: number | null;
 };
 
-type WarStartPointsCheckJob = {
-  clanTag: string;
-  opponentTag: string;
-  attempts: number;
-  maxAttempts: number;
-  nextAttemptAtMs: number;
-  completed: boolean;
-  status: "pending" | "in_sync" | "out_of_sync" | "max_attempts" | "error";
-  trackedPointBalanceSite: number | null;
-  trackedPointBalanceDb: number | null;
-  siteSyncNumber: number | null;
-  siteOpponentTag: string | null;
-  siteOpponentBalance: number | null;
-  inferredOpponentIsFwa: boolean | null;
-  opponentChecked: boolean;
-  lastCheckedAtMs: number | null;
-};
-
-type TrackedClanPointsScrape = {
-  version: number;
-  source: "points.fwafarm";
-  fetchedAtMs: number;
-  trackedClanName: string | null;
-  trackedClanTag: string;
-  opponentClanName: string | null;
-  opponentClanTag: string | null;
-  pointBalance: number | null;
-  opponentPointBalance: number | null;
-  activeFwa: boolean;
-  syncNumber: number | null;
-  matchup: string;
-  pointsSiteUpToDate: boolean;
-};
-
-/** Purpose: format badge emoji inline. */
-function formatBadgeEmojiInline(emoji: { id: string; name: string; animated?: boolean } | null): string {
-  if (!emoji) return "Unavailable";
-  return emoji.animated ? `<a:${emoji.name}:${emoji.id}>` : `<:${emoji.name}:${emoji.id}>`;
-}
-
-/** Purpose: parse badge emoji map. */
-function parseBadgeEmojiMap(): Record<string, string> {
-  const raw = (process.env.WAR_EVENT_BADGE_EMOJI_BY_TAG ?? "").trim();
-  if (!raw) return {};
-  try {
-    const parsed = JSON.parse(raw) as Record<string, string>;
-    const out: Record<string, string> = {};
-    for (const [key, value] of Object.entries(parsed)) {
-      const tag = normalizeTag(key);
-      const emoji = String(value ?? "").trim();
-      if (!tag || !emoji) continue;
-      out[tag] = emoji;
-    }
-    return out;
-  } catch {
-    return {};
-  }
-}
-
 
 export class WarEventLogService {
   private readonly points: PointsProjectionService;
   private readonly settings: SettingsService;
-  private readonly badgeEmojiByTag: Record<string, string>;
-  private static readonly PREVIOUS_SYNC_KEY = "previousSyncNum";
-  private static readonly WAR_START_POINTS_JOB_PREFIX = "warStartPointsCheck";
-  private static readonly WAR_START_POINTS_RECHECK_MS = 30 * 60 * 1000;
-  private static readonly WAR_START_POINTS_MAX_ATTEMPTS = 10;
+  private readonly pointsSync: WarStartPointsSyncService;
+  private readonly history: WarEventHistoryService;
 
   /** Purpose: initialize service dependencies. */
   constructor(private readonly client: Client, private readonly coc: CoCService) {
     this.points = new PointsProjectionService(coc);
     this.settings = new SettingsService();
-    this.badgeEmojiByTag = parseBadgeEmojiMap();
-  }
-
-  /** Purpose: recover previous sync num from points. */
-  private async recoverPreviousSyncNumFromPoints(): Promise<number | null> {
-    const tracked = await prisma.trackedClan.findMany({
-      orderBy: { createdAt: "asc" },
-      select: { tag: true },
-    });
-    for (const clan of tracked) {
-      const tag = normalizeTag(clan.tag);
-      const war = await this.coc.getCurrentWar(tag).catch(() => null);
-      const opponentTag = normalizeTag(war?.opponent?.tag ?? "");
-      if (!opponentTag) continue;
-
-      const snapshot = await this.points.fetchSnapshot(tag).catch(() => null);
-      if (!snapshot || snapshot.winnerBoxSync === null) continue;
-
-      const siteUpdated = snapshot.winnerBoxTags
-        .map((t) => normalizeTag(t))
-        .includes(opponentTag);
-      const recoveredPrevious = siteUpdated
-        ? snapshot.winnerBoxSync - 1
-        : snapshot.winnerBoxSync;
-      if (!Number.isFinite(recoveredPrevious) || recoveredPrevious < 0) continue;
-
-      const next = Math.trunc(recoveredPrevious);
-      await this.settings.set(WarEventLogService.PREVIOUS_SYNC_KEY, String(next));
-      return next;
-    }
-    return null;
-  }
-
-  /** Purpose: get previous sync num. */
-  private async getPreviousSyncNum(): Promise<number | null> {
-    const raw = await this.settings.get(WarEventLogService.PREVIOUS_SYNC_KEY);
-    const parsed = raw === null ? NaN : Number(raw);
-    if (Number.isFinite(parsed)) return Math.trunc(parsed);
-    return this.recoverPreviousSyncNumFromPoints();
-  }
-
-  /** Purpose: build war start points job key. */
-  private buildWarStartPointsJobKey(clanTag: string): string {
-    return `${WarEventLogService.WAR_START_POINTS_JOB_PREFIX}:${normalizeTagBare(clanTag)}`;
-  }
-
-  /** Purpose: get war start points job. */
-  private async getWarStartPointsJob(clanTag: string): Promise<WarStartPointsCheckJob | null> {
-    const raw = await this.settings.get(this.buildWarStartPointsJobKey(clanTag));
-    if (!raw) return null;
-    try {
-      const parsed = JSON.parse(raw) as WarStartPointsCheckJob;
-      if (!parsed || typeof parsed !== "object") return null;
-      return parsed;
-    } catch {
-      return null;
-    }
-  }
-
-  /** Purpose: set war start points job. */
-  private async setWarStartPointsJob(job: WarStartPointsCheckJob): Promise<void> {
-    await this.settings.set(this.buildWarStartPointsJobKey(job.clanTag), JSON.stringify(job));
-  }
-
-  private buildPointsSiteMatchupSummary(input: {
-    trackedClanName: string | null;
-    trackedClanTag: string;
-    opponentClanName: string | null;
-    opponentClanTag: string | null;
-    trackedPoints: number | null;
-    opponentPoints: number | null;
-    syncNumber: number | null;
-    activeFwa: boolean;
-  }): string {
-    if (!input.activeFwa) return "Not marked as an FWA match.";
-    const primaryName = input.trackedClanName ?? normalizeTagBare(input.trackedClanTag);
-    const opponentName = input.opponentClanName ?? normalizeTagBare(input.opponentClanTag ?? "");
-    const x = input.trackedPoints;
-    const y = input.opponentPoints;
-    if (
-      x === null ||
-      y === null ||
-      !Number.isFinite(x) ||
-      !Number.isFinite(y)
-    ) {
-      return "Not marked as an FWA match.";
-    }
-    if (x > y) return `${primaryName} should win by points (${x} > ${y})`;
-    if (x < y) return `${opponentName} should win by points (${x} < ${y})`;
-    if (input.syncNumber === null || !Number.isFinite(input.syncNumber)) {
-      return "Not marked as an FWA match.";
-    }
-    const mode = input.syncNumber % 2 === 0 ? "high sync" : "low sync";
-    const cmp = compareTagsForTiebreak(input.trackedClanTag, input.opponentClanTag ?? "");
-    if (cmp === 0) return "Not marked as an FWA match.";
-    const winner = mode === "low sync" ? (cmp < 0 ? primaryName : opponentName) : cmp > 0 ? primaryName : opponentName;
-    return `${winner} should win by tiebreak (${x} = ${y}, ${mode})`;
-  }
-
-  private async persistTrackedClanPointsScrape(input: {
-    trackedClanTag: string;
-    trackedClanName: string | null;
-    opponentClanTag: string | null;
-    opponentClanName: string | null;
-    trackedPoints: number | null;
-    opponentPoints: number | null;
-    syncNumber: number | null;
-    pointsSiteUpToDate: boolean;
-    activeFwa: boolean;
-  }): Promise<void> {
-    const blob: TrackedClanPointsScrape = {
-      version: 1,
-      source: "points.fwafarm",
-      fetchedAtMs: Date.now(),
-      trackedClanName: input.trackedClanName?.trim() || null,
-      trackedClanTag: normalizeTag(input.trackedClanTag),
-      opponentClanName: input.opponentClanName?.trim() || null,
-      opponentClanTag: normalizeTag(input.opponentClanTag ?? "") || null,
-      pointBalance:
-        input.trackedPoints !== null && Number.isFinite(input.trackedPoints)
-          ? input.trackedPoints
-          : null,
-      opponentPointBalance:
-        input.opponentPoints !== null && Number.isFinite(input.opponentPoints)
-          ? input.opponentPoints
-          : null,
-      activeFwa: Boolean(input.activeFwa),
-      syncNumber:
-        input.syncNumber !== null && Number.isFinite(input.syncNumber)
-          ? Math.trunc(input.syncNumber)
-          : null,
-      matchup: this.buildPointsSiteMatchupSummary({
-        trackedClanName: input.trackedClanName,
-        trackedClanTag: input.trackedClanTag,
-        opponentClanName: input.opponentClanName,
-        opponentClanTag: input.opponentClanTag,
-        trackedPoints: input.trackedPoints,
-        opponentPoints: input.opponentPoints,
-        syncNumber: input.syncNumber,
-        activeFwa: input.activeFwa,
-      }),
-      pointsSiteUpToDate: input.pointsSiteUpToDate,
-    };
-
-    await prisma.trackedClan.updateMany({
-      where: { tag: { equals: blob.trackedClanTag, mode: "insensitive" } },
-      data: { pointsScrape: blob },
-    });
-  }
-
-  private async resetWarStartPointsJob(
-    clanTag: string,
-    opponentTag: string
-  ): Promise<WarStartPointsCheckJob> {
-    const now = Date.now();
-    const next: WarStartPointsCheckJob = {
-      clanTag: normalizeTag(clanTag),
-      opponentTag: normalizeTag(opponentTag),
-      attempts: 0,
-      maxAttempts: WarEventLogService.WAR_START_POINTS_MAX_ATTEMPTS,
-      nextAttemptAtMs: now,
-      completed: false,
-      status: "pending",
-      trackedPointBalanceSite: null,
-      trackedPointBalanceDb: null,
-      siteSyncNumber: null,
-      siteOpponentTag: null,
-      siteOpponentBalance: null,
-      inferredOpponentIsFwa: null,
-      opponentChecked: false,
-      lastCheckedAtMs: null,
-    };
-    await this.setWarStartPointsJob(next);
-    return next;
-  }
-
-  private async maybeRunWarStartPointsCheck(
-    sub: SubscriptionRow,
-    opponentTagInput: string,
-    clanNameInput: string | null,
-    opponentNameInput: string | null
-  ): Promise<void> {
-    const clanTag = normalizeTag(sub.clanTag);
-    const opponentTag = normalizeTag(opponentTagInput);
-    if (!clanTag || !opponentTag) return;
-
-    let job = await this.getWarStartPointsJob(clanTag);
-    if (!job || normalizeTag(job.opponentTag) !== opponentTag) {
-      job = await this.resetWarStartPointsJob(clanTag, opponentTag);
-    }
-    if (job.completed) return;
-    if (Date.now() < job.nextAttemptAtMs) return;
-
-    const nextAttempt = job.attempts + 1;
-    try {
-      const primary = await this.points.fetchSnapshot(clanTag);
-      const siteUpdated = primary.winnerBoxTags.map((t) => normalizeTag(t)).includes(opponentTag);
-      const trackedDb = sub.fwaPoints ?? null;
-      const trackedSite =
-        primary.balance !== null && Number.isFinite(primary.balance) ? primary.balance : null;
-
-      let inferredOpponentIsFwa = job.inferredOpponentIsFwa;
-      let opponentChecked = job.opponentChecked;
-      let opponentBalance = job.siteOpponentBalance;
-      if (!opponentChecked) {
-        const opp = await this.points.fetchSnapshot(opponentTag).catch(() => null);
-        opponentChecked = true;
-        inferredOpponentIsFwa =
-          opp?.balance !== null && opp?.balance !== undefined && Number.isFinite(opp.balance);
-        opponentBalance =
-          opp?.balance !== null && opp?.balance !== undefined && Number.isFinite(opp.balance)
-            ? opp.balance
-            : null;
-      }
-
-      const mismatch =
-        siteUpdated &&
-        trackedDb !== null &&
-        trackedSite !== null &&
-        Number.isFinite(trackedDb) &&
-        Number.isFinite(trackedSite) &&
-        trackedDb !== trackedSite;
-
-      const exhausted = !siteUpdated && nextAttempt >= job.maxAttempts;
-      const completed = siteUpdated || exhausted;
-      const status: WarStartPointsCheckJob["status"] = siteUpdated
-        ? mismatch
-          ? "out_of_sync"
-          : "in_sync"
-        : exhausted
-          ? "max_attempts"
-          : "pending";
-
-      await this.setWarStartPointsJob({
-        ...job,
-        attempts: nextAttempt,
-        nextAttemptAtMs: completed
-          ? Date.now()
-          : Date.now() + WarEventLogService.WAR_START_POINTS_RECHECK_MS,
-        completed,
-        status,
-        trackedPointBalanceSite: trackedSite,
-        trackedPointBalanceDb: trackedDb,
-        siteSyncNumber:
-          primary.winnerBoxSync !== null && Number.isFinite(primary.winnerBoxSync)
-            ? Math.trunc(primary.winnerBoxSync)
-            : null,
-        siteOpponentTag: siteUpdated ? opponentTag : null,
-        siteOpponentBalance: opponentBalance,
-        inferredOpponentIsFwa,
-        opponentChecked,
-        lastCheckedAtMs: Date.now(),
-      });
-      if (siteUpdated) {
-        await this.persistTrackedClanPointsScrape({
-          trackedClanTag: clanTag,
-          trackedClanName: sanitizeClanName(clanNameInput) ?? sanitizeClanName(primary.clanName),
-          opponentClanTag: opponentTag,
-          opponentClanName: sanitizeClanName(opponentNameInput),
-          trackedPoints: trackedSite,
-          opponentPoints: opponentBalance,
-          syncNumber:
-            primary.winnerBoxSync !== null && Number.isFinite(primary.winnerBoxSync)
-              ? Math.trunc(primary.winnerBoxSync)
-              : null,
-          pointsSiteUpToDate: true,
-          activeFwa: true,
-        });
-      }
-    } catch {
-      const exhausted = nextAttempt >= job.maxAttempts;
-      await this.setWarStartPointsJob({
-        ...job,
-        attempts: nextAttempt,
-        completed: exhausted,
-        status: exhausted ? "max_attempts" : "error",
-        nextAttemptAtMs: exhausted
-          ? Date.now()
-          : Date.now() + WarEventLogService.WAR_START_POINTS_RECHECK_MS,
-        lastCheckedAtMs: Date.now(),
-      });
-    }
+    this.pointsSync = new WarStartPointsSyncService(coc, this.points, this.settings);
+    this.history = new WarEventHistoryService(coc);
   }
 
   /** Purpose: poll. */
   async poll(): Promise<void> {
-    const previousSync = await this.getPreviousSyncNum();
+    const previousSync = await this.pointsSync.getPreviousSyncNum();
     const syncContext: PollSyncContext = {
       previousSync,
       activeSync: previousSync === null ? null : previousSync + 1,
@@ -459,7 +109,7 @@ export class WarEventLogService {
     }
     if (sawWarEnded && syncContext.activeSync !== null) {
       await this.settings.set(
-        WarEventLogService.PREVIOUS_SYNC_KEY,
+        WarStartPointsSyncService.PREVIOUS_SYNC_KEY,
         String(syncContext.activeSync)
       );
     }
@@ -475,7 +125,7 @@ export class WarEventLogService {
     if (!sub) return { ok: false, reason: "No war event subscription found for that guild+clan." };
     if (!sub.channelId) return { ok: false, reason: "Subscription has no configured channel." };
 
-    const previousSync = await this.getPreviousSyncNum();
+    const previousSync = await this.pointsSync.getPreviousSyncNum();
     const activeSync = previousSync === null ? null : previousSync + 1;
     const syncNumber = params.source === "last" ? previousSync : activeSync;
 
@@ -657,10 +307,10 @@ export class WarEventLogService {
           ? syncContext.previousSync
           : syncContext.activeSync;
     if (eventType === "war_started" && nextOpponentTag) {
-      await this.resetWarStartPointsJob(sub.clanTag, nextOpponentTag).catch(() => null);
+      await this.pointsSync.resetWarStartPointsJob(sub.clanTag, nextOpponentTag).catch(() => null);
     }
     if (currentState !== "notInWar" && nextOpponentTag) {
-      await this.maybeRunWarStartPointsCheck(
+      await this.pointsSync.maybeRunWarStartPointsCheck(
         sub,
         nextOpponentTag,
         nextClanName,
@@ -734,7 +384,7 @@ export class WarEventLogService {
     }
 
     if (eventType === "war_ended" && nextMatchType === "BL") {
-      const finalResult = await this.getWarEndResultSnapshot({
+      const finalResult = await this.history.getWarEndResultSnapshot({
         clanTag: sub.clanTag,
         opponentTag: nextOpponentTag || normalizeTag(sub.lastOpponentTag ?? ""),
         fallbackClanStars: nextClanStars,
@@ -776,7 +426,7 @@ export class WarEventLogService {
       } as const;
 
       if (eventType === "war_ended") {
-        await this.persistWarEndHistory(eventPayload).catch((err) => {
+        await this.history.persistWarEndHistory(eventPayload).catch((err) => {
           console.error(
             `[war-events] persist war history failed guild=${sub.guildId} clan=${sub.clanTag} error=${formatError(err)}`
           );
@@ -881,7 +531,7 @@ export class WarEventLogService {
         });
         embed.addFields({
           name: "War Plan",
-          value: (await this.buildWarPlanText(payload.matchType, payload.outcome, payload.clanTag)) ?? "N/A",
+          value: (await this.history.buildWarPlanText(payload.matchType, payload.outcome, payload.clanTag)) ?? "N/A",
           inline: false,
         });
       }
@@ -914,21 +564,21 @@ export class WarEventLogService {
         });
         embed.addFields({
           name: "War Plan",
-          value: (await this.buildWarPlanText(payload.matchType, payload.outcome, payload.clanTag)) ?? "N/A",
+          value: (await this.history.buildWarPlanText(payload.matchType, payload.outcome, payload.clanTag)) ?? "N/A",
           inline: false,
         });
       }
     }
 
     if (payload.eventType === "war_ended") {
-      const finalResult = await this.getWarEndResultSnapshot({
+      const finalResult = await this.history.getWarEndResultSnapshot({
         clanTag: payload.clanTag,
         opponentTag: payload.opponentTag,
         fallbackClanStars: payload.lastClanStars,
         fallbackOpponentStars: payload.lastOpponentStars,
         warStartTime: payload.warStartTime,
       });
-      const compliance = await this.getWarComplianceSnapshot(
+      const compliance = await this.history.getWarComplianceSnapshot(
         payload.clanTag,
         payload.warStartTime,
         payload.matchType,
@@ -945,7 +595,7 @@ export class WarEventLogService {
       });
       embed.addFields({
         name: "FWA Points",
-        value: this.buildWarEndPointsLine(payload, finalResult),
+        value: this.history.buildWarEndPointsLine(payload, finalResult),
         inline: false,
       });
       embed.addFields({
@@ -975,359 +625,4 @@ export class WarEventLogService {
     });
   }
 
-  private resolveTrackedClanBadgeEmoji(
-    channel: GuildBasedChannel | PublicThreadChannel<boolean> | PrivateThreadChannel,
-    clanTag: string,
-    clanName: string
-  ): string {
-    const mapped = this.badgeEmojiByTag[normalizeTag(clanTag)];
-    if (mapped) return mapped;
-
-    const fromSyncBadgeMap = findSyncBadgeEmojiForClan(this.client.user?.id, clanName);
-    if (fromSyncBadgeMap) {
-      return formatBadgeEmojiInline({
-        id: fromSyncBadgeMap.id,
-        name: fromSyncBadgeMap.name,
-      });
-    }
-
-    const guild = "guild" in channel ? channel.guild : null;
-    if (!guild) return "Unavailable";
-    const emojis = [...guild.emojis.cache.values()];
-    if (emojis.length === 0) return "Unavailable";
-
-    const normalizedName = clanName.toLowerCase().replace(/[^a-z0-9]+/g, "");
-    const initials = clanName
-      .split(/[^a-zA-Z0-9]+/)
-      .filter(Boolean)
-      .map((w) => w[0]?.toLowerCase() ?? "")
-      .join("");
-    const candidates = new Set<string>([
-      normalizeTagBare(clanTag).toLowerCase(),
-      normalizedName,
-      initials,
-    ]);
-
-    for (const emoji of emojis) {
-      const rawName = String(emoji.name ?? "").trim();
-      if (!rawName) continue;
-      const name = rawName.toLowerCase();
-      if ([...candidates].some((candidate) => candidate && (name === candidate || name.includes(candidate)))) {
-        return formatBadgeEmojiInline({
-          id: emoji.id,
-          name: rawName,
-          animated: emoji.animated === true,
-        });
-      }
-    }
-    return "Unavailable";
-  }
-
-  private buildWarEndPointsLine(
-    payload: {
-      clanName: string;
-      matchType: MatchType;
-      warStartFwaPoints: number | null;
-      warEndFwaPoints: number | null;
-    },
-    finalResult: WarEndResultSnapshot
-  ): string {
-    const before = payload.warStartFwaPoints;
-    const delta = this.computeWarPointsDelta({
-      matchType: payload.matchType,
-      before,
-      after: payload.warEndFwaPoints,
-      finalResult,
-    });
-
-    if (payload.matchType === "BL") {
-      const afterFromRow = payload.warEndFwaPoints;
-      const after =
-        afterFromRow !== null && Number.isFinite(afterFromRow)
-          ? afterFromRow
-          : before !== null && Number.isFinite(before) && delta !== null
-            ? before + delta
-            : null;
-      const resolvedBefore =
-        before !== null && Number.isFinite(before)
-          ? before
-          : after !== null && Number.isFinite(after) && delta !== null
-            ? after - delta
-            : null;
-      return `${payload.clanName}: ${resolvedBefore ?? "unknown"} -> ${after ?? "unknown"} (${delta !== null && delta >= 0 ? `+${delta}` : String(delta ?? "unknown")}) [BL]`;
-    }
-
-    const after = payload.warEndFwaPoints;
-    if (
-      before !== null &&
-      Number.isFinite(before) &&
-      after !== null &&
-      Number.isFinite(after)
-    ) {
-      return `${payload.clanName}: ${before} -> ${after} (${delta !== null && delta >= 0 ? `+${delta}` : String(delta ?? after - before)})`;
-    }
-    return `${payload.clanName}: ${before ?? "unknown"} -> ${after ?? "unknown"}`;
-  }
-
-  private computeWarPointsDelta(input: {
-    matchType: MatchType;
-    before: number | null;
-    after: number | null;
-    finalResult: WarEndResultSnapshot;
-  }): number | null {
-    return computeWarPointsDeltaForTest(input);
-  }
-
-  private async buildWarPlanText(
-    matchType: MatchType,
-    expectedOutcome: "WIN" | "LOSE" | null,
-    clanTag: string
-  ): Promise<string | null> {
-    if (matchType !== "FWA") return null;
-    if (expectedOutcome === "WIN") {
-      return [
-        "Win plan: if clan stars are under 100 and time remaining is over 12h,",
-        "one attack must be a 3-star on mirror. Other attack can be 3-star on already-tripled base,",
-        "or 2-star/1-star any base. Outside that window, free hit plan applies.",
-      ].join(" ");
-    }
-    if (expectedOutcome === "LOSE") {
-      const loseStyle = await this.getLoseStyleForClan(normalizeTag(clanTag));
-      if (loseStyle === "TRIPLE_TOP_30") {
-        return "Lose plan (Triple Top 30): hit only top 30 bases with both attacks; do not hit bottom 20.";
-      }
-      return [
-        "Lose plan (Traditional): when under 12h remaining, do mirror 2-star plus non-mirror 1-star.",
-        "Before that, do 1-star/2-star hits while keeping clan stars at or under 100.",
-      ].join(" ");
-    }
-    return "FWA plan unavailable (expected outcome unknown).";
-  }
-
-  /** Purpose: get lose style for clan. */
-  private async getLoseStyleForClan(clanTagInput: string): Promise<FwaLoseStyle> {
-    const clanTag = normalizeTag(clanTagInput);
-    if (!clanTag) return "TRIPLE_TOP_30";
-    const row = await prisma.trackedClan.findUnique({
-      where: { tag: clanTag },
-      select: { loseStyle: true },
-    });
-    const loseStyle = String(row?.loseStyle ?? "").toUpperCase();
-    if (loseStyle === "TRADITIONAL" || loseStyle === "TRIPLE_TOP_30") {
-      return loseStyle;
-    }
-    return "TRIPLE_TOP_30";
-  }
-
-  private async persistWarEndHistory(payload: {
-    eventType: EventType;
-    clanTag: string;
-    clanName: string;
-    opponentTag: string;
-    opponentName: string;
-    syncNumber: number | null;
-    notifyRole: string | null;
-    fwaPoints: number | null;
-    opponentFwaPoints: number | null;
-    outcome: "WIN" | "LOSE" | null;
-    matchType: MatchType;
-    warStartFwaPoints: number | null;
-    warEndFwaPoints: number | null;
-    lastClanStars: number | null;
-    lastOpponentStars: number | null;
-    warStartTime: Date | null;
-  }): Promise<void> {
-    if (payload.eventType !== "war_ended") return;
-
-    const clanTag = normalizeTag(payload.clanTag);
-    const warStartTime =
-      payload.warStartTime ??
-      (
-        await prisma.warHistoryParticipant.findFirst({
-          where: { clanTag, warEndTime: { not: null } },
-          orderBy: { warStartTime: "desc" },
-          select: { warStartTime: true },
-        })
-      )?.warStartTime ??
-      null;
-    if (!warStartTime) return;
-
-    const finalResult = await this.getWarEndResultSnapshot({
-      clanTag: payload.clanTag,
-      opponentTag: payload.opponentTag,
-      fallbackClanStars: payload.lastClanStars,
-      fallbackOpponentStars: payload.lastOpponentStars,
-      warStartTime,
-    });
-    const attacks = await prisma.warHistoryAttack.findMany({
-      where: { clanTag, warStartTime },
-      orderBy: [{ attackSeenAt: "asc" }, { attackOrder: "asc" }, { playerTag: "asc" }],
-    });
-    const warEndTime =
-      finalResult.warEndTime ??
-      (await prisma.warHistoryParticipant.findFirst({
-        where: { clanTag, warStartTime },
-        orderBy: { updatedAt: "desc" },
-        select: { warEndTime: true },
-      }))?.warEndTime ??
-      null;
-
-    const pointsDelta = this.computeWarPointsDelta({
-      matchType: payload.matchType,
-      before: payload.warStartFwaPoints,
-      after: payload.warEndFwaPoints,
-      finalResult,
-    });
-    const enemyPoints =
-      payload.matchType === "FWA" &&
-      payload.opponentFwaPoints !== null &&
-      Number.isFinite(payload.opponentFwaPoints)
-        ? payload.opponentFwaPoints
-        : null;
-
-    const row = await prisma.$queryRaw<Array<{ warId: number }>>(
-      Prisma.sql`
-        INSERT INTO "WarClanHistory"
-          ("syncNumber","matchType","clanStars","clanDestruction","opponentStars","opponentDestruction","fwaPointsGained","expectedOutcome","actualOutcome","enemyPoints","warStartTime","warEndTime","clanName","clanTag","opponentName","opponentTag","updatedAt")
-        VALUES
-          (${payload.syncNumber}, ${payload.matchType}, ${finalResult.clanStars}, ${finalResult.clanDestruction}, ${finalResult.opponentStars}, ${finalResult.opponentDestruction}, ${pointsDelta}, ${payload.outcome}, ${finalResult.resultLabel}, ${enemyPoints}, ${warStartTime}, ${warEndTime}, ${payload.clanName}, ${clanTag}, ${payload.opponentName}, ${normalizeTag(payload.opponentTag) || null}, NOW())
-        ON CONFLICT ("clanTag","warStartTime")
-        DO UPDATE SET
-          "syncNumber" = EXCLUDED."syncNumber",
-          "matchType" = EXCLUDED."matchType",
-          "clanStars" = EXCLUDED."clanStars",
-          "clanDestruction" = EXCLUDED."clanDestruction",
-          "opponentStars" = EXCLUDED."opponentStars",
-          "opponentDestruction" = EXCLUDED."opponentDestruction",
-          "fwaPointsGained" = EXCLUDED."fwaPointsGained",
-          "expectedOutcome" = EXCLUDED."expectedOutcome",
-          "actualOutcome" = EXCLUDED."actualOutcome",
-          "enemyPoints" = EXCLUDED."enemyPoints",
-          "warEndTime" = EXCLUDED."warEndTime",
-          "clanName" = EXCLUDED."clanName",
-          "opponentName" = EXCLUDED."opponentName",
-          "opponentTag" = EXCLUDED."opponentTag",
-          "updatedAt" = NOW()
-        RETURNING "warId"
-      `
-    );
-    const warId = Number(row[0]?.warId ?? NaN);
-    if (!Number.isFinite(warId)) return;
-
-    await prisma.$executeRaw(
-      Prisma.sql`
-        INSERT INTO "WarLookup" ("warId","payload","updatedAt")
-        VALUES (${warId}, ${JSON.stringify(attacks)}::jsonb, NOW())
-        ON CONFLICT ("warId")
-        DO UPDATE SET
-          "payload" = EXCLUDED."payload",
-          "updatedAt" = NOW()
-      `
-    );
-  }
-
-  private async getWarEndResultSnapshot(input: {
-    clanTag: string;
-    opponentTag: string;
-    fallbackClanStars: number | null;
-    fallbackOpponentStars: number | null;
-    warStartTime: Date | null;
-  }): Promise<WarEndResultSnapshot> {
-    const log = await this.coc.getClanWarLog(input.clanTag, 10);
-    const normalizedOpponentTag = normalizeTag(input.opponentTag);
-
-    const matched =
-      log.find((entry) => normalizeTag(entry.opponent?.tag ?? "") === normalizedOpponentTag) ??
-      log[0] ??
-      null;
-
-    const clanStars =
-      Number.isFinite(Number(matched?.clan?.stars))
-        ? Number(matched?.clan?.stars)
-        : input.fallbackClanStars;
-    const opponentStars =
-      Number.isFinite(Number(matched?.opponent?.stars))
-        ? Number(matched?.opponent?.stars)
-        : input.fallbackOpponentStars;
-    const clanDestruction = Number.isFinite(Number(matched?.clan?.destructionPercentage))
-      ? Number(matched?.clan?.destructionPercentage)
-      : null;
-    const opponentDestruction = Number.isFinite(Number(matched?.opponent?.destructionPercentage))
-      ? Number(matched?.opponent?.destructionPercentage)
-      : null;
-    const warEndTime = parseCocTime(matched?.endTime ?? null);
-
-    let resultLabel: "WIN" | "LOSE" | "TIE" | "UNKNOWN" = "UNKNOWN";
-    if (clanStars !== null && opponentStars !== null) {
-      resultLabel = clanStars > opponentStars ? "WIN" : clanStars < opponentStars ? "LOSE" : "TIE";
-    } else if (matched?.result) {
-      const result = String(matched.result).toLowerCase();
-      if (result.includes("win")) resultLabel = "WIN";
-      else if (result.includes("lose")) resultLabel = "LOSE";
-      else if (result.includes("tie")) resultLabel = "TIE";
-    }
-
-    return {
-      clanStars,
-      opponentStars,
-      clanDestruction,
-      opponentDestruction,
-      warEndTime,
-      resultLabel,
-    };
-  }
-
-  private async getWarComplianceSnapshot(
-    clanTagInput: string,
-    preferredWarStartTime: Date | null,
-    matchType: MatchType,
-    expectedOutcome: "WIN" | "LOSE" | null
-  ): Promise<WarComplianceSnapshot> {
-    if (matchType === "BL" || matchType === "MM") {
-      return { missedBoth: [], notFollowingPlan: [] };
-    }
-    const clanTag = normalizeTag(clanTagInput);
-    const warStartTime = preferredWarStartTime
-      ? preferredWarStartTime
-      : (
-          await prisma.warHistoryParticipant.findFirst({
-            where: { clanTag, warEndTime: { not: null } },
-            orderBy: { warStartTime: "desc" },
-            select: { warStartTime: true },
-          })
-        )?.warStartTime ?? null;
-    if (!warStartTime) {
-      return { missedBoth: [], notFollowingPlan: [] };
-    }
-
-    const participants = await prisma.warHistoryParticipant.findMany({
-      where: { clanTag, warStartTime },
-      select: { playerName: true, playerTag: true, attacksUsed: true, playerPosition: true },
-      orderBy: [{ playerPosition: "asc" }, { playerName: "asc" }],
-    });
-    const attacks = await prisma.warHistoryAttack.findMany({
-      where: { clanTag, warStartTime },
-      select: {
-        playerTag: true,
-        playerName: true,
-        playerPosition: true,
-        defenderPosition: true,
-        stars: true,
-        trueStars: true,
-        attackSeenAt: true,
-        warEndTime: true,
-        attackOrder: true,
-      },
-      orderBy: [{ attackSeenAt: "asc" }, { attackOrder: "asc" }, { playerTag: "asc" }],
-    });
-    const loseStyle = await this.getLoseStyleForClan(clanTag);
-    return computeWarComplianceForTest({
-      clanTag,
-      participants,
-      attacks,
-      matchType,
-      expectedOutcome,
-      loseStyle,
-    });
-  }
 }

--- a/src/services/WarHistoryService.ts
+++ b/src/services/WarHistoryService.ts
@@ -3,12 +3,14 @@ import { formatError } from "../helper/formatError";
 import { prisma } from "../prisma";
 import { CoCService } from "./CoCService";
 
+/** Purpose: normalize tag. */
 function normalizeTag(input: string | null | undefined): string {
   const raw = String(input ?? "").trim().toUpperCase();
   if (!raw) return "";
   return raw.startsWith("#") ? raw : `#${raw}`;
 }
 
+/** Purpose: parse coc time. */
 function parseCocTime(input: string | null | undefined): Date | null {
   if (!input) return null;
   const m = input.match(/^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})\.\d{3}Z$/);
@@ -30,8 +32,10 @@ type WarMember = {
 };
 
 export class WarHistoryService {
+  /** Purpose: initialize service dependencies. */
   constructor(private readonly coc: CoCService) {}
 
+  /** Purpose: observe clan war. */
   async observeClanWar(clanTagInput: string): Promise<void> {
     const clanTag = normalizeTag(clanTagInput);
     if (!clanTag) return;

--- a/src/services/war-events/core.ts
+++ b/src/services/war-events/core.ts
@@ -1,0 +1,319 @@
+/** Purpose: shared core types and pure helper logic for war event processing. */
+
+export type WarState = "notInWar" | "preparation" | "inWar";
+export type EventType = "war_started" | "battle_day" | "war_ended";
+export type MatchType = "FWA" | "BL" | "MM" | null;
+export type FwaLoseStyle = "TRIPLE_TOP_30" | "TRADITIONAL";
+
+export type WarEndResultSnapshot = {
+  clanStars: number | null;
+  opponentStars: number | null;
+  clanDestruction: number | null;
+  opponentDestruction: number | null;
+  warEndTime: Date | null;
+  resultLabel: "WIN" | "LOSE" | "TIE" | "UNKNOWN";
+};
+
+export type WarComplianceSnapshot = {
+  missedBoth: string[];
+  notFollowingPlan: string[];
+};
+
+export type WarComplianceParticipant = {
+  playerName: string | null;
+  playerTag: string;
+  attacksUsed: number | null;
+  playerPosition: number | null;
+};
+
+export type WarComplianceAttack = {
+  playerTag: string;
+  playerName: string | null;
+  playerPosition: number | null;
+  defenderPosition: number | null;
+  stars: number | null;
+  trueStars: number | null;
+  attackSeenAt: Date;
+  warEndTime: Date | null;
+  attackOrder: number;
+};
+
+/** Purpose: normalize a clan/player tag to uppercase with leading '#'. */
+export function normalizeTag(input: string | null | undefined): string {
+  const raw = String(input ?? "").trim().toUpperCase();
+  if (!raw) return "";
+  return raw.startsWith("#") ? raw : `#${raw}`;
+}
+
+/** Purpose: normalize a clan/player tag to uppercase without leading '#'. */
+export function normalizeTagBare(input: string | null | undefined): string {
+  return normalizeTag(input).replace(/^#/, "");
+}
+
+/** Purpose: map CoC war state text to internal state enum. */
+export function deriveState(rawState: string | null | undefined): WarState {
+  const state = String(rawState ?? "").toLowerCase();
+  if (state.includes("preparation")) return "preparation";
+  if (state.includes("inwar")) return "inWar";
+  return "notInWar";
+}
+
+/** Purpose: map event type to user-facing event title. */
+export function eventTitle(eventType: EventType): string {
+  if (eventType === "war_started") return "War Started";
+  if (eventType === "battle_day") return "Battle Day";
+  return "War Ended";
+}
+
+/** Purpose: decide which event should fire for a state transition. */
+export function shouldEmit(prev: WarState, next: WarState): EventType | null {
+  if (prev === "notInWar" && next === "preparation") return "war_started";
+  if ((prev === "preparation" || prev === "notInWar") && next === "inWar") return "battle_day";
+  if ((prev === "inWar" || prev === "preparation") && next === "notInWar") return "war_ended";
+  return null;
+}
+
+/** Purpose: compute sortable rank for a single clan-tag character in tiebreak order. */
+export function rankChar(ch: string): number {
+  const order = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+  const idx = order.indexOf(ch);
+  return idx >= 0 ? idx : Number.MAX_SAFE_INTEGER;
+}
+
+/** Purpose: compare clan tags according to FWA tiebreak ordering. */
+export function compareTagsForTiebreak(primaryTag: string, opponentTag: string): number {
+  const a = normalizeTag(primaryTag);
+  const b = normalizeTag(opponentTag);
+  const maxLen = Math.max(a.length, b.length);
+  for (let i = 0; i < maxLen; i += 1) {
+    const ra = rankChar(a[i] ?? "");
+    const rb = rankChar(b[i] ?? "");
+    if (ra === rb) continue;
+    return ra - rb;
+  }
+  return 0;
+}
+
+/** Purpose: derive expected WIN/LOSE outcome from points and sync tiebreak rules. */
+export function deriveExpectedOutcome(
+  clanTag: string,
+  opponentTag: string,
+  clanPoints: number | null,
+  opponentPoints: number | null,
+  syncNumber: number | null
+): "WIN" | "LOSE" | null {
+  if (clanPoints === null || opponentPoints === null) return null;
+  if (clanPoints > opponentPoints) return "WIN";
+  if (clanPoints < opponentPoints) return "LOSE";
+  if (syncNumber === null) return null;
+  const mode = syncNumber % 2 === 0 ? "high" : "low";
+  const cmp = compareTagsForTiebreak(clanTag, opponentTag);
+  if (cmp === 0) return null;
+  const wins = mode === "low" ? cmp < 0 : cmp > 0;
+  return wins ? "WIN" : "LOSE";
+}
+
+/** Purpose: parse CoC API timestamp string to Date. */
+export function parseCocTime(input: string | null | undefined): Date | null {
+  if (!input) return null;
+  const m = input.match(/^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})\.\d{3}Z$/);
+  if (!m) return null;
+  const [, y, mo, d, h, mi, s] = m;
+  return new Date(Date.UTC(Number(y), Number(mo) - 1, Number(d), Number(h), Number(mi), Number(s)));
+}
+
+/** Purpose: normalize expected outcome string to WIN/LOSE/null. */
+export function normalizeOutcome(input: string | null | undefined): "WIN" | "LOSE" | null {
+  const normalized = String(input ?? "").trim().toUpperCase();
+  if (normalized === "WIN" || normalized === "LOSE") return normalized;
+  return null;
+}
+
+/** Purpose: trim/normalize clan display name values. */
+export function sanitizeClanName(input: string | null | undefined): string | null {
+  const value = String(input ?? "").trim();
+  return value ? value : null;
+}
+
+/** Purpose: format war destruction percentage for embeds. */
+export function formatPercent(value: number | null): string {
+  if (value === null || !Number.isFinite(value)) return "unknown";
+  return `${value.toFixed(2)}%`;
+}
+
+/** Purpose: format a member list for compact embed output. */
+export function formatList(items: string[]): string {
+  if (items.length === 0) return "None";
+  const capped = items.slice(0, 15);
+  const extra = items.length - capped.length;
+  return extra > 0 ? `${capped.join(", ")} (+${extra} more)` : capped.join(", ");
+}
+
+/** Purpose: format a Date as Discord relative-time token. */
+export function toDiscordRelativeTime(value: Date | null): string {
+  if (!(value instanceof Date) || Number.isNaN(value.getTime())) return "unknown";
+  return `<t:${Math.floor(value.getTime() / 1000)}:R>`;
+}
+
+/** Purpose: compute war-end points delta according to match type rules. */
+export function computeWarPointsDeltaForTest(input: {
+  matchType: MatchType;
+  before: number | null;
+  after: number | null;
+  finalResult: WarEndResultSnapshot;
+}): number | null {
+  if (input.matchType === "BL") {
+    if (input.finalResult.resultLabel === "WIN") return 3;
+    if ((input.finalResult.clanDestruction ?? 0) >= 60) return 2;
+    return 1;
+  }
+  if (
+    input.before !== null &&
+    Number.isFinite(input.before) &&
+    input.after !== null &&
+    Number.isFinite(input.after)
+  ) {
+    return input.after - input.before;
+  }
+  return null;
+}
+
+/** Purpose: compute missed/violating members for war-plan compliance checks. */
+export function computeWarComplianceForTest(input: {
+  clanTag: string;
+  participants: WarComplianceParticipant[];
+  attacks: WarComplianceAttack[];
+  matchType: MatchType;
+  expectedOutcome: "WIN" | "LOSE" | null;
+  loseStyle: FwaLoseStyle;
+}): WarComplianceSnapshot {
+  if (input.matchType === "BL" || input.matchType === "MM") {
+    return { missedBoth: [], notFollowingPlan: [] };
+  }
+
+  const participants = [...input.participants].sort((a, b) => {
+    const posA = a.playerPosition ?? Number.MAX_SAFE_INTEGER;
+    const posB = b.playerPosition ?? Number.MAX_SAFE_INTEGER;
+    if (posA !== posB) return posA - posB;
+    return String(a.playerName ?? "").localeCompare(String(b.playerName ?? ""));
+  });
+  const attacks = [...input.attacks].sort((a, b) => {
+    const t = a.attackSeenAt.getTime() - b.attackSeenAt.getTime();
+    if (t !== 0) return t;
+    const o = (a.attackOrder ?? 0) - (b.attackOrder ?? 0);
+    if (o !== 0) return o;
+    return normalizeTag(a.playerTag).localeCompare(normalizeTag(b.playerTag));
+  });
+
+  const missedBoth = participants
+    .filter((p) => Number(p.attacksUsed ?? 0) <= 0)
+    .map((p) => String(p.playerName ?? p.playerTag).trim())
+    .filter(Boolean);
+
+  const labelForTag = new Map<string, string>();
+  for (const p of participants) {
+    const playerTag = normalizeTag(p.playerTag);
+    const label = String(p.playerName ?? p.playerTag).trim();
+    if (playerTag && label) labelForTag.set(playerTag, label);
+  }
+  const notFollowing = new Set<string>();
+  const addViolation = (playerTagRaw: string | null | undefined, fallbackName: string | null | undefined) => {
+    const playerTag = normalizeTag(playerTagRaw);
+    const label = labelForTag.get(playerTag) ?? String(fallbackName ?? playerTagRaw ?? "").trim();
+    if (label) notFollowing.add(label);
+  };
+
+  if (input.matchType === "FWA" && input.expectedOutcome) {
+    let cumulativeClanStars = 0;
+    const starsBeforeAttack = new Map<number, number>();
+    const starsAfterAttack = new Map<number, number>();
+    for (let i = 0; i < attacks.length; i += 1) {
+      const attack = attacks[i];
+      const before = cumulativeClanStars;
+      const gain = Math.max(0, Number(attack.trueStars ?? 0));
+      cumulativeClanStars += gain;
+      starsBeforeAttack.set(i, before);
+      starsAfterAttack.set(i, cumulativeClanStars);
+    }
+
+    if (input.expectedOutcome === "WIN") {
+      const mirrorTripleByPlayer = new Map<string, boolean>();
+      const strictWindowSeenByPlayer = new Map<string, boolean>();
+      for (let i = 0; i < attacks.length; i += 1) {
+        const attack = attacks[i];
+        const playerTag = normalizeTag(attack.playerTag);
+        const playerPos = attack.playerPosition ?? null;
+        const defenderPos = attack.defenderPosition ?? null;
+        const stars = Number(attack.stars ?? 0);
+        const trueStars = Number(attack.trueStars ?? 0);
+        const hoursRemaining =
+          attack.warEndTime instanceof Date
+            ? (attack.warEndTime.getTime() - attack.attackSeenAt.getTime()) / (60 * 60 * 1000)
+            : null;
+        const isStrictWindow =
+          hoursRemaining !== null &&
+          Number.isFinite(hoursRemaining) &&
+          hoursRemaining > 12 &&
+          (starsBeforeAttack.get(i) ?? 0) < 100;
+        if (isStrictWindow) {
+          strictWindowSeenByPlayer.set(playerTag, true);
+          const isMirror = playerPos !== null && defenderPos !== null && playerPos === defenderPos;
+          if (isMirror && stars >= 3) {
+            mirrorTripleByPlayer.set(playerTag, true);
+          }
+          if (!isMirror) {
+            if (stars === 3 && trueStars > 0) addViolation(attack.playerTag, attack.playerName);
+            if (stars <= 0) addViolation(attack.playerTag, attack.playerName);
+          }
+        }
+      }
+      for (const [playerTag, seenStrict] of strictWindowSeenByPlayer.entries()) {
+        if (!seenStrict) continue;
+        if (!mirrorTripleByPlayer.get(playerTag)) {
+          addViolation(playerTag, labelForTag.get(playerTag) ?? playerTag);
+        }
+      }
+    } else if (input.loseStyle === "TRIPLE_TOP_30") {
+      for (const attack of attacks) {
+        const defenderPos = attack.defenderPosition ?? null;
+        if (defenderPos !== null && defenderPos > 30) {
+          addViolation(attack.playerTag, attack.playerName);
+        }
+      }
+    } else {
+      for (let i = 0; i < attacks.length; i += 1) {
+        const attack = attacks[i];
+        const hoursRemaining =
+          attack.warEndTime instanceof Date
+            ? (attack.warEndTime.getTime() - attack.attackSeenAt.getTime()) / (60 * 60 * 1000)
+            : null;
+        const stars = Number(attack.stars ?? 0);
+        if (hoursRemaining !== null && Number.isFinite(hoursRemaining) && hoursRemaining < 12) {
+          const playerPos = attack.playerPosition ?? null;
+          const defenderPos = attack.defenderPosition ?? null;
+          const isMirror = playerPos !== null && defenderPos !== null && playerPos === defenderPos;
+          const validLate = (isMirror && stars === 2) || (!isMirror && stars === 1);
+          if (!validLate) addViolation(attack.playerTag, attack.playerName);
+          continue;
+        }
+        if (!(stars === 1 || stars === 2)) addViolation(attack.playerTag, attack.playerName);
+        if ((starsAfterAttack.get(i) ?? 0) > 100) addViolation(attack.playerTag, attack.playerName);
+      }
+    }
+  } else {
+    for (const attack of attacks) {
+      const playerPos = attack.playerPosition ?? null;
+      const defenderPos = attack.defenderPosition ?? null;
+      if (playerPos === null || defenderPos === null) continue;
+      if (playerPos !== defenderPos) {
+        addViolation(attack.playerTag, attack.playerName);
+      }
+    }
+  }
+
+  return {
+    missedBoth,
+    notFollowingPlan: [...notFollowing].sort((a, b) => a.localeCompare(b)),
+  };
+}
+

--- a/src/services/war-events/history.ts
+++ b/src/services/war-events/history.ts
@@ -1,0 +1,335 @@
+import { Prisma } from "@prisma/client";
+import { prisma } from "../../prisma";
+import { CoCService } from "../CoCService";
+import {
+  type EventType,
+  type FwaLoseStyle,
+  type MatchType,
+  type WarComplianceSnapshot,
+  type WarEndResultSnapshot,
+  computeWarComplianceForTest,
+  computeWarPointsDeltaForTest,
+  normalizeTag,
+  parseCocTime,
+} from "./core";
+
+/** Purpose: encapsulate war-end history, compliance, and war-plan related logic. */
+export class WarEventHistoryService {
+  /** Purpose: initialize war history service dependencies. */
+  constructor(private readonly coc: CoCService) {}
+
+  /** Purpose: build the war-end points line text shown in event embeds. */
+  buildWarEndPointsLine(
+    payload: {
+      clanName: string;
+      matchType: MatchType;
+      warStartFwaPoints: number | null;
+      warEndFwaPoints: number | null;
+    },
+    finalResult: WarEndResultSnapshot
+  ): string {
+    const before = payload.warStartFwaPoints;
+    const delta = this.computeWarPointsDelta({
+      matchType: payload.matchType,
+      before,
+      after: payload.warEndFwaPoints,
+      finalResult,
+    });
+
+    if (payload.matchType === "BL") {
+      const afterFromRow = payload.warEndFwaPoints;
+      const after =
+        afterFromRow !== null && Number.isFinite(afterFromRow)
+          ? afterFromRow
+          : before !== null && Number.isFinite(before) && delta !== null
+            ? before + delta
+            : null;
+      const resolvedBefore =
+        before !== null && Number.isFinite(before)
+          ? before
+          : after !== null && Number.isFinite(after) && delta !== null
+            ? after - delta
+            : null;
+      return `${payload.clanName}: ${resolvedBefore ?? "unknown"} -> ${after ?? "unknown"} (${delta !== null && delta >= 0 ? `+${delta}` : String(delta ?? "unknown")}) [BL]`;
+    }
+
+    const after = payload.warEndFwaPoints;
+    if (
+      before !== null &&
+      Number.isFinite(before) &&
+      after !== null &&
+      Number.isFinite(after)
+    ) {
+      return `${payload.clanName}: ${before} -> ${after} (${delta !== null && delta >= 0 ? `+${delta}` : String(delta ?? after - before)})`;
+    }
+    return `${payload.clanName}: ${before ?? "unknown"} -> ${after ?? "unknown"}`;
+  }
+
+  /** Purpose: build per-clan war-plan instruction text for start/battle embeds. */
+  async buildWarPlanText(
+    matchType: MatchType,
+    expectedOutcome: "WIN" | "LOSE" | null,
+    clanTag: string
+  ): Promise<string | null> {
+    if (matchType !== "FWA") return null;
+    if (expectedOutcome === "WIN") {
+      return [
+        "Win plan: if clan stars are under 100 and time remaining is over 12h,",
+        "one attack must be a 3-star on mirror. Other attack can be 3-star on already-tripled base,",
+        "or 2-star/1-star any base. Outside that window, free hit plan applies.",
+      ].join(" ");
+    }
+    if (expectedOutcome === "LOSE") {
+      const loseStyle = await this.getLoseStyleForClan(normalizeTag(clanTag));
+      if (loseStyle === "TRIPLE_TOP_30") {
+        return "Lose plan (Triple Top 30): hit only top 30 bases with both attacks; do not hit bottom 20.";
+      }
+      return [
+        "Lose plan (Traditional): when under 12h remaining, do mirror 2-star plus non-mirror 1-star.",
+        "Before that, do 1-star/2-star hits while keeping clan stars at or under 100.",
+      ].join(" ");
+    }
+    return "FWA plan unavailable (expected outcome unknown).";
+  }
+
+  /** Purpose: persist clan-level war-end summary and full attack payload into history/lookup tables. */
+  async persistWarEndHistory(payload: {
+    eventType: EventType;
+    clanTag: string;
+    clanName: string;
+    opponentTag: string;
+    opponentName: string;
+    syncNumber: number | null;
+    notifyRole: string | null;
+    fwaPoints: number | null;
+    opponentFwaPoints: number | null;
+    outcome: "WIN" | "LOSE" | null;
+    matchType: MatchType;
+    warStartFwaPoints: number | null;
+    warEndFwaPoints: number | null;
+    lastClanStars: number | null;
+    lastOpponentStars: number | null;
+    warStartTime: Date | null;
+  }): Promise<void> {
+    if (payload.eventType !== "war_ended") return;
+
+    const clanTag = normalizeTag(payload.clanTag);
+    const warStartTime =
+      payload.warStartTime ??
+      (
+        await prisma.warHistoryParticipant.findFirst({
+          where: { clanTag, warEndTime: { not: null } },
+          orderBy: { warStartTime: "desc" },
+          select: { warStartTime: true },
+        })
+      )?.warStartTime ??
+      null;
+    if (!warStartTime) return;
+
+    const finalResult = await this.getWarEndResultSnapshot({
+      clanTag: payload.clanTag,
+      opponentTag: payload.opponentTag,
+      fallbackClanStars: payload.lastClanStars,
+      fallbackOpponentStars: payload.lastOpponentStars,
+      warStartTime,
+    });
+    const attacks = await prisma.warHistoryAttack.findMany({
+      where: { clanTag, warStartTime },
+      orderBy: [{ attackSeenAt: "asc" }, { attackOrder: "asc" }, { playerTag: "asc" }],
+    });
+    const warEndTime =
+      finalResult.warEndTime ??
+      (await prisma.warHistoryParticipant.findFirst({
+        where: { clanTag, warStartTime },
+        orderBy: { updatedAt: "desc" },
+        select: { warEndTime: true },
+      }))?.warEndTime ??
+      null;
+
+    const pointsDelta = this.computeWarPointsDelta({
+      matchType: payload.matchType,
+      before: payload.warStartFwaPoints,
+      after: payload.warEndFwaPoints,
+      finalResult,
+    });
+    const enemyPoints =
+      payload.matchType === "FWA" &&
+      payload.opponentFwaPoints !== null &&
+      Number.isFinite(payload.opponentFwaPoints)
+        ? payload.opponentFwaPoints
+        : null;
+
+    const row = await prisma.$queryRaw<Array<{ warId: number }>>(
+      Prisma.sql`
+        INSERT INTO "WarClanHistory"
+          ("syncNumber","matchType","clanStars","clanDestruction","opponentStars","opponentDestruction","fwaPointsGained","expectedOutcome","actualOutcome","enemyPoints","warStartTime","warEndTime","clanName","clanTag","opponentName","opponentTag","updatedAt")
+        VALUES
+          (${payload.syncNumber}, ${payload.matchType}, ${finalResult.clanStars}, ${finalResult.clanDestruction}, ${finalResult.opponentStars}, ${finalResult.opponentDestruction}, ${pointsDelta}, ${payload.outcome}, ${finalResult.resultLabel}, ${enemyPoints}, ${warStartTime}, ${warEndTime}, ${payload.clanName}, ${clanTag}, ${payload.opponentName}, ${normalizeTag(payload.opponentTag) || null}, NOW())
+        ON CONFLICT ("clanTag","warStartTime")
+        DO UPDATE SET
+          "syncNumber" = EXCLUDED."syncNumber",
+          "matchType" = EXCLUDED."matchType",
+          "clanStars" = EXCLUDED."clanStars",
+          "clanDestruction" = EXCLUDED."clanDestruction",
+          "opponentStars" = EXCLUDED."opponentStars",
+          "opponentDestruction" = EXCLUDED."opponentDestruction",
+          "fwaPointsGained" = EXCLUDED."fwaPointsGained",
+          "expectedOutcome" = EXCLUDED."expectedOutcome",
+          "actualOutcome" = EXCLUDED."actualOutcome",
+          "enemyPoints" = EXCLUDED."enemyPoints",
+          "warEndTime" = EXCLUDED."warEndTime",
+          "clanName" = EXCLUDED."clanName",
+          "opponentName" = EXCLUDED."opponentName",
+          "opponentTag" = EXCLUDED."opponentTag",
+          "updatedAt" = NOW()
+        RETURNING "warId"
+      `
+    );
+    const warId = Number(row[0]?.warId ?? NaN);
+    if (!Number.isFinite(warId)) return;
+
+    await prisma.$executeRaw(
+      Prisma.sql`
+        INSERT INTO "WarLookup" ("warId","payload","updatedAt")
+        VALUES (${warId}, ${JSON.stringify(attacks)}::jsonb, NOW())
+        ON CONFLICT ("warId")
+        DO UPDATE SET
+          "payload" = EXCLUDED."payload",
+          "updatedAt" = NOW()
+      `
+    );
+  }
+
+  /** Purpose: resolve final result snapshot from war log with fallbacks. */
+  async getWarEndResultSnapshot(input: {
+    clanTag: string;
+    opponentTag: string;
+    fallbackClanStars: number | null;
+    fallbackOpponentStars: number | null;
+    warStartTime: Date | null;
+  }): Promise<WarEndResultSnapshot> {
+    const log = await this.coc.getClanWarLog(input.clanTag, 10);
+    const normalizedOpponentTag = normalizeTag(input.opponentTag);
+
+    const matched =
+      log.find((entry) => normalizeTag(entry.opponent?.tag ?? "") === normalizedOpponentTag) ??
+      log[0] ??
+      null;
+
+    const clanStars =
+      Number.isFinite(Number(matched?.clan?.stars))
+        ? Number(matched?.clan?.stars)
+        : input.fallbackClanStars;
+    const opponentStars =
+      Number.isFinite(Number(matched?.opponent?.stars))
+        ? Number(matched?.opponent?.stars)
+        : input.fallbackOpponentStars;
+    const clanDestruction = Number.isFinite(Number(matched?.clan?.destructionPercentage))
+      ? Number(matched?.clan?.destructionPercentage)
+      : null;
+    const opponentDestruction = Number.isFinite(Number(matched?.opponent?.destructionPercentage))
+      ? Number(matched?.opponent?.destructionPercentage)
+      : null;
+    const warEndTime = parseCocTime(matched?.endTime ?? null);
+
+    let resultLabel: "WIN" | "LOSE" | "TIE" | "UNKNOWN" = "UNKNOWN";
+    if (clanStars !== null && opponentStars !== null) {
+      resultLabel = clanStars > opponentStars ? "WIN" : clanStars < opponentStars ? "LOSE" : "TIE";
+    } else if (matched?.result) {
+      const result = String(matched.result).toLowerCase();
+      if (result.includes("win")) resultLabel = "WIN";
+      else if (result.includes("lose")) resultLabel = "LOSE";
+      else if (result.includes("tie")) resultLabel = "TIE";
+    }
+
+    return {
+      clanStars,
+      opponentStars,
+      clanDestruction,
+      opponentDestruction,
+      warEndTime,
+      resultLabel,
+    };
+  }
+
+  /** Purpose: compute missed-both and not-following-plan member lists for the target war. */
+  async getWarComplianceSnapshot(
+    clanTagInput: string,
+    preferredWarStartTime: Date | null,
+    matchType: MatchType,
+    expectedOutcome: "WIN" | "LOSE" | null
+  ): Promise<WarComplianceSnapshot> {
+    if (matchType === "BL" || matchType === "MM") {
+      return { missedBoth: [], notFollowingPlan: [] };
+    }
+    const clanTag = normalizeTag(clanTagInput);
+    const warStartTime = preferredWarStartTime
+      ? preferredWarStartTime
+      : (
+          await prisma.warHistoryParticipant.findFirst({
+            where: { clanTag, warEndTime: { not: null } },
+            orderBy: { warStartTime: "desc" },
+            select: { warStartTime: true },
+          })
+        )?.warStartTime ?? null;
+    if (!warStartTime) {
+      return { missedBoth: [], notFollowingPlan: [] };
+    }
+
+    const participants = await prisma.warHistoryParticipant.findMany({
+      where: { clanTag, warStartTime },
+      select: { playerName: true, playerTag: true, attacksUsed: true, playerPosition: true },
+      orderBy: [{ playerPosition: "asc" }, { playerName: "asc" }],
+    });
+    const attacks = await prisma.warHistoryAttack.findMany({
+      where: { clanTag, warStartTime },
+      select: {
+        playerTag: true,
+        playerName: true,
+        playerPosition: true,
+        defenderPosition: true,
+        stars: true,
+        trueStars: true,
+        attackSeenAt: true,
+        warEndTime: true,
+        attackOrder: true,
+      },
+      orderBy: [{ attackSeenAt: "asc" }, { attackOrder: "asc" }, { playerTag: "asc" }],
+    });
+    const loseStyle = await this.getLoseStyleForClan(clanTag);
+    return computeWarComplianceForTest({
+      clanTag,
+      participants,
+      attacks,
+      matchType,
+      expectedOutcome,
+      loseStyle,
+    });
+  }
+
+  /** Purpose: read configured lose-war style for a tracked clan. */
+  private async getLoseStyleForClan(clanTagInput: string): Promise<FwaLoseStyle> {
+    const clanTag = normalizeTag(clanTagInput);
+    if (!clanTag) return "TRIPLE_TOP_30";
+    const row = await prisma.trackedClan.findUnique({
+      where: { tag: clanTag },
+      select: { loseStyle: true },
+    });
+    const loseStyle = String(row?.loseStyle ?? "").toUpperCase();
+    if (loseStyle === "TRADITIONAL" || loseStyle === "TRIPLE_TOP_30") {
+      return loseStyle;
+    }
+    return "TRIPLE_TOP_30";
+  }
+
+  /** Purpose: delegate war-end points delta calculation to shared core logic. */
+  private computeWarPointsDelta(input: {
+    matchType: MatchType;
+    before: number | null;
+    after: number | null;
+    finalResult: WarEndResultSnapshot;
+  }): number | null {
+    return computeWarPointsDeltaForTest(input);
+  }
+}
+

--- a/src/services/war-events/history.ts
+++ b/src/services/war-events/history.ts
@@ -69,7 +69,8 @@ export class WarEventHistoryService {
   async buildWarPlanText(
     matchType: MatchType,
     expectedOutcome: "WIN" | "LOSE" | null,
-    clanTag: string
+    clanTag: string,
+    _opponentNameInput?: string | null
   ): Promise<string | null> {
     if (matchType !== "FWA") return null;
     if (expectedOutcome === "WIN") {

--- a/src/services/war-events/history.ts
+++ b/src/services/war-events/history.ts
@@ -70,25 +70,35 @@ export class WarEventHistoryService {
     matchType: MatchType,
     expectedOutcome: "WIN" | "LOSE" | null,
     clanTag: string,
-    _opponentNameInput?: string | null
+    opponentNameInput?: string | null
   ): Promise<string | null> {
     if (matchType !== "FWA") return null;
+    const opponentName = String(opponentNameInput ?? "").trim() || "Unknown";
     if (expectedOutcome === "WIN") {
       return [
-        "Win plan: if clan stars are under 100 and time remaining is over 12h,",
-        "one attack must be a 3-star on mirror. Other attack can be 3-star on already-tripled base,",
-        "or 2-star/1-star any base. Outside that window, free hit plan applies.",
-      ].join(" ");
+        `**💚 WIN WAR 🆚 ${opponentName} 🟢 **`,
+        "🗡️ 1st Attack: ★ ★ ★ -> Mirror",
+        "🗡️ 2nd Attack: ★ ★ ☆ -> any",
+        "⌛️ Only after 101+ stars -> Attack ANY base",
+      ].join("\n");
     }
     if (expectedOutcome === "LOSE") {
       const loseStyle = await this.getLoseStyleForClan(normalizeTag(clanTag));
       if (loseStyle === "TRIPLE_TOP_30") {
-        return "Lose plan (Triple Top 30): hit only top 30 bases with both attacks; do not hit bottom 20.";
+        return [
+          `**❤️ LOSE WAR 🆚 ${opponentName} 🔴**`,
+          "🗡️ Attack any of the top 30 bases for 1-3 stars",
+          "🚫 Do NOT attack the bottom 20 bases",
+          "🎯 Goal is 90 stars (do not cross)",
+        ].join("\n");
       }
       return [
-        "Lose plan (Traditional): when under 12h remaining, do mirror 2-star plus non-mirror 1-star.",
-        "Before that, do 1-star/2-star hits while keeping clan stars at or under 100.",
-      ].join(" ");
+        `**❤️ LOSE WAR 🆚 ${opponentName} 🔴**`,
+        "🗡️ 1st Attack: ★ ★ ☆ -> Mirror",
+        "🗡️ 2nd Attack: ★ ☆ ☆ -> any",
+        "⏳ Last 12hrs: ★ ★ ☆ -> any",
+        "🎯 Do NOT surpass 100 ★",
+      ].join("\n");
     }
     return "FWA plan unavailable (expected outcome unknown).";
   }

--- a/src/services/war-events/pointsSync.ts
+++ b/src/services/war-events/pointsSync.ts
@@ -1,0 +1,357 @@
+import { prisma } from "../../prisma";
+import { CoCService } from "../CoCService";
+import { PointsProjectionService } from "../PointsProjectionService";
+import { SettingsService } from "../SettingsService";
+import {
+  compareTagsForTiebreak,
+  normalizeTag,
+  normalizeTagBare,
+  sanitizeClanName,
+} from "./core";
+
+type WarStartPointsCheckJob = {
+  clanTag: string;
+  opponentTag: string;
+  attempts: number;
+  maxAttempts: number;
+  nextAttemptAtMs: number;
+  completed: boolean;
+  status: "pending" | "in_sync" | "out_of_sync" | "max_attempts" | "error";
+  trackedPointBalanceSite: number | null;
+  trackedPointBalanceDb: number | null;
+  siteSyncNumber: number | null;
+  siteOpponentTag: string | null;
+  siteOpponentBalance: number | null;
+  inferredOpponentIsFwa: boolean | null;
+  opponentChecked: boolean;
+  lastCheckedAtMs: number | null;
+};
+
+type TrackedClanPointsScrape = {
+  version: number;
+  source: "points.fwafarm";
+  fetchedAtMs: number;
+  trackedClanName: string | null;
+  trackedClanTag: string;
+  opponentClanName: string | null;
+  opponentClanTag: string | null;
+  pointBalance: number | null;
+  opponentPointBalance: number | null;
+  activeFwa: boolean;
+  syncNumber: number | null;
+  matchup: string;
+  pointsSiteUpToDate: boolean;
+};
+
+export type PointsSyncSubscriptionLike = {
+  clanTag: string;
+  fwaPoints: number | null;
+};
+
+/** Purpose: manage previous sync recovery and war-start points-site retry jobs. */
+export class WarStartPointsSyncService {
+  static readonly PREVIOUS_SYNC_KEY = "previousSyncNum";
+  private static readonly WAR_START_POINTS_JOB_PREFIX = "warStartPointsCheck";
+  private static readonly WAR_START_POINTS_RECHECK_MS = 30 * 60 * 1000;
+  private static readonly WAR_START_POINTS_MAX_ATTEMPTS = 10;
+
+  /** Purpose: initialize points sync service dependencies. */
+  constructor(
+    private readonly coc: CoCService,
+    private readonly points: PointsProjectionService,
+    private readonly settings: SettingsService
+  ) {}
+
+  /** Purpose: read previous sync from settings or recover it from points site state. */
+  async getPreviousSyncNum(): Promise<number | null> {
+    const raw = await this.settings.get(WarStartPointsSyncService.PREVIOUS_SYNC_KEY);
+    const parsed = raw === null ? NaN : Number(raw);
+    if (Number.isFinite(parsed)) return Math.trunc(parsed);
+    return this.recoverPreviousSyncNumFromPoints();
+  }
+
+  /** Purpose: reset/start a new war-start points check job for a clan+opponent pair. */
+  async resetWarStartPointsJob(
+    clanTag: string,
+    opponentTag: string
+  ): Promise<void> {
+    const now = Date.now();
+    const next: WarStartPointsCheckJob = {
+      clanTag: normalizeTag(clanTag),
+      opponentTag: normalizeTag(opponentTag),
+      attempts: 0,
+      maxAttempts: WarStartPointsSyncService.WAR_START_POINTS_MAX_ATTEMPTS,
+      nextAttemptAtMs: now,
+      completed: false,
+      status: "pending",
+      trackedPointBalanceSite: null,
+      trackedPointBalanceDb: null,
+      siteSyncNumber: null,
+      siteOpponentTag: null,
+      siteOpponentBalance: null,
+      inferredOpponentIsFwa: null,
+      opponentChecked: false,
+      lastCheckedAtMs: null,
+    };
+    await this.setWarStartPointsJob(next);
+  }
+
+  /** Purpose: run/advance the retrying points-site sync check for an in-war clan. */
+  async maybeRunWarStartPointsCheck(
+    sub: PointsSyncSubscriptionLike,
+    opponentTagInput: string,
+    clanNameInput: string | null,
+    opponentNameInput: string | null
+  ): Promise<void> {
+    const clanTag = normalizeTag(sub.clanTag);
+    const opponentTag = normalizeTag(opponentTagInput);
+    if (!clanTag || !opponentTag) return;
+
+    let job = await this.getWarStartPointsJob(clanTag);
+    if (!job || normalizeTag(job.opponentTag) !== opponentTag) {
+      await this.resetWarStartPointsJob(clanTag, opponentTag);
+      job = await this.getWarStartPointsJob(clanTag);
+    }
+    if (!job || job.completed) return;
+    if (Date.now() < job.nextAttemptAtMs) return;
+
+    const nextAttempt = job.attempts + 1;
+    try {
+      const primary = await this.points.fetchSnapshot(clanTag);
+      const siteUpdated = primary.winnerBoxTags.map((t) => normalizeTag(t)).includes(opponentTag);
+      const trackedDb = sub.fwaPoints ?? null;
+      const trackedSite =
+        primary.balance !== null && Number.isFinite(primary.balance) ? primary.balance : null;
+
+      let inferredOpponentIsFwa = job.inferredOpponentIsFwa;
+      let opponentChecked = job.opponentChecked;
+      let opponentBalance = job.siteOpponentBalance;
+      if (!opponentChecked) {
+        const opp = await this.points.fetchSnapshot(opponentTag).catch(() => null);
+        opponentChecked = true;
+        inferredOpponentIsFwa =
+          opp?.balance !== null && opp?.balance !== undefined && Number.isFinite(opp.balance);
+        opponentBalance =
+          opp?.balance !== null && opp?.balance !== undefined && Number.isFinite(opp.balance)
+            ? opp.balance
+            : null;
+      }
+
+      const mismatch =
+        siteUpdated &&
+        trackedDb !== null &&
+        trackedSite !== null &&
+        Number.isFinite(trackedDb) &&
+        Number.isFinite(trackedSite) &&
+        trackedDb !== trackedSite;
+
+      const exhausted = !siteUpdated && nextAttempt >= job.maxAttempts;
+      const completed = siteUpdated || exhausted;
+      const status: WarStartPointsCheckJob["status"] = siteUpdated
+        ? mismatch
+          ? "out_of_sync"
+          : "in_sync"
+        : exhausted
+          ? "max_attempts"
+          : "pending";
+
+      await this.setWarStartPointsJob({
+        ...job,
+        attempts: nextAttempt,
+        nextAttemptAtMs: completed
+          ? Date.now()
+          : Date.now() + WarStartPointsSyncService.WAR_START_POINTS_RECHECK_MS,
+        completed,
+        status,
+        trackedPointBalanceSite: trackedSite,
+        trackedPointBalanceDb: trackedDb,
+        siteSyncNumber:
+          primary.winnerBoxSync !== null && Number.isFinite(primary.winnerBoxSync)
+            ? Math.trunc(primary.winnerBoxSync)
+            : null,
+        siteOpponentTag: siteUpdated ? opponentTag : null,
+        siteOpponentBalance: opponentBalance,
+        inferredOpponentIsFwa,
+        opponentChecked,
+        lastCheckedAtMs: Date.now(),
+      });
+      if (siteUpdated) {
+        await this.persistTrackedClanPointsScrape({
+          trackedClanTag: clanTag,
+          trackedClanName: sanitizeClanName(clanNameInput) ?? sanitizeClanName(primary.clanName),
+          opponentClanTag: opponentTag,
+          opponentClanName: sanitizeClanName(opponentNameInput),
+          trackedPoints: trackedSite,
+          opponentPoints: opponentBalance,
+          syncNumber:
+            primary.winnerBoxSync !== null && Number.isFinite(primary.winnerBoxSync)
+              ? Math.trunc(primary.winnerBoxSync)
+              : null,
+          pointsSiteUpToDate: true,
+          activeFwa: true,
+        });
+      }
+    } catch {
+      const exhausted = nextAttempt >= job.maxAttempts;
+      await this.setWarStartPointsJob({
+        ...job,
+        attempts: nextAttempt,
+        completed: exhausted,
+        status: exhausted ? "max_attempts" : "error",
+        nextAttemptAtMs: exhausted
+          ? Date.now()
+          : Date.now() + WarStartPointsSyncService.WAR_START_POINTS_RECHECK_MS,
+        lastCheckedAtMs: Date.now(),
+      });
+    }
+  }
+
+  /** Purpose: recover previous sync by comparing tracked clans and live points-site opponent linkage. */
+  private async recoverPreviousSyncNumFromPoints(): Promise<number | null> {
+    const tracked = await prisma.trackedClan.findMany({
+      orderBy: { createdAt: "asc" },
+      select: { tag: true },
+    });
+    for (const clan of tracked) {
+      const tag = normalizeTag(clan.tag);
+      const war = await this.coc.getCurrentWar(tag).catch(() => null);
+      const opponentTag = normalizeTag(war?.opponent?.tag ?? "");
+      if (!opponentTag) continue;
+
+      const snapshot = await this.points.fetchSnapshot(tag).catch(() => null);
+      if (!snapshot || snapshot.winnerBoxSync === null) continue;
+
+      const siteUpdated = snapshot.winnerBoxTags
+        .map((t) => normalizeTag(t))
+        .includes(opponentTag);
+      const recoveredPrevious = siteUpdated
+        ? snapshot.winnerBoxSync - 1
+        : snapshot.winnerBoxSync;
+      if (!Number.isFinite(recoveredPrevious) || recoveredPrevious < 0) continue;
+
+      const next = Math.trunc(recoveredPrevious);
+      await this.settings.set(WarStartPointsSyncService.PREVIOUS_SYNC_KEY, String(next));
+      return next;
+    }
+    return null;
+  }
+
+  /** Purpose: build the settings key used to store a clan's war-start sync-check job blob. */
+  private buildWarStartPointsJobKey(clanTag: string): string {
+    return `${WarStartPointsSyncService.WAR_START_POINTS_JOB_PREFIX}:${normalizeTagBare(clanTag)}`;
+  }
+
+  /** Purpose: load the persisted war-start sync-check job blob for a clan. */
+  private async getWarStartPointsJob(clanTag: string): Promise<WarStartPointsCheckJob | null> {
+    const raw = await this.settings.get(this.buildWarStartPointsJobKey(clanTag));
+    if (!raw) return null;
+    try {
+      const parsed = JSON.parse(raw) as WarStartPointsCheckJob;
+      if (!parsed || typeof parsed !== "object") return null;
+      return parsed;
+    } catch {
+      return null;
+    }
+  }
+
+  /** Purpose: persist the current war-start sync-check job blob for a clan. */
+  private async setWarStartPointsJob(job: WarStartPointsCheckJob): Promise<void> {
+    await this.settings.set(this.buildWarStartPointsJobKey(job.clanTag), JSON.stringify(job));
+  }
+
+  /** Purpose: store points-site key fields into TrackedClan.pointsScrape when site data is confirmed current. */
+  private async persistTrackedClanPointsScrape(input: {
+    trackedClanTag: string;
+    trackedClanName: string | null;
+    opponentClanTag: string | null;
+    opponentClanName: string | null;
+    trackedPoints: number | null;
+    opponentPoints: number | null;
+    syncNumber: number | null;
+    pointsSiteUpToDate: boolean;
+    activeFwa: boolean;
+  }): Promise<void> {
+    const blob: TrackedClanPointsScrape = {
+      version: 1,
+      source: "points.fwafarm",
+      fetchedAtMs: Date.now(),
+      trackedClanName: input.trackedClanName?.trim() || null,
+      trackedClanTag: normalizeTag(input.trackedClanTag),
+      opponentClanName: input.opponentClanName?.trim() || null,
+      opponentClanTag: normalizeTag(input.opponentClanTag ?? "") || null,
+      pointBalance:
+        input.trackedPoints !== null && Number.isFinite(input.trackedPoints)
+          ? input.trackedPoints
+          : null,
+      opponentPointBalance:
+        input.opponentPoints !== null && Number.isFinite(input.opponentPoints)
+          ? input.opponentPoints
+          : null,
+      activeFwa: Boolean(input.activeFwa),
+      syncNumber:
+        input.syncNumber !== null && Number.isFinite(input.syncNumber)
+          ? Math.trunc(input.syncNumber)
+          : null,
+      matchup: this.buildPointsSiteMatchupSummary({
+        trackedClanName: input.trackedClanName,
+        trackedClanTag: input.trackedClanTag,
+        opponentClanName: input.opponentClanName,
+        opponentClanTag: input.opponentClanTag,
+        trackedPoints: input.trackedPoints,
+        opponentPoints: input.opponentPoints,
+        syncNumber: input.syncNumber,
+        activeFwa: input.activeFwa,
+      }),
+      pointsSiteUpToDate: input.pointsSiteUpToDate,
+    };
+
+    await prisma.trackedClan.updateMany({
+      where: { tag: { equals: blob.trackedClanTag, mode: "insensitive" } },
+      data: { pointsScrape: blob },
+    });
+  }
+
+  /** Purpose: compose the points-site matchup evaluation string stored in pointsScrape. */
+  private buildPointsSiteMatchupSummary(input: {
+    trackedClanName: string | null;
+    trackedClanTag: string;
+    opponentClanName: string | null;
+    opponentClanTag: string | null;
+    trackedPoints: number | null;
+    opponentPoints: number | null;
+    syncNumber: number | null;
+    activeFwa: boolean;
+  }): string {
+    if (!input.activeFwa) return "Not marked as an FWA match.";
+    const primaryName = input.trackedClanName ?? normalizeTagBare(input.trackedClanTag);
+    const opponentName = input.opponentClanName ?? normalizeTagBare(input.opponentClanTag ?? "");
+    const x = input.trackedPoints;
+    const y = input.opponentPoints;
+    if (
+      x === null ||
+      y === null ||
+      !Number.isFinite(x) ||
+      !Number.isFinite(y)
+    ) {
+      return "Not marked as an FWA match.";
+    }
+    if (x > y) return `${primaryName} should win by points (${x} > ${y})`;
+    if (x < y) return `${opponentName} should win by points (${x} < ${y})`;
+    if (input.syncNumber === null || !Number.isFinite(input.syncNumber)) {
+      return "Not marked as an FWA match.";
+    }
+    const mode = input.syncNumber % 2 === 0 ? "high sync" : "low sync";
+    const cmp = compareTagsForTiebreak(input.trackedClanTag, input.opponentClanTag ?? "");
+    if (cmp === 0) return "Not marked as an FWA match.";
+    const winner =
+      mode === "low sync"
+        ? cmp < 0
+          ? primaryName
+          : opponentName
+        : cmp > 0
+          ? primaryName
+          : opponentName;
+    return `${winner} should win by tiebreak (${x} = ${y}, ${mode})`;
+  }
+}
+

--- a/tests/commandCoverage.test.ts
+++ b/tests/commandCoverage.test.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { Commands } from "../src/Commands";
+import { getHelpDocumentedCommandNames } from "../src/commands/Help";
+import { hasPermissionTargetForCommand } from "../src/services/CommandPermissionService";
+
+function readmeCommandNames(): Set<string> {
+  const readmePath = join(process.cwd(), "README.md");
+  const text = readFileSync(readmePath, "utf8");
+  const names = new Set<string>();
+  const regex = /\/([a-z0-9-]+)/gi;
+  let match: RegExpExecArray | null = regex.exec(text);
+  while (match) {
+    const name = String(match[1] ?? "").trim().toLowerCase();
+    if (name) names.add(name);
+    match = regex.exec(text);
+  }
+  return names;
+}
+
+describe("command coverage", () => {
+  it("ensures every registered command has a permissions target", () => {
+    const missing = Commands.map((command) => command.name).filter(
+      (name) => !hasPermissionTargetForCommand(name)
+    );
+    expect(missing).toEqual([]);
+  });
+
+  it("ensures every registered command has help docs", () => {
+    const documented = new Set(getHelpDocumentedCommandNames());
+    const missing = Commands.map((command) => command.name).filter(
+      (name) => !documented.has(name)
+    );
+    expect(missing).toEqual([]);
+  });
+
+  it("ensures every registered command is documented in README", () => {
+    const readmeNames = readmeCommandNames();
+    const missing = Commands.map((command) => command.name).filter(
+      (name) => !readmeNames.has(name)
+    );
+    expect(missing).toEqual([]);
+  });
+});

--- a/tests/commandCoverage.test.ts
+++ b/tests/commandCoverage.test.ts
@@ -5,9 +5,9 @@ import { Commands } from "../src/Commands";
 import { getHelpDocumentedCommandNames } from "../src/commands/Help";
 import { hasPermissionTargetForCommand } from "../src/services/CommandPermissionService";
 
-function readmeCommandNames(): Set<string> {
-  const readmePath = join(process.cwd(), "README.md");
-  const text = readFileSync(readmePath, "utf8");
+function docsCommandNames(): Set<string> {
+  const commandsDocPath = join(process.cwd(), "docs", "commands.md");
+  const text = readFileSync(commandsDocPath, "utf8");
   const names = new Set<string>();
   const regex = /\/([a-z0-9-]+)/gi;
   let match: RegExpExecArray | null = regex.exec(text);
@@ -35,8 +35,8 @@ describe("command coverage", () => {
     expect(missing).toEqual([]);
   });
 
-  it("ensures every registered command is documented in README", () => {
-    const readmeNames = readmeCommandNames();
+  it("ensures every registered command is documented in docs/commands.md", () => {
+    const readmeNames = docsCommandNames();
     const missing = Commands.map((command) => command.name).filter(
       (name) => !readmeNames.has(name)
     );

--- a/tests/formatError.test.ts
+++ b/tests/formatError.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { formatError } from "../src/helper/formatError";
+
+describe("formatError", () => {
+  it("returns fallback for empty values", () => {
+    expect(formatError(null)).toBe("Unknown error");
+  });
+
+  it("returns strings unchanged", () => {
+    expect(formatError("boom")).toBe("boom");
+  });
+
+  it("formats object error details", () => {
+    const message = formatError({
+      message: "Request failed",
+      code: "E_FAIL",
+      status: 500,
+      response: { status: 429 },
+    });
+    expect(message).toBe("Request failed | code=E_FAIL | status=500 | http=429");
+  });
+});
+

--- a/tests/fwaMissedSync.logic.test.ts
+++ b/tests/fwaMissedSync.logic.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { isMissedSyncClanForTest } from "../src/commands/Fwa";
+
+describe("isMissedSyncClanForTest", () => {
+  const baseline = Date.UTC(2026, 2, 1, 8, 0, 0);
+  const twoHoursMs = 2 * 60 * 60 * 1000;
+
+  it("returns false when baseline is unknown", () => {
+    expect(
+      isMissedSyncClanForTest({
+        baselineWarStartMs: null,
+        clanWarState: "notInWar",
+        clanWarStartMs: null,
+        nowMs: baseline + twoHoursMs + 1,
+      })
+    ).toBe(false);
+  });
+
+  it("marks notInWar clan as missed sync after 2h from baseline", () => {
+    expect(
+      isMissedSyncClanForTest({
+        baselineWarStartMs: baseline,
+        clanWarState: "notInWar",
+        clanWarStartMs: null,
+        nowMs: baseline + twoHoursMs + 1,
+      })
+    ).toBe(true);
+  });
+
+  it("marks late-started clan as missed sync when start is >2h after baseline", () => {
+    expect(
+      isMissedSyncClanForTest({
+        baselineWarStartMs: baseline,
+        clanWarState: "preparation",
+        clanWarStartMs: baseline + twoHoursMs + 60 * 1000,
+        nowMs: baseline + twoHoursMs + 60 * 1000,
+      })
+    ).toBe(true);
+  });
+
+  it("does not mark clan as missed sync when start is within 2h window", () => {
+    expect(
+      isMissedSyncClanForTest({
+        baselineWarStartMs: baseline,
+        clanWarState: "inWar",
+        clanWarStartMs: baseline + twoHoursMs - 1,
+        nowMs: baseline + twoHoursMs + 1,
+      })
+    ).toBe(false);
+  });
+});

--- a/tests/warEventLog.logic.test.ts
+++ b/tests/warEventLog.logic.test.ts
@@ -1,0 +1,286 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeWarComplianceForTest,
+  computeWarPointsDeltaForTest,
+} from "../src/services/WarEventLogService";
+
+function dateAt(hour: number): Date {
+  return new Date(Date.UTC(2026, 0, 1, hour, 0, 0));
+}
+
+describe("WarEventLogService.computeWarPointsDeltaForTest", () => {
+  it("BL war: returns +3 points when final result is WIN", () => {
+    const delta = computeWarPointsDeltaForTest({
+      matchType: "BL",
+      before: 100,
+      after: 100,
+      finalResult: {
+        clanStars: 100,
+        opponentStars: 99,
+        clanDestruction: 59,
+        opponentDestruction: 58,
+        warEndTime: null,
+        resultLabel: "WIN",
+      },
+    });
+    expect(delta).toBe(3);
+  });
+
+  it("BL war: returns +2 points when not a win but clan destruction is >= 60%", () => {
+    const delta = computeWarPointsDeltaForTest({
+      matchType: "BL",
+      before: 100,
+      after: 100,
+      finalResult: {
+        clanStars: 90,
+        opponentStars: 100,
+        clanDestruction: 60,
+        opponentDestruction: 70,
+        warEndTime: null,
+        resultLabel: "LOSE",
+      },
+    });
+    expect(delta).toBe(2);
+  });
+
+  it("BL war: returns +1 point when not a win and clan destruction is < 60%", () => {
+    const delta = computeWarPointsDeltaForTest({
+      matchType: "BL",
+      before: 100,
+      after: 100,
+      finalResult: {
+        clanStars: 90,
+        opponentStars: 100,
+        clanDestruction: 59.99,
+        opponentDestruction: 70,
+        warEndTime: null,
+        resultLabel: "LOSE",
+      },
+    });
+    expect(delta).toBe(1);
+  });
+
+  it("FWA/MM war: returns arithmetic delta (after - before) when both values are present", () => {
+    expect(
+      computeWarPointsDeltaForTest({
+        matchType: "FWA",
+        before: 1200,
+        after: 1205,
+        finalResult: {
+          clanStars: null,
+          opponentStars: null,
+          clanDestruction: null,
+          opponentDestruction: null,
+          warEndTime: null,
+          resultLabel: "UNKNOWN",
+        },
+      })
+    ).toBe(5);
+    expect(
+      computeWarPointsDeltaForTest({
+        matchType: "MM",
+        before: 1200,
+        after: 1197,
+        finalResult: {
+          clanStars: null,
+          opponentStars: null,
+          clanDestruction: null,
+          opponentDestruction: null,
+          warEndTime: null,
+          resultLabel: "UNKNOWN",
+        },
+      })
+    ).toBe(-3);
+  });
+
+  it("FWA/MM war: returns null when before/after values are incomplete", () => {
+    const delta = computeWarPointsDeltaForTest({
+      matchType: "FWA",
+      before: null,
+      after: 100,
+      finalResult: {
+        clanStars: null,
+        opponentStars: null,
+        clanDestruction: null,
+        opponentDestruction: null,
+        warEndTime: null,
+        resultLabel: "UNKNOWN",
+      },
+    });
+    expect(delta).toBeNull();
+  });
+});
+
+describe("WarEventLogService.computeWarComplianceForTest", () => {
+  const participants = [
+    { playerName: "Alice", playerTag: "#A", attacksUsed: 2, playerPosition: 1 },
+    { playerName: "Bob", playerTag: "#B", attacksUsed: 2, playerPosition: 2 },
+    { playerName: "Cory", playerTag: "#C", attacksUsed: 0, playerPosition: 3 },
+  ];
+
+  it("BL war: returns empty missedBoth and notFollowingPlan because war-plan enforcement is disabled", () => {
+    const result = computeWarComplianceForTest({
+      clanTag: "#CLAN",
+      participants,
+      attacks: [],
+      matchType: "BL",
+      expectedOutcome: "LOSE",
+      loseStyle: "TRADITIONAL",
+    });
+    expect(result).toEqual({ missedBoth: [], notFollowingPlan: [] });
+  });
+
+  it("MM war: returns empty missedBoth and notFollowingPlan because war-plan enforcement is disabled", () => {
+    const result = computeWarComplianceForTest({
+      clanTag: "#CLAN",
+      participants,
+      attacks: [
+        {
+          playerTag: "#A",
+          playerName: "Alice",
+          playerPosition: 1,
+          defenderPosition: 2,
+          stars: 2,
+          trueStars: 2,
+          attackSeenAt: dateAt(1),
+          warEndTime: dateAt(20),
+          attackOrder: 1,
+        },
+      ],
+      matchType: "MM",
+      expectedOutcome: null,
+      loseStyle: "TRADITIONAL",
+    });
+    expect(result).toEqual({ missedBoth: [], notFollowingPlan: [] });
+  });
+
+  it("FWA WIN plan: flags players who miss required mirror triple during strict window and invalid non-mirror strict-window hits", () => {
+    const result = computeWarComplianceForTest({
+      clanTag: "#CLAN",
+      participants,
+      attacks: [
+        {
+          playerTag: "#A",
+          playerName: "Alice",
+          playerPosition: 1,
+          defenderPosition: 2,
+          stars: 3,
+          trueStars: 3,
+          attackSeenAt: dateAt(1),
+          warEndTime: dateAt(20),
+          attackOrder: 1,
+        },
+        {
+          playerTag: "#B",
+          playerName: "Bob",
+          playerPosition: 2,
+          defenderPosition: 2,
+          stars: 2,
+          trueStars: 2,
+          attackSeenAt: dateAt(1),
+          warEndTime: dateAt(20),
+          attackOrder: 2,
+        },
+      ],
+      matchType: "FWA",
+      expectedOutcome: "WIN",
+      loseStyle: "TRADITIONAL",
+    });
+    expect(result.missedBoth).toEqual(["Cory"]);
+    expect(result.notFollowingPlan).toEqual(["Alice", "Bob"]);
+  });
+
+  it("FWA LOSE Triple-top-30 plan: flags attacks on defender positions 31-50", () => {
+    const result = computeWarComplianceForTest({
+      clanTag: "#CLAN",
+      participants,
+      attacks: [
+        {
+          playerTag: "#A",
+          playerName: "Alice",
+          playerPosition: 1,
+          defenderPosition: 31,
+          stars: 1,
+          trueStars: 1,
+          attackSeenAt: dateAt(2),
+          warEndTime: dateAt(20),
+          attackOrder: 1,
+        },
+      ],
+      matchType: "FWA",
+      expectedOutcome: "LOSE",
+      loseStyle: "TRIPLE_TOP_30",
+    });
+    expect(result.notFollowingPlan).toEqual(["Alice"]);
+  });
+
+  it("FWA LOSE Traditional plan (late window <12h): flags mirror!=2-star and non-mirror!=1-star attacks", () => {
+    const result = computeWarComplianceForTest({
+      clanTag: "#CLAN",
+      participants,
+      attacks: [
+        {
+          playerTag: "#A",
+          playerName: "Alice",
+          playerPosition: 1,
+          defenderPosition: 1,
+          stars: 1,
+          trueStars: 1,
+          attackSeenAt: dateAt(11),
+          warEndTime: dateAt(20),
+          attackOrder: 1,
+        },
+        {
+          playerTag: "#B",
+          playerName: "Bob",
+          playerPosition: 2,
+          defenderPosition: 1,
+          stars: 2,
+          trueStars: 2,
+          attackSeenAt: dateAt(11),
+          warEndTime: dateAt(20),
+          attackOrder: 2,
+        },
+      ],
+      matchType: "FWA",
+      expectedOutcome: "LOSE",
+      loseStyle: "TRADITIONAL",
+    });
+    expect(result.notFollowingPlan).toEqual(["Alice", "Bob"]);
+  });
+
+  it("FWA LOSE Traditional plan (early window >=12h): flags stars outside 1-2 and attacks that push cumulative stars over 100", () => {
+    const result = computeWarComplianceForTest({
+      clanTag: "#CLAN",
+      participants,
+      attacks: [
+        {
+          playerTag: "#A",
+          playerName: "Alice",
+          playerPosition: 1,
+          defenderPosition: 1,
+          stars: 3,
+          trueStars: 3,
+          attackSeenAt: dateAt(1),
+          warEndTime: dateAt(20),
+          attackOrder: 1,
+        },
+        {
+          playerTag: "#B",
+          playerName: "Bob",
+          playerPosition: 2,
+          defenderPosition: 2,
+          stars: 2,
+          trueStars: 101,
+          attackSeenAt: dateAt(2),
+          warEndTime: dateAt(20),
+          attackOrder: 2,
+        },
+      ],
+      matchType: "FWA",
+      expectedOutcome: "LOSE",
+      loseStyle: "TRADITIONAL",
+    });
+    expect(result.notFollowingPlan).toEqual(["Alice", "Bob"]);
+  });
+});

--- a/tests/warPlanText.test.ts
+++ b/tests/warPlanText.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+import { WarEventHistoryService } from "../src/services/war-events/history";
+
+describe("WarEventHistoryService.buildWarPlanText", () => {
+  it("returns exact WIN plan lines", async () => {
+    const svc = new WarEventHistoryService({} as never);
+    const out = await svc.buildWarPlanText("FWA", "WIN", "ABC123", "OPPONENT_NAME");
+    expect(out).toBe(
+      [
+        "**💚 WIN WAR 🆚 OPPONENT_NAME 🟢 **",
+        "🗡️ 1st Attack: ★ ★ ★ -> Mirror",
+        "🗡️ 2nd Attack: ★ ★ ☆ -> any",
+        "⌛️ Only after 101+ stars -> Attack ANY base",
+      ].join("\n")
+    );
+  });
+
+  it("returns exact LOSE TRIPLE_TOP_30 plan lines", async () => {
+    const svc = new WarEventHistoryService({} as never);
+    (svc as any).getLoseStyleForClan = vi.fn().mockResolvedValue("TRIPLE_TOP_30");
+    const out = await svc.buildWarPlanText("FWA", "LOSE", "ABC123", "OPPONENT_NAME");
+    expect(out).toBe(
+      [
+        "**❤️ LOSE WAR 🆚 OPPONENT_NAME 🔴**",
+        "🗡️ Attack any of the top 30 bases for 1-3 stars",
+        "🚫 Do NOT attack the bottom 20 bases",
+        "🎯 Goal is 90 stars (do not cross)",
+      ].join("\n")
+    );
+  });
+
+  it("returns exact LOSE TRADITIONAL plan lines", async () => {
+    const svc = new WarEventHistoryService({} as never);
+    (svc as any).getLoseStyleForClan = vi.fn().mockResolvedValue("TRADITIONAL");
+    const out = await svc.buildWarPlanText("FWA", "LOSE", "ABC123", "OPPONENT_NAME");
+    expect(out).toBe(
+      [
+        "**❤️ LOSE WAR 🆚 OPPONENT_NAME 🔴**",
+        "🗡️ 1st Attack: ★ ★ ☆ -> Mirror",
+        "🗡️ 2nd Attack: ★ ☆ ☆ -> any",
+        "⏳ Last 12hrs: ★ ★ ☆ -> any",
+        "🎯 Do NOT surpass 100 ★",
+      ].join("\n")
+    );
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts", "tests/**/*.test.ts"],
+    coverage: {
+      enabled: false,
+    },
+  },
+});
+

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,19 @@
 # yarn lockfile v1
 
 
+"@ampproject/remapping@^2.2.1":
+  version "2.3.0"
+  resolved "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz"
+  integrity sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==
+  dependencies:
+    "@jridgewell/gen-mapping" "^0.3.5"
+    "@jridgewell/trace-mapping" "^0.3.24"
+
+"@bcoe/v8-coverage@^0.2.3":
+  version "0.2.3"
+  resolved "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz"
+  integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
+
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"
   resolved "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz"
@@ -124,6 +137,11 @@
   resolved "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz"
   integrity sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==
 
+"@istanbuljs/schema@^0.1.2":
+  version "0.1.3"
+  resolved "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz"
+  integrity sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==
+
 "@jest/schemas@^29.6.3":
   version "29.6.3"
   resolved "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz"
@@ -131,15 +149,39 @@
   dependencies:
     "@sinclair/typebox" "^0.27.8"
 
-"@jridgewell/resolve-uri@^3.0.3":
+"@jridgewell/gen-mapping@^0.3.5":
+  version "0.3.13"
+  resolved "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz"
+  integrity sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.5.0"
+    "@jridgewell/trace-mapping" "^0.3.24"
+
+"@jridgewell/resolve-uri@^3.0.3", "@jridgewell/resolve-uri@^3.1.0":
   version "3.1.1"
   resolved "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz"
   integrity sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==
 
-"@jridgewell/sourcemap-codec@^1.4.10", "@jridgewell/sourcemap-codec@^1.5.5":
+"@jridgewell/sourcemap-codec@^1.4.10", "@jridgewell/sourcemap-codec@^1.4.14", "@jridgewell/sourcemap-codec@^1.5.0", "@jridgewell/sourcemap-codec@^1.5.5":
   version "1.5.5"
   resolved "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz"
   integrity sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
+
+"@jridgewell/trace-mapping@^0.3.12":
+  version "0.3.31"
+  resolved "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz"
+  integrity sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.1.0"
+    "@jridgewell/sourcemap-codec" "^1.4.14"
+
+"@jridgewell/trace-mapping@^0.3.24":
+  version "0.3.31"
+  resolved "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz"
+  integrity sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.1.0"
+    "@jridgewell/sourcemap-codec" "^1.4.14"
 
 "@jridgewell/trace-mapping@0.3.9":
   version "0.3.9"
@@ -274,7 +316,7 @@
   resolved "https://registry.npmjs.org/@types/chai-subset/-/chai-subset-1.3.6.tgz"
   integrity sha512-m8lERkkQj+uek18hXOZuec3W/fCRTrU4hrnXjH3qhHy96ytuPaPiWGgu7sJb7tZxZonO75vYAjCvpe/e4VUwRw==
 
-"@types/chai@^4.3.5":
+"@types/chai@^4.3.5", "@types/chai@<5.2.0":
   version "4.3.20"
   resolved "https://registry.npmjs.org/@types/chai/-/chai-4.3.20.tgz"
   integrity sha512-/pC9HAB5I/xMlc5FP77qjCnI16ChlJfW0tGa0IUcFn38VJrTV6DeZ60NU5KZBtaOZqjdpwTWohz5HU1RrhiYxQ==
@@ -284,12 +326,17 @@
   resolved "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz"
   integrity sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==
 
+"@types/istanbul-lib-coverage@^2.0.1":
+  version "2.0.6"
+  resolved "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz"
+  integrity sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==
+
 "@types/json-schema@^7.0.12":
   version "7.0.15"
   resolved "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
 
-"@types/node@*", "@types/node@^20.4.2":
+"@types/node@*", "@types/node@^18.0.0 || >=20.0.0", "@types/node@^20.4.2":
   version "20.4.2"
   resolved "https://registry.npmjs.org/@types/node/-/node-20.4.2.tgz"
   integrity sha512-Dd0BYtWgnWJKwO1jkmTrzofjK2QXXcai0dmtzvIBhcA+RsG5h8R3xlyta0kGOZRNfL9GuRtb1knmPEhQrePCEw==
@@ -323,7 +370,7 @@
     semver "^7.5.4"
     ts-api-utils "^1.0.1"
 
-"@typescript-eslint/parser@^6.21.0":
+"@typescript-eslint/parser@^6.0.0 || ^6.0.0-alpha", "@typescript-eslint/parser@^6.21.0":
   version "6.21.0"
   resolved "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz"
   integrity sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==
@@ -397,6 +444,23 @@
   resolved "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz"
   integrity sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==
 
+"@vitest/coverage-v8@^0.34.6":
+  version "0.34.6"
+  resolved "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-0.34.6.tgz"
+  integrity sha512-fivy/OK2d/EsJFoEoxHFEnNGTg+MmdZBAVK9Ka4qhXR2K3J0DS08vcGVwzDtXSuUMabLv4KtPcpSKkcMXFDViw==
+  dependencies:
+    "@ampproject/remapping" "^2.2.1"
+    "@bcoe/v8-coverage" "^0.2.3"
+    istanbul-lib-coverage "^3.2.0"
+    istanbul-lib-report "^3.0.1"
+    istanbul-lib-source-maps "^4.0.1"
+    istanbul-reports "^3.1.5"
+    magic-string "^0.30.1"
+    picocolors "^1.0.0"
+    std-env "^3.3.3"
+    test-exclude "^6.0.0"
+    v8-to-istanbul "^9.1.0"
+
 "@vitest/expect@0.34.6":
   version "0.34.6"
   resolved "https://registry.npmjs.org/@vitest/expect/-/expect-0.34.6.tgz"
@@ -455,7 +519,7 @@ acorn-walk@^8.1.1, acorn-walk@^8.2.0:
   resolved "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz"
   integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
 
-acorn@^8.10.0, acorn@^8.15.0, acorn@^8.4.1, acorn@^8.9.0:
+"acorn@^6.0.0 || ^7.0.0 || ^8.0.0", acorn@^8.10.0, acorn@^8.15.0, acorn@^8.4.1, acorn@^8.9.0:
   version "8.16.0"
   resolved "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz"
   integrity sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==
@@ -665,6 +729,11 @@ confbox@^0.1.8:
   resolved "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz"
   integrity sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==
 
+convert-source-map@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz"
+  integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
+
 create-require@^1.1.0:
   version "1.1.1"
   resolved "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz"
@@ -679,7 +748,7 @@ cross-spawn@^7.0.2:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-debug@^4, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4:
+debug@^4, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4:
   version "4.4.3"
   resolved "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz"
   integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
@@ -840,7 +909,7 @@ eslint-visitor-keys@^3.4.1, eslint-visitor-keys@^3.4.3:
   resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz"
   integrity sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
 
-eslint@^8.57.1:
+"eslint@^6.0.0 || ^7.0.0 || >=8.0.0", "eslint@^7.0.0 || ^8.0.0", eslint@^8.57.1:
   version "8.57.1"
   resolved "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz"
   integrity sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==
@@ -1064,7 +1133,7 @@ glob-parent@^6.0.2:
   dependencies:
     is-glob "^4.0.3"
 
-glob@^7.1.3:
+glob@^7.1.3, glob@^7.1.4:
   version "7.2.3"
   resolved "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz"
   integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
@@ -1133,6 +1202,11 @@ hasown@^2.0.2:
   integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
   dependencies:
     function-bind "^1.1.2"
+
+html-escaper@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz"
+  integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
 
 ieee754@^1.2.1:
   version "1.2.1"
@@ -1208,6 +1282,37 @@ isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
+
+istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.2.0:
+  version "3.2.2"
+  resolved "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz"
+  integrity sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==
+
+istanbul-lib-report@^3.0.0, istanbul-lib-report@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz"
+  integrity sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==
+  dependencies:
+    istanbul-lib-coverage "^3.0.0"
+    make-dir "^4.0.0"
+    supports-color "^7.1.0"
+
+istanbul-lib-source-maps@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz"
+  integrity sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==
+  dependencies:
+    debug "^4.1.1"
+    istanbul-lib-coverage "^3.0.0"
+    source-map "^0.6.1"
+
+istanbul-reports@^3.1.5:
+  version "3.2.0"
+  resolved "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz"
+  integrity sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==
+  dependencies:
+    html-escaper "^2.0.0"
+    istanbul-lib-report "^3.0.0"
 
 js-yaml@^4.1.0:
   version "4.1.1"
@@ -1292,6 +1397,13 @@ magic-string@^0.30.1:
   dependencies:
     "@jridgewell/sourcemap-codec" "^1.5.5"
 
+make-dir@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz"
+  integrity sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==
+  dependencies:
+    semver "^7.5.3"
+
 make-error@^1.1.1:
   version "1.3.6"
   resolved "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz"
@@ -1327,7 +1439,7 @@ mime-types@^2.1.12:
   dependencies:
     mime-db "1.52.0"
 
-minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
+minimatch@^3.0.4, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
   version "3.1.5"
   resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz"
   integrity sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==
@@ -1533,7 +1645,7 @@ pretty-format@^29.5.0:
     ansi-styles "^5.0.0"
     react-is "^18.0.0"
 
-prisma@^5.22.0:
+prisma@*, prisma@^5.22.0:
   version "5.22.0"
   resolved "https://registry.npmjs.org/prisma/-/prisma-5.22.0.tgz"
   integrity sha512-vtpjW3XuYCSnMsNVBjLMNkTj6OZbudcPPTPYHqX0CJfpcdWciI1dM8uHETwmDxxiqEwCIE6WvXucWUetJgfu/A==
@@ -1697,6 +1809,11 @@ source-map-js@^1.2.1:
   resolved "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz"
   integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
 
+source-map@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz"
+  integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+
 stackback@0.0.2:
   version "0.0.2"
   resolved "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz"
@@ -1759,6 +1876,15 @@ supports-color@^7.1.0:
   integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
   dependencies:
     has-flag "^4.0.0"
+
+test-exclude@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz"
+  integrity sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==
+  dependencies:
+    "@istanbuljs/schema" "^0.1.2"
+    glob "^7.1.4"
+    minimatch "^3.0.4"
 
 text-table@^0.2.0:
   version "0.2.0"
@@ -1856,7 +1982,7 @@ type-fest@^0.20.2:
   resolved "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz"
   integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
 
-typescript@^5.9.3:
+typescript@^5.9.3, typescript@>=2.7, typescript@>=4.2.0:
   version "5.9.3"
   resolved "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz"
   integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
@@ -1895,6 +2021,15 @@ v8-compile-cache-lib@^3.0.1:
   resolved "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz"
   integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
 
+v8-to-istanbul@^9.1.0:
+  version "9.3.0"
+  resolved "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz"
+  integrity sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==
+  dependencies:
+    "@jridgewell/trace-mapping" "^0.3.12"
+    "@types/istanbul-lib-coverage" "^2.0.1"
+    convert-source-map "^2.0.0"
+
 vite-node@0.34.6:
   version "0.34.6"
   resolved "https://registry.npmjs.org/vite-node/-/vite-node-0.34.6.tgz"
@@ -1918,7 +2053,7 @@ vite-node@0.34.6:
   optionalDependencies:
     fsevents "~2.3.3"
 
-vitest@^0.34.6:
+vitest@^0.34.6, "vitest@>=0.32.0 <1":
   version "0.34.6"
   resolved "https://registry.npmjs.org/vitest/-/vitest-0.34.6.tgz"
   integrity sha512-+5CALsOvbNKnS+ZHMXtuUC7nL8/7F1F2DnHGjSsszX8zCjWSSviphCb/NuS9Nzf4Q03KyyDRBAXhF/8lffME4Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -68,15 +68,78 @@
     tslib "^2.5.0"
     ws "^8.13.0"
 
+"@esbuild/win32-x64@0.21.5":
+  version "0.21.5"
+  resolved "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz"
+  integrity sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==
+
+"@eslint-community/eslint-utils@^4.2.0", "@eslint-community/eslint-utils@^4.4.0":
+  version "4.9.1"
+  resolved "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz"
+  integrity sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==
+  dependencies:
+    eslint-visitor-keys "^3.4.3"
+
+"@eslint-community/regexpp@^4.5.1", "@eslint-community/regexpp@^4.6.1":
+  version "4.12.2"
+  resolved "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz"
+  integrity sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==
+
+"@eslint/eslintrc@^2.1.4":
+  version "2.1.4"
+  resolved "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz"
+  integrity sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==
+  dependencies:
+    ajv "^6.12.4"
+    debug "^4.3.2"
+    espree "^9.6.0"
+    globals "^13.19.0"
+    ignore "^5.2.0"
+    import-fresh "^3.2.1"
+    js-yaml "^4.1.0"
+    minimatch "^3.1.2"
+    strip-json-comments "^3.1.1"
+
+"@eslint/js@8.57.1":
+  version "8.57.1"
+  resolved "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz"
+  integrity sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==
+
+"@humanwhocodes/config-array@^0.13.0":
+  version "0.13.0"
+  resolved "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz"
+  integrity sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==
+  dependencies:
+    "@humanwhocodes/object-schema" "^2.0.3"
+    debug "^4.3.1"
+    minimatch "^3.0.5"
+
+"@humanwhocodes/module-importer@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz"
+  integrity sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==
+
+"@humanwhocodes/object-schema@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz"
+  integrity sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==
+
+"@jest/schemas@^29.6.3":
+  version "29.6.3"
+  resolved "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz"
+  integrity sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==
+  dependencies:
+    "@sinclair/typebox" "^0.27.8"
+
 "@jridgewell/resolve-uri@^3.0.3":
   version "3.1.1"
   resolved "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz"
   integrity sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==
 
-"@jridgewell/sourcemap-codec@^1.4.10":
-  version "1.4.15"
-  resolved "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz"
-  integrity sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==
+"@jridgewell/sourcemap-codec@^1.4.10", "@jridgewell/sourcemap-codec@^1.5.5":
+  version "1.5.5"
+  resolved "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz"
+  integrity sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==
 
 "@jridgewell/trace-mapping@0.3.9":
   version "0.3.9"
@@ -85,6 +148,27 @@
   dependencies:
     "@jridgewell/resolve-uri" "^3.0.3"
     "@jridgewell/sourcemap-codec" "^1.4.10"
+
+"@nodelib/fs.scandir@2.1.5":
+  version "2.1.5"
+  resolved "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz"
+  integrity sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==
+  dependencies:
+    "@nodelib/fs.stat" "2.0.5"
+    run-parallel "^1.1.9"
+
+"@nodelib/fs.stat@^2.0.2", "@nodelib/fs.stat@2.0.5":
+  version "2.0.5"
+  resolved "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz"
+  integrity sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==
+
+"@nodelib/fs.walk@^1.2.3", "@nodelib/fs.walk@^1.2.8":
+  version "1.2.8"
+  resolved "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz"
+  integrity sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==
+  dependencies:
+    "@nodelib/fs.scandir" "2.1.5"
+    fastq "^1.6.0"
 
 "@prisma/client@^5.22.0":
   version "5.22.0"
@@ -127,6 +211,16 @@
   dependencies:
     "@prisma/debug" "5.22.0"
 
+"@rollup/rollup-win32-x64-gnu@4.59.0":
+  version "4.59.0"
+  resolved "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz"
+  integrity sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==
+
+"@rollup/rollup-win32-x64-msvc@4.59.0":
+  version "4.59.0"
+  resolved "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz"
+  integrity sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==
+
 "@sapphire/async-queue@^1.5.0":
   version "1.5.0"
   resolved "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.0.tgz"
@@ -144,6 +238,11 @@
   version "3.5.1"
   resolved "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.1.tgz"
   integrity sha512-BxcYGzgEsdlG0dKAyOm0ehLGm2CafIrfQTZGWgkfKYbj+pNNsorZ7EotuZukc2MT70E0UbppVbtpBrqpzVzjNA==
+
+"@sinclair/typebox@^0.27.8":
+  version "0.27.10"
+  resolved "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz"
+  integrity sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==
 
 "@tokenizer/token@^0.3.0":
   version "0.3.0"
@@ -170,10 +269,35 @@
   resolved "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz"
   integrity sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==
 
+"@types/chai-subset@^1.3.3":
+  version "1.3.6"
+  resolved "https://registry.npmjs.org/@types/chai-subset/-/chai-subset-1.3.6.tgz"
+  integrity sha512-m8lERkkQj+uek18hXOZuec3W/fCRTrU4hrnXjH3qhHy96ytuPaPiWGgu7sJb7tZxZonO75vYAjCvpe/e4VUwRw==
+
+"@types/chai@^4.3.5":
+  version "4.3.20"
+  resolved "https://registry.npmjs.org/@types/chai/-/chai-4.3.20.tgz"
+  integrity sha512-/pC9HAB5I/xMlc5FP77qjCnI16ChlJfW0tGa0IUcFn38VJrTV6DeZ60NU5KZBtaOZqjdpwTWohz5HU1RrhiYxQ==
+
+"@types/estree@1.0.8":
+  version "1.0.8"
+  resolved "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz"
+  integrity sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==
+
+"@types/json-schema@^7.0.12":
+  version "7.0.15"
+  resolved "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz"
+  integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
+
 "@types/node@*", "@types/node@^20.4.2":
   version "20.4.2"
   resolved "https://registry.npmjs.org/@types/node/-/node-20.4.2.tgz"
   integrity sha512-Dd0BYtWgnWJKwO1jkmTrzofjK2QXXcai0dmtzvIBhcA+RsG5h8R3xlyta0kGOZRNfL9GuRtb1knmPEhQrePCEw==
+
+"@types/semver@^7.5.0":
+  version "7.7.1"
+  resolved "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz"
+  integrity sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==
 
 "@types/ws@^8.5.4":
   version "8.5.5"
@@ -182,20 +306,186 @@
   dependencies:
     "@types/node" "*"
 
+"@typescript-eslint/eslint-plugin@^6.21.0":
+  version "6.21.0"
+  resolved "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.21.0.tgz"
+  integrity sha512-oy9+hTPCUFpngkEZUSzbf9MxI65wbKFoQYsgPdILTfbUldp5ovUuphZVe4i30emU9M/kP+T64Di0mxl7dSw3MA==
+  dependencies:
+    "@eslint-community/regexpp" "^4.5.1"
+    "@typescript-eslint/scope-manager" "6.21.0"
+    "@typescript-eslint/type-utils" "6.21.0"
+    "@typescript-eslint/utils" "6.21.0"
+    "@typescript-eslint/visitor-keys" "6.21.0"
+    debug "^4.3.4"
+    graphemer "^1.4.0"
+    ignore "^5.2.4"
+    natural-compare "^1.4.0"
+    semver "^7.5.4"
+    ts-api-utils "^1.0.1"
+
+"@typescript-eslint/parser@^6.21.0":
+  version "6.21.0"
+  resolved "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz"
+  integrity sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==
+  dependencies:
+    "@typescript-eslint/scope-manager" "6.21.0"
+    "@typescript-eslint/types" "6.21.0"
+    "@typescript-eslint/typescript-estree" "6.21.0"
+    "@typescript-eslint/visitor-keys" "6.21.0"
+    debug "^4.3.4"
+
+"@typescript-eslint/scope-manager@6.21.0":
+  version "6.21.0"
+  resolved "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz"
+  integrity sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==
+  dependencies:
+    "@typescript-eslint/types" "6.21.0"
+    "@typescript-eslint/visitor-keys" "6.21.0"
+
+"@typescript-eslint/type-utils@6.21.0":
+  version "6.21.0"
+  resolved "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.21.0.tgz"
+  integrity sha512-rZQI7wHfao8qMX3Rd3xqeYSMCL3SoiSQLBATSiVKARdFGCYSRvmViieZjqc58jKgs8Y8i9YvVVhRbHSTA4VBag==
+  dependencies:
+    "@typescript-eslint/typescript-estree" "6.21.0"
+    "@typescript-eslint/utils" "6.21.0"
+    debug "^4.3.4"
+    ts-api-utils "^1.0.1"
+
+"@typescript-eslint/types@6.21.0":
+  version "6.21.0"
+  resolved "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz"
+  integrity sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==
+
+"@typescript-eslint/typescript-estree@6.21.0":
+  version "6.21.0"
+  resolved "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz"
+  integrity sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==
+  dependencies:
+    "@typescript-eslint/types" "6.21.0"
+    "@typescript-eslint/visitor-keys" "6.21.0"
+    debug "^4.3.4"
+    globby "^11.1.0"
+    is-glob "^4.0.3"
+    minimatch "9.0.3"
+    semver "^7.5.4"
+    ts-api-utils "^1.0.1"
+
+"@typescript-eslint/utils@6.21.0":
+  version "6.21.0"
+  resolved "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.21.0.tgz"
+  integrity sha512-NfWVaC8HP9T8cbKQxHcsJBY5YE1O33+jpMwN45qzWWaPDZgLIbo12toGMWnmhvCpd3sIxkpDw3Wv1B3dYrbDQQ==
+  dependencies:
+    "@eslint-community/eslint-utils" "^4.4.0"
+    "@types/json-schema" "^7.0.12"
+    "@types/semver" "^7.5.0"
+    "@typescript-eslint/scope-manager" "6.21.0"
+    "@typescript-eslint/types" "6.21.0"
+    "@typescript-eslint/typescript-estree" "6.21.0"
+    semver "^7.5.4"
+
+"@typescript-eslint/visitor-keys@6.21.0":
+  version "6.21.0"
+  resolved "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz"
+  integrity sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==
+  dependencies:
+    "@typescript-eslint/types" "6.21.0"
+    eslint-visitor-keys "^3.4.1"
+
+"@ungap/structured-clone@^1.2.0":
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz"
+  integrity sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==
+
+"@vitest/expect@0.34.6":
+  version "0.34.6"
+  resolved "https://registry.npmjs.org/@vitest/expect/-/expect-0.34.6.tgz"
+  integrity sha512-QUzKpUQRc1qC7qdGo7rMK3AkETI7w18gTCUrsNnyjjJKYiuUB9+TQK3QnR1unhCnWRC0AbKv2omLGQDF/mIjOw==
+  dependencies:
+    "@vitest/spy" "0.34.6"
+    "@vitest/utils" "0.34.6"
+    chai "^4.3.10"
+
+"@vitest/runner@0.34.6":
+  version "0.34.6"
+  resolved "https://registry.npmjs.org/@vitest/runner/-/runner-0.34.6.tgz"
+  integrity sha512-1CUQgtJSLF47NnhN+F9X2ycxUP0kLHQ/JWvNHbeBfwW8CzEGgeskzNnHDyv1ieKTltuR6sdIHV+nmR6kPxQqzQ==
+  dependencies:
+    "@vitest/utils" "0.34.6"
+    p-limit "^4.0.0"
+    pathe "^1.1.1"
+
+"@vitest/snapshot@0.34.6":
+  version "0.34.6"
+  resolved "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-0.34.6.tgz"
+  integrity sha512-B3OZqYn6k4VaN011D+ve+AA4whM4QkcwcrwaKwAbyyvS/NB1hCWjFIBQxAQQSQir9/RtyAAGuq+4RJmbn2dH4w==
+  dependencies:
+    magic-string "^0.30.1"
+    pathe "^1.1.1"
+    pretty-format "^29.5.0"
+
+"@vitest/spy@0.34.6":
+  version "0.34.6"
+  resolved "https://registry.npmjs.org/@vitest/spy/-/spy-0.34.6.tgz"
+  integrity sha512-xaCvneSaeBw/cz8ySmF7ZwGvL0lBjfvqc1LpQ/vcdHEvpLn3Ff1vAvjw+CoGn0802l++5L/pxb7whwcWAw+DUQ==
+  dependencies:
+    tinyspy "^2.1.1"
+
+"@vitest/utils@0.34.6":
+  version "0.34.6"
+  resolved "https://registry.npmjs.org/@vitest/utils/-/utils-0.34.6.tgz"
+  integrity sha512-IG5aDD8S6zlvloDsnzHw0Ut5xczlF+kv2BOTo+iXfPr54Yhi5qbVOgGB1hZaVq4iJ4C/MZ2J0y15IlsV/ZcI0A==
+  dependencies:
+    diff-sequences "^29.4.3"
+    loupe "^2.3.6"
+    pretty-format "^29.5.0"
+
 "@vladfrangu/async_event_emitter@^2.2.1":
   version "2.2.2"
   resolved "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.2.2.tgz"
   integrity sha512-HIzRG7sy88UZjBJamssEczH5q7t5+axva19UbZLO6u0ySbYPrwzWiXBcC0WuHyhKKoeCyneH+FvYzKQq/zTtkQ==
 
-acorn-walk@^8.1.1:
+acorn-jsx@^5.3.2:
+  version "5.3.2"
+  resolved "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz"
+  integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
+
+acorn-walk@^8.1.1, acorn-walk@^8.2.0:
   version "8.2.0"
   resolved "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz"
   integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
 
-acorn@^8.4.1:
-  version "8.10.0"
-  resolved "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz"
-  integrity sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==
+acorn@^8.10.0, acorn@^8.15.0, acorn@^8.4.1, acorn@^8.9.0:
+  version "8.16.0"
+  resolved "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz"
+  integrity sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==
+
+ajv@^6.12.4:
+  version "6.14.0"
+  resolved "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz"
+  integrity sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
+ansi-regex@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz"
+  integrity sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==
+
+ansi-styles@^4.1.0:
+  version "4.3.0"
+  resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz"
+  integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
+  dependencies:
+    color-convert "^2.0.1"
+
+ansi-styles@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz"
+  integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
 
 anymatch@~3.1.2:
   version "3.1.3"
@@ -210,15 +500,30 @@ arg@^4.1.0:
   resolved "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz"
   integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
+argparse@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz"
+  integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
+
+array-union@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz"
+  integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
+
+assertion-error@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz"
+  integrity sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
+
 asynckit@^0.4.0:
   version "0.4.0"
-  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
+  resolved "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
 axios@^1.13.5:
-  version "1.13.5"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-1.13.5.tgz#5e464688fa127e11a660a2c49441c009f6567a43"
-  integrity sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==
+  version "1.13.6"
+  resolved "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz"
+  integrity sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==
   dependencies:
     follow-redirects "^1.15.11"
     form-data "^4.0.5"
@@ -242,7 +547,14 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-braces@~3.0.2:
+brace-expansion@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz"
+  integrity sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==
+  dependencies:
+    balanced-match "^1.0.0"
+
+braces@^3.0.3, braces@~3.0.2:
   version "3.0.3"
   resolved "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz"
   integrity sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==
@@ -256,13 +568,51 @@ busboy@^1.6.0:
   dependencies:
     streamsearch "^1.1.0"
 
+cac@^6.7.14:
+  version "6.7.14"
+  resolved "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz"
+  integrity sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==
+
 call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz#4b5428c222be985d79c3d82657479dbe0b59b2d6"
+  resolved "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz"
   integrity sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==
   dependencies:
     es-errors "^1.3.0"
     function-bind "^1.1.2"
+
+callsites@^3.0.0:
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz"
+  integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
+
+chai@^4.3.10:
+  version "4.5.0"
+  resolved "https://registry.npmjs.org/chai/-/chai-4.5.0.tgz"
+  integrity sha512-RITGBfijLkBddZvnn8jdqoTypxvqbOLYQkGGxXzeFjVHvudaPw0HNFD9x928/eUwYWd2dPCugVqspGALTZZQKw==
+  dependencies:
+    assertion-error "^1.1.0"
+    check-error "^1.0.3"
+    deep-eql "^4.1.3"
+    get-func-name "^2.0.2"
+    loupe "^2.3.6"
+    pathval "^1.1.1"
+    type-detect "^4.1.0"
+
+chalk@^4.0.0:
+  version "4.1.2"
+  resolved "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz"
+  integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
+  dependencies:
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
+
+check-error@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz"
+  integrity sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==
+  dependencies:
+    get-func-name "^2.0.2"
 
 chokidar@^3.5.2:
   version "3.6.0"
@@ -286,9 +636,21 @@ clashofclans.js@^3.1.0:
   dependencies:
     node-fetch "^2.6.7"
 
+color-convert@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz"
+  integrity sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
+  dependencies:
+    color-name "~1.1.4"
+
+color-name@~1.1.4:
+  version "1.1.4"
+  resolved "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz"
+  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
 combined-stream@^1.0.8:
   version "1.0.8"
-  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
+  resolved "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
   dependencies:
     delayed-stream "~1.0.0"
@@ -298,27 +660,65 @@ concat-map@0.0.1:
   resolved "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
+confbox@^0.1.8:
+  version "0.1.8"
+  resolved "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz"
+  integrity sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==
+
 create-require@^1.1.0:
   version "1.1.1"
   resolved "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz"
   integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
 
-debug@^4:
+cross-spawn@^7.0.2:
+  version "7.0.6"
+  resolved "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz"
+  integrity sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==
+  dependencies:
+    path-key "^3.1.0"
+    shebang-command "^2.0.0"
+    which "^2.0.1"
+
+debug@^4, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4:
   version "4.4.3"
   resolved "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz"
   integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
   dependencies:
     ms "^2.1.3"
 
+deep-eql@^4.1.3:
+  version "4.1.4"
+  resolved "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.4.tgz"
+  integrity sha512-SUwdGfqdKOwxCPeVYjwSyRpJ7Z+fhpwIAtmCUdZIWZ/YP5R9WAsyuSgpLVDi9bjWoN2LXHNss/dk3urXtdQxGg==
+  dependencies:
+    type-detect "^4.0.0"
+
+deep-is@^0.1.3:
+  version "0.1.4"
+  resolved "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz"
+  integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
+
 delayed-stream@~1.0.0:
   version "1.0.0"
-  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+  resolved "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
   integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
+
+diff-sequences@^29.4.3:
+  version "29.6.3"
+  resolved "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz"
+  integrity sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==
 
 diff@^4.0.1:
   version "4.0.2"
   resolved "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz"
   integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
+
+dir-glob@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz"
+  integrity sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==
+  dependencies:
+    path-type "^4.0.0"
 
 discord-api-types@^0.37.41:
   version "0.37.49"
@@ -345,6 +745,13 @@ discord.js@^14.11.0:
     undici "^5.22.0"
     ws "^8.13.0"
 
+doctrine@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz"
+  integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
+  dependencies:
+    esutils "^2.0.2"
+
 dotenv@^16.3.1:
   version "16.3.1"
   resolved "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz"
@@ -352,7 +759,7 @@ dotenv@^16.3.1:
 
 dunder-proto@^1.0.1:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/dunder-proto/-/dunder-proto-1.0.1.tgz#d7ae667e1dc83482f8b70fd0f6eefc50da30f58a"
+  resolved "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz"
   integrity sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==
   dependencies:
     call-bind-apply-helpers "^1.0.1"
@@ -361,24 +768,24 @@ dunder-proto@^1.0.1:
 
 es-define-property@^1.0.1:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/es-define-property/-/es-define-property-1.0.1.tgz#983eb2f9a6724e9303f61addf011c72e09e0b0fa"
+  resolved "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz"
   integrity sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==
 
 es-errors@^1.3.0:
   version "1.3.0"
-  resolved "https://registry.yarnpkg.com/es-errors/-/es-errors-1.3.0.tgz#05f75a25dab98e4fb1dcd5e1472c0546d5057c8f"
+  resolved "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz"
   integrity sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==
 
 es-object-atoms@^1.0.0, es-object-atoms@^1.1.1:
   version "1.1.1"
-  resolved "https://registry.yarnpkg.com/es-object-atoms/-/es-object-atoms-1.1.1.tgz#1c4f2c4837327597ce69d2ca190a7fdd172338c1"
+  resolved "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz"
   integrity sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==
   dependencies:
     es-errors "^1.3.0"
 
 es-set-tostringtag@^2.1.0:
   version "2.1.0"
-  resolved "https://registry.yarnpkg.com/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz#f31dbbe0c183b00a6d26eb6325c810c0fd18bd4d"
+  resolved "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz"
   integrity sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==
   dependencies:
     es-errors "^1.3.0"
@@ -386,10 +793,169 @@ es-set-tostringtag@^2.1.0:
     has-tostringtag "^1.0.2"
     hasown "^2.0.2"
 
-fast-deep-equal@^3.1.3:
+esbuild@^0.21.3:
+  version "0.21.5"
+  resolved "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz"
+  integrity sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==
+  optionalDependencies:
+    "@esbuild/aix-ppc64" "0.21.5"
+    "@esbuild/android-arm" "0.21.5"
+    "@esbuild/android-arm64" "0.21.5"
+    "@esbuild/android-x64" "0.21.5"
+    "@esbuild/darwin-arm64" "0.21.5"
+    "@esbuild/darwin-x64" "0.21.5"
+    "@esbuild/freebsd-arm64" "0.21.5"
+    "@esbuild/freebsd-x64" "0.21.5"
+    "@esbuild/linux-arm" "0.21.5"
+    "@esbuild/linux-arm64" "0.21.5"
+    "@esbuild/linux-ia32" "0.21.5"
+    "@esbuild/linux-loong64" "0.21.5"
+    "@esbuild/linux-mips64el" "0.21.5"
+    "@esbuild/linux-ppc64" "0.21.5"
+    "@esbuild/linux-riscv64" "0.21.5"
+    "@esbuild/linux-s390x" "0.21.5"
+    "@esbuild/linux-x64" "0.21.5"
+    "@esbuild/netbsd-x64" "0.21.5"
+    "@esbuild/openbsd-x64" "0.21.5"
+    "@esbuild/sunos-x64" "0.21.5"
+    "@esbuild/win32-arm64" "0.21.5"
+    "@esbuild/win32-ia32" "0.21.5"
+    "@esbuild/win32-x64" "0.21.5"
+
+escape-string-regexp@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz"
+  integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
+
+eslint-scope@^7.2.2:
+  version "7.2.2"
+  resolved "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz"
+  integrity sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==
+  dependencies:
+    esrecurse "^4.3.0"
+    estraverse "^5.2.0"
+
+eslint-visitor-keys@^3.4.1, eslint-visitor-keys@^3.4.3:
+  version "3.4.3"
+  resolved "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz"
+  integrity sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
+
+eslint@^8.57.1:
+  version "8.57.1"
+  resolved "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz"
+  integrity sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==
+  dependencies:
+    "@eslint-community/eslint-utils" "^4.2.0"
+    "@eslint-community/regexpp" "^4.6.1"
+    "@eslint/eslintrc" "^2.1.4"
+    "@eslint/js" "8.57.1"
+    "@humanwhocodes/config-array" "^0.13.0"
+    "@humanwhocodes/module-importer" "^1.0.1"
+    "@nodelib/fs.walk" "^1.2.8"
+    "@ungap/structured-clone" "^1.2.0"
+    ajv "^6.12.4"
+    chalk "^4.0.0"
+    cross-spawn "^7.0.2"
+    debug "^4.3.2"
+    doctrine "^3.0.0"
+    escape-string-regexp "^4.0.0"
+    eslint-scope "^7.2.2"
+    eslint-visitor-keys "^3.4.3"
+    espree "^9.6.1"
+    esquery "^1.4.2"
+    esutils "^2.0.2"
+    fast-deep-equal "^3.1.3"
+    file-entry-cache "^6.0.1"
+    find-up "^5.0.0"
+    glob-parent "^6.0.2"
+    globals "^13.19.0"
+    graphemer "^1.4.0"
+    ignore "^5.2.0"
+    imurmurhash "^0.1.4"
+    is-glob "^4.0.0"
+    is-path-inside "^3.0.3"
+    js-yaml "^4.1.0"
+    json-stable-stringify-without-jsonify "^1.0.1"
+    levn "^0.4.1"
+    lodash.merge "^4.6.2"
+    minimatch "^3.1.2"
+    natural-compare "^1.4.0"
+    optionator "^0.9.3"
+    strip-ansi "^6.0.1"
+    text-table "^0.2.0"
+
+espree@^9.6.0, espree@^9.6.1:
+  version "9.6.1"
+  resolved "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz"
+  integrity sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==
+  dependencies:
+    acorn "^8.9.0"
+    acorn-jsx "^5.3.2"
+    eslint-visitor-keys "^3.4.1"
+
+esquery@^1.4.2:
+  version "1.7.0"
+  resolved "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz"
+  integrity sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==
+  dependencies:
+    estraverse "^5.1.0"
+
+esrecurse@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz"
+  integrity sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==
+  dependencies:
+    estraverse "^5.2.0"
+
+estraverse@^5.1.0, estraverse@^5.2.0:
+  version "5.3.0"
+  resolved "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz"
+  integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
+
+esutils@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz"
+  integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
+
+fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
+
+fast-glob@^3.2.9:
+  version "3.3.3"
+  resolved "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz"
+  integrity sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==
+  dependencies:
+    "@nodelib/fs.stat" "^2.0.2"
+    "@nodelib/fs.walk" "^1.2.3"
+    glob-parent "^5.1.2"
+    merge2 "^1.3.0"
+    micromatch "^4.0.8"
+
+fast-json-stable-stringify@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz"
+  integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
+
+fast-levenshtein@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz"
+  integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
+
+fastq@^1.6.0:
+  version "1.20.1"
+  resolved "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz"
+  integrity sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==
+  dependencies:
+    reusify "^1.0.4"
+
+file-entry-cache@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz"
+  integrity sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==
+  dependencies:
+    flat-cache "^3.0.4"
 
 file-type@^18.3.0:
   version "18.5.0"
@@ -407,14 +973,36 @@ fill-range@^7.1.1:
   dependencies:
     to-regex-range "^5.0.1"
 
+find-up@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz"
+  integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
+  dependencies:
+    locate-path "^6.0.0"
+    path-exists "^4.0.0"
+
+flat-cache@^3.0.4:
+  version "3.2.0"
+  resolved "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz"
+  integrity sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==
+  dependencies:
+    flatted "^3.2.9"
+    keyv "^4.5.3"
+    rimraf "^3.0.2"
+
+flatted@^3.2.9:
+  version "3.3.3"
+  resolved "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz"
+  integrity sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==
+
 follow-redirects@^1.15.11:
   version "1.15.11"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.11.tgz#777d73d72a92f8ec4d2e410eb47352a56b8e8340"
+  resolved "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz"
   integrity sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==
 
 form-data@^4.0.5:
   version "4.0.5"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.5.tgz#b49e48858045ff4cbf6b03e1805cebcad3679053"
+  resolved "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz"
   integrity sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==
   dependencies:
     asynckit "^0.4.0"
@@ -423,19 +1011,24 @@ form-data@^4.0.5:
     hasown "^2.0.2"
     mime-types "^2.1.12"
 
-fsevents@2.3.3, fsevents@~2.3.2:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
-  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
+fs.realpath@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
+  integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
 function-bind@^1.1.2:
   version "1.1.2"
-  resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.2.tgz#2c02d864d97f3ea6c8830c464cbd11ab6eab7a1c"
+  resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz"
   integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
+
+get-func-name@^2.0.1, get-func-name@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz"
+  integrity sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==
 
 get-intrinsic@^1.2.6:
   version "1.3.0"
-  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz#743f0e3b6964a93a5491ed1bffaae054d7f98d01"
+  resolved "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz"
   integrity sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==
   dependencies:
     call-bind-apply-helpers "^1.0.2"
@@ -451,44 +1044,92 @@ get-intrinsic@^1.2.6:
 
 get-proto@^1.0.1:
   version "1.0.1"
-  resolved "https://registry.yarnpkg.com/get-proto/-/get-proto-1.0.1.tgz#150b3f2743869ef3e851ec0c49d15b1d14d00ee1"
+  resolved "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz"
   integrity sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==
   dependencies:
     dunder-proto "^1.0.1"
     es-object-atoms "^1.0.0"
 
-glob-parent@~5.1.2:
+glob-parent@^5.1.2, glob-parent@~5.1.2:
   version "5.1.2"
   resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz"
   integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
   dependencies:
     is-glob "^4.0.1"
 
+glob-parent@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz"
+  integrity sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==
+  dependencies:
+    is-glob "^4.0.3"
+
+glob@^7.1.3:
+  version "7.2.3"
+  resolved "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz"
+  integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
+  dependencies:
+    fs.realpath "^1.0.0"
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "^3.1.1"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
+globals@^13.19.0:
+  version "13.24.0"
+  resolved "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz"
+  integrity sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==
+  dependencies:
+    type-fest "^0.20.2"
+
+globby@^11.1.0:
+  version "11.1.0"
+  resolved "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz"
+  integrity sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==
+  dependencies:
+    array-union "^2.1.0"
+    dir-glob "^3.0.1"
+    fast-glob "^3.2.9"
+    ignore "^5.2.0"
+    merge2 "^1.4.1"
+    slash "^3.0.0"
+
 gopd@^1.2.0:
   version "1.2.0"
-  resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"
+  resolved "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz"
   integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
+
+graphemer@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz"
+  integrity sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==
 
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz"
   integrity sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==
 
+has-flag@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz"
+  integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
+
 has-symbols@^1.0.3, has-symbols@^1.1.0:
   version "1.1.0"
-  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.1.0.tgz#fc9c6a783a084951d0b971fe1018de813707a338"
+  resolved "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz"
   integrity sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==
 
 has-tostringtag@^1.0.2:
   version "1.0.2"
-  resolved "https://registry.yarnpkg.com/has-tostringtag/-/has-tostringtag-1.0.2.tgz#2cdc42d40bef2e5b4eeab7c01a73c54ce7ab5abc"
+  resolved "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz"
   integrity sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==
   dependencies:
     has-symbols "^1.0.3"
 
 hasown@^2.0.2:
   version "2.0.2"
-  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.2.tgz#003eaf91be7adc372e84ec59dc37252cedb80003"
+  resolved "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz"
   integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
   dependencies:
     function-bind "^1.1.2"
@@ -503,7 +1144,33 @@ ignore-by-default@^1.0.1:
   resolved "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz"
   integrity sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==
 
-inherits@^2.0.3:
+ignore@^5.2.0, ignore@^5.2.4:
+  version "5.3.2"
+  resolved "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz"
+  integrity sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==
+
+import-fresh@^3.2.1:
+  version "3.3.1"
+  resolved "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz"
+  integrity sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==
+  dependencies:
+    parent-module "^1.0.0"
+    resolve-from "^4.0.0"
+
+imurmurhash@^0.1.4:
+  version "0.1.4"
+  resolved "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz"
+  integrity sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==
+
+inflight@^1.0.4:
+  version "1.0.6"
+  resolved "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz"
+  integrity sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==
+  dependencies:
+    once "^1.3.0"
+    wrappy "1"
+
+inherits@^2.0.3, inherits@2:
   version "2.0.4"
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -520,7 +1187,7 @@ is-extglob@^2.1.1:
   resolved "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz"
   integrity sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==
 
-is-glob@^4.0.1, is-glob@~4.0.1:
+is-glob@^4.0.0, is-glob@^4.0.1, is-glob@^4.0.3, is-glob@~4.0.1:
   version "4.0.3"
   resolved "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz"
   integrity sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==
@@ -532,10 +1199,74 @@ is-number@^7.0.0:
   resolved "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
+is-path-inside@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz"
+  integrity sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==
+
+isexe@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
+  integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
+
+js-yaml@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz"
+  integrity sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==
+  dependencies:
+    argparse "^2.0.1"
+
+json-buffer@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz"
+  integrity sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==
+
+json-schema-traverse@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz"
+  integrity sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
+
+json-stable-stringify-without-jsonify@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz"
+  integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
+
+keyv@^4.5.3:
+  version "4.5.4"
+  resolved "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz"
+  integrity sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==
+  dependencies:
+    json-buffer "3.0.1"
+
 knockout@^3.5.1:
   version "3.5.1"
   resolved "https://registry.npmjs.org/knockout/-/knockout-3.5.1.tgz"
   integrity sha512-wRJ9I4az0QcsH7A4v4l0enUpkS++MBx0BnL/68KaLzJg7x1qmbjSlwEoCNol7KTYZ+pmtI7Eh2J0Nu6/2Z5J/Q==
+
+levn@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz"
+  integrity sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==
+  dependencies:
+    prelude-ls "^1.2.1"
+    type-check "~0.4.0"
+
+local-pkg@^0.4.3:
+  version "0.4.3"
+  resolved "https://registry.npmjs.org/local-pkg/-/local-pkg-0.4.3.tgz"
+  integrity sha512-SFppqq5p42fe2qcZQqqEOiVRXl+WCP1MdT6k7BDEW1j++sp5fIY+/fdRQitvKgB5BrBcmrs5m/L0v2FrU5MY1g==
+
+locate-path@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz"
+  integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
+  dependencies:
+    p-locate "^5.0.0"
+
+lodash.merge@^4.6.2:
+  version "4.6.2"
+  resolved "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz"
+  integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
 lodash.snakecase@^4.1.1:
   version "4.1.1"
@@ -547,6 +1278,20 @@ lodash@^4.17.21:
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
+loupe@^2.3.6:
+  version "2.3.7"
+  resolved "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz"
+  integrity sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==
+  dependencies:
+    get-func-name "^2.0.1"
+
+magic-string@^0.30.1:
+  version "0.30.21"
+  resolved "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz"
+  integrity sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==
+  dependencies:
+    "@jridgewell/sourcemap-codec" "^1.5.5"
+
 make-error@^1.1.1:
   version "1.3.6"
   resolved "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz"
@@ -554,32 +1299,72 @@ make-error@^1.1.1:
 
 math-intrinsics@^1.1.0:
   version "1.1.0"
-  resolved "https://registry.yarnpkg.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz#a0dd74be81e2aa5c2f27e65ce283605ee4e2b7f9"
+  resolved "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz"
   integrity sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==
+
+merge2@^1.3.0, merge2@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz"
+  integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
+
+micromatch@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz"
+  integrity sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==
+  dependencies:
+    braces "^3.0.3"
+    picomatch "^2.3.1"
 
 mime-db@1.52.0:
   version "1.52.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
+  resolved "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
 mime-types@^2.1.12:
   version "2.1.35"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
+  resolved "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
   dependencies:
     mime-db "1.52.0"
 
-minimatch@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz"
-  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
+  version "3.1.5"
+  resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz"
+  integrity sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==
   dependencies:
     brace-expansion "^1.1.7"
+
+minimatch@9.0.3:
+  version "9.0.3"
+  resolved "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz"
+  integrity sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==
+  dependencies:
+    brace-expansion "^2.0.1"
+
+mlly@^1.4.0, mlly@^1.7.4:
+  version "1.8.0"
+  resolved "https://registry.npmjs.org/mlly/-/mlly-1.8.0.tgz"
+  integrity sha512-l8D9ODSRWLe2KHJSifWGwBqpTZXIXTeo8mlKjY+E2HAakaTeNpqAyBZ8GSqLzHgw4XmHmC8whvpjJNMbFZN7/g==
+  dependencies:
+    acorn "^8.15.0"
+    pathe "^2.0.3"
+    pkg-types "^1.3.1"
+    ufo "^1.6.1"
 
 ms@^2.1.3:
   version "2.1.3"
   resolved "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
+
+nanoid@^3.3.11:
+  version "3.3.11"
+  resolved "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz"
+  integrity sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==
+
+natural-compare@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz"
+  integrity sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==
 
 node-fetch@^2.6.7:
   version "2.6.12"
@@ -609,20 +1394,144 @@ normalize-path@^3.0.0, normalize-path@~3.0.0:
   resolved "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
 
+once@^1.3.0:
+  version "1.4.0"
+  resolved "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
+  integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
+  dependencies:
+    wrappy "1"
+
+optionator@^0.9.3:
+  version "0.9.4"
+  resolved "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz"
+  integrity sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==
+  dependencies:
+    deep-is "^0.1.3"
+    fast-levenshtein "^2.0.6"
+    levn "^0.4.1"
+    prelude-ls "^1.2.1"
+    type-check "^0.4.0"
+    word-wrap "^1.2.5"
+
+p-limit@^3.0.2:
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz"
+  integrity sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
+  dependencies:
+    yocto-queue "^0.1.0"
+
+p-limit@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz"
+  integrity sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==
+  dependencies:
+    yocto-queue "^1.0.0"
+
+p-locate@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz"
+  integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
+  dependencies:
+    p-limit "^3.0.2"
+
+parent-module@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz"
+  integrity sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
+  dependencies:
+    callsites "^3.0.0"
+
+path-exists@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz"
+  integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
+
+path-is-absolute@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+  integrity sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==
+
+path-key@^3.1.0:
+  version "3.1.1"
+  resolved "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz"
+  integrity sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
+
+path-type@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz"
+  integrity sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
+
+pathe@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz"
+  integrity sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==
+
+pathe@^2.0.1:
+  version "2.0.3"
+  resolved "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz"
+  integrity sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==
+
+pathe@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz"
+  integrity sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==
+
+pathval@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz"
+  integrity sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==
+
 peek-readable@^5.0.0:
   version "5.0.0"
   resolved "https://registry.npmjs.org/peek-readable/-/peek-readable-5.0.0.tgz"
   integrity sha512-YtCKvLUOvwtMGmrniQPdO7MwPjgkFBtFIrmfSbYmYuq3tKDV/mcfAhBth1+C3ru7uXIZasc/pHnb+YDYNkkj4A==
 
-picomatch@^2.0.4, picomatch@^2.2.1:
+picocolors@^1.0.0, picocolors@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz"
+  integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
+
+picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
+pkg-types@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz"
+  integrity sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==
+  dependencies:
+    confbox "^0.1.8"
+    mlly "^1.7.4"
+    pathe "^2.0.1"
+
 pngjs@^7.0.0:
   version "7.0.0"
-  resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-7.0.0.tgz#a8b7446020ebbc6ac739db6c5415a65d17090e26"
+  resolved "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz"
   integrity sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==
+
+postcss@^8.4.43:
+  version "8.5.6"
+  resolved "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz"
+  integrity sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==
+  dependencies:
+    nanoid "^3.3.11"
+    picocolors "^1.1.1"
+    source-map-js "^1.2.1"
+
+prelude-ls@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz"
+  integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
+
+pretty-format@^29.5.0:
+  version "29.7.0"
+  resolved "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz"
+  integrity sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==
+  dependencies:
+    "@jest/schemas" "^29.6.3"
+    ansi-styles "^5.0.0"
+    react-is "^18.0.0"
 
 prisma@^5.22.0:
   version "5.22.0"
@@ -635,7 +1544,7 @@ prisma@^5.22.0:
 
 proxy-from-env@^1.1.0:
   version "1.1.0"
-  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
+  resolved "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz"
   integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
 
 pstree.remy@^1.1.8:
@@ -643,10 +1552,25 @@ pstree.remy@^1.1.8:
   resolved "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz"
   integrity sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==
 
+punycode@^2.1.0:
+  version "2.3.1"
+  resolved "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz"
+  integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
+
 q@^1.5.1:
   version "1.5.1"
   resolved "https://registry.npmjs.org/q/-/q-1.5.1.tgz"
   integrity sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw==
+
+queue-microtask@^1.2.2:
+  version "1.2.3"
+  resolved "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz"
+  integrity sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==
+
+react-is@^18.0.0:
+  version "18.3.1"
+  resolved "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz"
+  integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
 
 readable-stream@^3.6.0:
   version "3.6.2"
@@ -671,15 +1595,90 @@ readdirp@~3.6.0:
   dependencies:
     picomatch "^2.2.1"
 
+resolve-from@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz"
+  integrity sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
+
+reusify@^1.0.4:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz"
+  integrity sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==
+
+rimraf@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+  dependencies:
+    glob "^7.1.3"
+
+rollup@^4.20.0:
+  version "4.59.0"
+  resolved "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz"
+  integrity sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==
+  dependencies:
+    "@types/estree" "1.0.8"
+  optionalDependencies:
+    "@rollup/rollup-android-arm-eabi" "4.59.0"
+    "@rollup/rollup-android-arm64" "4.59.0"
+    "@rollup/rollup-darwin-arm64" "4.59.0"
+    "@rollup/rollup-darwin-x64" "4.59.0"
+    "@rollup/rollup-freebsd-arm64" "4.59.0"
+    "@rollup/rollup-freebsd-x64" "4.59.0"
+    "@rollup/rollup-linux-arm-gnueabihf" "4.59.0"
+    "@rollup/rollup-linux-arm-musleabihf" "4.59.0"
+    "@rollup/rollup-linux-arm64-gnu" "4.59.0"
+    "@rollup/rollup-linux-arm64-musl" "4.59.0"
+    "@rollup/rollup-linux-loong64-gnu" "4.59.0"
+    "@rollup/rollup-linux-loong64-musl" "4.59.0"
+    "@rollup/rollup-linux-ppc64-gnu" "4.59.0"
+    "@rollup/rollup-linux-ppc64-musl" "4.59.0"
+    "@rollup/rollup-linux-riscv64-gnu" "4.59.0"
+    "@rollup/rollup-linux-riscv64-musl" "4.59.0"
+    "@rollup/rollup-linux-s390x-gnu" "4.59.0"
+    "@rollup/rollup-linux-x64-gnu" "4.59.0"
+    "@rollup/rollup-linux-x64-musl" "4.59.0"
+    "@rollup/rollup-openbsd-x64" "4.59.0"
+    "@rollup/rollup-openharmony-arm64" "4.59.0"
+    "@rollup/rollup-win32-arm64-msvc" "4.59.0"
+    "@rollup/rollup-win32-ia32-msvc" "4.59.0"
+    "@rollup/rollup-win32-x64-gnu" "4.59.0"
+    "@rollup/rollup-win32-x64-msvc" "4.59.0"
+    fsevents "~2.3.2"
+
+run-parallel@^1.1.9:
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz"
+  integrity sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==
+  dependencies:
+    queue-microtask "^1.2.2"
+
 safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
-semver@^7.5.3:
+semver@^7.5.3, semver@^7.5.4:
   version "7.7.3"
   resolved "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz"
   integrity sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==
+
+shebang-command@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz"
+  integrity sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
+  dependencies:
+    shebang-regex "^3.0.0"
+
+shebang-regex@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz"
+  integrity sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
+
+siginfo@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz"
+  integrity sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==
 
 simple-update-notifier@^2.0.0:
   version "2.0.0"
@@ -687,6 +1686,26 @@ simple-update-notifier@^2.0.0:
   integrity sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==
   dependencies:
     semver "^7.5.3"
+
+slash@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz"
+  integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
+
+source-map-js@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz"
+  integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
+
+stackback@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz"
+  integrity sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==
+
+std-env@^3.3.3:
+  version "3.10.0"
+  resolved "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz"
+  integrity sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==
 
 streamsearch@^1.1.0:
   version "1.1.0"
@@ -699,6 +1718,25 @@ string_decoder@^1.1.1:
   integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
   dependencies:
     safe-buffer "~5.2.0"
+
+strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
+
+strip-json-comments@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz"
+  integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
+
+strip-literal@^1.0.1:
+  version "1.3.0"
+  resolved "https://registry.npmjs.org/strip-literal/-/strip-literal-1.3.0.tgz"
+  integrity sha512-PugKzOsyXpArk0yWmUwqOZecSO0GH0bPoctLcqNDH9J04pVW3lflYE0ujElBGTloevcxF5MofAOZ7C5l2b+wLg==
+  dependencies:
+    acorn "^8.10.0"
 
 strtok3@^7.0.0:
   version "7.0.0"
@@ -714,6 +1752,33 @@ supports-color@^5.5.0:
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
   dependencies:
     has-flag "^3.0.0"
+
+supports-color@^7.1.0:
+  version "7.2.0"
+  resolved "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz"
+  integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
+  dependencies:
+    has-flag "^4.0.0"
+
+text-table@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz"
+  integrity sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==
+
+tinybench@^2.5.0:
+  version "2.9.0"
+  resolved "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz"
+  integrity sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==
+
+tinypool@^0.7.0:
+  version "0.7.0"
+  resolved "https://registry.npmjs.org/tinypool/-/tinypool-0.7.0.tgz"
+  integrity sha512-zSYNUlYSMhJ6Zdou4cJwo/p7w5nmAH17GRfU/ui3ctvjXFErXXkruT4MWW6poDeXgCaIBlGLrfU6TbTXxyGMww==
+
+tinyspy@^2.1.1:
+  version "2.2.1"
+  resolved "https://registry.npmjs.org/tinyspy/-/tinyspy-2.2.1.tgz"
+  integrity sha512-KYad6Vy5VDWV4GH3fjpseMQ/XU2BhIYP7Vzd0LG44qRWm/Yt2WCOTicFdvmgo6gWaqooMQCawTtILVQJupKu7A==
 
 to-regex-range@^5.0.1:
   version "5.0.1"
@@ -739,6 +1804,11 @@ tr46@~0.0.3:
   version "0.0.3"
   resolved "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz"
   integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
+
+ts-api-utils@^1.0.1:
+  version "1.4.3"
+  resolved "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz"
+  integrity sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==
 
 ts-mixer@^6.0.3:
   version "6.0.3"
@@ -769,10 +1839,32 @@ tslib@^2.5.0:
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz"
   integrity sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==
 
+type-check@^0.4.0, type-check@~0.4.0:
+  version "0.4.0"
+  resolved "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz"
+  integrity sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==
+  dependencies:
+    prelude-ls "^1.2.1"
+
+type-detect@^4.0.0, type-detect@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.npmjs.org/type-detect/-/type-detect-4.1.0.tgz"
+  integrity sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==
+
+type-fest@^0.20.2:
+  version "0.20.2"
+  resolved "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz"
+  integrity sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==
+
 typescript@^5.9.3:
   version "5.9.3"
   resolved "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz"
   integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
+
+ufo@^1.6.1:
+  version "1.6.3"
+  resolved "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz"
+  integrity sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==
 
 undefsafe@^2.0.5:
   version "2.0.5"
@@ -786,6 +1878,13 @@ undici@^5.22.0:
   dependencies:
     busboy "^1.6.0"
 
+uri-js@^4.2.2:
+  version "4.4.1"
+  resolved "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz"
+  integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
+  dependencies:
+    punycode "^2.1.0"
+
 util-deprecate@^1.0.1:
   version "1.0.2"
   resolved "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
@@ -795,6 +1894,59 @@ v8-compile-cache-lib@^3.0.1:
   version "3.0.1"
   resolved "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz"
   integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
+
+vite-node@0.34.6:
+  version "0.34.6"
+  resolved "https://registry.npmjs.org/vite-node/-/vite-node-0.34.6.tgz"
+  integrity sha512-nlBMJ9x6n7/Amaz6F3zJ97EBwR2FkzhBRxF5e+jE6LA3yi6Wtc2lyTij1OnDMIr34v5g/tVQtsVAzhT0jc5ygA==
+  dependencies:
+    cac "^6.7.14"
+    debug "^4.3.4"
+    mlly "^1.4.0"
+    pathe "^1.1.1"
+    picocolors "^1.0.0"
+    vite "^3.0.0 || ^4.0.0 || ^5.0.0-0"
+
+"vite@^3.0.0 || ^4.0.0 || ^5.0.0-0", "vite@^3.1.0 || ^4.0.0 || ^5.0.0-0":
+  version "5.4.21"
+  resolved "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz"
+  integrity sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==
+  dependencies:
+    esbuild "^0.21.3"
+    postcss "^8.4.43"
+    rollup "^4.20.0"
+  optionalDependencies:
+    fsevents "~2.3.3"
+
+vitest@^0.34.6:
+  version "0.34.6"
+  resolved "https://registry.npmjs.org/vitest/-/vitest-0.34.6.tgz"
+  integrity sha512-+5CALsOvbNKnS+ZHMXtuUC7nL8/7F1F2DnHGjSsszX8zCjWSSviphCb/NuS9Nzf4Q03KyyDRBAXhF/8lffME4Q==
+  dependencies:
+    "@types/chai" "^4.3.5"
+    "@types/chai-subset" "^1.3.3"
+    "@types/node" "*"
+    "@vitest/expect" "0.34.6"
+    "@vitest/runner" "0.34.6"
+    "@vitest/snapshot" "0.34.6"
+    "@vitest/spy" "0.34.6"
+    "@vitest/utils" "0.34.6"
+    acorn "^8.9.0"
+    acorn-walk "^8.2.0"
+    cac "^6.7.14"
+    chai "^4.3.10"
+    debug "^4.3.4"
+    local-pkg "^0.4.3"
+    magic-string "^0.30.1"
+    pathe "^1.1.1"
+    picocolors "^1.0.0"
+    std-env "^3.3.3"
+    strip-literal "^1.0.1"
+    tinybench "^2.5.0"
+    tinypool "^0.7.0"
+    vite "^3.1.0 || ^4.0.0 || ^5.0.0-0"
+    vite-node "0.34.6"
+    why-is-node-running "^2.2.2"
 
 webidl-conversions@^3.0.0:
   version "3.0.1"
@@ -809,6 +1961,31 @@ whatwg-url@^5.0.0:
     tr46 "~0.0.3"
     webidl-conversions "^3.0.0"
 
+which@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.npmjs.org/which/-/which-2.0.2.tgz"
+  integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
+  dependencies:
+    isexe "^2.0.0"
+
+why-is-node-running@^2.2.2:
+  version "2.3.0"
+  resolved "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz"
+  integrity sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==
+  dependencies:
+    siginfo "^2.0.0"
+    stackback "0.0.2"
+
+word-wrap@^1.2.5:
+  version "1.2.5"
+  resolved "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz"
+  integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
+
+wrappy@1:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+  integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
+
 ws@^8.13.0:
   version "8.13.0"
   resolved "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz"
@@ -818,3 +1995,13 @@ yn@3.1.1:
   version "3.1.1"
   resolved "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz"
   integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
+
+yocto-queue@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz"
+  integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+yocto-queue@^1.0.0:
+  version "1.2.2"
+  resolved "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz"
+  integrity sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==


### PR DESCRIPTION
## Summary
This PR promotes recent FWA/war-event improvements from `dev` to `main`, including:
- Sync source-of-truth hardening (`previousSyncNum`) and recovery fixes
- `/fwa points` and `/fwa match overview` sync display cleanup
- War event embed wording/format updates (FWA/BL/MM scenarios)
- BL/MM-specific war-start and battle-day guidance messaging
- Test coverage additions for exact war-plan output

## Key Changes

### 1. Sync Source of Truth (`BotSetting.previousSyncNum`)
- Enforced correct rule: `previousSyncNum = current Sync# - 1` when points site is confirmed up-to-date.
- Fixed `/fwa sync force` so it only upserts sync when matchup is current for opponent.
- Prevented stale-site paths from writing incorrect raw sync values.
- Recovery path now requires up-to-date opponent linkage before persisting recovered sync.

### 2. `/fwa points` Summary
- Removed noisy per-clan sync rollup in summary.
- Summary now shows a single source-of-truth sync line:
  - `Sync#: #<previousSyncNum + 1>`
- Kept missed-sync ignore accounting in summary.

### 3. `/fwa match` Alliance Overview
- Added top-level source-of-truth sync line in alliance view.
- Removed per-clan sync lines from alliance entries.
- Kept per-clan sync details in single-clan view.

### 4. War Event Embeds (`war_started`, `battle_day`)
- Updated FWA WIN/LOSE (TRIPLE_TOP_30/TRADITIONAL) plan text to exact requested wording/line structure.
- Added/updated BL and MM scenario messaging:
  - `war_started`: BL and MM blocks
  - `battle_day`: BL and MM blocks
- Included additional BL war-base resource line in `war_started`.

### 5. Tests
- Added/updated unit coverage for exact war-plan string output.
- Existing suite passes after changes.

## Validation
- Build: `npm run build` ✅
- Tests: `npm run test` ✅

## Notes
- `/notify war-test` and live war event posts use the same embed rendering path (`emitEvent`), so formatting changes apply consistently across both.