### PR TITLE
fix(warplan): apply custom plan text in mails and event embeds

### DIFF
--- a/src/commands/WarPlan.ts
+++ b/src/commands/WarPlan.ts
@@ -77,7 +77,7 @@ async function resolveCustomEmojiShortcodes(
   }
 
   return text.replace(
-    /(^|[\s([{"'])\:([a-zA-Z0-9_]{2,32})\:(?=$|[\s)\]}".,!?:;'"-])/g,
+    /(^|[\s([{"']):([a-zA-Z0-9_]{2,32}):(?=$|[\s)\]}".,!?:;'"-])/g,
     (full, prefix: string, emojiName: string) => {
       const match = guild.emojis.cache.find((emoji) => emoji.name === emojiName);
       if (!match) return full;

--- a/src/services/war-events/history.ts
+++ b/src/services/war-events/history.ts
@@ -108,6 +108,7 @@ export class WarEventHistoryService {
     }
 
     const normalizedClanTag = normalizeTag(clanTag);
+    const normalizedClanTagHash = normalizedClanTag ? `#${normalizedClanTag}` : "";
     const opponentName = String(opponentNameInputResolved ?? "").trim() || "Unknown";
     let loseStyleCache: FwaLoseStyle | null = null;
     const getLoseStyle = async (): Promise<FwaLoseStyle> => {
@@ -136,7 +137,10 @@ export class WarEventHistoryService {
           where: {
             guildId,
             scope: "CUSTOM",
-            clanTag: normalizedClanTag,
+            OR: [
+              { clanTag: normalizedClanTag },
+              { clanTag: normalizedClanTagHash },
+            ],
             matchType: matchTypeKey,
             outcome: outcomeKey,
             loseStyle: { in: [loseStyleKey, "ANY"] },
@@ -610,8 +614,13 @@ export class WarEventHistoryService {
   private async getLoseStyleForClan(clanTagInput: string): Promise<FwaLoseStyle> {
     const clanTag = normalizeTag(clanTagInput);
     if (!clanTag) return "TRIPLE_TOP_30";
-    const row = await prisma.trackedClan.findUnique({
-      where: { tag: clanTag },
+    const row = await prisma.trackedClan.findFirst({
+      where: {
+        OR: [
+          { tag: `#${clanTag}` },
+          { tag: clanTag },
+        ],
+      },
       select: { loseStyle: true },
     });
     const loseStyle = String(row?.loseStyle ?? "").toUpperCase();


### PR DESCRIPTION
- make custom warplan lookup accept both TAG and #TAG clanTag formats
- fix lose-style lookup to match tracked clan tags stored with # prefix
- keep fallback behavior unchanged when no custom/default row exists
- fix warplan emoji shortcode regex escaping to satisfy lint