### PR TITLE
fix(fwa): cast SKIP to WarMatchType in skip-sync history upserts

### DIFF
--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -2342,7 +2342,7 @@ export async function handleFwaMatchSkipSyncConfirmButton(
         INSERT INTO "ClanWarHistory"
           ("warId","syncNumber","matchType","warStartTime","warEndTime","clanName","clanTag","opponentName","opponentTag","updatedAt")
         VALUES
-          (${skipWarId}, ${resolvedSyncNum}, ${"SKIP"}, ${skipWarStart}, NULL, ${clanName}, ${clanTagWithHash}, ${"SKIP"}, ${skipOpponentTagWithHash}, NOW())
+          (${skipWarId}, ${resolvedSyncNum}, CAST(${"SKIP"} AS "WarMatchType"), ${skipWarStart}, NULL, ${clanName}, ${clanTagWithHash}, ${"SKIP"}, ${skipOpponentTagWithHash}, NOW())
         ON CONFLICT ("warId")
         DO UPDATE SET
           "syncNumber" = EXCLUDED."syncNumber",
@@ -2365,7 +2365,7 @@ export async function handleFwaMatchSkipSyncConfirmButton(
         INSERT INTO "ClanWarHistory"
           ("syncNumber","matchType","warStartTime","warEndTime","clanName","clanTag","opponentName","opponentTag","updatedAt")
         VALUES
-          (${resolvedSyncNum}, ${"SKIP"}, ${skipWarStart}, NULL, ${clanName}, ${clanTagWithHash}, ${"SKIP"}, ${skipOpponentTagWithHash}, NOW())
+          (${resolvedSyncNum}, CAST(${"SKIP"} AS "WarMatchType"), ${skipWarStart}, NULL, ${clanName}, ${clanTagWithHash}, ${"SKIP"}, ${skipOpponentTagWithHash}, NOW())
         ON CONFLICT ("warStartTime","clanTag","opponentTag")
         DO UPDATE SET
           "syncNumber" = EXCLUDED."syncNumber",


### PR DESCRIPTION
- fix /fwa match SKIP confirm raw SQL failing with Postgres enum mismatch
- cast SKIP matchType values to "WarMatchType" in both ClanWarHistory insert/upsert paths
- resolves Prisma P2010 / Postgres 42804 when confirming SKIP