### PR TITLE
refactor(war-events): limit history writes to war-end flow

### DIFF
--- a/src/services/WarEventLogService.ts
+++ b/src/services/WarEventLogService.ts
@@ -182,18 +182,6 @@ function formatWarPercent(input: unknown): string {
   return `${withPrecision.replace(/\.00$/, "")}%`;
 }
 
-function parseNullableInt(input: unknown): number | null {
-  const value = Number(input);
-  if (!Number.isFinite(value)) return null;
-  return Math.trunc(value);
-}
-
-function parseNullableFloat(input: unknown): number | null {
-  const value = Number(input);
-  if (!Number.isFinite(value)) return null;
-  return value;
-}
-
 function buildWarStatsLines(stats: EmbedWarStats): string[] {
   const starsLeft = formatWarInt(stats.clanStars);
   const starsRight = formatWarInt(stats.opponentStars);
@@ -916,34 +904,6 @@ export class WarEventLogService {
       }
     }
 
-    if (currentState !== "notInWar") {
-      await this.upsertCurrentWarHistory({
-        clanTag: sub.clanTag,
-        warStartTime: nextWarStartTime,
-        warEndTime: nextWarEndTime,
-        syncNumber: syncNumberForEvent,
-        matchType: nextMatchType,
-        expectedOutcome: normalizeOutcome(nextOutcome),
-        clanName: nextClanName,
-        opponentName: nextOpponentName || sub.lastOpponentName || "Unknown",
-        opponentTag: nextOpponentTag || normalizeTag(sub.lastOpponentTag ?? ""),
-        stats: {
-          clanStars: nextClanStars,
-          opponentStars: nextOpponentStars,
-          clanAttacks: nextClanAttacks,
-          opponentAttacks: nextOpponentAttacks,
-          teamSize: nextTeamSize,
-          attacksPerMember: nextAttacksPerMember,
-          clanDestruction: nextClanDestruction,
-          opponentDestruction: nextOpponentDestruction,
-        },
-      }).catch((err) => {
-        console.error(
-          `[war-events] current-war history upsert failed guild=${sub.guildId} clan=${sub.clanTag} error=${formatError(err)}`
-        );
-      });
-    }
-
     if (eventType) {
       console.log(
         `[war-events] transition detected guild=${sub.guildId} clan=${sub.clanTag} event=${eventType} prev=${prevState} current=${currentState} sync=${syncNumberForEvent ?? "unknown"} warStart=${nextWarStartTime?.toISOString() ?? "unknown"} warEnd=${nextWarEndTime?.toISOString() ?? "unknown"} opponent=${nextOpponentTag || normalizeTag(sub.lastOpponentTag ?? "") || "unknown"}`
@@ -1377,35 +1337,30 @@ export class WarEventLogService {
 
     const warStartTime = parseCocTime(war.startTime ?? null) ?? sub.lastWarStartTime ?? null;
     const warEndTime = parseCocTime(war.endTime ?? null);
-    await this.upsertCurrentWarHistory({
-      clanTag: sub.clanTag,
-      warStartTime,
-      warEndTime,
-      syncNumber: await this.pointsSync.getPreviousSyncNum(),
-      matchType: sub.matchType,
-      expectedOutcome: normalizeOutcome(sub.outcome),
-      clanName: String(war.clan?.name ?? sub.clanName ?? sub.clanTag).trim() || sub.clanTag,
-      opponentName: String(war.opponent?.name ?? sub.lastOpponentName ?? "Unknown").trim() || "Unknown",
-      opponentTag: normalizeTag(war.opponent?.tag ?? sub.lastOpponentTag ?? ""),
-      stats: {
-        clanStars: Number.isFinite(Number(war.clan?.stars)) ? Number(war.clan?.stars) : sub.lastClanStars,
-        opponentStars: Number.isFinite(Number(war.opponent?.stars))
-          ? Number(war.opponent?.stars)
-          : sub.lastOpponentStars,
-        clanAttacks: Number.isFinite(Number(war.clan?.attacks)) ? Number(war.clan?.attacks) : null,
-        opponentAttacks: Number.isFinite(Number(war.opponent?.attacks))
-          ? Number(war.opponent?.attacks)
-          : null,
-        teamSize: Number.isFinite(Number(war.teamSize)) ? Number(war.teamSize) : null,
-        attacksPerMember: Number.isFinite(Number(war.attacksPerMember))
-          ? Number(war.attacksPerMember)
-          : null,
-        clanDestruction: Number.isFinite(Number(war.clan?.destructionPercentage))
-          ? Number(war.clan?.destructionPercentage)
-          : null,
-        opponentDestruction: Number.isFinite(Number(war.opponent?.destructionPercentage))
-          ? Number(war.opponent?.destructionPercentage)
-          : null,
+    const nextClanName = String(war.clan?.name ?? sub.clanName ?? sub.clanTag).trim() || sub.clanTag;
+    const nextOpponentTag = normalizeTag(war.opponent?.tag ?? sub.lastOpponentTag ?? "");
+    const nextOpponentName =
+      String(war.opponent?.name ?? sub.lastOpponentName ?? "Unknown").trim() || "Unknown";
+    const nextClanStars = Number.isFinite(Number(war.clan?.stars))
+      ? Number(war.clan?.stars)
+      : sub.lastClanStars;
+    const nextOpponentStars = Number.isFinite(Number(war.opponent?.stars))
+      ? Number(war.opponent?.stars)
+      : sub.lastOpponentStars;
+    const resolvedWarId =
+      warStartTime === null ? null : await this.resolveWarId(sub.clanTag, warStartTime);
+    await prisma.currentWar.update({
+      where: { id: sub.id },
+      data: {
+        warId: resolvedWarId,
+        lastState: "inWar",
+        lastWarStartTime: warStartTime,
+        lastOpponentTag: nextOpponentTag || sub.lastOpponentTag,
+        lastOpponentName: nextOpponentName || sub.lastOpponentName,
+        clanName: nextClanName,
+        lastClanStars: nextClanStars,
+        lastOpponentStars: nextOpponentStars,
+        updatedAt: new Date(),
       },
     });
 
@@ -1490,55 +1445,6 @@ export class WarEventLogService {
             .setStyle(ButtonStyle.Secondary)
         ),
       ],
-    });
-  }
-
-  private async upsertCurrentWarHistory(input: {
-    clanTag: string;
-    warStartTime: Date | null;
-    warEndTime: Date | null;
-    syncNumber: number | null;
-    matchType: MatchType;
-    expectedOutcome: "WIN" | "LOSE" | null;
-    clanName: string;
-    opponentName: string;
-    opponentTag: string;
-    stats: EmbedWarStats;
-  }): Promise<void> {
-    const clanTag = normalizeTag(input.clanTag);
-    if (!clanTag || !input.warStartTime) return;
-    const opponentTag = normalizeTag(input.opponentTag) || null;
-    const upsertData = {
-      syncNumber: input.syncNumber,
-      matchType: input.matchType,
-      clanStars: parseNullableInt(input.stats.clanStars),
-      clanDestruction: parseNullableFloat(input.stats.clanDestruction),
-      opponentStars: parseNullableInt(input.stats.opponentStars),
-      opponentDestruction: parseNullableFloat(input.stats.opponentDestruction),
-      expectedOutcome: input.expectedOutcome,
-      warEndTime: input.warEndTime,
-      clanName: input.clanName,
-      opponentName: input.opponentName,
-      opponentTag,
-    };
-    const existing = await prisma.clanWarHistory.findFirst({
-      where: { clanTag, warStartTime: input.warStartTime, opponentTag },
-      orderBy: { warId: "desc" },
-      select: { warId: true },
-    });
-    if (existing?.warId) {
-      await prisma.clanWarHistory.update({
-        where: { warId: existing.warId },
-        data: upsertData,
-      });
-      return;
-    }
-    await prisma.clanWarHistory.create({
-      data: {
-        ...upsertData,
-        warStartTime: input.warStartTime,
-        clanTag,
-      },
     });
   }
 


### PR DESCRIPTION
- stop writing ClanWarHistory during recurring war event poll cycles
- stop writing ClanWarHistory during battle-day refresh loop
- update battle-day refresh to write fresh CoC state to CurrentWar instead (state/opponent/name/stars/warId)
- keep ClanWarHistory persistence in dedicated war-ended flow only