### PR TITLE
fix(sheet): surface google api error body for 400 troubleshooting

### DIFF
--- a/src/helper/formatError.ts
+++ b/src/helper/formatError.ts
@@ -5,6 +5,45 @@ type ErrorLike = {
   response?: { status?: number; data?: unknown };
 };
 
+function compactResponseData(data: unknown): string | null {
+  if (data === null || data === undefined) return null;
+  if (typeof data === "string") {
+    const trimmed = data.trim();
+    if (!trimmed) return null;
+    return trimmed.length > 300 ? `${trimmed.slice(0, 300)}...` : trimmed;
+  }
+  if (typeof data === "object") {
+    const obj = data as Record<string, unknown>;
+    const candidates: string[] = [];
+    const direct = ["error_description", "error", "message", "status"];
+    for (const key of direct) {
+      const value = obj[key];
+      if (typeof value === "string" && value.trim()) {
+        candidates.push(`${key}=${value.trim()}`);
+      }
+    }
+    const nestedError = obj.error as Record<string, unknown> | undefined;
+    if (nestedError && typeof nestedError === "object") {
+      const nestedMessage = nestedError.message;
+      if (typeof nestedMessage === "string" && nestedMessage.trim()) {
+        candidates.push(`error.message=${nestedMessage.trim()}`);
+      }
+      const nestedStatus = nestedError.status;
+      if (typeof nestedStatus === "string" && nestedStatus.trim()) {
+        candidates.push(`error.status=${nestedStatus.trim()}`);
+      }
+    }
+    if (candidates.length > 0) return candidates.join(" | ");
+    try {
+      const raw = JSON.stringify(data);
+      return raw.length > 300 ? `${raw.slice(0, 300)}...` : raw;
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
 export function formatError(err: unknown): string {
   if (!err) return "Unknown error";
   if (typeof err === "string") return err;
@@ -16,6 +55,8 @@ export function formatError(err: unknown): string {
   if (e.code) parts.push(`code=${String(e.code)}`);
   if (e.status) parts.push(`status=${e.status}`);
   if (e.response?.status) parts.push(`http=${e.response.status}`);
+  const responseData = compactResponseData(e.response?.data);
+  if (responseData) parts.push(`response=${responseData}`);
 
   if (parts.length > 0) return parts.join(" | ");
   return "Unhandled non-error throw";


### PR DESCRIPTION
- include compact response.data details in formatError output
- expose oauth/sheets error_description and nested error.message fields
- make /sheet link failures diagnosable beyond generic ERR_BAD_REQUEST