### PR TITLE
fix(notify): refine war-preview post flow and preview war id

### DIFF
--- a/src/commands/Notify.ts
+++ b/src/commands/Notify.ts
@@ -104,7 +104,7 @@ export async function handleNotifyWarPreviewPostButton(
     return;
   }
 
-  await interaction.deferReply({ ephemeral: true });
+  await interaction.deferUpdate();
   const warEventService = new WarEventLogService(interaction.client, cocService);
   const result = await warEventService.emitTestEventForClan({
     guildId: request.guildId,
@@ -113,16 +113,23 @@ export async function handleNotifyWarPreviewPostButton(
     source: request.source,
   });
   if (!result.ok) {
-    await interaction.editReply(
+    await interaction.followUp({
+      ephemeral: true,
+      content:
       `Failed to post preview publicly for ${request.clanName} (${request.clanTag}): ${result.reason ?? "unknown reason"}`
-    );
+    });
     return;
   }
 
   notifyWarPreviewRequests.delete(parsed.key);
-  await interaction.editReply(
-    `Posted ${request.eventType} for **${request.clanName}** (${request.clanTag}) to <#${request.channelId}>.`
-  );
+  await interaction.deleteReply().catch(async () => {
+    await interaction.editReply({
+      content:
+        `Posted ${request.eventType} for **${request.clanName}** (${request.clanTag}) to <#${request.channelId}>.`,
+      embeds: [],
+      components: [],
+    });
+  });
 }
 
 export const Notify: Command = {

--- a/src/services/WarEventLogService.ts
+++ b/src/services/WarEventLogService.ts
@@ -290,9 +290,11 @@ export class WarEventLogService {
     if (!sub.channelId) return { ok: false, reason: "Subscription has no configured channel." };
 
     const payload = await this.buildTestEventPayload(sub, params);
+    const warId = await this.resolveWarId(payload.clanTag, payload.warStartTime);
     const message = await this.buildEventMessage(payload, params.guildId, {
       includeRoleMention: false,
       includeEventComponents: false,
+      warId,
     });
     return {
       ok: true,
@@ -1013,6 +1015,25 @@ export class WarEventLogService {
     return eventType === "war_ended";
   }
 
+  private async resolveWarId(clanTagInput: string, warStartTime: Date | null): Promise<number | null> {
+    if (!warStartTime) return null;
+    const clanTag = normalizeTag(clanTagInput);
+    if (!clanTag) return null;
+    return (
+      await prisma.warClanHistory
+        .findUnique({
+          where: {
+            clanTag_warStartTime: {
+              clanTag,
+              warStartTime,
+            },
+          },
+          select: { warId: true },
+        })
+        .catch(() => null)
+    )?.warId ?? null;
+  }
+
   private async emitEvent(
     channelId: string,
     payload: {
@@ -1069,22 +1090,7 @@ export class WarEventLogService {
     }
 
     const guildId = (channel as { guildId?: string }).guildId ?? null;
-    const warId =
-      payload.warStartTime && normalizeTag(payload.clanTag)
-        ? (
-            await prisma.warClanHistory
-              .findUnique({
-                where: {
-                  clanTag_warStartTime: {
-                    clanTag: normalizeTag(payload.clanTag),
-                    warStartTime: payload.warStartTime,
-                  },
-                },
-                select: { warId: true },
-              })
-              .catch(() => null)
-          )?.warId ?? null
-        : null;
+    const warId = await this.resolveWarId(payload.clanTag, payload.warStartTime);
     const opponentTag = normalizeTag(payload.opponentTag);
     const embed = new EmbedBuilder()
       .setTitle(`Event: ${eventTitle(payload.eventType)} - ${payload.clanName}`)


### PR DESCRIPTION
- resolve war id for /notify war-preview from WarClanHistory (clanTag + warStartTime)
- reuse shared war-id resolver in emit path for consistent dataset lookup
- switch Confirm Post button handling to deferUpdate + cleanup of preview message
- remove preview embed/buttons after successful post (with safe fallback edit)