### PR TITLE
fix(force): handle bootstrap subcommand without group

### DIFF
--- a/src/commands/Force.ts
+++ b/src/commands/Force.ts
@@ -270,7 +270,7 @@ export const Force: Command = {
       await runForcePollWarEventsCommand(client, interaction, cocService);
       return;
     }
-    if (subcommandGroup === undefined && subcommand === "bootstrap-war-state") {
+    if (subcommandGroup == null && subcommand === "bootstrap-war-state") {
       await runForceBootstrapWarStateCommand(client, interaction, cocService);
       return;
     }


### PR DESCRIPTION
- route /force bootstrap-war-state when no subcommand group is present
- accept Discord.js null return from getSubcommandGroup(false)