### PR TITLE
Release: Harden War Mail/Notify Refresh Flow and Add Force Mail Update Command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -47,3 +47,4 @@
 - `/sync post status [message-id:<id>]` - Show claimed vs unclaimed clan badge reactions for the active sync-time post, or for a specific message in the channel.
 - `/force sync data tag:<trackedClanTag> [datapoint:points|syncNum]` - Manually force-sync tracked clan points and/or sync number from points.fwafarm.
 - `/force sync mail tag:<trackedClanTag> message-type:<mail|notify:war start|notify:battle start|notify:war end> message-id:<id>` - Upsert `CurrentWar.mailConfig` with current match configuration plus a posted message reference.
+- `/remaining war tag:<trackedClanTag>` - Show localized phase-end time and remaining duration for the clan's current war phase (preparation or battle day).

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -47,4 +47,5 @@
 - `/sync post status [message-id:<id>]` - Show claimed vs unclaimed clan badge reactions for the active sync-time post, or for a specific message in the channel.
 - `/force sync data tag:<trackedClanTag> [datapoint:points|syncNum]` - Manually force-sync tracked clan points and/or sync number from points.fwafarm.
 - `/force sync mail tag:<trackedClanTag> message-type:<mail|notify:war start|notify:battle start|notify:war end> message-id:<id>` - Upsert `CurrentWar.mailConfig` with current match configuration plus a posted message reference.
+- `/force mail update tag:<trackedClanTag>` - Refresh an existing sent war-mail embed in place (no re-ping) and resume 20-minute refresh tracking.
 - `/remaining war tag:<trackedClanTag>` - Show localized phase-end time and remaining duration for the clan's current war phase (preparation or battle day).

--- a/src/commands/Force.ts
+++ b/src/commands/Force.ts
@@ -8,6 +8,7 @@ import { Command } from "../Command";
 import { prisma } from "../prisma";
 import { CoCService } from "../services/CoCService";
 import {
+  runForceMailUpdateCommand,
   runForceSyncDataCommand,
   runForceSyncMailCommand,
 } from "./Fwa";
@@ -83,6 +84,27 @@ export const Force: Command = {
         },
       ],
     },
+    {
+      name: "mail",
+      description: "Force operations for posted war mail",
+      type: ApplicationCommandOptionType.SubcommandGroup,
+      options: [
+        {
+          name: "update",
+          description: "Refresh existing sent mail embed in place and resume tracking",
+          type: ApplicationCommandOptionType.Subcommand,
+          options: [
+            {
+              name: "tag",
+              description: "Tracked clan tag (with or without #)",
+              type: ApplicationCommandOptionType.String,
+              required: true,
+              autocomplete: true,
+            },
+          ],
+        },
+      ],
+    },
   ],
   run: async (
     _client: Client,
@@ -98,6 +120,10 @@ export const Force: Command = {
     }
     if (subcommandGroup === "sync" && subcommand === "mail") {
       await runForceSyncMailCommand(interaction, cocService);
+      return;
+    }
+    if (subcommandGroup === "mail" && subcommand === "update") {
+      await runForceMailUpdateCommand(interaction);
       return;
     }
 

--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -314,6 +314,10 @@ const fwaMailPreviewPayloads = new Map<string, FwaMailPreviewPayload>();
 const fwaMailPostedPayloads = new Map<string, FwaMailPostedPayload>();
 const fwaMailPollers = new Map<string, ReturnType<typeof setInterval>>();
 
+function createTransientFwaKey(): string {
+  return `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
+}
+
 function buildFwaMatchCopyCustomId(
   userId: string,
   key: string,
@@ -1489,6 +1493,59 @@ async function refreshWarMailPost(client: Client, key: string): Promise<void> {
     embeds: [rendered.embed],
     components: buildWarMailPostedComponents(key),
   });
+}
+
+async function refreshWarMailPostByResolvedTarget(params: {
+  client: Client;
+  guildId: string;
+  tag: string;
+  channelId: string;
+  messageId: string;
+  key?: string;
+}): Promise<boolean> {
+  const normalizedTag = normalizeTag(params.tag);
+  if (!normalizedTag) return false;
+  const channel = await params.client.channels.fetch(params.channelId).catch(() => null);
+  if (!channel || !channel.isTextBased()) return false;
+  const message = await (channel as any).messages.fetch(params.messageId).catch(() => null);
+  if (!message) return false;
+  const cocService = new CoCService();
+  const rendered = await buildWarMailEmbedForTag(cocService, params.guildId, normalizedTag);
+  await message.edit({
+    embeds: [rendered.embed],
+    components: buildWarMailPostedComponents(params.key ?? createTransientFwaKey()),
+  });
+  return true;
+}
+
+function extractWarMailTagFromMessage(message: ButtonInteraction["message"]): string | null {
+  const title = String(message.embeds?.[0]?.title ?? "");
+  const match = title.match(/\(#([A-Z0-9]+)\)\s*$/i);
+  if (!match?.[1]) return null;
+  return normalizeTag(match[1]);
+}
+
+async function findWarMailTargetFromConfig(params: {
+  guildId: string;
+  channelId: string;
+  messageId: string;
+}): Promise<{ tag: string; channelId: string; messageId: string } | null> {
+  const rows = await prisma.currentWar.findMany({
+    where: { guildId: params.guildId },
+    select: { clanTag: true, mailConfig: true },
+  });
+  for (const row of rows) {
+    const config = parseMatchMailConfig(row.mailConfig as Prisma.JsonValue | null | undefined);
+    if (!config.lastPostedChannelId || !config.lastPostedMessageId) continue;
+    if (config.lastPostedChannelId !== params.channelId) continue;
+    if (config.lastPostedMessageId !== params.messageId) continue;
+    return {
+      tag: normalizeTag(row.clanTag),
+      channelId: config.lastPostedChannelId,
+      messageId: config.lastPostedMessageId,
+    };
+  }
+  return null;
 }
 
 function startWarMailPolling(client: Client, key: string): void {
@@ -2938,18 +2995,96 @@ export async function handleFwaMailRefreshButton(interaction: ButtonInteraction)
   const parsed = parseFwaMailRefreshCustomId(interaction.customId);
   if (!parsed) return;
   const payload = fwaMailPostedPayloads.get(parsed.key);
-  if (!payload) {
+  if (payload) {
+    await refreshWarMailPost(interaction.client, parsed.key);
+    await interaction.reply({
+      ephemeral: true,
+      content: "War mail refreshed.",
+    });
+    return;
+  }
+  const guildId = interaction.guildId ?? "";
+  const fallbackTag = extractWarMailTagFromMessage(interaction.message);
+  const fallbackTarget =
+    guildId && fallbackTag
+      ? {
+          tag: fallbackTag,
+          channelId: interaction.channelId,
+          messageId: interaction.message.id,
+        }
+      : guildId
+        ? await findWarMailTargetFromConfig({
+            guildId,
+            channelId: interaction.channelId,
+            messageId: interaction.message.id,
+          })
+        : null;
+  if (!guildId || !fallbackTarget) {
     await interaction.reply({
       ephemeral: true,
       content: "This mail post can no longer be refreshed.",
     });
     return;
   }
-  await refreshWarMailPost(interaction.client, parsed.key);
+  const refreshed = await refreshWarMailPostByResolvedTarget({
+    client: interaction.client,
+    guildId,
+    tag: fallbackTarget.tag,
+    channelId: fallbackTarget.channelId,
+    messageId: fallbackTarget.messageId,
+  }).catch(() => false);
   await interaction.reply({
     ephemeral: true,
-    content: "War mail refreshed.",
+    content: refreshed ? "War mail refreshed." : "This mail post can no longer be refreshed.",
   });
+}
+
+export async function refreshAllTrackedWarMailPosts(client: Client): Promise<void> {
+  const rows = await prisma.currentWar.findMany({
+    select: {
+      guildId: true,
+      clanTag: true,
+      mailConfig: true,
+    },
+  });
+
+  for (const row of rows) {
+    const guildId = row.guildId?.trim() ?? "";
+    if (!guildId) continue;
+    const config = parseMatchMailConfig(row.mailConfig as Prisma.JsonValue | null | undefined);
+    const channelId = config.lastPostedChannelId?.trim() ?? "";
+    const messageId = config.lastPostedMessageId?.trim() ?? "";
+    if (!channelId || !messageId) continue;
+
+    const existingInMemory = findLatestPostedWarMailForClan({
+      guildId,
+      tag: row.clanTag,
+    });
+    const refreshed = await refreshWarMailPostByResolvedTarget({
+      client,
+      guildId,
+      tag: row.clanTag,
+      channelId,
+      messageId,
+      key: existingInMemory?.key,
+    }).catch(() => false);
+    if (!refreshed) continue;
+
+    if (!existingInMemory) {
+      const postKey = createTransientFwaKey();
+      fwaMailPostedPayloads.set(postKey, {
+        guildId,
+        tag: normalizeTag(row.clanTag),
+        warStartMs: config.lastWarStartMs ?? null,
+        channelId,
+        messageId,
+        sentAtMs: Date.now(),
+        matchType: config.lastMatchType ?? "UNKNOWN",
+        expectedOutcome: config.lastExpectedOutcome ?? null,
+      });
+      startWarMailPolling(client, postKey);
+    }
+  }
 }
 
 export async function handlePointsPostButton(interaction: ButtonInteraction): Promise<void> {

--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -3087,6 +3087,90 @@ export async function refreshAllTrackedWarMailPosts(client: Client): Promise<voi
   }
 }
 
+export async function runForceMailUpdateCommand(
+  interaction: ChatInputCommandInteraction
+): Promise<void> {
+  const visibility = interaction.options.getString("visibility", false) ?? "private";
+  const isPublic = visibility === "public";
+  await interaction.deferReply({ ephemeral: !isPublic });
+
+  if (!interaction.guildId) {
+    await interaction.editReply("This command can only be used in a server.");
+    return;
+  }
+
+  const tag = normalizeTag(interaction.options.getString("tag", true));
+  const trackedClan = await prisma.trackedClan.findFirst({
+    where: { tag: { equals: `#${tag}`, mode: "insensitive" } },
+    select: { tag: true, name: true },
+  });
+  if (!trackedClan) {
+    await interaction.editReply(`Clan #${tag} is not in tracked clans.`);
+    return;
+  }
+
+  const current = await prisma.currentWar.findUnique({
+    where: {
+      guildId_clanTag: {
+        guildId: interaction.guildId,
+        clanTag: `#${tag}`,
+      },
+    },
+    select: { mailConfig: true },
+  });
+  const config = parseMatchMailConfig(current?.mailConfig as Prisma.JsonValue | null | undefined);
+  const channelId = config.lastPostedChannelId?.trim() ?? "";
+  const messageId = config.lastPostedMessageId?.trim() ?? "";
+  if (!channelId || !messageId) {
+    await interaction.editReply(
+      `No active sent mail reference found for #${tag}. Send mail first or sync it via \`/force sync mail\`.`
+    );
+    return;
+  }
+
+  const refreshed = await refreshWarMailPostByResolvedTarget({
+    client: interaction.client,
+    guildId: interaction.guildId,
+    tag,
+    channelId,
+    messageId,
+  }).catch(() => false);
+  if (!refreshed) {
+    await interaction.editReply(
+      `Could not refresh #${tag} mail in place. The referenced message may be missing or inaccessible.`
+    );
+    return;
+  }
+
+  const existingInMemory = findLatestPostedWarMailForClan({
+    guildId: interaction.guildId,
+    tag,
+  });
+  if (!existingInMemory) {
+    const postKey = createTransientFwaKey();
+    fwaMailPostedPayloads.set(postKey, {
+      guildId: interaction.guildId,
+      tag,
+      warStartMs: config.lastWarStartMs ?? null,
+      channelId,
+      messageId,
+      sentAtMs: Date.now(),
+      matchType: config.lastMatchType ?? "UNKNOWN",
+      expectedOutcome: config.lastExpectedOutcome ?? null,
+    });
+    startWarMailPolling(interaction.client, postKey);
+  }
+
+  await interaction.editReply(
+    [
+      `Force mail update complete for #${tag}.`,
+      "Updated existing message in place (no new ping).",
+      "20-minute refresh tracking is active for this post.",
+      `Message: https://discord.com/channels/${interaction.guildId}/${channelId}/${messageId}`,
+    ].join("\n")
+  );
+}
+
 export async function handlePointsPostButton(interaction: ButtonInteraction): Promise<void> {
   const parsed = parsePointsPostButtonCustomId(interaction.customId);
   if (!parsed) return;

--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -66,6 +66,7 @@ const FWA_MATCH_ALLIANCE_PREFIX = "fwa-match-alliance";
 const FWA_MAIL_CONFIRM_PREFIX = "fwa-mail-confirm";
 const FWA_MAIL_REFRESH_PREFIX = "fwa-mail-refresh";
 const FWA_MATCH_SEND_MAIL_PREFIX = "fwa-match-send-mail";
+const WAR_MAIL_REFRESH_MS = 20 * 60 * 1000;
 const MAILBOX_SENT_EMOJI = "📬";
 const MAILBOX_NOT_SENT_EMOJI = "📭";
 const POINTS_REQUEST_HEADERS = {
@@ -1474,6 +1475,16 @@ function buildWarMailPostedComponents(key: string): Array<ActionRowBuilder<Butto
   ];
 }
 
+function buildNextRefreshRelativeLabel(intervalMs: number): string {
+  return `Next refresh <t:${Math.floor((Date.now() + intervalMs) / 1000)}:R>`;
+}
+
+function buildWarMailPostedContent(roleId?: string | null): string {
+  const nextRefresh = buildNextRefreshRelativeLabel(WAR_MAIL_REFRESH_MS);
+  if (roleId) return `<@&${roleId}>\n${nextRefresh}`;
+  return nextRefresh;
+}
+
 async function refreshWarMailPost(client: Client, key: string): Promise<void> {
   const payload = fwaMailPostedPayloads.get(key);
   if (!payload) return;
@@ -1490,6 +1501,7 @@ async function refreshWarMailPost(client: Client, key: string): Promise<void> {
   const message = await (channel as any).messages.fetch(payload.messageId).catch(() => null);
   if (!message) return;
   await message.edit({
+    content: buildWarMailPostedContent(),
     embeds: [rendered.embed],
     components: buildWarMailPostedComponents(key),
   });
@@ -1512,6 +1524,7 @@ async function refreshWarMailPostByResolvedTarget(params: {
   const cocService = new CoCService();
   const rendered = await buildWarMailEmbedForTag(cocService, params.guildId, normalizedTag);
   await message.edit({
+    content: buildWarMailPostedContent(),
     embeds: [rendered.embed],
     components: buildWarMailPostedComponents(params.key ?? createTransientFwaKey()),
   });
@@ -1552,7 +1565,7 @@ function startWarMailPolling(client: Client, key: string): void {
   stopWarMailPolling(key);
   const timer = setInterval(() => {
     refreshWarMailPost(client, key).catch(() => undefined);
-  }, 20 * 60 * 1000);
+  }, WAR_MAIL_REFRESH_MS);
   fwaMailPollers.set(key, timer);
 }
 
@@ -2838,7 +2851,7 @@ export async function handleFwaMailConfirmButton(interaction: ButtonInteraction)
   }
   const postKey = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
   const sent = await (channel as any).send({
-    content: rendered.clanRoleId ? `<@&${rendered.clanRoleId}>` : undefined,
+    content: buildWarMailPostedContent(rendered.clanRoleId),
     allowedMentions: rendered.clanRoleId ? { roles: [rendered.clanRoleId] } : undefined,
     embeds: [rendered.embed],
     components: buildWarMailPostedComponents(postKey),

--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -257,6 +257,7 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
     details: [
       "`/force sync data` manually overwrites tracked clan points and/or sync number from points.fwafarm.",
       "`/force sync mail` upserts `CurrentWar.mailConfig` message references for posted mail/notify messages.",
+      "`/force mail update` refreshes an existing sent war-mail message in place and re-attaches it to the 20-minute refresh loop.",
       "`force sync` commands are admin-only by default.",
     ],
     examples: [
@@ -264,6 +265,7 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
       "/force sync data tag:2QG2C08UP datapoint:points",
       "/force sync mail tag:2QG2C08UP message-type:mail message-id:1234567890123456789",
       "/force sync mail tag:2QG2C08UP message-type:notify:war start message-id:1234567890123456789",
+      "/force mail update tag:2QG2C08UP",
     ],
   },
   remaining: {

--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -266,6 +266,15 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
       "/force sync mail tag:2QG2C08UP message-type:notify:war start message-id:1234567890123456789",
     ],
   },
+  remaining: {
+    summary: "Show remaining time for a tracked clan's current war phase.",
+    details: [
+      "`/remaining war` reports whether the clan is in preparation or battle day.",
+      "Returns localized phase-end and relative remaining time from current CoC API state.",
+      "Tag supports autocomplete from tracked clans.",
+    ],
+    examples: ["/remaining war tag:2QG2C08UP"],
+  },
   permission: {
     summary: "Control which roles can run each command target.",
     details: [

--- a/src/listeners/ready.ts
+++ b/src/listeners/ready.ts
@@ -17,6 +17,7 @@ import {
   WarEventLogService,
   notifyWarBattleDayRefreshIntervalMs,
 } from "../services/WarEventLogService";
+import { refreshAllTrackedWarMailPosts } from "../commands/Fwa";
 
 const DEFAULT_OBSERVE_INTERVAL_MINUTES = 30;
 const RECRUITMENT_REMINDER_INTERVAL_MS = 5 * 60 * 1000;
@@ -318,6 +319,22 @@ export default (client: Client, cocService: CoCService): void => {
         }
       });
     };
+    const runWarMailRefresh = async () => {
+      await runFetchTelemetryBatch("war_mail_refresh_cycle", async () => {
+        try {
+          await refreshAllTrackedWarMailPosts(client);
+        } catch (err) {
+          console.error(`[fwa-mail] refresh loop failed: ${formatError(err)}`);
+        }
+      });
+    };
+    await runWarMailRefresh();
+    setInterval(() => {
+      runWarMailRefresh().catch((err) => {
+        console.error(`[fwa-mail] refresh interval failed: ${formatError(err)}`);
+      });
+    }, notifyWarBattleDayRefreshIntervalMs);
+    console.log("War mail refresh enabled (every 20 minute(s)).");
     setInterval(() => {
       runBattleDayRefresh().catch((err) => {
         console.error(`[war-events] battle-day refresh interval failed: ${formatError(err)}`);

--- a/src/services/CommandPermissionService.ts
+++ b/src/services/CommandPermissionService.ts
@@ -35,6 +35,7 @@ export const COMMAND_PERMISSION_TARGETS = [
   "fwa:leader-role",
   "force:sync:data",
   "force:sync:mail",
+  "force:mail:update",
   "remaining",
   "remaining:war",
   "recruitment:show",
@@ -70,6 +71,7 @@ const ADMIN_DEFAULT_TARGETS = new Set<string>([
   "fwa:leader-role",
   "force:sync:data",
   "force:sync:mail",
+  "force:mail:update",
   `${MANAGE_COMMAND_ROLES_COMMAND}:add`,
   `${MANAGE_COMMAND_ROLES_COMMAND}:remove`,
 ]);

--- a/src/services/CommandPermissionService.ts
+++ b/src/services/CommandPermissionService.ts
@@ -35,6 +35,8 @@ export const COMMAND_PERMISSION_TARGETS = [
   "fwa:leader-role",
   "force:sync:data",
   "force:sync:mail",
+  "remaining",
+  "remaining:war",
   "recruitment:show",
   "recruitment:edit",
   "recruitment:dashboard",

--- a/src/services/WarEventLogService.ts
+++ b/src/services/WarEventLogService.ts
@@ -41,6 +41,10 @@ const NOTIFY_WAR_REFRESH_PREFIX = "notify-war-refresh";
 const BATTLE_DAY_REFRESH_MS = 20 * 60 * 1000;
 const battleDayPostByGuildTag = new Map<string, { channelId: string; messageId: string }>();
 
+function buildNextRefreshRelativeLabel(intervalMs: number): string {
+  return `Next refresh <t:${Math.floor((Date.now() + intervalMs) / 1000)}:R>`;
+}
+
 type TestSource = "current" | "last";
 
 type SubscriptionRow = {
@@ -663,6 +667,14 @@ export class WarEventLogService {
 
     const roleMention =
       includeRoleMention && payload.pingRole && payload.notifyRole ? `<@&${payload.notifyRole}>` : null;
+    const nextRefreshLabel =
+      payload.eventType === "battle_day" ? buildNextRefreshRelativeLabel(BATTLE_DAY_REFRESH_MS) : null;
+    const content =
+      payload.eventType === "battle_day"
+        ? roleMention
+          ? `${roleMention}\n${nextRefreshLabel}`
+          : (nextRefreshLabel ?? undefined)
+        : (roleMention ?? undefined);
     const components =
       includeEventComponents && payload.eventType === "battle_day" && guildId
         ? [
@@ -676,7 +688,7 @@ export class WarEventLogService {
         : [];
 
     return {
-      content: roleMention ?? undefined,
+      content,
       embeds: [embed],
       components,
       allowedMentions: roleMention ? { roles: [payload.notifyRole as string] } : undefined,
@@ -981,6 +993,18 @@ export class WarEventLogService {
     if (!warStartTime) return null;
     const clanTag = normalizeTag(clanTagInput);
     if (!clanTag) return null;
+    const currentWarId = await prisma.currentWar
+      .findFirst({
+        where: {
+          clanTag,
+          lastWarStartTime: warStartTime,
+        },
+        select: { warId: true },
+      })
+      .catch(() => null);
+    if (currentWarId?.warId !== null && currentWarId?.warId !== undefined) {
+      return Number(currentWarId.warId);
+    }
     return (
       await prisma.clanWarHistory
         .findFirst({
@@ -1436,6 +1460,7 @@ export class WarEventLogService {
     const embed = EmbedBuilder.from(message.embeds[0] ?? new EmbedBuilder());
     const next = await this.buildBattleDayRefreshEmbed(payload, warId, embed);
     await message.edit({
+      content: buildNextRefreshRelativeLabel(BATTLE_DAY_REFRESH_MS),
       embeds: [next],
       components: [
         new ActionRowBuilder<ButtonBuilder>().addComponents(

--- a/src/services/WarEventLogService.ts
+++ b/src/services/WarEventLogService.ts
@@ -1002,21 +1002,9 @@ export class WarEventLogService {
         select: { warId: true },
       })
       .catch(() => null);
-    if (currentWarId?.warId !== null && currentWarId?.warId !== undefined) {
-      return Number(currentWarId.warId);
-    }
-    return (
-      await prisma.clanWarHistory
-        .findFirst({
-          where: {
-            clanTag,
-            warStartTime,
-          },
-          orderBy: { warId: "desc" },
-          select: { warId: true },
-        })
-        .catch(() => null)
-    )?.warId ?? null;
+    return currentWarId?.warId !== null && currentWarId?.warId !== undefined
+      ? Number(currentWarId.warId)
+      : null;
   }
 
   private async emitEvent(


### PR DESCRIPTION
## Release Summary
- Release version: `vX.Y.Z`
- Base: `dev` -> `main`
- Objective: Promote war-refresh reliability and force-mail recovery updates to production.

## Included Changes
- Added persistent war-mail refresh recovery:
  - War-mail refresh now works after restarts/redeploys by using `CurrentWar.mailConfig` fallback when in-memory keys are missing.
  - Added recurring war-mail refresh cycle to rehydrate tracking and keep posted mail refreshed.
- Added new admin command:
  - `/force mail update tag:<trackedClanTag>`
  - Refreshes existing sent war-mail embed in place (no re-ping), and reattaches 20-minute tracking.
- Added next-refresh visibility:
  - War mail and battle-day notify embeds now show `Next refresh <t:...:R>`.
  - Label updates each time embeds are refreshed.
- Updated notify warId behavior:
  - Active notify warId resolution now uses `CurrentWar.warId` only (removed `ClanWarHistory` fallback).
- Coverage/docs updates:
  - Registered `/remaining` in permission/help/docs coverage checks.
  - Updated command docs/help for new `/force mail update` flow.

## Validation Evidence
- [x] Changes were tested in staging Discord server
- [x] Required CI checks passed
- [x] Railway deployment status is healthy for staging path

## Operational Notes
- Required env var updates in production:
  - `None`
- Migration or data changes:
  - `None` (logic/config-path changes only)

## Post-Merge Steps
- [ ] Sync `dev` to `main` to keep branch history aligned:
  1. `git fetch origin`
  2. `git switch dev`
  3. `git merge --ff-only origin/main`
  4. `git push origin dev`
- [ ] Verify alignment:
  - `git rev-list --left-right --count origin/main...origin/dev`
  - Expected: `0    0`
- [ ] Create GitHub release tag with same notes