### PR TITLE
fix(sheet): quote tab names in google sheets ranges to avoid 400s

### DIFF
--- a/src/services/GoogleSheetsService.ts
+++ b/src/services/GoogleSheetsService.ts
@@ -76,7 +76,7 @@ export class GoogleSheetsService {
   /** Purpose: test access. */
   async testAccess(sheetId: string, tabName?: string): Promise<void> {
     const range = tabName?.trim()
-      ? `${tabName.trim()}!A1:A1`
+      ? `${escapeSheetTabName(tabName.trim())}!A1:A1`
       : "A1:A1";
     await this.readValues(sheetId, range);
   }
@@ -93,7 +93,7 @@ export class GoogleSheetsService {
       throw new Error("No linked Google Sheet found.");
     }
 
-    const effectiveRange = range ?? (tabName ? `${tabName}!A1:D10` : "A1:D10");
+    const effectiveRange = range ?? (tabName ? `${escapeSheetTabName(tabName)}!A1:D10` : "A1:D10");
     return this.readValues(sheetId, effectiveRange);
   }
 
@@ -275,4 +275,9 @@ export class GoogleSheetsService {
       tabKey: SHEET_SETTING_WAR_TAB_KEY,
     };
   }
+}
+
+function escapeSheetTabName(tabName: string): string {
+  const escaped = String(tabName ?? "").trim().replace(/'/g, "''");
+  return `'${escaped}'`;
 }


### PR DESCRIPTION
- escape/quote tab names for testAccess A1 checks
- escape/quote default tab-based linked reads
- prevent "Unable to parse range" errors for tabs with spaces/special chars