### PR TITLE
feat(war-events): add idempotent event guards and posted message trac…

### DIFF
--- a/prisma/migrations/20260305100000_add_clan_posted_message/migration.sql
+++ b/prisma/migrations/20260305100000_add_clan_posted_message/migration.sql
@@ -1,0 +1,21 @@
+CREATE TABLE "ClanPostedMessage" (
+    "id" TEXT NOT NULL,
+    "guildId" TEXT NOT NULL,
+    "clanTag" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "event" TEXT,
+    "channelId" TEXT NOT NULL,
+    "messageId" TEXT NOT NULL,
+    "messageUrl" TEXT NOT NULL,
+    "warId" TEXT,
+    "syncNum" INTEGER,
+    "configHash" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ClanPostedMessage_pkey" PRIMARY KEY ("id")
+);
+
+CREATE INDEX "ClanPostedMessage_guildId_clanTag_idx" ON "ClanPostedMessage"("guildId", "clanTag");
+CREATE INDEX "ClanPostedMessage_clanTag_warId_idx" ON "ClanPostedMessage"("clanTag", "warId");
+CREATE UNIQUE INDEX "ClanPostedMessage_guildId_clanTag_warId_type_event_key"
+ON "ClanPostedMessage"("guildId", "clanTag", "warId", "type", "event");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -269,6 +269,25 @@ model WarEvent {
   @@index([clanTag, createdAt(sort: Desc)])
 }
 
+model ClanPostedMessage {
+  id         String   @id @default(cuid())
+  guildId    String
+  clanTag    String
+  type       String
+  event      String?
+  channelId  String
+  messageId  String
+  messageUrl String
+  warId      String?
+  syncNum    Int?
+  configHash String?
+  createdAt  DateTime @default(now())
+
+  @@index([guildId, clanTag])
+  @@index([clanTag, warId])
+  @@unique([guildId, clanTag, warId, type, event])
+}
+
 model ApiUsage {
   endpoint String   @id
   lastCall DateTime

--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -50,15 +50,12 @@ import {
 import {
   asMailConfigInputJson,
   buildDiscordMessageUrl,
-  collectMailPostTargetsFromConfig,
   type ForceMailMessageType,
-  getPrimaryMailMessageRef,
-  type MailPostTarget,
   type MatchMailConfig,
   parseForceMailMessageType,
   parseMatchMailConfig,
-  withRecoveredMailReference,
 } from "./fwa/mailConfig";
+import { PostedMessageService } from "../services/PostedMessageService";
 export { isMissedSyncClanForTest } from "./fwa/matchState";
 
 const POINTS_BASE_URL = "https://points.fwafarm.com/clan?tag=";
@@ -82,6 +79,7 @@ const FWA_MATCH_SEND_MAIL_PREFIX = "fwa-match-send-mail";
 const WAR_MAIL_REFRESH_MS = 20 * 60 * 1000;
 const MAILBOX_SENT_EMOJI = "📬";
 const MAILBOX_NOT_SENT_EMOJI = "📭";
+const postedMessageService = new PostedMessageService();
 const POINTS_REQUEST_HEADERS = {
   "User-Agent":
     "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36",
@@ -754,12 +752,31 @@ async function recordMatchMailUpdated(params: {
   expectedOutcome: "WIN" | "LOSE" | "UNKNOWN" | null;
 }): Promise<MatchMailConfig> {
   const current = await getCurrentWarMailConfig(params.guildId, params.tag);
-  const deduped = current.messages.filter((entry) => entry.messageType !== "mail");
-  deduped.push({
-    messageType: "mail",
-    messageID: params.messageId,
+  const currentWar = await prisma.currentWar.findUnique({
+    where: {
+      clanTag_guildId: {
+        guildId: params.guildId,
+        clanTag: `#${normalizeTag(params.tag)}`,
+      },
+    },
+    select: { warId: true, syncNum: true },
+  });
+
+  await postedMessageService.savePostedMessage({
+    guildId: params.guildId,
+    clanTag: params.tag,
+    type: "mail",
+    event: null,
+    warId:
+      currentWar?.warId !== null && currentWar?.warId !== undefined
+        ? String(currentWar.warId)
+        : null,
+    syncNum: currentWar?.syncNum ?? null,
     channelId: params.channelId,
-    messageUrl: params.messageUrl,
+    messageId: params.messageId,
+    messageUrl:
+      params.messageUrl ?? buildDiscordMessageUrl(params.guildId, params.channelId, params.messageId),
+    configHash: null,
   });
 
   const next: MatchMailConfig = {
@@ -771,7 +788,6 @@ async function recordMatchMailUpdated(params: {
     lastMatchType: params.matchType,
     lastExpectedOutcome: params.expectedOutcome,
     lastDataChangedAtUnix: Math.floor(params.sentAtMs / 1000),
-    messages: deduped,
   };
   await saveCurrentWarMailConfig({
     guildId: params.guildId,
@@ -1123,17 +1139,34 @@ function findLatestPostedWarMailForClan(params: {
   return latest;
 }
 
-function getMailStatusEmojiForClan(params: {
+async function findStoredMailTarget(params: {
+  guildId: string;
+  tag: string;
+  warId?: string | null;
+}): Promise<{ channelId: string; messageId: string; messageUrl: string } | null> {
+  const existing = await postedMessageService.findMailMessage({
+    guildId: params.guildId,
+    clanTag: params.tag,
+    warId: params.warId ?? null,
+  });
+  if (!existing) return null;
+  return {
+    channelId: existing.channelId,
+    messageId: existing.messageId,
+    messageUrl: existing.messageUrl,
+  };
+}
+
+async function getMailStatusEmojiForClan(params: {
   guildId: string | null;
   tag: string;
   warStartMs: number | null;
   mailConfig?: MatchMailConfig | null;
   liveMatchType?: "FWA" | "BL" | "MM" | "SKIP" | "UNKNOWN" | null;
   liveExpectedOutcome?: "WIN" | "LOSE" | "UNKNOWN" | null;
-}): string {
+}): Promise<string> {
   if (!params.guildId) return MAILBOX_NOT_SENT_EMOJI;
   const config = params.mailConfig ?? null;
-  const primaryMail = getPrimaryMailMessageRef(config);
   const liveMatchesPosted = isPostedMailCurrentForLiveState({
     postedMatchType: config?.lastMatchType ?? null,
     postedExpectedOutcome: config?.lastExpectedOutcome ?? null,
@@ -1141,7 +1174,11 @@ function getMailStatusEmojiForClan(params: {
     liveExpectedOutcome: params.liveExpectedOutcome,
   });
   if (!liveMatchesPosted) return MAILBOX_NOT_SENT_EMOJI;
-  if (primaryMail) {
+  const storedMail = await findStoredMailTarget({
+    guildId: params.guildId,
+    tag: params.tag,
+  });
+  if (storedMail || (config?.lastPostedChannelId && config?.lastPostedMessageId)) {
     if (
       params.warStartMs !== null &&
       config?.lastWarStartMs !== null &&
@@ -1211,13 +1248,20 @@ function clearPostedMailTrackingForClan(params: {
 async function hasPostedMailMessage(params: {
   client: Client | null | undefined;
   guildId: string | null;
+  tag?: string | null;
   mailConfig: MatchMailConfig | null | undefined;
 }): Promise<boolean> {
   if (!params.client || !params.guildId || !params.mailConfig) return false;
-  const primary = getPrimaryMailMessageRef(params.mailConfig);
-  if (!primary) return false;
-  const channelId = primary.channelId;
-  const messageId = primary.messageId;
+  const stored =
+    params.tag
+      ? await findStoredMailTarget({
+          guildId: params.guildId,
+          tag: params.tag,
+        })
+      : null;
+  const channelId = stored?.channelId ?? params.mailConfig.lastPostedChannelId ?? "";
+  const messageId = stored?.messageId ?? params.mailConfig.lastPostedMessageId ?? "";
+  if (!channelId || !messageId) return false;
   const channel = await params.client.channels.fetch(channelId).catch(() => null);
   if (!channel || !channel.isTextBased()) return false;
   const message = await (channel as any).messages.fetch(messageId).catch(() => null);
@@ -1414,22 +1458,22 @@ async function findWarMailTargetFromConfig(params: {
   channelId: string;
   messageId: string;
 }): Promise<{ tag: string; channelId: string; messageId: string } | null> {
-  const rows = await prisma.trackedClan.findMany({
-    select: { tag: true, mailConfig: true },
+  const row = await prisma.clanPostedMessage.findFirst({
+    where: {
+      guildId: params.guildId,
+      type: "mail",
+      channelId: params.channelId,
+      messageId: params.messageId,
+    },
+    orderBy: { createdAt: "desc" },
+    select: { clanTag: true, channelId: true, messageId: true },
   });
-  for (const row of rows) {
-    const config = parseMatchMailConfig(row.mailConfig as Prisma.JsonValue | null | undefined);
-    const primary = getPrimaryMailMessageRef(config);
-    if (!primary) continue;
-    if (primary.channelId !== params.channelId) continue;
-    if (primary.messageId !== params.messageId) continue;
-    return {
-      tag: normalizeTag(row.tag),
-      channelId: primary.channelId,
-      messageId: primary.messageId,
-    };
-  }
-  return null;
+  if (!row) return null;
+  return {
+    tag: normalizeTag(row.clanTag),
+    channelId: row.channelId,
+    messageId: row.messageId,
+  };
 }
 
 function startWarMailPolling(client: Client, key: string): void {
@@ -2934,39 +2978,37 @@ export async function refreshAllTrackedWarMailPosts(client: Client): Promise<voi
     const guildId = row.guildId?.trim() ?? "";
     if (!guildId) continue;
     const config = await getCurrentWarMailConfig(guildId, normalizeTag(row.clanTag));
-    const candidates = collectMailPostTargetsFromConfig(config);
-    if (candidates.length === 0) continue;
+    const stored = await findStoredMailTarget({
+      guildId,
+      tag: row.clanTag,
+    });
+    if (!stored) continue;
 
     const existingInMemory = findLatestPostedWarMailForClan({
       guildId,
       tag: row.clanTag,
     });
-    let resolved: MailPostTarget | null = null;
-    for (const candidate of candidates) {
-      const ok = await refreshWarMailPostByResolvedTarget({
-        client,
-        guildId,
-        tag: row.clanTag,
-        channelId: candidate.channelId,
-        messageId: candidate.messageId,
-        key: existingInMemory?.key,
-      }).catch(() => false);
-      if (ok) {
-        resolved = candidate;
-        break;
-      }
-    }
-    const refreshed = Boolean(resolved);
+    const refreshed = await refreshWarMailPostByResolvedTarget({
+      client,
+      guildId,
+      tag: row.clanTag,
+      channelId: stored.channelId,
+      messageId: stored.messageId,
+      key: existingInMemory?.key,
+    }).catch(() => false);
     if (!refreshed) continue;
-    const channelId = resolved?.channelId ?? "";
-    const messageId = resolved?.messageId ?? "";
-    if (!channelId || !messageId) continue;
+    const channelId = stored.channelId;
+    const messageId = stored.messageId;
 
     if (
       config.lastPostedChannelId !== channelId ||
       config.lastPostedMessageId !== messageId
     ) {
-      const next = withRecoveredMailReference(config, { channelId, messageId }, guildId);
+      const next = {
+        ...config,
+        lastPostedChannelId: channelId,
+        lastPostedMessageId: messageId,
+      };
       await saveCurrentWarMailConfig({
         guildId,
         tag: row.clanTag,
@@ -3024,42 +3066,42 @@ export async function runForceMailUpdateCommand(
     select: { clanTag: true },
   });
   const config = await getCurrentWarMailConfig(interaction.guildId, tag);
-  const candidates = collectMailPostTargetsFromConfig(config);
-  if (candidates.length === 0) {
+  const stored = await findStoredMailTarget({
+    guildId: interaction.guildId,
+    tag,
+  });
+  if (!stored) {
     await interaction.editReply(
       `No active sent mail reference found for #${tag}. Send mail first or sync it via \`/force sync mail\`.`
     );
     return;
   }
 
-  let resolved: MailPostTarget | null = null;
-  for (const candidate of candidates) {
-    const ok = await refreshWarMailPostByResolvedTarget({
-      client: interaction.client,
-      guildId: interaction.guildId,
-      tag,
-      channelId: candidate.channelId,
-      messageId: candidate.messageId,
-    }).catch(() => false);
-    if (ok) {
-      resolved = candidate;
-      break;
-    }
-  }
-  if (!resolved) {
+  const refreshed = await refreshWarMailPostByResolvedTarget({
+    client: interaction.client,
+    guildId: interaction.guildId,
+    tag,
+    channelId: stored.channelId,
+    messageId: stored.messageId,
+  }).catch(() => false);
+  if (!refreshed) {
     await interaction.editReply(
-      `Could not refresh #${tag} mail in place. Tried ${candidates.length} stored reference(s), but each message was missing or inaccessible.`
+      `Could not refresh #${tag} mail in place. The stored message was missing or inaccessible.`
     );
     return;
   }
-  const channelId = resolved.channelId;
-  const messageId = resolved.messageId;
+  const channelId = stored.channelId;
+  const messageId = stored.messageId;
 
   if (
     config.lastPostedChannelId !== channelId ||
     config.lastPostedMessageId !== messageId
   ) {
-    const next = withRecoveredMailReference(config, resolved, interaction.guildId);
+    const next = {
+      ...config,
+      lastPostedChannelId: channelId,
+      lastPostedMessageId: messageId,
+    };
     await saveCurrentWarMailConfig({
       guildId: interaction.guildId,
       tag,
@@ -4043,7 +4085,7 @@ async function buildTrackedMatchOverview(
     const clanWarStartMs = warStartMsByClanTag.get(clanTag) ?? null;
     const sub = subByTag.get(clanTag);
     const parsedMailConfig = trackedMailConfigByTag.get(clanTag) ?? parseMatchMailConfig(null);
-    const baseMailStatusEmoji = getMailStatusEmojiForClan({
+    const baseMailStatusEmoji = await getMailStatusEmojiForClan({
       guildId,
       tag: clanTag,
       warStartMs: clanWarStartMs,
@@ -4056,6 +4098,7 @@ async function buildTrackedMatchOverview(
         ? await hasPostedMailMessage({
             client: client ?? null,
             guildId,
+            tag: clanTag,
             mailConfig: parsedMailConfig,
           })
         : false;
@@ -4391,6 +4434,7 @@ async function buildTrackedMatchOverview(
     const postedMailExists = await hasPostedMailMessage({
       client: client ?? null,
       guildId,
+      tag: clanTag,
       mailConfig: parsedMailConfig,
     });
     const mailBlockedReason = inferredMatchType
@@ -4800,6 +4844,7 @@ export async function runForceSyncMailCommand(
       },
     },
     select: {
+      warId: true,
       matchType: true,
       outcome: true,
       startTime: true,
@@ -4811,27 +4856,6 @@ export async function runForceSyncMailCommand(
     existing?.startTime?.getTime() ?? warStartMsFromApi ?? null;
   const nowUnix = Math.floor(Date.now() / 1000);
   const current = await getCurrentWarMailConfig(interaction.guildId, tag);
-  const messages = current.messages.filter(
-    (entry) =>
-      !(
-        entry.messageID === messageID &&
-        entry.messageType === parsedType.messageType &&
-        (parsedType.messageType !== "notify" || entry.notifyType === parsedType.notifyType)
-      )
-  );
-  if (parsedType.messageType === "mail") {
-    for (let i = messages.length - 1; i >= 0; i -= 1) {
-      if (messages[i]?.messageType === "mail") messages.splice(i, 1);
-    }
-  }
-  messages.push({
-    messageType: parsedType.messageType,
-    messageID,
-    channelId: interaction.channelId,
-    messageUrl: buildDiscordMessageUrl(interaction.guildId, interaction.channelId, messageID),
-    notifyType: parsedType.messageType === "notify" ? parsedType.notifyType : undefined,
-  });
-
   const matchType = existing?.matchType ?? current.lastMatchType ?? "UNKNOWN";
   const expectedOutcome: "WIN" | "LOSE" | "UNKNOWN" | null =
     existing?.outcome === "WIN" || existing?.outcome === "LOSE"
@@ -4843,7 +4867,6 @@ export async function runForceSyncMailCommand(
     lastWarStartMs: warStartMs,
     lastMatchType: matchType,
     lastExpectedOutcome: expectedOutcome,
-    messages,
   };
   if (parsedType.messageType === "mail") {
     next.lastPostedMessageId = messageID;
@@ -4858,6 +4881,21 @@ export async function runForceSyncMailCommand(
     mailConfig: next,
   });
 
+  await postedMessageService.savePostedMessage({
+    guildId: interaction.guildId,
+    clanTag: tag,
+    type: parsedType.messageType,
+    event:
+      parsedType.messageType === "notify" ? parsedType.notifyType ?? null : null,
+    warId:
+      existing?.warId !== null && existing?.warId !== undefined ? String(existing.warId) : null,
+    syncNum: null,
+    channelId: interaction.channelId,
+    messageId: messageID,
+    messageUrl: buildDiscordMessageUrl(interaction.guildId, interaction.channelId, messageID),
+    configHash: null,
+  });
+
   const messageTypeLabel =
     parsedType.messageType === "mail"
       ? "mail"
@@ -4870,7 +4908,7 @@ export async function runForceSyncMailCommand(
       `War start: ${warStartMs !== null ? `<t:${Math.floor(warStartMs / 1000)}:F>` : "unknown"}`,
       `Match type: **${next.lastMatchType ?? "UNKNOWN"}**`,
       `Expected outcome: **${next.lastExpectedOutcome ?? "UNKNOWN"}**`,
-      `Tracked message refs: **${next.messages.length}**`,
+      `Posted message tracking saved in **ClanPostedMessage**.`,
     ].join("\n")
   );
 }
@@ -6117,7 +6155,7 @@ export const Fwa: Command = {
           const parsedMailConfig = parseMatchMailConfig(
             trackedClanMeta?.mailConfig as Prisma.JsonValue | null | undefined
           );
-          const baseMailStatusEmoji = getMailStatusEmojiForClan({
+          const baseMailStatusEmoji = await getMailStatusEmojiForClan({
             guildId: interaction.guildId ?? null,
             tag,
             warStartMs: null,
@@ -6130,6 +6168,7 @@ export const Fwa: Command = {
               ? await hasPostedMailMessage({
                   client: interaction.client,
                   guildId: interaction.guildId ?? null,
+                  tag,
                   mailConfig: parsedMailConfig,
                 })
               : false;
@@ -6421,6 +6460,7 @@ export const Fwa: Command = {
         const postedMailExists = await hasPostedMailMessage({
           client: interaction.client,
           guildId: interaction.guildId ?? null,
+          tag,
           mailConfig: parsedMailConfig,
         });
         const mailBlockedReason = inferredMatchType

--- a/src/commands/fwa/mailConfig.ts
+++ b/src/commands/fwa/mailConfig.ts
@@ -1,13 +1,5 @@
 import { Prisma } from "@prisma/client";
 
-export type MatchMailMessageRef = {
-  messageType: "mail" | "notify";
-  messageID: string;
-  channelId?: string;
-  messageUrl?: string;
-  notifyType?: "war_start" | "battle_start" | "war_end";
-};
-
 export type MatchMailConfig = {
   lastPostedMessageId: string | null;
   lastPostedChannelId: string | null;
@@ -16,7 +8,6 @@ export type MatchMailConfig = {
   lastMatchType: "FWA" | "BL" | "MM" | "SKIP" | "UNKNOWN" | null;
   lastExpectedOutcome: "WIN" | "LOSE" | "UNKNOWN" | null;
   lastDataChangedAtUnix: number | null;
-  messages: MatchMailMessageRef[];
   skipSyncHistory: {
     warId: number;
     warStartUnix: number;
@@ -42,7 +33,6 @@ export const MATCH_MAIL_CONFIG_DEFAULT: MatchMailConfig = {
   lastMatchType: null,
   lastExpectedOutcome: null,
   lastDataChangedAtUnix: null,
-  messages: [],
   skipSyncHistory: null,
 };
 
@@ -86,30 +76,6 @@ export function parseMatchMailConfig(value: Prisma.JsonValue | null | undefined)
       ? (maybeVersioned.data as Record<string, unknown>)
       : root;
   const obj = payload;
-  const rawMessages = Array.isArray(obj.messages) ? obj.messages : [];
-  const messages: MatchMailMessageRef[] = [];
-  for (const entry of rawMessages) {
-    if (!entry || typeof entry !== "object" || Array.isArray(entry)) continue;
-    const item = entry as Record<string, unknown>;
-    const messageType = item.messageType;
-    const messageID = typeof item.messageID === "string" ? item.messageID.trim() : "";
-    const channelId = typeof item.channelId === "string" ? item.channelId.trim() : "";
-    const messageUrl = typeof item.messageUrl === "string" ? item.messageUrl.trim() : "";
-    const notifyTypeRaw = typeof item.notifyType === "string" ? item.notifyType.trim() : "";
-    const notifyType =
-      notifyTypeRaw === "war_start" || notifyTypeRaw === "battle_start" || notifyTypeRaw === "war_end"
-        ? notifyTypeRaw
-        : undefined;
-    if ((messageType !== "mail" && messageType !== "notify") || !messageID) continue;
-    messages.push({
-      messageType,
-      messageID,
-      channelId: channelId || undefined,
-      messageUrl: messageUrl || undefined,
-      notifyType: messageType === "notify" ? notifyType : undefined,
-    });
-  }
-
   const lastPostedMessageId =
     typeof obj.lastPostedMessageId === "string" && obj.lastPostedMessageId.trim()
       ? obj.lastPostedMessageId.trim()
@@ -165,7 +131,6 @@ export function parseMatchMailConfig(value: Prisma.JsonValue | null | undefined)
     lastMatchType,
     lastExpectedOutcome,
     lastDataChangedAtUnix,
-    messages,
     skipSyncHistory,
   };
 }
@@ -187,75 +152,4 @@ export function parseDiscordMessageUrl(url: string | null | undefined): MailPost
   const match = raw.match(/\/channels\/\d+\/(\d+)\/(\d+)(?:$|[/?#])/i);
   if (!match?.[1] || !match?.[2]) return null;
   return { channelId: match[1], messageId: match[2] };
-}
-
-export function getPrimaryMailMessageRef(
-  config: MatchMailConfig | null | undefined
-): { channelId: string; messageId: string } | null {
-  if (!config) return null;
-  for (let i = config.messages.length - 1; i >= 0; i -= 1) {
-    const entry = config.messages[i];
-    if (!entry || entry.messageType !== "mail") continue;
-    const fromUrl = parseDiscordMessageUrl(entry.messageUrl);
-    const channelId = (entry.channelId ?? "").trim() || fromUrl?.channelId || "";
-    const messageId = (entry.messageID ?? "").trim() || fromUrl?.messageId || "";
-    if (/^\d+$/.test(channelId) && /^\d+$/.test(messageId)) {
-      return { channelId, messageId };
-    }
-  }
-  const fallbackChannelId = config.lastPostedChannelId?.trim() ?? "";
-  const fallbackMessageId = config.lastPostedMessageId?.trim() ?? "";
-  if (/^\d+$/.test(fallbackChannelId) && /^\d+$/.test(fallbackMessageId)) {
-    return { channelId: fallbackChannelId, messageId: fallbackMessageId };
-  }
-  return null;
-}
-
-export function collectMailPostTargetsFromConfig(config: MatchMailConfig): MailPostTarget[] {
-  const out: MailPostTarget[] = [];
-  const push = (candidate: MailPostTarget | null) => {
-    if (!candidate?.channelId || !candidate?.messageId) return;
-    if (!/^\d+$/.test(candidate.channelId) || !/^\d+$/.test(candidate.messageId)) return;
-    out.push(candidate);
-  };
-
-  for (const entry of config.messages) {
-    if (entry.messageType !== "mail") continue;
-    const fromUrl = parseDiscordMessageUrl(entry.messageUrl);
-    const channelId = (entry.channelId ?? "").trim() || fromUrl?.channelId || "";
-    const messageId = (entry.messageID ?? "").trim() || fromUrl?.messageId || "";
-    push(channelId && messageId ? { channelId, messageId } : null);
-  }
-
-  push(
-    config.lastPostedChannelId && config.lastPostedMessageId
-      ? { channelId: config.lastPostedChannelId, messageId: config.lastPostedMessageId }
-      : null
-  );
-
-  const deduped = new Map<string, MailPostTarget>();
-  for (const candidate of out) {
-    deduped.set(`${candidate.channelId}:${candidate.messageId}`, candidate);
-  }
-  return [...deduped.values()];
-}
-
-export function withRecoveredMailReference(
-  config: MatchMailConfig,
-  target: MailPostTarget,
-  guildId: string
-): MatchMailConfig {
-  const messages = config.messages.filter((entry) => entry.messageType !== "mail");
-  messages.push({
-    messageType: "mail",
-    messageID: target.messageId,
-    channelId: target.channelId,
-    messageUrl: buildDiscordMessageUrl(guildId, target.channelId, target.messageId),
-  });
-  return {
-    ...config,
-    lastPostedChannelId: target.channelId,
-    lastPostedMessageId: target.messageId,
-    messages,
-  };
 }

--- a/src/helper/hashConfig.ts
+++ b/src/helper/hashConfig.ts
@@ -1,0 +1,21 @@
+import { createHash } from "crypto";
+
+function sortValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => sortValue(item));
+  }
+  if (value && typeof value === "object") {
+    return Object.keys(value as Record<string, unknown>)
+      .sort((a, b) => a.localeCompare(b))
+      .reduce<Record<string, unknown>>((acc, key) => {
+        acc[key] = sortValue((value as Record<string, unknown>)[key]);
+        return acc;
+      }, {});
+  }
+  return value;
+}
+
+export function hashMessageConfig(config: unknown): string {
+  const normalized = JSON.stringify(sortValue(config) ?? null);
+  return createHash("sha256").update(normalized).digest("hex");
+}

--- a/src/services/PostedMessageService.ts
+++ b/src/services/PostedMessageService.ts
@@ -1,0 +1,99 @@
+import { prisma } from "../prisma";
+
+type SavePostedMessageInput = {
+  guildId: string;
+  clanTag: string;
+  type: string;
+  event?: string | null;
+  warId?: string | null;
+  syncNum?: number | null;
+  channelId: string;
+  messageId: string;
+  messageUrl: string;
+  configHash?: string | null;
+};
+
+type FindExistingMessageInput = {
+  guildId: string;
+  clanTag: string;
+  warId?: string | null;
+  type: string;
+  event?: string | null;
+};
+
+type FindMailMessageInput = {
+  guildId: string;
+  clanTag: string;
+  warId?: string | null;
+};
+
+function normalizeTag(input: string): string {
+  return input.trim().toUpperCase().replace(/^#/, "");
+}
+
+export class PostedMessageService {
+  async savePostedMessage(input: SavePostedMessageInput) {
+    const clanTag = `#${normalizeTag(input.clanTag)}`;
+    const existing = await prisma.clanPostedMessage.findFirst({
+      where: {
+        guildId: input.guildId,
+        clanTag,
+        warId: input.warId ?? null,
+        type: input.type,
+        event: input.event ?? null,
+      },
+      orderBy: { createdAt: "desc" },
+    });
+    if (existing) {
+      return prisma.clanPostedMessage.update({
+        where: { id: existing.id },
+        data: {
+          channelId: input.channelId,
+          messageId: input.messageId,
+          messageUrl: input.messageUrl,
+          syncNum: input.syncNum ?? null,
+          configHash: input.configHash ?? null,
+        },
+      });
+    }
+    return prisma.clanPostedMessage.create({
+      data: {
+        guildId: input.guildId,
+        clanTag,
+        type: input.type,
+        event: input.event ?? null,
+        channelId: input.channelId,
+        messageId: input.messageId,
+        messageUrl: input.messageUrl,
+        warId: input.warId ?? null,
+        syncNum: input.syncNum ?? null,
+        configHash: input.configHash ?? null,
+      },
+    });
+  }
+
+  async findExistingMessage(input: FindExistingMessageInput) {
+    return prisma.clanPostedMessage.findFirst({
+      where: {
+        guildId: input.guildId,
+        clanTag: `#${normalizeTag(input.clanTag)}`,
+        warId: input.warId ?? null,
+        type: input.type,
+        event: input.event ?? null,
+      },
+      orderBy: { createdAt: "desc" },
+    });
+  }
+
+  async findMailMessage(input: FindMailMessageInput) {
+    return prisma.clanPostedMessage.findFirst({
+      where: {
+        guildId: input.guildId,
+        clanTag: `#${normalizeTag(input.clanTag)}`,
+        type: "mail",
+        warId: input.warId ?? null,
+      },
+      orderBy: { createdAt: "desc" },
+    });
+  }
+}

--- a/src/services/WarEventLogService.ts
+++ b/src/services/WarEventLogService.ts
@@ -8,10 +8,12 @@ import {
   EmbedBuilder,
 } from "discord.js";
 import { Prisma } from "@prisma/client";
+import { hashMessageConfig } from "../helper/hashConfig";
 import { formatError } from "../helper/formatError";
 import { prisma } from "../prisma";
 import { CoCService } from "./CoCService";
 import { PointsProjectionService } from "./PointsProjectionService";
+import { PostedMessageService } from "./PostedMessageService";
 import { SettingsService } from "./SettingsService";
 import { WarEventHistoryService } from "./war-events/history";
 import { WarStartPointsSyncService } from "./war-events/pointsSync";
@@ -240,12 +242,14 @@ export class WarEventLogService {
   private readonly points: PointsProjectionService;
   private readonly pointsSync: WarStartPointsSyncService;
   private readonly history: WarEventHistoryService;
+  private readonly postedMessages: PostedMessageService;
 
   /** Purpose: initialize service dependencies. */
   constructor(private readonly client: Client, private readonly coc: CoCService) {
     this.points = new PointsProjectionService(coc);
     this.pointsSync = new WarStartPointsSyncService(this.points, new SettingsService());
     this.history = new WarEventHistoryService(coc);
+    this.postedMessages = new PostedMessageService();
   }
 
   /** Purpose: poll. */
@@ -1304,25 +1308,81 @@ export class WarEventLogService {
       });
     }
     if (!params.sub.notify || !params.sub.channelId) return;
-    if (
-      (params.payload.eventType === "battle_day" || params.payload.eventType === "war_ended") &&
-      !(await this.reserveEventDelivery(params))
-    ) {
+    const reserved = await this.reserveEventDelivery(params);
+    if (!reserved.allowed) {
+      return;
+    }
+    if (reserved.existingMessage) {
+      console.log(
+        `[notify] existing message found guild=${params.sub.guildId} clan=${params.sub.clanTag} event=${params.payload.eventType} message=${reserved.existingMessage.messageId}`
+      );
+      if (params.payload.eventType === "battle_day") {
+        battleDayPostByGuildTag.set(makeBattleDayPostKey(params.sub.guildId, params.sub.clanTag), {
+          channelId: reserved.existingMessage.channelId,
+          messageId: reserved.existingMessage.messageId,
+        });
+      }
       return;
     }
     console.log(
       `[war-events] emit start guild=${params.sub.guildId} channel=${params.sub.channelId} clan=${params.payload.clanTag} event=${params.payload.eventType}`
     );
-    await this.emitEvent(params.sub.channelId, params.payload, params.resolvedWarId);
+    await this.emitEvent(
+      params.sub.channelId,
+      params.payload,
+      params.resolvedWarId,
+      params.sub
+    );
+  }
+
+  private async tryCreateEventGuard(
+    warId: string,
+    clanTag: string,
+    eventType: string
+  ): Promise<boolean> {
+    try {
+      await prisma.warEvent.create({
+        data: {
+          warId: Math.trunc(Number(warId)),
+          clanTag: normalizeTag(clanTag),
+          eventType,
+          payload: {},
+        },
+      });
+      return true;
+    } catch (error) {
+      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
+        console.log(`[WarEvent] Duplicate ${eventType} skipped clan=#${normalizeTag(clanTag)} warId=${warId}`);
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  private buildNotifyConfigHash(sub: SubscriptionRow, eventType: EventType): string {
+    return hashMessageConfig({
+      type: "notify",
+      event: eventType,
+      channel: sub.channelId,
+      role: sub.notifyRole,
+      pingEnabled: sub.pingRole,
+      embedEnabled: sub.embedEnabled,
+    });
   }
 
   private async reserveEventDelivery(params: {
     sub: SubscriptionRow;
     payload: EventEmitPayload;
     resolvedWarId: number | null;
-  }): Promise<boolean> {
+  }): Promise<{
+    allowed: boolean;
+    existingMessage: {
+      channelId: string;
+      messageId: string;
+    } | null;
+    warId: string | null;
+  }> {
     const eventType = params.payload.eventType;
-    if (eventType !== "battle_day" && eventType !== "war_ended") return true;
     const warId =
       params.resolvedWarId ??
       params.sub.warId ??
@@ -1331,34 +1391,27 @@ export class WarEventLogService {
       console.warn(
         `[war-events] emit skipped guild=${params.sub.guildId} clan=${params.sub.clanTag} event=${eventType} reason=missing_war_id_for_idempotency`
       );
-      return false;
+      return { allowed: false, existingMessage: null, warId: null };
     }
-    try {
-      await prisma.warEvent.create({
-        data: {
-          warId: Math.trunc(Number(warId)),
-          clanTag: normalizeTag(params.payload.clanTag),
-          eventType,
-          payload: {
-            guildId: params.sub.guildId,
-            channelId: params.sub.channelId,
-            opponentTag: normalizeTag(params.payload.opponentTag),
-            warStartTime: params.payload.warStartTime?.toISOString?.() ?? null,
-            warEndTime: params.payload.warEndTime?.toISOString?.() ?? null,
-            syncNumber: params.payload.syncNumber ?? null,
-          },
-        },
-      });
-      return true;
-    } catch (error) {
-      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002") {
-        console.log(
-          `[war-events] emit deduped guild=${params.sub.guildId} clan=${params.sub.clanTag} warId=${warId} event=${eventType}`
-        );
-        return false;
-      }
-      throw error;
+    const warIdText = String(Math.trunc(Number(warId)));
+    const allowed = await this.tryCreateEventGuard(warIdText, params.payload.clanTag, eventType);
+    if (!allowed) {
+      return { allowed: false, existingMessage: null, warId: warIdText };
     }
+    const existingMessage = await this.postedMessages.findExistingMessage({
+      guildId: params.sub.guildId,
+      clanTag: params.payload.clanTag,
+      warId: warIdText,
+      type: "notify",
+      event: eventType,
+    });
+    return {
+      allowed: true,
+      existingMessage: existingMessage
+        ? { channelId: existingMessage.channelId, messageId: existingMessage.messageId }
+        : null,
+      warId: warIdText,
+    };
   }
 
   private async resolveWarId(clanTagInput: string, warStartTime: Date | null): Promise<number | null> {
@@ -1409,7 +1462,8 @@ export class WarEventLogService {
       opponentDestruction: number | null;
       testFinalResultOverride?: WarEndResultSnapshot | null;
     },
-    resolvedWarIdOverride?: number | null
+    resolvedWarIdOverride?: number | null,
+    sub?: SubscriptionRow
   ): Promise<void> {
     const channel = await this.client.channels.fetch(channelId).catch(() => null);
     if (!channel) {
@@ -1668,6 +1722,20 @@ export class WarEventLogService {
       }
     }
     if (sent) {
+      if (guildId && sub && warId !== null && warId !== undefined) {
+        await this.postedMessages.savePostedMessage({
+          guildId,
+          clanTag: payload.clanTag,
+          type: "notify",
+          event: payload.eventType,
+          warId: String(warId),
+          syncNum: payload.syncNumber ?? null,
+          channelId,
+          messageId: sent.id,
+          messageUrl: `https://discord.com/channels/${guildId}/${channelId}/${sent.id}`,
+          configHash: this.buildNotifyConfigHash(sub, payload.eventType),
+        });
+      }
       console.log(
         `[war-events] emit success guild=${guildId ?? "unknown"} channel=${channelId} message=${sent.id} clan=${payload.clanTag} event=${payload.eventType}`
       );
@@ -1675,6 +1743,24 @@ export class WarEventLogService {
   }
 
   async refreshBattleDayPosts(): Promise<void> {
+    const storedPosts = await prisma.clanPostedMessage.findMany({
+      where: {
+        type: "notify",
+        event: "battle_day",
+      },
+      select: {
+        guildId: true,
+        clanTag: true,
+        channelId: true,
+        messageId: true,
+      },
+    });
+    for (const stored of storedPosts) {
+      battleDayPostByGuildTag.set(makeBattleDayPostKey(stored.guildId, stored.clanTag), {
+        channelId: stored.channelId,
+        messageId: stored.messageId,
+      });
+    }
     const keys = [...battleDayPostByGuildTag.keys()];
     for (const key of keys) {
       await this.refreshBattleDayPostByKey(key).catch((err) => {


### PR DESCRIPTION
…king

Implement redeploy-safe war event messaging by adding DB-backed message tracking and using WarEvent as an event guard.

- add ClanPostedMessage model and migration
- add hashConfig helper and PostedMessageService
- use WarEvent guard + existing message lookup before notify posts
- persist notify message metadata for battle day, war start, and war end
- replace mailConfig.messages[] mail lookup/write paths with ClanPostedMessage
- keep mailConfig focused on settings and last-posted metadata