### PR TITLE
feat(telemetry): add ApiUsage table and persist API/web call counters

### DIFF
--- a/prisma/migrations/20260305050000_add_api_usage/migration.sql
+++ b/prisma/migrations/20260305050000_add_api_usage/migration.sql
@@ -1,0 +1,6 @@
+CREATE TABLE "ApiUsage" (
+  "endpoint" TEXT NOT NULL,
+  "lastCall" TIMESTAMP(3) NOT NULL,
+  "callCount" INTEGER NOT NULL DEFAULT 0,
+  CONSTRAINT "ApiUsage_pkey" PRIMARY KEY ("endpoint")
+);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -262,3 +262,9 @@ model WarEvent {
   @@index([clanTag, createdAt(sort: Desc)])
 }
 
+model ApiUsage {
+  endpoint String   @id
+  lastCall DateTime
+  callCount Int     @default(0)
+}
+

--- a/src/commands/Sheet.ts
+++ b/src/commands/Sheet.ts
@@ -6,6 +6,7 @@ import {
 } from "discord.js";
 import { Command } from "../Command";
 import { formatError } from "../helper/formatError";
+import { recordFetchEvent } from "../helper/fetchTelemetry";
 import { safeReply } from "../helper/safeReply";
 import { CoCService } from "../services/CoCService";
 import { GoogleSheetsService } from "../services/GoogleSheetsService";
@@ -109,6 +110,12 @@ async function postRefreshWebhook(
 
   try {
     const response = await makeRequest();
+    recordFetchEvent({
+      namespace: "google_sheets",
+      operation: "apps_script_refresh",
+      source: "web",
+      detail: `action=${action} status=${response.status}`,
+    });
     return String(response.data ?? "").trim();
   } catch (firstErr) {
     const hint = formatError(firstErr).toLowerCase();
@@ -123,6 +130,12 @@ async function postRefreshWebhook(
     if (!retryable) throw firstErr;
 
     const second = await makeRequest();
+    recordFetchEvent({
+      namespace: "google_sheets",
+      operation: "apps_script_refresh",
+      source: "web",
+      detail: `action=${action} status=${second.status} retry=true`,
+    });
     return String(second.data ?? "").trim();
   }
 }

--- a/src/helper/fetchTelemetry.ts
+++ b/src/helper/fetchTelemetry.ts
@@ -1,4 +1,5 @@
 import { AsyncLocalStorage } from "node:async_hooks";
+import { prisma } from "../prisma";
 
 type FetchSource = "api" | "web" | "cache_hit" | "cache_miss" | "fallback_cache";
 
@@ -49,6 +50,23 @@ function getOrCreateTotals(map: Map<string, Totals>, key: string): Totals {
   const created = makeEmptyTotals();
   map.set(key, created);
   return created;
+}
+
+function trackApiUsage(endpoint: string, incrementBy: number): void {
+  void prisma.apiUsage
+    .upsert({
+      where: { endpoint },
+      create: {
+        endpoint,
+        lastCall: new Date(),
+        callCount: incrementBy,
+      },
+      update: {
+        lastCall: new Date(),
+        callCount: { increment: incrementBy },
+      },
+    })
+    .catch(() => undefined);
 }
 
 export async function runFetchTelemetryBatch<T>(
@@ -105,6 +123,9 @@ export function recordFetchEvent(event: FetchEvent): void {
 
   const totals = getOrCreateTotals(operationTotals, opKey);
   totals[event.source] += incrementBy;
+  if (event.source === "api" || event.source === "web") {
+    trackApiUsage(`${event.namespace}:${event.operation}`, incrementBy);
+  }
 
   const batch = telemetryBatchStorage.getStore();
   if (batch) {

--- a/src/services/ClashKingService.ts
+++ b/src/services/ClashKingService.ts
@@ -167,8 +167,20 @@ export class ClashKingService {
           "Content-Type": "application/json",
         },
       });
+      recordFetchEvent({
+        namespace: "clashking",
+        operation: "discord_links_fallback",
+        source: "api",
+        detail: `tag=${normalizeTag(playerTag)} status=${response.status}`,
+      });
       return extractDiscordUserId(response.data);
     } catch (err) {
+      recordFetchEvent({
+        namespace: "clashking",
+        operation: "discord_links_fallback",
+        source: "api",
+        detail: `tag=${normalizeTag(playerTag)} result=error`,
+      });
       console.warn(
         `[clashking] link lookup fallback failed tag=${normalizeTag(playerTag)} error=${formatError(err)}`
       );

--- a/src/services/GoogleSheetsService.ts
+++ b/src/services/GoogleSheetsService.ts
@@ -1,5 +1,6 @@
 import axios from "axios";
 import { createSign } from "crypto";
+import { recordFetchEvent } from "../helper/fetchTelemetry";
 import { SettingsService } from "./SettingsService";
 
 export const SHEET_SETTING_ID_KEY = "google_sheet_id";
@@ -110,14 +111,29 @@ export class GoogleSheetsService {
     const encodedSheetId = encodeURIComponent(sheetId);
     const url = `https://sheets.googleapis.com/v4/spreadsheets/${encodedSheetId}/values/${encodedRange}`;
 
-    const response = await axios.get<{ values?: string[][] }>(url, {
-      headers: {
-        Authorization: `Bearer ${token}`,
-      },
-      timeout: GOOGLE_API_TIMEOUT_MS,
-    });
-
-    return response.data.values ?? [];
+    try {
+      const response = await axios.get<{ values?: string[][] }>(url, {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+        timeout: GOOGLE_API_TIMEOUT_MS,
+      });
+      recordFetchEvent({
+        namespace: "google_sheets",
+        operation: "read_values",
+        source: "api",
+        detail: `sheet=${sheetId}`,
+      });
+      return response.data.values ?? [];
+    } catch (err) {
+      recordFetchEvent({
+        namespace: "google_sheets",
+        operation: "read_values",
+        source: "api",
+        detail: `sheet=${sheetId} result=error`,
+      });
+      throw err;
+    }
   }
 
   private async readValuesViaAppsScriptProxy(
@@ -146,6 +162,12 @@ export class GoogleSheetsService {
     });
 
     if (response.status >= 400) {
+      recordFetchEvent({
+        namespace: "google_sheets",
+        operation: "apps_script_proxy",
+        source: "web",
+        detail: `action=readValues status=${response.status}`,
+      });
       const message =
         typeof response.data?.error === "string"
           ? response.data.error
@@ -154,6 +176,12 @@ export class GoogleSheetsService {
             : `Apps Script proxy returned HTTP ${response.status}`;
       throw new Error(message);
     }
+    recordFetchEvent({
+      namespace: "google_sheets",
+      operation: "apps_script_proxy",
+      source: "web",
+      detail: `action=readValues status=${response.status}`,
+    });
 
     const rawValues =
       response.data?.values ??
@@ -200,7 +228,7 @@ export class GoogleSheetsService {
     const oauthRefreshToken = process.env.GOOGLE_OAUTH_REFRESH_TOKEN?.trim();
 
     if (oauthClientId && oauthClientSecret && oauthRefreshToken) {
-      return axios.post<{
+      const response = await axios.post<{
         access_token: string;
         expires_in: number;
         token_type: string;
@@ -217,10 +245,17 @@ export class GoogleSheetsService {
           timeout: GOOGLE_API_TIMEOUT_MS,
         }
       );
+      recordFetchEvent({
+        namespace: "google_oauth",
+        operation: "token_exchange",
+        source: "api",
+        detail: "grant=refresh_token",
+      });
+      return response;
     }
 
     const assertion = this.buildServiceAccountAssertion();
-    return axios.post<{
+    const response = await axios.post<{
       access_token: string;
       expires_in: number;
       token_type: string;
@@ -235,6 +270,13 @@ export class GoogleSheetsService {
         timeout: GOOGLE_API_TIMEOUT_MS,
       }
     );
+    recordFetchEvent({
+      namespace: "google_oauth",
+      operation: "token_exchange",
+      source: "api",
+      detail: "grant=jwt_bearer",
+    });
+    return response;
   }
 
   /** Purpose: build service account assertion. */

--- a/src/services/PointsProjectionService.ts
+++ b/src/services/PointsProjectionService.ts
@@ -1,5 +1,6 @@
 import axios from "axios";
 import { CoCService } from "./CoCService";
+import { recordFetchEvent } from "../helper/fetchTelemetry";
 
 const POINTS_BASE_URL = "https://points.fwafarm.com/clan?tag=";
 const TIEBREAK_ORDER = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
@@ -146,6 +147,12 @@ export class PointsProjectionService {
       responseType: "text",
       headers: POINTS_REQUEST_HEADERS,
       validateStatus: () => true,
+    });
+    recordFetchEvent({
+      namespace: "points",
+      operation: "projection_fetch",
+      source: "web",
+      detail: `tag=${normalizedTag} status=${response.status}`,
     });
     if (response.status >= 400) {
       return {


### PR DESCRIPTION
- add `ApiUsage` table (`endpoint`, `lastCall`, `callCount`) with endpoint primary key
- wire `recordFetchEvent` to upsert/increment `ApiUsage` for all `source=api|web` events
- add telemetry emission for previously untracked direct calls (Google Sheets, Apps Script refresh, ClashKing fallback, points projection fetch)
- keep existing runtime telemetry logs while adding durable DB-level usage tracking