### PR TITLE
feat(db): update war unique keys for war-centric lookups

### DIFF
--- a/prisma/migrations/20260303213000_update_war_unique_keys/migration.sql
+++ b/prisma/migrations/20260303213000_update_war_unique_keys/migration.sql
@@ -1,0 +1,15 @@
+-- Update war table unique constraints.
+
+-- WarAttacks: use warId + playerTag + attackNumber.
+DROP INDEX IF EXISTS "WarAttacks_clanTag_warStartTime_playerTag_attackOrder_key";
+CREATE UNIQUE INDEX "WarAttacks_warId_playerTag_attackNumber_key"
+ON "WarAttacks"("warId", "playerTag", "attackNumber");
+
+-- ClanWarHistory: include opponentTag in the war identity.
+DROP INDEX IF EXISTS "ClanWarHistory_clanTag_warStartTime_key";
+CREATE UNIQUE INDEX "ClanWarHistory_warStartTime_clanTag_opponentTag_key"
+ON "ClanWarHistory"("warStartTime", "clanTag", "opponentTag");
+
+-- CurrentWar: add an index for current-war identity fields.
+CREATE INDEX IF NOT EXISTS "CurrentWar_lastWarStartTime_clanTag_lastOpponentTag_idx"
+ON "CurrentWar"("lastWarStartTime", "clanTag", "lastOpponentTag");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -173,7 +173,7 @@ model WarAttacks {
   updatedAt        DateTime  @updatedAt
   createdAt        DateTime  @default(now())
 
-  @@unique([clanTag, warStartTime, playerTag, attackOrder])
+  @@unique([warId, playerTag, attackNumber])
   @@index([clanTag, warStartTime])
   @@index([playerTag, warStartTime])
   @@index([warId])
@@ -209,6 +209,7 @@ model CurrentWar {
   @@unique([guildId, clanTag])
   @@index([guildId, notify])
   @@index([warId])
+  @@index([lastWarStartTime, clanTag, lastOpponentTag])
 }
 
 model ClanWarHistory {
@@ -233,7 +234,7 @@ model ClanWarHistory {
   updatedAt           DateTime      @updatedAt
   lookup              WarLookup?
 
-  @@unique([clanTag, warStartTime])
+  @@unique([warStartTime, clanTag, opponentTag])
   @@index([clanTag, warEndTime])
 }
 


### PR DESCRIPTION
- change WarAttacks unique key to (warId, playerTag, attackNumber)
- change ClanWarHistory unique key to (warStartTime, clanTag, opponentTag)
- add CurrentWar index on (lastWarStartTime, clanTag, lastOpponentTag)
- keep CurrentWar guildId+clanTag unique identity to preserve notify upsert flows