### PR TITLE
fix(refresh-labels): align Next refresh timestamps to shared 20m loop…

### DIFF
--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -27,6 +27,7 @@ import {
 } from "../services/CommandPermissionService";
 import { GoogleSheetsService } from "../services/GoogleSheetsService";
 import { SettingsService } from "../services/SettingsService";
+import { getNextWarMailRefreshAtMs } from "../services/refreshSchedule";
 import { WarEventHistoryService } from "../services/war-events/history";
 import {
   buildOutcomeMismatchWarning,
@@ -1346,12 +1347,26 @@ function buildWarMailPostedComponents(key: string): Array<ActionRowBuilder<Butto
   ];
 }
 
-function buildNextRefreshRelativeLabel(intervalMs: number, nowMs = Date.now()): string {
-  return `Next refresh <t:${Math.floor((nowMs + intervalMs) / 1000)}:R>`;
+function buildNextRefreshRelativeLabel(
+  intervalMs: number,
+  nowMs = Date.now(),
+  nextScheduledAtMs?: number | null
+): string {
+  const nextAtMs =
+    nextScheduledAtMs !== null &&
+    nextScheduledAtMs !== undefined &&
+    Number.isFinite(nextScheduledAtMs)
+      ? Math.trunc(nextScheduledAtMs)
+      : Math.trunc(nowMs + intervalMs);
+  return `Next refresh <t:${Math.floor(nextAtMs / 1000)}:R>`;
 }
 
 function buildWarMailPostedContent(roleId?: string | null, nowMs?: number): string {
-  const nextRefresh = buildNextRefreshRelativeLabel(WAR_MAIL_REFRESH_MS, nowMs);
+  const nextRefresh = buildNextRefreshRelativeLabel(
+    WAR_MAIL_REFRESH_MS,
+    nowMs,
+    getNextWarMailRefreshAtMs()
+  );
   if (roleId) return `<@&${roleId}>\n${nextRefresh}`;
   return nextRefresh;
 }

--- a/src/listeners/ready.ts
+++ b/src/listeners/ready.ts
@@ -18,6 +18,10 @@ import {
   notifyWarBattleDayRefreshIntervalMs,
 } from "../services/WarEventLogService";
 import { refreshAllTrackedWarMailPosts } from "../commands/Fwa";
+import {
+  setNextNotifyRefreshAtMs,
+  setNextWarMailRefreshAtMs,
+} from "../services/refreshSchedule";
 
 const DEFAULT_OBSERVE_INTERVAL_MINUTES = 30;
 const RECRUITMENT_REMINDER_INTERVAL_MS = 5 * 60 * 1000;
@@ -329,13 +333,17 @@ export default (client: Client, cocService: CoCService): void => {
       });
     };
     await runWarMailRefresh();
+    setNextWarMailRefreshAtMs(Date.now() + notifyWarBattleDayRefreshIntervalMs);
     setInterval(() => {
+      setNextWarMailRefreshAtMs(Date.now() + notifyWarBattleDayRefreshIntervalMs);
       runWarMailRefresh().catch((err) => {
         console.error(`[fwa-mail] refresh interval failed: ${formatError(err)}`);
       });
     }, notifyWarBattleDayRefreshIntervalMs);
     console.log("War mail refresh enabled (every 20 minute(s)).");
+    setNextNotifyRefreshAtMs(Date.now() + notifyWarBattleDayRefreshIntervalMs);
     setInterval(() => {
+      setNextNotifyRefreshAtMs(Date.now() + notifyWarBattleDayRefreshIntervalMs);
       runBattleDayRefresh().catch((err) => {
         console.error(`[war-events] battle-day refresh interval failed: ${formatError(err)}`);
       });

--- a/src/services/WarEventLogService.ts
+++ b/src/services/WarEventLogService.ts
@@ -15,6 +15,7 @@ import { PointsProjectionService } from "./PointsProjectionService";
 import { SettingsService } from "./SettingsService";
 import { WarEventHistoryService } from "./war-events/history";
 import { WarStartPointsSyncService } from "./war-events/pointsSync";
+import { getNextNotifyRefreshAtMs } from "./refreshSchedule";
 import {
   type EventType,
   type MatchType,
@@ -41,8 +42,18 @@ const NOTIFY_WAR_REFRESH_PREFIX = "notify-war-refresh";
 const BATTLE_DAY_REFRESH_MS = 20 * 60 * 1000;
 const battleDayPostByGuildTag = new Map<string, { channelId: string; messageId: string }>();
 
-function buildNextRefreshRelativeLabel(intervalMs: number, nowMs = Date.now()): string {
-  return `Next refresh <t:${Math.floor((nowMs + intervalMs) / 1000)}:R>`;
+function buildNextRefreshRelativeLabel(
+  intervalMs: number,
+  nowMs = Date.now(),
+  nextScheduledAtMs?: number | null
+): string {
+  const nextAtMs =
+    nextScheduledAtMs !== null &&
+    nextScheduledAtMs !== undefined &&
+    Number.isFinite(nextScheduledAtMs)
+      ? Math.trunc(nextScheduledAtMs)
+      : Math.trunc(nowMs + intervalMs);
+  return `Next refresh <t:${Math.floor(nextAtMs / 1000)}:R>`;
 }
 
 export const buildNotifyNextRefreshLabelForTest = buildNextRefreshRelativeLabel;
@@ -670,7 +681,13 @@ export class WarEventLogService {
     const roleMention =
       includeRoleMention && payload.pingRole && payload.notifyRole ? `<@&${payload.notifyRole}>` : null;
     const nextRefreshLabel =
-      payload.eventType === "battle_day" ? buildNextRefreshRelativeLabel(BATTLE_DAY_REFRESH_MS) : null;
+      payload.eventType === "battle_day"
+        ? buildNextRefreshRelativeLabel(
+            BATTLE_DAY_REFRESH_MS,
+            Date.now(),
+            getNextNotifyRefreshAtMs()
+          )
+        : null;
     const content =
       payload.eventType === "battle_day"
         ? roleMention
@@ -1489,7 +1506,11 @@ export class WarEventLogService {
     const embed = EmbedBuilder.from(message.embeds[0] ?? new EmbedBuilder());
     const next = await this.buildBattleDayRefreshEmbed(payload, warId, embed);
     await message.edit({
-      content: buildNextRefreshRelativeLabel(BATTLE_DAY_REFRESH_MS),
+      content: buildNextRefreshRelativeLabel(
+        BATTLE_DAY_REFRESH_MS,
+        Date.now(),
+        getNextNotifyRefreshAtMs()
+      ),
       embeds: [next],
       components: [
         new ActionRowBuilder<ButtonBuilder>().addComponents(

--- a/src/services/refreshSchedule.ts
+++ b/src/services/refreshSchedule.ts
@@ -1,0 +1,19 @@
+let nextWarMailRefreshAtMs: number | null = null;
+let nextNotifyRefreshAtMs: number | null = null;
+
+export function setNextWarMailRefreshAtMs(nextAtMs: number): void {
+  nextWarMailRefreshAtMs = Number.isFinite(nextAtMs) ? Math.trunc(nextAtMs) : null;
+}
+
+export function getNextWarMailRefreshAtMs(): number | null {
+  return nextWarMailRefreshAtMs;
+}
+
+export function setNextNotifyRefreshAtMs(nextAtMs: number): void {
+  nextNotifyRefreshAtMs = Number.isFinite(nextAtMs) ? Math.trunc(nextAtMs) : null;
+}
+
+export function getNextNotifyRefreshAtMs(): number | null {
+  return nextNotifyRefreshAtMs;
+}
+


### PR DESCRIPTION
… schedule

Stop computing labels as now+20m on manual refresh.

- Add shared in-memory scheduler state for next war-mail and notify refresh ticks
- Update ready loop to publish next scheduled run timestamps
- Use scheduled timestamps when rendering "Next refresh <t:...:R>" for:
  - war mail posts
  - /notify battle-day embeds

Manual refresh now preserves alignment with the actual recurring loop.