### PR TITLE
feat(warplan): allow phase to be optional in /warplan set

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -22,7 +22,7 @@
 - `/cc clan tag:<tag>` - Build `https://cc.fwafarm.com/cc_n/clan.php?tag=<tag>`.
 - `/notify war clan-tag:<tag> target-channel:<channel> [role:<discordRole>]` - Enable war-state event logs (war start, battle day, war end) for a clan in a selected channel. Optional role is pinged when event logs are posted.
 - `/notify war-preview clan-tag:<tag> event:<war_started|battle_day|war_ended> [source:current|last]` - Show an ephemeral preview embed and confirm before posting publicly to the configured notify channel.
-- `/warplan set clan-tag:<tag> phase:<prep|battle> plan-text:<text>` - Save a custom prep-day or battle-day plan for a tracked clan.
+- `/warplan set clan-tag:<tag> [phase:<prep|battle>] plan-text:<text>` - Save a custom prep-day or battle-day plan for a tracked clan. If `phase` is omitted, the same text is saved to both prep and battle.
 - `/warplan show clan-tag:<tag>` - Show the effective prep and battle plans for a tracked clan, including defaults when no custom text is stored.
 - `/warplan reset clan-tag:<tag>` - Remove stored custom war plans for a tracked clan.
 - `/war history clan-tag:<tag> [limit:<number>]` - Show recent clan-level war history from stored war records.

--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -172,11 +172,13 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
   warplan: {
     summary: "Manage custom prep and battle war plan text for tracked clans.",
     details: [
-      "`set` saves one phase-specific custom plan per tracked clan.",
+      "`set` saves one phase-specific custom plan, or sets both phases when `phase` is omitted.",
       "`show` displays the effective prep and battle plans, including defaults when no custom text exists.",
       "`reset` removes stored custom plan text for that clan.",
     ],
     examples: [
+      "/warplan set clan-tag:2QG2C08UP phase:prep outcome:lose plan-text:Swap to war base during prep.",
+      "/warplan set clan-tag:2QG2C08UP outcome:lose plan-text:Swap to war base and follow mail instructions.",
       "/warplan set clan-tag:2QG2C08UP phase:prep outcome:lose plan-text:Swap to war base during prep.",
       "/warplan show clan-tag:2QG2C08UP",
       "/warplan reset clan-tag:2QG2C08UP",

--- a/src/commands/WarPlan.ts
+++ b/src/commands/WarPlan.ts
@@ -108,7 +108,7 @@ export const WarPlan: Command = {
   options: [
     {
       name: "set",
-      description: "Set a custom prep or battle plan for a tracked clan",
+      description: "Set a custom prep plan, battle plan, or both for a tracked clan",
       type: ApplicationCommandOptionType.Subcommand,
       options: [
         {
@@ -122,7 +122,7 @@ export const WarPlan: Command = {
           name: "phase",
           description: "Plan phase to customize",
           type: ApplicationCommandOptionType.String,
-          required: true,
+          required: false,
           choices: [
             { name: "prep", value: "prep" },
             { name: "battle", value: "battle" },
@@ -200,7 +200,7 @@ export const WarPlan: Command = {
     }
 
     if (subcommand === "set") {
-      const phase = interaction.options.getString("phase", true) as "prep" | "battle";
+      const phase = interaction.options.getString("phase", false) as "prep" | "battle" | null;
       const outcome = interaction.options.getString("outcome", true) as "WIN" | "LOSE";
       const planTextInput = interaction.options.getString("plan-text", true);
       if (!planTextInput.length) {
@@ -220,14 +220,26 @@ export const WarPlan: Command = {
             clanTag,
           },
         },
-        update: phase === "prep" ? { prepPlan: planText } : { battlePlan: planText },
+        update:
+          phase === "prep"
+            ? { prepPlan: planText }
+            : phase === "battle"
+              ? { battlePlan: planText }
+              : { prepPlan: planText, battlePlan: planText },
         create: {
           guildId: interaction.guildId,
           clanTag,
-          prepPlan: phase === "prep" ? planText : null,
-          battlePlan: phase === "battle" ? planText : null,
+          prepPlan: phase === "battle" ? null : planText,
+          battlePlan: phase === "prep" ? null : planText,
         },
       });
+
+      if (!phase) {
+        await interaction.editReply(
+          `Saved PREP and BATTLE (${outcome}) plans for **${trackedClan.name ?? clanTag}** (${clanTag}).\nLength: ${Math.max(row.prepPlan?.length ?? 0, row.battlePlan?.length ?? 0)} chars each`
+        );
+        return;
+      }
 
       await interaction.editReply(
         `Saved ${phase.toUpperCase()} (${outcome}) plan for **${trackedClan.name ?? clanTag}** (${clanTag}).\nLength: ${phase === "prep" ? row.prepPlan?.length ?? 0 : row.battlePlan?.length ?? 0} chars`


### PR DESCRIPTION
- make `phase` optional for `/warplan set`
- when `phase` is omitted, save the same `plan-text` to both prep and battle
- update response text for dual-phase saves
- update help and command docs to describe optional phase behavior