### PR TITLE
fix(fwa): align single match sync display with alliance and points

### DIFF
--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -3661,7 +3661,10 @@ function buildStoredSyncSummary(input: {
     (input.fallbackSyncNum !== null && Number.isFinite(input.fallbackSyncNum)
       ? Math.trunc(input.fallbackSyncNum)
       : null);
-  const syncLine = withSyncModeLabel(getSyncDisplay(syncNumber, input.warState), syncNumber);
+  const syncLine =
+    syncNumber !== null && Number.isFinite(syncNumber)
+      ? `#${Math.trunc(syncNumber)} (${Math.trunc(syncNumber) % 2 === 0 ? "High Sync" : "Low Sync"})`
+      : "unknown";
   const syncFetchedAtMs = input.syncRow?.syncFetchedAt?.getTime?.() ?? NaN;
   const updatedLine =
     Number.isFinite(syncFetchedAtMs) && syncFetchedAtMs > 0


### PR DESCRIPTION
- render stored/site sync values as the observed sync number (no +1)
- compute high/low sync label from observed sync parity
- fix /fwa match single clan sync line being one ahead of alliance and /fwa points