### PR TITLE
fix(ci): reduce extra spacing in dev build Discord embed

### DIFF
--- a/.github/workflows/discord-dev-builds.yml
+++ b/.github/workflows/discord-dev-builds.yml
@@ -54,7 +54,7 @@ jobs:
               embeds: [{
                 title: $title,
                 description:
-                  ("`" + $workflow_name + "` run #" + $run_number + " passed on `" + $branch + "`.\n\n" +
+                  ("`" + $workflow_name + "` run #" + $run_number + " passed on `" + $branch + "`.\n" +
                    "## Highlights\n" +
                    ($commit_msg | if length > 3800 then .[0:3800] + "..." else . end)),
                 color: 5763719,


### PR DESCRIPTION
- change dev build embed description formatting to use a single newline between workflow status line and `## Highlights`
- removes the large visual gap before Highlights in Discord