### PR TITLE
feat(tracked-clan): replace add/mail-set flow with configure settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Discord bot for Clash of Clans activity tooling.
 - Supports last seen and inactivity queries.
 - Manages tracked clans and roster/sheet integrations.
 - Provides FWA points and matchup tooling.
-- Supports FWA war mail channel config and send-preview flow via `/fwa mail ...`.
+- Supports tracked-clan mail channel config via `/tracked-clan configure` and send-preview flow via `/fwa mail send`.
 
 ## Quick Start
 ```bash

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -8,9 +8,9 @@
 - `/inactive days:<number>` - List players inactive for N days.
 - `/inactive wars:<number>` - List tracked-clan members who used 0/2 attacks in each of the last N ended wars (requires war-history tracking window).
 - `/role-users role:<discordRole>` - List users in a role with pagination.
-- `/tracked-clan add tag:<tag>` - Add tracked clan.
+- `/tracked-clan configure tag:<tag> [lose-style:triple-top-30|traditional] [mail-channel:<discordChannel>] [log-channel:<discordChannel>] [clan-role:<discordRole>]` - Add/update tracked clan settings.
 - `/tracked-clan remove tag:<tag>` - Remove tracked clan.
-- `/tracked-clan list` - List tracked clans.
+- `/tracked-clan list` - List tracked clans and settings.
 - `/sheet link sheet_id_or_url:<id-or-url> [tab:<tab-name>] [mode:actual|war]` - Link or relink sheet; mode is optional.
 - `/sheet show [mode:actual|war]` - Show linked sheet settings (single mode or all).
 - `/sheet unlink [mode:actual|war]` - Remove one mode link or all links.
@@ -27,7 +27,6 @@
 - `/fwa points [visibility:private|public] [tag:<tag>]` - Fetch current point balance from `https://points.fwafarm.com/clan?tag=<tag-without-#>`. If `tag` is omitted, fetches all tracked clans.
 - `/fwa match [visibility:private|public] tag:<tag>` - Resolve current war opponent from CoC API, then return projected win/lose by points (or sync-based tiebreak on tie).
 - `/fwa match-type [visibility:private|public] [tag:<trackedClanTag>] [type:FWA|BL|MM]` - Manually set or view per-clan match type override used by matchup output. If no args, lists overrides for all tracked clans.
-- `/fwa mail set tag:<trackedClanTag> mail-channel:<discordChannel>` - Upsert the tracked clan mail output channel.
 - `/fwa mail send tag:<trackedClanTag>` - Show ephemeral war mail preview with confirm-and-send to the tracked clan mail channel.
 - `/fwa match` single-clan view includes a `Send Mail` button that follows the same access policy as `/fwa mail send`.
 - `/recruitment show platform:discord|reddit|band clan:<tag>` - Render platform-specific recruitment template output for a tracked clan.

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -6,7 +6,7 @@
 - `/fwa mail send` defaults to FWA leader-role + Administrator when no explicit whitelist is set.
 
 ## Default Administrator-Only Targets
-- `/tracked-clan add`, `/tracked-clan remove`
+- `/tracked-clan configure`, `/tracked-clan remove`
 - `/permission add`, `/permission remove`
 - `/sheet link`, `/sheet unlink`, `/sheet show`, `/sheet refresh`
 - `/kick-list build`, `/kick-list add`, `/kick-list remove`, `/kick-list show`, `/kick-list clear`

--- a/prisma/migrations/20260301090000_add_tracked_clan_log_channel_and_role_id/migration.sql
+++ b/prisma/migrations/20260301090000_add_tracked_clan_log_channel_and_role_id/migration.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "TrackedClan"
+ADD COLUMN "logChannelId" TEXT,
+ADD COLUMN "clanRoleId" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -33,6 +33,8 @@ model TrackedClan {
   name      String?
   loseStyle LoseStyle @default(TRIPLE_TOP_30)
   mailChannelId String?
+  logChannelId String?
+  clanRoleId String?
   pointsScrape Json?
   createdAt DateTime  @default(now())
 }

--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -19,7 +19,7 @@ const OVERVIEW_PAGE_SIZE = 4;
 const HELP_TIMEOUT_MS = 10 * 60 * 1000;
 const HELP_POST_BUTTON_PREFIX = "help-post-channel";
 const ADMIN_DEFAULT_TARGETS = new Set<string>([
-  "tracked-clan:add",
+  "tracked-clan:configure",
   "tracked-clan:remove",
   "sheet:link",
   "sheet:unlink",
@@ -89,13 +89,13 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
   "tracked-clan": {
     summary: "Manage tracked clans used by activity features.",
     details: [
-      "Add/remove tracked clans or list current tracked set.",
-      "Set clan lose-style on add (defaults to TRIPLE_TOP_30). Re-running add updates lose-style.",
-      "`add` and `remove` are admin-only by default.",
+      "Configure/remove tracked clans or list current tracked set.",
+      "`configure` upserts tracked clan settings (lose-style, mail channel, log channel, clan role).",
+      "`configure` and `remove` are admin-only by default.",
     ],
     examples: [
-      "/tracked-clan add tag:#2QG2C08UP",
-      "/tracked-clan add tag:#2QG2C08UP lose-style:Traditional",
+      "/tracked-clan configure tag:#2QG2C08UP",
+      "/tracked-clan configure tag:#2QG2C08UP lose-style:Traditional mail-channel:#war-mail",
       "/tracked-clan remove tag:#2QG2C08UP",
       "/tracked-clan list",
     ],
@@ -189,7 +189,7 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
       "`/fwa points` returns point balances (single clan tag or all tracked if tag omitted).",
       "`/fwa match` auto-resolves current war opponent from CoC API and evaluates win/lose/tiebreak using the same points logic.",
       "If match type is inferred, `/fwa match` shows a warning and quick verify link, with action buttons to confirm FWA/BL/MM.",
-      "`/fwa mail set` upserts the tracked clan mail channel used for war mail posts.",
+      "Tracked clan mail channel is configured via `/tracked-clan configure ... mail-channel`.",
       "`/fwa mail send` opens an ephemeral war mail preview with confirm/send.",
       "The `/fwa match` single-clan `Send Mail` button uses the same permissions as `/fwa mail send`.",
       "Default access for `/fwa mail send` is FWA leader role + Administrator (or override via `/permission add command:fwa:mail:send`).",
@@ -201,7 +201,7 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
       "/fwa points tag:2QG2C08UP",
       "/fwa points",
       "/fwa match tag:2QG2C08UP",
-      "/fwa mail set tag:2QG2C08UP mail-channel:#war-mail",
+      "/tracked-clan configure tag:#2QG2C08UP mail-channel:#war-mail",
       "/fwa mail send tag:2QG2C08UP",
       "/fwa leader-role role:@FWA-Leaders",
       "/fwa points tag:2QG2C08UP visibility:public",

--- a/src/commands/Inactive.ts
+++ b/src/commands/Inactive.ts
@@ -203,7 +203,7 @@ async function runDaysMode(
 
   if (roster.trackedTags.length === 0) {
     await interaction.editReply(
-      "No tracked clans configured. Configure at least one clan with `/tracked-clan add` before using `/inactive`."
+      "No tracked clans configured. Configure at least one clan with `/tracked-clan configure` before using `/inactive`."
     );
     return;
   }
@@ -334,7 +334,7 @@ async function runWarsMode(
   const roster = await getRosterSnapshot(cocService);
   if (roster.trackedTags.length === 0) {
     await interaction.editReply(
-      "No tracked clans configured. Configure at least one clan with `/tracked-clan add` before using `/inactive`."
+      "No tracked clans configured. Configure at least one clan with `/tracked-clan configure` before using `/inactive`."
     );
     return;
   }

--- a/src/commands/Recruitment.ts
+++ b/src/commands/Recruitment.ts
@@ -238,7 +238,7 @@ async function handleShowSubcommand(
 
   const trackedClan = await findTrackedClan(clanTag);
   if (!trackedClan) {
-    await interaction.editReply("Clan is not tracked. Add it first with `/tracked-clan add`.");
+    await interaction.editReply("Clan is not tracked. Add it first with `/tracked-clan configure`.");
     return;
   }
 
@@ -310,7 +310,7 @@ async function handleEditSubcommand(
   if (!tracked) {
     await interaction.reply({
       ephemeral: true,
-      content: "Clan is not tracked. Add it first with `/tracked-clan add`.",
+      content: "Clan is not tracked. Add it first with `/tracked-clan configure`.",
     });
     return;
   }
@@ -401,7 +401,7 @@ async function handleCountdownStartSubcommand(
 
   const tracked = await findTrackedClan(clanTag);
   if (!tracked) {
-    await interaction.editReply("Clan is not tracked. Add it first with `/tracked-clan add`.");
+    await interaction.editReply("Clan is not tracked. Add it first with `/tracked-clan configure`.");
     return;
   }
 

--- a/src/listeners/ready.ts
+++ b/src/listeners/ready.ts
@@ -157,7 +157,7 @@ export default (client: Client, cocService: CoCService): void => {
 
         if (trackedTags.length === 0) {
           console.warn(
-            "No tracked clans configured. Use /tracked-clan add."
+            "No tracked clans configured. Use /tracked-clan configure."
           );
           return [];
         }

--- a/src/services/CommandPermissionService.ts
+++ b/src/services/CommandPermissionService.ts
@@ -16,7 +16,7 @@ export const COMMAND_PERMISSION_TARGETS = [
   "accounts",
   "war",
   "notify",
-  "tracked-clan:add",
+  "tracked-clan:configure",
   "tracked-clan:remove",
   "tracked-clan:list",
   "sheet:link",
@@ -56,7 +56,7 @@ export type CommandPermissionTarget = (typeof COMMAND_PERMISSION_TARGETS)[number
 type GuildInteraction = ChatInputCommandInteraction | ModalSubmitInteraction;
 
 const ADMIN_DEFAULT_TARGETS = new Set<string>([
-  "tracked-clan:add",
+  "tracked-clan:configure",
   "tracked-clan:remove",
   "sheet:link",
   "sheet:unlink",


### PR DESCRIPTION
- rename `/tracked-clan add` to `/tracked-clan configure`
- add optional configure settings: `lose-style`, `mail-channel`, `log-channel`, and `clan-role`
- persist `logChannelId` and `clanRoleId` on `TrackedClan` with new Prisma migration
- add tracked clan tag autocomplete for `configure` and `remove`
- show lose-style/mail/log/role settings in `/tracked-clan list`
- remove `/fwa mail set` subcommand and route mail-channel guidance to `/tracked-clan configure`
- update permission targets from `tracked-clan:add` to `tracked-clan:configure`
- update help text, command docs, permissions docs, README, and user-facing command hints
- regenerate Prisma client and verify unit tests pass