### PR TITLE
feat(ci): align dev build Discord workflow with release-style embeds

### DIFF
--- a/.github/workflows/discord-dev-builds.yml
+++ b/.github/workflows/discord-dev-builds.yml
@@ -13,23 +13,18 @@ jobs:
     steps:
       - name: Send Dev Build Update to Discord
         env:
-          DISCORD_DEV_BUILD: ${{ secrets.DISCORD_DEV_BUILD }}
-          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          DISCORD_DEV_WEBHOOK_URL_DEV: ${{ secrets.DISCORD_DEV_WEBHOOK_URL_DEV }}
           WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
           RUN_NUMBER: ${{ github.event.workflow_run.run_number }}
-          RUN_URL: ${{ github.event.workflow_run.html_url }}
           COMMIT_SHA: ${{ github.event.workflow_run.head_sha }}
           COMMIT_MESSAGE: ${{ github.event.workflow_run.head_commit.message }}
-          ACTOR: ${{ github.event.workflow_run.actor.login }}
-          REPO: ${{ github.repository }}
           BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
           SHORT_SHA="${COMMIT_SHA:0:7}"
-          COMMIT_URL="https://github.com/${REPO}/commit/${COMMIT_SHA}"
-          WEBHOOK_BASE="${DISCORD_DEV_BUILD:-$DISCORD_WEBHOOK_URL}"
+          WEBHOOK_BASE="${DISCORD_DEV_WEBHOOK_URL_DEV}"
 
           if [[ -z "$WEBHOOK_BASE" ]]; then
-            echo "Missing Discord webhook secret. Set DISCORD_DEV_BUILD (preferred) or DISCORD_WEBHOOK_URL."
+            echo "Missing Discord webhook secret. Set DISCORD_DEV_WEBHOOK_URL_DEV."
             exit 1
           fi
 
@@ -39,34 +34,31 @@ jobs:
             WEBHOOK_ENDPOINT="${WEBHOOK_BASE}?wait=true&with_components=true"
           fi
 
+          SANITIZED_MESSAGE="$(printf '%s' "$COMMIT_MESSAGE" | sed -E 's/(from[[:space:]]+)[^[:space:]\/]+\/([^[:space:]]+)/\1\2/g')"
+          if [[ -z "$SANITIZED_MESSAGE" ]]; then
+            SANITIZED_MESSAGE="No commit message provided."
+          fi
+
           PAYLOAD="$(jq -n \
+            --arg role "1478455692569481347" \
             --arg title "Dev Build Succeeded" \
+            --arg branch "$BRANCH" \
+            --arg short_sha "$SHORT_SHA" \
             --arg workflow_name "$WORKFLOW_NAME" \
             --arg run_number "$RUN_NUMBER" \
-            --arg branch "$BRANCH" \
-            --arg actor "$ACTOR" \
-            --arg short_sha "$SHORT_SHA" \
-            --arg commit_msg "$COMMIT_MESSAGE" \
-            --arg run_url "$RUN_URL" \
-            --arg commit_url "$COMMIT_URL" \
+            --arg commit_msg "$SANITIZED_MESSAGE" \
             '{
+              content: ("<@&" + $role + ">"),
+              allowed_mentions: { roles: [$role] },
               username: "ClashCookies",
               embeds: [{
                 title: $title,
-                description: ("`" + $workflow_name + "` run #" + $run_number + " passed on `" + $branch + "`."),
+                description:
+                  ("`" + $workflow_name + "` run #" + $run_number + " passed on `" + $branch + "`.\n\n" +
+                   "## Highlights\n" +
+                   ($commit_msg | if length > 3800 then .[0:3800] + "..." else . end)),
                 color: 5763719,
-                fields: [
-                  { name: "Actor", value: $actor, inline: true },
-                  { name: "Commit", value: ("`" + $short_sha + "`"), inline: true },
-                  { name: "Message", value: ($commit_msg | if length > 1000 then .[0:1000] + "..." else . end), inline: false }
-                ]
-              }],
-              components: [{
-                type: 1,
-                components: [
-                  { type: 2, style: 5, label: "View CI Run", url: $run_url },
-                  { type: 2, style: 5, label: "View Commit", url: $commit_url }
-                ]
+                footer: { text: ("Build #" + $run_number + " | " + $short_sha) }
               }]
             }')"
 

--- a/.github/workflows/discord-releases.yml
+++ b/.github/workflows/discord-releases.yml
@@ -10,22 +10,15 @@ jobs:
     steps:
       - name: Send Release to Discord
         env:
-          DISCORD_RELEASE_WEBHOOK: ${{ secrets.DISCORD_RELEASE_WEBHOOK }}
-          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          DISCORD_RELEASE_WEBHOOK_DEV: ${{ secrets.DISCORD_RELEASE_WEBHOOK_DEV }}
+          DISCORD_RELEASE_WEBHOOK_PROD: ${{ secrets.DISCORD_RELEASE_WEBHOOK_PROD }}
           RELEASE_NAME: ${{ github.event.release.name }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
           RELEASE_BODY: ${{ github.event.release.body }}
         run: |
-          WEBHOOK_BASE="${DISCORD_RELEASE_WEBHOOK:-$DISCORD_WEBHOOK_URL}"
-          if [[ -z "$WEBHOOK_BASE" ]]; then
-            echo "Missing Discord webhook secret. Set DISCORD_RELEASE_WEBHOOK (preferred) or DISCORD_WEBHOOK_URL."
+          if [[ -z "$DISCORD_RELEASE_WEBHOOK_DEV" && -z "$DISCORD_RELEASE_WEBHOOK_PROD" ]]; then
+            echo "Missing Discord webhook secrets. Set DISCORD_RELEASE_WEBHOOK_DEV and/or DISCORD_RELEASE_WEBHOOK_PROD."
             exit 1
-          fi
-
-          if [[ "$WEBHOOK_BASE" == *\?* ]]; then
-            WEBHOOK_ENDPOINT="${WEBHOOK_BASE}&wait=true&with_components=true"
-          else
-            WEBHOOK_ENDPOINT="${WEBHOOK_BASE}?wait=true&with_components=true"
           fi
 
           HIGHLIGHTS="$(printf '%s' "$RELEASE_BODY" | awk '
@@ -55,8 +48,19 @@ jobs:
               }]
             }')"
 
-          curl --fail-with-body \
-            -H "Content-Type: application/json" \
-            -X POST \
-            -d "$PAYLOAD" \
-            "$WEBHOOK_ENDPOINT"
+          for WEBHOOK_BASE in "$DISCORD_RELEASE_WEBHOOK_DEV" "$DISCORD_RELEASE_WEBHOOK_PROD"; do
+            if [[ -z "$WEBHOOK_BASE" ]]; then
+              continue
+            fi
+            if [[ "$WEBHOOK_BASE" == *\?* ]]; then
+              WEBHOOK_ENDPOINT="${WEBHOOK_BASE}&wait=true&with_components=true"
+            else
+              WEBHOOK_ENDPOINT="${WEBHOOK_BASE}?wait=true&with_components=true"
+            fi
+
+            curl --fail-with-body \
+              -H "Content-Type: application/json" \
+              -X POST \
+              -d "$PAYLOAD" \
+              "$WEBHOOK_ENDPOINT"
+          done


### PR DESCRIPTION
- rename workflow file to `.github/workflows/discord-dev-builds.yml`
- switch dev build webhook secret to `DISCORD_DEV_WEBHOOK_URL_DEV`
- remove actor field and all button/link components from dev build Discord payload
- sanitize merge message text to drop owner prefixes (e.g. `from owner/branch` -> `from branch`)
- ping dev role `<@&1478455692569481347>` in dev build notifications
- update release workflow secret usage to `DISCORD_RELEASE_WEBHOOK_DEV`
- post release notifications to both dev and prod webhooks using `DISCORD_RELEASE_WEBHOOK_DEV` and `DISCORD_RELEASE_WEBHOOK_PROD`