### PR TITLE
refactor(schema): harden war keys, add versioned JSON blobs, and tune…

### DIFF
--- a/prisma/migrations/20260305033000_warattacks_pk_and_indexes/migration.sql
+++ b/prisma/migrations/20260305033000_warattacks_pk_and_indexes/migration.sql
@@ -1,0 +1,41 @@
+-- Backfill missing warId values before making warId part of primary key.
+WITH max_ids AS (
+  SELECT GREATEST(
+    COALESCE((SELECT MAX("warId") FROM "ClanWarHistory"), 0),
+    COALESCE((SELECT MAX("warId") FROM "CurrentWar"), 0),
+    COALESCE((SELECT MAX("warId") FROM "WarAttacks"), 0)
+  ) AS max_war_id
+), numbered AS (
+  SELECT
+    ctid,
+    ROW_NUMBER() OVER (ORDER BY "createdAt" ASC, "updatedAt" ASC) AS rn
+  FROM "WarAttacks"
+  WHERE "warId" IS NULL
+)
+UPDATE "WarAttacks" wa
+SET "warId" = mi.max_war_id + n.rn
+FROM numbered n
+CROSS JOIN max_ids mi
+WHERE wa.ctid = n.ctid;
+
+-- Remove any accidental duplicates on the target composite key before adding PK.
+DELETE FROM "WarAttacks" a
+USING "WarAttacks" b
+WHERE a.ctid < b.ctid
+  AND a."warId" = b."warId"
+  AND a."playerTag" = b."playerTag"
+  AND a."attackNumber" = b."attackNumber";
+
+ALTER TABLE "WarAttacks" DROP CONSTRAINT IF EXISTS "WarAttacks_pkey";
+ALTER TABLE "WarAttacks" DROP CONSTRAINT IF EXISTS "WarAttacks_warId_playerTag_attackNumber_key";
+ALTER TABLE "WarAttacks" ALTER COLUMN "warId" SET NOT NULL;
+ALTER TABLE "WarAttacks" ADD CONSTRAINT "WarAttacks_pkey" PRIMARY KEY ("warId","playerTag","attackNumber");
+CREATE UNIQUE INDEX IF NOT EXISTS "WarAttacks_clanTag_warStartTime_playerTag_attackOrder_key"
+  ON "WarAttacks"("clanTag","warStartTime","playerTag","attackOrder");
+ALTER TABLE "WarAttacks" DROP COLUMN IF EXISTS "id";
+
+CREATE INDEX IF NOT EXISTS "BotSetting_updatedAt_idx" ON "BotSetting"("updatedAt");
+CREATE INDEX IF NOT EXISTS "RecruitmentCooldown_expiresAt_idx" ON "RecruitmentCooldown"("expiresAt");
+
+DROP INDEX IF EXISTS "WarEvent_clanTag_createdAt_idx";
+CREATE INDEX "WarEvent_clanTag_createdAt_idx" ON "WarEvent"("clanTag","createdAt" DESC);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -49,6 +49,8 @@ model BotSetting {
   value     String
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+
+  @@index([updatedAt])
 }
 
 model PlayerLink {
@@ -129,11 +131,11 @@ model RecruitmentCooldown {
   @@unique([userId, clanTag, platform])
   @@index([userId, expiresAt])
   @@index([expiresAt, reminded])
+  @@index([expiresAt])
 }
 
 model WarAttacks {
-  id               Int       @id @default(autoincrement())
-  warId            Int?
+  warId            Int
   clanTag          String
   clanName         String?
   opponentClanTag  String?
@@ -157,7 +159,8 @@ model WarAttacks {
   updatedAt        DateTime  @updatedAt
   createdAt        DateTime  @default(now())
 
-  @@unique([warId, playerTag, attackNumber])
+  @@id([warId, playerTag, attackNumber])
+  @@unique([clanTag, warStartTime, playerTag, attackOrder])
   @@index([clanTag, warStartTime])
   @@index([playerTag, warStartTime])
   @@index([warId])
@@ -256,6 +259,6 @@ model WarEvent {
   payload   Json
 
   @@id([warId, clanTag, eventType])
-  @@index([clanTag, createdAt])
+  @@index([clanTag, createdAt(sort: Desc)])
 }
 

--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -3333,6 +3333,11 @@ type TrackedClanPointsScrape = {
   pointsSiteUpToDate: boolean;
 };
 
+type VersionedJsonBlob = {
+  version?: number;
+  data?: unknown;
+};
+
 type ActualSheetClanSnapshot = {
   totalWeight: string | null;
   weightCompo: string | null;
@@ -3417,7 +3422,16 @@ function extractMatchupHeader(topText: string): MatchupHeader {
 
 function parseTrackedClanPointsScrape(value: unknown): TrackedClanPointsScrape | null {
   if (!value || typeof value !== "object") return null;
-  const obj = value as Record<string, unknown>;
+  const root = value as Record<string, unknown>;
+  const maybeVersioned = root as VersionedJsonBlob;
+  const payload =
+    typeof maybeVersioned.version === "number" &&
+    maybeVersioned.data &&
+    typeof maybeVersioned.data === "object" &&
+    !Array.isArray(maybeVersioned.data)
+      ? (maybeVersioned.data as Record<string, unknown>)
+      : root;
+  const obj = payload;
   const trackedClanTag = normalizeTag(String(obj.trackedClanTag ?? ""));
   if (!trackedClanTag) return null;
   const opponentClanTagRaw = String(obj.opponentClanTag ?? "").trim();
@@ -3446,6 +3460,15 @@ function parseTrackedClanPointsScrape(value: unknown): TrackedClanPointsScrape |
     matchup: String(obj.matchup ?? ""),
     pointsSiteUpToDate: Boolean(obj.pointsSiteUpToDate),
   };
+}
+
+function asVersionedPointsScrapeInputJson(
+  scrape: TrackedClanPointsScrape
+): Prisma.InputJsonValue {
+  return {
+    version: 1,
+    data: scrape,
+  } as Prisma.InputJsonValue;
 }
 
 function buildSnapshotFromTrackedScrape(
@@ -4697,7 +4720,7 @@ export async function runForceSyncDataCommand(
   };
   await prisma.trackedClan.update({
     where: { tag: `#${tag}` },
-    data: { pointsScrape },
+    data: { pointsScrape: asVersionedPointsScrapeInputJson(pointsScrape) },
   });
 
   await interaction.editReply(

--- a/src/commands/fwa/mailConfig.ts
+++ b/src/commands/fwa/mailConfig.ts
@@ -46,6 +46,11 @@ export const MATCH_MAIL_CONFIG_DEFAULT: MatchMailConfig = {
   skipSyncHistory: null,
 };
 
+type VersionedBlob = {
+  version?: number;
+  data?: unknown;
+};
+
 function normalizeTag(input: string): string {
   return input.trim().toUpperCase().replace(/^#/, "");
 }
@@ -71,7 +76,16 @@ export function parseMatchMailConfig(value: Prisma.JsonValue | null | undefined)
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return { ...MATCH_MAIL_CONFIG_DEFAULT };
   }
-  const obj = value as Record<string, unknown>;
+  const root = value as Record<string, unknown>;
+  const maybeVersioned = root as VersionedBlob;
+  const payload =
+    typeof maybeVersioned.version === "number" &&
+    maybeVersioned.data &&
+    typeof maybeVersioned.data === "object" &&
+    !Array.isArray(maybeVersioned.data)
+      ? (maybeVersioned.data as Record<string, unknown>)
+      : root;
+  const obj = payload;
   const rawMessages = Array.isArray(obj.messages) ? obj.messages : [];
   const messages: MatchMailMessageRef[] = [];
   for (const entry of rawMessages) {
@@ -157,7 +171,10 @@ export function parseMatchMailConfig(value: Prisma.JsonValue | null | undefined)
 }
 
 export function asMailConfigInputJson(config: MatchMailConfig): Prisma.InputJsonValue {
-  return config as unknown as Prisma.InputJsonValue;
+  return {
+    version: 1,
+    data: config,
+  } as unknown as Prisma.InputJsonValue;
 }
 
 export function buildDiscordMessageUrl(guildId: string, channelId: string, messageId: string): string {

--- a/src/listeners/ready.ts
+++ b/src/listeners/ready.ts
@@ -23,7 +23,7 @@ import {
 } from "../services/refreshSchedule";
 
 const DEFAULT_OBSERVE_INTERVAL_MINUTES = 30;
-const RECRUITMENT_REMINDER_INTERVAL_MS = 5 * 60 * 1000;
+const RECRUITMENT_REMINDER_INTERVAL_MS = 60 * 60 * 1000;
 const DEFAULT_WAR_EVENT_POLL_INTERVAL_MINUTES = 5;
 const OBSERVE_LAST_RUN_AT_KEY = "activity_observe:last_run_at_ms";
 const VISIBILITY_OPTION = {
@@ -282,7 +282,7 @@ export default (client: Client, cocService: CoCService): void => {
         console.error(`[recruitment] reminder interval failed: ${formatError(err)}`);
       });
     }, RECRUITMENT_REMINDER_INTERVAL_MS);
-    console.log("Recruitment reminder loop enabled (every 5 minute(s)).");
+    console.log("Recruitment reminder loop enabled (every 60 minute(s)).");
 
     const warEventPollMinutesRaw = Number(
       process.env.WAR_EVENT_LOG_POLL_INTERVAL_MINUTES ?? DEFAULT_WAR_EVENT_POLL_INTERVAL_MINUTES

--- a/src/services/WarEventLogService.ts
+++ b/src/services/WarEventLogService.ts
@@ -273,6 +273,7 @@ export class WarEventLogService {
           ON UPPER(REPLACE(tc."tag",'#','')) = UPPER(REPLACE(cw."clanTag",'#',''))
         LEFT JOIN "ClanNotifyConfig" cnc
           ON cnc."guildId" = cw."guildId" AND UPPER(REPLACE(cnc."clanTag",'#','')) = UPPER(REPLACE(cw."clanTag",'#',''))
+        WHERE cw."endTime" > NOW() - INTERVAL '2 hours'
         ORDER BY cw."updatedAt" ASC
       `
     );
@@ -1135,6 +1136,13 @@ export class WarEventLogService {
     resolvedWarId: number | null;
     fallbackWarStartTime: Date | null;
   }): Promise<void> {
+    if (
+      params.resolvedWarId === null ||
+      params.resolvedWarId === undefined ||
+      !Number.isFinite(Number(params.resolvedWarId))
+    ) {
+      return;
+    }
     const war = params.war;
     const ownClanTag = normalizeTag(war?.clan?.tag ?? params.clanTag);
     if (!ownClanTag) return;

--- a/src/services/war-events/history.ts
+++ b/src/services/war-events/history.ts
@@ -13,6 +13,26 @@ import {
   parseCocTime,
 } from "./core";
 
+type VersionedJsonBlob = {
+  version?: number;
+  data?: unknown;
+};
+
+function unwrapVersionedRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const root = value as Record<string, unknown>;
+  const maybeVersioned = root as VersionedJsonBlob;
+  if (
+    typeof maybeVersioned.version === "number" &&
+    maybeVersioned.data &&
+    typeof maybeVersioned.data === "object" &&
+    !Array.isArray(maybeVersioned.data)
+  ) {
+    return maybeVersioned.data as Record<string, unknown>;
+  }
+  return root;
+}
+
 /** Purpose: encapsulate war-end history, compliance, and war-plan related logic. */
 export class WarEventHistoryService {
   /** Purpose: initialize war history service dependencies. */
@@ -220,7 +240,7 @@ export class WarEventHistoryService {
 
     // Normalize ended-war rows to carry resolved warId before archive/delete lifecycle.
     await prisma.warAttacks.updateMany({
-      where: { clanTag, warStartTime, warId: null },
+      where: { clanTag, warStartTime },
       data: { warId },
     });
     await prisma.currentWar.updateMany({
@@ -325,16 +345,19 @@ export class WarEventHistoryService {
       where: { tag: clanTag },
       select: { pointsScrape: true },
     });
-    if (tracked?.pointsScrape && typeof tracked.pointsScrape === "object") {
-      const blob = tracked.pointsScrape as Record<string, unknown>;
+    const trackedBlob = unwrapVersionedRecord(tracked?.pointsScrape);
+    if (trackedBlob) {
       await prisma.trackedClan.update({
         where: { tag: clanTag },
         data: {
           pointsScrape: {
-            ...(blob as object),
-            pointsSiteUpToDate: false,
-            activeFwa: false,
-            fetchedAtMs: Date.now(),
+            version: 1,
+            data: {
+              ...(trackedBlob as object),
+              pointsSiteUpToDate: false,
+              activeFwa: false,
+              fetchedAtMs: Date.now(),
+            },
           },
         },
       });

--- a/src/services/war-events/pointsSync.ts
+++ b/src/services/war-events/pointsSync.ts
@@ -42,6 +42,26 @@ type TrackedClanPointsScrape = {
   pointsSiteUpToDate: boolean;
 };
 
+type VersionedJsonBlob = {
+  version?: number;
+  data?: unknown;
+};
+
+function unwrapVersionedRecord(value: unknown): Record<string, unknown> | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const root = value as Record<string, unknown>;
+  const maybeVersioned = root as VersionedJsonBlob;
+  if (
+    typeof maybeVersioned.version === "number" &&
+    maybeVersioned.data &&
+    typeof maybeVersioned.data === "object" &&
+    !Array.isArray(maybeVersioned.data)
+  ) {
+    return maybeVersioned.data as Record<string, unknown>;
+  }
+  return root;
+}
+
 export type PointsSyncSubscriptionLike = {
   clanTag: string;
   fwaPoints: number | null;
@@ -66,7 +86,7 @@ export class WarStartPointsSyncService {
     });
     const scrapeCandidates = tracked
       .map((row) => {
-        const value = row.pointsScrape as Record<string, unknown> | null;
+        const value = unwrapVersionedRecord(row.pointsScrape);
         if (!value || typeof value !== "object" || Array.isArray(value)) return null;
         if (!value.pointsSiteUpToDate) return null;
         const syncRaw = Number(value.syncNumber ?? NaN);
@@ -295,7 +315,12 @@ export class WarStartPointsSyncService {
 
     await prisma.trackedClan.updateMany({
       where: { tag: { equals: blob.trackedClanTag, mode: "insensitive" } },
-      data: { pointsScrape: blob },
+      data: {
+        pointsScrape: {
+          version: 1,
+          data: blob,
+        },
+      },
     });
   }
 


### PR DESCRIPTION
… poll/reminder loops

- promote `WarAttacks` to composite primary key `(warId, playerTag, attackNumber)` and drop `id`
- make `WarAttacks.warId` non-null with migration backfill for existing null rows
- add unique index for `WarAttacks(clanTag, warStartTime, playerTag, attackOrder)` to support conflict-safe upserts
- add `BotSetting(updatedAt)` and `RecruitmentCooldown(expiresAt)` indexes
- switch `WarEvent` lookup index to `(clanTag, createdAt DESC)`
- wrap `TrackedClan.pointsScrape` and `TrackedClan.mailConfig` in versioned JSON `{ version, data }` with backward-compatible readers
- move recruitment reminder interval from 5 minutes to 60 minutes
- add war poll filtering to recent/active windows (`CurrentWar.endTime > NOW() - INTERVAL '2 hours'`)
- update war history/points sync paths for new `WarAttacks` key constraints and versioned blob handling