### PR TITLE
fix(war-events): poll notInWar rows to prevent warId initialization s…

### DIFF
--- a/src/services/WarEventLogService.ts
+++ b/src/services/WarEventLogService.ts
@@ -273,7 +273,8 @@ export class WarEventLogService {
           ON UPPER(REPLACE(tc."tag",'#','')) = UPPER(REPLACE(cw."clanTag",'#',''))
         LEFT JOIN "ClanNotifyConfig" cnc
           ON cnc."guildId" = cw."guildId" AND UPPER(REPLACE(cnc."clanTag",'#','')) = UPPER(REPLACE(cw."clanTag",'#',''))
-        WHERE cw."endTime" > NOW() - INTERVAL '2 hours'
+        WHERE cw."state" = 'notInWar'
+           OR cw."endTime" > NOW() - INTERVAL '2 hours'
         ORDER BY cw."updatedAt" ASC
       `
     );


### PR DESCRIPTION
…kips

Ensure war-event polling includes notInWar CurrentWar rows so clans entering preparation are processed, transitions are detected, and warId can be allocated.

- update poll query filter to include state=notInWar
- keep recent endTime window for active/recent wars