### PR TITLE
fix(warplan): reorder /warplan set options to satisfy Discord validation

### DIFF
--- a/src/commands/WarPlan.ts
+++ b/src/commands/WarPlan.ts
@@ -119,16 +119,6 @@ export const WarPlan: Command = {
           autocomplete: true,
         },
         {
-          name: "phase",
-          description: "Plan phase to customize",
-          type: ApplicationCommandOptionType.String,
-          required: false,
-          choices: [
-            { name: "prep", value: "prep" },
-            { name: "battle", value: "battle" },
-          ],
-        },
-        {
           name: "outcome",
           description: "Expected outcome context for this plan",
           type: ApplicationCommandOptionType.String,
@@ -143,6 +133,16 @@ export const WarPlan: Command = {
           description: "Custom plan text (max 1500 chars)",
           type: ApplicationCommandOptionType.String,
           required: true,
+        },
+        {
+          name: "phase",
+          description: "Plan phase to customize",
+          type: ApplicationCommandOptionType.String,
+          required: false,
+          choices: [
+            { name: "prep", value: "prep" },
+            { name: "battle", value: "battle" },
+          ],
         },
       ],
     },


### PR DESCRIPTION
- move optional `phase` after required options in `warplan set`
- keep optional-phase behavior (sets both prep and battle when omitted)
- fix startup command registration crash: required options must come before optional