### PR TITLE
fix(sync): use ClanWarHistory syncNumber as sync source of truth

### DIFF
--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -2212,19 +2212,18 @@ function getSyncMode(syncNumber: number | null): "low" | "high" | null {
 
 async function getSourceOfTruthSync(
   settings: SettingsService,
-  guildId?: string | null
+  _guildId?: string | null
 ): Promise<number | null> {
-  const latestCurrent = await prisma.currentWar.findFirst({
+  const latestHistory = await prisma.clanWarHistory.findFirst({
     where: {
-      currentSyncNum: { not: null },
-      ...(guildId ? { guildId } : {}),
+      syncNumber: { not: null },
     },
-    orderBy: { updatedAt: "desc" },
-    select: { currentSyncNum: true },
+    orderBy: { warStartTime: "desc" },
+    select: { syncNumber: true },
   });
-  const currentSync = Number(latestCurrent?.currentSyncNum ?? NaN);
-  if (Number.isFinite(currentSync)) {
-    return Math.max(0, Math.trunc(currentSync) - 1);
+  const latestSync = Number(latestHistory?.syncNumber ?? NaN);
+  if (Number.isFinite(latestSync)) {
+    return Math.max(0, Math.trunc(latestSync) - 1);
   }
   const raw = await settings.get(PREVIOUS_SYNC_KEY);
   if (!raw) return null;

--- a/src/services/war-events/pointsSync.ts
+++ b/src/services/war-events/pointsSync.ts
@@ -64,14 +64,14 @@ export class WarStartPointsSyncService {
 
   /** Purpose: read previous sync from settings or recover it from points site state. */
   async getPreviousSyncNum(): Promise<number | null> {
-    const latestCurrent = await prisma.currentWar.findFirst({
-      where: { currentSyncNum: { not: null } },
-      orderBy: { updatedAt: "desc" },
-      select: { currentSyncNum: true },
+    const latestHistory = await prisma.clanWarHistory.findFirst({
+      where: { syncNumber: { not: null } },
+      orderBy: { warStartTime: "desc" },
+      select: { syncNumber: true },
     });
-    const currentSync = Number(latestCurrent?.currentSyncNum ?? NaN);
-    if (Number.isFinite(currentSync)) {
-      return Math.max(0, Math.trunc(currentSync) - 1);
+    const latestSync = Number(latestHistory?.syncNumber ?? NaN);
+    if (Number.isFinite(latestSync)) {
+      return Math.max(0, Math.trunc(latestSync) - 1);
     }
     const raw = await this.settings.get(WarStartPointsSyncService.PREVIOUS_SYNC_KEY);
     const parsed = raw === null ? NaN : Number(raw);


### PR DESCRIPTION
- prefer latest ClanWarHistory.syncNumber when resolving sync context
- derive previous sync as syncNumber - 1 for tie-break calculations
- keep BotSetting.previousSyncNum as fallback when history sync is unavailable