### PR TITLE
fix(fwa): use unicode warning emoji in alliance clan match dropdown

### DIFF
--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -1611,7 +1611,7 @@ function buildFwaMatchCopyComponents(
           entries.map((tag) => {
             const viewForTag = payload.singleViews[tag];
             const clanName = (viewForTag?.clanName ?? `#${tag}`).trim();
-            const warningSuffix = viewForTag?.inferredMatchType ? " :warning:" : "";
+            const warningSuffix = viewForTag?.inferredMatchType ? " ⚠️" : "";
             const mailStatusEmoji = viewForTag?.mailStatusEmoji ?? MAILBOX_NOT_SENT_EMOJI;
             return {
               label: `${mailStatusEmoji} ${clanName}${warningSuffix}`.slice(0, 100),


### PR DESCRIPTION
Replace Discord shortcode text in select-option labels with a real Unicode warning emoji so inferred-match warnings render correctly in the "Open clan match view" dropdown.