### PR TITLE
feat(sheet): add apps script proxy reads for linked google sheet

### DIFF
--- a/src/commands/Sheet.ts
+++ b/src/commands/Sheet.ts
@@ -19,6 +19,7 @@ function extractSheetId(input: string): string {
 
 function getSheetErrorHint(err: unknown): string {
   const message = formatError(err).toLowerCase();
+  const usingProxy = Boolean(process.env.GS_WEBHOOK_URL?.trim());
 
   if (message.includes("invalid_grant")) {
     return "Invalid Google auth grant. For OAuth, re-check GOOGLE_OAUTH_* values and refresh token.";
@@ -41,6 +42,9 @@ function getSheetErrorHint(err: unknown): string {
   }
   if (message.includes("unable to parse range") || message.includes("badrequest")) {
     return "Range/tab is invalid. Try a valid tab name or omit range.";
+  }
+  if (usingProxy) {
+    return "Apps Script proxy read failed. Check GS_WEBHOOK_URL deployment access, readValues action support, and Apps Script logs.";
   }
   if (message.includes("relation \"botsetting\" does not exist")) {
     return "Database migration missing. Run prisma migrate deploy for BotSetting.";

--- a/src/services/GoogleSheetsService.ts
+++ b/src/services/GoogleSheetsService.ts
@@ -9,6 +9,7 @@ export const SHEET_SETTING_ACTUAL_TAB_KEY = "google_sheet_actual_tab";
 export const SHEET_SETTING_WAR_ID_KEY = "google_sheet_war_id";
 export const SHEET_SETTING_WAR_TAB_KEY = "google_sheet_war_tab";
 const GOOGLE_API_TIMEOUT_MS = 20000;
+const APPS_SCRIPT_PROXY_TIMEOUT_MS = 30000;
 
 export type GoogleSheetMode = "actual" | "war";
 
@@ -99,6 +100,11 @@ export class GoogleSheetsService {
 
   /** Purpose: read values. */
   async readValues(sheetId: string, range: string): Promise<string[][]> {
+    const proxyUrl = process.env.GS_WEBHOOK_URL?.trim();
+    if (proxyUrl) {
+      return this.readValuesViaAppsScriptProxy(proxyUrl, sheetId, range);
+    }
+
     const token = await this.getAccessToken();
     const encodedRange = encodeURIComponent(range);
     const encodedSheetId = encodeURIComponent(sheetId);
@@ -112,6 +118,53 @@ export class GoogleSheetsService {
     });
 
     return response.data.values ?? [];
+  }
+
+  private async readValuesViaAppsScriptProxy(
+    url: string,
+    sheetId: string,
+    range: string
+  ): Promise<string[][]> {
+    const token = process.env.GS_WEBHOOK_SHARED_SECRET?.trim();
+    const payload: Record<string, string> = {
+      action: "readValues",
+      sheetId,
+      range,
+    };
+    if (token) payload.token = token;
+
+    const response = await axios.post<{
+      values?: unknown;
+      ok?: boolean;
+      error?: unknown;
+      message?: unknown;
+      result?: { values?: unknown };
+    }>(url, payload, {
+      headers: { "Content-Type": "application/json" },
+      timeout: APPS_SCRIPT_PROXY_TIMEOUT_MS,
+      validateStatus: () => true,
+    });
+
+    if (response.status >= 400) {
+      const message =
+        typeof response.data?.error === "string"
+          ? response.data.error
+          : typeof response.data?.message === "string"
+            ? response.data.message
+            : `Apps Script proxy returned HTTP ${response.status}`;
+      throw new Error(message);
+    }
+
+    const rawValues =
+      response.data?.values ??
+      response.data?.result?.values ??
+      null;
+    if (!Array.isArray(rawValues)) return [];
+
+    return rawValues.map((row) => {
+      if (!Array.isArray(row)) return [];
+      return row.map((cell) => String(cell ?? ""));
+    });
   }
 
   /** Purpose: get access token. */


### PR DESCRIPTION
- route Google sheet readValues through GS_WEBHOOK_URL when configured
- add readValues proxy payload support with optional GS_WEBHOOK_SHARED_SECRET token
- preserve existing direct Google Sheets API fallback when proxy is not configured
- update /sheet error hinting for proxy-based read failures