### PR TITLE
feat(notify): unify war remove/ping controls under /notify toggle

### DIFF
--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -141,7 +141,7 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
     details: [
       "`war` enables war-state event embeds for a clan in a selected channel.",
       "`show` lists notify routing (channel/role/status) for tracked clans, optionally filtered by tag.",
-      "`war-remove` removes a clan's war event subscription for this server.",
+      "`toggle` turns `war embed` or `ping` on/off for an existing clan subscription.",
       "Optional `role` pings that role whenever a war event embed is posted.",
       "Works with clans outside tracked-clans table (tag must still be valid in CoC API).",
       "Posts at war start, battle day, and war end with opponent + points projection.",
@@ -149,8 +149,9 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
     examples: [
       "/notify war clan-tag:2QG2C08UP target-channel:#war-events role:@Leaders",
       "/notify war clan-tag:2QG2C08UP target-channel:#new-war-events",
+      "/notify toggle clan-tag:2QG2C08UP target:war embed toggle:off",
+      "/notify toggle clan-tag:2QG2C08UP target:ping toggle:on",
       "/notify war-preview clan-tag:2QG2C08UP event:battle day start source:current",
-      "/notify war-remove clan-tag:2QG2C08UP",
       "/notify show",
       "/notify show clan-tag:2QG2C08UP",
     ],

--- a/src/commands/Notify.ts
+++ b/src/commands/Notify.ts
@@ -162,8 +162,8 @@ export const Notify: Command = {
       ],
     },
     {
-      name: "war-ping",
-      description: "Toggle role ping on/off for an existing /notify war subscription",
+      name: "toggle",
+      description: "Toggle war embed or ping on/off for an existing /notify war subscription",
       type: ApplicationCommandOptionType.Subcommand,
       options: [
         {
@@ -174,10 +174,24 @@ export const Notify: Command = {
           autocomplete: true,
         },
         {
-          name: "enabled",
-          description: "Enable or disable role ping for war event posts",
-          type: ApplicationCommandOptionType.Boolean,
+          name: "target",
+          description: "What setting to toggle",
+          type: ApplicationCommandOptionType.String,
           required: true,
+          choices: [
+            { name: "war embed", value: "war_embed" },
+            { name: "ping", value: "ping" },
+          ],
+        },
+        {
+          name: "toggle",
+          description: "Enable or disable the selected target",
+          type: ApplicationCommandOptionType.String,
+          required: true,
+          choices: [
+            { name: "on", value: "on" },
+            { name: "off", value: "off" },
+          ],
         },
       ],
     },
@@ -230,20 +244,6 @@ export const Notify: Command = {
         },
       ],
     },
-    {
-      name: "war-remove",
-      description: "Remove war event log subscription for a clan",
-      type: ApplicationCommandOptionType.Subcommand,
-      options: [
-        {
-          name: "clan-tag",
-          description: "Clan tag to remove from notify routing",
-          type: ApplicationCommandOptionType.String,
-          required: true,
-          autocomplete: true,
-        },
-      ],
-    },
   ],
   run: async (
     _client: Client,
@@ -257,27 +257,6 @@ export const Notify: Command = {
     }
 
     const sub = interaction.options.getSubcommand(true);
-    if (sub === "war-remove") {
-      const clanTag = normalizeClanTag(interaction.options.getString("clan-tag", true));
-      if (!clanTag) {
-        await interaction.editReply("Invalid clan tag.");
-        return;
-      }
-
-      const deleted = await prisma.warEventLogSubscription.deleteMany({
-        where: {
-          guildId: interaction.guildId,
-          clanTag,
-        },
-      });
-      if (deleted.count === 0) {
-        await interaction.editReply(`No /notify war subscription found for ${clanTag}.`);
-        return;
-      }
-      await interaction.editReply(`Removed /notify war subscription for ${clanTag}.`);
-      return;
-    }
-
     if (sub === "show") {
       const rawTag = interaction.options.getString("clan-tag", false);
       const normalizedFilter = rawTag ? normalizeClanTag(rawTag) : "";
@@ -341,25 +320,40 @@ export const Notify: Command = {
       return;
     }
 
-    if (sub === "war-ping") {
+    if (sub === "toggle") {
       const clanTag = normalizeClanTag(interaction.options.getString("clan-tag", true));
-      const enabled = interaction.options.getBoolean("enabled", true);
-      const updated = await prisma.$executeRaw(
-        Prisma.sql`
-          UPDATE "WarEventLogSubscription"
-          SET "pingRole" = ${enabled}, "updatedAt" = NOW()
-          WHERE "guildId" = ${interaction.guildId}
-            AND UPPER(REPLACE("clanTag",'#','')) = ${normalizeClanTagInput(clanTag)}
-        `
-      );
+      const target = interaction.options.getString("target", true);
+      const toggle = interaction.options.getString("toggle", true);
+      const enabled = toggle === "on";
+      if (target !== "war_embed" && target !== "ping") {
+        await interaction.editReply("Invalid target. Use `war embed` or `ping`.");
+        return;
+      }
+      const updated =
+        target === "war_embed"
+          ? await prisma.$executeRaw(
+              Prisma.sql`
+                UPDATE "WarEventLogSubscription"
+                SET "notify" = ${enabled}, "updatedAt" = NOW()
+                WHERE "guildId" = ${interaction.guildId}
+                  AND UPPER(REPLACE("clanTag",'#','')) = ${normalizeClanTagInput(clanTag)}
+              `
+            )
+          : await prisma.$executeRaw(
+              Prisma.sql`
+                UPDATE "WarEventLogSubscription"
+                SET "pingRole" = ${enabled}, "updatedAt" = NOW()
+                WHERE "guildId" = ${interaction.guildId}
+                  AND UPPER(REPLACE("clanTag",'#','')) = ${normalizeClanTagInput(clanTag)}
+              `
+            );
       if (updated === 0) {
         await interaction.editReply(`No /notify war subscription found for ${clanTag}.`);
         return;
       }
 
-      await interaction.editReply(
-        `Role ping is now **${enabled ? "on" : "off"}** for ${clanTag}.`
-      );
+      const targetLabel = target === "war_embed" ? "War embed" : "Ping";
+      await interaction.editReply(`${targetLabel} is now **${enabled ? "on" : "off"}** for ${clanTag}.`);
       return;
     }
 


### PR DESCRIPTION
- replace /notify war-ping and /notify war-remove with /notify toggle
- add toggle target choices: war embed or ping
- add toggle choices: on or off
- keep /notify war for subscription creation/update
- update help text and examples for new toggle flow