### PR TITLE
fix(fwa): correct single-history warId alias in force sync backfill

### DIFF
--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -5020,7 +5020,7 @@ export async function runForceSyncWarIdCommand(
           WITH single_history AS (
             SELECT
               UPPER(REPLACE("clanTag",'#','')) AS clan_norm,
-              MIN("warId") AS warId
+              MIN("warId") AS "warId"
             FROM "ClanWarHistory"
             WHERE "warId" IS NOT NULL
               ${tagFilterHistory}


### PR DESCRIPTION
Quote the CTE warId alias in /force sync warId so it matches the update reference (sh."warId"). This resolves Postgres 42703 ("column sh.warId does not exist") during warId backfill.