### PR TITLE
feat(tracked-clan): add clan-badge option with server emoji support

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -8,7 +8,7 @@
 - `/inactive days:<number>` - List players inactive for N days.
 - `/inactive wars:<number>` - List tracked-clan members who used 0/2 attacks in each of the last N ended wars (requires war-history tracking window).
 - `/role-users role:<discordRole>` - List users in a role with pagination.
-- `/tracked-clan configure tag:<tag> [lose-style:triple-top-30|traditional] [mail-channel:<discordChannel>] [log-channel:<discordChannel>] [clan-role:<discordRole>]` - Add/update tracked clan settings.
+- `/tracked-clan configure tag:<tag> [lose-style:triple-top-30|traditional] [mail-channel:<discordChannel>] [log-channel:<discordChannel>] [clan-role:<discordRole>] [clan-badge:<emoji>]` - Add/update tracked clan settings.
 - `/tracked-clan remove tag:<tag>` - Remove tracked clan.
 - `/tracked-clan list` - List tracked clans and settings.
 - `/sheet link sheet_id_or_url:<id-or-url> [tab:<tab-name>] [mode:actual|war]` - Link or relink sheet; mode is optional.

--- a/prisma/migrations/20260302102000_add_tracked_clan_badge/migration.sql
+++ b/prisma/migrations/20260302102000_add_tracked_clan_badge/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "TrackedClan"
+ADD COLUMN "clanBadge" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -35,6 +35,7 @@ model TrackedClan {
   mailChannelId String?
   logChannelId String?
   clanRoleId String?
+  clanBadge String?
   pointsScrape Json?
   createdAt DateTime  @default(now())
 }

--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -90,12 +90,13 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
     summary: "Manage tracked clans used by activity features.",
     details: [
       "Configure/remove tracked clans or list current tracked set.",
-      "`configure` upserts tracked clan settings (lose-style, mail channel, log channel, clan role).",
+      "`configure` upserts tracked clan settings (lose-style, mail channel, log channel, clan role, clan badge emoji).",
       "`configure` and `remove` are admin-only by default.",
     ],
     examples: [
       "/tracked-clan configure tag:#2QG2C08UP",
       "/tracked-clan configure tag:#2QG2C08UP lose-style:Traditional mail-channel:#war-mail",
+      "/tracked-clan configure tag:#2QG2C08UP clan-badge::Logo_Gabbar:",
       "/tracked-clan remove tag:#2QG2C08UP",
       "/tracked-clan list",
     ],

--- a/src/commands/TrackedClan.ts
+++ b/src/commands/TrackedClan.ts
@@ -16,6 +16,47 @@ function normalizeClanTag(input: string): string {
   return `#${cleaned}`;
 }
 
+const CUSTOM_EMOJI_PATTERN = /^<(a?):([A-Za-z0-9_]+):(\d+)>$/;
+const SHORTCODE_EMOJI_PATTERN = /^:([A-Za-z0-9_]+):$/;
+
+async function normalizeClanBadgeInput(
+  interaction: ChatInputCommandInteraction,
+  input: string
+): Promise<string | null> {
+  const value = input.trim();
+  if (!value) return null;
+
+  const customMatch = value.match(CUSTOM_EMOJI_PATTERN);
+  if (customMatch) {
+    const animated = customMatch[1] === "a";
+    const name = customMatch[2];
+    const id = customMatch[3];
+    return `<${animated ? "a" : ""}:${name}:${id}>`;
+  }
+
+  const shortcodeMatch = value.match(SHORTCODE_EMOJI_PATTERN);
+  if (shortcodeMatch) {
+    const guild = interaction.guild;
+    if (!guild) {
+      throw new Error("CLAN_BADGE_GUILD_REQUIRED");
+    }
+
+    const shortcodeName = shortcodeMatch[1];
+    let emoji = guild.emojis.cache.find((e) => e.name === shortcodeName);
+    if (!emoji) {
+      await guild.emojis.fetch();
+      emoji = guild.emojis.cache.find((e) => e.name === shortcodeName);
+    }
+    if (!emoji) {
+      throw new Error("CLAN_BADGE_SHORTCODE_NOT_FOUND");
+    }
+
+    return `<${emoji.animated ? "a" : ""}:${emoji.name}:${emoji.id}>`;
+  }
+
+  return value;
+}
+
 export const TrackedClan: Command = {
   name: "tracked-clan",
   description: "Configure, remove, or list tracked clans",
@@ -58,6 +99,12 @@ export const TrackedClan: Command = {
           name: "clan-role",
           description: "Discord role associated with this tracked clan",
           type: ApplicationCommandOptionType.Role,
+          required: false,
+        },
+        {
+          name: "clan-badge",
+          description: "Emoji badge for this tracked clan",
+          type: ApplicationCommandOptionType.String,
           required: false,
         },
       ],
@@ -110,7 +157,8 @@ export const TrackedClan: Command = {
           const mailChannel = clan.mailChannelId ? `<#${clan.mailChannelId}>` : "not set";
           const logChannel = clan.logChannelId ? `<#${clan.logChannelId}>` : "not set";
           const clanRole = clan.clanRoleId ? `<@&${clan.clanRoleId}>` : "not set";
-          return `- ${label} | lose-style: ${clan.loseStyle} | mailChannel: ${mailChannel} | logChannel: ${logChannel} | clanRole: ${clanRole}`;
+          const clanBadge = clan.clanBadge ?? "not set";
+          return `- ${label} | lose-style: ${clan.loseStyle} | mailChannel: ${mailChannel} | logChannel: ${logChannel} | clanRole: ${clanRole} | clanBadge: ${clanBadge}`;
         });
         await safeReply(interaction, {
           ephemeral: true,
@@ -130,6 +178,8 @@ export const TrackedClan: Command = {
         const mailChannel = interaction.options.getChannel("mail-channel", false);
         const logChannel = interaction.options.getChannel("log-channel", false);
         const clanRole = interaction.options.getRole("clan-role", false);
+        const clanBadgeInput = interaction.options.getString("clan-badge", false);
+        let clanBadge: string | null = null;
         if (mailChannel && (!("isTextBased" in mailChannel) || !(mailChannel as any).isTextBased())) {
           await safeReply(interaction, {
             ephemeral: true,
@@ -151,6 +201,24 @@ export const TrackedClan: Command = {
           });
           return;
         }
+        if (clanBadgeInput) {
+          try {
+            clanBadge = await normalizeClanBadgeInput(interaction, clanBadgeInput);
+          } catch (badgeErr) {
+            const badgeCode = formatError(badgeErr);
+            const badgeHint =
+              badgeCode === "CLAN_BADGE_GUILD_REQUIRED"
+                ? "Custom clan-badge shortcodes can only be resolved in a server."
+                : badgeCode === "CLAN_BADGE_SHORTCODE_NOT_FOUND"
+                  ? "Could not find that emoji in this server. Use an existing server emoji, unicode emoji, or full custom emoji format like `<:Logo_Gabbar:123456789012345678>`."
+                  : "Invalid clan-badge value. Use unicode emoji, `:emoji_name:` from this server, or full custom emoji format.";
+            await safeReply(interaction, {
+              ephemeral: true,
+              content: badgeHint,
+            });
+            return;
+          }
+        }
         const clan = await cocService.getClan(tag);
         const activityService = new ActivityService(cocService);
         const existing = await prisma.trackedClan.findUnique({
@@ -166,6 +234,7 @@ export const TrackedClan: Command = {
             mailChannelId: mailChannel?.id ?? null,
             logChannelId: logChannel?.id ?? null,
             clanRoleId: clanRole?.id ?? null,
+            clanBadge,
           },
           update: {
             name: clan.name ?? null,
@@ -173,6 +242,7 @@ export const TrackedClan: Command = {
             ...(mailChannel ? { mailChannelId: mailChannel.id } : {}),
             ...(logChannel ? { logChannelId: logChannel.id } : {}),
             ...(clanRole ? { clanRoleId: clanRole.id } : {}),
+            ...(clanBadge ? { clanBadge } : {}),
           },
         });
 
@@ -189,6 +259,7 @@ export const TrackedClan: Command = {
           `mailChannel: ${saved.mailChannelId ? `<#${saved.mailChannelId}>` : "not set"}`,
           `logChannel: ${saved.logChannelId ? `<#${saved.logChannelId}>` : "not set"}`,
           `clanRole: ${saved.clanRoleId ? `<@&${saved.clanRoleId}>` : "not set"}`,
+          `clanBadge: ${saved.clanBadge ?? "not set"}`,
         ].join(" | ");
 
         await safeReply(interaction, {


### PR DESCRIPTION
Add an optional `clan-badge` argument to `/tracked-clan configure` and persist it on tracked clan records.

- Resolve `:emoji_name:` shortcodes against server custom emojis
- Accept full custom emoji format (`<:name:id>` / `<a:name:id>`) and unicode emoji
- Include clan badge in configure/list output
- Add Prisma schema + migration for `TrackedClan.clanBadge`
- Update help and command reference docs