### PR TITLE
feat(fwa-mail): delete preview on confirm and supersede old mails cle…

### DIFF
--- a/tests/fwaMailRevision.logic.test.ts
+++ b/tests/fwaMailRevision.logic.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { buildWarMailRevisionLinesForTest } from "../src/commands/Fwa";
+import {
+  buildSupersededWarMailDescriptionForTest,
+  buildWarMailRevisionLinesForTest,
+} from "../src/commands/Fwa";
 
 describe("war mail revision log", () => {
   it("includes both match type and expected outcome changes", () => {
@@ -25,5 +28,16 @@ describe("war mail revision log", () => {
     });
 
     expect(lines).toEqual([]);
+  });
+
+  it("builds superseded description with only revision details", () => {
+    const description = buildSupersededWarMailDescriptionForTest({
+      changedAtMs: 1_700_000_000_000,
+      revisionLines: ["- Match Type: **FWA** -> **BL**"],
+    });
+
+    expect(description).toBe(
+      "Superseded at <t:1700000000:F>\n- Match Type: **FWA** -> **BL**"
+    );
   });
 });


### PR DESCRIPTION
…anly

- clear the ephemeral mail preview immediately after "Confirm and Send"
- send success feedback as a separate ephemeral follow-up
- when a newer mail supersedes an older one, replace the old embed body with change-log-only content
- remove refresh components from superseded mail embeds
- stop polling and remove superseded mail entries from in-memory refresh tracking
- add logic helper tests for superseded description rendering