### PR TITLE
feat(force): add /force sync data/mail and migrate manual fwa sync

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -45,3 +45,5 @@
 - `/kick-list clear [mode:all|auto|manual]` - Clear kick-list entries.
 - `/sync time post [role:<discordRole>]` - Open modal, compose sync-time message, post it, and pin it.
 - `/sync post status [message-id:<id>]` - Show claimed vs unclaimed clan badge reactions for the active sync-time post, or for a specific message in the channel.
+- `/force sync data tag:<trackedClanTag> [datapoint:points|syncNum]` - Manually force-sync tracked clan points and/or sync number from points.fwafarm.
+- `/force sync mail tag:<trackedClanTag> message-type:<mail|notify:war start|notify:battle start|notify:war end> message-id:<id>` - Upsert `CurrentWar.mailConfig` with current match configuration plus a posted message reference.

--- a/src/Commands.ts
+++ b/src/Commands.ts
@@ -14,6 +14,7 @@ import { Recruitment } from "./commands/Recruitment";
 import { Accounts } from "./commands/Accounts";
 import { Notify } from "./commands/Notify";
 import { War } from "./commands/War";
+import { Force } from "./commands/Force";
 
 // ...existing code...
 export const Commands = [
@@ -31,6 +32,7 @@ export const Commands = [
   Notify,
   Recruitment,
   KickList,
+  Force,
   Post,
   CommandRole,
 ];

--- a/src/commands/Force.ts
+++ b/src/commands/Force.ts
@@ -1,0 +1,138 @@
+import {
+  ApplicationCommandOptionType,
+  AutocompleteInteraction,
+  ChatInputCommandInteraction,
+  Client,
+} from "discord.js";
+import { Command } from "../Command";
+import { prisma } from "../prisma";
+import { CoCService } from "../services/CoCService";
+import {
+  runForceSyncDataCommand,
+  runForceSyncMailCommand,
+} from "./Fwa";
+
+function normalizeTag(input: string): string {
+  return input.trim().toUpperCase().replace(/^#/, "");
+}
+
+export const Force: Command = {
+  name: "force",
+  description: "Manual force-sync utilities",
+  options: [
+    {
+      name: "sync",
+      description: "Force sync data and message references",
+      type: ApplicationCommandOptionType.SubcommandGroup,
+      options: [
+        {
+          name: "data",
+          description: "Force-refresh points and sync number for a tracked clan",
+          type: ApplicationCommandOptionType.Subcommand,
+          options: [
+            {
+              name: "tag",
+              description: "Tracked clan tag (with or without #)",
+              type: ApplicationCommandOptionType.String,
+              required: true,
+              autocomplete: true,
+            },
+            {
+              name: "datapoint",
+              description: "Choose which value to overwrite",
+              type: ApplicationCommandOptionType.String,
+              required: false,
+              choices: [
+                { name: "points", value: "points" },
+                { name: "syncNum", value: "syncNum" },
+              ],
+            },
+          ],
+        },
+        {
+          name: "mail",
+          description: "Upsert MailConfig for a tracked clan message",
+          type: ApplicationCommandOptionType.Subcommand,
+          options: [
+            {
+              name: "tag",
+              description: "Tracked clan tag (with or without #)",
+              type: ApplicationCommandOptionType.String,
+              required: true,
+              autocomplete: true,
+            },
+            {
+              name: "message_type",
+              description: "Message type to record in MailConfig",
+              type: ApplicationCommandOptionType.String,
+              required: true,
+              choices: [
+                { name: "mail", value: "mail" },
+                { name: "notify:war start", value: "notify:war_start" },
+                { name: "notify:battle start", value: "notify:battle_start" },
+                { name: "notify:war end", value: "notify:war_end" },
+              ],
+            },
+            {
+              name: "message_id",
+              description: "Discord message ID to store",
+              type: ApplicationCommandOptionType.String,
+              required: true,
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  run: async (
+    _client: Client,
+    interaction: ChatInputCommandInteraction,
+    cocService: CoCService
+  ) => {
+    const subcommandGroup = interaction.options.getSubcommandGroup(true);
+    const subcommand = interaction.options.getSubcommand(true);
+
+    if (subcommandGroup === "sync" && subcommand === "data") {
+      await runForceSyncDataCommand(interaction, cocService);
+      return;
+    }
+    if (subcommandGroup === "sync" && subcommand === "mail") {
+      await runForceSyncMailCommand(interaction, cocService);
+      return;
+    }
+
+    await interaction.reply({
+      ephemeral: true,
+      content: "Unsupported /force command usage.",
+    });
+  },
+  autocomplete: async (interaction: AutocompleteInteraction) => {
+    const focused = interaction.options.getFocused(true);
+    if (focused.name !== "tag") {
+      await interaction.respond([]);
+      return;
+    }
+
+    const query = String(focused.value ?? "").trim().toLowerCase();
+    const tracked = await prisma.trackedClan.findMany({
+      orderBy: { createdAt: "asc" },
+      select: { name: true, tag: true },
+    });
+
+    const choices = tracked
+      .map((c) => {
+        const normalized = normalizeTag(c.tag);
+        const label = c.name?.trim() ? `${c.name.trim()} (#${normalized})` : `#${normalized}`;
+        return { name: label.slice(0, 100), value: normalized };
+      })
+      .filter(
+        (c) =>
+          c.name.toLowerCase().includes(query) ||
+          c.value.toLowerCase().includes(query)
+      )
+      .slice(0, 25);
+
+    await interaction.respond(choices);
+  },
+};
+

--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -251,6 +251,7 @@ type MatchMailMessageRef = {
   messageType: "mail" | "notify";
   messageID: string;
   channelId?: string;
+  notifyType?: "war_start" | "battle_start" | "war_end";
 };
 
 type MatchMailConfig = {
@@ -264,6 +265,11 @@ type MatchMailConfig = {
   messages: MatchMailMessageRef[];
 };
 
+type ForceMailMessageType = {
+  messageType: "mail" | "notify";
+  notifyType?: "war_start" | "battle_start" | "war_end";
+};
+
 const MATCH_MAIL_CONFIG_DEFAULT: MatchMailConfig = {
   lastPostedMessageId: null,
   lastPostedChannelId: null,
@@ -274,6 +280,23 @@ const MATCH_MAIL_CONFIG_DEFAULT: MatchMailConfig = {
   lastDataChangedAtUnix: null,
   messages: [],
 };
+
+function parseForceMailMessageType(value: string): ForceMailMessageType | null {
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "mail") {
+    return { messageType: "mail" };
+  }
+  if (normalized === "notify:war_start") {
+    return { messageType: "notify", notifyType: "war_start" };
+  }
+  if (normalized === "notify:battle_start") {
+    return { messageType: "notify", notifyType: "battle_start" };
+  }
+  if (normalized === "notify:war_end") {
+    return { messageType: "notify", notifyType: "war_end" };
+  }
+  return null;
+}
 
 const fwaMatchCopyPayloads = new Map<string, FwaMatchCopyPayload>();
 const fwaMailPreviewPayloads = new Map<string, FwaMailPreviewPayload>();
@@ -638,11 +661,19 @@ function parseMatchMailConfig(value: Prisma.JsonValue | null | undefined): Match
     const messageType = item.messageType;
     const messageID = typeof item.messageID === "string" ? item.messageID.trim() : "";
     const channelId = typeof item.channelId === "string" ? item.channelId.trim() : "";
+    const notifyTypeRaw = typeof item.notifyType === "string" ? item.notifyType.trim() : "";
+    const notifyType =
+      notifyTypeRaw === "war_start" ||
+      notifyTypeRaw === "battle_start" ||
+      notifyTypeRaw === "war_end"
+        ? notifyTypeRaw
+        : undefined;
     if ((messageType !== "mail" && messageType !== "notify") || !messageID) continue;
     messages.push({
       messageType,
       messageID,
       channelId: channelId || undefined,
+      notifyType: messageType === "notify" ? notifyType : undefined,
     });
   }
 
@@ -3810,6 +3841,281 @@ async function buildTrackedMatchOverview(
   };
 }
 
+export async function runForceSyncDataCommand(
+  interaction: ChatInputCommandInteraction,
+  cocService: CoCService
+): Promise<void> {
+  const visibility = interaction.options.getString("visibility", false) ?? "private";
+  const isPublic = visibility === "public";
+  const settings = new SettingsService();
+  const warLookupCache: WarLookupCache = new Map();
+  let sourceSync = await getSourceOfTruthSync(settings, interaction.guildId ?? null);
+  if (sourceSync === null) {
+    sourceSync = await recoverPreviousSyncNumFromPoints(settings, cocService, warLookupCache);
+  }
+  await interaction.deferReply({ ephemeral: !isPublic });
+
+  const rawTag = interaction.options.getString("tag", true);
+  const tag = normalizeTag(rawTag);
+  const datapoint = interaction.options.getString("datapoint", false) ?? "all";
+  const shouldOverwritePoints = datapoint === "all" || datapoint === "points";
+  const shouldOverwriteSyncNum = datapoint === "all" || datapoint === "syncNum";
+  const trackedClan = await prisma.trackedClan.findFirst({
+    where: { tag: { equals: `#${tag}`, mode: "insensitive" } },
+    select: { tag: true, name: true },
+  });
+  if (!trackedClan) {
+    await interaction.editReply(`Clan #${tag} is not in tracked clans.`);
+    return;
+  }
+
+  const war = await getCurrentWarCached(cocService, tag, warLookupCache).catch(() => null);
+  const opponentTag = normalizeTag(String(war?.opponent?.tag ?? ""));
+  const opponentName = sanitizeClanName(String(war?.opponent?.name ?? "")) ?? null;
+  const fresh = await scrapeClanPoints(tag);
+
+  const siteSync = fresh.winnerBoxSync;
+  const siteUpdatedForOpponent = Boolean(opponentTag && isPointsSiteUpdatedForOpponent(fresh, opponentTag, null));
+  let previousSyncSet: number | null = null;
+  if (
+    shouldOverwriteSyncNum &&
+    siteUpdatedForOpponent &&
+    siteSync !== null &&
+    Number.isFinite(siteSync)
+  ) {
+    const recoveredPrevious = siteSync - 1;
+    if (Number.isFinite(recoveredPrevious) && recoveredPrevious >= 0) {
+      previousSyncSet = Math.trunc(recoveredPrevious);
+      await settings.set(PREVIOUS_SYNC_KEY, String(previousSyncSet));
+      sourceSync = previousSyncSet;
+    }
+  }
+
+  if (shouldOverwritePoints && interaction.guildId) {
+    await prisma.currentWar.upsert({
+      where: {
+        guildId_clanTag: {
+          guildId: interaction.guildId,
+          clanTag: `#${tag}`,
+        },
+      },
+      create: {
+        guildId: interaction.guildId,
+        clanTag: `#${tag}`,
+        channelId: interaction.channelId,
+        notify: false,
+        currentSyncNum:
+          shouldOverwriteSyncNum &&
+          siteSync !== null &&
+          Number.isFinite(siteSync)
+            ? Math.trunc(siteSync)
+            : null,
+        fwaPoints:
+          fresh.balance !== null && Number.isFinite(fresh.balance) ? fresh.balance : null,
+      },
+      update: {
+        currentSyncNum:
+          shouldOverwriteSyncNum &&
+          siteSync !== null &&
+          Number.isFinite(siteSync)
+            ? Math.trunc(siteSync)
+            : undefined,
+        fwaPoints:
+          fresh.balance !== null && Number.isFinite(fresh.balance) ? fresh.balance : null,
+        updatedAt: new Date(),
+      },
+    });
+  }
+
+  let opponentSnapshot: PointsSnapshot | null = null;
+  let opponentBalance: number | null = null;
+  if (siteUpdatedForOpponent) {
+    const fromPrimary = deriveOpponentBalanceFromPrimarySnapshot(fresh, tag, opponentTag);
+    if (fromPrimary !== null && Number.isFinite(fromPrimary)) {
+      opponentBalance = fromPrimary;
+    } else if (opponentTag) {
+      opponentSnapshot = await scrapeClanPoints(opponentTag).catch(() => null);
+      opponentBalance =
+        opponentSnapshot?.balance !== null &&
+        opponentSnapshot?.balance !== undefined &&
+        Number.isFinite(opponentSnapshot.balance)
+          ? opponentSnapshot.balance
+          : null;
+    }
+  }
+  if (shouldOverwritePoints && siteUpdatedForOpponent) {
+    const pointsScrape: TrackedClanPointsScrape = {
+      version: 1,
+      source: "points.fwafarm",
+      fetchedAtMs: Date.now(),
+      trackedClanName:
+        sanitizeClanName(trackedClan.name) ?? sanitizeClanName(fresh.clanName) ?? null,
+      trackedClanTag: tag,
+      opponentClanName: opponentName,
+      opponentClanTag: opponentTag || null,
+      pointBalance:
+        fresh.balance !== null && Number.isFinite(fresh.balance) ? fresh.balance : null,
+      opponentPointBalance: opponentBalance,
+      activeFwa: true,
+      syncNumber:
+        siteSync !== null && Number.isFinite(siteSync) ? Math.trunc(siteSync) : null,
+      matchup: buildPointsScrapeMatchupSummary(
+        sanitizeClanName(trackedClan.name) ?? sanitizeClanName(fresh.clanName) ?? null,
+        tag,
+        opponentName,
+        opponentTag || null,
+        fresh.balance !== null && Number.isFinite(fresh.balance) ? fresh.balance : null,
+        opponentBalance,
+        siteSync !== null && Number.isFinite(siteSync) ? Math.trunc(siteSync) : null,
+        true
+      ),
+      pointsSiteUpToDate: true,
+    };
+    await prisma.trackedClan.update({
+      where: { tag: `#${tag}` },
+      data: { pointsScrape },
+    });
+  }
+
+  await interaction.editReply(
+    [
+      `Forced sync complete for #${tag} (${datapoint === "all" ? "points + syncNum" : datapoint}).`,
+      `Point balance: ${
+        fresh.balance !== null && Number.isFinite(fresh.balance)
+          ? `**${formatPoints(fresh.balance)}**`
+          : "unavailable"
+      }`,
+      `Site sync #: ${siteSync !== null && Number.isFinite(siteSync) ? `#${Math.trunc(siteSync)}` : "unknown"}`,
+      `Stored previousSyncNum: ${
+        shouldOverwriteSyncNum
+          ? previousSyncSet !== null
+            ? `#${previousSyncSet}`
+            : "unchanged"
+          : "skipped"
+      }`,
+      shouldOverwritePoints
+        ? siteUpdatedForOpponent
+          ? "pointsScrape updated from points.fwafarm."
+          : "points.fwafarm not up-to-date for current opponent; pointsScrape not updated."
+        : "points overwrite skipped.",
+    ].join("\n")
+  );
+}
+
+export async function runForceSyncMailCommand(
+  interaction: ChatInputCommandInteraction,
+  cocService: CoCService
+): Promise<void> {
+  const visibility = interaction.options.getString("visibility", false) ?? "private";
+  const isPublic = visibility === "public";
+  await interaction.deferReply({ ephemeral: !isPublic });
+
+  if (!interaction.guildId) {
+    await interaction.editReply("This command can only be used in a server.");
+    return;
+  }
+
+  const tag = normalizeTag(interaction.options.getString("tag", true));
+  const messageID = interaction.options.getString("message_id", true).trim();
+  const messageTypeRaw = interaction.options.getString("message_type", true);
+  const parsedType = parseForceMailMessageType(messageTypeRaw);
+  if (!parsedType) {
+    await interaction.editReply("Invalid `message_type`.");
+    return;
+  }
+  if (!messageID) {
+    await interaction.editReply("Please provide `message_id`.");
+    return;
+  }
+
+  const trackedClan = await prisma.trackedClan.findFirst({
+    where: { tag: { equals: `#${tag}`, mode: "insensitive" } },
+    select: { tag: true, name: true },
+  });
+  if (!trackedClan) {
+    await interaction.editReply(`Clan #${tag} is not in tracked clans.`);
+    return;
+  }
+
+  const existing = await prisma.currentWar.findUnique({
+    where: {
+      guildId_clanTag: {
+        guildId: interaction.guildId,
+        clanTag: `#${tag}`,
+      },
+    },
+    select: {
+      matchType: true,
+      outcome: true,
+      lastWarStartTime: true,
+      mailConfig: true,
+    },
+  });
+  const currentWar = await getCurrentWarCached(cocService, tag).catch(() => null);
+  const warStartMsFromApi = parseCocApiTime(currentWar?.startTime);
+  const warStartMs =
+    existing?.lastWarStartTime?.getTime() ?? warStartMsFromApi ?? null;
+  const nowUnix = Math.floor(Date.now() / 1000);
+  const current = parseMatchMailConfig(existing?.mailConfig as Prisma.JsonValue | null | undefined);
+  const messages = current.messages.filter(
+    (entry) =>
+      !(
+        entry.messageID === messageID &&
+        entry.messageType === parsedType.messageType &&
+        (parsedType.messageType !== "notify" || entry.notifyType === parsedType.notifyType)
+      )
+  );
+  messages.push({
+    messageType: parsedType.messageType,
+    messageID,
+    channelId: interaction.channelId,
+    notifyType: parsedType.messageType === "notify" ? parsedType.notifyType : undefined,
+  });
+
+  const matchType = existing?.matchType ?? current.lastMatchType ?? "UNKNOWN";
+  const expectedOutcome: "WIN" | "LOSE" | "UNKNOWN" | null =
+    existing?.outcome === "WIN" || existing?.outcome === "LOSE"
+      ? existing.outcome
+      : current.lastExpectedOutcome ?? "UNKNOWN";
+
+  const next: MatchMailConfig = {
+    ...current,
+    lastWarStartMs: warStartMs,
+    lastMatchType: matchType,
+    lastExpectedOutcome: expectedOutcome,
+    messages,
+  };
+  if (parsedType.messageType === "mail") {
+    next.lastPostedMessageId = messageID;
+    next.lastPostedChannelId = interaction.channelId;
+    next.lastPostedAtUnix = nowUnix;
+    next.lastDataChangedAtUnix = nowUnix;
+  }
+
+  await saveCurrentWarMailConfig({
+    guildId: interaction.guildId,
+    tag,
+    channelId: interaction.channelId,
+    mailConfig: next,
+  });
+
+  const messageTypeLabel =
+    parsedType.messageType === "mail"
+      ? "mail"
+      : `notify:${parsedType.notifyType?.replace("_", " ") ?? "unknown"}`;
+  await interaction.editReply(
+    [
+      `Force sync mail config complete for #${tag}.`,
+      `Message type: **${messageTypeLabel}**`,
+      `Message ID: \`${messageID}\``,
+      `War start: ${warStartMs !== null ? `<t:${Math.floor(warStartMs / 1000)}:F>` : "unknown"}`,
+      `Match type: **${next.lastMatchType ?? "UNKNOWN"}**`,
+      `Expected outcome: **${next.lastExpectedOutcome ?? "UNKNOWN"}**`,
+      `Tracked message refs: **${next.messages.length}**`,
+    ].join("\n")
+  );
+}
+
 export const Fwa: Command = {
   name: "fwa",
   description: "FWA points and matchup tools",
@@ -3872,37 +4178,6 @@ export const Fwa: Command = {
           description: "Role to set as the FWA leader role",
           type: ApplicationCommandOptionType.Role,
           required: true,
-        },
-      ],
-    },
-    {
-      name: "sync",
-      description: "Sync FWA data from points.fwafarm",
-      type: ApplicationCommandOptionType.SubcommandGroup,
-      options: [
-        {
-          name: "force",
-          description: "Force-refresh points and sync number for a tracked clan",
-          type: ApplicationCommandOptionType.Subcommand,
-          options: [
-            {
-              name: "tag",
-              description: "Tracked clan tag (with or without #)",
-              type: ApplicationCommandOptionType.String,
-              required: true,
-              autocomplete: true,
-            },
-            {
-              name: "datapoint",
-              description: "Choose which value to overwrite",
-              type: ApplicationCommandOptionType.String,
-              required: false,
-              choices: [
-                { name: "points", value: "points" },
-                { name: "syncNum", value: "syncNum" },
-              ],
-            },
-          ],
         },
       ],
     },
@@ -4016,159 +4291,6 @@ export const Fwa: Command = {
         return;
       }
       await showWarMailPreview(interaction, interaction.guildId, interaction.user.id, tag, cocService);
-      return;
-    }
-
-    if (subcommandGroup === "sync" && subcommand === "force") {
-      if (!tag) {
-        await editReplySafe("Please provide `tag`.");
-        return;
-      }
-      const datapoint = interaction.options.getString("datapoint", false) ?? "all";
-      const shouldOverwritePoints = datapoint === "all" || datapoint === "points";
-      const shouldOverwriteSyncNum = datapoint === "all" || datapoint === "syncNum";
-      const trackedClan = await prisma.trackedClan.findFirst({
-        where: { tag: { equals: `#${tag}`, mode: "insensitive" } },
-        select: { tag: true, name: true },
-      });
-      if (!trackedClan) {
-        await editReplySafe(`Clan #${tag} is not in tracked clans.`);
-        return;
-      }
-
-      const war = await getCurrentWarCached(cocService, tag, warLookupCache).catch(() => null);
-      const opponentTag = normalizeTag(String(war?.opponent?.tag ?? ""));
-      const opponentName = sanitizeClanName(String(war?.opponent?.name ?? "")) ?? null;
-      const fresh = await scrapeClanPoints(tag);
-
-      const siteSync = fresh.winnerBoxSync;
-      const siteUpdatedForOpponent = Boolean(
-        opponentTag && isPointsSiteUpdatedForOpponent(fresh, opponentTag, null)
-      );
-      let previousSyncSet: number | null = null;
-      if (
-        shouldOverwriteSyncNum &&
-        siteUpdatedForOpponent &&
-        siteSync !== null &&
-        Number.isFinite(siteSync)
-      ) {
-        const recoveredPrevious = siteSync - 1;
-        if (Number.isFinite(recoveredPrevious) && recoveredPrevious >= 0) {
-          previousSyncSet = Math.trunc(recoveredPrevious);
-          await settings.set(PREVIOUS_SYNC_KEY, String(previousSyncSet));
-          sourceSync = previousSyncSet;
-        }
-      }
-
-      if (shouldOverwritePoints && interaction.guildId) {
-        await prisma.currentWar.upsert({
-          where: {
-            guildId_clanTag: {
-              guildId: interaction.guildId,
-              clanTag: `#${tag}`,
-            },
-          },
-          create: {
-            guildId: interaction.guildId,
-            clanTag: `#${tag}`,
-            channelId: interaction.channelId,
-            notify: false,
-            currentSyncNum:
-              shouldOverwriteSyncNum &&
-              siteSync !== null &&
-              Number.isFinite(siteSync)
-                ? Math.trunc(siteSync)
-                : null,
-            fwaPoints:
-              fresh.balance !== null && Number.isFinite(fresh.balance) ? fresh.balance : null,
-          },
-          update: {
-            currentSyncNum:
-              shouldOverwriteSyncNum &&
-              siteSync !== null &&
-              Number.isFinite(siteSync)
-                ? Math.trunc(siteSync)
-                : undefined,
-            fwaPoints:
-              fresh.balance !== null && Number.isFinite(fresh.balance) ? fresh.balance : null,
-            updatedAt: new Date(),
-          },
-        });
-      }
-
-      let opponentSnapshot: PointsSnapshot | null = null;
-      let opponentBalance: number | null = null;
-      if (siteUpdatedForOpponent) {
-        const fromPrimary = deriveOpponentBalanceFromPrimarySnapshot(fresh, tag, opponentTag);
-        if (fromPrimary !== null && Number.isFinite(fromPrimary)) {
-          opponentBalance = fromPrimary;
-        } else if (opponentTag) {
-          opponentSnapshot = await scrapeClanPoints(opponentTag).catch(() => null);
-          opponentBalance =
-            opponentSnapshot?.balance !== null &&
-            opponentSnapshot?.balance !== undefined &&
-            Number.isFinite(opponentSnapshot.balance)
-              ? opponentSnapshot.balance
-              : null;
-        }
-      }
-      if (shouldOverwritePoints && siteUpdatedForOpponent) {
-        const pointsScrape: TrackedClanPointsScrape = {
-          version: 1,
-          source: "points.fwafarm",
-          fetchedAtMs: Date.now(),
-          trackedClanName:
-            sanitizeClanName(trackedClan.name) ?? sanitizeClanName(fresh.clanName) ?? null,
-          trackedClanTag: tag,
-          opponentClanName: opponentName,
-          opponentClanTag: opponentTag || null,
-          pointBalance:
-            fresh.balance !== null && Number.isFinite(fresh.balance) ? fresh.balance : null,
-          opponentPointBalance: opponentBalance,
-          activeFwa: true,
-          syncNumber:
-            siteSync !== null && Number.isFinite(siteSync) ? Math.trunc(siteSync) : null,
-          matchup: buildPointsScrapeMatchupSummary(
-            sanitizeClanName(trackedClan.name) ?? sanitizeClanName(fresh.clanName) ?? null,
-            tag,
-            opponentName,
-            opponentTag || null,
-            fresh.balance !== null && Number.isFinite(fresh.balance) ? fresh.balance : null,
-            opponentBalance,
-            siteSync !== null && Number.isFinite(siteSync) ? Math.trunc(siteSync) : null,
-            true
-          ),
-          pointsSiteUpToDate: true,
-        };
-        await prisma.trackedClan.update({
-          where: { tag: `#${tag}` },
-          data: { pointsScrape },
-        });
-      }
-
-      await editReplySafe(
-        [
-          `Forced sync complete for #${tag} (${datapoint === "all" ? "points + syncNum" : datapoint}).`,
-          `Point balance: ${
-            fresh.balance !== null && Number.isFinite(fresh.balance)
-              ? `**${formatPoints(fresh.balance)}**`
-              : "unavailable"
-          }`,
-          `Site sync #: ${siteSync !== null && Number.isFinite(siteSync) ? `#${Math.trunc(siteSync)}` : "unknown"}`,
-          `Stored previousSyncNum: ${
-            shouldOverwriteSyncNum
-              ? previousSyncSet !== null
-                ? `#${previousSyncSet}`
-                : "unchanged"
-              : "skipped"
-          }`,
-          shouldOverwritePoints
-            ? siteUpdatedForOpponent
-              ? "pointsScrape updated from points.fwafarm."
-              : "points.fwafarm not up-to-date for current opponent; pointsScrape not updated."
-            : "points overwrite skipped.",
-        ].join("\n")
-      );
       return;
     }
 

--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -252,6 +252,20 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
     ],
     examples: ["/sync time post role:@War", "/sync post status", "/sync post status message-id:123456789012345678"],
   },
+  force: {
+    summary: "Run manual force-sync actions for war data and MailConfig references.",
+    details: [
+      "`/force sync data` manually overwrites tracked clan points and/or sync number from points.fwafarm.",
+      "`/force sync mail` upserts `CurrentWar.mailConfig` message references for posted mail/notify messages.",
+      "`force sync` commands are admin-only by default.",
+    ],
+    examples: [
+      "/force sync data tag:2QG2C08UP datapoint:syncNum",
+      "/force sync data tag:2QG2C08UP datapoint:points",
+      "/force sync mail tag:2QG2C08UP message-type:mail message-id:1234567890123456789",
+      "/force sync mail tag:2QG2C08UP message-type:notify:war start message-id:1234567890123456789",
+    ],
+  },
   permission: {
     summary: "Control which roles can run each command target.",
     details: [

--- a/src/commands/Post.ts
+++ b/src/commands/Post.ts
@@ -858,7 +858,7 @@ export async function handlePostModalSubmit(
     notices.push(`Scheduled sync rollover for <t:${epochSeconds}:F>.`);
   } else if (rollover.reason === "previous_sync_missing") {
     notices.push(
-      "Sync rollover is due but previousSyncNum is unset; run `/fwa sync force datapoint:syncNum` to seed it."
+      "Sync rollover is due but previousSyncNum is unset; run `/force sync data datapoint:syncNum` to seed it."
     );
   }
 

--- a/src/services/CommandPermissionService.ts
+++ b/src/services/CommandPermissionService.ts
@@ -33,6 +33,8 @@ export const COMMAND_PERMISSION_TARGETS = [
   "fwa:match",
   "fwa:mail:send",
   "fwa:leader-role",
+  "force:sync:data",
+  "force:sync:mail",
   "recruitment:show",
   "recruitment:edit",
   "recruitment:dashboard",
@@ -64,6 +66,8 @@ const ADMIN_DEFAULT_TARGETS = new Set<string>([
   "kick-list:clear",
   "notify:war",
   "fwa:leader-role",
+  "force:sync:data",
+  "force:sync:mail",
   `${MANAGE_COMMAND_ROLES_COMMAND}:add`,
   `${MANAGE_COMMAND_ROLES_COMMAND}:remove`,
 ]);


### PR DESCRIPTION
- add new top-level `/force` command with `/force sync data` and `/force sync mail`
- move manual data sync path from `/fwa sync force` to `/force sync data`
- add `/force sync mail` to upsert CurrentWar.mailConfig message refs for mail/notify posts
- extend MailConfig message refs to capture notify subtype metadata (war_start, battle_start, war_end)
- remove `/fwa sync force` command option and update rollover guidance to use `/force sync data`