### PR TITLE
fix(fwa-match): reliably flip mailbox indicator to sent after confirm

### DIFF
--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -928,12 +928,21 @@ function getMailStatusEmojiForClan(params: {
   warStartMs: number | null;
 }): string {
   if (!params.guildId) return MAILBOX_NOT_SENT_EMOJI;
-  const sent = findLatestPostedWarMailForClan({
-    guildId: params.guildId,
-    tag: params.tag,
-    warStartMs: params.warStartMs,
-    strictWarStart: params.warStartMs !== null,
-  });
+  const sentForSameWar =
+    params.warStartMs !== null
+      ? findLatestPostedWarMailForClan({
+          guildId: params.guildId,
+          tag: params.tag,
+          warStartMs: params.warStartMs,
+          strictWarStart: true,
+        })
+      : null;
+  const sent =
+    sentForSameWar ??
+    findLatestPostedWarMailForClan({
+      guildId: params.guildId,
+      tag: params.tag,
+    });
   return sent ? MAILBOX_SENT_EMOJI : MAILBOX_NOT_SENT_EMOJI;
 }
 


### PR DESCRIPTION
- update mailbox status resolution to prefer same-war sent mail match first
- add fallback to any sent mail for the same guild+clan when strict war-start match is unavailable
- ensures `/fwa match` single view/alliance view/dropdown can flip from ?? to ?? immediately after confirm/send