### PR TITLE
feat(war-events): split current war time fields and persist prep/star…

### DIFF
--- a/prisma/migrations/20260304113000_split_current_war_time_columns/migration.sql
+++ b/prisma/migrations/20260304113000_split_current_war_time_columns/migration.sql
@@ -1,0 +1,30 @@
+-- Replace CurrentWar.lastWarStartTime with explicit prep/start/end timestamps
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'CurrentWar'
+      AND column_name = 'lastWarStartTime'
+  ) AND NOT EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'CurrentWar'
+      AND column_name = 'startTime'
+  ) THEN
+    ALTER TABLE "CurrentWar" RENAME COLUMN "lastWarStartTime" TO "startTime";
+  END IF;
+END $$;
+
+ALTER TABLE "CurrentWar"
+  ADD COLUMN IF NOT EXISTS "prepStartTime" TIMESTAMP(3),
+  ADD COLUMN IF NOT EXISTS "endTime" TIMESTAMP(3);
+
+ALTER TABLE "ClanWarHistory"
+  ADD COLUMN IF NOT EXISTS "prepStartTime" TIMESTAMP(3);
+
+DROP INDEX IF EXISTS "CurrentWar_lastWarStartTime_clanTag_lastOpponentTag_idx";
+CREATE INDEX IF NOT EXISTS "CurrentWar_startTime_clanTag_lastOpponentTag_idx"
+  ON "CurrentWar"("startTime", "clanTag", "lastOpponentTag");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -200,7 +200,9 @@ model CurrentWar {
   lastClanStars     Int?
   lastOpponentStars Int?
   lastState         String?
-  lastWarStartTime  DateTime?
+  prepStartTime     DateTime?
+  startTime         DateTime?
+  endTime           DateTime?
   lastOpponentTag   String?
   lastOpponentName  String?
   clanName          String?
@@ -211,7 +213,7 @@ model CurrentWar {
   @@unique([guildId, clanTag])
   @@index([guildId, notify])
   @@index([warId])
-  @@index([lastWarStartTime, clanTag, lastOpponentTag])
+  @@index([startTime, clanTag, lastOpponentTag])
 }
 
 model ClanWarHistory {
@@ -226,6 +228,7 @@ model ClanWarHistory {
   expectedOutcome     String?
   actualOutcome       String?
   enemyPoints         Int?
+  prepStartTime       DateTime?
   warStartTime        DateTime
   warEndTime          DateTime?
   clanName            String?

--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -978,7 +978,7 @@ async function buildWarMailEmbedForTag(
         clanTag: `#${normalizedTag}`,
       },
     },
-    select: { matchType: true, inferredMatchType: true, outcome: true, lastWarStartTime: true },
+    select: { matchType: true, inferredMatchType: true, outcome: true, startTime: true },
   });
 
   let inferredMatchType = Boolean(subscription?.inferredMatchType);
@@ -1040,11 +1040,11 @@ async function buildWarMailEmbedForTag(
     ].join("\n");
   }
 
-  const prepTargetMs = parseCocApiTime(war?.startTime);
+  const prepTargetMs = parseCocApiTime(war?.preparationStartTime);
   const battleTargetMs = parseCocApiTime(war?.endTime);
   const warStartMs = parseCocApiTime(war?.startTime);
-  const fallbackWarStartMs = subscription?.lastWarStartTime
-    ? subscription.lastWarStartTime.getTime()
+  const fallbackWarStartMs = subscription?.startTime
+    ? subscription.startTime.getTime()
     : null;
   const effectiveWarStartMs = warStartMs ?? fallbackWarStartMs;
   const expectedOutcome = matchType === "FWA" ? (outcome ?? "UNKNOWN") : null;
@@ -2270,7 +2270,7 @@ export async function handleFwaMatchSkipSyncConfirmButton(
     },
     select: {
       warId: true,
-      lastWarStartTime: true,
+      startTime: true,
       mailConfig: true,
     },
   });
@@ -2281,7 +2281,7 @@ export async function handleFwaMatchSkipSyncConfirmButton(
   const skipWarStart =
     existingSkipHistory?.warStartUnix !== undefined && existingSkipHistory?.warStartUnix !== null
       ? new Date(existingSkipHistory.warStartUnix * 1000)
-      : existingCurrent?.lastWarStartTime ??
+      : existingCurrent?.startTime ??
         new Date(Math.floor(Date.now() / (60 * 60 * 1000)) * 60 * 60 * 1000);
   const skipOpponentTag = normalizeTag(existingSkipHistory?.opponentTag ?? "SKIP");
   const skipOpponentTagWithHash = `#${skipOpponentTag}`;
@@ -4795,14 +4795,14 @@ export async function runForceSyncMailCommand(
     select: {
       matchType: true,
       outcome: true,
-      lastWarStartTime: true,
+      startTime: true,
       mailConfig: true,
     },
   });
   const currentWar = await getCurrentWarCached(cocService, tag).catch(() => null);
   const warStartMsFromApi = parseCocApiTime(currentWar?.startTime);
   const warStartMs =
-    existing?.lastWarStartTime?.getTime() ?? warStartMsFromApi ?? null;
+    existing?.startTime?.getTime() ?? warStartMsFromApi ?? null;
   const nowUnix = Math.floor(Date.now() / 1000);
   const current = parseMatchMailConfig(existing?.mailConfig as Prisma.JsonValue | null | undefined);
   const messages = current.messages.filter(
@@ -4941,7 +4941,7 @@ export async function runForceSyncWarIdCommand(
             SELECT
               cw."id",
               cw."clanTag",
-              cw."lastWarStartTime" AS "warStartTime",
+              cw."startTime" AS "warStartTime",
               cw."currentSyncNum" AS "syncNumber",
               cw."lastOpponentTag" AS "opponentTag",
               cw."warId" AS "existingWarId",
@@ -4949,7 +4949,7 @@ export async function runForceSyncWarIdCommand(
             FROM "CurrentWar" cw
             WHERE 1=1
               ${tag ? Prisma.sql`AND UPPER(REPLACE(cw."clanTag",'#','')) = ${tag}` : Prisma.empty}
-              ${warStartTime ? Prisma.sql`AND cw."lastWarStartTime" = ${warStartTime}` : Prisma.empty}
+              ${warStartTime ? Prisma.sql`AND cw."startTime" = ${warStartTime}` : Prisma.empty}
               ${syncNumber !== null ? Prisma.sql`AND cw."currentSyncNum" = ${syncNumber}` : Prisma.empty}
               ${opponentTag ? Prisma.sql`AND UPPER(REPLACE(cw."lastOpponentTag",'#','')) = ${opponentTag}` : Prisma.empty}
               ${filterWarId !== null ? Prisma.sql`AND cw."warId" = ${filterWarId}` : Prisma.empty}
@@ -5043,7 +5043,7 @@ export async function runForceSyncWarIdCommand(
               FROM "CurrentWar" cw
               WHERE 1=1
                 ${tag ? Prisma.sql`AND UPPER(REPLACE(cw."clanTag",'#','')) = ${tag}` : Prisma.empty}
-                ${warStartTime ? Prisma.sql`AND cw."lastWarStartTime" = ${warStartTime}` : Prisma.empty}
+                ${warStartTime ? Prisma.sql`AND cw."startTime" = ${warStartTime}` : Prisma.empty}
                 ${syncNumber !== null ? Prisma.sql`AND cw."currentSyncNum" = ${syncNumber}` : Prisma.empty}
                 ${opponentTag ? Prisma.sql`AND UPPER(REPLACE(cw."lastOpponentTag",'#','')) = ${opponentTag}` : Prisma.empty}
                 ${filterWarId !== null ? Prisma.sql`AND cw."warId" = ${filterWarId}` : Prisma.empty}
@@ -5181,7 +5181,7 @@ export async function runForceSyncWarIdCommand(
              AND h."warId" IS NOT NULL
             LEFT JOIN "CurrentWar" cw
               ON UPPER(REPLACE(wa."clanTag",'#','')) = UPPER(REPLACE(cw."clanTag",'#',''))
-             AND wa."warStartTime" = cw."lastWarStartTime"
+             AND wa."warStartTime" = cw."startTime"
              AND cw."warId" IS NOT NULL
             WHERE 1=1
               ${tag ? Prisma.sql`AND UPPER(REPLACE(wa."clanTag",'#','')) = ${tag}` : Prisma.empty}
@@ -5256,7 +5256,7 @@ export async function runForceSyncWarIdCommand(
                AND h."warId" IS NOT NULL
               LEFT JOIN "CurrentWar" cw
                 ON UPPER(REPLACE(wa."clanTag",'#','')) = UPPER(REPLACE(cw."clanTag",'#',''))
-               AND wa."warStartTime" = cw."lastWarStartTime"
+               AND wa."warStartTime" = cw."startTime"
                AND cw."warId" IS NOT NULL
               WHERE 1=1
                 ${tag ? Prisma.sql`AND UPPER(REPLACE(wa."clanTag",'#','')) = ${tag}` : Prisma.empty}
@@ -5336,14 +5336,14 @@ export async function runForceSyncWarIdCommand(
         )
         SELECT
           cw."clanTag",
-          cw."lastWarStartTime" AS "warStartTime",
+          cw."startTime" AS "warStartTime",
           cw."currentSyncNum" AS "syncNumber",
           cw."lastOpponentTag" AS "opponentTag",
           COALESCE(h_exact."warId", history_latest."warId") AS "proposedWarId"
         FROM "CurrentWar" cw
         LEFT JOIN "ClanWarHistory" h_exact
           ON UPPER(REPLACE(cw."clanTag",'#','')) = UPPER(REPLACE(h_exact."clanTag",'#',''))
-         AND cw."lastWarStartTime" = h_exact."warStartTime"
+         AND cw."startTime" = h_exact."warStartTime"
          AND h_exact."warId" IS NOT NULL
         LEFT JOIN history_latest
           ON UPPER(REPLACE(cw."clanTag",'#','')) = history_latest.clan_norm
@@ -5492,7 +5492,7 @@ export async function runForceSyncWarIdCommand(
           FROM "ClanWarHistory" h
           WHERE cw."warId" IS NULL
             AND UPPER(REPLACE(cw."clanTag",'#','')) = UPPER(REPLACE(h."clanTag",'#',''))
-            AND cw."lastWarStartTime" = h."warStartTime"
+            AND cw."startTime" = h."warStartTime"
             AND h."warId" IS NOT NULL
             ${tagFilterCurrentAlias}
         `
@@ -5500,10 +5500,10 @@ export async function runForceSyncWarIdCommand(
     );
 
     const currentWarRowsNeedingAllocation = await tx.$queryRaw<
-      Array<{ id: number; clanTag: string; lastWarStartTime: Date | null }>
+      Array<{ id: number; clanTag: string; startTime: Date | null }>
     >(
       Prisma.sql`
-        SELECT "id","clanTag","lastWarStartTime"
+        SELECT "id","clanTag","startTime"
         FROM "CurrentWar"
         WHERE "warId" IS NULL
           AND "lastState" IN ('preparation','inWar')
@@ -5534,7 +5534,7 @@ export async function runForceSyncWarIdCommand(
       );
       currentWarAllocated += updatedCurrent;
 
-      if (updatedCurrent > 0 && row.lastWarStartTime) {
+      if (updatedCurrent > 0 && row.startTime) {
         const updatedAttacks = Number(
           await tx.$executeRaw(
             Prisma.sql`
@@ -5550,7 +5550,7 @@ export async function runForceSyncWarIdCommand(
                 FROM "WarAttacks" wa
                 WHERE wa."warId" IS NULL
                   AND UPPER(REPLACE(wa."clanTag",'#','')) = UPPER(REPLACE(${row.clanTag},'#',''))
-                  AND wa."warStartTime" = ${row.lastWarStartTime}
+                  AND wa."warStartTime" = ${row.startTime}
               ),
               safe AS (
                 SELECT c."id"

--- a/src/commands/Notify.ts
+++ b/src/commands/Notify.ts
@@ -29,6 +29,14 @@ function deriveWarState(raw: string | null | undefined): string {
   return "notInWar";
 }
 
+function parseCocTime(raw: string | null | undefined): Date | null {
+  const value = String(raw ?? "").trim();
+  const m = value.match(/^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})\.\d{3}Z$/);
+  if (!m) return null;
+  const [, y, mo, d, h, mi, s] = m;
+  return new Date(Date.UTC(Number(y), Number(mo) - 1, Number(d), Number(h), Number(mi), Number(s)));
+}
+
 function normalizeClanTagInput(input: string): string {
   return input.trim().toUpperCase().replace(/^#/, "");
 }
@@ -461,6 +469,8 @@ export const Notify: Command = {
       const [, y, mo, d, h, mi, s] = m;
       return new Date(Date.UTC(Number(y), Number(mo) - 1, Number(d), Number(h), Number(mi), Number(s)));
     })();
+    const prepStartTime = parseCocTime(war?.preparationStartTime ?? null);
+    const warEndTime = parseCocTime(war?.endTime ?? null);
     const warId =
       warStartTime && clanTag
         ? (
@@ -480,9 +490,9 @@ export const Notify: Command = {
     await prisma.$executeRaw(
       Prisma.sql`
         INSERT INTO "CurrentWar"
-          ("guildId","clanTag","warId","channelId","notify","notifyRole","pingRole","lastState","lastWarStartTime","lastOpponentTag","lastOpponentName","clanName","createdAt","updatedAt")
+          ("guildId","clanTag","warId","channelId","notify","notifyRole","pingRole","lastState","prepStartTime","startTime","endTime","lastOpponentTag","lastOpponentName","clanName","createdAt","updatedAt")
         VALUES
-          (${interaction.guildId}, ${clanTag}, ${warId}, ${target.id}, true, ${notifyRole?.id ?? null}, ${rolePingEnabled}, ${lastState}, ${warStartTime}, ${opponentTag}, ${opponentName}, ${clanName}, NOW(), NOW())
+          (${interaction.guildId}, ${clanTag}, ${warId}, ${target.id}, true, ${notifyRole?.id ?? null}, ${rolePingEnabled}, ${lastState}, ${prepStartTime}, ${warStartTime}, ${warEndTime}, ${opponentTag}, ${opponentName}, ${clanName}, NOW(), NOW())
         ON CONFLICT ("guildId","clanTag")
         DO UPDATE SET
           "warId" = EXCLUDED."warId",
@@ -491,7 +501,9 @@ export const Notify: Command = {
           "notifyRole" = EXCLUDED."notifyRole",
           "pingRole" = EXCLUDED."pingRole",
           "lastState" = EXCLUDED."lastState",
-          "lastWarStartTime" = EXCLUDED."lastWarStartTime",
+          "prepStartTime" = EXCLUDED."prepStartTime",
+          "startTime" = EXCLUDED."startTime",
+          "endTime" = EXCLUDED."endTime",
           "lastOpponentTag" = EXCLUDED."lastOpponentTag",
           "lastOpponentName" = EXCLUDED."lastOpponentName",
           "clanName" = EXCLUDED."clanName",

--- a/src/commands/TrackedClan.ts
+++ b/src/commands/TrackedClan.ts
@@ -423,6 +423,38 @@ export const TrackedClan: Command = {
                 )
               )
             : null;
+          const prepStartTimeRaw = String(activeWar?.preparationStartTime ?? "");
+          const prepStartMatch = prepStartTimeRaw.match(
+            /^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})\.\d{3}Z$/
+          );
+          const prepStartTime = prepStartMatch
+            ? new Date(
+                Date.UTC(
+                  Number(prepStartMatch[1]),
+                  Number(prepStartMatch[2]) - 1,
+                  Number(prepStartMatch[3]),
+                  Number(prepStartMatch[4]),
+                  Number(prepStartMatch[5]),
+                  Number(prepStartMatch[6])
+                )
+              )
+            : null;
+          const warEndTimeRaw = String(activeWar?.endTime ?? "");
+          const warEndMatch = warEndTimeRaw.match(
+            /^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})\.\d{3}Z$/
+          );
+          const warEndTime = warEndMatch
+            ? new Date(
+                Date.UTC(
+                  Number(warEndMatch[1]),
+                  Number(warEndMatch[2]) - 1,
+                  Number(warEndMatch[3]),
+                  Number(warEndMatch[4]),
+                  Number(warEndMatch[5]),
+                  Number(warEndMatch[6])
+                )
+              )
+            : null;
           await prisma.currentWar.upsert({
             where: {
               guildId_clanTag: {
@@ -436,7 +468,9 @@ export const TrackedClan: Command = {
               channelId: interaction.channelId,
               notify: false,
               lastState,
-              lastWarStartTime: warStartTime,
+              prepStartTime,
+              startTime: warStartTime,
+              endTime: warEndTime,
               lastOpponentTag: opponentTag || null,
               lastOpponentName: opponentName,
               clanName: saved.name ?? null,
@@ -444,7 +478,9 @@ export const TrackedClan: Command = {
             update: {
               clanName: saved.name ?? null,
               lastState,
-              lastWarStartTime: warStartTime,
+              prepStartTime,
+              startTime: warStartTime,
+              endTime: warEndTime,
               lastOpponentTag: opponentTag || null,
               lastOpponentName: opponentName,
               updatedAt: new Date(),

--- a/src/services/WarEventLogService.ts
+++ b/src/services/WarEventLogService.ts
@@ -80,7 +80,9 @@ type SubscriptionRow = {
   lastClanStars: number | null;
   lastOpponentStars: number | null;
   lastState: string | null;
-  lastWarStartTime: Date | null;
+  prepStartTime: Date | null;
+  startTime: Date | null;
+  endTime: Date | null;
   lastOpponentTag: string | null;
   lastOpponentName: string | null;
   clanName: string | null;
@@ -120,6 +122,7 @@ type EventEmitPayload = {
   warEndFwaPoints: number | null;
   lastClanStars: number | null;
   lastOpponentStars: number | null;
+  prepStartTime: Date | null;
   warStartTime: Date | null;
   warEndTime: Date | null;
   clanAttacks: number | null;
@@ -243,7 +246,7 @@ export class WarEventLogService {
     const subs = await prisma.$queryRaw<SubscriptionRow[]>(
       Prisma.sql`
         SELECT
-          "id","guildId","clanTag","warId","currentSyncNum","channelId","notify","pingRole","inferredMatchType","notifyRole","fwaPoints","opponentFwaPoints","outcome","matchType","warStartFwaPoints","warEndFwaPoints","lastClanStars","lastOpponentStars","lastState","lastWarStartTime","lastOpponentTag","lastOpponentName","clanName"
+          "id","guildId","clanTag","warId","currentSyncNum","channelId","notify","pingRole","inferredMatchType","notifyRole","fwaPoints","opponentFwaPoints","outcome","matchType","warStartFwaPoints","warEndFwaPoints","lastClanStars","lastOpponentStars","lastState","prepStartTime","startTime","endTime","lastOpponentTag","lastOpponentName","clanName"
         FROM "CurrentWar"
         ORDER BY "updatedAt" ASC
       `
@@ -371,8 +374,8 @@ export class WarEventLogService {
     const currentWarStartTime = parseCocTime(currentWar?.startTime ?? null);
     const testWarStartTime =
       params.source === "current"
-        ? currentWarStartTime ?? sub.lastWarStartTime
-        : lastWarRow?.warStartTime ?? sub.lastWarStartTime ?? currentWarStartTime;
+        ? currentWarStartTime ?? sub.startTime
+        : lastWarRow?.warStartTime ?? sub.startTime ?? currentWarStartTime;
     const currentClanStars = Number.isFinite(Number(currentWar?.clan?.stars))
       ? Number(currentWar?.clan?.stars)
       : sub.lastClanStars;
@@ -445,6 +448,7 @@ export class WarEventLogService {
           : Number.isFinite(Number(currentWar?.opponent?.stars))
             ? Number(currentWar?.opponent?.stars)
             : sub.lastOpponentStars,
+      prepStartTime: parseCocTime(currentWar?.preparationStartTime ?? null) ?? sub.prepStartTime,
       warStartTime: testWarStartTime,
       warEndTime: parseCocTime(currentWar?.endTime ?? null),
       clanAttacks: Number.isFinite(Number(currentWar?.clan?.attacks))
@@ -721,7 +725,7 @@ export class WarEventLogService {
     const rows = await prisma.$queryRaw<SubscriptionRow[]>(
       Prisma.sql`
         SELECT
-          "id","guildId","clanTag","warId","currentSyncNum","channelId","notify","pingRole","inferredMatchType","notifyRole","fwaPoints","opponentFwaPoints","outcome","matchType","warStartFwaPoints","warEndFwaPoints","lastClanStars","lastOpponentStars","lastState","lastWarStartTime","lastOpponentTag","lastOpponentName","clanName"
+          "id","guildId","clanTag","warId","currentSyncNum","channelId","notify","pingRole","inferredMatchType","notifyRole","fwaPoints","opponentFwaPoints","outcome","matchType","warStartFwaPoints","warEndFwaPoints","lastClanStars","lastOpponentStars","lastState","prepStartTime","startTime","endTime","lastOpponentTag","lastOpponentName","clanName"
         FROM "CurrentWar"
         WHERE "guildId" = ${guildId} AND UPPER(REPLACE("clanTag",'#','')) = ${normalizeTagBare(clanTag)}
         LIMIT 1
@@ -775,8 +779,8 @@ export class WarEventLogService {
     if (
       params.sub.warId !== null &&
       params.sub.warId !== undefined &&
-      params.sub.lastWarStartTime &&
-      params.sub.lastWarStartTime.getTime() === params.warStartTime.getTime()
+      params.sub.startTime &&
+      params.sub.startTime.getTime() === params.warStartTime.getTime()
     ) {
       return params.sub.warId;
     }
@@ -784,7 +788,7 @@ export class WarEventLogService {
     const existing = await prisma.currentWar.findFirst({
       where: {
         clanTag: params.sub.clanTag,
-        lastWarStartTime: params.warStartTime,
+        startTime: params.warStartTime,
         warId: { not: null },
       },
       orderBy: { updatedAt: "desc" },
@@ -804,7 +808,7 @@ export class WarEventLogService {
     const rows = await prisma.$queryRaw<SubscriptionRow[]>(
       Prisma.sql`
         SELECT
-          "id","guildId","clanTag","warId","currentSyncNum","channelId","notify","pingRole","inferredMatchType","notifyRole","fwaPoints","opponentFwaPoints","outcome","matchType","warStartFwaPoints","warEndFwaPoints","lastClanStars","lastOpponentStars","lastState","lastWarStartTime","lastOpponentTag","lastOpponentName","clanName"
+          "id","guildId","clanTag","warId","currentSyncNum","channelId","notify","pingRole","inferredMatchType","notifyRole","fwaPoints","opponentFwaPoints","outcome","matchType","warStartFwaPoints","warEndFwaPoints","lastClanStars","lastOpponentStars","lastState","prepStartTime","startTime","endTime","lastOpponentTag","lastOpponentName","clanName"
         FROM "CurrentWar"
         WHERE "id" = ${subscriptionId}
         LIMIT 1
@@ -825,17 +829,18 @@ export class WarEventLogService {
     const nextOpponentName = String(war?.opponent?.name ?? sub.lastOpponentName ?? "").trim() || null;
     const nextWarStartTime = (() => {
       const raw = war?.startTime;
-      if (!raw) return sub.lastWarStartTime;
+      if (!raw) return sub.startTime;
       const m = raw.match(/^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})\.\d{3}Z$/);
-      if (!m) return sub.lastWarStartTime;
+      if (!m) return sub.startTime;
       const [, y, mo, d, h, mi, s] = m;
       return new Date(Date.UTC(Number(y), Number(mo) - 1, Number(d), Number(h), Number(mi), Number(s)));
     })();
+    const nextPrepStartTime = parseCocTime(war?.preparationStartTime ?? null) ?? sub.prepStartTime;
     const nextWarEndTime = parseCocTime(war?.endTime ?? null);
 
     const eventTypeRaw = shouldEmit(prevState, currentState);
     let eventType = eventTypeRaw;
-    if (!eventType && isNewWarCycle(sub.lastWarStartTime, nextWarStartTime)) {
+    if (!eventType && isNewWarCycle(sub.startTime, nextWarStartTime)) {
       if (currentState === "preparation") {
         eventType = "war_started";
       } else if (currentState === "inWar") {
@@ -843,14 +848,14 @@ export class WarEventLogService {
       }
     }
     if (eventType === "war_ended") {
-      if (!sub.lastWarStartTime) {
+      if (!sub.startTime) {
         console.log(
           `[war-events] war_ended suppressed guild=${sub.guildId} clan=${sub.clanTag} reason=no_last_war_start prev=${prevState} current=${currentState}`
         );
         eventType = null;
-      } else if (await this.hasWarEndRecorded(sub.clanTag, sub.lastWarStartTime)) {
+      } else if (await this.hasWarEndRecorded(sub.clanTag, sub.startTime)) {
         console.log(
-          `[war-events] war_ended suppressed guild=${sub.guildId} clan=${sub.clanTag} reason=already_recorded warStart=${sub.lastWarStartTime.toISOString()}`
+          `[war-events] war_ended suppressed guild=${sub.guildId} clan=${sub.clanTag} reason=already_recorded warStart=${sub.startTime.toISOString()}`
         );
         eventType = null;
       }
@@ -1005,6 +1010,7 @@ export class WarEventLogService {
         warEndFwaPoints: nextWarEndFwaPoints,
         lastClanStars: nextClanStars,
         lastOpponentStars: nextOpponentStars,
+        prepStartTime: nextPrepStartTime,
         warStartTime: nextWarStartTime,
         warEndTime: nextWarEndTime,
         clanAttacks: nextClanAttacks,
@@ -1044,7 +1050,9 @@ export class WarEventLogService {
         warEndFwaPoints: nextWarEndFwaPoints,
         lastClanStars: nextClanStars,
         lastOpponentStars: nextOpponentStars,
-        lastWarStartTime: currentState === "notInWar" ? null : nextWarStartTime,
+        prepStartTime: currentState === "notInWar" ? null : nextPrepStartTime,
+        startTime: currentState === "notInWar" ? null : nextWarStartTime,
+        endTime: currentState === "notInWar" ? null : nextWarEndTime,
         lastOpponentTag: nextOpponentTag || sub.lastOpponentTag,
         lastOpponentName: nextOpponentName || sub.lastOpponentName,
         clanName: nextClanName,
@@ -1062,7 +1070,7 @@ export class WarEventLogService {
       .findFirst({
         where: {
           clanTag,
-          lastWarStartTime: warStartTime,
+          startTime: warStartTime,
         },
         select: { warId: true },
       })
@@ -1091,6 +1099,7 @@ export class WarEventLogService {
       warEndFwaPoints: number | null;
       lastClanStars: number | null;
       lastOpponentStars: number | null;
+      prepStartTime: Date | null;
       warStartTime: Date | null;
       warEndTime: Date | null;
       clanAttacks: number | null;
@@ -1414,7 +1423,8 @@ export class WarEventLogService {
       return;
     }
 
-    const warStartTime = parseCocTime(war.startTime ?? null) ?? sub.lastWarStartTime ?? null;
+    const prepStartTime = parseCocTime(war.preparationStartTime ?? null) ?? sub.prepStartTime ?? null;
+    const warStartTime = parseCocTime(war.startTime ?? null) ?? sub.startTime ?? null;
     const warEndTime = parseCocTime(war.endTime ?? null);
     const nextClanName = String(war.clan?.name ?? sub.clanName ?? sub.clanTag).trim() || sub.clanTag;
     const nextOpponentTag = normalizeTag(war.opponent?.tag ?? sub.lastOpponentTag ?? "");
@@ -1436,7 +1446,9 @@ export class WarEventLogService {
       data: {
         warId: resolvedWarId,
         lastState: "inWar",
-        lastWarStartTime: warStartTime,
+        prepStartTime,
+        startTime: warStartTime,
+        endTime: warEndTime,
         lastOpponentTag: nextOpponentTag || sub.lastOpponentTag,
         lastOpponentName: nextOpponentName || sub.lastOpponentName,
         clanName: nextClanName,

--- a/src/services/war-events/history.ts
+++ b/src/services/war-events/history.ts
@@ -131,6 +131,7 @@ export class WarEventHistoryService {
     warEndFwaPoints: number | null;
     lastClanStars: number | null;
     lastOpponentStars: number | null;
+    prepStartTime: Date | null;
     warStartTime: Date | null;
   }): Promise<void> {
     if (payload.eventType !== "war_ended") return;
@@ -184,9 +185,9 @@ export class WarEventHistoryService {
     const row = await prisma.$queryRaw<Array<{ warId: number }>>(
       Prisma.sql`
         INSERT INTO "ClanWarHistory"
-          ("syncNumber","matchType","clanStars","clanDestruction","opponentStars","opponentDestruction","fwaPointsGained","expectedOutcome","actualOutcome","enemyPoints","warStartTime","warEndTime","clanName","clanTag","opponentName","opponentTag","updatedAt")
+          ("syncNumber","matchType","clanStars","clanDestruction","opponentStars","opponentDestruction","fwaPointsGained","expectedOutcome","actualOutcome","enemyPoints","prepStartTime","warStartTime","warEndTime","clanName","clanTag","opponentName","opponentTag","updatedAt")
         VALUES
-          (${payload.syncNumber}, ${payload.matchType}, ${finalResult.clanStars}, ${finalResult.clanDestruction}, ${finalResult.opponentStars}, ${finalResult.opponentDestruction}, ${pointsDelta}, ${payload.outcome}, ${finalResult.resultLabel}, ${enemyPoints}, ${warStartTime}, ${warEndTime}, ${payload.clanName}, ${clanTag}, ${payload.opponentName}, ${normalizeTag(payload.opponentTag) || null}, NOW())
+          (${payload.syncNumber}, ${payload.matchType}, ${finalResult.clanStars}, ${finalResult.clanDestruction}, ${finalResult.opponentStars}, ${finalResult.opponentDestruction}, ${pointsDelta}, ${payload.outcome}, ${finalResult.resultLabel}, ${enemyPoints}, ${payload.prepStartTime}, ${warStartTime}, ${warEndTime}, ${payload.clanName}, ${clanTag}, ${payload.opponentName}, ${normalizeTag(payload.opponentTag) || null}, NOW())
         ON CONFLICT ("warStartTime","clanTag","opponentTag")
         DO UPDATE SET
           "syncNumber" = EXCLUDED."syncNumber",
@@ -199,6 +200,7 @@ export class WarEventHistoryService {
           "expectedOutcome" = EXCLUDED."expectedOutcome",
           "actualOutcome" = EXCLUDED."actualOutcome",
           "enemyPoints" = EXCLUDED."enemyPoints",
+          "prepStartTime" = EXCLUDED."prepStartTime",
           "warEndTime" = EXCLUDED."warEndTime",
           "clanName" = EXCLUDED."clanName",
           "opponentName" = EXCLUDED."opponentName",
@@ -215,7 +217,7 @@ export class WarEventHistoryService {
       data: { warId },
     });
     await prisma.currentWar.updateMany({
-      where: { clanTag, lastWarStartTime: warStartTime },
+      where: { clanTag, startTime: warStartTime },
       data: {
         warId,
       },


### PR DESCRIPTION
…t/end timestamps

- replace CurrentWar.lastWarStartTime with prepStartTime/startTime/endTime in Prisma schema and service/command flows
- add ClanWarHistory.prepStartTime and persist it during war-end history writes
- upsert exact CoC API preparationStartTime/startTime/endTime during notify/tracked-clan bootstrap and war event processing
- update war-id and mail paths to use CurrentWar.startTime after the column refactor
- add migration 20260304113000_split_current_war_time_columns to rename/add columns and update the CurrentWar time index
- fix prep countdown target in FWA mail embed to use preparationStartTime