### PR TITLE
feat(tracked-clan): add short-name config and use DB abbreviations in…

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -8,7 +8,7 @@
 - `/inactive days:<number>` - List players inactive for N days.
 - `/inactive wars:<number>` - List tracked-clan members who used 0/2 attacks in each of the last N ended wars (requires war-history tracking window).
 - `/role-users role:<discordRole>` - List users in a role with pagination.
-- `/tracked-clan configure tag:<tag> [lose-style:triple-top-30|traditional] [mail-channel:<discordChannel>] [log-channel:<discordChannel>] [clan-role:<discordRole>] [clan-badge:<emoji>]` - Add/update tracked clan settings.
+- `/tracked-clan configure tag:<tag> [lose-style:triple-top-30|traditional] [mail-channel:<discordChannel>] [log-channel:<discordChannel>] [clan-role:<discordRole>] [clan-badge:<emoji>] [short-name:<abbr>]` - Add/update tracked clan settings.
 - `/tracked-clan remove tag:<tag>` - Remove tracked clan.
 - `/tracked-clan list` - List tracked clans and settings.
 - `/sheet link sheet_id_or_url:<id-or-url> [tab:<tab-name>] [mode:actual|war]` - Link or relink sheet; mode is optional.

--- a/prisma/migrations/20260302123000_add_tracked_clan_short_name/migration.sql
+++ b/prisma/migrations/20260302123000_add_tracked_clan_short_name/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "TrackedClan"
+ADD COLUMN "shortName" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -36,6 +36,7 @@ model TrackedClan {
   logChannelId String?
   clanRoleId String?
   clanBadge String?
+  shortName String?
   pointsScrape Json?
   createdAt DateTime  @default(now())
 }

--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -90,13 +90,14 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
     summary: "Manage tracked clans used by activity features.",
     details: [
       "Configure/remove tracked clans or list current tracked set.",
-      "`configure` upserts tracked clan settings (lose-style, mail channel, log channel, clan role, clan badge emoji).",
+      "`configure` upserts tracked clan settings (lose-style, mail channel, log channel, clan role, clan badge emoji, short name).",
       "`configure` and `remove` are admin-only by default.",
     ],
     examples: [
       "/tracked-clan configure tag:#2QG2C08UP",
       "/tracked-clan configure tag:#2QG2C08UP lose-style:Traditional mail-channel:#war-mail",
       "/tracked-clan configure tag:#2QG2C08UP clan-badge::Logo_Gabbar:",
+      "/tracked-clan configure tag:#2QG2C08UP short-name:GB",
       "/tracked-clan remove tag:#2QG2C08UP",
       "/tracked-clan list",
     ],

--- a/src/commands/Post.ts
+++ b/src/commands/Post.ts
@@ -49,6 +49,25 @@ type SyncBadge = {
   name: string | null;
 };
 
+function toFallbackAbbreviation(clanName: string | null, clanTag: string): string {
+  const source = (clanName?.trim() || clanTag.replace(/^#/, "")).toUpperCase();
+  const lettersAndNumbers = source.replace(/[^A-Z0-9]/g, "");
+  const base = lettersAndNumbers.length > 0 ? lettersAndNumbers : source.replace(/\s+/g, "");
+  if (base.length >= 3) return base.slice(0, 3);
+  const tagBase = clanTag.replace(/^#/, "").toUpperCase();
+  return (base + tagBase).slice(0, 3);
+}
+
+function resolveAbbreviation(
+  shortName: string | null,
+  clanName: string | null,
+  clanTag: string
+): string {
+  const normalized = shortName?.trim().toUpperCase() ?? "";
+  if (normalized.length > 0) return normalized;
+  return toFallbackAbbreviation(clanName, clanTag);
+}
+
 function parseCustomEmoji(raw: string): {
   animated: boolean;
   name: string;
@@ -68,10 +87,11 @@ function makeSyncBadgeFromHardcoded(entry: {
   label: string;
   name: string;
   id: string;
-}): SyncBadge {
+},
+overrides?: { code?: string; label?: string }): SyncBadge {
   return {
-    code: entry.code,
-    label: entry.label,
+    code: overrides?.code ?? entry.code,
+    label: overrides?.label ?? entry.label,
     reactionIdentifier: `${entry.name}:${entry.id}`,
     emojiInline: `<:${entry.name}:${entry.id}>`,
     id: entry.id,
@@ -82,9 +102,10 @@ function makeSyncBadgeFromHardcoded(entry: {
 function makeSyncBadgeFromTrackedClan(
   clanTag: string,
   clanName: string | null,
-  configuredBadge: string
+  configuredBadge: string,
+  shortName: string | null
 ): SyncBadge {
-  const code = clanTag.replace(/^#/, "").toUpperCase();
+  const code = resolveAbbreviation(shortName, clanName, clanTag);
   const label = clanName?.trim() || clanTag;
   const trimmed = configuredBadge.trim();
   const custom = parseCustomEmoji(trimmed);
@@ -116,7 +137,7 @@ async function getSyncBadgesWithTrackedClanFallback(
 ): Promise<SyncBadge[]> {
   const tracked = await prisma.trackedClan.findMany({
     orderBy: { createdAt: "asc" },
-    select: { tag: true, name: true, clanBadge: true },
+    select: { tag: true, name: true, clanBadge: true, shortName: true },
   });
 
   const hardcoded = getSyncBadgeEmojis(botUserId);
@@ -138,17 +159,23 @@ async function getSyncBadgesWithTrackedClanFallback(
         }
         if (emoji) {
           const emojiToken = `<${emoji.animated ? "a" : ""}:${emoji.name}:${emoji.id}>`;
-          badges.push(makeSyncBadgeFromTrackedClan(clan.tag, clan.name, emojiToken));
+          badges.push(makeSyncBadgeFromTrackedClan(clan.tag, clan.name, emojiToken, clan.shortName));
           continue;
         }
       }
-      badges.push(makeSyncBadgeFromTrackedClan(clan.tag, clan.name, configuredBadge));
+      badges.push(makeSyncBadgeFromTrackedClan(clan.tag, clan.name, configuredBadge, clan.shortName));
       continue;
     }
 
-    const fallback = clan.name ? findSyncBadgeEmojiForClan(botUserId, clan.name) : null;
+    const fallbackCode = resolveAbbreviation(clan.shortName, clan.name, clan.tag);
+    const fallback = clan.name ? findSyncBadgeEmojiForClan(botUserId, clan.name, fallbackCode) : null;
     if (fallback) {
-      badges.push(makeSyncBadgeFromHardcoded(fallback));
+      badges.push(
+        makeSyncBadgeFromHardcoded(fallback, {
+          code: fallbackCode,
+          label: clan.name?.trim() || clan.tag,
+        })
+      );
     }
   }
 

--- a/src/commands/TrackedClan.ts
+++ b/src/commands/TrackedClan.ts
@@ -19,6 +19,11 @@ function normalizeClanTag(input: string): string {
 const CUSTOM_EMOJI_PATTERN = /^<(a?):([A-Za-z0-9_]+):(\d+)>$/;
 const SHORTCODE_EMOJI_PATTERN = /^:([A-Za-z0-9_]+):$/;
 
+function normalizeClanShortNameInput(input: string): string | null {
+  const normalized = input.trim().toUpperCase();
+  return normalized.length > 0 ? normalized : null;
+}
+
 async function normalizeClanBadgeInput(
   interaction: ChatInputCommandInteraction,
   input: string
@@ -107,6 +112,12 @@ export const TrackedClan: Command = {
           type: ApplicationCommandOptionType.String,
           required: false,
         },
+        {
+          name: "short-name",
+          description: "Short name/abbreviation for this tracked clan",
+          type: ApplicationCommandOptionType.String,
+          required: false,
+        },
       ],
     },
     {
@@ -158,7 +169,8 @@ export const TrackedClan: Command = {
           const logChannel = clan.logChannelId ? `<#${clan.logChannelId}>` : "not set";
           const clanRole = clan.clanRoleId ? `<@&${clan.clanRoleId}>` : "not set";
           const clanBadge = clan.clanBadge ?? "not set";
-          return `- ${label} | lose-style: ${clan.loseStyle} | mailChannel: ${mailChannel} | logChannel: ${logChannel} | clanRole: ${clanRole} | clanBadge: ${clanBadge}`;
+          const shortName = clan.shortName ?? "not set";
+          return `- ${label} | shortName: ${shortName} | lose-style: ${clan.loseStyle} | mailChannel: ${mailChannel} | logChannel: ${logChannel} | clanRole: ${clanRole} | clanBadge: ${clanBadge}`;
         });
         await safeReply(interaction, {
           ephemeral: true,
@@ -179,7 +191,9 @@ export const TrackedClan: Command = {
         const logChannel = interaction.options.getChannel("log-channel", false);
         const clanRole = interaction.options.getRole("clan-role", false);
         const clanBadgeInput = interaction.options.getString("clan-badge", false);
+        const shortNameInput = interaction.options.getString("short-name", false);
         let clanBadge: string | null = null;
+        const shortName = shortNameInput ? normalizeClanShortNameInput(shortNameInput) : null;
         if (mailChannel && (!("isTextBased" in mailChannel) || !(mailChannel as any).isTextBased())) {
           await safeReply(interaction, {
             ephemeral: true,
@@ -235,6 +249,7 @@ export const TrackedClan: Command = {
             logChannelId: logChannel?.id ?? null,
             clanRoleId: clanRole?.id ?? null,
             clanBadge,
+            shortName,
           },
           update: {
             name: clan.name ?? null,
@@ -243,6 +258,7 @@ export const TrackedClan: Command = {
             ...(logChannel ? { logChannelId: logChannel.id } : {}),
             ...(clanRole ? { clanRoleId: clanRole.id } : {}),
             ...(clanBadge ? { clanBadge } : {}),
+            ...(shortName ? { shortName } : {}),
           },
         });
 
@@ -260,6 +276,7 @@ export const TrackedClan: Command = {
           `logChannel: ${saved.logChannelId ? `<#${saved.logChannelId}>` : "not set"}`,
           `clanRole: ${saved.clanRoleId ? `<@&${saved.clanRoleId}>` : "not set"}`,
           `clanBadge: ${saved.clanBadge ?? "not set"}`,
+          `shortName: ${saved.shortName ?? "not set"}`,
         ].join(" | ");
 
         await safeReply(interaction, {

--- a/src/helper/syncBadgeEmoji.ts
+++ b/src/helper/syncBadgeEmoji.ts
@@ -65,13 +65,18 @@ export function getSyncBadgeEmojiIdentifiers(botUserId: string | undefined): str
 
 export function findSyncBadgeEmojiForClan(
   botUserId: string | undefined,
-  clanName: string
+  clanName: string,
+  clanCodeHint?: string
 ): SyncBadgeEmoji | null {
   const badges = getSyncBadgeEmojis(botUserId);
   if (badges.length === 0) return null;
   const normalized = normalizeClanName(clanName);
   const code = getClanCodeFromName(clanName);
+  const hintedCode = clanCodeHint?.trim().toUpperCase() ?? "";
   return (
+    (hintedCode
+      ? badges.find((b) => b.code.toUpperCase() === hintedCode)
+      : null) ??
     badges.find((b) => normalizeClanName(b.label) === normalized) ??
     badges.find((b) => b.code.toUpperCase() === code.toUpperCase()) ??
     null


### PR DESCRIPTION
… sync status

Add an optional `short-name` field to `/tracked-clan configure`, persist it on `TrackedClan`, and surface it in tracked-clan list/configure responses.

Update sync badge/status generation to use the stored tracked-clan short name as the abbreviation. When `shortName` is null, derive abbreviation from the first 3 letters of clan name (fallback to clan tag if needed).

Also update hardcoded badge fallback lookup to prefer the stored abbreviation hint before legacy name/code mapping.

Includes Prisma schema + migration for `TrackedClan.shortName` and docs/help updates for the new command option.