### PR TITLE
feat(notify): replace war-test with war-preview and confirm-post flow

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -21,6 +21,7 @@
 - `/cc player tag:<tag>` - Build `https://cc.fwafarm.com/cc_n/member.php?tag=<tag>`.
 - `/cc clan tag:<tag>` - Build `https://cc.fwafarm.com/cc_n/clan.php?tag=<tag>`.
 - `/notify war clan-tag:<tag> target-channel:<channel> [role:<discordRole>]` - Enable war-state event logs (war start, battle day, war end) for a clan in a selected channel. Optional role is pinged when event logs are posted.
+- `/notify war-preview clan-tag:<tag> event:<war_started|battle_day|war_ended> [source:current|last]` - Show an ephemeral preview embed and confirm before posting publicly to the configured notify channel.
 - `/war history clan-tag:<tag> [limit:<number>]` - Show recent clan-level war history from stored war records.
 - `/war war-id war-id:<number>` - Export stored war lookup payload for one war ID as CSV.
 - `/accounts [visibility:private|public] [tag:<playerTag>] [discord-id:<snowflake>]` - List linked player accounts grouped by current clan. Default is your own account; provide exactly one of `tag` or `discord-id` to inspect a different linked user.

--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -149,6 +149,7 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
     examples: [
       "/notify war clan-tag:2QG2C08UP target-channel:#war-events role:@Leaders",
       "/notify war clan-tag:2QG2C08UP target-channel:#new-war-events",
+      "/notify war-preview clan-tag:2QG2C08UP event:battle day start source:current",
       "/notify war-remove clan-tag:2QG2C08UP",
       "/notify show",
       "/notify show clan-tag:2QG2C08UP",

--- a/src/commands/Notify.ts
+++ b/src/commands/Notify.ts
@@ -1,11 +1,16 @@
 import {
+  ActionRowBuilder,
   ApplicationCommandOptionType,
   AutocompleteInteraction,
+  ButtonBuilder,
+  ButtonInteraction,
+  ButtonStyle,
   ChannelType,
   ChatInputCommandInteraction,
   Client,
   Role,
 } from "discord.js";
+import { randomUUID } from "crypto";
 import { Prisma } from "@prisma/client";
 import { Command } from "../Command";
 import { prisma } from "../prisma";
@@ -26,6 +31,98 @@ function deriveWarState(raw: string | null | undefined): string {
 
 function normalizeClanTagInput(input: string): string {
   return input.trim().toUpperCase().replace(/^#/, "");
+}
+
+const NOTIFY_WAR_PREVIEW_POST_PREFIX = "notify-war-preview-post";
+const notifyWarPreviewRequests = new Map<
+  string,
+  {
+    userId: string;
+    guildId: string;
+    clanTag: string;
+    eventType: "war_started" | "battle_day" | "war_ended";
+    source: "current" | "last";
+    channelId: string;
+    clanName: string;
+    createdAt: number;
+  }
+>();
+
+function buildNotifyWarPreviewPostCustomId(key: string): string {
+  return `${NOTIFY_WAR_PREVIEW_POST_PREFIX}:${key}`;
+}
+
+function parseNotifyWarPreviewPostCustomId(
+  customId: string
+): { key: string } | null {
+  const parts = String(customId ?? "").split(":");
+  if (parts.length !== 2 || parts[0] !== NOTIFY_WAR_PREVIEW_POST_PREFIX) return null;
+  const key = parts[1]?.trim() ?? "";
+  if (!key) return null;
+  return { key };
+}
+
+export function isNotifyWarPreviewPostButtonCustomId(customId: string): boolean {
+  return String(customId ?? "").startsWith(`${NOTIFY_WAR_PREVIEW_POST_PREFIX}:`);
+}
+
+export async function handleNotifyWarPreviewPostButton(
+  interaction: ButtonInteraction,
+  cocService: CoCService
+): Promise<void> {
+  const parsed = parseNotifyWarPreviewPostCustomId(interaction.customId);
+  if (!parsed) return;
+
+  const request = notifyWarPreviewRequests.get(parsed.key);
+  if (!request) {
+    await interaction.reply({
+      ephemeral: true,
+      content: "This preview has expired. Run `/notify war-preview` again.",
+    });
+    return;
+  }
+  if (request.userId !== interaction.user.id) {
+    await interaction.reply({
+      ephemeral: true,
+      content: "Only the user who generated this preview can confirm posting.",
+    });
+    return;
+  }
+  if (request.guildId !== interaction.guildId) {
+    await interaction.reply({
+      ephemeral: true,
+      content: "This preview is from a different server.",
+    });
+    return;
+  }
+  if (Date.now() - request.createdAt > 30 * 60 * 1000) {
+    notifyWarPreviewRequests.delete(parsed.key);
+    await interaction.reply({
+      ephemeral: true,
+      content: "This preview has expired. Run `/notify war-preview` again.",
+    });
+    return;
+  }
+
+  await interaction.deferReply({ ephemeral: true });
+  const warEventService = new WarEventLogService(interaction.client, cocService);
+  const result = await warEventService.emitTestEventForClan({
+    guildId: request.guildId,
+    clanTag: request.clanTag,
+    eventType: request.eventType,
+    source: request.source,
+  });
+  if (!result.ok) {
+    await interaction.editReply(
+      `Failed to post preview publicly for ${request.clanName} (${request.clanTag}): ${result.reason ?? "unknown reason"}`
+    );
+    return;
+  }
+
+  notifyWarPreviewRequests.delete(parsed.key);
+  await interaction.editReply(
+    `Posted ${request.eventType} for **${request.clanName}** (${request.clanTag}) to <#${request.channelId}>.`
+  );
 }
 
 export const Notify: Command = {
@@ -85,8 +182,8 @@ export const Notify: Command = {
       ],
     },
     {
-      name: "war-test",
-      description: "Trigger a test war event embed for a configured clan",
+      name: "war-preview",
+      description: "Preview a war event embed, then confirm posting publicly",
       type: ApplicationCommandOptionType.Subcommand,
       options: [
         {
@@ -266,7 +363,7 @@ export const Notify: Command = {
       return;
     }
 
-    if (sub === "war-test") {
+    if (sub === "war-preview") {
       const clanTag = normalizeClanTag(interaction.options.getString("clan-tag", true));
       const eventType = interaction.options.getString("event", true) as
         | "war_started"
@@ -277,7 +374,7 @@ export const Notify: Command = {
         | "last";
 
       const warEventService = new WarEventLogService(_client, cocService);
-      const result = await warEventService.emitTestEventForClan({
+      const result = await warEventService.buildTestEventPreviewForClan({
         guildId: interaction.guildId,
         clanTag,
         eventType,
@@ -285,13 +382,41 @@ export const Notify: Command = {
       });
 
       if (!result.ok) {
-        await interaction.editReply(`Failed to trigger test event: ${result.reason ?? "unknown reason"}`);
+        await interaction.editReply(`Failed to build preview: ${result.reason ?? "unknown reason"}`);
+        return;
+      }
+      if (!result.channelId || !result.clanName || !result.embeds || result.embeds.length === 0) {
+        await interaction.editReply("Failed to build preview: incomplete preview payload.");
         return;
       }
 
-      await interaction.editReply(
-        `Triggered test event \`${eventType}\` for ${clanTag} using \`${source}\` war data.`
-      );
+      const previewKey = randomUUID();
+      notifyWarPreviewRequests.set(previewKey, {
+        userId: interaction.user.id,
+        guildId: interaction.guildId,
+        clanTag,
+        eventType,
+        source,
+        channelId: result.channelId,
+        clanName: result.clanName,
+        createdAt: Date.now(),
+      });
+
+      await interaction.editReply({
+        content:
+          `Preview ready for **${result.clanName}** (${clanTag}).\n` +
+          `Target channel: <#${result.channelId}>.\n` +
+          "Click **Confirm Post** to publish this embed publicly.",
+        embeds: result.embeds ?? [],
+        components: [
+          new ActionRowBuilder<ButtonBuilder>().addComponents(
+            new ButtonBuilder()
+              .setCustomId(buildNotifyWarPreviewPostCustomId(previewKey))
+              .setLabel("Confirm Post")
+              .setStyle(ButtonStyle.Success)
+          ),
+        ],
+      });
       return;
     }
 

--- a/src/listeners/interactionCreate.ts
+++ b/src/listeners/interactionCreate.ts
@@ -47,6 +47,10 @@ import {
   getCommandTargetsFromInteraction,
 } from "../services/CommandPermissionService";
 import {
+  handleNotifyWarPreviewPostButton,
+  isNotifyWarPreviewPostButtonCustomId,
+} from "../commands/Notify";
+import {
   handleNotifyWarRefreshButton,
   isNotifyWarRefreshButtonCustomId,
 } from "../services/WarEventLogService";
@@ -156,7 +160,7 @@ export default (client: Client, cocService: CoCService): void => {
     }
 
   if (interaction.isButton()) {
-    await handleButtonInteraction(interaction);
+    await handleButtonInteraction(interaction, cocService);
     return;
   }
 
@@ -207,7 +211,10 @@ const handleSelectMenuInteraction = async (
   }
 };
 
-const handleButtonInteraction = async (interaction: Interaction): Promise<void> => {
+const handleButtonInteraction = async (
+  interaction: Interaction,
+  cocService: CoCService
+): Promise<void> => {
   if (!interaction.isButton()) return;
 
   if (isGlobalPostButtonCustomId(interaction.customId)) {
@@ -399,6 +406,20 @@ const handleButtonInteraction = async (interaction: Interaction): Promise<void> 
         await interaction.reply({
           ephemeral: true,
           content: "Failed to refresh battle-day embed.",
+        });
+      }
+    }
+  }
+
+  if (isNotifyWarPreviewPostButtonCustomId(interaction.customId)) {
+    try {
+      await handleNotifyWarPreviewPostButton(interaction, cocService);
+    } catch (err) {
+      console.error(`Notify war preview post button failed: ${formatError(err)}`);
+      if (!interaction.replied && !interaction.deferred) {
+        await interaction.reply({
+          ephemeral: true,
+          content: "Failed to post previewed war embed.",
         });
       }
     }

--- a/src/services/WarEventLogService.ts
+++ b/src/services/WarEventLogService.ts
@@ -84,6 +84,43 @@ type EmbedWarStats = {
   opponentDestruction: number | null;
 };
 
+type EventEmitPayload = {
+  eventType: EventType;
+  clanTag: string;
+  clanName: string;
+  opponentTag: string;
+  opponentName: string;
+  syncNumber: number | null;
+  notifyRole: string | null;
+  pingRole: boolean;
+  fwaPoints: number | null;
+  opponentFwaPoints: number | null;
+  outcome: "WIN" | "LOSE" | null;
+  matchType: MatchType;
+  warStartFwaPoints: number | null;
+  warEndFwaPoints: number | null;
+  lastClanStars: number | null;
+  lastOpponentStars: number | null;
+  warStartTime: Date | null;
+  warEndTime: Date | null;
+  clanAttacks: number | null;
+  opponentAttacks: number | null;
+  teamSize: number | null;
+  attacksPerMember: number | null;
+  clanDestruction: number | null;
+  opponentDestruction: number | null;
+  testFinalResultOverride?: WarEndResultSnapshot | null;
+};
+
+export type NotifyWarPreviewResult = {
+  ok: boolean;
+  reason?: string;
+  clanName?: string;
+  clanTag?: string;
+  channelId?: string;
+  embeds?: EmbedBuilder[];
+};
+
 /** Purpose: detect if current poll belongs to a newer war cycle than the stored snapshot. */
 function isNewWarCycle(
   previousWarStartTime: Date | null,
@@ -236,7 +273,40 @@ export class WarEventLogService {
     const sub = await this.findSubscriptionByGuildAndTag(params.guildId, params.clanTag);
     if (!sub) return { ok: false, reason: "No war event subscription found for that guild+clan." };
     if (!sub.channelId) return { ok: false, reason: "Subscription has no configured channel." };
+    const payload = await this.buildTestEventPayload(sub, params);
+    await this.emitEvent(sub.channelId, payload);
 
+    return { ok: true };
+  }
+
+  async buildTestEventPreviewForClan(params: {
+    guildId: string;
+    clanTag: string;
+    eventType: EventType;
+    source: TestSource;
+  }): Promise<NotifyWarPreviewResult> {
+    const sub = await this.findSubscriptionByGuildAndTag(params.guildId, params.clanTag);
+    if (!sub) return { ok: false, reason: "No war event subscription found for that guild+clan." };
+    if (!sub.channelId) return { ok: false, reason: "Subscription has no configured channel." };
+
+    const payload = await this.buildTestEventPayload(sub, params);
+    const message = await this.buildEventMessage(payload, params.guildId, {
+      includeRoleMention: false,
+      includeEventComponents: false,
+    });
+    return {
+      ok: true,
+      clanName: payload.clanName,
+      clanTag: payload.clanTag,
+      channelId: sub.channelId,
+      embeds: message.embeds,
+    };
+  }
+
+  private async buildTestEventPayload(
+    sub: SubscriptionRow,
+    params: { eventType: EventType; source: TestSource }
+  ): Promise<EventEmitPayload> {
     const previousSync = await this.pointsSync.getPreviousSyncNum();
     const activeSync = previousSync === null ? null : previousSync + 1;
     const syncNumber = params.source === "last" ? previousSync : activeSync;
@@ -286,8 +356,7 @@ export class WarEventLogService {
           lastWarRow?.opponentClanName ??
           sub.lastOpponentName ??
           "Unknown"
-      ).trim() ||
-      "Unknown";
+      ).trim() || "Unknown";
 
     let fwaPoints = sub.fwaPoints;
     let opponentFwaPoints = sub.opponentFwaPoints;
@@ -301,6 +370,7 @@ export class WarEventLogService {
       opponentFwaPoints = b.balance;
       outcome = deriveExpectedOutcome(clanTag, opponentTag, a.balance, b.balance, syncNumber);
     }
+
     const currentWarStartTime = parseCocTime(currentWar?.startTime ?? null);
     const testWarStartTime =
       params.source === "current"
@@ -347,7 +417,7 @@ export class WarEventLogService {
       }
     }
 
-    await this.emitEvent(sub.channelId, {
+    return {
       eventType: params.eventType,
       clanTag,
       clanName,
@@ -397,9 +467,240 @@ export class WarEventLogService {
         ? Number(currentWar?.opponent?.destructionPercentage)
         : null,
       testFinalResultOverride,
-    });
+    };
+  }
 
-    return { ok: true };
+  private async buildEventMessage(
+    payload: EventEmitPayload,
+    guildId: string | null,
+    options?: {
+      includeRoleMention?: boolean;
+      includeEventComponents?: boolean;
+      warId?: number | null;
+    }
+  ): Promise<{
+    content?: string;
+    embeds: EmbedBuilder[];
+    components: ActionRowBuilder<ButtonBuilder>[];
+    allowedMentions?: { roles: string[] };
+  }> {
+    const includeRoleMention = options?.includeRoleMention ?? true;
+    const includeEventComponents = options?.includeEventComponents ?? true;
+    const warId = options?.warId ?? null;
+    const opponentTag = normalizeTag(payload.opponentTag);
+    const embed = new EmbedBuilder()
+      .setTitle(`Event: ${eventTitle(payload.eventType)} - ${payload.clanName}`)
+      .setColor(
+        payload.eventType === "war_started"
+          ? 0x3498db
+          : payload.eventType === "battle_day"
+            ? 0xf1c40f
+            : 0x2ecc71
+      )
+      .setFooter({ text: `War ID: ${warId ?? "unknown"}` })
+      .setTimestamp(new Date());
+
+    embed.addFields(
+      {
+        name: "Opponent",
+        value: `${payload.opponentName} (${opponentTag ? `#${opponentTag}` : "unknown"})`,
+        inline: false,
+      },
+      {
+        name: "Sync #",
+        value: payload.syncNumber ? `#${payload.syncNumber}` : "unknown",
+        inline: true,
+      }
+    );
+
+    if (payload.eventType === "battle_day") {
+      embed.addFields(
+        {
+          name: "Battle Day Remaining",
+          value: toDiscordRelativeTime(payload.warEndTime),
+          inline: true,
+        },
+        {
+          name: "Match Type",
+          value: payload.matchType ?? "unknown",
+          inline: true,
+        }
+      );
+      if (payload.matchType !== "BL" && payload.matchType !== "MM") {
+        embed.addFields({
+          name: "War Plan",
+          value:
+            (await this.history.buildWarPlanText(
+              payload.matchType,
+              payload.outcome,
+              payload.clanTag,
+              payload.opponentName
+            )) ?? "N/A",
+          inline: false,
+        });
+      }
+      if (payload.matchType === "BL") {
+        embed.addFields({
+          name: "Message",
+          value:
+            "**Battle day has started! Thank you for helping with war bases; please switch back to FWA bases asap.**",
+          inline: false,
+        });
+      }
+      if (payload.matchType === "MM") {
+        embed.addFields({
+          name: "Message",
+          value: "Attack whatever you want! Free for all!",
+          inline: false,
+        });
+      }
+      embed.addFields({
+        name: "\u200b",
+        value: buildWarStatsLines({
+          clanStars: payload.lastClanStars,
+          opponentStars: payload.lastOpponentStars,
+          clanAttacks: payload.clanAttacks,
+          opponentAttacks: payload.opponentAttacks,
+          teamSize: payload.teamSize,
+          attacksPerMember: payload.attacksPerMember,
+          clanDestruction: payload.clanDestruction,
+          opponentDestruction: payload.opponentDestruction,
+        }).join("\n"),
+        inline: false,
+      });
+    }
+
+    if (payload.eventType === "war_started") {
+      embed.addFields(
+        {
+          name: "Prep Day Remaining",
+          value: toDiscordRelativeTime(payload.warStartTime),
+          inline: true,
+        },
+        {
+          name: "Match Type",
+          value: payload.matchType ?? "unknown",
+          inline: true,
+        }
+      );
+      if (payload.matchType === "FWA") {
+        embed.addFields({
+          name: "War Plan",
+          value:
+            (await this.history.buildWarPlanText(
+              payload.matchType,
+              payload.outcome,
+              payload.clanTag,
+              payload.opponentName
+            )) ?? "N/A",
+          inline: false,
+        });
+      }
+      if (payload.matchType === "BL") {
+        embed.addFields({
+          name: "Message",
+          value: [
+            `BLACKLIST WAR vs ${payload.opponentName}`,
+            "Everyone switch to WAR BASES!",
+            "This is an opportunity to gain extra FWA points.",
+          ].join("\n"),
+          inline: false,
+        });
+      }
+      if (payload.matchType === "MM") {
+        embed.addFields({
+          name: "Message",
+          value: [
+            `MISMATCHED WAR vs ${payload.opponentName}`,
+            "Keep war base active and attack what you can.",
+          ].join("\n"),
+          inline: false,
+        });
+      }
+    }
+
+    if (payload.eventType === "war_ended") {
+      const finalResult =
+        payload.testFinalResultOverride ??
+        (await this.history.getWarEndResultSnapshot({
+          clanTag: payload.clanTag,
+          opponentTag: payload.opponentTag,
+          fallbackClanStars: payload.lastClanStars,
+          fallbackOpponentStars: payload.lastOpponentStars,
+          warStartTime: payload.warStartTime,
+        }));
+      const compliance = await this.history.getWarComplianceSnapshot(
+        payload.clanTag,
+        payload.warStartTime,
+        payload.matchType,
+        payload.outcome
+      );
+      embed.addFields(
+        {
+          name: "Result",
+          value: formatResultLabelForEmbed(finalResult.resultLabel),
+          inline: false,
+        },
+        {
+          name: "Match Type",
+          value: payload.matchType ?? "unknown",
+          inline: true,
+        },
+        {
+          name: "\u200b",
+          value: buildWarStatsLines({
+            clanStars: finalResult.clanStars,
+            opponentStars: finalResult.opponentStars,
+            clanAttacks: payload.clanAttacks,
+            opponentAttacks: payload.opponentAttacks,
+            teamSize: payload.teamSize,
+            attacksPerMember: payload.attacksPerMember,
+            clanDestruction: finalResult.clanDestruction,
+            opponentDestruction: finalResult.opponentDestruction,
+          }).join("\n"),
+          inline: false,
+        },
+        {
+          name: "FWA Points",
+          value: this.history.buildWarEndPointsLine(payload, finalResult),
+          inline: false,
+        },
+        {
+          name: "Missed Both Attacks",
+          value: formatList(compliance.missedBoth),
+          inline: false,
+        },
+        {
+          name: "Didn't Follow War Plan",
+          value:
+            payload.matchType === "BL" || payload.matchType === "MM"
+              ? "N/A for BL/MM wars"
+              : formatList(compliance.notFollowingPlan),
+          inline: false,
+        }
+      );
+    }
+
+    const roleMention =
+      includeRoleMention && payload.pingRole && payload.notifyRole ? `<@&${payload.notifyRole}>` : null;
+    const components =
+      includeEventComponents && payload.eventType === "battle_day" && guildId
+        ? [
+            new ActionRowBuilder<ButtonBuilder>().addComponents(
+              new ButtonBuilder()
+                .setCustomId(buildNotifyWarRefreshCustomId(guildId, payload.clanTag))
+                .setLabel("Refresh")
+                .setStyle(ButtonStyle.Secondary)
+            ),
+          ]
+        : [];
+
+    return {
+      content: roleMention ?? undefined,
+      embeds: [embed],
+      components,
+      allowedMentions: roleMention ? { roles: [payload.notifyRole as string] } : undefined,
+    };
   }
 
   private async findSubscriptionByGuildAndTag(


### PR DESCRIPTION
Replace `/notify war-test` with `/notify war-preview` so test embeds are shown ephemerally first, then posted publicly only after explicit confirm.

- Add `/notify war-preview` subcommand
- Include clan name and configured target channel in preview feedback
- Add Confirm Post button to publish previewed event embed publicly
- Add interaction handler for preview confirmation button
- Reuse war-event payload generation for both preview and publish paths
- Update help and commands docs