### PR TITLE
fix(sync): resolve tracked clan shortcode badges and add GB fallback

### DIFF
--- a/src/commands/Post.ts
+++ b/src/commands/Post.ts
@@ -11,6 +11,7 @@ import {
   PermissionFlagsBits,
   TextInputBuilder,
   TextInputStyle,
+  type Guild,
 } from "discord.js";
 import { Command } from "../Command";
 import { formatError } from "../helper/formatError";
@@ -37,6 +38,7 @@ const ROLE_INPUT_ID = "role";
 const IANA_TIMEZONE_HELP_URL =
   "https://en.wikipedia.org/wiki/List_of_tz_database_time_zones";
 const CUSTOM_EMOJI_PATTERN = /^<(a?):([A-Za-z0-9_]+):(\d+)>$/;
+const SHORTCODE_EMOJI_PATTERN = /^:([A-Za-z0-9_]+):$/;
 
 type SyncBadge = {
   code: string;
@@ -109,7 +111,8 @@ function makeSyncBadgeFromTrackedClan(
 }
 
 async function getSyncBadgesWithTrackedClanFallback(
-  botUserId: string | undefined
+  botUserId: string | undefined,
+  guild: Guild | null
 ): Promise<SyncBadge[]> {
   const tracked = await prisma.trackedClan.findMany({
     orderBy: { createdAt: "asc" },
@@ -125,6 +128,20 @@ async function getSyncBadgesWithTrackedClanFallback(
   for (const clan of tracked) {
     const configuredBadge = clan.clanBadge?.trim() ?? "";
     if (configuredBadge.length > 0) {
+      const shortcodeMatch = configuredBadge.match(SHORTCODE_EMOJI_PATTERN);
+      if (shortcodeMatch && guild) {
+        const shortcodeName = shortcodeMatch[1];
+        let emoji = guild.emojis.cache.find((e) => e.name === shortcodeName);
+        if (!emoji) {
+          await guild.emojis.fetch().catch(() => null);
+          emoji = guild.emojis.cache.find((e) => e.name === shortcodeName);
+        }
+        if (emoji) {
+          const emojiToken = `<${emoji.animated ? "a" : ""}:${emoji.name}:${emoji.id}>`;
+          badges.push(makeSyncBadgeFromTrackedClan(clan.tag, clan.name, emojiToken));
+          continue;
+        }
+      }
       badges.push(makeSyncBadgeFromTrackedClan(clan.tag, clan.name, configuredBadge));
       continue;
     }
@@ -261,7 +278,10 @@ async function handleSyncStatusSubcommand(
     return;
   }
 
-  const badges = await getSyncBadgesWithTrackedClanFallback(interaction.client.user?.id);
+  const badges = await getSyncBadgesWithTrackedClanFallback(
+    interaction.client.user?.id,
+    interaction.guild
+  );
   if (badges.length === 0) {
     await interaction.editReply(
       "No clan badge emoji configuration found."
@@ -731,7 +751,10 @@ export async function handlePostModalSubmit(
     );
   }
 
-  const badges = await getSyncBadgesWithTrackedClanFallback(interaction.client.user?.id);
+  const badges = await getSyncBadgesWithTrackedClanFallback(
+    interaction.client.user?.id,
+    interaction.guild
+  );
   const badgeEmojiIdentifiers = badges.map((badge) => badge.reactionIdentifier);
   if (badgeEmojiIdentifiers.length > 0) {
     let reactedCount = 0;

--- a/src/helper/syncBadgeEmoji.ts
+++ b/src/helper/syncBadgeEmoji.ts
@@ -7,6 +7,7 @@ const SYNC_BADGE_EMOJIS_BY_BOT: Record<string, SyncBadgeEmoji[]> = {
   [STAGING_BOT_ID]: [
     { code: "ZG", label: "ZERO GRAVITY", name: "zg", id: "1476279645174366449" },
     { code: "TWC", label: "TheWiseCowboys", name: "twc", id: "1476279643660091452" },
+    { code: "GB", label: "GABBAR", name: "gb", id: "1478101511451185383" },
     { code: "SE", label: "Steel Empire 2", name: "se", id: "1476279635208573009" },
     { code: "RR", label: "Rocky Road", name: "rr", id: "1476279632729866242" },
     { code: "RD", label: "RISING DAWN", name: "rd", id: "1476279631345614902" },
@@ -17,6 +18,7 @@ const SYNC_BADGE_EMOJIS_BY_BOT: Record<string, SyncBadgeEmoji[]> = {
   [PROD_BOT_ID]: [
     { code: "ZG", label: "ZERO GRAVITY", name: "zg", id: "1476279778670673930" },
     { code: "TWC", label: "TheWiseCowboys", name: "twc", id: "1476279777466908755" },
+    { code: "GB", label: "GABBAR", name: "gb", id: "1478106834081546300" },
     { code: "SE", label: "Steel Empire 2", name: "se", id: "1476279774241493104" },
     { code: "RR", label: "Rocky Road", name: "rr", id: "1476279773243379762" },
     { code: "RD", label: "RISING DAWN", name: "rd", id: "1476279771884290100" },
@@ -44,6 +46,7 @@ function getClanCodeFromName(value: string): string {
     "DARK EMPIRE": "DE",
     "STEEL EMPIRE 2": "SE",
     "THEWISECOWBOYS": "TWC",
+    GABBAR: "GB",
     MARVELS: "MV",
     "ROCKY ROAD": "RR",
     AKATSUKI: "AK",


### PR DESCRIPTION
Ensure `/sync time post` and `/sync post status` include newly tracked clan badges when `TrackedClan.clanBadge` is set to shortcode-style values like `:gb:` by resolving them against guild emojis at runtime.

Also add GB to hardcoded bot badge libraries for fallback usage:
- staging: `gb` (1478101511451185383)
- prod: `gb` (1478106834081546300)

Map clan name `GABBAR` to code `GB` for name/code-based fallback matching.