### PR TITLE
feat(force): add /force mail update for in-place war mail refresh

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -47,4 +47,5 @@
 - `/sync post status [message-id:<id>]` - Show claimed vs unclaimed clan badge reactions for the active sync-time post, or for a specific message in the channel.
 - `/force sync data tag:<trackedClanTag> [datapoint:points|syncNum]` - Manually force-sync tracked clan points and/or sync number from points.fwafarm.
 - `/force sync mail tag:<trackedClanTag> message-type:<mail|notify:war start|notify:battle start|notify:war end> message-id:<id>` - Upsert `CurrentWar.mailConfig` with current match configuration plus a posted message reference.
+- `/force mail update tag:<trackedClanTag>` - Refresh an existing sent war-mail embed in place (no re-ping) and resume 20-minute refresh tracking.
 - `/remaining war tag:<trackedClanTag>` - Show localized phase-end time and remaining duration for the clan's current war phase (preparation or battle day).

--- a/src/commands/Force.ts
+++ b/src/commands/Force.ts
@@ -8,6 +8,7 @@ import { Command } from "../Command";
 import { prisma } from "../prisma";
 import { CoCService } from "../services/CoCService";
 import {
+  runForceMailUpdateCommand,
   runForceSyncDataCommand,
   runForceSyncMailCommand,
 } from "./Fwa";
@@ -83,6 +84,27 @@ export const Force: Command = {
         },
       ],
     },
+    {
+      name: "mail",
+      description: "Force operations for posted war mail",
+      type: ApplicationCommandOptionType.SubcommandGroup,
+      options: [
+        {
+          name: "update",
+          description: "Refresh existing sent mail embed in place and resume tracking",
+          type: ApplicationCommandOptionType.Subcommand,
+          options: [
+            {
+              name: "tag",
+              description: "Tracked clan tag (with or without #)",
+              type: ApplicationCommandOptionType.String,
+              required: true,
+              autocomplete: true,
+            },
+          ],
+        },
+      ],
+    },
   ],
   run: async (
     _client: Client,
@@ -98,6 +120,10 @@ export const Force: Command = {
     }
     if (subcommandGroup === "sync" && subcommand === "mail") {
       await runForceSyncMailCommand(interaction, cocService);
+      return;
+    }
+    if (subcommandGroup === "mail" && subcommand === "update") {
+      await runForceMailUpdateCommand(interaction);
       return;
     }
 

--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -3087,6 +3087,90 @@ export async function refreshAllTrackedWarMailPosts(client: Client): Promise<voi
   }
 }
 
+export async function runForceMailUpdateCommand(
+  interaction: ChatInputCommandInteraction
+): Promise<void> {
+  const visibility = interaction.options.getString("visibility", false) ?? "private";
+  const isPublic = visibility === "public";
+  await interaction.deferReply({ ephemeral: !isPublic });
+
+  if (!interaction.guildId) {
+    await interaction.editReply("This command can only be used in a server.");
+    return;
+  }
+
+  const tag = normalizeTag(interaction.options.getString("tag", true));
+  const trackedClan = await prisma.trackedClan.findFirst({
+    where: { tag: { equals: `#${tag}`, mode: "insensitive" } },
+    select: { tag: true, name: true },
+  });
+  if (!trackedClan) {
+    await interaction.editReply(`Clan #${tag} is not in tracked clans.`);
+    return;
+  }
+
+  const current = await prisma.currentWar.findUnique({
+    where: {
+      guildId_clanTag: {
+        guildId: interaction.guildId,
+        clanTag: `#${tag}`,
+      },
+    },
+    select: { mailConfig: true },
+  });
+  const config = parseMatchMailConfig(current?.mailConfig as Prisma.JsonValue | null | undefined);
+  const channelId = config.lastPostedChannelId?.trim() ?? "";
+  const messageId = config.lastPostedMessageId?.trim() ?? "";
+  if (!channelId || !messageId) {
+    await interaction.editReply(
+      `No active sent mail reference found for #${tag}. Send mail first or sync it via \`/force sync mail\`.`
+    );
+    return;
+  }
+
+  const refreshed = await refreshWarMailPostByResolvedTarget({
+    client: interaction.client,
+    guildId: interaction.guildId,
+    tag,
+    channelId,
+    messageId,
+  }).catch(() => false);
+  if (!refreshed) {
+    await interaction.editReply(
+      `Could not refresh #${tag} mail in place. The referenced message may be missing or inaccessible.`
+    );
+    return;
+  }
+
+  const existingInMemory = findLatestPostedWarMailForClan({
+    guildId: interaction.guildId,
+    tag,
+  });
+  if (!existingInMemory) {
+    const postKey = createTransientFwaKey();
+    fwaMailPostedPayloads.set(postKey, {
+      guildId: interaction.guildId,
+      tag,
+      warStartMs: config.lastWarStartMs ?? null,
+      channelId,
+      messageId,
+      sentAtMs: Date.now(),
+      matchType: config.lastMatchType ?? "UNKNOWN",
+      expectedOutcome: config.lastExpectedOutcome ?? null,
+    });
+    startWarMailPolling(interaction.client, postKey);
+  }
+
+  await interaction.editReply(
+    [
+      `Force mail update complete for #${tag}.`,
+      "Updated existing message in place (no new ping).",
+      "20-minute refresh tracking is active for this post.",
+      `Message: https://discord.com/channels/${interaction.guildId}/${channelId}/${messageId}`,
+    ].join("\n")
+  );
+}
+
 export async function handlePointsPostButton(interaction: ButtonInteraction): Promise<void> {
   const parsed = parsePointsPostButtonCustomId(interaction.customId);
   if (!parsed) return;

--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -257,6 +257,7 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
     details: [
       "`/force sync data` manually overwrites tracked clan points and/or sync number from points.fwafarm.",
       "`/force sync mail` upserts `CurrentWar.mailConfig` message references for posted mail/notify messages.",
+      "`/force mail update` refreshes an existing sent war-mail message in place and re-attaches it to the 20-minute refresh loop.",
       "`force sync` commands are admin-only by default.",
     ],
     examples: [
@@ -264,6 +265,7 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
       "/force sync data tag:2QG2C08UP datapoint:points",
       "/force sync mail tag:2QG2C08UP message-type:mail message-id:1234567890123456789",
       "/force sync mail tag:2QG2C08UP message-type:notify:war start message-id:1234567890123456789",
+      "/force mail update tag:2QG2C08UP",
     ],
   },
   remaining: {

--- a/src/services/CommandPermissionService.ts
+++ b/src/services/CommandPermissionService.ts
@@ -35,6 +35,7 @@ export const COMMAND_PERMISSION_TARGETS = [
   "fwa:leader-role",
   "force:sync:data",
   "force:sync:mail",
+  "force:mail:update",
   "remaining",
   "remaining:war",
   "recruitment:show",
@@ -70,6 +71,7 @@ const ADMIN_DEFAULT_TARGETS = new Set<string>([
   "fwa:leader-role",
   "force:sync:data",
   "force:sync:mail",
+  "force:mail:update",
   `${MANAGE_COMMAND_ROLES_COMMAND}:add`,
   `${MANAGE_COMMAND_ROLES_COMMAND}:remove`,
 ]);


### PR DESCRIPTION
- add /force mail update tag:<trackedClanTag> command path
- refresh existing sent war-mail embed in place using CurrentWar.mailConfig references
- resume/attach 20-minute refresh tracking for successfully refreshed posts
- add permission target force:mail:update and mark admin-default
- update help docs and commands reference for the new command