### PR TITLE
feat(warplan): require outcome option for set subcommand

### DIFF
--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -177,7 +177,7 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
       "`reset` removes stored custom plan text for that clan.",
     ],
     examples: [
-      "/warplan set clan-tag:2QG2C08UP phase:prep plan-text:Swap to war base during prep.",
+      "/warplan set clan-tag:2QG2C08UP phase:prep outcome:lose plan-text:Swap to war base during prep.",
       "/warplan show clan-tag:2QG2C08UP",
       "/warplan reset clan-tag:2QG2C08UP",
     ],

--- a/src/commands/WarPlan.ts
+++ b/src/commands/WarPlan.ts
@@ -129,6 +129,16 @@ export const WarPlan: Command = {
           ],
         },
         {
+          name: "outcome",
+          description: "Expected outcome context for this plan",
+          type: ApplicationCommandOptionType.String,
+          required: true,
+          choices: [
+            { name: "win", value: "WIN" },
+            { name: "lose", value: "LOSE" },
+          ],
+        },
+        {
           name: "plan-text",
           description: "Custom plan text (max 1500 chars)",
           type: ApplicationCommandOptionType.String,
@@ -191,6 +201,7 @@ export const WarPlan: Command = {
 
     if (subcommand === "set") {
       const phase = interaction.options.getString("phase", true) as "prep" | "battle";
+      const outcome = interaction.options.getString("outcome", true) as "WIN" | "LOSE";
       const planTextInput = interaction.options.getString("plan-text", true);
       if (!planTextInput.length) {
         await interaction.editReply("Plan text cannot be empty.");
@@ -219,7 +230,7 @@ export const WarPlan: Command = {
       });
 
       await interaction.editReply(
-        `Saved ${phase} plan for **${trackedClan.name ?? clanTag}** (${clanTag}).\nLength: ${phase === "prep" ? row.prepPlan?.length ?? 0 : row.battlePlan?.length ?? 0} chars`
+        `Saved ${phase.toUpperCase()} (${outcome}) plan for **${trackedClan.name ?? clanTag}** (${clanTag}).\nLength: ${phase === "prep" ? row.prepPlan?.length ?? 0 : row.battlePlan?.length ?? 0} chars`
       );
       return;
     }


### PR DESCRIPTION
- add required `outcome` choice (win|lose) to `/warplan set`
- parse outcome in command handler and include it in save confirmation text
- update `/help` warplan example to include outcome usage