### PR TITLE
feat(war-events): add idempotent war event log for battle-day and war…

### DIFF
--- a/prisma/migrations/20260305020000_add_war_event_log/migration.sql
+++ b/prisma/migrations/20260305020000_add_war_event_log/migration.sql
@@ -1,0 +1,11 @@
+CREATE TABLE "WarEvent" (
+  "warId" INTEGER NOT NULL,
+  "clanTag" TEXT NOT NULL,
+  "eventType" TEXT NOT NULL,
+  "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  "payload" JSONB NOT NULL,
+
+  CONSTRAINT "WarEvent_pkey" PRIMARY KEY ("warId","clanTag","eventType")
+);
+
+CREATE INDEX "WarEvent_clanTag_createdAt_idx" ON "WarEvent"("clanTag", "createdAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -248,3 +248,14 @@ model WarLookup {
   @@index([clanTag, startTime])
 }
 
+model WarEvent {
+  warId     Int
+  clanTag   String
+  eventType String
+  createdAt DateTime @default(now())
+  payload   Json
+
+  @@id([warId, clanTag, eventType])
+  @@index([clanTag, createdAt])
+}
+

--- a/src/services/WarEventLogService.ts
+++ b/src/services/WarEventLogService.ts
@@ -1124,10 +1124,61 @@ export class WarEventLogService {
       });
     }
     if (!params.sub.notify || !params.sub.channelId) return;
+    if (
+      (params.payload.eventType === "battle_day" || params.payload.eventType === "war_ended") &&
+      !(await this.reserveEventDelivery(params))
+    ) {
+      return;
+    }
     console.log(
       `[war-events] emit start guild=${params.sub.guildId} channel=${params.sub.channelId} clan=${params.payload.clanTag} event=${params.payload.eventType}`
     );
     await this.emitEvent(params.sub.channelId, params.payload, params.resolvedWarId);
+  }
+
+  private async reserveEventDelivery(params: {
+    sub: SubscriptionRow;
+    payload: EventEmitPayload;
+    resolvedWarId: number | null;
+  }): Promise<boolean> {
+    const eventType = params.payload.eventType;
+    if (eventType !== "battle_day" && eventType !== "war_ended") return true;
+    const warId =
+      params.resolvedWarId ??
+      params.sub.warId ??
+      (await this.resolveWarId(params.payload.clanTag, params.payload.warStartTime));
+    if (warId === null || warId === undefined || !Number.isFinite(Number(warId))) {
+      console.warn(
+        `[war-events] emit skipped guild=${params.sub.guildId} clan=${params.sub.clanTag} event=${eventType} reason=missing_war_id_for_idempotency`
+      );
+      return false;
+    }
+    try {
+      await prisma.warEvent.create({
+        data: {
+          warId: Math.trunc(Number(warId)),
+          clanTag: normalizeTag(params.payload.clanTag),
+          eventType,
+          payload: {
+            guildId: params.sub.guildId,
+            channelId: params.sub.channelId,
+            opponentTag: normalizeTag(params.payload.opponentTag),
+            warStartTime: params.payload.warStartTime?.toISOString?.() ?? null,
+            warEndTime: params.payload.warEndTime?.toISOString?.() ?? null,
+            syncNumber: params.payload.syncNumber ?? null,
+          },
+        },
+      });
+      return true;
+    } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
+        console.log(
+          `[war-events] emit deduped guild=${params.sub.guildId} clan=${params.sub.clanTag} warId=${warId} event=${eventType}`
+        );
+        return false;
+      }
+      throw error;
+    }
   }
 
   private async resolveWarId(clanTagInput: string, warStartTime: Date | null): Promise<number | null> {


### PR DESCRIPTION
…-end embeds

- add `WarEvent` table with payload and composite primary key `(warId, clanTag, eventType)`
- add migration to create `WarEvent` plus clan/time index for audit queries
- reserve battle-day and war-end emissions through `WarEvent` inserts before sending embeds
- skip duplicate emits on unique-key conflicts to guarantee one embed per event type and war
- enforce warId presence for idempotent battle-day/war-end delivery paths