### PR TITLE
refactor(war-data): make WarAttacks current-only and rework war archi…

### DIFF
--- a/prisma/migrations/20260304174000_rework_war_lookup_and_drop_participant/migration.sql
+++ b/prisma/migrations/20260304174000_rework_war_lookup_and_drop_participant/migration.sql
@@ -1,0 +1,53 @@
+DROP TABLE IF EXISTS "WarHistoryParticipant";
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.table_constraints
+    WHERE table_schema = 'public'
+      AND table_name = 'WarLookup'
+      AND constraint_name = 'WarLookup_warId_fkey'
+  ) THEN
+    ALTER TABLE "WarLookup" DROP CONSTRAINT "WarLookup_warId_fkey";
+  END IF;
+END $$;
+
+ALTER TABLE "WarLookup"
+  ALTER COLUMN "warId" TYPE TEXT USING "warId"::text;
+
+ALTER TABLE "WarLookup"
+  ADD COLUMN IF NOT EXISTS "clanTag" TEXT,
+  ADD COLUMN IF NOT EXISTS "opponentTag" TEXT,
+  ADD COLUMN IF NOT EXISTS "startTime" TIMESTAMP(3),
+  ADD COLUMN IF NOT EXISTS "endTime" TIMESTAMP(3),
+  ADD COLUMN IF NOT EXISTS "result" TEXT;
+
+UPDATE "WarLookup" w
+SET
+  "clanTag" = h."clanTag",
+  "opponentTag" = h."opponentTag",
+  "startTime" = h."warStartTime",
+  "endTime" = h."warEndTime",
+  "result" = COALESCE(LOWER(h."actualOutcome"), LOWER(h."expectedOutcome"), 'unknown')
+FROM "ClanWarHistory" h
+WHERE w."warId" ~ '^[0-9]+$'
+  AND h."warId" = w."warId"::INT;
+
+UPDATE "WarLookup"
+SET "clanTag" = COALESCE(NULLIF("clanTag", ''), 'UNKNOWN')
+WHERE "clanTag" IS NULL OR "clanTag" = '';
+
+UPDATE "WarLookup"
+SET "startTime" = COALESCE("startTime", "createdAt")
+WHERE "startTime" IS NULL;
+
+ALTER TABLE "WarLookup"
+  ALTER COLUMN "clanTag" SET NOT NULL,
+  ALTER COLUMN "startTime" SET NOT NULL;
+
+ALTER TABLE "WarLookup"
+  DROP COLUMN IF EXISTS "updatedAt";
+
+CREATE INDEX IF NOT EXISTS "WarLookup_clanTag_startTime_idx"
+  ON "WarLookup"("clanTag", "startTime");

--- a/prisma/migrations/20260304224500_add_notify_config_to_tracked_clan/migration.sql
+++ b/prisma/migrations/20260304224500_add_notify_config_to_tracked_clan/migration.sql
@@ -1,0 +1,25 @@
+ALTER TABLE "TrackedClan"
+  ADD COLUMN IF NOT EXISTS "notifyChannelId" TEXT,
+  ADD COLUMN IF NOT EXISTS "notifyRole" TEXT,
+  ADD COLUMN IF NOT EXISTS "notifyEnabled" BOOLEAN NOT NULL DEFAULT false;
+
+-- Backfill from CurrentWar (latest row per clan tag) when present.
+WITH latest AS (
+  SELECT DISTINCT ON (UPPER(REPLACE(cw."clanTag", '#', '')))
+    UPPER(REPLACE(cw."clanTag", '#', '')) AS clan_norm,
+    cw."channelId",
+    cw."notifyRole",
+    cw."notify"
+  FROM "CurrentWar" cw
+  ORDER BY UPPER(REPLACE(cw."clanTag", '#', '')), cw."updatedAt" DESC
+)
+UPDATE "TrackedClan" tc
+SET
+  "notifyChannelId" = COALESCE(tc."notifyChannelId", latest."channelId"),
+  "notifyRole" = COALESCE(tc."notifyRole", latest."notifyRole"),
+  "notifyEnabled" = CASE
+    WHEN tc."notifyEnabled" IS TRUE THEN TRUE
+    ELSE COALESCE(latest."notify", FALSE)
+  END
+FROM latest
+WHERE UPPER(REPLACE(tc."tag", '#', '')) = latest.clan_norm;

--- a/prisma/migrations/20260304232000_move_mail_config_to_tracked_clan/migration.sql
+++ b/prisma/migrations/20260304232000_move_mail_config_to_tracked_clan/migration.sql
@@ -1,0 +1,19 @@
+ALTER TABLE "TrackedClan"
+  ADD COLUMN IF NOT EXISTS "mailConfig" JSONB;
+
+WITH latest AS (
+  SELECT DISTINCT ON (UPPER(REPLACE(cw."clanTag", '#', '')))
+    UPPER(REPLACE(cw."clanTag", '#', '')) AS clan_norm,
+    cw."mailConfig"
+  FROM "CurrentWar" cw
+  WHERE cw."mailConfig" IS NOT NULL
+  ORDER BY UPPER(REPLACE(cw."clanTag", '#', '')), cw."updatedAt" DESC
+)
+UPDATE "TrackedClan" tc
+SET "mailConfig" = latest."mailConfig"
+FROM latest
+WHERE UPPER(REPLACE(tc."tag", '#', '')) = latest.clan_norm
+  AND tc."mailConfig" IS NULL;
+
+ALTER TABLE "CurrentWar"
+  DROP COLUMN IF EXISTS "mailConfig";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -127,27 +127,6 @@ model RecruitmentCooldown {
   @@index([expiresAt, reminded])
 }
 
-model WarHistoryParticipant {
-  id               Int       @id @default(autoincrement())
-  clanTag          String
-  clanName         String?
-  opponentClanTag  String?
-  opponentClanName String?
-  warStartTime     DateTime
-  warEndTime       DateTime?
-  warState         String?
-  playerTag        String
-  playerName       String?
-  playerPosition   Int?
-  attacksUsed      Int
-  updatedAt        DateTime  @updatedAt
-  createdAt        DateTime  @default(now())
-
-  @@unique([clanTag, warStartTime, playerTag])
-  @@index([clanTag, warStartTime])
-  @@index([playerTag, warStartTime])
-}
-
 model WarAttacks {
   id               Int       @id @default(autoincrement())
   warId            Int?
@@ -236,17 +215,20 @@ model ClanWarHistory {
   opponentTag         String?
   createdAt           DateTime      @default(now())
   updatedAt           DateTime      @updatedAt
-  lookup              WarLookup?
-
   @@unique([warStartTime, clanTag, opponentTag])
   @@index([clanTag, warEndTime])
 }
 
 model WarLookup {
-  warId      Int            @id
-  payload    Json
-  createdAt  DateTime       @default(now())
-  updatedAt  DateTime       @updatedAt
-  warHistory ClanWarHistory @relation(fields: [warId], references: [warId], onDelete: Cascade)
+  warId       String   @id
+  clanTag     String
+  opponentTag String?
+  startTime   DateTime
+  endTime     DateTime?
+  result      String?
+  payload     Json
+  createdAt   DateTime @default(now())
+
+  @@index([clanTag, startTime])
 }
 

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,17 +27,20 @@ model PlayerActivity {
 }
 
 model TrackedClan {
-  id            Int       @id @default(autoincrement())
-  tag           String    @unique
-  name          String?
-  loseStyle     LoseStyle @default(TRIPLE_TOP_30)
-  mailChannelId String?
-  logChannelId  String?
-  clanRoleId    String?
-  clanBadge     String?
-  shortName     String?
-  pointsScrape  Json?
-  createdAt     DateTime  @default(now())
+  id              Int       @id @default(autoincrement())
+  tag             String    @unique
+  name            String?
+  loseStyle       LoseStyle @default(TRIPLE_TOP_30)
+  mailChannelId   String?
+  logChannelId    String?
+  clanRoleId      String?
+  clanBadge       String?
+  shortName       String?
+  pointsScrape    Json?
+  notifyChannelId String?
+  notifyRole      String?
+  notifyEnabled   Boolean   @default(false)
+  createdAt       DateTime  @default(now())
 }
 
 model BotSetting {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -37,6 +37,7 @@ model TrackedClan {
   clanBadge       String?
   shortName       String?
   pointsScrape    Json?
+  mailConfig      Json?
   notifyChannelId String?
   notifyRole      String?
   notifyEnabled   Boolean   @default(false)
@@ -188,7 +189,6 @@ model CurrentWar {
   opponentTag   String?
   opponentName  String?
   clanName          String?
-  mailConfig        Json?
   createdAt         DateTime      @default(now())
   updatedAt         DateTime      @updatedAt
 

--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -720,13 +720,8 @@ async function getCurrentWarMailConfig(
   tag: string
 ): Promise<MatchMailConfig> {
   const normalizedTag = normalizeTag(tag);
-  const row = await prisma.currentWar.findUnique({
-    where: {
-      guildId_clanTag: {
-        guildId,
-        clanTag: `#${normalizedTag}`,
-      },
-    },
+  const row = await prisma.trackedClan.findUnique({
+    where: { tag: `#${normalizedTag}` },
     select: { mailConfig: true },
   });
   return parseMatchMailConfig(row?.mailConfig as Prisma.JsonValue | null | undefined);
@@ -739,23 +734,10 @@ async function saveCurrentWarMailConfig(params: {
   mailConfig: MatchMailConfig;
 }): Promise<void> {
   const normalizedTag = normalizeTag(params.tag);
-  await prisma.currentWar.upsert({
-    where: {
-      guildId_clanTag: {
-        guildId: params.guildId,
-        clanTag: `#${normalizedTag}`,
-      },
-    },
-    create: {
-      guildId: params.guildId,
-      clanTag: `#${normalizedTag}`,
-      channelId: params.channelId,
-      notify: false,
+  await prisma.trackedClan.update({
+    where: { tag: `#${normalizedTag}` },
+    data: {
       mailConfig: asMailConfigInputJson(params.mailConfig),
-    },
-    update: {
-      mailConfig: asMailConfigInputJson(params.mailConfig),
-      updatedAt: new Date(),
     },
   });
 }
@@ -1432,9 +1414,8 @@ async function findWarMailTargetFromConfig(params: {
   channelId: string;
   messageId: string;
 }): Promise<{ tag: string; channelId: string; messageId: string } | null> {
-  const rows = await prisma.currentWar.findMany({
-    where: { guildId: params.guildId },
-    select: { clanTag: true, mailConfig: true },
+  const rows = await prisma.trackedClan.findMany({
+    select: { tag: true, mailConfig: true },
   });
   for (const row of rows) {
     const config = parseMatchMailConfig(row.mailConfig as Prisma.JsonValue | null | undefined);
@@ -1443,7 +1424,7 @@ async function findWarMailTargetFromConfig(params: {
     if (primary.channelId !== params.channelId) continue;
     if (primary.messageId !== params.messageId) continue;
     return {
-      tag: normalizeTag(row.clanTag),
+      tag: normalizeTag(row.tag),
       channelId: primary.channelId,
       messageId: primary.messageId,
     };
@@ -2271,12 +2252,9 @@ export async function handleFwaMatchSkipSyncConfirmButton(
     select: {
       warId: true,
       startTime: true,
-      mailConfig: true,
     },
   });
-  const existingMailConfig = parseMatchMailConfig(
-    existingCurrent?.mailConfig as Prisma.JsonValue | null | undefined
-  );
+  const existingMailConfig = await getCurrentWarMailConfig(interaction.guildId, parsed.tag);
   const existingSkipHistory = existingMailConfig.skipSyncHistory;
   const skipWarStart =
     existingSkipHistory?.warStartUnix !== undefined && existingSkipHistory?.warStartUnix !== null
@@ -2465,11 +2443,9 @@ export async function handleFwaMatchSkipSyncUndoButton(
         clanTag: `#${parsed.tag}`,
       },
     },
-    select: { warId: true, mailConfig: true, channelId: true },
+    select: { warId: true, channelId: true },
   });
-  const existingMailConfig = parseMatchMailConfig(
-    current?.mailConfig as Prisma.JsonValue | null | undefined
-  );
+  const existingMailConfig = await getCurrentWarMailConfig(interaction.guildId, parsed.tag);
   const skipWarId = existingMailConfig.skipSyncHistory?.warId ?? current?.warId ?? null;
   if (skipWarId !== null && Number.isFinite(skipWarId)) {
     await prisma.clanWarHistory.deleteMany({
@@ -2947,14 +2923,13 @@ export async function refreshAllTrackedWarMailPosts(client: Client): Promise<voi
     select: {
       guildId: true,
       clanTag: true,
-      mailConfig: true,
     },
   });
 
   for (const row of rows) {
     const guildId = row.guildId?.trim() ?? "";
     if (!guildId) continue;
-    const config = parseMatchMailConfig(row.mailConfig as Prisma.JsonValue | null | undefined);
+    const config = await getCurrentWarMailConfig(guildId, normalizeTag(row.clanTag));
     const candidates = collectMailPostTargetsFromConfig(config);
     if (candidates.length === 0) continue;
 
@@ -3042,9 +3017,9 @@ export async function runForceMailUpdateCommand(
         clanTag: `#${tag}`,
       },
     },
-    select: { mailConfig: true },
+    select: { clanTag: true },
   });
-  const config = parseMatchMailConfig(current?.mailConfig as Prisma.JsonValue | null | undefined);
+  const config = await getCurrentWarMailConfig(interaction.guildId, tag);
   const candidates = collectMailPostTargetsFromConfig(config);
   if (candidates.length === 0) {
     await interaction.editReply(
@@ -3945,7 +3920,7 @@ async function buildTrackedMatchOverview(
   const actualByTag = await readActualSheetSnapshotByTag(settings).catch(() => new Map<string, ActualSheetClanSnapshot>());
   const tracked = await prisma.trackedClan.findMany({
     orderBy: { createdAt: "asc" },
-    select: { tag: true, name: true, pointsScrape: true },
+    select: { tag: true, name: true, pointsScrape: true, mailConfig: true },
   });
   const trackedMailRows = await prisma.$queryRaw<Array<{ tag: string; mailChannelId: string | null }>>(
     Prisma.sql`SELECT "tag","mailChannelId" FROM "TrackedClan"`
@@ -3972,9 +3947,14 @@ async function buildTrackedMatchOverview(
       outcome: true,
       fwaPoints: true,
       opponentFwaPoints: true,
-      mailConfig: true,
     },
   });
+  const trackedMailConfigByTag = new Map(
+    tracked.map((c) => [
+      normalizeTag(c.tag),
+      parseMatchMailConfig((c as { mailConfig?: Prisma.JsonValue | null }).mailConfig ?? null),
+    ])
+  );
   const subByTag = new Map(subscriptions.map((s) => [normalizeTag(s.clanTag), s]));
 
   const warByClanTag = new Map<string, CurrentWarResult | null>();
@@ -4035,7 +4015,7 @@ async function buildTrackedMatchOverview(
     const clanTimeRemainingLine = getWarStateRemaining(war, warState);
     const clanWarStartMs = warStartMsByClanTag.get(clanTag) ?? null;
     const sub = subByTag.get(clanTag);
-    const parsedMailConfig = parseMatchMailConfig(sub?.mailConfig ?? null);
+    const parsedMailConfig = trackedMailConfigByTag.get(clanTag) ?? parseMatchMailConfig(null);
     const baseMailStatusEmoji = getMailStatusEmojiForClan({
       guildId,
       tag: clanTag,
@@ -4796,7 +4776,6 @@ export async function runForceSyncMailCommand(
       matchType: true,
       outcome: true,
       startTime: true,
-      mailConfig: true,
     },
   });
   const currentWar = await getCurrentWarCached(cocService, tag).catch(() => null);
@@ -4804,7 +4783,7 @@ export async function runForceSyncMailCommand(
   const warStartMs =
     existing?.startTime?.getTime() ?? warStartMsFromApi ?? null;
   const nowUnix = Math.floor(Date.now() / 1000);
-  const current = parseMatchMailConfig(existing?.mailConfig as Prisma.JsonValue | null | undefined);
+  const current = await getCurrentWarMailConfig(interaction.guildId, tag);
   const messages = current.messages.filter(
     (entry) =>
       !(
@@ -6055,7 +6034,7 @@ export const Fwa: Command = {
         const currentSync = getCurrentSyncFromPrevious(sourceSync, warState);
         const trackedClanMeta = await prisma.trackedClan.findFirst({
           where: { tag: { equals: `#${tag}`, mode: "insensitive" } },
-          select: { name: true, pointsScrape: true },
+          select: { name: true, pointsScrape: true, mailConfig: true },
         });
         const subscription = interaction.guildId
           ? await prisma.currentWar.findUnique({
@@ -6074,7 +6053,6 @@ export const Fwa: Command = {
                 opponentFwaPoints: true,
                 warStartFwaPoints: true,
                 warEndFwaPoints: true,
-                mailConfig: true,
               },
             })
           : null;
@@ -6110,7 +6088,7 @@ export const Fwa: Command = {
           );
           const actual = actualByTag.get(tag) ?? null;
           const parsedMailConfig = parseMatchMailConfig(
-            subscription?.mailConfig as Prisma.JsonValue | null | undefined
+            trackedClanMeta?.mailConfig as Prisma.JsonValue | null | undefined
           );
           const baseMailStatusEmoji = getMailStatusEmojiForClan({
             guildId: interaction.guildId ?? null,
@@ -6404,8 +6382,9 @@ export const Fwa: Command = {
         );
         const siteStatusLine = buildPointsSyncStatusLine(siteUpdated, hasMismatch);
         const trackedMailConfig = await getTrackedClanMailConfig(tag);
-        const parsedMailConfig = parseMatchMailConfig(
-          subscription?.mailConfig as Prisma.JsonValue | null | undefined
+        const parsedMailConfig = await getCurrentWarMailConfig(
+          interaction.guildId ?? "",
+          tag
         );
         const currentExpectedOutcomeForMail: "WIN" | "LOSE" | "UNKNOWN" | null =
           matchType === "FWA" ? (effectiveOutcome ?? "UNKNOWN") : null;

--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -256,7 +256,7 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
     summary: "Run manual force-sync actions for war data and MailConfig references.",
     details: [
       "`/force sync data` manually overwrites tracked clan points and/or sync number from points.fwafarm.",
-      "`/force sync mail` upserts `CurrentWar.mailConfig` message references for posted mail/notify messages.",
+      "`/force sync mail` upserts `TrackedClan.mailConfig` message references for posted mail/notify messages.",
       "`/force sync warid` backfills missing `warId` values in `ClanWarHistory`, `WarAttacks`, and `CurrentWar` (DB-only).",
       "`/force mail update` refreshes an existing sent war-mail message in place and re-attaches it to the 20-minute refresh loop.",
       "`force sync` commands are admin-only by default.",

--- a/src/commands/Notify.ts
+++ b/src/commands/Notify.ts
@@ -286,16 +286,23 @@ export const Notify: Command = {
       const subscriptions = await prisma.$queryRaw<
         Array<{
           clanTag: string;
-          channelId: string;
+          notifyChannelId: string | null;
           notifyRole: string | null;
-          notify: boolean;
+          notifyEnabled: boolean;
           pingRole: boolean;
         }>
       >(
         Prisma.sql`
-          SELECT "clanTag","channelId","notifyRole","notify","pingRole"
-          FROM "CurrentWar"
-          WHERE "guildId" = ${interaction.guildId}
+          SELECT
+            tc."tag" AS "clanTag",
+            tc."notifyChannelId",
+            tc."notifyRole",
+            tc."notifyEnabled",
+            COALESCE(cw."pingRole", true) AS "pingRole"
+          FROM "TrackedClan" tc
+          LEFT JOIN "CurrentWar" cw
+            ON UPPER(REPLACE(cw."clanTag",'#','')) = UPPER(REPLACE(tc."tag",'#',''))
+           AND cw."guildId" = ${interaction.guildId}
         `
       );
       const subByTag = new Map(
@@ -309,9 +316,9 @@ export const Notify: Command = {
           return {
             clanName: clan.name?.trim() || clanTag,
             clanTag,
-            channelId: subRow?.channelId ?? null,
+            channelId: subRow?.notifyChannelId ?? null,
             notifyRole: subRow?.notifyRole ?? null,
-            enabled: Boolean(subRow?.notify),
+            enabled: Boolean(subRow?.notifyEnabled),
             rolePingEnabled: subRow?.pingRole ?? true,
           };
         })
@@ -351,10 +358,9 @@ export const Notify: Command = {
         target === "war_embed"
           ? await prisma.$executeRaw(
               Prisma.sql`
-                UPDATE "CurrentWar"
-                SET "notify" = ${enabled}, "updatedAt" = NOW()
-                WHERE "guildId" = ${interaction.guildId}
-                  AND UPPER(REPLACE("clanTag",'#','')) = ${normalizeClanTagInput(clanTag)}
+                UPDATE "TrackedClan"
+                SET "notifyEnabled" = ${enabled}
+                WHERE UPPER(REPLACE("tag",'#','')) = ${normalizeClanTagInput(clanTag)}
               `
             )
           : await prisma.$executeRaw(
@@ -489,6 +495,16 @@ export const Notify: Command = {
 
     await prisma.$executeRaw(
       Prisma.sql`
+        UPDATE "TrackedClan"
+        SET "notifyChannelId" = ${target.id},
+            "notifyRole" = ${notifyRole?.id ?? null},
+            "notifyEnabled" = true
+        WHERE UPPER(REPLACE("tag",'#','')) = ${normalizeClanTagInput(clanTag)}
+      `
+    );
+
+    await prisma.$executeRaw(
+      Prisma.sql`
         INSERT INTO "CurrentWar"
           ("guildId","clanTag","warId","channelId","notify","notifyRole","pingRole","state","prepStartTime","startTime","endTime","opponentTag","opponentName","clanName","createdAt","updatedAt")
         VALUES
@@ -497,8 +513,6 @@ export const Notify: Command = {
         DO UPDATE SET
           "warId" = EXCLUDED."warId",
           "channelId" = EXCLUDED."channelId",
-          "notify" = true,
-          "notifyRole" = EXCLUDED."notifyRole",
           "pingRole" = EXCLUDED."pingRole",
           "state" = EXCLUDED."state",
           "prepStartTime" = EXCLUDED."prepStartTime",

--- a/src/commands/War.ts
+++ b/src/commands/War.ts
@@ -90,8 +90,8 @@ export const War: Command = {
       options: [
         {
           name: "war-id",
-          description: "War ID (from /war history)",
-          type: ApplicationCommandOptionType.Integer,
+          description: "War ID (from /war history; text)",
+          type: ApplicationCommandOptionType.String,
           required: true,
         },
       ],
@@ -158,8 +158,8 @@ export const War: Command = {
     }
 
     if (sub === "war-id") {
-      const warId = interaction.options.getInteger("war-id", true);
-      if (!Number.isFinite(warId) || warId <= 0) {
+      const warId = String(interaction.options.getString("war-id", true) ?? "").trim();
+      if (!warId) {
         await interaction.editReply("Invalid war ID.");
         return;
       }
@@ -181,10 +181,22 @@ export const War: Command = {
       let attackRows: Array<Record<string, unknown>> = [];
       if (Array.isArray(payload)) {
         attackRows = payload as Array<Record<string, unknown>>;
+      } else if (payload && typeof payload === "object") {
+        const root = payload as Record<string, unknown>;
+        const attacks = root.attacks;
+        attackRows = Array.isArray(attacks) ? (attacks as Array<Record<string, unknown>>) : [];
       } else if (typeof payload === "string") {
         try {
           const parsed = JSON.parse(payload) as unknown;
-          attackRows = Array.isArray(parsed) ? (parsed as Array<Record<string, unknown>>) : [];
+          if (Array.isArray(parsed)) {
+            attackRows = parsed as Array<Record<string, unknown>>;
+          } else if (parsed && typeof parsed === "object") {
+            const root = parsed as Record<string, unknown>;
+            const attacks = root.attacks;
+            attackRows = Array.isArray(attacks) ? (attacks as Array<Record<string, unknown>>) : [];
+          } else {
+            attackRows = [];
+          }
         } catch {
           attackRows = [];
         }
@@ -196,28 +208,12 @@ export const War: Command = {
       }
 
       const headers = [
-        "id",
-        "clanTag",
-        "clanName",
-        "opponentClanTag",
-        "opponentClanName",
-        "warStartTime",
-        "warEndTime",
-        "warState",
-        "playerTag",
-        "playerName",
-        "playerPosition",
-        "attackOrder",
-        "attackNumber",
+        "attackerTag",
         "defenderTag",
-        "defenderName",
-        "defenderPosition",
         "stars",
-        "trueStars",
         "destruction",
-        "attackSeenAt",
-        "updatedAt",
-        "createdAt",
+        "order",
+        "duration",
       ];
 
       const csv = buildCsv(attackRows, headers);

--- a/src/services/WarEventLogService.ts
+++ b/src/services/WarEventLogService.ts
@@ -66,7 +66,7 @@ type SubscriptionRow = {
   clanTag: string;
   warId: number | null;
   syncNum: number | null;
-  channelId: string;
+  channelId: string | null;
   notify: boolean;
   pingRole: boolean;
   inferredMatchType: boolean;
@@ -246,9 +246,18 @@ export class WarEventLogService {
     const subs = await prisma.$queryRaw<SubscriptionRow[]>(
       Prisma.sql`
         SELECT
-          "id","guildId","clanTag","warId","syncNum","channelId","notify","pingRole","inferredMatchType","notifyRole","fwaPoints","opponentFwaPoints","outcome","matchType","warStartFwaPoints","warEndFwaPoints","clanStars","opponentStars","state","prepStartTime","startTime","endTime","opponentTag","opponentName","clanName"
-        FROM "CurrentWar"
-        ORDER BY "updatedAt" ASC
+          cw."id",cw."guildId",cw."clanTag",cw."warId",cw."syncNum",
+          tc."notifyChannelId" AS "channelId",
+          COALESCE(tc."notifyEnabled", false) AS "notify",
+          cw."pingRole",cw."inferredMatchType",
+          tc."notifyRole" AS "notifyRole",
+          cw."fwaPoints",cw."opponentFwaPoints",cw."outcome",cw."matchType",cw."warStartFwaPoints",cw."warEndFwaPoints",
+          cw."clanStars",cw."opponentStars",cw."state",cw."prepStartTime",cw."startTime",cw."endTime",
+          cw."opponentTag",cw."opponentName",cw."clanName"
+        FROM "CurrentWar" cw
+        LEFT JOIN "TrackedClan" tc
+          ON UPPER(REPLACE(tc."tag",'#','')) = UPPER(REPLACE(cw."clanTag",'#',''))
+        ORDER BY cw."updatedAt" ASC
       `
     );
     for (const sub of subs) {
@@ -725,9 +734,18 @@ export class WarEventLogService {
     const rows = await prisma.$queryRaw<SubscriptionRow[]>(
       Prisma.sql`
         SELECT
-          "id","guildId","clanTag","warId","syncNum","channelId","notify","pingRole","inferredMatchType","notifyRole","fwaPoints","opponentFwaPoints","outcome","matchType","warStartFwaPoints","warEndFwaPoints","clanStars","opponentStars","state","prepStartTime","startTime","endTime","opponentTag","opponentName","clanName"
-        FROM "CurrentWar"
-        WHERE "guildId" = ${guildId} AND UPPER(REPLACE("clanTag",'#','')) = ${normalizeTagBare(clanTag)}
+          cw."id",cw."guildId",cw."clanTag",cw."warId",cw."syncNum",
+          tc."notifyChannelId" AS "channelId",
+          COALESCE(tc."notifyEnabled", false) AS "notify",
+          cw."pingRole",cw."inferredMatchType",
+          tc."notifyRole" AS "notifyRole",
+          cw."fwaPoints",cw."opponentFwaPoints",cw."outcome",cw."matchType",cw."warStartFwaPoints",cw."warEndFwaPoints",
+          cw."clanStars",cw."opponentStars",cw."state",cw."prepStartTime",cw."startTime",cw."endTime",
+          cw."opponentTag",cw."opponentName",cw."clanName"
+        FROM "CurrentWar" cw
+        LEFT JOIN "TrackedClan" tc
+          ON UPPER(REPLACE(tc."tag",'#','')) = UPPER(REPLACE(cw."clanTag",'#',''))
+        WHERE cw."guildId" = ${guildId} AND UPPER(REPLACE(cw."clanTag",'#','')) = ${normalizeTagBare(clanTag)}
         LIMIT 1
       `
     );
@@ -808,9 +826,18 @@ export class WarEventLogService {
     const rows = await prisma.$queryRaw<SubscriptionRow[]>(
       Prisma.sql`
         SELECT
-          "id","guildId","clanTag","warId","syncNum","channelId","notify","pingRole","inferredMatchType","notifyRole","fwaPoints","opponentFwaPoints","outcome","matchType","warStartFwaPoints","warEndFwaPoints","clanStars","opponentStars","state","prepStartTime","startTime","endTime","opponentTag","opponentName","clanName"
-        FROM "CurrentWar"
-        WHERE "id" = ${subscriptionId}
+          cw."id",cw."guildId",cw."clanTag",cw."warId",cw."syncNum",
+          tc."notifyChannelId" AS "channelId",
+          COALESCE(tc."notifyEnabled", false) AS "notify",
+          cw."pingRole",cw."inferredMatchType",
+          tc."notifyRole" AS "notifyRole",
+          cw."fwaPoints",cw."opponentFwaPoints",cw."outcome",cw."matchType",cw."warStartFwaPoints",cw."warEndFwaPoints",
+          cw."clanStars",cw."opponentStars",cw."state",cw."prepStartTime",cw."startTime",cw."endTime",
+          cw."opponentTag",cw."opponentName",cw."clanName"
+        FROM "CurrentWar" cw
+        LEFT JOIN "TrackedClan" tc
+          ON UPPER(REPLACE(tc."tag",'#','')) = UPPER(REPLACE(cw."clanTag",'#',''))
+        WHERE cw."id" = ${subscriptionId}
         LIMIT 1
       `
     );
@@ -1031,7 +1058,7 @@ export class WarEventLogService {
       console.log(
         `[war-events] emit start guild=${sub.guildId} channel=${sub.channelId} clan=${eventPayload.clanTag} event=${eventPayload.eventType}`
       );
-      if (sub.notify) {
+      if (sub.notify && sub.channelId) {
         await this.emitEvent(sub.channelId, eventPayload, resolvedWarId);
       }
     }

--- a/src/services/WarHistoryService.ts
+++ b/src/services/WarHistoryService.ts
@@ -57,7 +57,12 @@ export class WarHistoryService {
 
     try {
       const war = await this.coc.getCurrentWar(clanTag);
-      if (!war?.clan?.tag || !war?.startTime) return;
+      if (!war?.clan?.tag || !war?.startTime) {
+        await prisma.warAttacks.deleteMany({
+          where: { clanTag },
+        });
+        return;
+      }
 
       const ownClanTag = normalizeTag(war.clan.tag);
       const ownClanName = String(war.clan.name ?? ownClanTag).trim() || ownClanTag;
@@ -69,6 +74,13 @@ export class WarHistoryService {
       const warState = String(war.state ?? "").trim() || null;
       const observedAt = new Date();
       const warId = await this.resolveWarId(ownClanTag, warStartTime);
+      // Keep WarAttacks as current-war-only storage for each clan.
+      await prisma.warAttacks.deleteMany({
+        where: {
+          clanTag: ownClanTag,
+          warStartTime: { not: warStartTime },
+        },
+      });
 
       const opponentMembers = Array.isArray(war.opponent?.members) ? (war.opponent?.members as WarMember[]) : [];
       const opponentByTag = new Map<string, WarMember>();

--- a/src/services/war-events/history.ts
+++ b/src/services/war-events/history.ts
@@ -218,16 +218,99 @@ export class WarEventHistoryService {
     const warId = Number(row[0]?.warId ?? NaN);
     if (!Number.isFinite(warId)) return;
 
-    await prisma.warAttacks.updateMany({
-      where: { clanTag, warStartTime },
-      data: { warId },
-    });
-    await prisma.currentWar.updateMany({
+    const currentSnapshot = await prisma.currentWar.findFirst({
       where: { clanTag, startTime: warStartTime },
-      data: {
-        warId,
+      select: {
+        inferredMatchType: true,
+        syncNum: true,
+        matchType: true,
+        state: true,
+        clanName: true,
+        opponentTag: true,
+        opponentName: true,
       },
     });
+    const participants = attacks.filter((a) => Number(a.attackOrder) === 0);
+    const teamSize = participants.length > 0 ? participants.length : null;
+    const pointsAwarded =
+      payload.warStartFwaPoints !== null &&
+      Number.isFinite(payload.warStartFwaPoints) &&
+      resolvedPointsAfterWar !== null &&
+      Number.isFinite(resolvedPointsAfterWar)
+        ? resolvedPointsAfterWar - payload.warStartFwaPoints
+        : pointsDelta;
+    const attacksPayload = attacks
+      .filter((a) => Number(a.attackOrder) > 0)
+      .map((a) => ({
+        attackerTag: a.playerTag,
+        defenderTag: a.defenderTag,
+        stars: a.stars,
+        destruction: a.destruction,
+        order: a.attackOrder,
+      }));
+    const mirrorHits = attacksPayload.filter((a) => {
+      const row = attacks.find(
+        (x) =>
+          x.playerTag === a.attackerTag &&
+          x.defenderTag === a.defenderTag &&
+          Number(x.attackOrder) === Number(a.order)
+      );
+      if (!row) return false;
+      return (
+        Number.isFinite(Number(row.playerPosition)) &&
+        Number.isFinite(Number(row.defenderPosition)) &&
+        Number(row.playerPosition) === Number(row.defenderPosition)
+      );
+    }).length;
+    const nonMirrorHits = Math.max(0, attacksPayload.length - mirrorHits);
+    const lookupPayload = {
+      warMeta: {
+        warId: String(warId),
+        clanTag,
+        opponentTag: normalizeTag(payload.opponentTag) || null,
+        state: "warEnded",
+        teamSize,
+        startTime: warStartTime.toISOString(),
+        endTime: warEndTime ? warEndTime.toISOString() : null,
+        result: resolvedActualOutcome.toLowerCase(),
+        synced: true,
+      },
+      score: {
+        clanStars: finalResult.clanStars,
+        opponentStars: finalResult.opponentStars,
+        clanDestruction: finalResult.clanDestruction,
+        opponentDestruction: finalResult.opponentDestruction,
+      },
+      fwa: {
+        syncNumber: payload.syncNumber ?? currentSnapshot?.syncNum ?? null,
+        pointsAwarded: pointsAwarded ?? null,
+        inferred: Boolean(currentSnapshot?.inferredMatchType),
+        mismatch: payload.matchType === "MM",
+        blacklist: payload.matchType === "BL",
+      },
+      clan: {
+        tag: clanTag,
+        name: payload.clanName ?? currentSnapshot?.clanName ?? clanTag,
+        members: participants.map((p) => ({
+          tag: p.playerTag,
+          name: p.playerName,
+          mapPosition: p.playerPosition,
+          townHall: null,
+        })),
+      },
+      opponent: {
+        tag: normalizeTag(payload.opponentTag) || currentSnapshot?.opponentTag || null,
+        name: payload.opponentName ?? currentSnapshot?.opponentName ?? null,
+        members: [],
+      },
+      attacks: attacksPayload,
+      compliance: {
+        mirrorHits,
+        nonMirrorHits,
+        lateHits: 0,
+        violations: [] as string[],
+      },
+    };
     const tracked = await prisma.trackedClan.findUnique({
       where: { tag: clanTag },
       select: { pointsScrape: true },
@@ -249,14 +332,21 @@ export class WarEventHistoryService {
 
     await prisma.$executeRaw(
       Prisma.sql`
-        INSERT INTO "WarLookup" ("warId","payload","updatedAt")
-        VALUES (${warId}, ${JSON.stringify(attacks)}::jsonb, NOW())
+        INSERT INTO "WarLookup" ("warId","clanTag","opponentTag","startTime","endTime","result","payload","createdAt")
+        VALUES (${String(warId)}, ${clanTag}, ${normalizeTag(payload.opponentTag) || null}, ${warStartTime}, ${warEndTime}, ${resolvedActualOutcome.toLowerCase()}, ${JSON.stringify(lookupPayload)}::jsonb, NOW())
         ON CONFLICT ("warId")
         DO UPDATE SET
-          "payload" = EXCLUDED."payload",
-          "updatedAt" = NOW()
+          "clanTag" = EXCLUDED."clanTag",
+          "opponentTag" = EXCLUDED."opponentTag",
+          "startTime" = EXCLUDED."startTime",
+          "endTime" = EXCLUDED."endTime",
+          "result" = EXCLUDED."result",
+          "payload" = EXCLUDED."payload"
       `
     );
+    await prisma.warAttacks.deleteMany({
+      where: { clanTag, warStartTime },
+    });
   }
 
   /** Purpose: resolve final result snapshot from war log with fallbacks. */

--- a/src/services/war-events/history.ts
+++ b/src/services/war-events/history.ts
@@ -218,6 +218,16 @@ export class WarEventHistoryService {
     const warId = Number(row[0]?.warId ?? NaN);
     if (!Number.isFinite(warId)) return;
 
+    // Normalize ended-war rows to carry resolved warId before archive/delete lifecycle.
+    await prisma.warAttacks.updateMany({
+      where: { clanTag, warStartTime, warId: null },
+      data: { warId },
+    });
+    await prisma.currentWar.updateMany({
+      where: { clanTag, startTime: warStartTime, warId: null },
+      data: { warId },
+    });
+
     const currentSnapshot = await prisma.currentWar.findFirst({
       where: { clanTag, startTime: warStartTime },
       select: {
@@ -344,8 +354,12 @@ export class WarEventHistoryService {
           "payload" = EXCLUDED."payload"
       `
     );
+    // Ephemeral lifecycle: archive complete, then clear active-war rows by warId.
     await prisma.warAttacks.deleteMany({
-      where: { clanTag, warStartTime },
+      where: { warId },
+    });
+    await prisma.currentWar.deleteMany({
+      where: { warId },
     });
   }
 


### PR DESCRIPTION
…ve payload

- remove WarHistoryParticipant model/table
- rework WarLookup schema: warId TEXT PK + clanTag/opponentTag/startTime/endTime/result/payload/createdAt
- update /war war-id to accept text warId and export attacks from the new payload object
- archive CurrentWar + WarAttacks into structured WarLookup payload at war_end
- keep WarAttacks current-war-only by purging stale/notInWar rows and deleting ended-war rows after archive
- add migration 20260304174000_rework_war_lookup_and_drop_participant