### PR TITLE
fix(war-events): treat inWar with missing opponent as notInWar

### DIFF
--- a/src/services/WarEventLogService.ts
+++ b/src/services/WarEventLogService.ts
@@ -752,7 +752,10 @@ export class WarEventLogService {
     if (!sub) return false;
 
     const war = await this.coc.getCurrentWar(sub.clanTag).catch(() => null);
-    const currentState: WarState = war ? deriveState(String(war.state ?? "")) : "notInWar";
+    const resolvedState: WarState = war ? deriveState(String(war.state ?? "")) : "notInWar";
+    const resolvedOpponentTag = normalizeTag(war?.opponent?.tag ?? "");
+    const currentState: WarState =
+      resolvedState === "inWar" && !resolvedOpponentTag ? "notInWar" : resolvedState;
     const prevState: WarState = deriveState(sub.lastState ?? "notInWar");
     const nextClanName =
       String(war?.clan?.name ?? sub.clanName ?? sub.clanTag).trim() || sub.clanTag;


### PR DESCRIPTION
- add guard in 5-minute war poll state resolution
- when CoC state resolves to inWar but opponentTag is missing, coerce state to notInWar
- prevents stale/invalid inWar state on CurrentWar rows with null opponent metadata