### PR TITLE
fix(war-history): resolve Prisma unique-key build failures across env…

### DIFF
--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -681,43 +681,40 @@ async function upsertCurrentWarHistoryAndGetWarId(params: {
   }
 
   const warStartTime = new Date(resolvedWarStartMs);
-  const saved = await prisma.clanWarHistory.upsert({
-    where: {
-      clanTag_warStartTime: {
-        clanTag: `#${params.normalizedTag}`,
-        warStartTime,
-      },
-    },
-    create: {
-      syncNumber: params.currentSync,
-      matchType: toWarMatchTypeOrNull(params.matchType),
-      clanStars: parseNullableInt(params.war?.clan?.stars),
-      clanDestruction: parseNullableFloat(params.war?.clan?.destructionPercentage),
-      opponentStars: parseNullableInt(params.war?.opponent?.stars),
-      opponentDestruction: parseNullableFloat(params.war?.opponent?.destructionPercentage),
-      expectedOutcome: params.expectedOutcome,
-      warStartTime,
-      warEndTime: resolvedWarEndMs !== null ? new Date(resolvedWarEndMs) : null,
-      clanName: params.clanName,
-      clanTag: `#${params.normalizedTag}`,
-      opponentName: params.opponentName,
-      opponentTag: params.opponentTag ? `#${params.opponentTag}` : null,
-    },
-    update: {
-      syncNumber: params.currentSync,
-      matchType: toWarMatchTypeOrNull(params.matchType),
-      clanStars: parseNullableInt(params.war?.clan?.stars),
-      clanDestruction: parseNullableFloat(params.war?.clan?.destructionPercentage),
-      opponentStars: parseNullableInt(params.war?.opponent?.stars),
-      opponentDestruction: parseNullableFloat(params.war?.opponent?.destructionPercentage),
-      expectedOutcome: params.expectedOutcome,
-      warEndTime: resolvedWarEndMs !== null ? new Date(resolvedWarEndMs) : null,
-      clanName: params.clanName,
-      opponentName: params.opponentName,
-      opponentTag: params.opponentTag ? `#${params.opponentTag}` : null,
-    },
+  const normalizedOpponentTag = params.opponentTag ? `#${params.opponentTag}` : null;
+  const clanTag = `#${params.normalizedTag}`;
+  const upsertData = {
+    syncNumber: params.currentSync,
+    matchType: toWarMatchTypeOrNull(params.matchType),
+    clanStars: parseNullableInt(params.war?.clan?.stars),
+    clanDestruction: parseNullableFloat(params.war?.clan?.destructionPercentage),
+    opponentStars: parseNullableInt(params.war?.opponent?.stars),
+    opponentDestruction: parseNullableFloat(params.war?.opponent?.destructionPercentage),
+    expectedOutcome: params.expectedOutcome,
+    warEndTime: resolvedWarEndMs !== null ? new Date(resolvedWarEndMs) : null,
+    clanName: params.clanName,
+    opponentName: params.opponentName,
+    opponentTag: normalizedOpponentTag,
+  };
+  const existing = await prisma.clanWarHistory.findFirst({
+    where: { clanTag, warStartTime, opponentTag: normalizedOpponentTag },
+    orderBy: { warId: "desc" },
     select: { warId: true },
   });
+  const saved = existing?.warId
+    ? await prisma.clanWarHistory.update({
+        where: { warId: existing.warId },
+        data: upsertData,
+        select: { warId: true },
+      })
+    : await prisma.clanWarHistory.create({
+        data: {
+          ...upsertData,
+          warStartTime,
+          clanTag,
+        },
+        select: { warId: true },
+      });
   warHistoryUpsertDedupedAt.set(dedupeKey, Date.now());
   if (warHistoryUpsertDedupedAt.size > 500) {
     const cutoff = Date.now() - WAR_HISTORY_UPSERT_DEDUPE_MS * 2;

--- a/src/commands/Notify.ts
+++ b/src/commands/Notify.ts
@@ -465,13 +465,12 @@ export const Notify: Command = {
       warStartTime && clanTag
         ? (
             await prisma.clanWarHistory
-              .findUnique({
+              .findFirst({
                 where: {
-                  clanTag_warStartTime: {
-                    clanTag,
-                    warStartTime,
-                  },
+                  clanTag,
+                  warStartTime,
                 },
+                orderBy: { warId: "desc" },
                 select: { warId: true },
               })
               .catch(() => null)

--- a/src/services/WarEventLogService.ts
+++ b/src/services/WarEventLogService.ts
@@ -725,8 +725,9 @@ export class WarEventLogService {
   /** Purpose: has war end recorded. */
   private async hasWarEndRecorded(clanTagInput: string, warStartTime: Date): Promise<boolean> {
     const clanTag = normalizeTag(clanTagInput);
-    const existing = await prisma.clanWarHistory.findUnique({
-      where: { clanTag_warStartTime: { clanTag, warStartTime } },
+    const existing = await prisma.clanWarHistory.findFirst({
+      where: { clanTag, warStartTime },
+      orderBy: { warId: "desc" },
       select: { warId: true },
     });
     return Boolean(existing?.warId);
@@ -1030,13 +1031,12 @@ export class WarEventLogService {
     if (!clanTag) return null;
     return (
       await prisma.clanWarHistory
-        .findUnique({
+        .findFirst({
           where: {
-            clanTag_warStartTime: {
-              clanTag,
-              warStartTime,
-            },
+            clanTag,
+            warStartTime,
           },
+          orderBy: { warId: "desc" },
           select: { warId: true },
         })
         .catch(() => null)
@@ -1476,10 +1476,12 @@ export class WarEventLogService {
     const warId =
       warStartTime && normalizeTag(payload.clanTag)
         ? (
-            await prisma.clanWarHistory.findUnique({
+            await prisma.clanWarHistory.findFirst({
               where: {
-                clanTag_warStartTime: { clanTag: normalizeTag(payload.clanTag), warStartTime },
+                clanTag: normalizeTag(payload.clanTag),
+                warStartTime,
               },
+              orderBy: { warId: "desc" },
               select: { warId: true },
             })
           )?.warId ?? null
@@ -1513,40 +1515,37 @@ export class WarEventLogService {
   }): Promise<void> {
     const clanTag = normalizeTag(input.clanTag);
     if (!clanTag || !input.warStartTime) return;
-    await prisma.clanWarHistory.upsert({
-      where: {
-        clanTag_warStartTime: {
-          clanTag,
-          warStartTime: input.warStartTime,
-        },
-      },
-      create: {
-        syncNumber: input.syncNumber,
-        matchType: input.matchType,
-        clanStars: parseNullableInt(input.stats.clanStars),
-        clanDestruction: parseNullableFloat(input.stats.clanDestruction),
-        opponentStars: parseNullableInt(input.stats.opponentStars),
-        opponentDestruction: parseNullableFloat(input.stats.opponentDestruction),
-        expectedOutcome: input.expectedOutcome,
+    const opponentTag = normalizeTag(input.opponentTag) || null;
+    const upsertData = {
+      syncNumber: input.syncNumber,
+      matchType: input.matchType,
+      clanStars: parseNullableInt(input.stats.clanStars),
+      clanDestruction: parseNullableFloat(input.stats.clanDestruction),
+      opponentStars: parseNullableInt(input.stats.opponentStars),
+      opponentDestruction: parseNullableFloat(input.stats.opponentDestruction),
+      expectedOutcome: input.expectedOutcome,
+      warEndTime: input.warEndTime,
+      clanName: input.clanName,
+      opponentName: input.opponentName,
+      opponentTag,
+    };
+    const existing = await prisma.clanWarHistory.findFirst({
+      where: { clanTag, warStartTime: input.warStartTime, opponentTag },
+      orderBy: { warId: "desc" },
+      select: { warId: true },
+    });
+    if (existing?.warId) {
+      await prisma.clanWarHistory.update({
+        where: { warId: existing.warId },
+        data: upsertData,
+      });
+      return;
+    }
+    await prisma.clanWarHistory.create({
+      data: {
+        ...upsertData,
         warStartTime: input.warStartTime,
-        warEndTime: input.warEndTime,
-        clanName: input.clanName,
         clanTag,
-        opponentName: input.opponentName,
-        opponentTag: normalizeTag(input.opponentTag) || null,
-      },
-      update: {
-        syncNumber: input.syncNumber,
-        matchType: input.matchType,
-        clanStars: parseNullableInt(input.stats.clanStars),
-        clanDestruction: parseNullableFloat(input.stats.clanDestruction),
-        opponentStars: parseNullableInt(input.stats.opponentStars),
-        opponentDestruction: parseNullableFloat(input.stats.opponentDestruction),
-        expectedOutcome: input.expectedOutcome,
-        warEndTime: input.warEndTime,
-        clanName: input.clanName,
-        opponentName: input.opponentName,
-        opponentTag: normalizeTag(input.opponentTag) || null,
       },
     });
   }

--- a/src/services/WarHistoryService.ts
+++ b/src/services/WarHistoryService.ts
@@ -38,13 +38,12 @@ export class WarHistoryService {
   private async resolveWarId(clanTag: string, warStartTime: Date): Promise<number | null> {
     return (
       await prisma.clanWarHistory
-        .findUnique({
+        .findFirst({
           where: {
-            clanTag_warStartTime: {
-              clanTag,
-              warStartTime,
-            },
+            clanTag,
+            warStartTime,
           },
+          orderBy: { warId: "desc" },
           select: { warId: true },
         })
         .catch(() => null)

--- a/src/services/war-events/history.ts
+++ b/src/services/war-events/history.ts
@@ -187,7 +187,7 @@ export class WarEventHistoryService {
           ("syncNumber","matchType","clanStars","clanDestruction","opponentStars","opponentDestruction","fwaPointsGained","expectedOutcome","actualOutcome","enemyPoints","warStartTime","warEndTime","clanName","clanTag","opponentName","opponentTag","updatedAt")
         VALUES
           (${payload.syncNumber}, ${payload.matchType}, ${finalResult.clanStars}, ${finalResult.clanDestruction}, ${finalResult.opponentStars}, ${finalResult.opponentDestruction}, ${pointsDelta}, ${payload.outcome}, ${finalResult.resultLabel}, ${enemyPoints}, ${warStartTime}, ${warEndTime}, ${payload.clanName}, ${clanTag}, ${payload.opponentName}, ${normalizeTag(payload.opponentTag) || null}, NOW())
-        ON CONFLICT ("clanTag","warStartTime")
+        ON CONFLICT ("warStartTime","clanTag","opponentTag")
         DO UPDATE SET
           "syncNumber" = EXCLUDED."syncNumber",
           "matchType" = EXCLUDED."matchType",


### PR DESCRIPTION
…ironments

- replace -based  usage with environment-safe lookup/update/create flows
- switch war history lookups to  with deterministic  ordering where compound unique aliases differ between generated Prisma clients
- update SQL  upsert conflict target to (, , ) to match current schema
- preserve  resolution and notification/history flows while restoring yarn run v1.22.19 $ tsc
Done in 4.29s. () success