### PR TITLE
release: promote dev to main (war notify + fwa mail workflow + tracked-clan configure)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Discord bot for Clash of Clans activity tooling.
 - Supports last seen and inactivity queries.
 - Manages tracked clans and roster/sheet integrations.
 - Provides FWA points and matchup tooling.
-- Supports FWA war mail channel config and send-preview flow via `/fwa mail ...`.
+- Supports tracked-clan mail channel config via `/tracked-clan configure` and send-preview flow via `/fwa mail send`.
 
 ## Quick Start
 ```bash

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -8,9 +8,9 @@
 - `/inactive days:<number>` - List players inactive for N days.
 - `/inactive wars:<number>` - List tracked-clan members who used 0/2 attacks in each of the last N ended wars (requires war-history tracking window).
 - `/role-users role:<discordRole>` - List users in a role with pagination.
-- `/tracked-clan add tag:<tag>` - Add tracked clan.
+- `/tracked-clan configure tag:<tag> [lose-style:triple-top-30|traditional] [mail-channel:<discordChannel>] [log-channel:<discordChannel>] [clan-role:<discordRole>]` - Add/update tracked clan settings.
 - `/tracked-clan remove tag:<tag>` - Remove tracked clan.
-- `/tracked-clan list` - List tracked clans.
+- `/tracked-clan list` - List tracked clans and settings.
 - `/sheet link sheet_id_or_url:<id-or-url> [tab:<tab-name>] [mode:actual|war]` - Link or relink sheet; mode is optional.
 - `/sheet show [mode:actual|war]` - Show linked sheet settings (single mode or all).
 - `/sheet unlink [mode:actual|war]` - Remove one mode link or all links.
@@ -27,7 +27,6 @@
 - `/fwa points [visibility:private|public] [tag:<tag>]` - Fetch current point balance from `https://points.fwafarm.com/clan?tag=<tag-without-#>`. If `tag` is omitted, fetches all tracked clans.
 - `/fwa match [visibility:private|public] tag:<tag>` - Resolve current war opponent from CoC API, then return projected win/lose by points (or sync-based tiebreak on tie).
 - `/fwa match-type [visibility:private|public] [tag:<trackedClanTag>] [type:FWA|BL|MM]` - Manually set or view per-clan match type override used by matchup output. If no args, lists overrides for all tracked clans.
-- `/fwa mail set tag:<trackedClanTag> mail-channel:<discordChannel>` - Upsert the tracked clan mail output channel.
 - `/fwa mail send tag:<trackedClanTag>` - Show ephemeral war mail preview with confirm-and-send to the tracked clan mail channel.
 - `/fwa match` single-clan view includes a `Send Mail` button that follows the same access policy as `/fwa mail send`.
 - `/recruitment show platform:discord|reddit|band clan:<tag>` - Render platform-specific recruitment template output for a tracked clan.

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -6,7 +6,7 @@
 - `/fwa mail send` defaults to FWA leader-role + Administrator when no explicit whitelist is set.
 
 ## Default Administrator-Only Targets
-- `/tracked-clan add`, `/tracked-clan remove`
+- `/tracked-clan configure`, `/tracked-clan remove`
 - `/permission add`, `/permission remove`
 - `/sheet link`, `/sheet unlink`, `/sheet show`, `/sheet refresh`
 - `/kick-list build`, `/kick-list add`, `/kick-list remove`, `/kick-list show`, `/kick-list clear`

--- a/prisma/migrations/20260301090000_add_tracked_clan_log_channel_and_role_id/migration.sql
+++ b/prisma/migrations/20260301090000_add_tracked_clan_log_channel_and_role_id/migration.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "TrackedClan"
+ADD COLUMN "logChannelId" TEXT,
+ADD COLUMN "clanRoleId" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -33,6 +33,8 @@ model TrackedClan {
   name      String?
   loseStyle LoseStyle @default(TRIPLE_TOP_30)
   mailChannelId String?
+  logChannelId String?
+  clanRoleId String?
   pointsScrape Json?
   createdAt DateTime  @default(now())
 }

--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -928,12 +928,21 @@ function getMailStatusEmojiForClan(params: {
   warStartMs: number | null;
 }): string {
   if (!params.guildId) return MAILBOX_NOT_SENT_EMOJI;
-  const sent = findLatestPostedWarMailForClan({
-    guildId: params.guildId,
-    tag: params.tag,
-    warStartMs: params.warStartMs,
-    strictWarStart: params.warStartMs !== null,
-  });
+  const sentForSameWar =
+    params.warStartMs !== null
+      ? findLatestPostedWarMailForClan({
+          guildId: params.guildId,
+          tag: params.tag,
+          warStartMs: params.warStartMs,
+          strictWarStart: true,
+        })
+      : null;
+  const sent =
+    sentForSameWar ??
+    findLatestPostedWarMailForClan({
+      guildId: params.guildId,
+      tag: params.tag,
+    });
   return sent ? MAILBOX_SENT_EMOJI : MAILBOX_NOT_SENT_EMOJI;
 }
 

--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -62,6 +62,7 @@ const FWA_MATCH_ALLIANCE_PREFIX = "fwa-match-alliance";
 const FWA_MAIL_CONFIRM_PREFIX = "fwa-mail-confirm";
 const FWA_MAIL_REFRESH_PREFIX = "fwa-mail-refresh";
 const FWA_MATCH_SEND_MAIL_PREFIX = "fwa-match-send-mail";
+const WAR_HISTORY_UPSERT_DEDUPE_MS = 20 * 60 * 1000;
 const MAILBOX_SENT_EMOJI = "📬";
 const MAILBOX_NOT_SENT_EMOJI = "📭";
 const POINTS_REQUEST_HEADERS = {
@@ -246,6 +247,7 @@ const fwaMatchCopyPayloads = new Map<string, FwaMatchCopyPayload>();
 const fwaMailPreviewPayloads = new Map<string, FwaMailPreviewPayload>();
 const fwaMailPostedPayloads = new Map<string, FwaMailPostedPayload>();
 const fwaMailPollers = new Map<string, ReturnType<typeof setInterval>>();
+const warHistoryUpsertDedupedAt = new Map<string, number>();
 
 function buildFwaMatchCopyCustomId(
   userId: string,
@@ -655,6 +657,12 @@ async function upsertCurrentWarHistoryAndGetWarId(params: {
     return null;
   }
 
+  const dedupeKey = `${params.normalizedTag}:${Math.trunc(params.warStartMs)}`;
+  const dedupedAt = warHistoryUpsertDedupedAt.get(dedupeKey) ?? null;
+  if (dedupedAt !== null && Date.now() - dedupedAt < WAR_HISTORY_UPSERT_DEDUPE_MS) {
+    return getCurrentWarIdForClan(params.normalizedTag, params.warStartMs);
+  }
+
   const warStartTime = new Date(params.warStartMs);
   const saved = await prisma.warClanHistory.upsert({
     where: {
@@ -693,6 +701,13 @@ async function upsertCurrentWarHistoryAndGetWarId(params: {
     },
     select: { warId: true },
   });
+  warHistoryUpsertDedupedAt.set(dedupeKey, Date.now());
+  if (warHistoryUpsertDedupedAt.size > 500) {
+    const cutoff = Date.now() - WAR_HISTORY_UPSERT_DEDUPE_MS * 2;
+    for (const [key, at] of warHistoryUpsertDedupedAt.entries()) {
+      if (at < cutoff) warHistoryUpsertDedupedAt.delete(key);
+    }
+  }
 
   return saved.warId ?? null;
 }

--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -653,17 +653,30 @@ async function upsertCurrentWarHistoryAndGetWarId(params: {
   opponentTag: string;
   war: Awaited<ReturnType<CoCService["getCurrentWar"]>>;
 }): Promise<number | null> {
-  if (params.warStartMs === null || !Number.isFinite(params.warStartMs)) {
-    return null;
+  const resolvedWarStartMs =
+    params.warStartMs !== null && Number.isFinite(params.warStartMs)
+      ? params.warStartMs
+      : parseCocApiTime(params.war?.startTime);
+  if (resolvedWarStartMs === null || !Number.isFinite(resolvedWarStartMs)) {
+    const fallback = await prisma.warClanHistory.findFirst({
+      where: { clanTag: `#${params.normalizedTag}` },
+      orderBy: { warStartTime: "desc" },
+      select: { warId: true },
+    });
+    return fallback?.warId ?? null;
   }
 
-  const dedupeKey = `${params.normalizedTag}:${Math.trunc(params.warStartMs)}`;
+  const resolvedWarEndMs =
+    params.warEndMs !== null && Number.isFinite(params.warEndMs)
+      ? params.warEndMs
+      : parseCocApiTime(params.war?.endTime);
+  const dedupeKey = `${params.normalizedTag}:${Math.trunc(resolvedWarStartMs)}`;
   const dedupedAt = warHistoryUpsertDedupedAt.get(dedupeKey) ?? null;
   if (dedupedAt !== null && Date.now() - dedupedAt < WAR_HISTORY_UPSERT_DEDUPE_MS) {
-    return getCurrentWarIdForClan(params.normalizedTag, params.warStartMs);
+    return getCurrentWarIdForClan(params.normalizedTag, resolvedWarStartMs);
   }
 
-  const warStartTime = new Date(params.warStartMs);
+  const warStartTime = new Date(resolvedWarStartMs);
   const saved = await prisma.warClanHistory.upsert({
     where: {
       clanTag_warStartTime: {
@@ -680,7 +693,7 @@ async function upsertCurrentWarHistoryAndGetWarId(params: {
       opponentDestruction: parseNullableFloat(params.war?.opponent?.destructionPercentage),
       expectedOutcome: params.expectedOutcome,
       warStartTime,
-      warEndTime: params.warEndMs !== null ? new Date(params.warEndMs) : null,
+      warEndTime: resolvedWarEndMs !== null ? new Date(resolvedWarEndMs) : null,
       clanName: params.clanName,
       clanTag: `#${params.normalizedTag}`,
       opponentName: params.opponentName,
@@ -694,7 +707,7 @@ async function upsertCurrentWarHistoryAndGetWarId(params: {
       opponentStars: parseNullableInt(params.war?.opponent?.stars),
       opponentDestruction: parseNullableFloat(params.war?.opponent?.destructionPercentage),
       expectedOutcome: params.expectedOutcome,
-      warEndTime: params.warEndMs !== null ? new Date(params.warEndMs) : null,
+      warEndTime: resolvedWarEndMs !== null ? new Date(resolvedWarEndMs) : null,
       clanName: params.clanName,
       opponentName: params.opponentName,
       opponentTag: params.opponentTag ? `#${params.opponentTag}` : null,
@@ -708,7 +721,6 @@ async function upsertCurrentWarHistoryAndGetWarId(params: {
       if (at < cutoff) warHistoryUpsertDedupedAt.delete(key);
     }
   }
-
   return saved.warId ?? null;
 }
 

--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -19,7 +19,7 @@ const OVERVIEW_PAGE_SIZE = 4;
 const HELP_TIMEOUT_MS = 10 * 60 * 1000;
 const HELP_POST_BUTTON_PREFIX = "help-post-channel";
 const ADMIN_DEFAULT_TARGETS = new Set<string>([
-  "tracked-clan:add",
+  "tracked-clan:configure",
   "tracked-clan:remove",
   "sheet:link",
   "sheet:unlink",
@@ -89,13 +89,13 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
   "tracked-clan": {
     summary: "Manage tracked clans used by activity features.",
     details: [
-      "Add/remove tracked clans or list current tracked set.",
-      "Set clan lose-style on add (defaults to TRIPLE_TOP_30). Re-running add updates lose-style.",
-      "`add` and `remove` are admin-only by default.",
+      "Configure/remove tracked clans or list current tracked set.",
+      "`configure` upserts tracked clan settings (lose-style, mail channel, log channel, clan role).",
+      "`configure` and `remove` are admin-only by default.",
     ],
     examples: [
-      "/tracked-clan add tag:#2QG2C08UP",
-      "/tracked-clan add tag:#2QG2C08UP lose-style:Traditional",
+      "/tracked-clan configure tag:#2QG2C08UP",
+      "/tracked-clan configure tag:#2QG2C08UP lose-style:Traditional mail-channel:#war-mail",
       "/tracked-clan remove tag:#2QG2C08UP",
       "/tracked-clan list",
     ],
@@ -189,7 +189,7 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
       "`/fwa points` returns point balances (single clan tag or all tracked if tag omitted).",
       "`/fwa match` auto-resolves current war opponent from CoC API and evaluates win/lose/tiebreak using the same points logic.",
       "If match type is inferred, `/fwa match` shows a warning and quick verify link, with action buttons to confirm FWA/BL/MM.",
-      "`/fwa mail set` upserts the tracked clan mail channel used for war mail posts.",
+      "Tracked clan mail channel is configured via `/tracked-clan configure ... mail-channel`.",
       "`/fwa mail send` opens an ephemeral war mail preview with confirm/send.",
       "The `/fwa match` single-clan `Send Mail` button uses the same permissions as `/fwa mail send`.",
       "Default access for `/fwa mail send` is FWA leader role + Administrator (or override via `/permission add command:fwa:mail:send`).",
@@ -201,7 +201,7 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
       "/fwa points tag:2QG2C08UP",
       "/fwa points",
       "/fwa match tag:2QG2C08UP",
-      "/fwa mail set tag:2QG2C08UP mail-channel:#war-mail",
+      "/tracked-clan configure tag:#2QG2C08UP mail-channel:#war-mail",
       "/fwa mail send tag:2QG2C08UP",
       "/fwa leader-role role:@FWA-Leaders",
       "/fwa points tag:2QG2C08UP visibility:public",

--- a/src/commands/Inactive.ts
+++ b/src/commands/Inactive.ts
@@ -203,7 +203,7 @@ async function runDaysMode(
 
   if (roster.trackedTags.length === 0) {
     await interaction.editReply(
-      "No tracked clans configured. Configure at least one clan with `/tracked-clan add` before using `/inactive`."
+      "No tracked clans configured. Configure at least one clan with `/tracked-clan configure` before using `/inactive`."
     );
     return;
   }
@@ -334,7 +334,7 @@ async function runWarsMode(
   const roster = await getRosterSnapshot(cocService);
   if (roster.trackedTags.length === 0) {
     await interaction.editReply(
-      "No tracked clans configured. Configure at least one clan with `/tracked-clan add` before using `/inactive`."
+      "No tracked clans configured. Configure at least one clan with `/tracked-clan configure` before using `/inactive`."
     );
     return;
   }

--- a/src/commands/Recruitment.ts
+++ b/src/commands/Recruitment.ts
@@ -238,7 +238,7 @@ async function handleShowSubcommand(
 
   const trackedClan = await findTrackedClan(clanTag);
   if (!trackedClan) {
-    await interaction.editReply("Clan is not tracked. Add it first with `/tracked-clan add`.");
+    await interaction.editReply("Clan is not tracked. Add it first with `/tracked-clan configure`.");
     return;
   }
 
@@ -310,7 +310,7 @@ async function handleEditSubcommand(
   if (!tracked) {
     await interaction.reply({
       ephemeral: true,
-      content: "Clan is not tracked. Add it first with `/tracked-clan add`.",
+      content: "Clan is not tracked. Add it first with `/tracked-clan configure`.",
     });
     return;
   }
@@ -401,7 +401,7 @@ async function handleCountdownStartSubcommand(
 
   const tracked = await findTrackedClan(clanTag);
   if (!tracked) {
-    await interaction.editReply("Clan is not tracked. Add it first with `/tracked-clan add`.");
+    await interaction.editReply("Clan is not tracked. Add it first with `/tracked-clan configure`.");
     return;
   }
 

--- a/src/listeners/interactionCreate.ts
+++ b/src/listeners/interactionCreate.ts
@@ -46,6 +46,10 @@ import {
   CommandPermissionService,
   getCommandTargetsFromInteraction,
 } from "../services/CommandPermissionService";
+import {
+  handleNotifyWarRefreshButton,
+  isNotifyWarRefreshButtonCustomId,
+} from "../services/WarEventLogService";
 
 const commandPermissionService = new CommandPermissionService();
 const GLOBAL_POST_BUTTON_PREFIX = "post-channel";
@@ -381,6 +385,20 @@ const handleButtonInteraction = async (interaction: Interaction): Promise<void> 
         await interaction.reply({
           ephemeral: true,
           content: "Failed to refresh war mail.",
+        });
+      }
+    }
+  }
+
+  if (isNotifyWarRefreshButtonCustomId(interaction.customId)) {
+    try {
+      await handleNotifyWarRefreshButton(interaction);
+    } catch (err) {
+      console.error(`Notify war refresh button failed: ${formatError(err)}`);
+      if (!interaction.replied && !interaction.deferred) {
+        await interaction.reply({
+          ephemeral: true,
+          content: "Failed to refresh battle-day embed.",
         });
       }
     }

--- a/src/listeners/ready.ts
+++ b/src/listeners/ready.ts
@@ -157,7 +157,7 @@ export default (client: Client, cocService: CoCService): void => {
 
         if (trackedTags.length === 0) {
           console.warn(
-            "No tracked clans configured. Use /tracked-clan add."
+            "No tracked clans configured. Use /tracked-clan configure."
           );
           return [];
         }

--- a/src/listeners/ready.ts
+++ b/src/listeners/ready.ts
@@ -13,7 +13,10 @@ import { processRecruitmentCooldownReminders } from "../services/RecruitmentServ
 import { SettingsService } from "../services/SettingsService";
 import { PlayerLinkSyncService } from "../services/PlayerLinkSyncService";
 import { WarHistoryService } from "../services/WarHistoryService";
-import { WarEventLogService } from "../services/WarEventLogService";
+import {
+  WarEventLogService,
+  notifyWarBattleDayRefreshIntervalMs,
+} from "../services/WarEventLogService";
 
 const DEFAULT_OBSERVE_INTERVAL_MINUTES = 30;
 const RECRUITMENT_REMINDER_INTERVAL_MS = 5 * 60 * 1000;
@@ -305,6 +308,22 @@ export default (client: Client, cocService: CoCService): void => {
       });
     }, warEventPollMs);
     console.log(`War event log listener enabled (every ${warEventPollMinutes} minute(s)).`);
+
+    const runBattleDayRefresh = async () => {
+      await runFetchTelemetryBatch("war_event_battle_day_refresh_cycle", async () => {
+        try {
+          await warEventLogService.refreshBattleDayPosts();
+        } catch (err) {
+          console.error(`[war-events] battle-day refresh loop failed: ${formatError(err)}`);
+        }
+      });
+    };
+    setInterval(() => {
+      runBattleDayRefresh().catch((err) => {
+        console.error(`[war-events] battle-day refresh interval failed: ${formatError(err)}`);
+      });
+    }, notifyWarBattleDayRefreshIntervalMs);
+    console.log("War battle-day embed refresh enabled (every 20 minute(s)).");
 
     console.log("ClashCookies is online");
   });

--- a/src/services/CommandPermissionService.ts
+++ b/src/services/CommandPermissionService.ts
@@ -16,7 +16,7 @@ export const COMMAND_PERMISSION_TARGETS = [
   "accounts",
   "war",
   "notify",
-  "tracked-clan:add",
+  "tracked-clan:configure",
   "tracked-clan:remove",
   "tracked-clan:list",
   "sheet:link",
@@ -56,7 +56,7 @@ export type CommandPermissionTarget = (typeof COMMAND_PERMISSION_TARGETS)[number
 type GuildInteraction = ChatInputCommandInteraction | ModalSubmitInteraction;
 
 const ADMIN_DEFAULT_TARGETS = new Set<string>([
-  "tracked-clan:add",
+  "tracked-clan:configure",
   "tracked-clan:remove",
   "sheet:link",
   "sheet:unlink",

--- a/src/services/WarEventLogService.ts
+++ b/src/services/WarEventLogService.ts
@@ -104,6 +104,15 @@ function deriveResultLabelFromStars(
   return "TIE";
 }
 
+function formatResultLabelForEmbed(
+  result: "WIN" | "LOSE" | "TIE" | "UNKNOWN"
+): "WIN" | "LOSS" | "DRAW" | "UNKNOWN" {
+  if (result === "WIN") return "WIN";
+  if (result === "LOSE") return "LOSS";
+  if (result === "TIE") return "DRAW";
+  return "UNKNOWN";
+}
+
 function makeBattleDayPostKey(guildId: string, clanTag: string): string {
   return `${guildId}:${normalizeTag(clanTag)}`;
 }
@@ -785,15 +794,6 @@ export class WarEventLogService {
         inline: true,
       });
       if (payload.matchType !== "BL" && payload.matchType !== "MM") {
-        const outcome = payload.outcome ? payload.outcome[0] + payload.outcome.slice(1).toLowerCase() : "Unknown";
-        embed.addFields({
-          name: "Outcome",
-          value:
-            payload.outcome === null
-              ? `Unknown war outcome against ${payload.opponentName}`
-              : `${outcome} war against ${payload.opponentName}`,
-          inline: false,
-        });
         embed.addFields({
           name: "War Plan",
           value:
@@ -853,11 +853,6 @@ export class WarEventLogService {
       });
       if (payload.matchType === "FWA") {
         embed.addFields({
-          name: "Outcome",
-          value: payload.outcome ?? "unknown",
-          inline: false,
-        });
-        embed.addFields({
           name: "War Plan",
           value:
             (await this.history.buildWarPlanText(
@@ -915,10 +910,7 @@ export class WarEventLogService {
       );
       embed.addFields({
         name: "Result",
-        value:
-          payload.matchType === "BL"
-            ? finalResult.resultLabel
-            : `Outcome: **${finalResult.resultLabel}**`,
+        value: formatResultLabelForEmbed(finalResult.resultLabel),
         inline: false,
       });
       embed.addFields({
@@ -1269,15 +1261,6 @@ export class WarEventLogService {
       inline: true,
     });
     if (payload.matchType !== "BL" && payload.matchType !== "MM") {
-      const outcome = payload.outcome ? payload.outcome[0] + payload.outcome.slice(1).toLowerCase() : "Unknown";
-      embed.addFields({
-        name: "Outcome",
-        value:
-          payload.outcome === null
-            ? `Unknown war outcome against ${payload.opponentName}`
-            : `${outcome} war against ${payload.opponentName}`,
-        inline: false,
-      });
       embed.addFields({
         name: "War Plan",
         value:

--- a/src/services/WarEventLogService.ts
+++ b/src/services/WarEventLogService.ts
@@ -1,4 +1,8 @@
 import {
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonInteraction,
+  ButtonStyle,
   ChannelType,
   Client,
   EmbedBuilder,
@@ -33,6 +37,10 @@ export {
   computeWarPointsDeltaForTest,
 } from "./war-events/core";
 
+const NOTIFY_WAR_REFRESH_PREFIX = "notify-war-refresh";
+const BATTLE_DAY_REFRESH_MS = 20 * 60 * 1000;
+const battleDayPostByGuildTag = new Map<string, { channelId: string; messageId: string }>();
+
 type TestSource = "current" | "last";
 
 type SubscriptionRow = {
@@ -65,6 +73,17 @@ type PollSyncContext = {
   activeSync: number | null;
 };
 
+type EmbedWarStats = {
+  clanStars: number | null;
+  opponentStars: number | null;
+  clanAttacks: number | null;
+  opponentAttacks: number | null;
+  teamSize: number | null;
+  attacksPerMember: number | null;
+  clanDestruction: number | null;
+  opponentDestruction: number | null;
+};
+
 /** Purpose: detect if current poll belongs to a newer war cycle than the stored snapshot. */
 function isNewWarCycle(
   previousWarStartTime: Date | null,
@@ -73,6 +92,70 @@ function isNewWarCycle(
   if (!(nextWarStartTime instanceof Date) || Number.isNaN(nextWarStartTime.getTime())) return false;
   if (!(previousWarStartTime instanceof Date) || Number.isNaN(previousWarStartTime.getTime())) return true;
   return nextWarStartTime.getTime() !== previousWarStartTime.getTime();
+}
+
+function makeBattleDayPostKey(guildId: string, clanTag: string): string {
+  return `${guildId}:${normalizeTag(clanTag)}`;
+}
+
+function formatWarStatCellLeft(value: string): string {
+  return value.padStart(10, " ");
+}
+
+function formatWarStatCellRight(value: string): string {
+  return value.padEnd(10, " ");
+}
+
+function formatWarStatLine(left: string, emoji: string, right: string): string {
+  return `\`${formatWarStatCellLeft(left)}\` ${emoji} \`${formatWarStatCellRight(right)}\``;
+}
+
+function formatWarInt(input: unknown): string {
+  const value = Number(input);
+  if (!Number.isFinite(value)) return "?";
+  return String(Math.max(0, Math.trunc(value)));
+}
+
+function formatWarPercent(input: unknown): string {
+  const value = Number(input);
+  if (!Number.isFinite(value)) return "?";
+  const rounded = Math.round(value * 100) / 100;
+  const withPrecision = Number.isInteger(rounded) ? `${rounded}` : `${rounded.toFixed(2)}`;
+  return `${withPrecision.replace(/\.00$/, "")}%`;
+}
+
+function parseNullableInt(input: unknown): number | null {
+  const value = Number(input);
+  if (!Number.isFinite(value)) return null;
+  return Math.trunc(value);
+}
+
+function parseNullableFloat(input: unknown): number | null {
+  const value = Number(input);
+  if (!Number.isFinite(value)) return null;
+  return value;
+}
+
+function buildWarStatsLines(stats: EmbedWarStats): string[] {
+  const starsLeft = formatWarInt(stats.clanStars);
+  const starsRight = formatWarInt(stats.opponentStars);
+  const attacksPerMember = Number.isFinite(Number(stats.attacksPerMember))
+    ? Math.max(1, Math.trunc(Number(stats.attacksPerMember)))
+    : 2;
+  const teamSize = Number.isFinite(Number(stats.teamSize))
+    ? Math.max(1, Math.trunc(Number(stats.teamSize)))
+    : 0;
+  const totalAttacks = teamSize > 0 ? teamSize * attacksPerMember : 0;
+  const attacksLeft = formatWarInt(stats.clanAttacks);
+  const attacksRight = formatWarInt(stats.opponentAttacks);
+  const attacksLeftText = totalAttacks > 0 ? `${attacksLeft}/${totalAttacks}` : `${attacksLeft}/?`;
+  const attacksRightText = totalAttacks > 0 ? `${attacksRight}/${totalAttacks}` : `${attacksRight}/?`;
+  return [
+    "War Stats",
+    formatWarStatLine(starsLeft, ":star:", starsRight),
+    formatWarStatLine(attacksLeftText, ":crossed_swords:", attacksRightText),
+    formatWarStatLine(formatWarPercent(stats.clanDestruction), ":boom:", formatWarPercent(stats.opponentDestruction)),
+  ];
 }
 
 export class WarEventLogService {
@@ -232,6 +315,23 @@ export class WarEventLogService {
             ? Number(currentWar?.opponent?.stars)
             : sub.lastOpponentStars,
       warStartTime: lastWarRow?.warStartTime ?? sub.lastWarStartTime ?? parseCocTime(currentWar?.startTime ?? null),
+      warEndTime: parseCocTime(currentWar?.endTime ?? null),
+      clanAttacks: Number.isFinite(Number(currentWar?.clan?.attacks))
+        ? Number(currentWar?.clan?.attacks)
+        : null,
+      opponentAttacks: Number.isFinite(Number(currentWar?.opponent?.attacks))
+        ? Number(currentWar?.opponent?.attacks)
+        : null,
+      teamSize: Number.isFinite(Number(currentWar?.teamSize)) ? Number(currentWar?.teamSize) : null,
+      attacksPerMember: Number.isFinite(Number(currentWar?.attacksPerMember))
+        ? Number(currentWar?.attacksPerMember)
+        : null,
+      clanDestruction: Number.isFinite(Number(currentWar?.clan?.destructionPercentage))
+        ? Number(currentWar?.clan?.destructionPercentage)
+        : null,
+      opponentDestruction: Number.isFinite(Number(currentWar?.opponent?.destructionPercentage))
+        ? Number(currentWar?.opponent?.destructionPercentage)
+        : null,
     });
 
     return { ok: true };
@@ -301,6 +401,7 @@ export class WarEventLogService {
       const [, y, mo, d, h, mi, s] = m;
       return new Date(Date.UTC(Number(y), Number(mo) - 1, Number(d), Number(h), Number(mi), Number(s)));
     })();
+    const nextWarEndTime = parseCocTime(war?.endTime ?? null);
 
     const eventTypeRaw = shouldEmit(prevState, currentState);
     let eventType = eventTypeRaw;
@@ -349,6 +450,22 @@ export class WarEventLogService {
       Number.isFinite(Number((war as { opponent?: { stars?: number } } | null)?.opponent?.stars))
         ? Number((war as { opponent?: { stars?: number } }).opponent?.stars)
         : sub.lastOpponentStars;
+    const nextClanAttacks = Number.isFinite(Number(war?.clan?.attacks))
+      ? Number(war?.clan?.attacks)
+      : null;
+    const nextOpponentAttacks = Number.isFinite(Number(war?.opponent?.attacks))
+      ? Number(war?.opponent?.attacks)
+      : null;
+    const nextTeamSize = Number.isFinite(Number(war?.teamSize)) ? Number(war?.teamSize) : null;
+    const nextAttacksPerMember = Number.isFinite(Number(war?.attacksPerMember))
+      ? Number(war?.attacksPerMember)
+      : null;
+    const nextClanDestruction = Number.isFinite(Number(war?.clan?.destructionPercentage))
+      ? Number(war?.clan?.destructionPercentage)
+      : null;
+    const nextOpponentDestruction = Number.isFinite(Number(war?.opponent?.destructionPercentage))
+      ? Number(war?.opponent?.destructionPercentage)
+      : null;
     if (nextOpponentTag || normalizeTag(sub.lastOpponentTag ?? "")) {
       const projectionClanTag = sub.clanTag;
       const projectionOpponentTag = nextOpponentTag || normalizeTag(sub.lastOpponentTag ?? "");
@@ -423,6 +540,34 @@ export class WarEventLogService {
       }
     }
 
+    if (currentState !== "notInWar") {
+      await this.upsertCurrentWarHistory({
+        clanTag: sub.clanTag,
+        warStartTime: nextWarStartTime,
+        warEndTime: nextWarEndTime,
+        syncNumber: syncNumberForEvent,
+        matchType: nextMatchType,
+        expectedOutcome: normalizeOutcome(nextOutcome),
+        clanName: nextClanName,
+        opponentName: nextOpponentName || sub.lastOpponentName || "Unknown",
+        opponentTag: nextOpponentTag || normalizeTag(sub.lastOpponentTag ?? ""),
+        stats: {
+          clanStars: nextClanStars,
+          opponentStars: nextOpponentStars,
+          clanAttacks: nextClanAttacks,
+          opponentAttacks: nextOpponentAttacks,
+          teamSize: nextTeamSize,
+          attacksPerMember: nextAttacksPerMember,
+          clanDestruction: nextClanDestruction,
+          opponentDestruction: nextOpponentDestruction,
+        },
+      }).catch((err) => {
+        console.error(
+          `[war-events] current-war history upsert failed guild=${sub.guildId} clan=${sub.clanTag} error=${formatError(err)}`
+        );
+      });
+    }
+
     if (eventType) {
       const eventPayload = {
         eventType,
@@ -442,6 +587,13 @@ export class WarEventLogService {
         lastClanStars: nextClanStars,
         lastOpponentStars: nextOpponentStars,
         warStartTime: nextWarStartTime,
+        warEndTime: nextWarEndTime,
+        clanAttacks: nextClanAttacks,
+        opponentAttacks: nextOpponentAttacks,
+        teamSize: nextTeamSize,
+        attacksPerMember: nextAttacksPerMember,
+        clanDestruction: nextClanDestruction,
+        opponentDestruction: nextOpponentDestruction,
       } as const;
 
       if (eventType === "war_ended") {
@@ -497,6 +649,13 @@ export class WarEventLogService {
       lastClanStars: number | null;
       lastOpponentStars: number | null;
       warStartTime: Date | null;
+      warEndTime: Date | null;
+      clanAttacks: number | null;
+      opponentAttacks: number | null;
+      teamSize: number | null;
+      attacksPerMember: number | null;
+      clanDestruction: number | null;
+      opponentDestruction: number | null;
     }
   ): Promise<void> {
     const channel = await this.client.channels.fetch(channelId).catch(() => null);
@@ -510,6 +669,23 @@ export class WarEventLogService {
       return;
     }
 
+    const guildId = (channel as { guildId?: string }).guildId ?? null;
+    const warId =
+      payload.warStartTime && normalizeTag(payload.clanTag)
+        ? (
+            await prisma.warClanHistory
+              .findUnique({
+                where: {
+                  clanTag_warStartTime: {
+                    clanTag: normalizeTag(payload.clanTag),
+                    warStartTime: payload.warStartTime,
+                  },
+                },
+                select: { warId: true },
+              })
+              .catch(() => null)
+          )?.warId ?? null
+        : null;
     const opponentTag = normalizeTag(payload.opponentTag);
     const embed = new EmbedBuilder()
       .setTitle(`Event: ${eventTitle(payload.eventType)} - ${payload.clanName}`)
@@ -520,6 +696,7 @@ export class WarEventLogService {
             ? 0xf1c40f
             : 0x2ecc71
       )
+      .setFooter({ text: `War ID: ${warId ?? "unknown"}` })
       .setTimestamp(new Date());
 
     embed.addFields({
@@ -534,6 +711,11 @@ export class WarEventLogService {
     });
 
     if (payload.eventType === "battle_day") {
+      embed.addFields({
+        name: "Battle Day Remaining",
+        value: toDiscordRelativeTime(payload.warEndTime),
+        inline: true,
+      });
       embed.addFields({
         name: "Match Type",
         value: payload.matchType ?? "unknown",
@@ -576,6 +758,23 @@ export class WarEventLogService {
           inline: false,
         });
       }
+    }
+
+    if (payload.eventType === "battle_day") {
+      embed.addFields({
+        name: "\u200b",
+        value: buildWarStatsLines({
+          clanStars: payload.lastClanStars,
+          opponentStars: payload.lastOpponentStars,
+          clanAttacks: payload.clanAttacks,
+          opponentAttacks: payload.opponentAttacks,
+          teamSize: payload.teamSize,
+          attacksPerMember: payload.attacksPerMember,
+          clanDestruction: payload.clanDestruction,
+          opponentDestruction: payload.opponentDestruction,
+        }).join("\n"),
+        inline: false,
+      });
     }
 
     if (payload.eventType === "war_started") {
@@ -651,11 +850,29 @@ export class WarEventLogService {
       );
       embed.addFields({
         name: "Result",
-        value: [
-          ...(payload.matchType === "BL" ? [] : [`Outcome: **${finalResult.resultLabel}**`]),
-          `Stars: **${payload.clanName}** ${finalResult.clanStars ?? "unknown"} | **${payload.opponentName}** ${finalResult.opponentStars ?? "unknown"}`,
-          `Destruction: **${payload.clanName}** ${formatPercent(finalResult.clanDestruction)} | **${payload.opponentName}** ${formatPercent(finalResult.opponentDestruction)}`,
-        ].join("\n"),
+        value:
+          payload.matchType === "BL"
+            ? finalResult.resultLabel
+            : `Outcome: **${finalResult.resultLabel}**`,
+        inline: false,
+      });
+      embed.addFields({
+        name: "Match Type",
+        value: payload.matchType ?? "unknown",
+        inline: true,
+      });
+      embed.addFields({
+        name: "\u200b",
+        value: buildWarStatsLines({
+          clanStars: finalResult.clanStars,
+          opponentStars: finalResult.opponentStars,
+          clanAttacks: payload.clanAttacks,
+          opponentAttacks: payload.opponentAttacks,
+          teamSize: payload.teamSize,
+          attacksPerMember: payload.attacksPerMember,
+          clanDestruction: finalResult.clanDestruction,
+          opponentDestruction: finalResult.opponentDestruction,
+        }).join("\n"),
         inline: false,
       });
       embed.addFields({
@@ -680,15 +897,387 @@ export class WarEventLogService {
 
     const roleMention =
       payload.pingRole && payload.notifyRole ? `<@&${payload.notifyRole}>` : null;
-    await channel.send({
-      content: roleMention ?? undefined,
-      embeds: [embed],
-      allowedMentions: roleMention ? { roles: [payload.notifyRole as string] } : undefined,
-    }).catch((err) => {
-      console.error(
-        `[war-events] send failed channel=${channelId} clan=${payload.clanTag} error=${formatError(err)}`
-      );
+    const components =
+      payload.eventType === "battle_day" && guildId
+        ? [
+            new ActionRowBuilder<ButtonBuilder>().addComponents(
+              new ButtonBuilder()
+                .setCustomId(buildNotifyWarRefreshCustomId(guildId, payload.clanTag))
+                .setLabel("Refresh")
+                .setStyle(ButtonStyle.Secondary)
+            ),
+          ]
+        : [];
+    const sent = await channel
+      .send({
+        content: roleMention ?? undefined,
+        embeds: [embed],
+        components,
+        allowedMentions: roleMention ? { roles: [payload.notifyRole as string] } : undefined,
+      })
+      .catch((err) => {
+        console.error(
+          `[war-events] send failed channel=${channelId} clan=${payload.clanTag} error=${formatError(err)}`
+        );
+        return null;
+      });
+    if (guildId) {
+      const key = makeBattleDayPostKey(guildId, payload.clanTag);
+      if (payload.eventType === "battle_day" && sent) {
+        battleDayPostByGuildTag.set(key, { channelId, messageId: sent.id });
+      } else if (payload.eventType !== "battle_day") {
+        battleDayPostByGuildTag.delete(key);
+      }
+    }
+  }
+
+  async refreshBattleDayPosts(): Promise<void> {
+    const keys = [...battleDayPostByGuildTag.keys()];
+    for (const key of keys) {
+      await this.refreshBattleDayPostByKey(key).catch((err) => {
+        console.error(`[war-events] battle-day refresh failed key=${key} error=${formatError(err)}`);
+      });
+    }
+  }
+
+  async refreshBattleDayPostByInteraction(interaction: ButtonInteraction): Promise<void> {
+    const parsed = parseNotifyWarRefreshCustomId(interaction.customId);
+    if (!parsed) {
+      if (!interaction.replied && !interaction.deferred) {
+        await interaction.reply({ ephemeral: true, content: "Invalid refresh action." });
+      }
+      return;
+    }
+    await interaction.deferReply({ ephemeral: true });
+    const key = makeBattleDayPostKey(parsed.guildId, parsed.clanTag);
+    battleDayPostByGuildTag.set(key, {
+      channelId: interaction.channelId,
+      messageId: interaction.message.id,
+    });
+    await this.refreshBattleDayPostByKey(key);
+    await interaction.editReply({ content: "Battle day embed refreshed." });
+  }
+
+  private async refreshBattleDayPostByKey(key: string): Promise<void> {
+    const tracked = battleDayPostByGuildTag.get(key);
+    if (!tracked) return;
+    const [guildId, clanTag] = key.split(":");
+    if (!guildId || !clanTag) {
+      battleDayPostByGuildTag.delete(key);
+      return;
+    }
+
+    const sub = await this.findSubscriptionByGuildAndTag(guildId, clanTag);
+    if (!sub || !sub.notify) {
+      battleDayPostByGuildTag.delete(key);
+      return;
+    }
+
+    const war = await this.coc.getCurrentWar(sub.clanTag).catch(() => null);
+    if (!war || deriveState(String(war.state ?? "")) !== "inWar") {
+      battleDayPostByGuildTag.delete(key);
+      return;
+    }
+
+    const warStartTime = parseCocTime(war.startTime ?? null) ?? sub.lastWarStartTime ?? null;
+    const warEndTime = parseCocTime(war.endTime ?? null);
+    await this.upsertCurrentWarHistory({
+      clanTag: sub.clanTag,
+      warStartTime,
+      warEndTime,
+      syncNumber: await this.pointsSync.getPreviousSyncNum(),
+      matchType: sub.matchType,
+      expectedOutcome: normalizeOutcome(sub.outcome),
+      clanName: String(war.clan?.name ?? sub.clanName ?? sub.clanTag).trim() || sub.clanTag,
+      opponentName: String(war.opponent?.name ?? sub.lastOpponentName ?? "Unknown").trim() || "Unknown",
+      opponentTag: normalizeTag(war.opponent?.tag ?? sub.lastOpponentTag ?? ""),
+      stats: {
+        clanStars: Number.isFinite(Number(war.clan?.stars)) ? Number(war.clan?.stars) : sub.lastClanStars,
+        opponentStars: Number.isFinite(Number(war.opponent?.stars))
+          ? Number(war.opponent?.stars)
+          : sub.lastOpponentStars,
+        clanAttacks: Number.isFinite(Number(war.clan?.attacks)) ? Number(war.clan?.attacks) : null,
+        opponentAttacks: Number.isFinite(Number(war.opponent?.attacks))
+          ? Number(war.opponent?.attacks)
+          : null,
+        teamSize: Number.isFinite(Number(war.teamSize)) ? Number(war.teamSize) : null,
+        attacksPerMember: Number.isFinite(Number(war.attacksPerMember))
+          ? Number(war.attacksPerMember)
+          : null,
+        clanDestruction: Number.isFinite(Number(war.clan?.destructionPercentage))
+          ? Number(war.clan?.destructionPercentage)
+          : null,
+        opponentDestruction: Number.isFinite(Number(war.opponent?.destructionPercentage))
+          ? Number(war.opponent?.destructionPercentage)
+          : null,
+      },
+    });
+
+    const refreshedSub = await this.findSubscriptionByGuildAndTag(guildId, clanTag);
+    if (!refreshedSub) {
+      battleDayPostByGuildTag.delete(key);
+      return;
+    }
+
+    const channel = await this.client.channels.fetch(tracked.channelId).catch(() => null);
+    if (!channel || !channel.isTextBased()) {
+      battleDayPostByGuildTag.delete(key);
+      return;
+    }
+    const message = await (channel as any).messages.fetch(tracked.messageId).catch(() => null);
+    if (!message) {
+      battleDayPostByGuildTag.delete(key);
+      return;
+    }
+
+    const payload = {
+      eventType: "battle_day" as const,
+      clanTag: refreshedSub.clanTag,
+      clanName: String(war.clan?.name ?? refreshedSub.clanName ?? refreshedSub.clanTag).trim() || refreshedSub.clanTag,
+      opponentTag: normalizeTag(war.opponent?.tag ?? refreshedSub.lastOpponentTag ?? ""),
+      opponentName:
+        String(war.opponent?.name ?? refreshedSub.lastOpponentName ?? "Unknown").trim() || "Unknown",
+      syncNumber: await this.pointsSync.getPreviousSyncNum(),
+      notifyRole: refreshedSub.notifyRole,
+      pingRole: refreshedSub.pingRole,
+      fwaPoints: refreshedSub.fwaPoints,
+      opponentFwaPoints: refreshedSub.opponentFwaPoints,
+      outcome: normalizeOutcome(refreshedSub.outcome),
+      matchType: refreshedSub.matchType,
+      warStartFwaPoints: refreshedSub.warStartFwaPoints,
+      warEndFwaPoints: refreshedSub.warEndFwaPoints,
+      lastClanStars: Number.isFinite(Number(war.clan?.stars))
+        ? Number(war.clan?.stars)
+        : refreshedSub.lastClanStars,
+      lastOpponentStars: Number.isFinite(Number(war.opponent?.stars))
+        ? Number(war.opponent?.stars)
+        : refreshedSub.lastOpponentStars,
+      warStartTime,
+      warEndTime,
+      clanAttacks: Number.isFinite(Number(war.clan?.attacks)) ? Number(war.clan?.attacks) : null,
+      opponentAttacks: Number.isFinite(Number(war.opponent?.attacks))
+        ? Number(war.opponent?.attacks)
+        : null,
+      teamSize: Number.isFinite(Number(war.teamSize)) ? Number(war.teamSize) : null,
+      attacksPerMember: Number.isFinite(Number(war.attacksPerMember))
+        ? Number(war.attacksPerMember)
+        : null,
+      clanDestruction: Number.isFinite(Number(war.clan?.destructionPercentage))
+        ? Number(war.clan?.destructionPercentage)
+        : null,
+      opponentDestruction: Number.isFinite(Number(war.opponent?.destructionPercentage))
+        ? Number(war.opponent?.destructionPercentage)
+        : null,
+    };
+    const warId =
+      warStartTime && normalizeTag(payload.clanTag)
+        ? (
+            await prisma.warClanHistory.findUnique({
+              where: {
+                clanTag_warStartTime: { clanTag: normalizeTag(payload.clanTag), warStartTime },
+              },
+              select: { warId: true },
+            })
+          )?.warId ?? null
+        : null;
+    const embed = EmbedBuilder.from(message.embeds[0] ?? new EmbedBuilder());
+    const next = await this.buildBattleDayRefreshEmbed(payload, warId, embed);
+    await message.edit({
+      embeds: [next],
+      components: [
+        new ActionRowBuilder<ButtonBuilder>().addComponents(
+          new ButtonBuilder()
+            .setCustomId(buildNotifyWarRefreshCustomId(guildId, payload.clanTag))
+            .setLabel("Refresh")
+            .setStyle(ButtonStyle.Secondary)
+        ),
+      ],
     });
   }
 
+  private async upsertCurrentWarHistory(input: {
+    clanTag: string;
+    warStartTime: Date | null;
+    warEndTime: Date | null;
+    syncNumber: number | null;
+    matchType: MatchType;
+    expectedOutcome: "WIN" | "LOSE" | null;
+    clanName: string;
+    opponentName: string;
+    opponentTag: string;
+    stats: EmbedWarStats;
+  }): Promise<void> {
+    const clanTag = normalizeTag(input.clanTag);
+    if (!clanTag || !input.warStartTime) return;
+    await prisma.warClanHistory.upsert({
+      where: {
+        clanTag_warStartTime: {
+          clanTag,
+          warStartTime: input.warStartTime,
+        },
+      },
+      create: {
+        syncNumber: input.syncNumber,
+        matchType: input.matchType,
+        clanStars: parseNullableInt(input.stats.clanStars),
+        clanDestruction: parseNullableFloat(input.stats.clanDestruction),
+        opponentStars: parseNullableInt(input.stats.opponentStars),
+        opponentDestruction: parseNullableFloat(input.stats.opponentDestruction),
+        expectedOutcome: input.expectedOutcome,
+        warStartTime: input.warStartTime,
+        warEndTime: input.warEndTime,
+        clanName: input.clanName,
+        clanTag,
+        opponentName: input.opponentName,
+        opponentTag: normalizeTag(input.opponentTag) || null,
+      },
+      update: {
+        syncNumber: input.syncNumber,
+        matchType: input.matchType,
+        clanStars: parseNullableInt(input.stats.clanStars),
+        clanDestruction: parseNullableFloat(input.stats.clanDestruction),
+        opponentStars: parseNullableInt(input.stats.opponentStars),
+        opponentDestruction: parseNullableFloat(input.stats.opponentDestruction),
+        expectedOutcome: input.expectedOutcome,
+        warEndTime: input.warEndTime,
+        clanName: input.clanName,
+        opponentName: input.opponentName,
+        opponentTag: normalizeTag(input.opponentTag) || null,
+      },
+    });
+  }
+
+  private async buildBattleDayRefreshEmbed(
+    payload: {
+      eventType: "battle_day";
+      clanTag: string;
+      clanName: string;
+      opponentTag: string;
+      opponentName: string;
+      syncNumber: number | null;
+      notifyRole: string | null;
+      pingRole: boolean;
+      fwaPoints: number | null;
+      opponentFwaPoints: number | null;
+      outcome: "WIN" | "LOSE" | null;
+      matchType: MatchType;
+      warStartFwaPoints: number | null;
+      warEndFwaPoints: number | null;
+      lastClanStars: number | null;
+      lastOpponentStars: number | null;
+      warStartTime: Date | null;
+      warEndTime: Date | null;
+      clanAttacks: number | null;
+      opponentAttacks: number | null;
+      teamSize: number | null;
+      attacksPerMember: number | null;
+      clanDestruction: number | null;
+      opponentDestruction: number | null;
+    },
+    warId: number | null,
+    _previous: EmbedBuilder
+  ): Promise<EmbedBuilder> {
+    const opponentTag = normalizeTag(payload.opponentTag);
+    const embed = new EmbedBuilder()
+      .setTitle(`Event: ${eventTitle(payload.eventType)} - ${payload.clanName}`)
+      .setColor(0xf1c40f)
+      .setFooter({ text: `War ID: ${warId ?? "unknown"}` })
+      .setTimestamp(new Date());
+    embed.addFields({
+      name: "Opponent",
+      value: `${payload.opponentName} (${opponentTag ? `#${opponentTag}` : "unknown"})`,
+      inline: false,
+    });
+    embed.addFields({
+      name: "Sync #",
+      value: payload.syncNumber ? `#${payload.syncNumber}` : "unknown",
+      inline: true,
+    });
+    embed.addFields({
+      name: "Battle Day Remaining",
+      value: toDiscordRelativeTime(payload.warEndTime),
+      inline: true,
+    });
+    embed.addFields({
+      name: "Match Type",
+      value: payload.matchType ?? "unknown",
+      inline: true,
+    });
+    if (payload.matchType !== "BL" && payload.matchType !== "MM") {
+      const outcome = payload.outcome ? payload.outcome[0] + payload.outcome.slice(1).toLowerCase() : "Unknown";
+      embed.addFields({
+        name: "Outcome",
+        value:
+          payload.outcome === null
+            ? `Unknown war outcome against ${payload.opponentName}`
+            : `${outcome} war against ${payload.opponentName}`,
+        inline: false,
+      });
+      embed.addFields({
+        name: "War Plan",
+        value:
+          (await this.history.buildWarPlanText(
+            payload.matchType,
+            payload.outcome,
+            payload.clanTag,
+            payload.opponentName
+          )) ?? "N/A",
+        inline: false,
+      });
+    } else if (payload.matchType === "BL") {
+      embed.addFields({
+        name: "Message",
+        value:
+          "**Battle day has started! Thank you for your help swapping to war bases, please swap back to FWA bases asap!**",
+        inline: false,
+      });
+    } else {
+      embed.addFields({
+        name: "Message",
+        value: "Attack whatever you want! Free for all! ⚔️",
+        inline: false,
+      });
+    }
+    embed.addFields({
+      name: "\u200b",
+      value: buildWarStatsLines({
+        clanStars: payload.lastClanStars,
+        opponentStars: payload.lastOpponentStars,
+        clanAttacks: payload.clanAttacks,
+        opponentAttacks: payload.opponentAttacks,
+        teamSize: payload.teamSize,
+        attacksPerMember: payload.attacksPerMember,
+        clanDestruction: payload.clanDestruction,
+        opponentDestruction: payload.opponentDestruction,
+      }).join("\n"),
+      inline: false,
+    });
+    return embed;
+  }
+
 }
+
+export function buildNotifyWarRefreshCustomId(guildId: string, clanTag: string): string {
+  return `${NOTIFY_WAR_REFRESH_PREFIX}:${guildId}:${normalizeTagBare(clanTag)}`;
+}
+
+export function parseNotifyWarRefreshCustomId(
+  customId: string
+): { guildId: string; clanTag: string } | null {
+  const [prefix, guildId, clanTagBare] = String(customId ?? "").split(":");
+  if (prefix !== NOTIFY_WAR_REFRESH_PREFIX || !guildId || !clanTagBare) return null;
+  return { guildId, clanTag: normalizeTag(clanTagBare) };
+}
+
+export function isNotifyWarRefreshButtonCustomId(customId: string): boolean {
+  return String(customId ?? "").startsWith(`${NOTIFY_WAR_REFRESH_PREFIX}:`);
+}
+
+export async function handleNotifyWarRefreshButton(
+  interaction: ButtonInteraction
+): Promise<void> {
+  const service = new WarEventLogService(interaction.client, new CoCService());
+  await service.refreshBattleDayPostByInteraction(interaction);
+}
+
+export const notifyWarBattleDayRefreshIntervalMs = BATTLE_DAY_REFRESH_MS;

--- a/src/services/WarEventLogService.ts
+++ b/src/services/WarEventLogService.ts
@@ -326,6 +326,10 @@ export class WarEventLogService {
         const before = testWarStartFwaPoints ?? fwaPoints;
         const delta = this.computeBlPointsDelta(testFinalResultOverride);
         testWarEndFwaPoints = before !== null && Number.isFinite(before) ? before + delta : null;
+      } else if (sub.matchType === "FWA" && testFinalResultOverride) {
+        const before = testWarStartFwaPoints ?? fwaPoints;
+        const delta = this.computeTestFwaPointsDelta(testFinalResultOverride);
+        testWarEndFwaPoints = before !== null && Number.isFinite(before) ? before + delta : null;
       } else if (sub.matchType === "MM") {
         const before = testWarStartFwaPoints ?? fwaPoints;
         testWarEndFwaPoints = before !== null && Number.isFinite(before) ? before : fwaPoints;
@@ -420,6 +424,12 @@ export class WarEventLogService {
     if (finalResult.resultLabel === "WIN") return 3;
     if ((finalResult.clanDestruction ?? 0) >= 60) return 2;
     return 1;
+  }
+
+  private computeTestFwaPointsDelta(finalResult: WarEndResultSnapshot): number {
+    if (finalResult.resultLabel === "WIN") return -1;
+    if (finalResult.resultLabel === "LOSE") return 1;
+    return 0;
   }
 
   private async processSubscription(

--- a/src/services/WarEventLogService.ts
+++ b/src/services/WarEventLogService.ts
@@ -94,6 +94,16 @@ function isNewWarCycle(
   return nextWarStartTime.getTime() !== previousWarStartTime.getTime();
 }
 
+function deriveResultLabelFromStars(
+  clanStars: number | null,
+  opponentStars: number | null
+): "WIN" | "LOSE" | "TIE" | "UNKNOWN" {
+  if (clanStars === null || opponentStars === null) return "UNKNOWN";
+  if (clanStars > opponentStars) return "WIN";
+  if (clanStars < opponentStars) return "LOSE";
+  return "TIE";
+}
+
 function makeBattleDayPostKey(guildId: string, clanTag: string): string {
   return `${guildId}:${normalizeTag(clanTag)}`;
 }
@@ -282,6 +292,47 @@ export class WarEventLogService {
       opponentFwaPoints = b.balance;
       outcome = deriveExpectedOutcome(clanTag, opponentTag, a.balance, b.balance, syncNumber);
     }
+    const currentWarStartTime = parseCocTime(currentWar?.startTime ?? null);
+    const testWarStartTime =
+      params.source === "current"
+        ? currentWarStartTime ?? sub.lastWarStartTime
+        : lastWarRow?.warStartTime ?? sub.lastWarStartTime ?? currentWarStartTime;
+    const currentClanStars = Number.isFinite(Number(currentWar?.clan?.stars))
+      ? Number(currentWar?.clan?.stars)
+      : sub.lastClanStars;
+    const currentOpponentStars = Number.isFinite(Number(currentWar?.opponent?.stars))
+      ? Number(currentWar?.opponent?.stars)
+      : sub.lastOpponentStars;
+    const testFinalResultOverride: WarEndResultSnapshot | null =
+      params.source === "current" && params.eventType === "war_ended"
+        ? {
+            clanStars: currentClanStars,
+            opponentStars: currentOpponentStars,
+            clanDestruction: Number.isFinite(Number(currentWar?.clan?.destructionPercentage))
+              ? Number(currentWar?.clan?.destructionPercentage)
+              : null,
+            opponentDestruction: Number.isFinite(Number(currentWar?.opponent?.destructionPercentage))
+              ? Number(currentWar?.opponent?.destructionPercentage)
+              : null,
+            warEndTime: new Date(),
+            resultLabel: deriveResultLabelFromStars(currentClanStars, currentOpponentStars),
+          }
+        : null;
+    const testWarStartFwaPoints =
+      params.source === "current" ? sub.warStartFwaPoints ?? fwaPoints : sub.warStartFwaPoints;
+    let testWarEndFwaPoints = sub.warEndFwaPoints;
+    if (params.source === "current" && params.eventType === "war_ended") {
+      if (sub.matchType === "BL" && testFinalResultOverride) {
+        const before = testWarStartFwaPoints ?? fwaPoints;
+        const delta = this.computeBlPointsDelta(testFinalResultOverride);
+        testWarEndFwaPoints = before !== null && Number.isFinite(before) ? before + delta : null;
+      } else if (sub.matchType === "MM") {
+        const before = testWarStartFwaPoints ?? fwaPoints;
+        testWarEndFwaPoints = before !== null && Number.isFinite(before) ? before : fwaPoints;
+      } else {
+        testWarEndFwaPoints = fwaPoints;
+      }
+    }
 
     await this.emitEvent(sub.channelId, {
       eventType: params.eventType,
@@ -296,8 +347,8 @@ export class WarEventLogService {
       opponentFwaPoints,
       outcome,
       matchType: sub.matchType,
-      warStartFwaPoints: sub.warStartFwaPoints,
-      warEndFwaPoints: sub.warEndFwaPoints,
+      warStartFwaPoints: testWarStartFwaPoints,
+      warEndFwaPoints: testWarEndFwaPoints,
       lastClanStars:
         params.source === "last"
           ? Number.isFinite(Number(lastWarLogEntry?.clan?.stars))
@@ -314,7 +365,7 @@ export class WarEventLogService {
           : Number.isFinite(Number(currentWar?.opponent?.stars))
             ? Number(currentWar?.opponent?.stars)
             : sub.lastOpponentStars,
-      warStartTime: lastWarRow?.warStartTime ?? sub.lastWarStartTime ?? parseCocTime(currentWar?.startTime ?? null),
+      warStartTime: testWarStartTime,
       warEndTime: parseCocTime(currentWar?.endTime ?? null),
       clanAttacks: Number.isFinite(Number(currentWar?.clan?.attacks))
         ? Number(currentWar?.clan?.attacks)
@@ -332,6 +383,7 @@ export class WarEventLogService {
       opponentDestruction: Number.isFinite(Number(currentWar?.opponent?.destructionPercentage))
         ? Number(currentWar?.opponent?.destructionPercentage)
         : null,
+      testFinalResultOverride,
     });
 
     return { ok: true };
@@ -656,6 +708,7 @@ export class WarEventLogService {
       attacksPerMember: number | null;
       clanDestruction: number | null;
       opponentDestruction: number | null;
+      testFinalResultOverride?: WarEndResultSnapshot | null;
     }
   ): Promise<void> {
     const channel = await this.client.channels.fetch(channelId).catch(() => null);
@@ -835,13 +888,15 @@ export class WarEventLogService {
     }
 
     if (payload.eventType === "war_ended") {
-      const finalResult = await this.history.getWarEndResultSnapshot({
-        clanTag: payload.clanTag,
-        opponentTag: payload.opponentTag,
-        fallbackClanStars: payload.lastClanStars,
-        fallbackOpponentStars: payload.lastOpponentStars,
-        warStartTime: payload.warStartTime,
-      });
+      const finalResult =
+        payload.testFinalResultOverride ??
+        (await this.history.getWarEndResultSnapshot({
+          clanTag: payload.clanTag,
+          opponentTag: payload.opponentTag,
+          fallbackClanStars: payload.lastClanStars,
+          fallbackOpponentStars: payload.lastOpponentStars,
+          warStartTime: payload.warStartTime,
+        }));
       const compliance = await this.history.getWarComplianceSnapshot(
         payload.clanTag,
         payload.warStartTime,

--- a/src/services/war-events/core.ts
+++ b/src/services/war-events/core.ts
@@ -167,6 +167,9 @@ export function computeWarPointsDeltaForTest(input: {
     if ((input.finalResult.clanDestruction ?? 0) >= 60) return 2;
     return 1;
   }
+  if (input.matchType === "MM") {
+    return 0;
+  }
   if (
     input.before !== null &&
     Number.isFinite(input.before) &&

--- a/src/services/war-events/history.ts
+++ b/src/services/war-events/history.ts
@@ -53,6 +53,17 @@ export class WarEventHistoryService {
       return `${payload.clanName}: ${resolvedBefore ?? "unknown"} -> ${after ?? "unknown"} (${delta !== null && delta >= 0 ? `+${delta}` : String(delta ?? "unknown")}) [BL]`;
     }
 
+    if (payload.matchType === "MM") {
+      const resolvedBefore =
+        before !== null && Number.isFinite(before)
+          ? before
+          : payload.warEndFwaPoints !== null && Number.isFinite(payload.warEndFwaPoints)
+            ? payload.warEndFwaPoints
+            : null;
+      const resolvedAfter = resolvedBefore;
+      return `${payload.clanName}: ${resolvedBefore ?? "unknown"} -> ${resolvedAfter ?? "unknown"} (+0) [MM]`;
+    }
+
     const after = payload.warEndFwaPoints;
     if (
       before !== null &&

--- a/tests/fwaMailRevision.logic.test.ts
+++ b/tests/fwaMailRevision.logic.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { buildWarMailRevisionLinesForTest } from "../src/commands/Fwa";
+import {
+  buildSupersededWarMailDescriptionForTest,
+  buildWarMailRevisionLinesForTest,
+} from "../src/commands/Fwa";
 
 describe("war mail revision log", () => {
   it("includes both match type and expected outcome changes", () => {
@@ -25,5 +28,16 @@ describe("war mail revision log", () => {
     });
 
     expect(lines).toEqual([]);
+  });
+
+  it("builds superseded description with only revision details", () => {
+    const description = buildSupersededWarMailDescriptionForTest({
+      changedAtMs: 1_700_000_000_000,
+      revisionLines: ["- Match Type: **FWA** -> **BL**"],
+    });
+
+    expect(description).toBe(
+      "Superseded at <t:1700000000:F>\n- Match Type: **FWA** -> **BL**"
+    );
   });
 });

--- a/tests/fwaMailRevision.logic.test.ts
+++ b/tests/fwaMailRevision.logic.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { buildWarMailRevisionLinesForTest } from "../src/commands/Fwa";
+
+describe("war mail revision log", () => {
+  it("includes both match type and expected outcome changes", () => {
+    const lines = buildWarMailRevisionLinesForTest({
+      previousMatchType: "FWA",
+      previousExpectedOutcome: "WIN",
+      nextMatchType: "BL",
+      nextExpectedOutcome: null,
+    });
+
+    expect(lines).toEqual([
+      "- Match Type: **FWA** -> **BL**",
+      "- Expected outcome: **WIN** -> **N/A**",
+    ]);
+  });
+
+  it("returns no lines when nothing changed", () => {
+    const lines = buildWarMailRevisionLinesForTest({
+      previousMatchType: "FWA",
+      previousExpectedOutcome: "LOSE",
+      nextMatchType: "FWA",
+      nextExpectedOutcome: "LOSE",
+    });
+
+    expect(lines).toEqual([]);
+  });
+});

--- a/tests/warEventLog.logic.test.ts
+++ b/tests/warEventLog.logic.test.ts
@@ -61,7 +61,7 @@ describe("WarEventLogService.computeWarPointsDeltaForTest", () => {
     expect(delta).toBe(1);
   });
 
-  it("FWA/MM war: returns arithmetic delta (after - before) when both values are present", () => {
+  it("FWA war: returns arithmetic delta (after - before) when both values are present", () => {
     expect(
       computeWarPointsDeltaForTest({
         matchType: "FWA",
@@ -77,6 +77,9 @@ describe("WarEventLogService.computeWarPointsDeltaForTest", () => {
         },
       })
     ).toBe(5);
+  });
+
+  it("MM war: always returns 0 points delta at war end", () => {
     expect(
       computeWarPointsDeltaForTest({
         matchType: "MM",
@@ -91,7 +94,7 @@ describe("WarEventLogService.computeWarPointsDeltaForTest", () => {
           resultLabel: "UNKNOWN",
         },
       })
-    ).toBe(-3);
+    ).toBe(0);
   });
 
   it("FWA/MM war: returns null when before/after values are incomplete", () => {
@@ -190,7 +193,7 @@ describe("WarEventHistoryService.buildWarEndPointsLine", () => {
     expect(line).toBe("Alpha: 1200 -> 1205 (+5)");
   });
 
-  it("MM war: renders negative arithmetic delta when points drop", () => {
+  it("MM war: renders no points change at war end", () => {
     const line = history.buildWarEndPointsLine(
       {
         clanName: "Alpha",
@@ -207,7 +210,7 @@ describe("WarEventHistoryService.buildWarEndPointsLine", () => {
         opponentDestruction: null,
       }
     );
-    expect(line).toBe("Alpha: 1200 -> 1197 (-3)");
+    expect(line).toBe("Alpha: 1200 -> 1200 (+0) [MM]");
   });
 });
 

--- a/tests/warEventLog.logic.test.ts
+++ b/tests/warEventLog.logic.test.ts
@@ -3,6 +3,7 @@ import {
   computeWarComplianceForTest,
   computeWarPointsDeltaForTest,
 } from "../src/services/WarEventLogService";
+import { WarEventHistoryService } from "../src/services/war-events/history";
 
 function dateAt(hour: number): Date {
   return new Date(Date.UTC(2026, 0, 1, hour, 0, 0));
@@ -108,6 +109,105 @@ describe("WarEventLogService.computeWarPointsDeltaForTest", () => {
       },
     });
     expect(delta).toBeNull();
+  });
+});
+
+describe("WarEventHistoryService.buildWarEndPointsLine", () => {
+  const history = new WarEventHistoryService({} as any);
+  const baseResult = {
+    clanStars: 100,
+    opponentStars: 99,
+    clanDestruction: 59,
+    opponentDestruction: 58,
+    warEndTime: null,
+    resultLabel: "WIN" as const,
+  };
+
+  it("BL win: derives +3 and renders before->after even when after is missing", () => {
+    const line = history.buildWarEndPointsLine(
+      {
+        clanName: "Alpha",
+        matchType: "BL",
+        warStartFwaPoints: 100,
+        warEndFwaPoints: null,
+      },
+      baseResult
+    );
+    expect(line).toBe("Alpha: 100 -> 103 (+3) [BL]");
+  });
+
+  it("BL lose with 60%+ destruction: derives +2", () => {
+    const line = history.buildWarEndPointsLine(
+      {
+        clanName: "Alpha",
+        matchType: "BL",
+        warStartFwaPoints: 100,
+        warEndFwaPoints: null,
+      },
+      {
+        ...baseResult,
+        resultLabel: "LOSE",
+        clanDestruction: 60,
+      }
+    );
+    expect(line).toBe("Alpha: 100 -> 102 (+2) [BL]");
+  });
+
+  it("BL lose below 60% destruction: derives +1", () => {
+    const line = history.buildWarEndPointsLine(
+      {
+        clanName: "Alpha",
+        matchType: "BL",
+        warStartFwaPoints: 100,
+        warEndFwaPoints: null,
+      },
+      {
+        ...baseResult,
+        resultLabel: "LOSE",
+        clanDestruction: 59.99,
+      }
+    );
+    expect(line).toBe("Alpha: 100 -> 101 (+1) [BL]");
+  });
+
+  it("FWA war: renders arithmetic delta using stored before/after", () => {
+    const line = history.buildWarEndPointsLine(
+      {
+        clanName: "Alpha",
+        matchType: "FWA",
+        warStartFwaPoints: 1200,
+        warEndFwaPoints: 1205,
+      },
+      {
+        ...baseResult,
+        resultLabel: "UNKNOWN",
+        clanStars: null,
+        opponentStars: null,
+        clanDestruction: null,
+        opponentDestruction: null,
+      }
+    );
+    expect(line).toBe("Alpha: 1200 -> 1205 (+5)");
+  });
+
+  it("MM war: renders negative arithmetic delta when points drop", () => {
+    const line = history.buildWarEndPointsLine(
+      {
+        clanName: "Alpha",
+        matchType: "MM",
+        warStartFwaPoints: 1200,
+        warEndFwaPoints: 1197,
+      },
+      {
+        ...baseResult,
+        resultLabel: "UNKNOWN",
+        clanStars: null,
+        opponentStars: null,
+        clanDestruction: null,
+        opponentDestruction: null,
+      }
+    );
+    expect(line).toBe("Alpha: 1200 -> 1197 (-3)");
   });
 });
 


### PR DESCRIPTION
## Summary
Promotes `dev` into `main` with major updates to war notifications, FWA mail workflow, tracked-clan configuration, and war-history/points correctness.

## Highlights
- Improved `/notify war` embeds:
  - Added War ID support across stages.
  - Battle Day embeds now include richer war stats and refresh behavior.
  - Removed redundant Outcome fields from war start/battle day.
  - War-end Result now displays plain `WIN` / `LOSS` / `DRAW`.
- Improved `/notify war-test` simulation:
  - `war-end current` now uses current-war snapshot data (as-if-ended-now).
  - Simulates points behavior for FWA and BL test paths (non-persistent).
- War history robustness:
  - Upsert current war history during mail refresh polling.
  - Added fallback behavior for missing war start times.
  - Added dedupe safeguards to avoid repeated same-war upserts.
- FWA mail workflow and UX fixes:
  - Confirm/send acknowledgment and single-clan view restore flow improved.
  - Mail status indicators (📬 / 📭) added and refreshed across views/dropdowns.
  - Previous mail supersede/change-log behavior improved.
- Tracked clan configuration improvements:
  - Moved to `/tracked-clan configure` flow for settings management.
  - Added support for `mailChannel`, `logChannel`, and `clanRole` settings in tracked clan config.

## Testing
- Added/updated war-events unit coverage, including:
  - End-to-end war-end points-line scenarios.
  - MM war-end points fixed to zero-delta behavior.
- Type checks and existing logic tests pass on `dev`.

## Notable command/behavior changes
- `/tracked-clan add` replaced by `/tracked-clan configure`.
- `/fwa:mail:set` flow removed/refactored in favor of tracked-clan configuration-backed mail channel behavior.
