### PR TITLE
feat(compo): migrate to single-sheet fixed mode rows for advice/state

### DIFF
--- a/src/commands/Compo.ts
+++ b/src/commands/Compo.ts
@@ -26,6 +26,96 @@ function readMode(interaction: ChatInputCommandInteraction): GoogleSheetMode {
   return rawMode === "war" ? "war" : "actual";
 }
 
+const COL_CLAN_NAME = 0; // A
+const COL_CLAN_TAG = 1; // B
+const COL_TOTAL_WEIGHT = 3; // D
+const COL_MISSING_WEIGHT = 20; // U
+const COL_BUCKET_START = 21; // V
+const COL_BUCKET_END = 26; // AA
+const COL_ADJUSTMENT = 53; // BB
+const COL_MODE = 55; // BD
+const FIXED_LAYOUT_RANGE = "AllianceDashboard!A6:BD500";
+const STATE_HEADERS = ["Clan", "Total", "Missing", "TH18", "TH17", "TH16", "TH15", "TH14", "<=TH13"];
+
+function normalizeTag(value: string): string {
+  return value.trim().toUpperCase().replace(/^#/, "");
+}
+
+function getModeRows(rows: string[][], mode: GoogleSheetMode): string[][] {
+  const wanted = mode.toUpperCase();
+  return rows.filter((row) => String(row[COL_MODE] ?? "").trim().toUpperCase() === wanted);
+}
+
+function renderStateSvg(mode: GoogleSheetMode, rows: string[][]): Buffer {
+  const tableRows = rows.length > 0 ? rows : [["(NO DATA)"]];
+  const colCount = Math.max(...tableRows.map((row) => row.length), 1);
+  const widths = Array.from({ length: colCount }, (_, col) =>
+    Math.min(40, Math.max(6, ...tableRows.map((row) => String(row[col] ?? "").length)))
+  );
+  const charPx = 8;
+  const paddingX = 12;
+  const rowHeight = 30;
+  const titleHeight = 46;
+  const margin = 16;
+  const colWidthsPx = widths.map((w) => w * charPx + paddingX * 2);
+  const tableWidth = colWidthsPx.reduce((sum, v) => sum + v, 0);
+  const width = margin * 2 + tableWidth;
+  const height = margin * 2 + titleHeight + tableRows.length * rowHeight;
+
+  const xStarts: number[] = [];
+  let runningX = margin;
+  for (const w of colWidthsPx) {
+    xStarts.push(runningX);
+    runningX += w;
+  }
+
+  const cells: string[] = [];
+  for (let r = 0; r < tableRows.length; r += 1) {
+    const y = margin + titleHeight + r * rowHeight;
+    const bg = r === 0 ? "#1f2d5a" : r % 2 === 0 ? "#171d34" : "#131a2f";
+    cells.push(`<rect x="${margin}" y="${y}" width="${tableWidth}" height="${rowHeight}" fill="${bg}" />`);
+    for (let c = 0; c < colCount; c += 1) {
+      const raw = String(tableRows[r][c] ?? "");
+      const text = raw
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;");
+      const color = r === 0 ? "#9ec2ff" : "#f0f4ff";
+      cells.push(
+        `<text x="${xStarts[c] + paddingX}" y="${y + 20}" font-size="14" font-family="Consolas, Menlo, monospace" fill="${color}">${text}</text>`
+      );
+    }
+  }
+
+  const verticalLines: string[] = [];
+  for (let c = 0; c <= colCount; c += 1) {
+    const x = c === colCount ? margin + tableWidth : xStarts[c];
+    verticalLines.push(
+      `<line x1="${x}" y1="${margin + titleHeight}" x2="${x}" y2="${margin + titleHeight + tableRows.length * rowHeight}" stroke="#2a3558" stroke-width="1" />`
+    );
+  }
+  const horizontalLines: string[] = [];
+  for (let r = 0; r <= tableRows.length; r += 1) {
+    const y = margin + titleHeight + r * rowHeight;
+    horizontalLines.push(
+      `<line x1="${margin}" y1="${y}" x2="${margin + tableWidth}" y2="${y}" stroke="#2a3558" stroke-width="1" />`
+    );
+  }
+
+  const title = `Alliance State (${mode.toUpperCase()})`;
+  const svg = [
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">`,
+    `<rect x="0" y="0" width="${width}" height="${height}" fill="#101427" />`,
+    `<text x="${margin}" y="${margin + 24}" font-size="20" font-family="Consolas, Menlo, monospace" fill="#9ec2ff">${title}</text>`,
+    ...cells,
+    ...verticalLines,
+    ...horizontalLines,
+    "</svg>",
+  ].join("");
+
+  return Buffer.from(svg, "utf8");
+}
+
 function parseNumber(value: string | undefined): number {
   if (!value) return 0;
   const digits = value.replace(/[^0-9-]/g, "");
@@ -350,15 +440,14 @@ export const Compo: Command = {
       type: ApplicationCommandOptionType.Subcommand,
       options: [
         {
-          name: "clan",
-          description: "Tracked clan name",
+          name: "tag",
+          description: "Tracked clan tag (with or without #)",
           type: ApplicationCommandOptionType.String,
           required: true,
-          autocomplete: true,
         },
         {
           name: "mode",
-          description: "Use the actual or war roster sheet link",
+          description: "Use ACTUAL or WAR fixed rows",
           type: ApplicationCommandOptionType.String,
           required: false,
           choices: COMPO_MODE_CHOICES,
@@ -372,7 +461,7 @@ export const Compo: Command = {
       options: [
         {
           name: "mode",
-          description: "Use the actual or war roster sheet link",
+          description: "Use ACTUAL or WAR fixed rows",
           type: ApplicationCommandOptionType.String,
           required: false,
           choices: COMPO_MODE_CHOICES,
@@ -405,48 +494,50 @@ export const Compo: Command = {
       const mode = readMode(interaction);
 
       if (subcommand === "advice") {
-        const clanInput = interaction.options.getString("clan", true);
-        const targetClan = normalize(clanInput);
+        const tagInput = interaction.options.getString("tag", true);
+        const targetTag = normalizeTag(tagInput);
 
         const settings = new SettingsService();
         const sheets = new GoogleSheetsService(settings);
-        const rows = await sheets.readLinkedValues("AllianceDashboard!A13:F20", mode);
+        const rows = await sheets.readLinkedValues(FIXED_LAYOUT_RANGE);
+        const modeRows = getModeRows(rows, mode);
 
-        if (rows.length === 0) {
+        if (modeRows.length === 0) {
           await safeReply(interaction, {
             ephemeral: true,
-            content: "No rows found in AllianceDashboard!A13:F20.",
+            content: `No ${mode.toUpperCase()} rows found in ${FIXED_LAYOUT_RANGE}.`,
           });
           return;
         }
 
-        for (const row of rows) {
-          const clanName = row[0]?.trim();
-          const advice = row[5]?.trim();
-          if (!clanName) continue;
+        for (const row of modeRows) {
+          const clanName = String(row[COL_CLAN_NAME] ?? "").trim();
+          const clanTag = normalizeTag(String(row[COL_CLAN_TAG] ?? ""));
+          const advice = String(row[COL_ADJUSTMENT] ?? "").trim();
+          if (!clanName || !clanTag) continue;
 
-          if (normalize(clanName) === targetClan) {
+          if (clanTag === targetTag) {
             await safeReply(interaction, {
               ephemeral: true,
               content:
                 advice && advice.length > 0
-                  ? `Mode: **${mode.toUpperCase()}**\n**${clanName}** adjustment:\n${advice}`
-                  : `Mode: **${mode.toUpperCase()}**\nFound **${clanName}**, but there is no advice text in AllianceDashboard!F13:F20.`,
+                  ? `Mode: **${mode.toUpperCase()}**\n**${clanName}** (\`#${clanTag}\`) adjustment:\n${advice}`
+                  : `Mode: **${mode.toUpperCase()}**\nFound **${clanName}** (\`#${clanTag}\`), but there is no adjustment text in column BB.`,
             });
             return;
           }
         }
 
-        const knownClans = rows
-          .map((row) => row[0]?.trim())
-          .filter((name): name is string => Boolean(name));
+        const knownTags = modeRows
+          .map((row) => normalizeTag(String(row[COL_CLAN_TAG] ?? "")))
+          .filter((tag): tag is string => Boolean(tag));
 
         await safeReply(interaction, {
           ephemeral: true,
           content:
-            knownClans.length > 0
-              ? `Mode: **${mode.toUpperCase()}**\nNo advice mapping found for "${clanInput}". Known clans: ${knownClans.join(", ")}`
-              : `Mode: **${mode.toUpperCase()}**\nNo advice mapping found for "${clanInput}".`,
+            knownTags.length > 0
+              ? `Mode: **${mode.toUpperCase()}**\nNo adjustment mapping found for tag \`#${targetTag}\`. Known tags in this mode: ${knownTags.map((t) => `#${t}`).join(", ")}`
+              : `Mode: **${mode.toUpperCase()}**\nNo adjustment mapping found for tag \`#${targetTag}\`.`,
         });
         return;
       }
@@ -454,21 +545,25 @@ export const Compo: Command = {
       if (subcommand === "state") {
         const settings = new SettingsService();
         const sheets = new GoogleSheetsService(settings);
-
-        const [leftBlock, middleBlock, rightBlock, targetBandBlock, refreshCell] = await Promise.all([
-          sheets.readLinkedValues("AllianceDashboard!A1:A9", mode),
-          sheets.readLinkedValues("AllianceDashboard!D1:E9", mode),
-          sheets.readLinkedValues("AllianceDashboard!U1:AA9", mode),
-          sheets.readLinkedValues("AllianceDashboard!AW1:AW9", mode),
-          sheets.readLinkedValues("Lookup!B10:B10", mode),
+        const [rows, refreshCell] = await Promise.all([
+          sheets.readLinkedValues(FIXED_LAYOUT_RANGE),
+          sheets.readLinkedValues("Lookup!B10:B10"),
         ]);
-
-        const mergedRows = mergeStateRows(
-          padRows(leftBlock, 9, 1),
-          padRows(middleBlock, 9, 2),
-          padRows(rightBlock, 9, 7),
-          padRows(targetBandBlock, 9, 1)
-        );
+        const modeRows = getModeRows(rows, mode);
+        const stateRows = [
+          STATE_HEADERS,
+          ...modeRows.map((row) => [
+            clampCell(String(row[COL_CLAN_NAME] ?? "")),
+            clampCell(String(row[COL_TOTAL_WEIGHT] ?? "")),
+            clampCell(String(row[COL_MISSING_WEIGHT] ?? "")),
+            clampCell(String(row[COL_BUCKET_START] ?? "")),
+            clampCell(String(row[COL_BUCKET_START + 1] ?? "")),
+            clampCell(String(row[COL_BUCKET_START + 2] ?? "")),
+            clampCell(String(row[COL_BUCKET_START + 3] ?? "")),
+            clampCell(String(row[COL_BUCKET_START + 4] ?? "")),
+            clampCell(String(row[COL_BUCKET_END] ?? "")),
+          ]),
+        ];
 
         const rawRefresh = refreshCell[0]?.[0]?.trim();
         const refreshLine =
@@ -477,14 +572,14 @@ export const Compo: Command = {
             : "RAW Data last refreshed: (not available)";
 
         const content = [`Mode Displayed: **${mode.toUpperCase()}**`, refreshLine].join("\n");
-        const png = await renderStatePng(mode, mergedRows);
+        const svg = renderStateSvg(mode, stateRows);
 
         await interaction.editReply({
           content,
           files: [
             {
-              attachment: png,
-              name: `compo-state-${mode}.png`,
+              attachment: svg,
+              name: `compo-state-${mode}.svg`,
             },
           ],
         });

--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -105,13 +105,13 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
   sheet: {
     summary: "Link and manage Google Sheet settings.",
     details: [
-      "Supports mode-specific links (`actual` and `war`).",
-      "Refresh can trigger an Apps Script webhook per mode.",
+      "Uses one linked Google Sheet for both ACTUAL/WAR data modes.",
+      "Refresh triggers a shared Apps Script webhook and can target ACTUAL or WAR mode.",
       "`link`, `unlink`, `show`, and `refresh` are admin-only by default.",
     ],
     examples: [
-      "/sheet link sheet_id_or_url:https://docs.google.com/... mode:actual",
-      "/sheet show mode:war",
+      "/sheet link sheet_id_or_url:https://docs.google.com/...",
+      "/sheet show",
       "/sheet refresh mode:actual",
     ],
   },
@@ -123,7 +123,7 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
       "`place`: suggest placement by war weight.",
     ],
     examples: [
-      "/compo advice clan:Rising Dawn mode:actual",
+      "/compo advice tag:#2QG2C08UP mode:actual",
       "/compo state mode:war",
       "/compo place weight:145k",
     ],

--- a/src/commands/Sheet.ts
+++ b/src/commands/Sheet.ts
@@ -8,10 +8,7 @@ import { Command } from "../Command";
 import { formatError } from "../helper/formatError";
 import { safeReply } from "../helper/safeReply";
 import { CoCService } from "../services/CoCService";
-import {
-  GoogleSheetMode,
-  GoogleSheetsService,
-} from "../services/GoogleSheetsService";
+import { GoogleSheetsService } from "../services/GoogleSheetsService";
 import { SettingsService } from "../services/SettingsService";
 
 function extractSheetId(input: string): string {
@@ -64,7 +61,7 @@ function getRefreshErrorHint(err: unknown): string {
     return "Apps Script endpoint denied access. Re-check web app deployment access and secret.";
   }
   if (message.includes("404")) {
-    return "Apps Script webhook URL was not found. Re-check *_APPS_SCRIPT_WEBHOOK_URL.";
+    return "Apps Script webhook URL was not found. Re-check GS_WEBHOOK_URL.";
   }
   if (message.includes("500")) {
     return "Apps Script returned a server error. Check Apps Script execution logs.";
@@ -73,23 +70,25 @@ function getRefreshErrorHint(err: unknown): string {
   return "Could not trigger Apps Script refresh. Check webhook URL, shared secret, deployment access, and Apps Script logs.";
 }
 
-const SHEET_MODE_CHOICES = [
-  { name: "Actual Roster", value: "actual" },
-  { name: "War Roster", value: "war" },
+const SHEET_REFRESH_MODE_CHOICES = [
+  { name: "Actual", value: "actual" },
+  { name: "War", value: "war" },
 ];
 const SHEET_REFRESH_COOLDOWN_MS = 5 * 60 * 1000;
 const SHEET_REFRESH_TIMEOUT_MS = 120000;
-const lastRefreshAtMsByGuildMode = new Map<string, number>();
+const lastRefreshAtMsByGuild = new Map<string, number>();
 
 async function postRefreshWebhook(
   url: string,
-  token: string,
+  token: string | null,
   action: "refreshMembers" | "refreshWar"
 ): Promise<string> {
+  const payload: Record<string, string> = { action };
+  if (token) payload.token = token;
   const makeRequest = () =>
     axios.post<string>(
       url,
-      { token, action },
+      payload,
       {
         headers: { "Content-Type": "application/json" },
         timeout: SHEET_REFRESH_TIMEOUT_MS,
@@ -117,16 +116,6 @@ async function postRefreshWebhook(
   }
 }
 
-function getModeOptionValue(
-  interaction: ChatInputCommandInteraction
-): GoogleSheetMode | undefined {
-  const raw = interaction.options.getString("mode", false);
-  if (raw === "actual" || raw === "war") {
-    return raw;
-  }
-  return undefined;
-}
-
 export const Sheet: Command = {
   name: "sheet",
   description: "Manage Google Sheet link for this bot",
@@ -148,42 +137,17 @@ export const Sheet: Command = {
           type: ApplicationCommandOptionType.String,
           required: false,
         },
-        {
-          name: "mode",
-          description: "Link sheet for a specific roster mode",
-          type: ApplicationCommandOptionType.String,
-          required: false,
-          choices: SHEET_MODE_CHOICES,
-        },
       ],
     },
     {
       name: "show",
       description: "Show current linked Google Sheet",
       type: ApplicationCommandOptionType.Subcommand,
-      options: [
-        {
-          name: "mode",
-          description: "Show only one roster mode",
-          type: ApplicationCommandOptionType.String,
-          required: false,
-          choices: SHEET_MODE_CHOICES,
-        },
-      ],
     },
     {
       name: "unlink",
       description: "Unlink the current Google Sheet",
       type: ApplicationCommandOptionType.Subcommand,
-      options: [
-        {
-          name: "mode",
-          description: "Unlink only one roster mode",
-          type: ApplicationCommandOptionType.String,
-          required: false,
-          choices: SHEET_MODE_CHOICES,
-        },
-      ],
     },
     {
       name: "refresh",
@@ -194,8 +158,8 @@ export const Sheet: Command = {
           name: "mode",
           description: "Refresh actual or war raw data",
           type: ApplicationCommandOptionType.String,
-          required: true,
-          choices: SHEET_MODE_CHOICES,
+          required: false,
+          choices: SHEET_REFRESH_MODE_CHOICES,
         },
       ],
     },
@@ -210,62 +174,25 @@ export const Sheet: Command = {
       await interaction.deferReply({ ephemeral: true });
 
       subcommand = interaction.options.getSubcommand(true);
-      const mode = getModeOptionValue(interaction);
       const settings = new SettingsService();
       const sheets = new GoogleSheetsService(settings);
 
       if (subcommand === "show") {
-        if (mode) {
-          const { sheetId, tabName } = await sheets.getLinkedSheet(mode);
-          if (!sheetId) {
-            await safeReply(interaction, {
-              ephemeral: true,
-              content: `No Google Sheet is linked for ${mode} mode yet. Use \`/sheet link\` with mode.`,
-            });
-            return;
-          }
-
-          await safeReply(interaction, {
-            ephemeral: true,
-            content: `Linked sheet (${mode}): ${sheetId}\nDefault tab: ${tabName ?? "(not set)"}`,
-          });
-          return;
-        }
-
-        const [legacy, actual, war] = await Promise.all([
-          sheets.getLinkedSheet(),
-          sheets.getLinkedSheet("actual"),
-          sheets.getLinkedSheet("war"),
-        ]);
-
+        const { sheetId, tabName } = await sheets.getLinkedSheet();
         await safeReply(interaction, {
           ephemeral: true,
-          content:
-            `Legacy/default sheet: ${legacy.sheetId || "(not set)"} | tab: ${legacy.tabName ?? "(not set)"}\n` +
-            `Actual mode sheet: ${actual.sheetId || "(not set)"} | tab: ${actual.tabName ?? "(not set)"}\n` +
-            `War mode sheet: ${war.sheetId || "(not set)"} | tab: ${war.tabName ?? "(not set)"}`,
+          content: sheetId
+            ? `Linked sheet: ${sheetId}\nDefault tab: ${tabName ?? "(not set)"}`
+            : "No Google Sheet is linked yet. Use `/sheet link`.",
         });
         return;
       }
 
       if (subcommand === "unlink") {
-        if (mode) {
-          await sheets.clearLinkedSheet(mode);
-          await safeReply(interaction, {
-            ephemeral: true,
-            content: `Google Sheet unlinked for ${mode} mode.`,
-          });
-          return;
-        }
-
-        await Promise.all([
-          sheets.clearLinkedSheet(),
-          sheets.clearLinkedSheet("actual"),
-          sheets.clearLinkedSheet("war"),
-        ]);
+        await Promise.all([sheets.clearLinkedSheet(), sheets.clearLinkedSheet("actual"), sheets.clearLinkedSheet("war")]);
         await safeReply(interaction, {
           ephemeral: true,
-          content: "All Google Sheet links removed (legacy/default, actual, and war).",
+          content: "Google Sheet link removed.",
         });
         return;
       }
@@ -274,16 +201,14 @@ export const Sheet: Command = {
         const rawInput = interaction.options.getString("sheet_id_or_url", true);
         const sheetId = extractSheetId(rawInput);
         const tab = interaction.options.getString("tab", false) ?? undefined;
-        const selectedMode = mode;
 
         await sheets.testAccess(sheetId, tab);
-        await sheets.setLinkedSheet(sheetId, tab, selectedMode);
+        await sheets.setLinkedSheet(sheetId, tab);
 
         await safeReply(interaction, {
           ephemeral: true,
           content:
-            `Google Sheet linked${selectedMode ? ` for ${selectedMode} mode` : ""}.\n` +
-            `Sheet ID: ${sheetId}\n` +
+            `Google Sheet linked.\nSheet ID: ${sheetId}\n` +
             `Default tab: ${tab ?? "(unchanged)"}\n` +
             "You can relink anytime with `/sheet link`.",
         });
@@ -291,7 +216,7 @@ export const Sheet: Command = {
       }
 
       if (subcommand === "refresh") {
-        const refreshMode = interaction.options.getString("mode", true);
+        const refreshMode = interaction.options.getString("mode", false) ?? "actual";
         if (refreshMode !== "actual" && refreshMode !== "war") {
           await safeReply(interaction, {
             ephemeral: true,
@@ -300,9 +225,9 @@ export const Sheet: Command = {
           return;
         }
 
-        const guildModeKey = `${interaction.guildId ?? "dm"}:${refreshMode}`;
+        const guildKey = `${interaction.guildId ?? "dm"}`;
         const now = Date.now();
-        const lastRun = lastRefreshAtMsByGuildMode.get(guildModeKey);
+        const lastRun = lastRefreshAtMsByGuild.get(guildKey);
         if (lastRun && now - lastRun < SHEET_REFRESH_COOLDOWN_MS) {
           const availableAt = Math.floor(
             (lastRun + SHEET_REFRESH_COOLDOWN_MS) / 1000
@@ -314,26 +239,16 @@ export const Sheet: Command = {
           return;
         }
 
-        const config =
-          refreshMode === "actual"
-            ? {
-                url: process.env.ACTUAL_APPS_SCRIPT_WEBHOOK_URL?.trim(),
-                token: process.env.ACTUAL_APPS_SCRIPT_SHARED_SECRET?.trim(),
-                action: "refreshMembers",
-              }
-            : {
-                url: process.env.WAR_APPS_SCRIPT_WEBHOOK_URL?.trim(),
-                token: process.env.WAR_APPS_SCRIPT_SHARED_SECRET?.trim(),
-                action: "refreshWar",
-              };
+        const config = {
+          url: process.env.GS_WEBHOOK_URL?.trim(),
+          token: process.env.GS_WEBHOOK_SHARED_SECRET?.trim() ?? null,
+          action: refreshMode === "actual" ? "refreshMembers" : "refreshWar",
+        } as const;
 
-        if (!config.url || !config.token) {
+        if (!config.url) {
           await safeReply(interaction, {
             ephemeral: true,
-            content:
-              refreshMode === "actual"
-                ? "Missing ACTUAL_APPS_SCRIPT_WEBHOOK_URL or ACTUAL_APPS_SCRIPT_SHARED_SECRET."
-                : "Missing WAR_APPS_SCRIPT_WEBHOOK_URL or WAR_APPS_SCRIPT_SHARED_SECRET.",
+            content: "Missing GS_WEBHOOK_URL.",
           });
           return;
         }
@@ -349,7 +264,7 @@ export const Sheet: Command = {
           1000
         ).toFixed(2);
 
-        lastRefreshAtMsByGuildMode.set(guildModeKey, now);
+        lastRefreshAtMsByGuild.set(guildKey, now);
         await safeReply(interaction, {
           ephemeral: true,
           content:

--- a/src/services/GoogleSheetsService.ts
+++ b/src/services/GoogleSheetsService.ts
@@ -26,27 +26,19 @@ export class GoogleSheetsService {
   async getLinkedSheet(
     mode?: GoogleSheetMode
   ): Promise<{ sheetId: string; tabName: string | null }> {
-    if (mode) {
-      const modeKeys = this.getModeKeys(mode);
-      const modeSheetId = await this.settings.get(modeKeys.idKey);
-      const modeTabName = await this.settings.get(modeKeys.tabKey);
-
-      if (modeSheetId) {
-        return { sheetId: modeSheetId, tabName: modeTabName };
-      }
-
-      if (mode === "actual") {
-        const legacySheetId = await this.settings.get(SHEET_SETTING_ID_KEY);
-        const legacyTabName = await this.settings.get(SHEET_SETTING_TAB_KEY);
-        return { sheetId: legacySheetId ?? "", tabName: legacyTabName };
-      }
-
-      return { sheetId: "", tabName: null };
-    }
-
     const sheetId = await this.settings.get(SHEET_SETTING_ID_KEY);
     const tabName = await this.settings.get(SHEET_SETTING_TAB_KEY);
-    return { sheetId: sheetId ?? "", tabName };
+    if (sheetId) return { sheetId, tabName };
+
+    const actualSheetId = await this.settings.get(SHEET_SETTING_ACTUAL_ID_KEY);
+    const actualTabName = await this.settings.get(SHEET_SETTING_ACTUAL_TAB_KEY);
+    if (actualSheetId) return { sheetId: actualSheetId, tabName: actualTabName };
+
+    const warSheetId = await this.settings.get(SHEET_SETTING_WAR_ID_KEY);
+    const warTabName = await this.settings.get(SHEET_SETTING_WAR_TAB_KEY);
+    if (warSheetId) return { sheetId: warSheetId, tabName: warTabName };
+
+    return { sheetId: "", tabName: null };
   }
 
   async setLinkedSheet(
@@ -54,32 +46,31 @@ export class GoogleSheetsService {
     tabName?: string,
     mode?: GoogleSheetMode
   ): Promise<void> {
-    if (mode) {
-      const modeKeys = this.getModeKeys(mode);
-      await this.settings.set(modeKeys.idKey, sheetId);
-      if (tabName && tabName.trim().length > 0) {
-        await this.settings.set(modeKeys.tabKey, tabName.trim());
-      }
-      return;
-    }
-
     await this.settings.set(SHEET_SETTING_ID_KEY, sheetId);
     if (tabName && tabName.trim().length > 0) {
       await this.settings.set(SHEET_SETTING_TAB_KEY, tabName.trim());
     }
-  }
-
-  /** Purpose: clear linked sheet. */
-  async clearLinkedSheet(mode?: GoogleSheetMode): Promise<void> {
     if (mode) {
       const modeKeys = this.getModeKeys(mode);
       await this.settings.delete(modeKeys.idKey);
       await this.settings.delete(modeKeys.tabKey);
       return;
     }
+    await this.settings.delete(SHEET_SETTING_ACTUAL_ID_KEY);
+    await this.settings.delete(SHEET_SETTING_ACTUAL_TAB_KEY);
+    await this.settings.delete(SHEET_SETTING_WAR_ID_KEY);
+    await this.settings.delete(SHEET_SETTING_WAR_TAB_KEY);
+  }
 
+  /** Purpose: clear linked sheet. */
+  async clearLinkedSheet(mode?: GoogleSheetMode): Promise<void> {
     await this.settings.delete(SHEET_SETTING_ID_KEY);
     await this.settings.delete(SHEET_SETTING_TAB_KEY);
+    if (mode) {
+      const modeKeys = this.getModeKeys(mode);
+      await this.settings.delete(modeKeys.idKey);
+      await this.settings.delete(modeKeys.tabKey);
+    }
   }
 
   /** Purpose: test access. */


### PR DESCRIPTION
- switch sheet linking/showing to a single shared Google Sheet configuration
- update sheet refresh to use GS_WEBHOOK_URL with optional mode (default ACTUAL)
- update /compo advice to accept clan tag and read column BB by mode (BD) + tag (B)
- update /compo state to filter rows by mode (BD) and render A,D,U:AA as SVG
- add legacy sheet-setting fallback/migration behavior in GoogleSheetsService
- refresh help text/examples for new /sheet and /compo usage