### PR TITLE
fix(notify): keep confirm-post feedback after preview dismiss

### DIFF
--- a/src/commands/Notify.ts
+++ b/src/commands/Notify.ts
@@ -124,11 +124,14 @@ export async function handleNotifyWarPreviewPostButton(
   notifyWarPreviewRequests.delete(parsed.key);
   await interaction.deleteReply().catch(async () => {
     await interaction.editReply({
-      content:
-        `Posted ${request.eventType} for **${request.clanName}** (${request.clanTag}) to <#${request.channelId}>.`,
+      content: "Preview cleared.",
       embeds: [],
       components: [],
     });
+  });
+  await interaction.followUp({
+    ephemeral: true,
+    content: `Posted ${request.eventType} for **${request.clanName}** (${request.clanTag}) to <#${request.channelId}>.`,
   });
 }
 


### PR DESCRIPTION
- keep dismiss behavior for /notify war-preview message after Confirm Post
- send ephemeral follow-up confirmation with posted event, clan, tag, and channel
- retain failure follow-up path when preview publish fails