### PR TITLE
fix(fwa): restore war mail refresh after restarts and force-refresh f…

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -47,3 +47,4 @@
 - `/sync post status [message-id:<id>]` - Show claimed vs unclaimed clan badge reactions for the active sync-time post, or for a specific message in the channel.
 - `/force sync data tag:<trackedClanTag> [datapoint:points|syncNum]` - Manually force-sync tracked clan points and/or sync number from points.fwafarm.
 - `/force sync mail tag:<trackedClanTag> message-type:<mail|notify:war start|notify:battle start|notify:war end> message-id:<id>` - Upsert `CurrentWar.mailConfig` with current match configuration plus a posted message reference.
+- `/remaining war tag:<trackedClanTag>` - Show localized phase-end time and remaining duration for the clan's current war phase (preparation or battle day).

--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -314,6 +314,10 @@ const fwaMailPreviewPayloads = new Map<string, FwaMailPreviewPayload>();
 const fwaMailPostedPayloads = new Map<string, FwaMailPostedPayload>();
 const fwaMailPollers = new Map<string, ReturnType<typeof setInterval>>();
 
+function createTransientFwaKey(): string {
+  return `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
+}
+
 function buildFwaMatchCopyCustomId(
   userId: string,
   key: string,
@@ -1489,6 +1493,59 @@ async function refreshWarMailPost(client: Client, key: string): Promise<void> {
     embeds: [rendered.embed],
     components: buildWarMailPostedComponents(key),
   });
+}
+
+async function refreshWarMailPostByResolvedTarget(params: {
+  client: Client;
+  guildId: string;
+  tag: string;
+  channelId: string;
+  messageId: string;
+  key?: string;
+}): Promise<boolean> {
+  const normalizedTag = normalizeTag(params.tag);
+  if (!normalizedTag) return false;
+  const channel = await params.client.channels.fetch(params.channelId).catch(() => null);
+  if (!channel || !channel.isTextBased()) return false;
+  const message = await (channel as any).messages.fetch(params.messageId).catch(() => null);
+  if (!message) return false;
+  const cocService = new CoCService();
+  const rendered = await buildWarMailEmbedForTag(cocService, params.guildId, normalizedTag);
+  await message.edit({
+    embeds: [rendered.embed],
+    components: buildWarMailPostedComponents(params.key ?? createTransientFwaKey()),
+  });
+  return true;
+}
+
+function extractWarMailTagFromMessage(message: ButtonInteraction["message"]): string | null {
+  const title = String(message.embeds?.[0]?.title ?? "");
+  const match = title.match(/\(#([A-Z0-9]+)\)\s*$/i);
+  if (!match?.[1]) return null;
+  return normalizeTag(match[1]);
+}
+
+async function findWarMailTargetFromConfig(params: {
+  guildId: string;
+  channelId: string;
+  messageId: string;
+}): Promise<{ tag: string; channelId: string; messageId: string } | null> {
+  const rows = await prisma.currentWar.findMany({
+    where: { guildId: params.guildId },
+    select: { clanTag: true, mailConfig: true },
+  });
+  for (const row of rows) {
+    const config = parseMatchMailConfig(row.mailConfig as Prisma.JsonValue | null | undefined);
+    if (!config.lastPostedChannelId || !config.lastPostedMessageId) continue;
+    if (config.lastPostedChannelId !== params.channelId) continue;
+    if (config.lastPostedMessageId !== params.messageId) continue;
+    return {
+      tag: normalizeTag(row.clanTag),
+      channelId: config.lastPostedChannelId,
+      messageId: config.lastPostedMessageId,
+    };
+  }
+  return null;
 }
 
 function startWarMailPolling(client: Client, key: string): void {
@@ -2938,18 +2995,96 @@ export async function handleFwaMailRefreshButton(interaction: ButtonInteraction)
   const parsed = parseFwaMailRefreshCustomId(interaction.customId);
   if (!parsed) return;
   const payload = fwaMailPostedPayloads.get(parsed.key);
-  if (!payload) {
+  if (payload) {
+    await refreshWarMailPost(interaction.client, parsed.key);
+    await interaction.reply({
+      ephemeral: true,
+      content: "War mail refreshed.",
+    });
+    return;
+  }
+  const guildId = interaction.guildId ?? "";
+  const fallbackTag = extractWarMailTagFromMessage(interaction.message);
+  const fallbackTarget =
+    guildId && fallbackTag
+      ? {
+          tag: fallbackTag,
+          channelId: interaction.channelId,
+          messageId: interaction.message.id,
+        }
+      : guildId
+        ? await findWarMailTargetFromConfig({
+            guildId,
+            channelId: interaction.channelId,
+            messageId: interaction.message.id,
+          })
+        : null;
+  if (!guildId || !fallbackTarget) {
     await interaction.reply({
       ephemeral: true,
       content: "This mail post can no longer be refreshed.",
     });
     return;
   }
-  await refreshWarMailPost(interaction.client, parsed.key);
+  const refreshed = await refreshWarMailPostByResolvedTarget({
+    client: interaction.client,
+    guildId,
+    tag: fallbackTarget.tag,
+    channelId: fallbackTarget.channelId,
+    messageId: fallbackTarget.messageId,
+  }).catch(() => false);
   await interaction.reply({
     ephemeral: true,
-    content: "War mail refreshed.",
+    content: refreshed ? "War mail refreshed." : "This mail post can no longer be refreshed.",
   });
+}
+
+export async function refreshAllTrackedWarMailPosts(client: Client): Promise<void> {
+  const rows = await prisma.currentWar.findMany({
+    select: {
+      guildId: true,
+      clanTag: true,
+      mailConfig: true,
+    },
+  });
+
+  for (const row of rows) {
+    const guildId = row.guildId?.trim() ?? "";
+    if (!guildId) continue;
+    const config = parseMatchMailConfig(row.mailConfig as Prisma.JsonValue | null | undefined);
+    const channelId = config.lastPostedChannelId?.trim() ?? "";
+    const messageId = config.lastPostedMessageId?.trim() ?? "";
+    if (!channelId || !messageId) continue;
+
+    const existingInMemory = findLatestPostedWarMailForClan({
+      guildId,
+      tag: row.clanTag,
+    });
+    const refreshed = await refreshWarMailPostByResolvedTarget({
+      client,
+      guildId,
+      tag: row.clanTag,
+      channelId,
+      messageId,
+      key: existingInMemory?.key,
+    }).catch(() => false);
+    if (!refreshed) continue;
+
+    if (!existingInMemory) {
+      const postKey = createTransientFwaKey();
+      fwaMailPostedPayloads.set(postKey, {
+        guildId,
+        tag: normalizeTag(row.clanTag),
+        warStartMs: config.lastWarStartMs ?? null,
+        channelId,
+        messageId,
+        sentAtMs: Date.now(),
+        matchType: config.lastMatchType ?? "UNKNOWN",
+        expectedOutcome: config.lastExpectedOutcome ?? null,
+      });
+      startWarMailPolling(client, postKey);
+    }
+  }
 }
 
 export async function handlePointsPostButton(interaction: ButtonInteraction): Promise<void> {

--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -266,6 +266,15 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
       "/force sync mail tag:2QG2C08UP message-type:notify:war start message-id:1234567890123456789",
     ],
   },
+  remaining: {
+    summary: "Show remaining time for a tracked clan's current war phase.",
+    details: [
+      "`/remaining war` reports whether the clan is in preparation or battle day.",
+      "Returns localized phase-end and relative remaining time from current CoC API state.",
+      "Tag supports autocomplete from tracked clans.",
+    ],
+    examples: ["/remaining war tag:2QG2C08UP"],
+  },
   permission: {
     summary: "Control which roles can run each command target.",
     details: [

--- a/src/listeners/ready.ts
+++ b/src/listeners/ready.ts
@@ -17,6 +17,7 @@ import {
   WarEventLogService,
   notifyWarBattleDayRefreshIntervalMs,
 } from "../services/WarEventLogService";
+import { refreshAllTrackedWarMailPosts } from "../commands/Fwa";
 
 const DEFAULT_OBSERVE_INTERVAL_MINUTES = 30;
 const RECRUITMENT_REMINDER_INTERVAL_MS = 5 * 60 * 1000;
@@ -318,6 +319,22 @@ export default (client: Client, cocService: CoCService): void => {
         }
       });
     };
+    const runWarMailRefresh = async () => {
+      await runFetchTelemetryBatch("war_mail_refresh_cycle", async () => {
+        try {
+          await refreshAllTrackedWarMailPosts(client);
+        } catch (err) {
+          console.error(`[fwa-mail] refresh loop failed: ${formatError(err)}`);
+        }
+      });
+    };
+    await runWarMailRefresh();
+    setInterval(() => {
+      runWarMailRefresh().catch((err) => {
+        console.error(`[fwa-mail] refresh interval failed: ${formatError(err)}`);
+      });
+    }, notifyWarBattleDayRefreshIntervalMs);
+    console.log("War mail refresh enabled (every 20 minute(s)).");
     setInterval(() => {
       runBattleDayRefresh().catch((err) => {
         console.error(`[war-events] battle-day refresh interval failed: ${formatError(err)}`);

--- a/src/services/CommandPermissionService.ts
+++ b/src/services/CommandPermissionService.ts
@@ -35,6 +35,8 @@ export const COMMAND_PERMISSION_TARGETS = [
   "fwa:leader-role",
   "force:sync:data",
   "force:sync:mail",
+  "remaining",
+  "remaining:war",
   "recruitment:show",
   "recruitment:edit",
   "recruitment:dashboard",


### PR DESCRIPTION
…allback

- add DB-backed fallback for war-mail Refresh button when in-memory key is missing
- resolve refresh target from embed tag and CurrentWar.mailConfig references
- add recurring war-mail refresh cycle in ready listener (every 20 minutes)
- hydrate in-memory posted-mail tracking from CurrentWar.mailConfig so polling resumes
- keep manual refresh response accurate when post is no longer resolvable