### PR TITLE
refactor(db): rename war tables to WarAttacks, CurrentWar, and ClanWa…

### DIFF
--- a/prisma/migrations/20260303170000_rename_war_tables/migration.sql
+++ b/prisma/migrations/20260303170000_rename_war_tables/migration.sql
@@ -1,0 +1,29 @@
+ALTER TABLE "WarHistoryAttack" RENAME TO "WarAttacks";
+ALTER TABLE "WarEventLogSubscription" RENAME TO "CurrentWar";
+ALTER TABLE "WarClanHistory" RENAME TO "ClanWarHistory";
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_class
+    WHERE relkind = 'S'
+      AND relname = 'WarClanHistory_warId_seq'
+  ) THEN
+    EXECUTE 'ALTER SEQUENCE "WarClanHistory_warId_seq" RENAME TO "ClanWarHistory_warId_seq"';
+  END IF;
+END
+$$;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM pg_class
+    WHERE relkind = 'S'
+      AND relname = 'ClanWarHistory_warId_seq'
+  ) THEN
+    EXECUTE 'ALTER TABLE "ClanWarHistory" ALTER COLUMN "warId" SET DEFAULT nextval(''"ClanWarHistory_warId_seq"''::regclass)';
+  END IF;
+END
+$$;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,37 +8,36 @@ datasource db {
 }
 
 model PlayerActivity {
-  tag            String   @id
-  name           String
-  clanTag        String
+  tag     String @id
+  name    String
+  clanTag String
 
   lastDonationAt DateTime?
   lastCapitalAt  DateTime?
   lastTrophyAt   DateTime?
   lastWarAt      DateTime?
   lastBuilderAt  DateTime?
-  
-  lastTrophies          Int?
-  lastWarStars          Int?
-  lastBuilderTrophies   Int?
 
+  lastTrophies        Int?
+  lastWarStars        Int?
+  lastBuilderTrophies Int?
 
-  lastSeenAt     DateTime
-  updatedAt      DateTime @updatedAt
+  lastSeenAt DateTime
+  updatedAt  DateTime @updatedAt
 }
 
 model TrackedClan {
-  id        Int       @id @default(autoincrement())
-  tag       String    @unique
-  name      String?
-  loseStyle LoseStyle @default(TRIPLE_TOP_30)
+  id            Int       @id @default(autoincrement())
+  tag           String    @unique
+  name          String?
+  loseStyle     LoseStyle @default(TRIPLE_TOP_30)
   mailChannelId String?
-  logChannelId String?
-  clanRoleId String?
-  clanBadge String?
-  shortName String?
-  pointsScrape Json?
-  createdAt DateTime  @default(now())
+  logChannelId  String?
+  clanRoleId    String?
+  clanBadge     String?
+  shortName     String?
+  pointsScrape  Json?
+  createdAt     DateTime  @default(now())
 }
 
 model BotSetting {
@@ -49,10 +48,10 @@ model BotSetting {
 }
 
 model PlayerLink {
-  playerTag      String   @id
-  discordUserId  String
-  createdAt      DateTime @default(now())
-  updatedAt      DateTime @updatedAt
+  playerTag     String   @id
+  discordUserId String
+  createdAt     DateTime @default(now())
+  updatedAt     DateTime @updatedAt
 }
 
 enum KickListSource {
@@ -90,13 +89,13 @@ model KickListEntry {
   createdAt     DateTime       @default(now())
   updatedAt     DateTime       @updatedAt
 
+  @@unique([guildId, playerTag, source])
   @@index([guildId, playerTag])
   @@index([guildId, source])
-  @@unique([guildId, playerTag, source])
 }
 
 model RecruitmentTemplate {
-  id         Int      @id @default(autoincrement())
+  id         Int                 @id @default(autoincrement())
   clanTag    String
   platform   RecruitmentPlatform
   subject    String?
@@ -104,8 +103,8 @@ model RecruitmentTemplate {
   focus      String
   body       String
   imageUrls  String[]
-  createdAt  DateTime @default(now())
-  updatedAt  DateTime @updatedAt
+  createdAt  DateTime            @default(now())
+  updatedAt  DateTime            @updatedAt
 
   @@unique([clanTag, platform])
   @@index([clanTag])
@@ -128,28 +127,28 @@ model RecruitmentCooldown {
 }
 
 model WarHistoryParticipant {
-  id              Int      @id @default(autoincrement())
-  clanTag         String
-  clanName        String?
-  opponentClanTag String?
+  id               Int       @id @default(autoincrement())
+  clanTag          String
+  clanName         String?
+  opponentClanTag  String?
   opponentClanName String?
-  warStartTime    DateTime
-  warEndTime      DateTime?
-  warState        String?
-  playerTag       String
-  playerName      String?
-  playerPosition  Int?
-  attacksUsed     Int
-  updatedAt       DateTime @updatedAt
-  createdAt       DateTime @default(now())
+  warStartTime     DateTime
+  warEndTime       DateTime?
+  warState         String?
+  playerTag        String
+  playerName       String?
+  playerPosition   Int?
+  attacksUsed      Int
+  updatedAt        DateTime  @updatedAt
+  createdAt        DateTime  @default(now())
 
   @@unique([clanTag, warStartTime, playerTag])
   @@index([clanTag, warStartTime])
   @@index([playerTag, warStartTime])
 }
 
-model WarHistoryAttack {
-  id               Int      @id @default(autoincrement())
+model WarAttacks {
+  id               Int       @id @default(autoincrement())
   warId            Int?
   clanTag          String
   clanName         String?
@@ -161,7 +160,7 @@ model WarHistoryAttack {
   playerTag        String
   playerName       String?
   playerPosition   Int?
-  attacksUsed      Int      @default(0)
+  attacksUsed      Int       @default(0)
   attackOrder      Int
   attackNumber     Int
   defenderTag      String?
@@ -171,8 +170,8 @@ model WarHistoryAttack {
   trueStars        Int
   destruction      Float
   attackSeenAt     DateTime
-  updatedAt        DateTime @updatedAt
-  createdAt        DateTime @default(now())
+  updatedAt        DateTime  @updatedAt
+  createdAt        DateTime  @default(now())
 
   @@unique([clanTag, warStartTime, playerTag, attackOrder])
   @@index([clanTag, warStartTime])
@@ -180,38 +179,38 @@ model WarHistoryAttack {
   @@index([warId])
 }
 
-model WarEventLogSubscription {
-  id               Int      @id @default(autoincrement())
-  guildId          String
-  clanTag          String
-  warId            Int?
-  channelId        String
-  notify           Boolean  @default(true)
-  pingRole         Boolean  @default(true)
-  inferredMatchType Boolean @default(true)
-  notifyRole       String?
-  fwaPoints        Int?
+model CurrentWar {
+  id                Int           @id @default(autoincrement())
+  guildId           String
+  clanTag           String
+  warId             Int?
+  channelId         String
+  notify            Boolean       @default(true)
+  pingRole          Boolean       @default(true)
+  inferredMatchType Boolean       @default(true)
+  notifyRole        String?
+  fwaPoints         Int?
   opponentFwaPoints Int?
-  outcome          String?
-  matchType        WarMatchType?
+  outcome           String?
+  matchType         WarMatchType?
   warStartFwaPoints Int?
-  warEndFwaPoints  Int?
-  lastClanStars    Int?
+  warEndFwaPoints   Int?
+  lastClanStars     Int?
   lastOpponentStars Int?
-  lastState        String?
-  lastWarStartTime DateTime?
-  lastOpponentTag  String?
-  lastOpponentName String?
-  clanName         String?
-  createdAt        DateTime @default(now())
-  updatedAt        DateTime @updatedAt
+  lastState         String?
+  lastWarStartTime  DateTime?
+  lastOpponentTag   String?
+  lastOpponentName  String?
+  clanName          String?
+  createdAt         DateTime      @default(now())
+  updatedAt         DateTime      @updatedAt
 
   @@unique([guildId, clanTag])
   @@index([guildId, notify])
   @@index([warId])
 }
 
-model WarClanHistory {
+model ClanWarHistory {
   warId               Int           @id @default(autoincrement())
   syncNumber          Int?
   matchType           WarMatchType?
@@ -242,5 +241,5 @@ model WarLookup {
   payload    Json
   createdAt  DateTime       @default(now())
   updatedAt  DateTime       @updatedAt
-  warHistory WarClanHistory @relation(fields: [warId], references: [warId], onDelete: Cascade)
+  warHistory ClanWarHistory @relation(fields: [warId], references: [warId], onDelete: Cascade)
 }

--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -658,7 +658,7 @@ async function upsertCurrentWarHistoryAndGetWarId(params: {
       ? params.warStartMs
       : parseCocApiTime(params.war?.startTime);
   if (resolvedWarStartMs === null || !Number.isFinite(resolvedWarStartMs)) {
-    const fallback = await prisma.warClanHistory.findFirst({
+    const fallback = await prisma.clanWarHistory.findFirst({
       where: { clanTag: `#${params.normalizedTag}` },
       orderBy: { warStartTime: "desc" },
       select: { warId: true },
@@ -677,7 +677,7 @@ async function upsertCurrentWarHistoryAndGetWarId(params: {
   }
 
   const warStartTime = new Date(resolvedWarStartMs);
-  const saved = await prisma.warClanHistory.upsert({
+  const saved = await prisma.clanWarHistory.upsert({
     where: {
       clanTag_warStartTime: {
         clanTag: `#${params.normalizedTag}`,
@@ -729,7 +729,7 @@ async function getCurrentWarIdForClan(
   warStartMs: number | null
 ): Promise<number | null> {
   if (warStartMs !== null && Number.isFinite(warStartMs)) {
-    const exact = await prisma.warClanHistory.findFirst({
+    const exact = await prisma.clanWarHistory.findFirst({
       where: {
         clanTag: `#${normalizedTag}`,
         warStartTime: new Date(warStartMs),
@@ -739,7 +739,7 @@ async function getCurrentWarIdForClan(
     });
     if (exact?.warId) return exact.warId;
   }
-  const fallback = await prisma.warClanHistory.findFirst({
+  const fallback = await prisma.clanWarHistory.findFirst({
     where: { clanTag: `#${normalizedTag}` },
     orderBy: { warStartTime: "desc" },
     select: { warId: true },
@@ -780,7 +780,7 @@ async function buildWarMailEmbedForTag(
   const clanName =
     trackedConfig.name ?? sanitizeClanName(String(war?.clan?.name ?? "")) ?? `#${normalizedTag}`;
 
-  const subscription = await prisma.warEventLogSubscription.findUnique({
+  const subscription = await prisma.currentWar.findUnique({
     where: {
       guildId_clanTag: {
         guildId,
@@ -1402,7 +1402,7 @@ export async function handleFwaMatchTypeActionButton(interaction: ButtonInteract
     return;
   }
 
-  const existingSub = await prisma.warEventLogSubscription.findUnique({
+  const existingSub = await prisma.currentWar.findUnique({
     where: {
       guildId_clanTag: {
         guildId: interaction.guildId,
@@ -1413,7 +1413,7 @@ export async function handleFwaMatchTypeActionButton(interaction: ButtonInteract
   });
   const didMatchTypeChange = existingSub?.matchType !== parsed.targetType;
 
-  await prisma.warEventLogSubscription.upsert({
+  await prisma.currentWar.upsert({
     where: {
       guildId_clanTag: {
         guildId: interaction.guildId,
@@ -1551,7 +1551,7 @@ export async function handleFwaOutcomeActionButton(interaction: ButtonInteractio
   }
 
   const nextOutcome = parsed.currentOutcome === "WIN" ? "LOSE" : "WIN";
-  await prisma.warEventLogSubscription.upsert({
+  await prisma.currentWar.upsert({
     where: {
       guildId_clanTag: {
         guildId: interaction.guildId,
@@ -1673,7 +1673,7 @@ export async function handleFwaMatchSyncActionButton(
     return;
   }
 
-  await prisma.warEventLogSubscription.upsert({
+  await prisma.currentWar.upsert({
     where: {
       guildId_clanTag: {
         guildId: interaction.guildId,
@@ -2721,7 +2721,7 @@ async function buildLastWarMatchOverview(
   previousSync: number | null
 ): Promise<string | null> {
   const normalizedTag = normalizeTag(clanTag);
-  const lastWar = await prisma.warHistoryAttack.findFirst({
+  const lastWar = await prisma.warAttacks.findFirst({
     where: {
       clanTag: `#${normalizedTag}`,
       warEndTime: { not: null },
@@ -2738,7 +2738,7 @@ async function buildLastWarMatchOverview(
 
   if (!lastWar) return null;
 
-  const participants = await prisma.warHistoryAttack.findMany({
+  const participants = await prisma.warAttacks.findMany({
     where: {
       clanTag: `#${normalizedTag}`,
       warStartTime: lastWar.warStartTime,
@@ -2755,12 +2755,12 @@ async function buildLastWarMatchOverview(
 
   const starsRow = await prisma.$queryRaw<Array<{ stars: number }>>`
     SELECT COALESCE(SUM("trueStars"), 0)::int AS "stars"
-    FROM "WarHistoryAttack"
+    FROM "WarAttacks"
     WHERE "clanTag" = ${`#${normalizedTag}`} AND "warStartTime" = ${lastWar.warStartTime}
   `;
   const clanStarsTracked = Number(starsRow[0]?.stars ?? 0);
 
-  const sub = await prisma.warEventLogSubscription.findFirst({
+  const sub = await prisma.currentWar.findFirst({
     where: {
       clanTag: `#${normalizedTag}`,
       ...(guildId ? { guildId } : {}),
@@ -2845,7 +2845,7 @@ async function buildTrackedMatchOverview(
     };
   }
 
-  const subscriptions = await prisma.warEventLogSubscription.findMany({
+  const subscriptions = await prisma.currentWar.findMany({
     where: guildId ? { guildId } : undefined,
     select: {
       clanTag: true,
@@ -3036,7 +3036,7 @@ async function buildTrackedMatchOverview(
       (sub?.outcome as "WIN" | "LOSE" | null | undefined) ??
       (matchType === "FWA" ? derivedOutcome : null);
     if (matchTypeResolved === null && inferredFromPointsType && guildId) {
-      await prisma.warEventLogSubscription.upsert({
+      await prisma.currentWar.upsert({
         where: {
           guildId_clanTag: {
             guildId,
@@ -3085,7 +3085,7 @@ async function buildTrackedMatchOverview(
         },
       });
     } else if (guildId) {
-      await prisma.warEventLogSubscription.upsert({
+      await prisma.currentWar.upsert({
         where: {
           guildId_clanTag: {
             guildId,
@@ -3627,7 +3627,7 @@ export const Fwa: Command = {
       }
 
       if (shouldOverwritePoints && interaction.guildId) {
-        await prisma.warEventLogSubscription.upsert({
+        await prisma.currentWar.upsert({
           where: {
             guildId_clanTag: {
               guildId: interaction.guildId,
@@ -3736,7 +3736,7 @@ export const Fwa: Command = {
         { fwaPoints: number | null }
       >();
       if (interaction.guildId) {
-        const subs = await prisma.warEventLogSubscription.findMany({
+        const subs = await prisma.currentWar.findMany({
           where: { guildId: interaction.guildId },
           select: { clanTag: true, fwaPoints: true },
         });
@@ -3972,7 +3972,7 @@ export const Fwa: Command = {
           );
         }
         const subscription = interaction.guildId
-          ? await prisma.warEventLogSubscription.findUnique({
+          ? await prisma.currentWar.findUnique({
               where: {
                 guildId_clanTag: {
                   guildId: interaction.guildId,
@@ -4034,7 +4034,7 @@ export const Fwa: Command = {
           (subscription?.outcome as "WIN" | "LOSE" | null | undefined) ??
           (matchType === "FWA" ? derivedOutcome : null);
         if (interaction.guildId) {
-          await prisma.warEventLogSubscription.upsert({
+          await prisma.currentWar.upsert({
             where: {
               guildId_clanTag: {
                 guildId: interaction.guildId,
@@ -4346,7 +4346,7 @@ export const Fwa: Command = {
         "Unknown Clan";
       const subscription =
         interaction.guildId
-          ? await prisma.warEventLogSubscription.findUnique({
+          ? await prisma.currentWar.findUnique({
               where: {
                 guildId_clanTag: {
                   guildId: interaction.guildId,
@@ -4458,6 +4458,7 @@ export const Fwa: Command = {
     await interaction.respond(choices);
   },
 };
+
 
 
 

--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -159,7 +159,7 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
   war: {
     summary: "Query clan-level war history and export war attack payload by war ID.",
     details: [
-      "`/war history` shows recent clan-level war summary rows from WarClanHistory.",
+      "`/war history` shows recent clan-level war summary rows from ClanWarHistory.",
       "`/war war-id` exports the stored WarLookup payload as a CSV file for drill-down review.",
       "Use war IDs returned from `/war history` to retrieve detailed attack rows.",
     ],
@@ -672,3 +672,4 @@ export const Help: Command = {
     );
   },
 };
+

--- a/src/commands/Inactive.ts
+++ b/src/commands/Inactive.ts
@@ -352,7 +352,7 @@ async function runWarsMode(
     const selectedWars = await prisma.$queryRaw<Array<{ warStartTime: Date }>>(
       Prisma.sql`
         SELECT DISTINCT "warStartTime"
-        FROM "WarHistoryAttack"
+        FROM "WarAttacks"
         WHERE
           "clanTag" = ${clanTag}
           AND "attackOrder" = 0
@@ -382,7 +382,7 @@ async function runWarsMode(
           "playerName",
           "playerPosition",
           "attacksUsed"
-        FROM "WarHistoryAttack"
+        FROM "WarAttacks"
         WHERE
           "clanTag" = ${clanTag}
           AND "attackOrder" = 0
@@ -512,4 +512,5 @@ export const Inactive: Command = {
     await runWarsMode(interaction, cocService, warsValue);
   },
 };
+
 

--- a/src/commands/Notify.ts
+++ b/src/commands/Notify.ts
@@ -286,7 +286,7 @@ export const Notify: Command = {
       >(
         Prisma.sql`
           SELECT "clanTag","channelId","notifyRole","notify","pingRole"
-          FROM "WarEventLogSubscription"
+          FROM "CurrentWar"
           WHERE "guildId" = ${interaction.guildId}
         `
       );
@@ -343,7 +343,7 @@ export const Notify: Command = {
         target === "war_embed"
           ? await prisma.$executeRaw(
               Prisma.sql`
-                UPDATE "WarEventLogSubscription"
+                UPDATE "CurrentWar"
                 SET "notify" = ${enabled}, "updatedAt" = NOW()
                 WHERE "guildId" = ${interaction.guildId}
                   AND UPPER(REPLACE("clanTag",'#','')) = ${normalizeClanTagInput(clanTag)}
@@ -351,7 +351,7 @@ export const Notify: Command = {
             )
           : await prisma.$executeRaw(
               Prisma.sql`
-                UPDATE "WarEventLogSubscription"
+                UPDATE "CurrentWar"
                 SET "pingRole" = ${enabled}, "updatedAt" = NOW()
                 WHERE "guildId" = ${interaction.guildId}
                   AND UPPER(REPLACE("clanTag",'#','')) = ${normalizeClanTagInput(clanTag)}
@@ -464,7 +464,7 @@ export const Notify: Command = {
     const warId =
       warStartTime && clanTag
         ? (
-            await prisma.warClanHistory
+            await prisma.clanWarHistory
               .findUnique({
                 where: {
                   clanTag_warStartTime: {
@@ -480,7 +480,7 @@ export const Notify: Command = {
 
     await prisma.$executeRaw(
       Prisma.sql`
-        INSERT INTO "WarEventLogSubscription"
+        INSERT INTO "CurrentWar"
           ("guildId","clanTag","warId","channelId","notify","notifyRole","pingRole","lastState","lastWarStartTime","lastOpponentTag","lastOpponentName","clanName","createdAt","updatedAt")
         VALUES
           (${interaction.guildId}, ${clanTag}, ${warId}, ${target.id}, true, ${notifyRole?.id ?? null}, ${rolePingEnabled}, ${lastState}, ${warStartTime}, ${opponentTag}, ${opponentName}, ${clanName}, NOW(), NOW())
@@ -541,3 +541,4 @@ export const Notify: Command = {
     await interaction.respond(choices);
   },
 };
+

--- a/src/commands/War.ts
+++ b/src/commands/War.ts
@@ -120,7 +120,7 @@ export const War: Command = {
         Prisma.sql`
           SELECT
             "warId","syncNumber","matchType","clanStars","clanDestruction","opponentStars","opponentDestruction","fwaPointsGained","expectedOutcome","actualOutcome","enemyPoints","warStartTime","warEndTime","clanName","clanTag","opponentName","opponentTag"
-          FROM "WarClanHistory"
+          FROM "ClanWarHistory"
           WHERE UPPER(REPLACE("clanTag",'#','')) = ${tagBare}
           ORDER BY "warStartTime" DESC
           LIMIT ${limit}
@@ -257,4 +257,5 @@ export const War: Command = {
     await interaction.respond(choices);
   },
 };
+
 

--- a/src/services/WarEventLogService.ts
+++ b/src/services/WarEventLogService.ts
@@ -240,7 +240,7 @@ export class WarEventLogService {
       Prisma.sql`
         SELECT
           "id","guildId","clanTag","warId","channelId","notify","pingRole","inferredMatchType","notifyRole","fwaPoints","opponentFwaPoints","outcome","matchType","warStartFwaPoints","warEndFwaPoints","lastClanStars","lastOpponentStars","lastState","lastWarStartTime","lastOpponentTag","lastOpponentName","clanName"
-        FROM "WarEventLogSubscription"
+        FROM "CurrentWar"
         WHERE "notify" = true
         ORDER BY "updatedAt" ASC
       `
@@ -324,7 +324,7 @@ export class WarEventLogService {
         : null;
     const lastWarRow =
       params.source === "last"
-        ? await prisma.warHistoryAttack.findFirst({
+        ? await prisma.warAttacks.findFirst({
             where: { clanTag: normalizeTag(sub.clanTag), warEndTime: { not: null }, attackOrder: 0 },
             orderBy: { warStartTime: "desc" },
             select: {
@@ -714,7 +714,7 @@ export class WarEventLogService {
       Prisma.sql`
         SELECT
           "id","guildId","clanTag","warId","channelId","notify","pingRole","inferredMatchType","notifyRole","fwaPoints","opponentFwaPoints","outcome","matchType","warStartFwaPoints","warEndFwaPoints","lastClanStars","lastOpponentStars","lastState","lastWarStartTime","lastOpponentTag","lastOpponentName","clanName"
-        FROM "WarEventLogSubscription"
+        FROM "CurrentWar"
         WHERE "guildId" = ${guildId} AND UPPER(REPLACE("clanTag",'#','')) = ${normalizeTagBare(clanTag)}
         LIMIT 1
       `
@@ -725,7 +725,7 @@ export class WarEventLogService {
   /** Purpose: has war end recorded. */
   private async hasWarEndRecorded(clanTagInput: string, warStartTime: Date): Promise<boolean> {
     const clanTag = normalizeTag(clanTagInput);
-    const existing = await prisma.warClanHistory.findUnique({
+    const existing = await prisma.clanWarHistory.findUnique({
       where: { clanTag_warStartTime: { clanTag, warStartTime } },
       select: { warId: true },
     });
@@ -753,7 +753,7 @@ export class WarEventLogService {
       Prisma.sql`
         SELECT
           "id","guildId","clanTag","warId","channelId","notify","pingRole","inferredMatchType","notifyRole","fwaPoints","opponentFwaPoints","outcome","matchType","warStartFwaPoints","warEndFwaPoints","lastClanStars","lastOpponentStars","lastState","lastWarStartTime","lastOpponentTag","lastOpponentName","clanName"
-        FROM "WarEventLogSubscription"
+        FROM "CurrentWar"
         WHERE "id" = ${subscriptionId}
         LIMIT 1
       `
@@ -996,7 +996,7 @@ export class WarEventLogService {
     const resolvedWarId =
       currentState === "notInWar" ? null : await this.resolveWarId(sub.clanTag, nextWarStartTime);
 
-    await prisma.warEventLogSubscription.update({
+    await prisma.currentWar.update({
       where: { id: sub.id },
       data: {
         warId: resolvedWarId,
@@ -1025,7 +1025,7 @@ export class WarEventLogService {
     const clanTag = normalizeTag(clanTagInput);
     if (!clanTag) return null;
     return (
-      await prisma.warClanHistory
+      await prisma.clanWarHistory
         .findUnique({
           where: {
             clanTag_warStartTime: {
@@ -1472,7 +1472,7 @@ export class WarEventLogService {
     const warId =
       warStartTime && normalizeTag(payload.clanTag)
         ? (
-            await prisma.warClanHistory.findUnique({
+            await prisma.clanWarHistory.findUnique({
               where: {
                 clanTag_warStartTime: { clanTag: normalizeTag(payload.clanTag), warStartTime },
               },
@@ -1509,7 +1509,7 @@ export class WarEventLogService {
   }): Promise<void> {
     const clanTag = normalizeTag(input.clanTag);
     if (!clanTag || !input.warStartTime) return;
-    await prisma.warClanHistory.upsert({
+    await prisma.clanWarHistory.upsert({
       where: {
         clanTag_warStartTime: {
           clanTag,
@@ -1672,3 +1672,4 @@ export async function handleNotifyWarRefreshButton(
 }
 
 export const notifyWarBattleDayRefreshIntervalMs = BATTLE_DAY_REFRESH_MS;
+

--- a/src/services/WarHistoryService.ts
+++ b/src/services/WarHistoryService.ts
@@ -37,7 +37,7 @@ export class WarHistoryService {
 
   private async resolveWarId(clanTag: string, warStartTime: Date): Promise<number | null> {
     return (
-      await prisma.warClanHistory
+      await prisma.clanWarHistory
         .findUnique({
           where: {
             clanTag_warStartTime: {
@@ -92,7 +92,7 @@ export class WarHistoryService {
 
         await prisma.$executeRaw(
           Prisma.sql`
-            INSERT INTO "WarHistoryAttack"
+            INSERT INTO "WarAttacks"
               ("warId","clanTag","clanName","opponentClanTag","opponentClanName","warStartTime","warEndTime","warState","playerTag","playerName","playerPosition","attacksUsed","attackOrder","attackNumber","defenderTag","defenderName","defenderPosition","stars","trueStars","destruction","attackSeenAt","createdAt","updatedAt")
             VALUES
               (${warId}, ${ownClanTag}, ${ownClanName}, ${opponentClanTag || null}, ${opponentClanName || null}, ${warStartTime}, ${warEndTime}, ${warState}, ${playerTag}, ${playerName}, ${playerPosition}, ${sortedAttacks.length}, 0, 0, NULL, NULL, NULL, 0, 0, 0, ${observedAt}, NOW(), NOW())
@@ -134,7 +134,7 @@ export class WarHistoryService {
 
           await prisma.$executeRaw(
             Prisma.sql`
-              INSERT INTO "WarHistoryAttack"
+              INSERT INTO "WarAttacks"
                 ("warId","clanTag","clanName","opponentClanTag","opponentClanName","warStartTime","warEndTime","warState","playerTag","playerName","playerPosition","attacksUsed","attackOrder","attackNumber","defenderTag","defenderName","defenderPosition","stars","trueStars","destruction","attackSeenAt","createdAt","updatedAt")
               VALUES
                 (${warId}, ${ownClanTag}, ${ownClanName}, ${opponentClanTag || null}, ${opponentClanName || null}, ${warStartTime}, ${warEndTime}, ${warState}, ${playerTag}, ${playerName}, ${playerPosition}, ${sortedAttacks.length}, ${attackOrder}, ${attackNum}, ${defenderTag || null}, ${defenderName}, ${defenderPosition}, ${stars}, ${trueStars}, ${destruction}, ${observedAt}, NOW(), NOW())
@@ -167,3 +167,4 @@ export class WarHistoryService {
     }
   }
 }
+

--- a/src/services/war-events/history.ts
+++ b/src/services/war-events/history.ts
@@ -139,7 +139,7 @@ export class WarEventHistoryService {
     const warStartTime =
       payload.warStartTime ??
       (
-        await prisma.warHistoryAttack.findFirst({
+        await prisma.warAttacks.findFirst({
           where: { clanTag, warEndTime: { not: null }, attackOrder: 0 },
           orderBy: { warStartTime: "desc" },
           select: { warStartTime: true },
@@ -155,13 +155,13 @@ export class WarEventHistoryService {
       fallbackOpponentStars: payload.lastOpponentStars,
       warStartTime,
     });
-    const attacks = await prisma.warHistoryAttack.findMany({
+    const attacks = await prisma.warAttacks.findMany({
       where: { clanTag, warStartTime },
       orderBy: [{ attackSeenAt: "asc" }, { attackOrder: "asc" }, { playerTag: "asc" }],
     });
     const warEndTime =
       finalResult.warEndTime ??
-      (await prisma.warHistoryAttack.findFirst({
+      (await prisma.warAttacks.findFirst({
         where: { clanTag, warStartTime, attackOrder: 0 },
         orderBy: { updatedAt: "desc" },
         select: { warEndTime: true },
@@ -183,7 +183,7 @@ export class WarEventHistoryService {
 
     const row = await prisma.$queryRaw<Array<{ warId: number }>>(
       Prisma.sql`
-        INSERT INTO "WarClanHistory"
+        INSERT INTO "ClanWarHistory"
           ("syncNumber","matchType","clanStars","clanDestruction","opponentStars","opponentDestruction","fwaPointsGained","expectedOutcome","actualOutcome","enemyPoints","warStartTime","warEndTime","clanName","clanTag","opponentName","opponentTag","updatedAt")
         VALUES
           (${payload.syncNumber}, ${payload.matchType}, ${finalResult.clanStars}, ${finalResult.clanDestruction}, ${finalResult.opponentStars}, ${finalResult.opponentDestruction}, ${pointsDelta}, ${payload.outcome}, ${finalResult.resultLabel}, ${enemyPoints}, ${warStartTime}, ${warEndTime}, ${payload.clanName}, ${clanTag}, ${payload.opponentName}, ${normalizeTag(payload.opponentTag) || null}, NOW())
@@ -210,11 +210,11 @@ export class WarEventHistoryService {
     const warId = Number(row[0]?.warId ?? NaN);
     if (!Number.isFinite(warId)) return;
 
-    await prisma.warHistoryAttack.updateMany({
+    await prisma.warAttacks.updateMany({
       where: { clanTag, warStartTime },
       data: { warId },
     });
-    await prisma.warEventLogSubscription.updateMany({
+    await prisma.currentWar.updateMany({
       where: { clanTag, lastWarStartTime: warStartTime },
       data: { warId },
     });
@@ -297,7 +297,7 @@ export class WarEventHistoryService {
     const warStartTime = preferredWarStartTime
       ? preferredWarStartTime
       : (
-          await prisma.warHistoryAttack.findFirst({
+          await prisma.warAttacks.findFirst({
             where: { clanTag, warEndTime: { not: null }, attackOrder: 0 },
             orderBy: { warStartTime: "desc" },
             select: { warStartTime: true },
@@ -307,12 +307,12 @@ export class WarEventHistoryService {
       return { missedBoth: [], notFollowingPlan: [] };
     }
 
-    const participants = await prisma.warHistoryAttack.findMany({
+    const participants = await prisma.warAttacks.findMany({
       where: { clanTag, warStartTime, attackOrder: 0 },
       select: { playerName: true, playerTag: true, attacksUsed: true, playerPosition: true },
       orderBy: [{ playerPosition: "asc" }, { playerName: "asc" }],
     });
-    const attacks = await prisma.warHistoryAttack.findMany({
+    const attacks = await prisma.warAttacks.findMany({
       where: { clanTag, warStartTime },
       select: {
         playerTag: true,
@@ -363,4 +363,5 @@ export class WarEventHistoryService {
     return computeWarPointsDeltaForTest(input);
   }
 }
+
 


### PR DESCRIPTION
…rHistory

- rename Prisma models and client usages to the new table names
- update raw SQL queries in commands/services to target renamed tables
- add migration to rename physical Postgres tables and ClanWarHistory sequence