### PR TITLE
Enhance sync and tracked-clan workflows with DB-backed badge/abbreviation support, duplicate sync protection, and release webhook button fix

### DIFF
--- a/src/commands/Post.ts
+++ b/src/commands/Post.ts
@@ -47,7 +47,13 @@ type SyncBadge = {
   emojiInline: string;
   id: string | null;
   name: string | null;
+  matchEmojiIds: string[];
+  matchEmojiNames: string[];
 };
+
+function dedupe(values: Array<string | null | undefined>): string[] {
+  return [...new Set(values.filter((v): v is string => Boolean(v && v.trim())).map((v) => v.trim()))];
+}
 
 function toFallbackAbbreviation(clanName: string | null, clanTag: string): string {
   const source = (clanName?.trim() || clanTag.replace(/^#/, "")).toUpperCase();
@@ -96,6 +102,8 @@ overrides?: { code?: string; label?: string }): SyncBadge {
     emojiInline: `<:${entry.name}:${entry.id}>`,
     id: entry.id,
     name: entry.name,
+    matchEmojiIds: dedupe([entry.id]),
+    matchEmojiNames: dedupe([entry.name]),
   };
 }
 
@@ -118,6 +126,8 @@ function makeSyncBadgeFromTrackedClan(
       emojiInline: `<${custom.animated ? "a" : ""}:${custom.name}:${custom.id}>`,
       id: custom.id,
       name: custom.name,
+      matchEmojiIds: dedupe([custom.id]),
+      matchEmojiNames: dedupe([custom.name]),
     };
   }
 
@@ -128,6 +138,20 @@ function makeSyncBadgeFromTrackedClan(
     emojiInline: trimmed,
     id: null,
     name: trimmed,
+    matchEmojiIds: [],
+    matchEmojiNames: dedupe([trimmed]),
+  };
+}
+
+function addAlternateEmojiMatch(
+  badge: SyncBadge,
+  alternate: { id: string; name: string } | null
+): SyncBadge {
+  if (!alternate) return badge;
+  return {
+    ...badge,
+    matchEmojiIds: dedupe([...badge.matchEmojiIds, alternate.id]),
+    matchEmojiNames: dedupe([...badge.matchEmojiNames, alternate.name]),
   };
 }
 
@@ -149,6 +173,11 @@ async function getSyncBadgesWithTrackedClanFallback(
   for (const clan of tracked) {
     const configuredBadge = clan.clanBadge?.trim() ?? "";
     if (configuredBadge.length > 0) {
+      const fallbackCode = resolveAbbreviation(clan.shortName, clan.name, clan.tag);
+      const fallback = clan.name
+        ? findSyncBadgeEmojiForClan(botUserId, clan.name, fallbackCode)
+        : null;
+
       const shortcodeMatch = configuredBadge.match(SHORTCODE_EMOJI_PATTERN);
       if (shortcodeMatch && guild) {
         const shortcodeName = shortcodeMatch[1];
@@ -159,11 +188,21 @@ async function getSyncBadgesWithTrackedClanFallback(
         }
         if (emoji) {
           const emojiToken = `<${emoji.animated ? "a" : ""}:${emoji.name}:${emoji.id}>`;
-          badges.push(makeSyncBadgeFromTrackedClan(clan.tag, clan.name, emojiToken, clan.shortName));
+          badges.push(
+            addAlternateEmojiMatch(
+              makeSyncBadgeFromTrackedClan(clan.tag, clan.name, emojiToken, clan.shortName),
+              fallback
+            )
+          );
           continue;
         }
       }
-      badges.push(makeSyncBadgeFromTrackedClan(clan.tag, clan.name, configuredBadge, clan.shortName));
+      badges.push(
+        addAlternateEmojiMatch(
+          makeSyncBadgeFromTrackedClan(clan.tag, clan.name, configuredBadge, clan.shortName),
+          fallback
+        )
+      );
       continue;
     }
 
@@ -572,8 +611,8 @@ function reactionMatchesBadge(
   reaction: { emoji: { id: string | null; name: string | null } },
   badge: SyncBadge
 ): boolean {
-  if (reaction.emoji.id && reaction.emoji.id === badge.id) return true;
-  return Boolean(!badge.id && reaction.emoji.name && reaction.emoji.name === badge.name);
+  if (reaction.emoji.id && badge.matchEmojiIds.includes(reaction.emoji.id)) return true;
+  return Boolean(reaction.emoji.name && badge.matchEmojiNames.includes(reaction.emoji.name));
 }
 
 function buildModalCustomId(userId: string): string {


### PR DESCRIPTION
### Summary
This PR brings sync workflow improvements, tracked-clan configuration enhancements, and release notification reliability updates.

### Highlights

1. **Tracked clan configuration improvements**
- Added `/tracked-clan configure` support for:
  - `clan-badge`
  - `short-name` (abbreviation)
- Both fields are persisted in `TrackedClan`.
- `/tracked-clan list` formatting is now multi-line and easier to read.

2. **Sync badge + status accuracy**
- `/sync time post` now uses tracked-clan badge config first, with hardcoded bot emoji fallback.
- `/sync post status` now counts reactions from both:
  - configured server emoji
  - fallback bot emoji
- Shortcode badge inputs (e.g. `:gb:`) are resolved correctly.
- Duplicate `/sync time post` submissions (same timestamp) are blocked with link to existing post.

3. **Performance and UX**
- `/tracked-clan configure` skips `observeClan` for metadata-only updates (reduces API/DB noise).
- `/sheet refresh` success reply now includes refresh duration.

4. **CI/Release workflow**
- Fixed `.github/workflows/discord-releases.yml` so release webhook posts include a working “View Release” button via webhook components.

### DB / migration changes
- Added `TrackedClan.clanBadge`
- Added `TrackedClan.shortName`
- Included Prisma migrations for both fields.

### Ops notes
- Run Prisma migrations before deploy.
- No new env vars required for app runtime.
- Existing `DISCORD_WEBHOOK_URL` is reused for release button fix.