### PR TITLE
fix(fwa): show correct war mail time remaining for prep vs battle day

### DIFF
--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -1038,7 +1038,6 @@ async function buildWarMailEmbedForTag(
     ].join("\n");
   }
 
-  const prepTargetMs = parseCocApiTime(war?.preparationStartTime);
   const battleTargetMs = parseCocApiTime(war?.endTime);
   const warStartMs = parseCocApiTime(war?.startTime);
   const fallbackWarStartMs = subscription?.startTime
@@ -1047,7 +1046,7 @@ async function buildWarMailEmbedForTag(
   const effectiveWarStartMs = warStartMs ?? fallbackWarStartMs;
   const expectedOutcome = matchType === "FWA" ? (outcome ?? "UNKNOWN") : null;
   const remainingText = formatDiscordRelativeMs(
-    warState === "preparation" ? prepTargetMs : battleTargetMs
+    warState === "preparation" ? effectiveWarStartMs : battleTargetMs
   );
   const warId =
     (await upsertCurrentWarHistoryAndGetWarId({


### PR DESCRIPTION
Use war start time for prep-day mail embeds and war end time for battle-day mail embeds so the relative time remaining matches the current phase.