### PR TITLE
test(fwa,war-refresh): add coverage for mail staleness and 20-minute …

### DIFF
--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -1323,13 +1323,14 @@ function getMailStatusEmojiForClan(params: {
   if (!params.guildId) return MAILBOX_NOT_SENT_EMOJI;
   const config = params.mailConfig ?? null;
   const primaryMail = getPrimaryMailMessageRef(config);
-  const liveProvided = params.liveMatchType !== undefined || params.liveExpectedOutcome !== undefined;
-  const liveMatchesPosted = !liveProvided
-    ? true
-    : (config?.lastMatchType ?? null) === (params.liveMatchType ?? null) &&
-      (config?.lastExpectedOutcome ?? null) === (params.liveExpectedOutcome ?? null);
+  const liveMatchesPosted = isPostedMailCurrentForLiveState({
+    postedMatchType: config?.lastMatchType ?? null,
+    postedExpectedOutcome: config?.lastExpectedOutcome ?? null,
+    liveMatchType: params.liveMatchType,
+    liveExpectedOutcome: params.liveExpectedOutcome,
+  });
+  if (!liveMatchesPosted) return MAILBOX_NOT_SENT_EMOJI;
   if (primaryMail) {
-    if (!liveMatchesPosted) return MAILBOX_NOT_SENT_EMOJI;
     if (
       params.warStartMs !== null &&
       config?.lastWarStartMs !== null &&
@@ -1364,6 +1365,24 @@ function getMailStatusEmojiForClan(params: {
     });
   return sent ? MAILBOX_SENT_EMOJI : MAILBOX_NOT_SENT_EMOJI;
 }
+
+type PostedMailLiveStateParams = {
+  postedMatchType: "FWA" | "BL" | "MM" | "SKIP" | "UNKNOWN" | null;
+  postedExpectedOutcome: "WIN" | "LOSE" | "UNKNOWN" | null;
+  liveMatchType?: "FWA" | "BL" | "MM" | "SKIP" | "UNKNOWN" | null;
+  liveExpectedOutcome?: "WIN" | "LOSE" | "UNKNOWN" | null;
+};
+
+function isPostedMailCurrentForLiveState(params: PostedMailLiveStateParams): boolean {
+  const hasLive = params.liveMatchType !== undefined || params.liveExpectedOutcome !== undefined;
+  if (!hasLive) return true;
+  return (
+    (params.postedMatchType ?? null) === (params.liveMatchType ?? null) &&
+    (params.postedExpectedOutcome ?? null) === (params.liveExpectedOutcome ?? null)
+  );
+}
+
+export const isPostedMailCurrentForLiveStateForTest = isPostedMailCurrentForLiveState;
 
 function clearPostedMailTrackingForClan(params: {
   guildId: string;
@@ -1499,12 +1518,12 @@ function buildWarMailPostedComponents(key: string): Array<ActionRowBuilder<Butto
   ];
 }
 
-function buildNextRefreshRelativeLabel(intervalMs: number): string {
-  return `Next refresh <t:${Math.floor((Date.now() + intervalMs) / 1000)}:R>`;
+function buildNextRefreshRelativeLabel(intervalMs: number, nowMs = Date.now()): string {
+  return `Next refresh <t:${Math.floor((nowMs + intervalMs) / 1000)}:R>`;
 }
 
-function buildWarMailPostedContent(roleId?: string | null): string {
-  const nextRefresh = buildNextRefreshRelativeLabel(WAR_MAIL_REFRESH_MS);
+function buildWarMailPostedContent(roleId?: string | null, nowMs?: number): string {
+  const nextRefresh = buildNextRefreshRelativeLabel(WAR_MAIL_REFRESH_MS, nowMs);
   if (roleId) return `<@&${roleId}>\n${nextRefresh}`;
   return nextRefresh;
 }
@@ -1573,6 +1592,8 @@ function withRecoveredMailReference(
     messages,
   };
 }
+export const buildWarMailPostedContentForTest = buildWarMailPostedContent;
+export const buildWarMailNextRefreshLabelForTest = buildNextRefreshRelativeLabel;
 
 async function refreshWarMailPost(client: Client, key: string): Promise<void> {
   const payload = fwaMailPostedPayloads.get(key);

--- a/src/services/WarEventLogService.ts
+++ b/src/services/WarEventLogService.ts
@@ -41,9 +41,11 @@ const NOTIFY_WAR_REFRESH_PREFIX = "notify-war-refresh";
 const BATTLE_DAY_REFRESH_MS = 20 * 60 * 1000;
 const battleDayPostByGuildTag = new Map<string, { channelId: string; messageId: string }>();
 
-function buildNextRefreshRelativeLabel(intervalMs: number): string {
-  return `Next refresh <t:${Math.floor((Date.now() + intervalMs) / 1000)}:R>`;
+function buildNextRefreshRelativeLabel(intervalMs: number, nowMs = Date.now()): string {
+  return `Next refresh <t:${Math.floor((nowMs + intervalMs) / 1000)}:R>`;
 }
+
+export const buildNotifyNextRefreshLabelForTest = buildNextRefreshRelativeLabel;
 
 type TestSource = "current" | "last";
 

--- a/tests/fwaMailDownstream.logic.test.ts
+++ b/tests/fwaMailDownstream.logic.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildWarMailPostedContentForTest,
+  isPostedMailCurrentForLiveStateForTest,
+} from "../src/commands/Fwa";
+
+describe("fwa mail downstream update gating", () => {
+  it("treats posted mail as stale when live match type changes in single-clan view", () => {
+    const isCurrent = isPostedMailCurrentForLiveStateForTest({
+      postedMatchType: "FWA",
+      postedExpectedOutcome: "WIN",
+      liveMatchType: "BL",
+      liveExpectedOutcome: "WIN",
+    });
+
+    expect(isCurrent).toBe(false);
+  });
+
+  it("treats posted mail as stale when live expected outcome changes", () => {
+    const isCurrent = isPostedMailCurrentForLiveStateForTest({
+      postedMatchType: "FWA",
+      postedExpectedOutcome: "WIN",
+      liveMatchType: "FWA",
+      liveExpectedOutcome: "LOSE",
+    });
+
+    expect(isCurrent).toBe(false);
+  });
+
+  it("treats posted mail as current when live match config is unchanged", () => {
+    const isCurrent = isPostedMailCurrentForLiveStateForTest({
+      postedMatchType: "FWA",
+      postedExpectedOutcome: "WIN",
+      liveMatchType: "FWA",
+      liveExpectedOutcome: "WIN",
+    });
+
+    expect(isCurrent).toBe(true);
+  });
+});
+
+describe("fwa war-mail posted content", () => {
+  it("includes role mention and relative next-refresh label", () => {
+    const content = buildWarMailPostedContentForTest("123456789", 0);
+    expect(content).toBe("<@&123456789>\nNext refresh <t:1200:R>");
+  });
+
+  it("includes next-refresh label without role mention", () => {
+    const content = buildWarMailPostedContentForTest(null, 0);
+    expect(content).toBe("Next refresh <t:1200:R>");
+  });
+});

--- a/tests/refreshLoopLabels.logic.test.ts
+++ b/tests/refreshLoopLabels.logic.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+import { buildWarMailNextRefreshLabelForTest } from "../src/commands/Fwa";
+import { buildNotifyNextRefreshLabelForTest } from "../src/services/WarEventLogService";
+
+describe("20-minute refresh loop labels", () => {
+  it("war-mail label advances with time", () => {
+    expect(buildWarMailNextRefreshLabelForTest(20 * 60 * 1000, 0)).toBe(
+      "Next refresh <t:1200:R>"
+    );
+    expect(buildWarMailNextRefreshLabelForTest(20 * 60 * 1000, 60_000)).toBe(
+      "Next refresh <t:1260:R>"
+    );
+  });
+
+  it("notify label advances with time", () => {
+    expect(buildNotifyNextRefreshLabelForTest(20 * 60 * 1000, 0)).toBe(
+      "Next refresh <t:1200:R>"
+    );
+    expect(buildNotifyNextRefreshLabelForTest(20 * 60 * 1000, 60_000)).toBe(
+      "Next refresh <t:1260:R>"
+    );
+  });
+});


### PR DESCRIPTION
…refresh labels

- add unit tests for single-clan matchType/outcome edits marking posted mail as stale
- add unit tests for war-mail posted content formatting with role mention + next-refresh label
- add unit tests for next-refresh label updates in mail and notify 20-minute loops
- export minimal pure helpers for deterministic label and downstream-staleness assertions