### PR TITLE
fix(war-events): make MM wars zero-point at war end

### DIFF
--- a/src/services/war-events/core.ts
+++ b/src/services/war-events/core.ts
@@ -167,6 +167,9 @@ export function computeWarPointsDeltaForTest(input: {
     if ((input.finalResult.clanDestruction ?? 0) >= 60) return 2;
     return 1;
   }
+  if (input.matchType === "MM") {
+    return 0;
+  }
   if (
     input.before !== null &&
     Number.isFinite(input.before) &&

--- a/src/services/war-events/history.ts
+++ b/src/services/war-events/history.ts
@@ -53,6 +53,17 @@ export class WarEventHistoryService {
       return `${payload.clanName}: ${resolvedBefore ?? "unknown"} -> ${after ?? "unknown"} (${delta !== null && delta >= 0 ? `+${delta}` : String(delta ?? "unknown")}) [BL]`;
     }
 
+    if (payload.matchType === "MM") {
+      const resolvedBefore =
+        before !== null && Number.isFinite(before)
+          ? before
+          : payload.warEndFwaPoints !== null && Number.isFinite(payload.warEndFwaPoints)
+            ? payload.warEndFwaPoints
+            : null;
+      const resolvedAfter = resolvedBefore;
+      return `${payload.clanName}: ${resolvedBefore ?? "unknown"} -> ${resolvedAfter ?? "unknown"} (+0) [MM]`;
+    }
+
     const after = payload.warEndFwaPoints;
     if (
       before !== null &&

--- a/tests/warEventLog.logic.test.ts
+++ b/tests/warEventLog.logic.test.ts
@@ -61,7 +61,7 @@ describe("WarEventLogService.computeWarPointsDeltaForTest", () => {
     expect(delta).toBe(1);
   });
 
-  it("FWA/MM war: returns arithmetic delta (after - before) when both values are present", () => {
+  it("FWA war: returns arithmetic delta (after - before) when both values are present", () => {
     expect(
       computeWarPointsDeltaForTest({
         matchType: "FWA",
@@ -77,6 +77,9 @@ describe("WarEventLogService.computeWarPointsDeltaForTest", () => {
         },
       })
     ).toBe(5);
+  });
+
+  it("MM war: always returns 0 points delta at war end", () => {
     expect(
       computeWarPointsDeltaForTest({
         matchType: "MM",
@@ -91,7 +94,7 @@ describe("WarEventLogService.computeWarPointsDeltaForTest", () => {
           resultLabel: "UNKNOWN",
         },
       })
-    ).toBe(-3);
+    ).toBe(0);
   });
 
   it("FWA/MM war: returns null when before/after values are incomplete", () => {
@@ -190,7 +193,7 @@ describe("WarEventHistoryService.buildWarEndPointsLine", () => {
     expect(line).toBe("Alpha: 1200 -> 1205 (+5)");
   });
 
-  it("MM war: renders negative arithmetic delta when points drop", () => {
+  it("MM war: renders no points change at war end", () => {
     const line = history.buildWarEndPointsLine(
       {
         clanName: "Alpha",
@@ -207,7 +210,7 @@ describe("WarEventHistoryService.buildWarEndPointsLine", () => {
         opponentDestruction: null,
       }
     );
-    expect(line).toBe("Alpha: 1200 -> 1197 (-3)");
+    expect(line).toBe("Alpha: 1200 -> 1200 (+0) [MM]");
   });
 });
 


### PR DESCRIPTION
- change war-end points delta logic so matchType MM always resolves to 0
- update war-end points line rendering to show no points change for MM
- adjust and extend war-event logic tests for MM zero-delta behavior