### PR TITLE
feat(fwa-mail): annotate previous mail when match assumptions change

### DIFF
--- a/tests/fwaMailRevision.logic.test.ts
+++ b/tests/fwaMailRevision.logic.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { buildWarMailRevisionLinesForTest } from "../src/commands/Fwa";
+
+describe("war mail revision log", () => {
+  it("includes both match type and expected outcome changes", () => {
+    const lines = buildWarMailRevisionLinesForTest({
+      previousMatchType: "FWA",
+      previousExpectedOutcome: "WIN",
+      nextMatchType: "BL",
+      nextExpectedOutcome: null,
+    });
+
+    expect(lines).toEqual([
+      "- Match Type: **FWA** -> **BL**",
+      "- Expected outcome: **WIN** -> **N/A**",
+    ]);
+  });
+
+  it("returns no lines when nothing changed", () => {
+    const lines = buildWarMailRevisionLinesForTest({
+      previousMatchType: "FWA",
+      previousExpectedOutcome: "LOSE",
+      nextMatchType: "FWA",
+      nextExpectedOutcome: "LOSE",
+    });
+
+    expect(lines).toEqual([]);
+  });
+});


### PR DESCRIPTION
- track sent war-mail metadata (match type, expected outcome, timestamp) in posted-mail state
- when a new war mail is sent for the same guild+clan, compare against latest sent metadata
- if match type or expected outcome changed, edit the previous mail embed with a revision log
- include localized Discord timestamp format (`<t:...:F>`) in the previous-mail revision note
- keep posted-mail metadata refreshed during periodic mail refresh polling
- add unit tests for war-mail revision diff generation logic