### PR TITLE
feat(ci): unify Discord dev/release notification workflows and add prod release fanout

### DIFF
--- a/.github/workflows/discord-dev-builds.yml
+++ b/.github/workflows/discord-dev-builds.yml
@@ -13,23 +13,18 @@ jobs:
     steps:
       - name: Send Dev Build Update to Discord
         env:
-          DISCORD_DEV_BUILD: ${{ secrets.DISCORD_DEV_BUILD }}
-          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          DISCORD_DEV_WEBHOOK_URL_DEV: ${{ secrets.DISCORD_DEV_WEBHOOK_URL_DEV }}
           WORKFLOW_NAME: ${{ github.event.workflow_run.name }}
           RUN_NUMBER: ${{ github.event.workflow_run.run_number }}
-          RUN_URL: ${{ github.event.workflow_run.html_url }}
           COMMIT_SHA: ${{ github.event.workflow_run.head_sha }}
           COMMIT_MESSAGE: ${{ github.event.workflow_run.head_commit.message }}
-          ACTOR: ${{ github.event.workflow_run.actor.login }}
-          REPO: ${{ github.repository }}
           BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
           SHORT_SHA="${COMMIT_SHA:0:7}"
-          COMMIT_URL="https://github.com/${REPO}/commit/${COMMIT_SHA}"
-          WEBHOOK_BASE="${DISCORD_DEV_BUILD:-$DISCORD_WEBHOOK_URL}"
+          WEBHOOK_BASE="${DISCORD_DEV_WEBHOOK_URL_DEV}"
 
           if [[ -z "$WEBHOOK_BASE" ]]; then
-            echo "Missing Discord webhook secret. Set DISCORD_DEV_BUILD (preferred) or DISCORD_WEBHOOK_URL."
+            echo "Missing Discord webhook secret. Set DISCORD_DEV_WEBHOOK_URL_DEV."
             exit 1
           fi
 
@@ -39,34 +34,31 @@ jobs:
             WEBHOOK_ENDPOINT="${WEBHOOK_BASE}?wait=true&with_components=true"
           fi
 
+          SANITIZED_MESSAGE="$(printf '%s' "$COMMIT_MESSAGE" | sed -E 's/(from[[:space:]]+)[^[:space:]\/]+\/([^[:space:]]+)/\1\2/g')"
+          if [[ -z "$SANITIZED_MESSAGE" ]]; then
+            SANITIZED_MESSAGE="No commit message provided."
+          fi
+
           PAYLOAD="$(jq -n \
+            --arg role "1478455692569481347" \
             --arg title "Dev Build Succeeded" \
+            --arg branch "$BRANCH" \
+            --arg short_sha "$SHORT_SHA" \
             --arg workflow_name "$WORKFLOW_NAME" \
             --arg run_number "$RUN_NUMBER" \
-            --arg branch "$BRANCH" \
-            --arg actor "$ACTOR" \
-            --arg short_sha "$SHORT_SHA" \
-            --arg commit_msg "$COMMIT_MESSAGE" \
-            --arg run_url "$RUN_URL" \
-            --arg commit_url "$COMMIT_URL" \
+            --arg commit_msg "$SANITIZED_MESSAGE" \
             '{
+              content: ("<@&" + $role + ">"),
+              allowed_mentions: { roles: [$role] },
               username: "ClashCookies",
               embeds: [{
                 title: $title,
-                description: ("`" + $workflow_name + "` run #" + $run_number + " passed on `" + $branch + "`."),
+                description:
+                  ("`" + $workflow_name + "` run #" + $run_number + " passed on `" + $branch + "`.\n\n" +
+                   "## Highlights\n" +
+                   ($commit_msg | if length > 3800 then .[0:3800] + "..." else . end)),
                 color: 5763719,
-                fields: [
-                  { name: "Actor", value: $actor, inline: true },
-                  { name: "Commit", value: ("`" + $short_sha + "`"), inline: true },
-                  { name: "Message", value: ($commit_msg | if length > 1000 then .[0:1000] + "..." else . end), inline: false }
-                ]
-              }],
-              components: [{
-                type: 1,
-                components: [
-                  { type: 2, style: 5, label: "View CI Run", url: $run_url },
-                  { type: 2, style: 5, label: "View Commit", url: $commit_url }
-                ]
+                footer: { text: ("Build #" + $run_number + " | " + $short_sha) }
               }]
             }')"
 

--- a/.github/workflows/discord-dev-builds.yml
+++ b/.github/workflows/discord-dev-builds.yml
@@ -54,7 +54,7 @@ jobs:
               embeds: [{
                 title: $title,
                 description:
-                  ("`" + $workflow_name + "` run #" + $run_number + " passed on `" + $branch + "`.\n\n" +
+                  ("`" + $workflow_name + "` run #" + $run_number + " passed on `" + $branch + "`.\n" +
                    "## Highlights\n" +
                    ($commit_msg | if length > 3800 then .[0:3800] + "..." else . end)),
                 color: 5763719,

--- a/.github/workflows/discord-releases.yml
+++ b/.github/workflows/discord-releases.yml
@@ -14,7 +14,7 @@ jobs:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           RELEASE_NAME: ${{ github.event.release.name }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
-          RELEASE_URL: ${{ github.event.release.html_url }}
+          RELEASE_BODY: ${{ github.event.release.body }}
         run: |
           WEBHOOK_BASE="${DISCORD_RELEASE_WEBHOOK:-$DISCORD_WEBHOOK_URL}"
           if [[ -z "$WEBHOOK_BASE" ]]; then
@@ -28,30 +28,30 @@ jobs:
             WEBHOOK_ENDPOINT="${WEBHOOK_BASE}?wait=true&with_components=true"
           fi
 
+          HIGHLIGHTS="$(printf '%s' "$RELEASE_BODY" | awk '
+            BEGIN { in_section = 0 }
+            /^##[[:space:]]+Highlights[[:space:]]*$/ { in_section = 1; next }
+            /^##[[:space:]]+/ { if (in_section) exit }
+            { if (in_section) print }
+          ')"
+          if [[ -z "$HIGHLIGHTS" ]]; then
+            HIGHLIGHTS="No Highlights section found in release notes."
+          fi
+
           PAYLOAD="$(jq -n \
             --arg role "1477488801478869196" \
             --arg title "New Release: ${RELEASE_NAME}" \
             --arg tag "${RELEASE_TAG}" \
-            --arg release_url "${RELEASE_URL}" \
+            --arg highlights "${HIGHLIGHTS}" \
             '{
               content: ("<@&" + $role + ">"),
               allowed_mentions: { roles: [$role] },
               username: "ClashCookies",
               embeds: [{
                 title: $title,
-                url: $release_url,
-                description: ("Click the button below to view the full changelog.\n[View Full Changelog](" + $release_url + ")"),
+                description: ("## Highlights\n" + $highlights),
                 color: 5814783,
                 footer: { text: ("Version " + $tag) }
-              }],
-              components: [{
-                type: 1,
-                components: [{
-                  type: 2,
-                  style: 5,
-                  label: "View Release",
-                  url: $release_url
-                }]
               }]
             }')"
 

--- a/.github/workflows/discord-releases.yml
+++ b/.github/workflows/discord-releases.yml
@@ -10,22 +10,15 @@ jobs:
     steps:
       - name: Send Release to Discord
         env:
-          DISCORD_RELEASE_WEBHOOK: ${{ secrets.DISCORD_RELEASE_WEBHOOK }}
-          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          DISCORD_RELEASE_WEBHOOK_DEV: ${{ secrets.DISCORD_RELEASE_WEBHOOK_DEV }}
+          DISCORD_RELEASE_WEBHOOK_PROD: ${{ secrets.DISCORD_RELEASE_WEBHOOK_PROD }}
           RELEASE_NAME: ${{ github.event.release.name }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
           RELEASE_BODY: ${{ github.event.release.body }}
         run: |
-          WEBHOOK_BASE="${DISCORD_RELEASE_WEBHOOK:-$DISCORD_WEBHOOK_URL}"
-          if [[ -z "$WEBHOOK_BASE" ]]; then
-            echo "Missing Discord webhook secret. Set DISCORD_RELEASE_WEBHOOK (preferred) or DISCORD_WEBHOOK_URL."
+          if [[ -z "$DISCORD_RELEASE_WEBHOOK_DEV" && -z "$DISCORD_RELEASE_WEBHOOK_PROD" ]]; then
+            echo "Missing Discord webhook secrets. Set DISCORD_RELEASE_WEBHOOK_DEV and/or DISCORD_RELEASE_WEBHOOK_PROD."
             exit 1
-          fi
-
-          if [[ "$WEBHOOK_BASE" == *\?* ]]; then
-            WEBHOOK_ENDPOINT="${WEBHOOK_BASE}&wait=true&with_components=true"
-          else
-            WEBHOOK_ENDPOINT="${WEBHOOK_BASE}?wait=true&with_components=true"
           fi
 
           HIGHLIGHTS="$(printf '%s' "$RELEASE_BODY" | awk '
@@ -55,8 +48,19 @@ jobs:
               }]
             }')"
 
-          curl --fail-with-body \
-            -H "Content-Type: application/json" \
-            -X POST \
-            -d "$PAYLOAD" \
-            "$WEBHOOK_ENDPOINT"
+          for WEBHOOK_BASE in "$DISCORD_RELEASE_WEBHOOK_DEV" "$DISCORD_RELEASE_WEBHOOK_PROD"; do
+            if [[ -z "$WEBHOOK_BASE" ]]; then
+              continue
+            fi
+            if [[ "$WEBHOOK_BASE" == *\?* ]]; then
+              WEBHOOK_ENDPOINT="${WEBHOOK_BASE}&wait=true&with_components=true"
+            else
+              WEBHOOK_ENDPOINT="${WEBHOOK_BASE}?wait=true&with_components=true"
+            fi
+
+            curl --fail-with-body \
+              -H "Content-Type: application/json" \
+              -X POST \
+              -d "$PAYLOAD" \
+              "$WEBHOOK_ENDPOINT"
+          done


### PR DESCRIPTION
**Summary**
- Aligns Discord automation for release + dev-build notifications with cleaner, role-pinged embeds and updated secret naming.
- Simplifies dev build messaging by removing buttons/actor fields and normalizing branch text in merge messages.

**What Changed**
1. `discord-dev-build-updates.yml` renamed to `discord-dev-builds.yml`.
2. Dev build webhook secret updated:
   - from `DISCORD_DEV_BUILD`/fallbacks
   - to `DISCORD_DEV_WEBHOOK_URL_DEV`.
3. Release webhook secret usage updated:
   - from `DISCORD_WEBHOOK_URL` fallback pattern
   - to explicit `DISCORD_RELEASE_WEBHOOK_DEV`.
4. Added second release destination:
   - posts release payload to both `DISCORD_RELEASE_WEBHOOK_DEV` and `DISCORD_RELEASE_WEBHOOK_PROD`.
5. Dev build embed now mirrors release style more closely:
   - includes role ping `<@&1478455692569481347>`
   - removes actor field
   - removes GitHub buttons/links.
6. Commit message sanitization for dev build posts:
   - rewrites `from owner/branch` to `from branch`.
7. Dev build embed spacing adjusted:
   - removed extra blank line before `## Highlights`.

**Behavioral Impact**
- Release posts fan out to two Discord servers/channels (dev + prod webhooks).
- Dev build posts are cleaner and less noisy, with no clickable buttons and no actor display.
- Merge text shown in highlights no longer includes owner prefix.

**Operational Notes**
- Ensure these GitHub secrets exist in the target repo:
  - `DISCORD_DEV_WEBHOOK_URL_DEV`
  - `DISCORD_RELEASE_WEBHOOK_DEV`
  - `DISCORD_RELEASE_WEBHOOK_PROD`
- Existing old secrets (`DISCORD_WEBHOOK_URL`, `DISCORD_DEV_BUILD`) are no longer used by these workflows.

**Validation Suggestions**
1. Trigger a dev push on `dev` and verify:
   - role ping works
   - no buttons shown
   - highlights formatting/spacing is correct.
2. Publish a release and verify:
   - message is posted to both configured release webhooks
   - full `## Highlights` section appears as expected.