### PR TITLE
test(war-events): add end-to-end points line cases for war-end outcomes

### DIFF
--- a/tests/warEventLog.logic.test.ts
+++ b/tests/warEventLog.logic.test.ts
@@ -3,6 +3,7 @@ import {
   computeWarComplianceForTest,
   computeWarPointsDeltaForTest,
 } from "../src/services/WarEventLogService";
+import { WarEventHistoryService } from "../src/services/war-events/history";
 
 function dateAt(hour: number): Date {
   return new Date(Date.UTC(2026, 0, 1, hour, 0, 0));
@@ -108,6 +109,105 @@ describe("WarEventLogService.computeWarPointsDeltaForTest", () => {
       },
     });
     expect(delta).toBeNull();
+  });
+});
+
+describe("WarEventHistoryService.buildWarEndPointsLine", () => {
+  const history = new WarEventHistoryService({} as any);
+  const baseResult = {
+    clanStars: 100,
+    opponentStars: 99,
+    clanDestruction: 59,
+    opponentDestruction: 58,
+    warEndTime: null,
+    resultLabel: "WIN" as const,
+  };
+
+  it("BL win: derives +3 and renders before->after even when after is missing", () => {
+    const line = history.buildWarEndPointsLine(
+      {
+        clanName: "Alpha",
+        matchType: "BL",
+        warStartFwaPoints: 100,
+        warEndFwaPoints: null,
+      },
+      baseResult
+    );
+    expect(line).toBe("Alpha: 100 -> 103 (+3) [BL]");
+  });
+
+  it("BL lose with 60%+ destruction: derives +2", () => {
+    const line = history.buildWarEndPointsLine(
+      {
+        clanName: "Alpha",
+        matchType: "BL",
+        warStartFwaPoints: 100,
+        warEndFwaPoints: null,
+      },
+      {
+        ...baseResult,
+        resultLabel: "LOSE",
+        clanDestruction: 60,
+      }
+    );
+    expect(line).toBe("Alpha: 100 -> 102 (+2) [BL]");
+  });
+
+  it("BL lose below 60% destruction: derives +1", () => {
+    const line = history.buildWarEndPointsLine(
+      {
+        clanName: "Alpha",
+        matchType: "BL",
+        warStartFwaPoints: 100,
+        warEndFwaPoints: null,
+      },
+      {
+        ...baseResult,
+        resultLabel: "LOSE",
+        clanDestruction: 59.99,
+      }
+    );
+    expect(line).toBe("Alpha: 100 -> 101 (+1) [BL]");
+  });
+
+  it("FWA war: renders arithmetic delta using stored before/after", () => {
+    const line = history.buildWarEndPointsLine(
+      {
+        clanName: "Alpha",
+        matchType: "FWA",
+        warStartFwaPoints: 1200,
+        warEndFwaPoints: 1205,
+      },
+      {
+        ...baseResult,
+        resultLabel: "UNKNOWN",
+        clanStars: null,
+        opponentStars: null,
+        clanDestruction: null,
+        opponentDestruction: null,
+      }
+    );
+    expect(line).toBe("Alpha: 1200 -> 1205 (+5)");
+  });
+
+  it("MM war: renders negative arithmetic delta when points drop", () => {
+    const line = history.buildWarEndPointsLine(
+      {
+        clanName: "Alpha",
+        matchType: "MM",
+        warStartFwaPoints: 1200,
+        warEndFwaPoints: 1197,
+      },
+      {
+        ...baseResult,
+        resultLabel: "UNKNOWN",
+        clanStars: null,
+        opponentStars: null,
+        clanDestruction: null,
+        opponentDestruction: null,
+      }
+    );
+    expect(line).toBe("Alpha: 1200 -> 1197 (-3)");
   });
 });
 


### PR DESCRIPTION
- add focused tests for WarEventHistoryService.buildWarEndPointsLine
- cover BL +3/+2/+1 derivation from final war result snapshots
- cover FWA/MM arithmetic delta rendering from before/after points
- keep existing war-event logic suite as single validation entrypoint