### PR TITLE
fix(force): defer /force sync warid before table-scoped editReply paths

### DIFF
--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -4860,6 +4860,10 @@ export async function runForceSyncMailCommand(
 export async function runForceSyncWarIdCommand(
   interaction: ChatInputCommandInteraction
 ): Promise<void> {
+  const visibility = interaction.options.getString("visibility", false) ?? "private";
+  const isPublic = visibility === "public";
+  await interaction.deferReply({ ephemeral: !isPublic });
+
   type WarIdTable = "currentwar" | "clanwarhistory" | "warattacks";
   const table = interaction.options.getString("table", false) as WarIdTable | null;
   if (table) {
@@ -5229,10 +5233,6 @@ export async function runForceSyncWarIdCommand(
     await interaction.editReply(`Unsupported table: ${table}`);
     return;
   }
-
-  const visibility = interaction.options.getString("visibility", false) ?? "private";
-  const isPublic = visibility === "public";
-  await interaction.deferReply({ ephemeral: !isPublic });
 
   const tagRaw = interaction.options.getString("tag", false);
   const tag = tagRaw ? normalizeTag(tagRaw) : null;


### PR DESCRIPTION
Always defer the interaction at the start of runForceSyncWarIdCommand so table-scoped preview/apply flows can safely call editReply.

This fixes InteractionNotReplied errors when using: /force sync warid table:currentwar ...