### PR TITLE
Enhance sync and tracked-clan configuration with DB-backed badges/abbreviations, duplicate post protection, and lower configure telemetry

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -8,7 +8,7 @@
 - `/inactive days:<number>` - List players inactive for N days.
 - `/inactive wars:<number>` - List tracked-clan members who used 0/2 attacks in each of the last N ended wars (requires war-history tracking window).
 - `/role-users role:<discordRole>` - List users in a role with pagination.
-- `/tracked-clan configure tag:<tag> [lose-style:triple-top-30|traditional] [mail-channel:<discordChannel>] [log-channel:<discordChannel>] [clan-role:<discordRole>]` - Add/update tracked clan settings.
+- `/tracked-clan configure tag:<tag> [lose-style:triple-top-30|traditional] [mail-channel:<discordChannel>] [log-channel:<discordChannel>] [clan-role:<discordRole>] [clan-badge:<emoji>]` - Add/update tracked clan settings.
 - `/tracked-clan remove tag:<tag>` - Remove tracked clan.
 - `/tracked-clan list` - List tracked clans and settings.
 - `/sheet link sheet_id_or_url:<id-or-url> [tab:<tab-name>] [mode:actual|war]` - Link or relink sheet; mode is optional.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -8,7 +8,7 @@
 - `/inactive days:<number>` - List players inactive for N days.
 - `/inactive wars:<number>` - List tracked-clan members who used 0/2 attacks in each of the last N ended wars (requires war-history tracking window).
 - `/role-users role:<discordRole>` - List users in a role with pagination.
-- `/tracked-clan configure tag:<tag> [lose-style:triple-top-30|traditional] [mail-channel:<discordChannel>] [log-channel:<discordChannel>] [clan-role:<discordRole>] [clan-badge:<emoji>]` - Add/update tracked clan settings.
+- `/tracked-clan configure tag:<tag> [lose-style:triple-top-30|traditional] [mail-channel:<discordChannel>] [log-channel:<discordChannel>] [clan-role:<discordRole>] [clan-badge:<emoji>] [short-name:<abbr>]` - Add/update tracked clan settings.
 - `/tracked-clan remove tag:<tag>` - Remove tracked clan.
 - `/tracked-clan list` - List tracked clans and settings.
 - `/sheet link sheet_id_or_url:<id-or-url> [tab:<tab-name>] [mode:actual|war]` - Link or relink sheet; mode is optional.

--- a/prisma/migrations/20260302102000_add_tracked_clan_badge/migration.sql
+++ b/prisma/migrations/20260302102000_add_tracked_clan_badge/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "TrackedClan"
+ADD COLUMN "clanBadge" TEXT;

--- a/prisma/migrations/20260302123000_add_tracked_clan_short_name/migration.sql
+++ b/prisma/migrations/20260302123000_add_tracked_clan_short_name/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "TrackedClan"
+ADD COLUMN "shortName" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -35,6 +35,7 @@ model TrackedClan {
   mailChannelId String?
   logChannelId String?
   clanRoleId String?
+  clanBadge String?
   pointsScrape Json?
   createdAt DateTime  @default(now())
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -36,6 +36,7 @@ model TrackedClan {
   logChannelId String?
   clanRoleId String?
   clanBadge String?
+  shortName String?
   pointsScrape Json?
   createdAt DateTime  @default(now())
 }

--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -90,13 +90,14 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
     summary: "Manage tracked clans used by activity features.",
     details: [
       "Configure/remove tracked clans or list current tracked set.",
-      "`configure` upserts tracked clan settings (lose-style, mail channel, log channel, clan role, clan badge emoji).",
+      "`configure` upserts tracked clan settings (lose-style, mail channel, log channel, clan role, clan badge emoji, short name).",
       "`configure` and `remove` are admin-only by default.",
     ],
     examples: [
       "/tracked-clan configure tag:#2QG2C08UP",
       "/tracked-clan configure tag:#2QG2C08UP lose-style:Traditional mail-channel:#war-mail",
       "/tracked-clan configure tag:#2QG2C08UP clan-badge::Logo_Gabbar:",
+      "/tracked-clan configure tag:#2QG2C08UP short-name:GB",
       "/tracked-clan remove tag:#2QG2C08UP",
       "/tracked-clan list",
     ],

--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -90,12 +90,13 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
     summary: "Manage tracked clans used by activity features.",
     details: [
       "Configure/remove tracked clans or list current tracked set.",
-      "`configure` upserts tracked clan settings (lose-style, mail channel, log channel, clan role).",
+      "`configure` upserts tracked clan settings (lose-style, mail channel, log channel, clan role, clan badge emoji).",
       "`configure` and `remove` are admin-only by default.",
     ],
     examples: [
       "/tracked-clan configure tag:#2QG2C08UP",
       "/tracked-clan configure tag:#2QG2C08UP lose-style:Traditional mail-channel:#war-mail",
+      "/tracked-clan configure tag:#2QG2C08UP clan-badge::Logo_Gabbar:",
       "/tracked-clan remove tag:#2QG2C08UP",
       "/tracked-clan list",
     ],

--- a/src/commands/Post.ts
+++ b/src/commands/Post.ts
@@ -15,10 +15,10 @@ import {
 import { Command } from "../Command";
 import { formatError } from "../helper/formatError";
 import {
+  findSyncBadgeEmojiForClan,
   getSyncBadgeEmojis,
-  getSyncBadgeEmojiIdentifiers,
-  type SyncBadgeEmoji as BadgeEmoji,
 } from "../helper/syncBadgeEmoji";
+import { prisma } from "../prisma";
 import { safeReply } from "../helper/safeReply";
 import { CoCService } from "../services/CoCService";
 import {
@@ -36,6 +36,112 @@ const TIMEZONE_INPUT_ID = "timezone";
 const ROLE_INPUT_ID = "role";
 const IANA_TIMEZONE_HELP_URL =
   "https://en.wikipedia.org/wiki/List_of_tz_database_time_zones";
+const CUSTOM_EMOJI_PATTERN = /^<(a?):([A-Za-z0-9_]+):(\d+)>$/;
+
+type SyncBadge = {
+  code: string;
+  label: string;
+  reactionIdentifier: string;
+  emojiInline: string;
+  id: string | null;
+  name: string | null;
+};
+
+function parseCustomEmoji(raw: string): {
+  animated: boolean;
+  name: string;
+  id: string;
+} | null {
+  const match = raw.trim().match(CUSTOM_EMOJI_PATTERN);
+  if (!match) return null;
+  return {
+    animated: match[1] === "a",
+    name: match[2],
+    id: match[3],
+  };
+}
+
+function makeSyncBadgeFromHardcoded(entry: {
+  code: string;
+  label: string;
+  name: string;
+  id: string;
+}): SyncBadge {
+  return {
+    code: entry.code,
+    label: entry.label,
+    reactionIdentifier: `${entry.name}:${entry.id}`,
+    emojiInline: `<:${entry.name}:${entry.id}>`,
+    id: entry.id,
+    name: entry.name,
+  };
+}
+
+function makeSyncBadgeFromTrackedClan(
+  clanTag: string,
+  clanName: string | null,
+  configuredBadge: string
+): SyncBadge {
+  const code = clanTag.replace(/^#/, "").toUpperCase();
+  const label = clanName?.trim() || clanTag;
+  const trimmed = configuredBadge.trim();
+  const custom = parseCustomEmoji(trimmed);
+
+  if (custom) {
+    return {
+      code,
+      label,
+      reactionIdentifier: `${custom.name}:${custom.id}`,
+      emojiInline: `<${custom.animated ? "a" : ""}:${custom.name}:${custom.id}>`,
+      id: custom.id,
+      name: custom.name,
+    };
+  }
+
+  return {
+    code,
+    label,
+    reactionIdentifier: trimmed,
+    emojiInline: trimmed,
+    id: null,
+    name: trimmed,
+  };
+}
+
+async function getSyncBadgesWithTrackedClanFallback(
+  botUserId: string | undefined
+): Promise<SyncBadge[]> {
+  const tracked = await prisma.trackedClan.findMany({
+    orderBy: { createdAt: "asc" },
+    select: { tag: true, name: true, clanBadge: true },
+  });
+
+  const hardcoded = getSyncBadgeEmojis(botUserId);
+  if (tracked.length === 0) {
+    return hardcoded.map((entry) => makeSyncBadgeFromHardcoded(entry));
+  }
+
+  const badges: SyncBadge[] = [];
+  for (const clan of tracked) {
+    const configuredBadge = clan.clanBadge?.trim() ?? "";
+    if (configuredBadge.length > 0) {
+      badges.push(makeSyncBadgeFromTrackedClan(clan.tag, clan.name, configuredBadge));
+      continue;
+    }
+
+    const fallback = clan.name ? findSyncBadgeEmojiForClan(botUserId, clan.name) : null;
+    if (fallback) {
+      badges.push(makeSyncBadgeFromHardcoded(fallback));
+    }
+  }
+
+  if (badges.length === 0) {
+    return hardcoded.map((entry) => makeSyncBadgeFromHardcoded(entry));
+  }
+
+  return badges;
+}
+
 function parseAllowedRoleIds(raw: string | null): string[] {
   if (!raw) return [];
   return [...new Set(raw.split(",").map((s) => s.trim()).filter((s) => /^\d+$/.test(s)))];
@@ -155,10 +261,10 @@ async function handleSyncStatusSubcommand(
     return;
   }
 
-  const badges = getSyncBadgeEmojis(interaction.client.user?.id);
+  const badges = await getSyncBadgesWithTrackedClanFallback(interaction.client.user?.id);
   if (badges.length === 0) {
     await interaction.editReply(
-      "No badge emoji configuration found for this bot ID."
+      "No clan badge emoji configuration found."
     );
     return;
   }
@@ -203,7 +309,7 @@ async function handleSyncStatusSubcommand(
       }
     }
 
-    const emojiInline = `<:${badge.name}:${badge.id}>`;
+    const emojiInline = badge.emojiInline;
     if (claimedBy.length > 0) {
       const extra =
         nonLeader.length > 0 ? ` | non-leader: ${[...new Set(nonLeader)].join(", ")}` : "";
@@ -417,10 +523,10 @@ function extractSyncEpochSeconds(content: string): number | null {
 
 function reactionMatchesBadge(
   reaction: { emoji: { id: string | null; name: string | null } },
-  badge: BadgeEmoji
+  badge: SyncBadge
 ): boolean {
   if (reaction.emoji.id && reaction.emoji.id === badge.id) return true;
-  return Boolean(reaction.emoji.name && reaction.emoji.name === badge.name);
+  return Boolean(!badge.id && reaction.emoji.name && reaction.emoji.name === badge.name);
 }
 
 function buildModalCustomId(userId: string): string {
@@ -625,7 +731,8 @@ export async function handlePostModalSubmit(
     );
   }
 
-  const badgeEmojiIdentifiers = getSyncBadgeEmojiIdentifiers(interaction.client.user?.id);
+  const badges = await getSyncBadgesWithTrackedClanFallback(interaction.client.user?.id);
+  const badgeEmojiIdentifiers = badges.map((badge) => badge.reactionIdentifier);
   if (badgeEmojiIdentifiers.length > 0) {
     let reactedCount = 0;
     for (const emojiIdentifier of badgeEmojiIdentifiers) {

--- a/src/commands/Post.ts
+++ b/src/commands/Post.ts
@@ -49,6 +49,25 @@ type SyncBadge = {
   name: string | null;
 };
 
+function toFallbackAbbreviation(clanName: string | null, clanTag: string): string {
+  const source = (clanName?.trim() || clanTag.replace(/^#/, "")).toUpperCase();
+  const lettersAndNumbers = source.replace(/[^A-Z0-9]/g, "");
+  const base = lettersAndNumbers.length > 0 ? lettersAndNumbers : source.replace(/\s+/g, "");
+  if (base.length >= 3) return base.slice(0, 3);
+  const tagBase = clanTag.replace(/^#/, "").toUpperCase();
+  return (base + tagBase).slice(0, 3);
+}
+
+function resolveAbbreviation(
+  shortName: string | null,
+  clanName: string | null,
+  clanTag: string
+): string {
+  const normalized = shortName?.trim().toUpperCase() ?? "";
+  if (normalized.length > 0) return normalized;
+  return toFallbackAbbreviation(clanName, clanTag);
+}
+
 function parseCustomEmoji(raw: string): {
   animated: boolean;
   name: string;
@@ -68,10 +87,11 @@ function makeSyncBadgeFromHardcoded(entry: {
   label: string;
   name: string;
   id: string;
-}): SyncBadge {
+},
+overrides?: { code?: string; label?: string }): SyncBadge {
   return {
-    code: entry.code,
-    label: entry.label,
+    code: overrides?.code ?? entry.code,
+    label: overrides?.label ?? entry.label,
     reactionIdentifier: `${entry.name}:${entry.id}`,
     emojiInline: `<:${entry.name}:${entry.id}>`,
     id: entry.id,
@@ -82,9 +102,10 @@ function makeSyncBadgeFromHardcoded(entry: {
 function makeSyncBadgeFromTrackedClan(
   clanTag: string,
   clanName: string | null,
-  configuredBadge: string
+  configuredBadge: string,
+  shortName: string | null
 ): SyncBadge {
-  const code = clanTag.replace(/^#/, "").toUpperCase();
+  const code = resolveAbbreviation(shortName, clanName, clanTag);
   const label = clanName?.trim() || clanTag;
   const trimmed = configuredBadge.trim();
   const custom = parseCustomEmoji(trimmed);
@@ -116,7 +137,7 @@ async function getSyncBadgesWithTrackedClanFallback(
 ): Promise<SyncBadge[]> {
   const tracked = await prisma.trackedClan.findMany({
     orderBy: { createdAt: "asc" },
-    select: { tag: true, name: true, clanBadge: true },
+    select: { tag: true, name: true, clanBadge: true, shortName: true },
   });
 
   const hardcoded = getSyncBadgeEmojis(botUserId);
@@ -138,17 +159,23 @@ async function getSyncBadgesWithTrackedClanFallback(
         }
         if (emoji) {
           const emojiToken = `<${emoji.animated ? "a" : ""}:${emoji.name}:${emoji.id}>`;
-          badges.push(makeSyncBadgeFromTrackedClan(clan.tag, clan.name, emojiToken));
+          badges.push(makeSyncBadgeFromTrackedClan(clan.tag, clan.name, emojiToken, clan.shortName));
           continue;
         }
       }
-      badges.push(makeSyncBadgeFromTrackedClan(clan.tag, clan.name, configuredBadge));
+      badges.push(makeSyncBadgeFromTrackedClan(clan.tag, clan.name, configuredBadge, clan.shortName));
       continue;
     }
 
-    const fallback = clan.name ? findSyncBadgeEmojiForClan(botUserId, clan.name) : null;
+    const fallbackCode = resolveAbbreviation(clan.shortName, clan.name, clan.tag);
+    const fallback = clan.name ? findSyncBadgeEmojiForClan(botUserId, clan.name, fallbackCode) : null;
     if (fallback) {
-      badges.push(makeSyncBadgeFromHardcoded(fallback));
+      badges.push(
+        makeSyncBadgeFromHardcoded(fallback, {
+          code: fallbackCode,
+          label: clan.name?.trim() || clan.tag,
+        })
+      );
     }
   }
 

--- a/src/commands/Post.ts
+++ b/src/commands/Post.ts
@@ -225,10 +225,10 @@ function parseActiveSyncPost(
 }
 
 async function resolveStoredActiveSyncMessage(
-  interaction: ChatInputCommandInteraction,
+  context: { guild: Guild | null },
   settings: SettingsService
 ) {
-  const guild = interaction.guild;
+  const guild = context.guild;
   if (!guild) return null;
   const guildId = guild.id;
 
@@ -723,6 +723,42 @@ export async function handlePostModalSubmit(
   if (!("permissionsFor" in channel)) {
     await interaction.editReply("This command can only post in guild text channels.");
     return;
+  }
+
+  // Block duplicate submissions when a sync post already exists for the same epoch.
+  const existingActiveSyncPost = await resolveStoredActiveSyncMessage(interaction, settings);
+  const existingActiveEpoch = existingActiveSyncPost
+    ? extractSyncEpochSeconds(existingActiveSyncPost.content)
+    : null;
+  if (existingActiveSyncPost && existingActiveEpoch === epochSeconds) {
+    const existingLink = `https://discord.com/channels/${guild.id}/${existingActiveSyncPost.channelId}/${existingActiveSyncPost.id}`;
+    await interaction.editReply(
+      `A sync time post for <t:${epochSeconds}:F> already exists: ${existingLink}`
+    );
+    return;
+  }
+
+  try {
+    const pinned = await channel.messages.fetchPinned();
+    const duplicatePinned = [...pinned.values()].find((msg) => {
+      if (!msg.author.bot) return false;
+      if (!isBotSyncTimeMessage(msg.content)) return false;
+      const msgEpoch = extractSyncEpochSeconds(msg.content);
+      return msgEpoch === epochSeconds;
+    });
+    if (duplicatePinned) {
+      const existingLink = `https://discord.com/channels/${guild.id}/${duplicatePinned.channelId}/${duplicatePinned.id}`;
+      await interaction.editReply(
+        `A sync time post for <t:${epochSeconds}:F> is already pinned: ${existingLink}`
+      );
+      return;
+    }
+  } catch (err) {
+    console.error(
+      `[post sync time] duplicate-check pinned fetch failed guild=${interaction.guildId} channel=${interaction.channelId} user=${interaction.user.id} error=${formatError(
+        err
+      )}`
+    );
   }
 
   const me = guild.members.me ?? (await guild.members.fetchMe().catch(() => null));

--- a/src/commands/Post.ts
+++ b/src/commands/Post.ts
@@ -11,6 +11,7 @@ import {
   PermissionFlagsBits,
   TextInputBuilder,
   TextInputStyle,
+  type Guild,
 } from "discord.js";
 import { Command } from "../Command";
 import { formatError } from "../helper/formatError";
@@ -37,6 +38,7 @@ const ROLE_INPUT_ID = "role";
 const IANA_TIMEZONE_HELP_URL =
   "https://en.wikipedia.org/wiki/List_of_tz_database_time_zones";
 const CUSTOM_EMOJI_PATTERN = /^<(a?):([A-Za-z0-9_]+):(\d+)>$/;
+const SHORTCODE_EMOJI_PATTERN = /^:([A-Za-z0-9_]+):$/;
 
 type SyncBadge = {
   code: string;
@@ -109,7 +111,8 @@ function makeSyncBadgeFromTrackedClan(
 }
 
 async function getSyncBadgesWithTrackedClanFallback(
-  botUserId: string | undefined
+  botUserId: string | undefined,
+  guild: Guild | null
 ): Promise<SyncBadge[]> {
   const tracked = await prisma.trackedClan.findMany({
     orderBy: { createdAt: "asc" },
@@ -125,6 +128,20 @@ async function getSyncBadgesWithTrackedClanFallback(
   for (const clan of tracked) {
     const configuredBadge = clan.clanBadge?.trim() ?? "";
     if (configuredBadge.length > 0) {
+      const shortcodeMatch = configuredBadge.match(SHORTCODE_EMOJI_PATTERN);
+      if (shortcodeMatch && guild) {
+        const shortcodeName = shortcodeMatch[1];
+        let emoji = guild.emojis.cache.find((e) => e.name === shortcodeName);
+        if (!emoji) {
+          await guild.emojis.fetch().catch(() => null);
+          emoji = guild.emojis.cache.find((e) => e.name === shortcodeName);
+        }
+        if (emoji) {
+          const emojiToken = `<${emoji.animated ? "a" : ""}:${emoji.name}:${emoji.id}>`;
+          badges.push(makeSyncBadgeFromTrackedClan(clan.tag, clan.name, emojiToken));
+          continue;
+        }
+      }
       badges.push(makeSyncBadgeFromTrackedClan(clan.tag, clan.name, configuredBadge));
       continue;
     }
@@ -261,7 +278,10 @@ async function handleSyncStatusSubcommand(
     return;
   }
 
-  const badges = await getSyncBadgesWithTrackedClanFallback(interaction.client.user?.id);
+  const badges = await getSyncBadgesWithTrackedClanFallback(
+    interaction.client.user?.id,
+    interaction.guild
+  );
   if (badges.length === 0) {
     await interaction.editReply(
       "No clan badge emoji configuration found."
@@ -731,7 +751,10 @@ export async function handlePostModalSubmit(
     );
   }
 
-  const badges = await getSyncBadgesWithTrackedClanFallback(interaction.client.user?.id);
+  const badges = await getSyncBadgesWithTrackedClanFallback(
+    interaction.client.user?.id,
+    interaction.guild
+  );
   const badgeEmojiIdentifiers = badges.map((badge) => badge.reactionIdentifier);
   if (badgeEmojiIdentifiers.length > 0) {
     let reactedCount = 0;

--- a/src/commands/Sheet.ts
+++ b/src/commands/Sheet.ts
@@ -338,19 +338,24 @@ export const Sheet: Command = {
           return;
         }
 
+        const refreshStartedAtMs = Date.now();
         const resultText = await postRefreshWebhook(
           config.url,
           config.token,
           config.action as "refreshMembers" | "refreshWar"
         );
+        const refreshDurationSeconds = (
+          (Date.now() - refreshStartedAtMs) /
+          1000
+        ).toFixed(2);
 
         lastRefreshAtMsByGuildMode.set(guildModeKey, now);
         await safeReply(interaction, {
           ephemeral: true,
           content:
             resultText.length > 0
-              ? `Refresh triggered for **${refreshMode.toUpperCase()}** mode.\n${resultText}`
-              : `Refresh triggered for **${refreshMode.toUpperCase()}** mode.`,
+              ? `Refresh triggered for **${refreshMode.toUpperCase()}** mode in **${refreshDurationSeconds}s**.\n${resultText}`
+              : `Refresh triggered for **${refreshMode.toUpperCase()}** mode in **${refreshDurationSeconds}s**.`,
         });
         return;
       }

--- a/src/commands/TrackedClan.ts
+++ b/src/commands/TrackedClan.ts
@@ -19,6 +19,11 @@ function normalizeClanTag(input: string): string {
 const CUSTOM_EMOJI_PATTERN = /^<(a?):([A-Za-z0-9_]+):(\d+)>$/;
 const SHORTCODE_EMOJI_PATTERN = /^:([A-Za-z0-9_]+):$/;
 
+function normalizeClanShortNameInput(input: string): string | null {
+  const normalized = input.trim().toUpperCase();
+  return normalized.length > 0 ? normalized : null;
+}
+
 async function normalizeClanBadgeInput(
   interaction: ChatInputCommandInteraction,
   input: string
@@ -107,6 +112,12 @@ export const TrackedClan: Command = {
           type: ApplicationCommandOptionType.String,
           required: false,
         },
+        {
+          name: "short-name",
+          description: "Short name/abbreviation for this tracked clan",
+          type: ApplicationCommandOptionType.String,
+          required: false,
+        },
       ],
     },
     {
@@ -158,7 +169,8 @@ export const TrackedClan: Command = {
           const logChannel = clan.logChannelId ? `<#${clan.logChannelId}>` : "not set";
           const clanRole = clan.clanRoleId ? `<@&${clan.clanRoleId}>` : "not set";
           const clanBadge = clan.clanBadge ?? "not set";
-          return `- ${label} | lose-style: ${clan.loseStyle} | mailChannel: ${mailChannel} | logChannel: ${logChannel} | clanRole: ${clanRole} | clanBadge: ${clanBadge}`;
+          const shortName = clan.shortName ?? "not set";
+          return `- ${label} | shortName: ${shortName} | lose-style: ${clan.loseStyle} | mailChannel: ${mailChannel} | logChannel: ${logChannel} | clanRole: ${clanRole} | clanBadge: ${clanBadge}`;
         });
         await safeReply(interaction, {
           ephemeral: true,
@@ -179,7 +191,9 @@ export const TrackedClan: Command = {
         const logChannel = interaction.options.getChannel("log-channel", false);
         const clanRole = interaction.options.getRole("clan-role", false);
         const clanBadgeInput = interaction.options.getString("clan-badge", false);
+        const shortNameInput = interaction.options.getString("short-name", false);
         let clanBadge: string | null = null;
+        const shortName = shortNameInput ? normalizeClanShortNameInput(shortNameInput) : null;
         if (mailChannel && (!("isTextBased" in mailChannel) || !(mailChannel as any).isTextBased())) {
           await safeReply(interaction, {
             ephemeral: true,
@@ -235,6 +249,7 @@ export const TrackedClan: Command = {
             logChannelId: logChannel?.id ?? null,
             clanRoleId: clanRole?.id ?? null,
             clanBadge,
+            shortName,
           },
           update: {
             name: clan.name ?? null,
@@ -243,6 +258,7 @@ export const TrackedClan: Command = {
             ...(logChannel ? { logChannelId: logChannel.id } : {}),
             ...(clanRole ? { clanRoleId: clanRole.id } : {}),
             ...(clanBadge ? { clanBadge } : {}),
+            ...(shortName ? { shortName } : {}),
           },
         });
 
@@ -260,6 +276,7 @@ export const TrackedClan: Command = {
           `logChannel: ${saved.logChannelId ? `<#${saved.logChannelId}>` : "not set"}`,
           `clanRole: ${saved.clanRoleId ? `<@&${saved.clanRoleId}>` : "not set"}`,
           `clanBadge: ${saved.clanBadge ?? "not set"}`,
+          `shortName: ${saved.shortName ?? "not set"}`,
         ].join(" | ");
 
         await safeReply(interaction, {

--- a/src/commands/TrackedClan.ts
+++ b/src/commands/TrackedClan.ts
@@ -233,11 +233,11 @@ export const TrackedClan: Command = {
             return;
           }
         }
-        const clan = await cocService.getClan(tag);
-        const activityService = new ActivityService(cocService);
         const existing = await prisma.trackedClan.findUnique({
           where: { tag },
         });
+        const clan = await cocService.getClan(tag);
+        const activityService = new ActivityService(cocService);
         const createLoseStyle = loseStyle ?? "TRIPLE_TOP_30";
         const saved = await prisma.trackedClan.upsert({
           where: { tag },
@@ -262,12 +262,14 @@ export const TrackedClan: Command = {
           },
         });
 
-        try {
-          await activityService.observeClan(tag);
-        } catch (observeErr) {
-          console.error(
-            `tracked-clan configure observe failed for ${tag}: ${formatError(observeErr)}`
-          );
+        if (!existing) {
+          try {
+            await activityService.observeClan(tag);
+          } catch (observeErr) {
+            console.error(
+              `tracked-clan configure observe failed for ${tag}: ${formatError(observeErr)}`
+            );
+          }
         }
 
         const summary = [

--- a/src/commands/TrackedClan.ts
+++ b/src/commands/TrackedClan.ts
@@ -16,6 +16,47 @@ function normalizeClanTag(input: string): string {
   return `#${cleaned}`;
 }
 
+const CUSTOM_EMOJI_PATTERN = /^<(a?):([A-Za-z0-9_]+):(\d+)>$/;
+const SHORTCODE_EMOJI_PATTERN = /^:([A-Za-z0-9_]+):$/;
+
+async function normalizeClanBadgeInput(
+  interaction: ChatInputCommandInteraction,
+  input: string
+): Promise<string | null> {
+  const value = input.trim();
+  if (!value) return null;
+
+  const customMatch = value.match(CUSTOM_EMOJI_PATTERN);
+  if (customMatch) {
+    const animated = customMatch[1] === "a";
+    const name = customMatch[2];
+    const id = customMatch[3];
+    return `<${animated ? "a" : ""}:${name}:${id}>`;
+  }
+
+  const shortcodeMatch = value.match(SHORTCODE_EMOJI_PATTERN);
+  if (shortcodeMatch) {
+    const guild = interaction.guild;
+    if (!guild) {
+      throw new Error("CLAN_BADGE_GUILD_REQUIRED");
+    }
+
+    const shortcodeName = shortcodeMatch[1];
+    let emoji = guild.emojis.cache.find((e) => e.name === shortcodeName);
+    if (!emoji) {
+      await guild.emojis.fetch();
+      emoji = guild.emojis.cache.find((e) => e.name === shortcodeName);
+    }
+    if (!emoji) {
+      throw new Error("CLAN_BADGE_SHORTCODE_NOT_FOUND");
+    }
+
+    return `<${emoji.animated ? "a" : ""}:${emoji.name}:${emoji.id}>`;
+  }
+
+  return value;
+}
+
 export const TrackedClan: Command = {
   name: "tracked-clan",
   description: "Configure, remove, or list tracked clans",
@@ -58,6 +99,12 @@ export const TrackedClan: Command = {
           name: "clan-role",
           description: "Discord role associated with this tracked clan",
           type: ApplicationCommandOptionType.Role,
+          required: false,
+        },
+        {
+          name: "clan-badge",
+          description: "Emoji badge for this tracked clan",
+          type: ApplicationCommandOptionType.String,
           required: false,
         },
       ],
@@ -110,7 +157,8 @@ export const TrackedClan: Command = {
           const mailChannel = clan.mailChannelId ? `<#${clan.mailChannelId}>` : "not set";
           const logChannel = clan.logChannelId ? `<#${clan.logChannelId}>` : "not set";
           const clanRole = clan.clanRoleId ? `<@&${clan.clanRoleId}>` : "not set";
-          return `- ${label} | lose-style: ${clan.loseStyle} | mailChannel: ${mailChannel} | logChannel: ${logChannel} | clanRole: ${clanRole}`;
+          const clanBadge = clan.clanBadge ?? "not set";
+          return `- ${label} | lose-style: ${clan.loseStyle} | mailChannel: ${mailChannel} | logChannel: ${logChannel} | clanRole: ${clanRole} | clanBadge: ${clanBadge}`;
         });
         await safeReply(interaction, {
           ephemeral: true,
@@ -130,6 +178,8 @@ export const TrackedClan: Command = {
         const mailChannel = interaction.options.getChannel("mail-channel", false);
         const logChannel = interaction.options.getChannel("log-channel", false);
         const clanRole = interaction.options.getRole("clan-role", false);
+        const clanBadgeInput = interaction.options.getString("clan-badge", false);
+        let clanBadge: string | null = null;
         if (mailChannel && (!("isTextBased" in mailChannel) || !(mailChannel as any).isTextBased())) {
           await safeReply(interaction, {
             ephemeral: true,
@@ -151,6 +201,24 @@ export const TrackedClan: Command = {
           });
           return;
         }
+        if (clanBadgeInput) {
+          try {
+            clanBadge = await normalizeClanBadgeInput(interaction, clanBadgeInput);
+          } catch (badgeErr) {
+            const badgeCode = formatError(badgeErr);
+            const badgeHint =
+              badgeCode === "CLAN_BADGE_GUILD_REQUIRED"
+                ? "Custom clan-badge shortcodes can only be resolved in a server."
+                : badgeCode === "CLAN_BADGE_SHORTCODE_NOT_FOUND"
+                  ? "Could not find that emoji in this server. Use an existing server emoji, unicode emoji, or full custom emoji format like `<:Logo_Gabbar:123456789012345678>`."
+                  : "Invalid clan-badge value. Use unicode emoji, `:emoji_name:` from this server, or full custom emoji format.";
+            await safeReply(interaction, {
+              ephemeral: true,
+              content: badgeHint,
+            });
+            return;
+          }
+        }
         const clan = await cocService.getClan(tag);
         const activityService = new ActivityService(cocService);
         const existing = await prisma.trackedClan.findUnique({
@@ -166,6 +234,7 @@ export const TrackedClan: Command = {
             mailChannelId: mailChannel?.id ?? null,
             logChannelId: logChannel?.id ?? null,
             clanRoleId: clanRole?.id ?? null,
+            clanBadge,
           },
           update: {
             name: clan.name ?? null,
@@ -173,6 +242,7 @@ export const TrackedClan: Command = {
             ...(mailChannel ? { mailChannelId: mailChannel.id } : {}),
             ...(logChannel ? { logChannelId: logChannel.id } : {}),
             ...(clanRole ? { clanRoleId: clanRole.id } : {}),
+            ...(clanBadge ? { clanBadge } : {}),
           },
         });
 
@@ -189,6 +259,7 @@ export const TrackedClan: Command = {
           `mailChannel: ${saved.mailChannelId ? `<#${saved.mailChannelId}>` : "not set"}`,
           `logChannel: ${saved.logChannelId ? `<#${saved.logChannelId}>` : "not set"}`,
           `clanRole: ${saved.clanRoleId ? `<@&${saved.clanRoleId}>` : "not set"}`,
+          `clanBadge: ${saved.clanBadge ?? "not set"}`,
         ].join(" | ");
 
         await safeReply(interaction, {

--- a/src/helper/syncBadgeEmoji.ts
+++ b/src/helper/syncBadgeEmoji.ts
@@ -7,6 +7,7 @@ const SYNC_BADGE_EMOJIS_BY_BOT: Record<string, SyncBadgeEmoji[]> = {
   [STAGING_BOT_ID]: [
     { code: "ZG", label: "ZERO GRAVITY", name: "zg", id: "1476279645174366449" },
     { code: "TWC", label: "TheWiseCowboys", name: "twc", id: "1476279643660091452" },
+    { code: "GB", label: "GABBAR", name: "gb", id: "1478101511451185383" },
     { code: "SE", label: "Steel Empire 2", name: "se", id: "1476279635208573009" },
     { code: "RR", label: "Rocky Road", name: "rr", id: "1476279632729866242" },
     { code: "RD", label: "RISING DAWN", name: "rd", id: "1476279631345614902" },
@@ -17,6 +18,7 @@ const SYNC_BADGE_EMOJIS_BY_BOT: Record<string, SyncBadgeEmoji[]> = {
   [PROD_BOT_ID]: [
     { code: "ZG", label: "ZERO GRAVITY", name: "zg", id: "1476279778670673930" },
     { code: "TWC", label: "TheWiseCowboys", name: "twc", id: "1476279777466908755" },
+    { code: "GB", label: "GABBAR", name: "gb", id: "1478106834081546300" },
     { code: "SE", label: "Steel Empire 2", name: "se", id: "1476279774241493104" },
     { code: "RR", label: "Rocky Road", name: "rr", id: "1476279773243379762" },
     { code: "RD", label: "RISING DAWN", name: "rd", id: "1476279771884290100" },
@@ -44,6 +46,7 @@ function getClanCodeFromName(value: string): string {
     "DARK EMPIRE": "DE",
     "STEEL EMPIRE 2": "SE",
     "THEWISECOWBOYS": "TWC",
+    GABBAR: "GB",
     MARVELS: "MV",
     "ROCKY ROAD": "RR",
     AKATSUKI: "AK",

--- a/src/helper/syncBadgeEmoji.ts
+++ b/src/helper/syncBadgeEmoji.ts
@@ -65,13 +65,18 @@ export function getSyncBadgeEmojiIdentifiers(botUserId: string | undefined): str
 
 export function findSyncBadgeEmojiForClan(
   botUserId: string | undefined,
-  clanName: string
+  clanName: string,
+  clanCodeHint?: string
 ): SyncBadgeEmoji | null {
   const badges = getSyncBadgeEmojis(botUserId);
   if (badges.length === 0) return null;
   const normalized = normalizeClanName(clanName);
   const code = getClanCodeFromName(clanName);
+  const hintedCode = clanCodeHint?.trim().toUpperCase() ?? "";
   return (
+    (hintedCode
+      ? badges.find((b) => b.code.toUpperCase() === hintedCode)
+      : null) ??
     badges.find((b) => normalizeClanName(b.label) === normalized) ??
     badges.find((b) => b.code.toUpperCase() === code.toUpperCase()) ??
     null


### PR DESCRIPTION
### Summary
This PR bundles quality-of-life and reliability improvements around sheet refresh, tracked clan configuration, and sync-time posting.

### Key Changes

1. **`/sheet refresh` now reports duration**
- Success message includes elapsed refresh time in seconds.

2. **Tracked clan configuration expanded**
- Added optional `clan-badge` in `/tracked-clan configure`.
- Added optional `short-name` (abbreviation) in `/tracked-clan configure`.
- Both fields are persisted to `TrackedClan`.

3. **Sync badge source now DB-first with fallback**
- `/sync time post` and `/sync post status` now use `TrackedClan.clanBadge` first.
- If `clanBadge` is null, fallback uses hardcoded bot emoji mapping.
- Shortcode-style values like `:gb:` are resolved to guild custom emoji IDs at runtime.
- Added `GB` emoji fallback entries:
  - staging: `1478101511451185383`
  - prod: `1478106834081546300`

4. **Sync status abbreviation source updated**
- Abbreviation now uses `TrackedClan.shortName`.
- If `shortName` is null, fallback is first 3 chars of clan name (then clan tag if needed).
- Hardcoded lookup path also respects stored abbreviation hint.

5. **Duplicate sync-time post protection**
- Blocks `/sync time post` submission when the same timestamp already exists.
- Returns warning + direct link to existing sync-time post.

6. **Telemetry/perf reduction for tracked-clan updates**
- `/tracked-clan configure` now skips `observeClan` for existing tracked clans (metadata-only updates).
- `observeClan` runs only on first-time tracked clan creation.

### Database / Migration
- Added `TrackedClan.clanBadge` column.
- Added `TrackedClan.shortName` column.
- New migrations included for both fields.

### User Impact
- Less API churn during metadata-only tracked-clan edits.
- Better sync UX (no duplicate timestamp posts).
- Sync badge/abbreviation behavior now configurable per tracked clan.

### Validation
- TypeScript build passes (`npm run build`).