### PR TITLE
refactor(sync): finalize ClanPointsSync as runtime source of truth

### DIFF
--- a/prisma/migrations/20260306113000_rename_clan_points_sync_timestamp_and_add_latest_index/migration.sql
+++ b/prisma/migrations/20260306113000_rename_clan_points_sync_timestamp_and_add_latest_index/migration.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "ClanPointsSync"
+RENAME COLUMN "syncedAt" TO "syncFetchedAt";
+
+CREATE INDEX "ClanPointsSync_guildId_clanTag_warStartTime_idx"
+ON "ClanPointsSync"("guildId", "clanTag", "warStartTime" DESC);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -300,13 +300,14 @@ model ClanPointsSync {
   opponentPoints Int
   outcome        String?
   isFwa          Boolean
-  syncedAt       DateTime @default(now())
+  syncFetchedAt  DateTime @default(now())
   createdAt      DateTime @default(now())
   updatedAt      DateTime @updatedAt
 
   @@index([guildId, clanTag])
   @@index([clanTag, warStartTime])
   @@index([guildId, clanTag, warId])
+  @@index([guildId, clanTag, warStartTime(sort: Desc)])
   @@unique([guildId, clanTag, warStartTime])
 }
 

--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -703,28 +703,6 @@ async function getTrackedClanMailConfig(tag: string): Promise<{
   };
 }
 
-async function resolveCurrentSyncNumForMailConfirm(tag: string): Promise<number | null> {
-  const normalizedTag = normalizeTag(tag);
-  const latestSync = await pointsSyncService.findLatestSyncNum({ clanTag: normalizedTag });
-  if (latestSync !== null) {
-    return latestSync;
-  }
-  const lastHistory = await prisma.clanWarHistory.findFirst({
-    where: {
-      clanTag: normalizedTag,
-      syncNumber: { not: null },
-      matchType: { in: ["MM", "BL", "SKIP"] },
-    },
-    orderBy: { warStartTime: "desc" },
-    select: { syncNumber: true },
-  });
-  const previousSync = Number(lastHistory?.syncNumber ?? NaN);
-  if (Number.isFinite(previousSync)) {
-    return Math.max(0, Math.trunc(previousSync) + 1);
-  }
-  return null;
-}
-
 function isMatchTypeValue(value: unknown): value is "FWA" | "BL" | "MM" | "SKIP" | "UNKNOWN" {
   return value === "FWA" || value === "BL" || value === "MM" || value === "SKIP" || value === "UNKNOWN";
 }
@@ -787,8 +765,20 @@ async function recordMatchMailUpdated(params: {
         clanTag: `#${normalizeTag(params.tag)}`,
       },
     },
-    select: { warId: true, syncNum: true },
+    select: { warId: true, startTime: true },
   });
+  const syncRow =
+    currentWar?.startTime
+      ? await pointsSyncService.getCurrentSyncForClan({
+          guildId: params.guildId,
+          clanTag: params.tag,
+          warId:
+            currentWar.warId !== null && currentWar.warId !== undefined
+              ? String(Math.trunc(currentWar.warId))
+              : null,
+          warStartTime: currentWar.startTime,
+        })
+      : null;
 
   await postedMessageService.savePostedMessage({
     guildId: params.guildId,
@@ -799,7 +789,7 @@ async function recordMatchMailUpdated(params: {
       currentWar?.warId !== null && currentWar?.warId !== undefined
         ? String(currentWar.warId)
         : null,
-    syncNum: currentWar?.syncNum ?? null,
+    syncNum: syncRow?.syncNum ?? null,
     channelId: params.channelId,
     messageId: params.messageId,
     messageUrl:
@@ -2837,7 +2827,6 @@ export async function handleFwaMailConfirmButton(interaction: ButtonInteraction)
     embeds: [rendered.embed],
     components: buildWarMailPostedComponents(postKey),
   });
-  const resolvedCurrentSyncNum = await resolveCurrentSyncNumForMailConfirm(payload.tag);
   await prisma.currentWar.upsert({
     where: {
       clanTag_guildId: {
@@ -2850,10 +2839,8 @@ export async function handleFwaMailConfirmButton(interaction: ButtonInteraction)
       clanTag: `#${normalizeTag(payload.tag)}`,
       channelId: channel.id,
       notify: false,
-      syncNum: resolvedCurrentSyncNum,
     },
     update: {
-      syncNum: resolvedCurrentSyncNum ?? undefined,
       updatedAt: new Date(),
     },
   });
@@ -3437,6 +3424,7 @@ function buildSyncValidationState(input: {
     clanPoints: number;
     opponentPoints: number;
     warStartTime: Date;
+    syncFetchedAt: Date;
     outcome: string | null;
     isFwa: boolean | null;
   } | null;
@@ -3509,6 +3497,25 @@ function buildSyncValidationState(input: {
         ? "⚠ Data not fully synced with points.fwafarm"
         : "✅ Data is in sync with points.fwafarm",
   };
+}
+
+function buildStoredSyncSummary(input: {
+  syncRow: { syncNum: number; syncFetchedAt: Date } | null;
+  fallbackSyncNum: number | null;
+  warState: WarStateForSync;
+}): { syncLine: string; updatedLine: string | null } {
+  const syncNumber =
+    input.syncRow?.syncNum ??
+    (input.fallbackSyncNum !== null && Number.isFinite(input.fallbackSyncNum)
+      ? Math.trunc(input.fallbackSyncNum)
+      : null);
+  const syncLine = withSyncModeLabel(getSyncDisplay(syncNumber, input.warState), syncNumber);
+  const syncFetchedAtMs = input.syncRow?.syncFetchedAt?.getTime?.() ?? NaN;
+  const updatedLine =
+    Number.isFinite(syncFetchedAtMs) && syncFetchedAtMs > 0
+      ? `<t:${Math.floor(syncFetchedAtMs / 1000)}:R>`
+      : null;
+  return { syncLine, updatedLine };
 }
 
 async function persistClanPointsSyncIfCurrent(input: {
@@ -4096,7 +4103,6 @@ async function buildTrackedMatchOverview(
       clanTag: true,
       warId: true,
       startTime: true,
-      syncNum: true,
       matchType: true,
       inferredMatchType: true,
       outcome: true,
@@ -4498,7 +4504,7 @@ async function buildTrackedMatchOverview(
       outcome: derivedOutcome,
       isFwa: primaryPoints?.activeFwa ?? false,
     });
-    const syncRow = await pointsSyncService.findSyncRecord({
+    const syncRow = await pointsSyncService.getCurrentSyncForClan({
       guildId: guildId ?? "",
       clanTag,
       warId:
@@ -4506,6 +4512,11 @@ async function buildTrackedMatchOverview(
           ? String(Math.trunc(sub.warId))
           : null,
       warStartTime: warStartTimeForSync,
+    });
+    const storedSyncSummary = buildStoredSyncSummary({
+      syncRow,
+      fallbackSyncNum: siteSyncObservedForWrite,
+      warState,
     });
     const validationState = buildSyncValidationState({
       syncRow,
@@ -4696,7 +4707,8 @@ async function buildTrackedMatchOverview(
       matchType === "FWA" ? `Expected outcome: **${effectiveOutcome ?? "UNKNOWN"}**` : "",
       `War state: **${formatWarStateLabel(warState)}**`,
       `Time remaining: **${getWarStateRemaining(war, warState)}**`,
-      `Sync: **${withSyncModeLabel(getSyncDisplay(sourceSync, warState), sourceSync)}**`,
+      `Sync #: **${storedSyncSummary.syncLine}**`,
+      storedSyncSummary.updatedLine ? `Updated: **${storedSyncSummary.updatedLine}**` : "",
       mismatchLines,
     ]
       .filter(Boolean)
@@ -6116,7 +6128,6 @@ export const Fwa: Command = {
                 state: true,
                 warId: true,
                 startTime: true,
-                syncNum: true,
                 matchType: true,
                 inferredMatchType: true,
                 outcome: true,
@@ -6397,7 +6408,6 @@ export const Fwa: Command = {
               .split("\n")[1]
               ?.trim() ?? "Projection unavailable."
           : `This is a ${matchType} match.`;
-        const syncDisplay = withSyncModeLabel(getSyncDisplay(sourceSync, warState), sourceSync);
         const leftName = resolvedPrimaryName ?? primaryNameFromApi ?? tag;
         const rightName = resolvedOpponentName ?? opponentNameFromApi ?? opponentTag;
         const trackedMismatch = siteUpdated
@@ -6428,7 +6438,7 @@ export const Fwa: Command = {
           outcome: effectiveOutcome,
           isFwa: primary.activeFwa ?? false,
         });
-        const syncRow = await pointsSyncService.findSyncRecord({
+        const syncRow = await pointsSyncService.getCurrentSyncForClan({
           guildId: interaction.guildId ?? "",
           clanTag: tag,
           warId:
@@ -6436,8 +6446,13 @@ export const Fwa: Command = {
             subscription?.warId !== undefined &&
             Number.isFinite(subscription?.warId)
               ? String(Math.trunc(subscription.warId))
-              : null,
+            : null,
           warStartTime: warStartTimeForSync,
+        });
+        const storedSyncSummary = buildStoredSyncSummary({
+          syncRow,
+          fallbackSyncNum: siteSyncObservedForWrite,
+          warState,
         });
         const validationState = buildSyncValidationState({
           syncRow,
@@ -6538,7 +6553,9 @@ export const Fwa: Command = {
               outcomeLine ? `\nExpected outcome: **${outcomeLine}**` : ""
             }\n${siteStatusLine}${
               mailBlockedReasonLine ? `\n${mailBlockedReasonLine}` : ""
-            }\nWar state: **${formatWarStateLabel(warState)}**\nTime remaining: **${warRemaining}**\nSync: **${syncDisplay}**${
+            }\nWar state: **${formatWarStateLabel(warState)}**\nTime remaining: **${warRemaining}**\nSync #: **${storedSyncSummary.syncLine}**${
+              storedSyncSummary.updatedLine ? `\nUpdated: **${storedSyncSummary.updatedLine}**` : ""
+            }${
               mismatchLines ? `\n${mismatchLines}` : ""
             }`
           )
@@ -6569,7 +6586,8 @@ export const Fwa: Command = {
             mailBlockedReasonLine
               ? `${mailBlockedReasonLine.replace(/^:warning: /, "Warning: ").replace(/^:envelope_with_arrow: /, "Mail: ")}`
               : "",
-            `Sync: ${syncDisplay}`,
+            `Sync #: ${storedSyncSummary.syncLine}`,
+            storedSyncSummary.updatedLine ? `Updated: ${storedSyncSummary.updatedLine}` : "",
             `War State: ${formatWarStateLabel(warState)}`,
             `Time Remaining: ${warRemaining}`,
             `## Opponent Name`,

--- a/src/services/PointsSyncService.ts
+++ b/src/services/PointsSyncService.ts
@@ -44,7 +44,7 @@ export class PointsSyncService {
         opponentPoints: Math.trunc(input.opponentPoints),
         outcome: input.outcome ?? null,
         isFwa: input.isFwa,
-        syncedAt: new Date(),
+        syncFetchedAt: new Date(),
       },
       create: {
         guildId: input.guildId,
@@ -57,11 +57,12 @@ export class PointsSyncService {
         opponentPoints: Math.trunc(input.opponentPoints),
         outcome: input.outcome ?? null,
         isFwa: input.isFwa,
+        syncFetchedAt: new Date(),
       },
     });
   }
 
-  async findSyncRecord(input: FindPointsSyncInput) {
+  async getCurrentSyncForClan(input: FindPointsSyncInput) {
     const clanTag = normalizeTag(input.clanTag);
     if (input.warId) {
       const byWarId = await prisma.clanPointsSync.findFirst({
@@ -70,20 +71,33 @@ export class PointsSyncService {
           clanTag,
           warId: String(input.warId),
         },
-        orderBy: [{ syncedAt: "desc" }, { updatedAt: "desc" }],
+        orderBy: [{ syncFetchedAt: "desc" }, { updatedAt: "desc" }],
       });
       if (byWarId) return byWarId;
     }
-    if (!input.warStartTime) return null;
-    return prisma.clanPointsSync.findUnique({
-      where: {
-        guildId_clanTag_warStartTime: {
-          guildId: input.guildId,
-          clanTag,
-          warStartTime: input.warStartTime,
+    if (input.warStartTime) {
+      const byWarStartTime = await prisma.clanPointsSync.findUnique({
+        where: {
+          guildId_clanTag_warStartTime: {
+            guildId: input.guildId,
+            clanTag,
+            warStartTime: input.warStartTime,
+          },
         },
+      });
+      if (byWarStartTime) return byWarStartTime;
+    }
+    return prisma.clanPointsSync.findFirst({
+      where: {
+        guildId: input.guildId,
+        clanTag,
       },
+      orderBy: [{ warStartTime: "desc" }, { syncFetchedAt: "desc" }, { updatedAt: "desc" }],
     });
+  }
+
+  async findSyncRecord(input: FindPointsSyncInput) {
+    return this.getCurrentSyncForClan(input);
   }
 
   async findLatestSyncNum(input?: {
@@ -95,7 +109,7 @@ export class PointsSyncService {
         ...(input?.guildId ? { guildId: input.guildId } : {}),
         ...(input?.clanTag ? { clanTag: normalizeTag(input.clanTag) } : {}),
       },
-      orderBy: [{ warStartTime: "desc" }, { syncedAt: "desc" }],
+      orderBy: [{ warStartTime: "desc" }, { syncFetchedAt: "desc" }],
       select: { syncNum: true },
     });
     const syncNum = Number(row?.syncNum ?? NaN);
@@ -117,7 +131,7 @@ export class PointsSyncService {
       },
       data: {
         warId: String(params.warId),
-        syncedAt: new Date(),
+        syncFetchedAt: new Date(),
       },
     });
   }

--- a/src/services/WarEventLogService.ts
+++ b/src/services/WarEventLogService.ts
@@ -14,6 +14,7 @@ import { prisma } from "../prisma";
 import { CoCService } from "./CoCService";
 import { PointsProjectionService } from "./PointsProjectionService";
 import { PostedMessageService } from "./PostedMessageService";
+import { PointsSyncService } from "./PointsSyncService";
 import { SettingsService } from "./SettingsService";
 import { WarEventHistoryService } from "./war-events/history";
 import { WarStartPointsSyncService } from "./war-events/pointsSync";
@@ -252,6 +253,7 @@ function buildWarStatsLines(stats: EmbedWarStats): string[] {
 export class WarEventLogService {
   private readonly points: PointsProjectionService;
   private readonly pointsSync: WarStartPointsSyncService;
+  private readonly currentSyncs: PointsSyncService;
   private readonly history: WarEventHistoryService;
   private readonly postedMessages: PostedMessageService;
 
@@ -259,6 +261,7 @@ export class WarEventLogService {
   constructor(private readonly client: Client, private readonly coc: CoCService) {
     this.points = new PointsProjectionService(coc);
     this.pointsSync = new WarStartPointsSyncService(this.points, new SettingsService());
+    this.currentSyncs = new PointsSyncService();
     this.history = new WarEventHistoryService(coc);
     this.postedMessages = new PostedMessageService();
   }
@@ -1061,14 +1064,6 @@ export class WarEventLogService {
         eventType = null;
       }
     }
-    const syncNumberForEvent =
-      eventType === "war_ended"
-        ? (sub.syncNum !== null && Number.isFinite(Number(sub.syncNum))
-            ? Math.trunc(Number(sub.syncNum))
-            : syncContext.activeSync)
-        : currentState === "notInWar"
-          ? syncContext.previousSync
-          : syncContext.activeSync;
     if (eventType === "war_started" && nextOpponentTag) {
       await this.pointsSync.resetWarStartPointsJob(sub.clanTag, nextOpponentTag).catch(() => null);
     }
@@ -1080,6 +1075,13 @@ export class WarEventLogService {
         nextOpponentName
       ).catch(() => null);
     }
+
+    const fallbackSyncNumberForEvent =
+      eventType === "war_ended"
+        ? syncContext.activeSync
+        : currentState === "notInWar"
+          ? syncContext.previousSync
+          : syncContext.activeSync;
 
     let nextFwaPoints = sub.fwaPoints;
     let nextOpponentFwaPoints = sub.opponentFwaPoints;
@@ -1124,7 +1126,7 @@ export class WarEventLogService {
         projectionOpponentTag,
         a.balance,
         b.balance,
-        syncNumberForEvent
+        fallbackSyncNumberForEvent
       );
       if (eventType === "war_started") {
         nextWarStartFwaPoints = a.balance;
@@ -1189,6 +1191,23 @@ export class WarEventLogService {
       warStartTime: nextWarStartTime,
       currentState,
     });
+    const syncRow =
+      guildId && nextWarStartTime
+        ? await this.currentSyncs.getCurrentSyncForClan({
+            guildId,
+            clanTag: sub.clanTag,
+            warId:
+              resolvedWarId !== null && resolvedWarId !== undefined
+                ? String(Math.trunc(Number(resolvedWarId)))
+                : sub.warId !== null && sub.warId !== undefined
+                  ? String(Math.trunc(Number(sub.warId)))
+                  : null,
+            warStartTime: nextWarStartTime,
+          })
+        : null;
+    const syncNumberForEvent =
+      syncRow?.syncNum ??
+      fallbackSyncNumberForEvent;
 
     const detectedEventPayload = eventType
       ? ({
@@ -1984,7 +2003,15 @@ export class WarEventLogService {
       clanName: nextClanName,
       opponentTag: nextOpponentTag,
       opponentName: nextOpponentName,
-      syncNumber: await this.pointsSync.getPreviousSyncNum(),
+      syncNumber:
+        (
+          await this.currentSyncs.getCurrentSyncForClan({
+            guildId,
+            clanTag,
+            warId: warIdText,
+            warStartTime,
+          })
+        )?.syncNum ?? null,
       notifyRole: refreshedSub.notifyRole,
       pingRole: refreshedSub.pingRole,
       fwaPoints: refreshedSub.fwaPoints,
@@ -2137,7 +2164,20 @@ export class WarEventLogService {
       opponentTag: normalizeTag(war.opponent?.tag ?? refreshedSub.opponentTag ?? ""),
       opponentName:
         String(war.opponent?.name ?? refreshedSub.opponentName ?? "Unknown").trim() || "Unknown",
-      syncNumber: await this.pointsSync.getPreviousSyncNum(),
+      syncNumber:
+        (
+          await this.currentSyncs.getCurrentSyncForClan({
+            guildId,
+            clanTag,
+            warId:
+              resolvedWarId !== null && resolvedWarId !== undefined
+                ? String(Math.trunc(Number(resolvedWarId)))
+                : refreshedSub.warId !== null && refreshedSub.warId !== undefined
+                  ? String(Math.trunc(Number(refreshedSub.warId)))
+                  : null,
+            warStartTime,
+          })
+        )?.syncNum ?? null,
       notifyRole: refreshedSub.notifyRole,
       pingRole: refreshedSub.pingRole,
       fwaPoints: refreshedSub.fwaPoints,

--- a/src/services/war-events/history.ts
+++ b/src/services/war-events/history.ts
@@ -242,7 +242,6 @@ export class WarEventHistoryService {
       select: {
         guildId: true,
         inferredMatchType: true,
-        syncNum: true,
         matchType: true,
         state: true,
         clanName: true,
@@ -252,6 +251,14 @@ export class WarEventHistoryService {
         endTime: true,
       },
     });
+    const syncRow = currentSnapshot?.guildId
+      ? await this.pointsSync.getCurrentSyncForClan({
+          guildId: currentSnapshot.guildId,
+          clanTag,
+          warId: String(warId),
+          warStartTime,
+        })
+      : null;
     const participants = attacks.filter((a) => Number(a.attackOrder) === 0);
     const teamSize = participants.length > 0 ? participants.length : null;
     const pointsAwarded =
@@ -306,7 +313,7 @@ export class WarEventHistoryService {
         opponentDestruction: finalResult.opponentDestruction,
       },
       fwa: {
-        syncNumber: payload.syncNumber ?? currentSnapshot?.syncNum ?? null,
+        syncNumber: payload.syncNumber ?? syncRow?.syncNum ?? null,
         pointsAwarded: pointsAwarded ?? null,
         inferred: Boolean(currentSnapshot?.inferredMatchType),
         mismatch: payload.matchType === "MM",


### PR DESCRIPTION
- rename ClanPointsSync timestamp field to syncFetchedAt
- add descending ClanPointsSync index for latest /fwa match lookups
- add PointsSyncService.getCurrentSyncForClan helper
- render sync number and last sync time from ClanPointsSync in /fwa match
- stop mail tracking and war history fallback from reading CurrentWar.syncNum
- use ClanPointsSync for war event payload sync lookups