### PR TITLE
fix(warplan): resolve custom MM plan lookup for legacy clan tag formats

### DIFF
--- a/src/services/war-events/history.ts
+++ b/src/services/war-events/history.ts
@@ -138,8 +138,8 @@ export class WarEventHistoryService {
             guildId,
             scope: "CUSTOM",
             OR: [
-              { clanTag: normalizedClanTag },
-              { clanTag: normalizedClanTagHash },
+              { clanTag: { equals: normalizedClanTag, mode: "insensitive" } },
+              { clanTag: { equals: normalizedClanTagHash, mode: "insensitive" } },
             ],
             matchType: matchTypeKey,
             outcome: outcomeKey,
@@ -617,8 +617,8 @@ export class WarEventHistoryService {
     const row = await prisma.trackedClan.findFirst({
       where: {
         OR: [
-          { tag: `#${clanTag}` },
-          { tag: clanTag },
+          { tag: { equals: `#${clanTag}`, mode: "insensitive" } },
+          { tag: { equals: clanTag, mode: "insensitive" } },
         ],
       },
       select: { loseStyle: true },


### PR DESCRIPTION
- make custom warplan lookup case-insensitive for TAG and #TAG values
- make tracked-clan lose-style lookup case-insensitive for TAG and #TAG
- ensure custom clan MM plans are found in mail/event embed rendering paths