### PR TITLE
fix(war-events): allocate warId from WarLookup instead of ClanWarHist…

### DIFF
--- a/src/services/WarEventLogService.ts
+++ b/src/services/WarEventLogService.ts
@@ -812,7 +812,25 @@ export class WarEventLogService {
 
   private async allocateNextWarId(): Promise<number | null> {
     const rows = await prisma.$queryRaw<Array<{ warId: bigint | number }>>(
-      Prisma.sql`SELECT nextval(pg_get_serial_sequence('"ClanWarHistory"', 'warId')) AS "warId"`
+      Prisma.sql`
+        SELECT
+          GREATEST(
+            COALESCE(
+              (
+                SELECT MAX(
+                  CASE
+                    WHEN "warId" ~ '^[0-9]+$' THEN "warId"::bigint
+                    ELSE NULL
+                  END
+                )
+                FROM "WarLookup"
+              ),
+              0
+            ),
+            COALESCE((SELECT MAX("warId")::bigint FROM "CurrentWar"), 0),
+            COALESCE((SELECT MAX("warId")::bigint FROM "WarAttacks"), 0)
+          ) + 1 AS "warId"
+      `
     );
     const raw = rows[0]?.warId;
     if (raw === null || raw === undefined) return null;


### PR DESCRIPTION
…ory sequence

Decouple current-war warId allocation from ClanWarHistory sequence wiring.

- replace allocateNextWarId source from pg_get_serial_sequence(ClanWarHistory.warId)
- derive next warId from numeric max WarLookup.warId
- guard uniqueness against active allocations in CurrentWar and WarAttacks