### PR TITLE
feat(fwa): add tracked-clan war mail config, preview/send flow, and r…

### DIFF
--- a/prisma/migrations/20260301031000_add_tracked_clan_mail_channel_id/migration.sql
+++ b/prisma/migrations/20260301031000_add_tracked_clan_mail_channel_id/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "TrackedClan"
+ADD COLUMN "mailChannelId" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -32,6 +32,7 @@ model TrackedClan {
   tag       String    @unique
   name      String?
   loseStyle LoseStyle @default(TRIPLE_TOP_30)
+  mailChannelId String?
   pointsScrape Json?
   createdAt DateTime  @default(now())
 }

--- a/src/listeners/interactionCreate.ts
+++ b/src/listeners/interactionCreate.ts
@@ -26,8 +26,14 @@ import {
   handleFwaOutcomeActionButton,
   handleFwaMatchTypeActionButton,
   handleFwaMatchSyncActionButton,
+  handleFwaMailConfirmButton,
+  handleFwaMailRefreshButton,
+  handleFwaMatchSendMailButton,
   isFwaMatchAllianceButtonCustomId,
   isFwaMatchSyncActionButtonCustomId,
+  isFwaMailConfirmButtonCustomId,
+  isFwaMailRefreshButtonCustomId,
+  isFwaMatchSendMailButtonCustomId,
   isFwaMatchTypeEditButtonCustomId,
   isFwaOutcomeActionButtonCustomId,
   isFwaMatchSelectCustomId,
@@ -333,6 +339,48 @@ const handleButtonInteraction = async (interaction: Interaction): Promise<void> 
         await interaction.reply({
           ephemeral: true,
           content: "Failed to sync points-site data.",
+        });
+      }
+    }
+  }
+
+  if (isFwaMatchSendMailButtonCustomId(interaction.customId)) {
+    try {
+      await handleFwaMatchSendMailButton(interaction);
+    } catch (err) {
+      console.error(`FWA match send-mail button failed: ${formatError(err)}`);
+      if (!interaction.replied && !interaction.deferred) {
+        await interaction.reply({
+          ephemeral: true,
+          content: "Failed to open war mail preview.",
+        });
+      }
+    }
+  }
+
+  if (isFwaMailConfirmButtonCustomId(interaction.customId)) {
+    try {
+      await handleFwaMailConfirmButton(interaction);
+    } catch (err) {
+      console.error(`FWA mail confirm button failed: ${formatError(err)}`);
+      if (!interaction.replied && !interaction.deferred) {
+        await interaction.reply({
+          ephemeral: true,
+          content: "Failed to send war mail.",
+        });
+      }
+    }
+  }
+
+  if (isFwaMailRefreshButtonCustomId(interaction.customId)) {
+    try {
+      await handleFwaMailRefreshButton(interaction);
+    } catch (err) {
+      console.error(`FWA mail refresh button failed: ${formatError(err)}`);
+      if (!interaction.replied && !interaction.deferred) {
+        await interaction.reply({
+          ephemeral: true,
+          content: "Failed to refresh war mail.",
         });
       }
     }


### PR DESCRIPTION
…efresh actions

- add /fwa mail set to upsert TrackedClan.mailChannelId and overwrite existing channel
- add /fwa mail send to generate ephemeral war-mail preview with confirm-and-send action
- build war mail embed from current war + source-of-truth sync and reuse notify-style war plan strings
- include war status/time remaining and battle-day star lines; add manual refresh button for posted mail
- add 20-minute polling refresh for posted war-mail embeds
- add Send Mail button to /fwa match single-clan view with disabled state and warnings when mail is unavailable or match type is inferred
- wire new mail confirm/refresh/send-mail button handlers in interaction listener
- add TrackedClan.mailChannelId schema field and migration