### PR TITLE
chore(lint): resolve no-unused-vars warnings across commands and serv…

### DIFF
--- a/src/commands/Compo.ts
+++ b/src/commands/Compo.ts
@@ -46,7 +46,7 @@ function getModeRows(rows: string[][], mode: GoogleSheetMode): string[][] {
   return rows.filter((row) => String(row[COL_MODE] ?? "").trim().toUpperCase() === wanted);
 }
 
-function renderStateSvg(mode: GoogleSheetMode, rows: string[][]): Buffer {
+function _renderStateSvg(mode: GoogleSheetMode, rows: string[][]): Buffer {
   const tableRows = rows.length > 0 ? rows : [["(NO DATA)"]];
   const colCount = Math.max(...tableRows.map((row) => row.length), 1);
   const widths = Array.from({ length: colCount }, (_, col) =>
@@ -216,7 +216,7 @@ function abbreviateClan(value: string): string {
   return map[normalized] ?? value;
 }
 
-function padRows(rows: string[][], rowCount: number, colCount: number): string[][] {
+function _padRows(rows: string[][], rowCount: number, colCount: number): string[][] {
   const padded: string[][] = [];
   for (let r = 0; r < rowCount; r += 1) {
     const source = rows[r] ?? [];
@@ -229,7 +229,7 @@ function padRows(rows: string[][], rowCount: number, colCount: number): string[]
   return padded;
 }
 
-function mergeStateRows(
+function _mergeStateRows(
   left: string[][],
   middle: string[][],
   right: string[][],

--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -18,7 +18,6 @@ import { Command } from "../Command";
 import { truncateDiscordContent } from "../helper/discordContent";
 import { recordFetchEvent } from "../helper/fetchTelemetry";
 import { formatError } from "../helper/formatError";
-import { safeReply } from "../helper/safeReply";
 import { prisma } from "../prisma";
 import { CoCService } from "../services/CoCService";
 import {
@@ -43,7 +42,6 @@ import {
   getSyncDisplay,
   getWarStateRemaining,
   isMissedSyncClan,
-  isMissedSyncClanForTest,
   isPointsSiteUpdatedForOpponent,
   type WarStateForSync,
   withSyncModeLabel,
@@ -51,7 +49,6 @@ import {
 import {
   asMailConfigInputJson,
   buildDiscordMessageUrl,
-  type ForceMailMessageType,
   type MatchMailConfig,
   parseForceMailMessageType,
   parseMatchMailConfig,
@@ -1337,7 +1334,7 @@ function isPostedMailCurrentForLiveState(params: PostedMailLiveStateParams): boo
 
 export const isPostedMailCurrentForLiveStateForTest = isPostedMailCurrentForLiveState;
 
-function clearPostedMailTrackingForClan(params: {
+function _clearPostedMailTrackingForClan(params: {
   guildId: string;
   tag: string;
 }): void {
@@ -3297,15 +3294,6 @@ export async function runForceMailUpdateCommand(
     return;
   }
 
-  const current = await prisma.currentWar.findUnique({
-    where: {
-      clanTag_guildId: {
-        guildId: interaction.guildId,
-        clanTag: `#${tag}`,
-      },
-    },
-    select: { clanTag: true },
-  });
   const config = await getCurrentWarMailConfig(interaction.guildId, tag);
   const stored = await findStoredMailTarget({
     guildId: interaction.guildId,
@@ -4024,7 +4012,7 @@ async function getClanPointsCached(
   tag: string,
   sourceSync: number | null,
   _warLookupCache?: WarLookupCache,
-  options?: {
+  _options?: {
     requiredOpponentTag?: string | null;
   }
 ): Promise<PointsSnapshot> {
@@ -4120,7 +4108,7 @@ function deriveProjectedOutcome(
   return wins ? "WIN" : "LOSE";
 }
 
-async function buildLastWarMatchOverview(
+async function _buildLastWarMatchOverview(
   clanTag: string,
   guildId: string | null,
   previousSync: number | null
@@ -4518,12 +4506,6 @@ async function buildTrackedMatchOverview(
       opponentPoints?.balance !== undefined &&
       !Number.isNaN(opponentPoints.balance);
     const siteSyncObservedForWrite = primaryPoints?.winnerBoxSync ?? null;
-    const syncNumberForWrite =
-      siteSyncObservedForWrite !== null && Number.isFinite(siteSyncObservedForWrite)
-        ? Math.trunc(siteSyncObservedForWrite)
-        : currentSync !== null && Number.isFinite(currentSync)
-          ? Math.trunc(currentSync)
-          : null;
     const inferredFromPointsType: "FWA" | "MM" | null = hasOpponentPoints ? "FWA" : "MM";
     const matchType = matchTypeResolved ?? inferredFromPointsType ?? "UNKNOWN";
     const inferredMatchType = Boolean(sub?.inferredMatchType) || (matchTypeResolved === null && inferredFromPointsType !== null);
@@ -5019,7 +5001,6 @@ export async function runForceSyncDataCommand(
   const rawTag = interaction.options.getString("tag", true);
   const tag = normalizeTag(rawTag);
   const datapoint = interaction.options.getString("datapoint", false) ?? "all";
-  const shouldOverwritePoints = datapoint === "all" || datapoint === "points";
   const trackedClan = await prisma.trackedClan.findFirst({
     where: { tag: { equals: `#${tag}`, mode: "insensitive" } },
     select: { tag: true, name: true },
@@ -5031,7 +5012,6 @@ export async function runForceSyncDataCommand(
 
   const war = await getCurrentWarCached(cocService, tag, warLookupCache).catch(() => null);
   const opponentTag = normalizeTag(String(war?.opponent?.tag ?? ""));
-  const opponentName = sanitizeClanName(String(war?.opponent?.name ?? "")) ?? null;
   const fresh = await scrapeClanPoints(tag);
 
   const siteSync = fresh.winnerBoxSync;
@@ -6441,12 +6421,6 @@ export const Fwa: Command = {
         const hasPrimaryPoints = primary.balance !== null && !Number.isNaN(primary.balance);
         const hasOpponentPoints = opponent.balance !== null && !Number.isNaN(opponent.balance);
         const siteSyncObservedForWrite = primary.winnerBoxSync ?? null;
-        const syncNumberForWrite =
-          siteSyncObservedForWrite !== null && Number.isFinite(siteSyncObservedForWrite)
-            ? Math.trunc(siteSyncObservedForWrite)
-            : currentSync !== null && Number.isFinite(currentSync)
-              ? Math.trunc(currentSync)
-              : null;
         if (!hasPrimaryPoints && hasOpponentPoints) {
           await editReplySafe(`Could not fetch point balance for #${tag}.`);
           return;

--- a/src/commands/Recruitment.ts
+++ b/src/commands/Recruitment.ts
@@ -9,7 +9,6 @@ import {
   TextInputBuilder,
   TextInputStyle,
 } from "discord.js";
-import { Prisma } from "@prisma/client";
 import { Command } from "../Command";
 import { truncateDiscordContent } from "../helper/discordContent";
 import { formatError } from "../helper/formatError";

--- a/src/helper/safeReply.ts
+++ b/src/helper/safeReply.ts
@@ -1,4 +1,4 @@
-import { ChatInputCommandInteraction, DiscordAPIError } from "discord.js";
+import { ChatInputCommandInteraction } from "discord.js";
 import { formatError } from "./formatError";
 import { truncateDiscordContent } from "./discordContent";
 

--- a/src/services/GoogleSheetsService.ts
+++ b/src/services/GoogleSheetsService.ts
@@ -26,7 +26,7 @@ export class GoogleSheetsService {
   constructor(private settings: SettingsService) {}
 
   async getLinkedSheet(
-    mode?: GoogleSheetMode
+    _mode?: GoogleSheetMode
   ): Promise<{ sheetId: string; tabName: string | null }> {
     const sheetId = await this.settings.get(SHEET_SETTING_ID_KEY);
     const tabName = await this.settings.get(SHEET_SETTING_TAB_KEY);

--- a/src/services/PointsProjectionService.ts
+++ b/src/services/PointsProjectionService.ts
@@ -193,7 +193,6 @@ export class PointsProjectionService {
   /** Purpose: build projection. */
   buildProjection(primary: Snapshot, opponent: Snapshot): string {
     const primaryName = primary.clanName ?? primary.tag;
-    const opponentName = opponent.clanName ?? opponent.tag;
     const x = primary.balance ?? 0;
     const y = opponent.balance ?? 0;
 

--- a/src/services/WarEventLogService.ts
+++ b/src/services/WarEventLogService.ts
@@ -28,7 +28,6 @@ import {
   deriveState,
   eventTitle,
   formatList,
-  formatPercent,
   normalizeOutcome,
   normalizeTag,
   normalizeTagBare,

--- a/src/services/war-events/history.ts
+++ b/src/services/war-events/history.ts
@@ -87,7 +87,7 @@ export class WarEventHistoryService {
     expectedOutcomeOrClanTag: "WIN" | "LOSE" | string | null,
     clanTagOrOpponentName?: string | null,
     opponentNameInput?: string | null,
-    phase: "prep" | "battle" = "battle"
+    _phase: "prep" | "battle" = "battle"
   ): Promise<string | null> {
     let guildId: string | null | undefined = guildIdOrMatchType;
     let matchType = matchTypeOrExpectedOutcome as MatchType;

--- a/src/services/war-events/pointsSync.ts
+++ b/src/services/war-events/pointsSync.ts
@@ -92,8 +92,8 @@ export class WarStartPointsSyncService {
   async maybeRunWarStartPointsCheck(
     sub: PointsSyncSubscriptionLike,
     opponentTagInput: string,
-    clanNameInput: string | null,
-    opponentNameInput: string | null
+    _clanNameInput: string | null,
+    _opponentNameInput: string | null
   ): Promise<void> {
     const clanTag = normalizeTag(sub.clanTag);
     const opponentTag = normalizeTag(opponentTagInput);


### PR DESCRIPTION
…ices

- remove unused imports and locals in fwa, recruitment, and helper modules
- prefix intentionally unused params/helpers with _ for lint compliance
- clean unused utility references in war-event and projection services
- leave runtime behavior unchanged while bringing eslint output to zero warnings