### PR TITLE
feat(multitenancy): scope activity and recruitment data by guild

### DIFF
--- a/prisma/migrations/20260305062000_add_guildid_multiserver/migration.sql
+++ b/prisma/migrations/20260305062000_add_guildid_multiserver/migration.sql
@@ -1,0 +1,24 @@
+-- PlayerActivity guild scoping
+ALTER TABLE "PlayerActivity" ADD COLUMN "guildId" TEXT;
+UPDATE "PlayerActivity" SET "guildId" = 'legacy' WHERE "guildId" IS NULL;
+ALTER TABLE "PlayerActivity" ALTER COLUMN "guildId" SET NOT NULL;
+ALTER TABLE "PlayerActivity" DROP CONSTRAINT "PlayerActivity_pkey";
+ALTER TABLE "PlayerActivity" ADD CONSTRAINT "PlayerActivity_pkey" PRIMARY KEY ("guildId", "tag");
+CREATE INDEX IF NOT EXISTS "PlayerActivity_guildId_clanTag_idx" ON "PlayerActivity"("guildId", "clanTag");
+
+-- RecruitmentTemplate guild scoping
+ALTER TABLE "RecruitmentTemplate" ADD COLUMN "guildId" TEXT;
+UPDATE "RecruitmentTemplate" SET "guildId" = 'legacy' WHERE "guildId" IS NULL;
+ALTER TABLE "RecruitmentTemplate" ALTER COLUMN "guildId" SET NOT NULL;
+ALTER TABLE "RecruitmentTemplate" DROP CONSTRAINT IF EXISTS "RecruitmentTemplate_clanTag_platform_key";
+CREATE UNIQUE INDEX "RecruitmentTemplate_guildId_clanTag_platform_key" ON "RecruitmentTemplate"("guildId", "clanTag", "platform");
+CREATE INDEX IF NOT EXISTS "RecruitmentTemplate_guildId_clanTag_idx" ON "RecruitmentTemplate"("guildId", "clanTag");
+
+-- RecruitmentCooldown guild scoping
+ALTER TABLE "RecruitmentCooldown" ADD COLUMN "guildId" TEXT;
+UPDATE "RecruitmentCooldown" SET "guildId" = 'legacy' WHERE "guildId" IS NULL;
+ALTER TABLE "RecruitmentCooldown" ALTER COLUMN "guildId" SET NOT NULL;
+ALTER TABLE "RecruitmentCooldown" DROP CONSTRAINT IF EXISTS "RecruitmentCooldown_userId_clanTag_platform_key";
+CREATE UNIQUE INDEX "RecruitmentCooldown_guildId_userId_clanTag_platform_key" ON "RecruitmentCooldown"("guildId", "userId", "clanTag", "platform");
+CREATE INDEX IF NOT EXISTS "RecruitmentCooldown_guildId_userId_expiresAt_idx" ON "RecruitmentCooldown"("guildId", "userId", "expiresAt");
+CREATE INDEX IF NOT EXISTS "RecruitmentCooldown_guildId_expiresAt_reminded_idx" ON "RecruitmentCooldown"("guildId", "expiresAt", "reminded");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,7 +8,8 @@ datasource db {
 }
 
 model PlayerActivity {
-  tag     String @id
+  guildId String
+  tag     String
   name    String
   clanTag String
 
@@ -24,6 +25,9 @@ model PlayerActivity {
 
   lastSeenAt DateTime
   updatedAt  DateTime @updatedAt
+
+  @@id([guildId, tag])
+  @@index([guildId, clanTag])
 }
 
 model TrackedClan {
@@ -103,6 +107,7 @@ model KickListEntry {
 
 model RecruitmentTemplate {
   id         Int                 @id @default(autoincrement())
+  guildId    String
   clanTag    String
   platform   RecruitmentPlatform
   subject    String?
@@ -113,12 +118,13 @@ model RecruitmentTemplate {
   createdAt  DateTime            @default(now())
   updatedAt  DateTime            @updatedAt
 
-  @@unique([clanTag, platform])
-  @@index([clanTag])
+  @@unique([guildId, clanTag, platform])
+  @@index([guildId, clanTag])
 }
 
 model RecruitmentCooldown {
   id        Int                 @id @default(autoincrement())
+  guildId   String
   userId    String
   clanTag   String
   platform  RecruitmentPlatform
@@ -128,10 +134,11 @@ model RecruitmentCooldown {
   createdAt DateTime            @default(now())
   updatedAt DateTime            @updatedAt
 
-  @@unique([userId, clanTag, platform])
-  @@index([userId, expiresAt])
+  @@unique([guildId, userId, clanTag, platform])
+  @@index([guildId, userId, expiresAt])
   @@index([expiresAt, reminded])
   @@index([expiresAt])
+  @@index([guildId, expiresAt, reminded])
 }
 
 model WarAttacks {

--- a/src/commands/Accounts.ts
+++ b/src/commands/Accounts.ts
@@ -164,6 +164,10 @@ export const Accounts: Command = {
     interaction: ChatInputCommandInteraction,
     cocService: CoCService
   ) => {
+    if (!interaction.guildId) {
+      await interaction.reply({ ephemeral: true, content: "This command can only be used in a server." });
+      return;
+    }
     const visibility = interaction.options.getString("visibility", false) ?? "private";
     const isPublic = visibility === "public";
     await interaction.deferReply({ ephemeral: !isPublic });
@@ -249,7 +253,7 @@ export const Accounts: Command = {
       .filter((t) => Boolean(t));
     const uniqueTags = [...new Set(tags)];
     const activity = await prisma.playerActivity.findMany({
-      where: { tag: { in: uniqueTags } },
+      where: { guildId: interaction.guildId, tag: { in: uniqueTags } },
       select: { tag: true, name: true, clanTag: true },
     });
     const activityByTag = new Map(

--- a/src/commands/Inactive.ts
+++ b/src/commands/Inactive.ts
@@ -198,6 +198,10 @@ async function runDaysMode(
   cocService: CoCService,
   days: number
 ): Promise<void> {
+  if (!interaction.guildId) {
+    await interaction.editReply("This command can only be used in a server.");
+    return;
+  }
   const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
   const roster = await getRosterSnapshot(cocService);
 
@@ -217,6 +221,7 @@ async function runDaysMode(
   const liveMemberTagList = [...roster.liveMemberTags];
   const activitySnapshot = await prisma.playerActivity.aggregate({
     where: {
+      guildId: interaction.guildId,
       tag: { in: liveMemberTagList },
     },
     _max: { updatedAt: true },
@@ -241,6 +246,7 @@ async function runDaysMode(
 
   const freshObservedCount = await prisma.playerActivity.count({
     where: {
+      guildId: interaction.guildId,
       tag: { in: liveMemberTagList },
       updatedAt: { gte: staleCutoff },
     },
@@ -266,6 +272,7 @@ async function runDaysMode(
 
   const inactivePlayers = await prisma.playerActivity.findMany({
     where: {
+      guildId: interaction.guildId,
       lastSeenAt: { lt: cutoff },
       updatedAt: { gte: staleCutoff },
       tag: { in: liveMemberTagList },

--- a/src/commands/KickList.ts
+++ b/src/commands/KickList.ts
@@ -272,6 +272,7 @@ export const KickList: Command = {
         (
           await prisma.playerActivity.findMany({
             where: {
+              guildId,
               tag: { in: memberTags },
               lastSeenAt: { lt: cutoff },
             },

--- a/src/commands/LastSeen.ts
+++ b/src/commands/LastSeen.ts
@@ -175,6 +175,10 @@ export const LastSeen: Command = {
     interaction: ChatInputCommandInteraction,
     cocService: CoCService
   ) => {
+    if (!interaction.guildId) {
+      await interaction.reply({ ephemeral: true, content: "This command can only be used in a server." });
+      return;
+    }
     await interaction.deferReply({ ephemeral: true });
 
     const tag = normalizePlayerTag(interaction.options.getString("tag", true));
@@ -185,7 +189,12 @@ export const LastSeen: Command = {
 
     const signalService = new ActivitySignalService();
     const activity = await prisma.playerActivity.findUnique({
-      where: { tag },
+      where: {
+        guildId_tag: {
+          guildId: interaction.guildId,
+          tag,
+        },
+      },
     });
 
     if (!activity) {
@@ -214,13 +223,19 @@ export const LastSeen: Command = {
         }
 
         await prisma.playerActivity.upsert({
-          where: { tag },
+          where: {
+            guildId_tag: {
+              guildId: interaction.guildId,
+              tag,
+            },
+          },
           update: {
             name: player.name,
             clanTag: player.clan?.tag ?? "UNKNOWN",
             lastSeenAt: inferredAt,
           },
           create: {
+            guildId: interaction.guildId,
             tag,
             name: player.name,
             clanTag: player.clan?.tag ?? "UNKNOWN",
@@ -305,6 +320,10 @@ export const LastSeen: Command = {
       await interaction.respond([]);
       return;
     }
+    if (!interaction.guildId) {
+      await interaction.respond([]);
+      return;
+    }
 
     const query = normalizePlayerTag(String(focused.value ?? "")).replace(/^#/, "");
     const tracked = await prisma.trackedClan.findMany({
@@ -320,6 +339,7 @@ export const LastSeen: Command = {
 
     const rows = await prisma.playerActivity.findMany({
       where: {
+        guildId: interaction.guildId,
         clanTag: { in: trackedTags },
       },
       orderBy: { updatedAt: "desc" },

--- a/src/commands/Recruitment.ts
+++ b/src/commands/Recruitment.ts
@@ -221,6 +221,10 @@ async function handleShowSubcommand(
   interaction: ChatInputCommandInteraction,
   cocService: CoCService
 ): Promise<void> {
+  if (!interaction.guildId) {
+    await interaction.reply({ ephemeral: true, content: "This command can only be used in a server." });
+    return;
+  }
   await interaction.deferReply({ ephemeral: true });
 
   const platformRaw = interaction.options.getString("platform", true);
@@ -242,7 +246,7 @@ async function handleShowSubcommand(
     return;
   }
 
-  const template = await getRecruitmentTemplate(clanTag, platform);
+  const template = await getRecruitmentTemplate(interaction.guildId, clanTag, platform);
   if (!template) {
     await interaction.editReply(
       `No ${platform} recruitment template found for ${formatClanTag(
@@ -252,7 +256,7 @@ async function handleShowSubcommand(
     return;
   }
 
-  const cooldown = await getRecruitmentCooldown(interaction.user.id, clanTag, platform);
+  const cooldown = await getRecruitmentCooldown(interaction.guildId, interaction.user.id, clanTag, platform);
   const cooldownLine = buildCooldownLine(cooldown?.expiresAt ?? null);
   const clanName =
     trackedClan.name ??
@@ -294,6 +298,10 @@ async function handleEditSubcommand(
   interaction: ChatInputCommandInteraction,
   cocService: CoCService
 ): Promise<void> {
+  if (!interaction.guildId) {
+    await interaction.reply({ ephemeral: true, content: "This command can only be used in a server." });
+    return;
+  }
   const clanTag = normalizeClanTag(interaction.options.getString("clan", true));
   const platformRaw = interaction.options.getString("platform", true);
   const platform = parseRecruitmentPlatform(platformRaw);
@@ -315,7 +323,7 @@ async function handleEditSubcommand(
     return;
   }
 
-  const existing = await getRecruitmentTemplate(clanTag, platform);
+  const existing = await getRecruitmentTemplate(interaction.guildId, clanTag, platform);
   const modal = new ModalBuilder()
     .setCustomId(buildModalCustomId(interaction.user.id, clanTag, platform))
     .setTitle(`Edit ${formatPlatform(platform)} ${formatClanTag(clanTag)}`);
@@ -384,6 +392,10 @@ async function handleEditSubcommand(
 async function handleCountdownStartSubcommand(
   interaction: ChatInputCommandInteraction
 ): Promise<void> {
+  if (!interaction.guildId) {
+    await interaction.reply({ ephemeral: true, content: "This command can only be used in a server." });
+    return;
+  }
   await interaction.deferReply({ ephemeral: true });
 
   const platformRaw = interaction.options.getString("platform", true);
@@ -405,7 +417,7 @@ async function handleCountdownStartSubcommand(
     return;
   }
 
-  const existing = await getRecruitmentCooldown(interaction.user.id, clanTag, platform);
+  const existing = await getRecruitmentCooldown(interaction.guildId, interaction.user.id, clanTag, platform);
   const now = Date.now();
   if (existing && existing.expiresAt.getTime() > now) {
     const unix = toUnixSeconds(existing.expiresAt);
@@ -421,6 +433,7 @@ async function handleCountdownStartSubcommand(
   const startedAt = new Date(now);
   const expiresAt = new Date(now + getRecruitmentCooldownDurationMs(platform));
   await startOrResetRecruitmentCooldown({
+    guildId: interaction.guildId,
     userId: interaction.user.id,
     clanTag,
     platform,
@@ -440,9 +453,13 @@ async function handleCountdownStartSubcommand(
 async function handleCountdownStatusSubcommand(
   interaction: ChatInputCommandInteraction
 ): Promise<void> {
+  if (!interaction.guildId) {
+    await interaction.reply({ ephemeral: true, content: "This command can only be used in a server." });
+    return;
+  }
   await interaction.deferReply({ ephemeral: true });
 
-  const rows = await listRecruitmentCooldownsForUser(interaction.user.id);
+  const rows = await listRecruitmentCooldownsForUser(interaction.guildId, interaction.user.id);
   if (rows.length === 0) {
     await interaction.editReply("No active recruitment cooldowns.");
     return;
@@ -465,6 +482,10 @@ async function handleCountdownStatusSubcommand(
 }
 
 async function handleDashboardSubcommand(interaction: ChatInputCommandInteraction): Promise<void> {
+  if (!interaction.guildId) {
+    await interaction.reply({ ephemeral: true, content: "This command can only be used in a server." });
+    return;
+  }
   await interaction.deferReply({ ephemeral: true });
 
   const tracked = await prisma.trackedClan.findMany({
@@ -477,7 +498,11 @@ async function handleDashboardSubcommand(interaction: ChatInputCommandInteractio
   }
 
   const tags = tracked.map((row) => normalizeClanTag(row.tag));
-  const cooldowns = await listRecruitmentCooldownsForUserByClanTags(interaction.user.id, tags);
+  const cooldowns = await listRecruitmentCooldownsForUserByClanTags(
+    interaction.guildId,
+    interaction.user.id,
+    tags
+  );
   const cooldownMap = new Map<string, Date>();
   for (const row of cooldowns) {
     cooldownMap.set(`${normalizeClanTag(row.clanTag)}:${row.platform}`, row.expiresAt);
@@ -510,6 +535,10 @@ export function isRecruitmentModalCustomId(customId: string): boolean {
 export async function handleRecruitmentModalSubmit(
   interaction: ModalSubmitInteraction
 ): Promise<void> {
+  if (!interaction.guildId) {
+    await interaction.reply({ ephemeral: true, content: "This command can only be used in a server." });
+    return;
+  }
   const parsed = parseModalCustomId(interaction.customId);
   if (!parsed) return;
 
@@ -570,6 +599,7 @@ export async function handleRecruitmentModalSubmit(
   }
 
   await upsertRecruitmentTemplate({
+    guildId: interaction.guildId,
     clanTag: parsed.clanTag,
     platform: parsed.platform,
     subject,

--- a/src/commands/TrackedClan.ts
+++ b/src/commands/TrackedClan.ts
@@ -392,9 +392,9 @@ export const TrackedClan: Command = {
           },
         });
 
-        if (!existing) {
+        if (!existing && interaction.guildId) {
           try {
-            await activityService.observeClan(tag);
+            await activityService.observeClan(interaction.guildId, tag);
           } catch (observeErr) {
             console.error(
               `tracked-clan configure observe failed for ${tag}: ${formatError(observeErr)}`

--- a/src/listeners/ready.ts
+++ b/src/listeners/ready.ts
@@ -168,7 +168,7 @@ export default (client: Client, cocService: CoCService): void => {
         const observedMemberTags = new Set<string>();
         for (const tag of trackedTags) {
           try {
-            const memberTags = await activityService.observeClan(tag);
+            const memberTags = await activityService.observeClan(guildId, tag);
             for (const memberTag of memberTags) {
               observedMemberTags.add(memberTag);
             }
@@ -266,7 +266,7 @@ export default (client: Client, cocService: CoCService): void => {
     const runRecruitmentReminders = async () => {
       await runFetchTelemetryBatch("recruitment_reminder_cycle", async () => {
         try {
-          await processRecruitmentCooldownReminders(client);
+          await processRecruitmentCooldownReminders(client, guildId);
         } catch (err) {
           console.error(`[recruitment] reminder loop failed: ${formatError(err)}`);
         }

--- a/src/services/ActivityService.ts
+++ b/src/services/ActivityService.ts
@@ -12,7 +12,7 @@ export class ActivityService {
   /**
    * Observe all members of a clan and update activity signals.
    */
-  async observeClan(clanTag: string): Promise<string[]> {
+  async observeClan(guildId: string, clanTag: string): Promise<string[]> {
     const clan = await this.coc.getClan(clanTag);
     const now = new Date();
     let playerApiCalls = 0;
@@ -31,6 +31,7 @@ export class ActivityService {
       }
 
       await this.observePlayer({
+        guildId,
         tag: player.tag,
         name: player.name,
         clanTag: clan.tag,
@@ -71,6 +72,7 @@ export class ActivityService {
    * Update activity signals for a single player.
    */
   private async observePlayer(input: {
+    guildId: string;
     tag: string;
     name: string;
     clanTag: string;
@@ -93,7 +95,12 @@ export class ActivityService {
     now: Date;
   }) {
     const existing = await prisma.playerActivity.findUnique({
-      where: { tag: input.tag },
+      where: {
+        guildId_tag: {
+          guildId: input.guildId,
+          tag: input.tag,
+        },
+      },
     });
 
     const updates: any = {
@@ -161,9 +168,15 @@ export class ActivityService {
     }
 
     await prisma.playerActivity.upsert({
-      where: { tag: input.tag },
+      where: {
+        guildId_tag: {
+          guildId: input.guildId,
+          tag: input.tag,
+        },
+      },
       update: updates,
       create: {
+        guildId: input.guildId,
         tag: input.tag,
         ...updates,
       },

--- a/src/services/RecruitmentService.ts
+++ b/src/services/RecruitmentService.ts
@@ -6,6 +6,7 @@ import { prisma } from "../prisma";
 export type RecruitmentPlatform = "discord" | "reddit" | "band";
 
 export type RecruitmentTemplateRecord = {
+  guildId: string;
   clanTag: string;
   platform: RecruitmentPlatform;
   subject: string | null;
@@ -16,6 +17,7 @@ export type RecruitmentTemplateRecord = {
 
 export type RecruitmentCooldownRecord = {
   id: number;
+  guildId: string;
   userId: string;
   clanTag: string;
   platform: RecruitmentPlatform;
@@ -68,6 +70,7 @@ export function toImageUrlsCsv(imageUrls: string[]): string {
 
 /** Purpose: get recruitment template. */
 export async function getRecruitmentTemplate(
+  guildId: string,
   clanTag: string,
   platform: RecruitmentPlatform
 ): Promise<RecruitmentTemplateRecord | null> {
@@ -83,6 +86,8 @@ export async function getRecruitmentTemplate(
         "updatedAt"
       FROM "RecruitmentTemplate"
       WHERE
+        "guildId" = ${guildId}
+        AND
         "clanTag" = ${normalized}
         AND "platform" = ${platform}::"RecruitmentPlatform"
       LIMIT 1
@@ -93,6 +98,7 @@ export async function getRecruitmentTemplate(
 
 /** Purpose: upsert recruitment template. */
 export async function upsertRecruitmentTemplate(input: {
+  guildId: string;
   clanTag: string;
   platform: RecruitmentPlatform;
   subject?: string | null;
@@ -103,10 +109,10 @@ export async function upsertRecruitmentTemplate(input: {
   await prisma.$executeRaw(
     Prisma.sql`
       INSERT INTO "RecruitmentTemplate"
-        ("clanTag", "platform", "subject", "requiredTH", "focus", "body", "imageUrls", "createdAt", "updatedAt")
+        ("guildId", "clanTag", "platform", "subject", "requiredTH", "focus", "body", "imageUrls", "createdAt", "updatedAt")
       VALUES
-        (${normalized}, ${input.platform}::"RecruitmentPlatform", ${input.subject ?? null}, '', '', ${input.body}, ${input.imageUrls}::text[], NOW(), NOW())
-      ON CONFLICT ("clanTag", "platform")
+        (${input.guildId}, ${normalized}, ${input.platform}::"RecruitmentPlatform", ${input.subject ?? null}, '', '', ${input.body}, ${input.imageUrls}::text[], NOW(), NOW())
+      ON CONFLICT ("guildId", "clanTag", "platform")
       DO UPDATE SET
         "subject" = EXCLUDED."subject",
         "body" = EXCLUDED."body",
@@ -118,6 +124,7 @@ export async function upsertRecruitmentTemplate(input: {
 
 /** Purpose: get recruitment cooldown. */
 export async function getRecruitmentCooldown(
+  guildId: string,
   userId: string,
   clanTag: string,
   platform: RecruitmentPlatform
@@ -127,6 +134,7 @@ export async function getRecruitmentCooldown(
     Prisma.sql`
       SELECT
         "id",
+        "guildId",
         "userId",
         "clanTag",
         "platform",
@@ -135,7 +143,8 @@ export async function getRecruitmentCooldown(
         "reminded"
       FROM "RecruitmentCooldown"
       WHERE
-        "userId" = ${userId}
+        "guildId" = ${guildId}
+        AND "userId" = ${userId}
         AND "clanTag" = ${normalized}
         AND "platform" = ${platform}::"RecruitmentPlatform"
       LIMIT 1
@@ -146,6 +155,7 @@ export async function getRecruitmentCooldown(
 
 /** Purpose: start or reset recruitment cooldown. */
 export async function startOrResetRecruitmentCooldown(input: {
+  guildId: string;
   userId: string;
   clanTag: string;
   platform: RecruitmentPlatform;
@@ -156,10 +166,10 @@ export async function startOrResetRecruitmentCooldown(input: {
   await prisma.$executeRaw(
     Prisma.sql`
       INSERT INTO "RecruitmentCooldown"
-        ("userId", "clanTag", "platform", "startedAt", "expiresAt", "reminded", "createdAt", "updatedAt")
+        ("guildId", "userId", "clanTag", "platform", "startedAt", "expiresAt", "reminded", "createdAt", "updatedAt")
       VALUES
-        (${input.userId}, ${normalized}, ${input.platform}::"RecruitmentPlatform", ${input.startedAt}, ${input.expiresAt}, false, NOW(), NOW())
-      ON CONFLICT ("userId", "clanTag", "platform")
+        (${input.guildId}, ${input.userId}, ${normalized}, ${input.platform}::"RecruitmentPlatform", ${input.startedAt}, ${input.expiresAt}, false, NOW(), NOW())
+      ON CONFLICT ("guildId", "userId", "clanTag", "platform")
       DO UPDATE SET
         "startedAt" = EXCLUDED."startedAt",
         "expiresAt" = EXCLUDED."expiresAt",
@@ -171,12 +181,14 @@ export async function startOrResetRecruitmentCooldown(input: {
 
 /** Purpose: list recruitment cooldowns for user. */
 export async function listRecruitmentCooldownsForUser(
+  guildId: string,
   userId: string
 ): Promise<RecruitmentCooldownRecord[]> {
   return prisma.$queryRaw<RecruitmentCooldownRecord[]>(
     Prisma.sql`
       SELECT
         "id",
+        "guildId",
         "userId",
         "clanTag",
         "platform",
@@ -184,7 +196,7 @@ export async function listRecruitmentCooldownsForUser(
         "expiresAt",
         "reminded"
       FROM "RecruitmentCooldown"
-      WHERE "userId" = ${userId}
+      WHERE "guildId" = ${guildId} AND "userId" = ${userId}
       ORDER BY "expiresAt" ASC
     `
   );
@@ -192,6 +204,7 @@ export async function listRecruitmentCooldownsForUser(
 
 /** Purpose: list recruitment cooldowns for user by clan tags. */
 export async function listRecruitmentCooldownsForUserByClanTags(
+  guildId: string,
   userId: string,
   clanTags: string[]
 ): Promise<RecruitmentCooldownRecord[]> {
@@ -202,6 +215,7 @@ export async function listRecruitmentCooldownsForUserByClanTags(
     Prisma.sql`
       SELECT
         "id",
+        "guildId",
         "userId",
         "clanTag",
         "platform",
@@ -210,7 +224,8 @@ export async function listRecruitmentCooldownsForUserByClanTags(
         "reminded"
       FROM "RecruitmentCooldown"
       WHERE
-        "userId" = ${userId}
+        "guildId" = ${guildId}
+        AND "userId" = ${userId}
         AND "clanTag" = ANY (${normalized}::text[])
       ORDER BY "clanTag" ASC, "platform" ASC
     `
@@ -239,12 +254,16 @@ export async function getTrackedClanNameMapByTags(
 }
 
 /** Purpose: process recruitment cooldown reminders. */
-export async function processRecruitmentCooldownReminders(client: Client): Promise<void> {
+export async function processRecruitmentCooldownReminders(
+  client: Client,
+  guildId: string
+): Promise<void> {
   const now = new Date();
   const dueRows = await prisma.$queryRaw<RecruitmentCooldownRecord[]>(
     Prisma.sql`
       SELECT
         "id",
+        "guildId",
         "userId",
         "clanTag",
         "platform",
@@ -253,7 +272,8 @@ export async function processRecruitmentCooldownReminders(client: Client): Promi
         "reminded"
       FROM "RecruitmentCooldown"
       WHERE
-        "expiresAt" <= ${now}
+        "guildId" = ${guildId}
+        AND "expiresAt" <= ${now}
         AND "reminded" = false
       ORDER BY "expiresAt" ASC
     `


### PR DESCRIPTION
- add guildId to PlayerActivity, RecruitmentTemplate, and RecruitmentCooldown
- add migration to backfill legacy rows and enforce guild-scoped keys/indexes
- update ActivityService and LastSeen/Inactive/Accounts/KickList queries to read/write guild-scoped PlayerActivity rows
- update Recruitment service/commands to require guildId for template and cooldown reads/writes
- update startup clan observe wiring to pass guildId

This enables safer multi-server data isolation and avoids cross-guild collisions.