### PR TITLE
fix(fwa-mail): apply clan custom warplan text to sent mail

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Discord bot for Clash of Clans activity tooling.
 - Manages tracked clans and roster/sheet integrations.
 - Provides FWA points and matchup tooling.
 - Supports tracked-clan mail channel config via `/tracked-clan configure` and send-preview flow via `/fwa mail send`.
-- Supports configurable war plans by match type/outcome via `/warplan set|show|reset`.
+- Supports configurable war plans by match type/outcome via `/warplan set|show|reset`; these templates are used in posted war mail content (including line breaks, emoji, and media links).
 
 ## Quick Start
 ```bash

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -22,7 +22,7 @@
 - `/cc clan tag:<tag>` - Build `https://cc.fwafarm.com/cc_n/clan.php?tag=<tag>`.
 - `/notify war clan-tag:<tag> target-channel:<channel> [role:<discordRole>]` - Enable war-state event logs (war start, battle day, war end) for a clan in a selected channel. Optional role is pinged when event logs are posted.
 - `/notify war-preview clan-tag:<tag> event:<war_started|battle_day|war_ended> [source:current|last]` - Show an ephemeral preview embed and confirm before posting publicly to the configured notify channel.
-- `/warplan set clan-tag:<tag> match-type:<BL|MM|FWA|FWA_WIN|FWA_LOSE_TRIPLE_TOP_30|FWA_LOSE_TRADITIONAL>` - Opens a modal to edit one clan custom plan. `clan-tag` supports autocomplete from tracked clans. Modal supports normal new lines plus markdown (bold/italic/code/code blocks).
+- `/warplan set clan-tag:<tag> match-type:<BL|MM|FWA|FWA_WIN|FWA_LOSE_TRIPLE_TOP_30|FWA_LOSE_TRADITIONAL>` - Opens a modal to edit one clan custom plan. `clan-tag` supports autocomplete from tracked clans. Modal supports normal new lines, markdown (bold/italic/code/code blocks), emoji shortcodes, and direct image/GIF links.
 - `/warplan show clan-tag:<tag> [match-type:<BL|MM|FWA|FWA_WIN|FWA_LOSE_TRIPLE_TOP_30|FWA_LOSE_TRADITIONAL>]` - Show effective clan plans. Precedence is clan custom -> editable guild default -> built-in fallback.
 - `/warplan reset clan-tag:<tag> [match-type:<BL|MM|FWA|FWA_WIN|FWA_LOSE_TRIPLE_TOP_30|FWA_LOSE_TRADITIONAL>]` - Reset clan custom plans. With no match-type, resets all custom plans for that clan.
 - `/warplan set-default match-type:<BL|MM|FWA|FWA_WIN|FWA_LOSE_TRIPLE_TOP_30|FWA_LOSE_TRADITIONAL>` - Opens a modal to edit one guild default plan used when a clan has no custom plan.

--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -900,7 +900,7 @@ function mailStatusLabelForState(state: WarStateForSync): string {
   return "Not In War";
 }
 
-function formatWarResultLabel(result: "WIN" | "LOSE" | "TIE" | "UNKNOWN"): string {
+function formatWarResultLabel(result: "WIN" | "LOSE" | "TIE" | "UNKNOWN"): "WIN" | "LOSS" | "DRAW" | "UNKNOWN" {
   if (result === "LOSE") return "LOSS";
   if (result === "TIE") return "DRAW";
   return result;
@@ -941,6 +941,48 @@ function formatWarPercent(input: unknown): string {
   const rounded = Math.round(value * 100) / 100;
   const withPrecision = Number.isInteger(rounded) ? `${rounded}` : `${rounded.toFixed(2)}`;
   return `${withPrecision.replace(/\.00$/, "")}%`;
+}
+
+function buildWarStatsLines(input: {
+  clanStars: unknown;
+  opponentStars: unknown;
+  clanAttacks: unknown;
+  opponentAttacks: unknown;
+  teamSize: unknown;
+  attacksPerMember: unknown;
+  clanDestruction: unknown;
+  opponentDestruction: unknown;
+}): string[] {
+  const starsLeft = formatWarInt(input.clanStars);
+  const starsRight = formatWarInt(input.opponentStars);
+  const attacksPerMember = Number.isFinite(Number(input.attacksPerMember))
+    ? Math.max(1, Math.trunc(Number(input.attacksPerMember)))
+    : 2;
+  const teamSize = Number.isFinite(Number(input.teamSize))
+    ? Math.max(1, Math.trunc(Number(input.teamSize)))
+    : 0;
+  const totalAttacks = teamSize > 0 ? teamSize * attacksPerMember : 0;
+  const attacksLeft = formatWarInt(input.clanAttacks);
+  const attacksRight = formatWarInt(input.opponentAttacks);
+  const attacksLeftText = totalAttacks > 0 ? `${attacksLeft}/${totalAttacks}` : `${attacksLeft}/?`;
+  const attacksRightText = totalAttacks > 0 ? `${attacksRight}/${totalAttacks}` : `${attacksRight}/?`;
+  return [
+    formatWarStatLine(starsLeft, ":star:", starsRight),
+    formatWarStatLine(attacksLeftText, ":crossed_swords:", attacksRightText),
+    formatWarStatLine(formatWarPercent(input.clanDestruction), ":boom:", formatWarPercent(input.opponentDestruction)),
+  ];
+}
+
+function mailStatusColorForState(state: WarStateForSync): number {
+  if (state === "preparation") return 0x3498db;
+  if (state === "inWar") return 0xf1c40f;
+  return 0x2ecc71;
+}
+
+function mailStatusTitleForState(state: WarStateForSync): string {
+  if (state === "preparation") return "War Started";
+  if (state === "inWar") return "Battle Day Started";
+  return "War Ended";
 }
 
 async function upsertCurrentWarHistoryAndGetWarId(params: {
@@ -990,6 +1032,7 @@ async function buildWarMailEmbedForTag(
   tag: string
 ): Promise<{
   embed: EmbedBuilder;
+  planText: string;
   inferredMatchType: boolean;
   mailChannelId: string | null;
   clanRoleId: string | null;
@@ -1133,22 +1176,14 @@ async function buildWarMailEmbedForTag(
       opponentTag: effectiveOpponentTag,
       war,
     })) ?? (await getCurrentWarIdForClan(guildId, normalizedTag, effectiveWarStartMs));
-  const starsLeft = formatWarInt(war?.clan?.stars);
-  const starsRight = formatWarInt(war?.opponent?.stars);
-  const attacksPerMember = Number.isFinite(Number(war?.attacksPerMember))
-    ? Math.max(1, Math.trunc(Number(war?.attacksPerMember)))
-    : 2;
-  const teamSize = Number.isFinite(Number(war?.teamSize))
-    ? Math.max(1, Math.trunc(Number(war?.teamSize)))
-    : 0;
-  const totalAttacks = teamSize > 0 ? teamSize * attacksPerMember : 0;
-  const attacksLeft = formatWarInt(war?.clan?.attacks);
-  const attacksRight = formatWarInt(war?.opponent?.attacks);
-  const attacksLeftText = totalAttacks > 0 ? `${attacksLeft}/${totalAttacks}` : `${attacksLeft}/?`;
-  const attacksRightText = totalAttacks > 0 ? `${attacksRight}/${totalAttacks}` : `${attacksRight}/?`;
-  const destructionLeft = formatWarPercent(war?.clan?.destructionPercentage);
-  const destructionRight = formatWarPercent(war?.opponent?.destructionPercentage);
-  const lines: string[] = [];
+  let displayClanStars = war?.clan?.stars ?? null;
+  let displayOpponentStars = war?.opponent?.stars ?? null;
+  let displayClanDestruction = war?.clan?.destructionPercentage ?? null;
+  let displayOpponentDestruction = war?.opponent?.destructionPercentage ?? null;
+  let statusLabel = mailStatusLabelForState(warState);
+  let timeFieldName = warState === "preparation" ? "Prep Day Remaining" : "Battle Day Remaining";
+  let timeFieldValue = remainingText;
+  let finalOutcomeLabel: "WIN" | "LOSS" | "DRAW" | "UNKNOWN" | null = null;
   if (freezeRefresh) {
     const finalResult = await history.getWarEndResultSnapshot({
       clanTag: normalizedTag,
@@ -1162,34 +1197,25 @@ async function buildWarMailEmbedForTag(
       subscription?.endTime?.getTime() ??
       battleTargetMs ??
       null;
-    lines.push(
-      `War Status: War Ended`,
-      `Time ended: ${formatDiscordFullAndRelativeMs(endedAtMs)}`,
-      "",
-      `Actual outcome: **${formatWarResultLabel(finalResult.resultLabel)}**`,
-      "",
-      "War Stats",
-      formatWarStatLine(formatWarInt(finalResult.clanStars), ":star:", formatWarInt(finalResult.opponentStars)),
-      formatWarStatLine(attacksLeftText, ":crossed_swords:", attacksRightText),
-      formatWarStatLine(
-        formatWarPercent(finalResult.clanDestruction),
-        ":boom:",
-        formatWarPercent(finalResult.opponentDestruction)
-      )
-    );
-  } else {
-    lines.push(
-      planText,
-      "------",
-      `War Status: ${mailStatusLabelForState(warState)}`,
-      `Time remaining: ${remainingText}`,
-      "",
-      "War Stats",
-      formatWarStatLine(starsLeft, ":star:", starsRight),
-      formatWarStatLine(attacksLeftText, ":crossed_swords:", attacksRightText),
-      formatWarStatLine(destructionLeft, ":boom:", destructionRight)
-    );
+    displayClanStars = finalResult.clanStars;
+    displayOpponentStars = finalResult.opponentStars;
+    displayClanDestruction = finalResult.clanDestruction;
+    displayOpponentDestruction = finalResult.opponentDestruction;
+    statusLabel = "War Ended";
+    timeFieldName = "Time Ended";
+    timeFieldValue = formatDiscordFullAndRelativeMs(endedAtMs);
+    finalOutcomeLabel = formatWarResultLabel(finalResult.resultLabel);
   }
+  const warStatsLines = buildWarStatsLines({
+    clanStars: displayClanStars,
+    opponentStars: displayOpponentStars,
+    clanAttacks: war?.clan?.attacks ?? null,
+    opponentAttacks: war?.opponent?.attacks ?? null,
+    teamSize: war?.teamSize ?? null,
+    attacksPerMember: war?.attacksPerMember ?? null,
+    clanDestruction: displayClanDestruction,
+    opponentDestruction: displayOpponentDestruction,
+  });
 
   const unavailableReasons: string[] = [];
   if (!trackedConfig.mailChannelId) {
@@ -1198,18 +1224,64 @@ async function buildWarMailEmbedForTag(
   if (inferredMatchType) {
     unavailableReasons.push("Match type is inferred. Confirm match type before sending war mail.");
   }
-  if (unavailableReasons.length > 0) {
-    lines.push("", ...unavailableReasons.map((r) => `:warning: ${r}`));
-  }
 
   const embed = new EmbedBuilder()
-    .setTitle(`War Mail - ${clanName} (#${normalizedTag})`)
-    .setDescription(lines.join("\n"))
+    .setTitle(`Event: ${mailStatusTitleForState(warState)} - ${clanName} (#${normalizedTag})`)
+    .setColor(mailStatusColorForState(warState))
     .setFooter({ text: `War ID: ${warId ?? "unknown"}` })
     .setTimestamp(new Date());
+  embed.addFields(
+    {
+      name: "Opponent",
+      value: `${effectiveOpponentName} (${effectiveOpponentTag ? `#${effectiveOpponentTag}` : "unknown"})`,
+      inline: false,
+    },
+    {
+      name: "War Status",
+      value: statusLabel,
+      inline: true,
+    },
+    {
+      name: timeFieldName,
+      value: timeFieldValue,
+      inline: true,
+    },
+    {
+      name: "Match Type",
+      value: matchType,
+      inline: true,
+    }
+  );
+  if (matchType === "FWA" && expectedOutcome) {
+    embed.addFields({
+      name: "Expected Outcome",
+      value: expectedOutcome,
+      inline: true,
+    });
+  }
+  if (finalOutcomeLabel) {
+    embed.addFields({
+      name: "Final Result",
+      value: finalOutcomeLabel,
+      inline: true,
+    });
+  }
+  embed.addFields({
+    name: "War Stats",
+    value: warStatsLines.join("\n"),
+    inline: false,
+  });
+  if (unavailableReasons.length > 0) {
+    embed.addFields({
+      name: "Warnings",
+      value: unavailableReasons.map((reason) => `:warning: ${reason}`).join("\n"),
+      inline: false,
+    });
+  }
 
   return {
     embed,
+    planText,
     inferredMatchType,
     mailChannelId: trackedConfig.mailChannelId,
     clanRoleId: trackedConfig.clanRoleId,
@@ -1404,6 +1476,13 @@ function buildSupersededWarMailDescription(params: {
 
 export const buildSupersededWarMailDescriptionForTest = buildSupersededWarMailDescription;
 
+function buildSupersededWarMailContent(params: {
+  changedAtMs: number;
+  revisionLines: string[];
+}): string {
+  return limitDiscordContent(`:warning: ${buildSupersededWarMailDescription(params)}`);
+}
+
 function stopWarMailPolling(key: string): void {
   const timer = fwaMailPollers.get(key);
   if (timer) {
@@ -1432,14 +1511,17 @@ async function annotatePreviousWarMailRevision(params: {
   if (!channel || !channel.isTextBased()) return false;
   const message = await (channel as any).messages.fetch(params.previous.messageId).catch(() => null);
   if (!message) return false;
+  const supersededSummary = buildSupersededWarMailDescription({
+    changedAtMs: params.changedAtMs,
+    revisionLines,
+  });
   const previousEmbed = message.embeds[0] ? EmbedBuilder.from(message.embeds[0]) : new EmbedBuilder();
-  previousEmbed.setDescription(
-    buildSupersededWarMailDescription({
+  previousEmbed.setDescription(supersededSummary.slice(0, 4096));
+  await message.edit({
+    content: buildSupersededWarMailContent({
       changedAtMs: params.changedAtMs,
       revisionLines,
-    }).slice(0, 4096)
-  );
-  await message.edit({
+    }),
     embeds: [previousEmbed],
     components: [],
   });
@@ -1505,15 +1587,24 @@ function buildNextRefreshRelativeLabel(
 function buildWarMailPostedContent(
   roleId?: string | null,
   nowMs?: number,
-  options?: { pingRole?: boolean }
+  options?: { pingRole?: boolean; planText?: string }
 ): string {
   const nextRefresh = buildNextRefreshRelativeLabel(
     WAR_MAIL_REFRESH_MS,
     nowMs,
     getNextWarMailRefreshAtMs()
   );
-  if (roleId && options?.pingRole !== false) return `<@&${roleId}>\n${nextRefresh}`;
-  return nextRefresh;
+  const planText = String(options?.planText ?? "").trim();
+  if (!planText) {
+    if (roleId && options?.pingRole !== false) return `<@&${roleId}>\n${nextRefresh}`;
+    return nextRefresh;
+  }
+  const sections: string[] = [];
+  if (roleId && options?.pingRole !== false) {
+    sections.push(`<@&${roleId}>`);
+  }
+  sections.push(planText, nextRefresh);
+  return limitDiscordContent(sections.join("\n\n"));
 }
 
 export const buildWarMailPostedContentForTest = buildWarMailPostedContent;
@@ -1532,7 +1623,13 @@ async function refreshWarMailPost(
   const message = await (channel as any).messages.fetch(payload.messageId).catch(() => null);
   if (!message) return "missing";
   await message.edit({
-    content: rendered.freezeRefresh ? undefined : buildWarMailPostedContent(),
+    content:
+      rendered.freezeRefresh
+        ? undefined
+        : buildWarMailPostedContent(undefined, undefined, {
+            pingRole: false,
+            planText: rendered.planText,
+          }),
     embeds: [rendered.embed],
     components: rendered.freezeRefresh ? [] : buildWarMailPostedComponents(key),
   });
@@ -1567,7 +1664,13 @@ async function refreshWarMailPostByResolvedTarget(params: {
   const cocService = new CoCService();
   const rendered = await buildWarMailEmbedForTag(cocService, params.guildId, normalizedTag);
   await message.edit({
-    content: rendered.freezeRefresh ? undefined : buildWarMailPostedContent(),
+    content:
+      rendered.freezeRefresh
+        ? undefined
+        : buildWarMailPostedContent(undefined, undefined, {
+            pingRole: false,
+            planText: rendered.planText,
+          }),
     embeds: [rendered.embed],
     components: rendered.freezeRefresh ? [] : buildWarMailPostedComponents(params.key ?? createTransientFwaKey()),
   });
@@ -2718,9 +2821,12 @@ async function showWarMailPreview(
     enabled || rendered.mailChannelId
       ? ""
       : "\n:warning: Tracked clan mail channel is missing or unavailable.";
-  const content = enabled
+  const previewSummary = enabled
     ? "Review mail preview and confirm send."
     : `Cannot send yet.${extraWarning}`;
+  const content = limitDiscordContent(
+    [previewSummary, "", "**Mail Text Preview**", rendered.planText].filter((part) => part.trim().length > 0).join("\n")
+  );
 
   if (interaction.isButton()) {
     await interaction.update({
@@ -2938,6 +3044,7 @@ async function handleFwaMailConfirmAction(
       ? undefined
       : buildWarMailPostedContent(rendered.clanRoleId, undefined, {
           pingRole: options.pingRole,
+          planText: rendered.planText,
         }),
     allowedMentions:
       options.pingRole && rendered.clanRoleId ? { roles: [rendered.clanRoleId] } : undefined,

--- a/src/commands/WarPlan.ts
+++ b/src/commands/WarPlan.ts
@@ -67,21 +67,40 @@ async function resolveCustomEmojiShortcodes(
   text: string,
   interaction: ChatInputCommandInteraction
 ): Promise<string> {
-  const guild = interaction.guild;
-  if (!guild) return text;
+  const exact = new Map<string, string>();
+  const lowercase = new Map<string, string>();
+  const pushEmoji = (name: string | null | undefined, token: string): void => {
+    if (!name) return;
+    if (!exact.has(name)) {
+      exact.set(name, token);
+    }
+    const lowered = name.toLowerCase();
+    if (!lowercase.has(lowered)) {
+      lowercase.set(lowered, token);
+    }
+  };
 
-  try {
-    await guild.emojis.fetch();
-  } catch {
-    return text;
+  const guild = interaction.guild;
+  if (guild) {
+    try {
+      await guild.emojis.fetch();
+    } catch {
+      // Keep going; we can still use cached/global emojis.
+    }
+    for (const emoji of guild.emojis.cache.values()) {
+      pushEmoji(emoji.name, `<${emoji.animated ? "a" : ""}:${emoji.name}:${emoji.id}>`);
+    }
+  }
+
+  for (const emoji of interaction.client.emojis.cache.values()) {
+    pushEmoji(emoji.name, `<${emoji.animated ? "a" : ""}:${emoji.name}:${emoji.id}>`);
   }
 
   return text.replace(
     /(^|[\s([{"']):([a-zA-Z0-9_]{2,32}):(?=$|[\s)\]}".,!?:;'"-])/g,
     (full, prefix: string, emojiName: string) => {
-      const match = guild.emojis.cache.find((emoji) => emoji.name === emojiName);
-      if (!match) return full;
-      const token = `<${match.animated ? "a" : ""}:${match.name}:${match.id}>`;
+      const token = exact.get(emojiName) ?? lowercase.get(emojiName.toLowerCase());
+      if (!token) return full;
       return `${prefix}${token}`;
     }
   );

--- a/tests/fwaMailDownstream.logic.test.ts
+++ b/tests/fwaMailDownstream.logic.test.ts
@@ -54,4 +54,14 @@ describe("fwa war-mail posted content", () => {
     const content = buildWarMailPostedContentForTest("123456789", 0, { pingRole: false });
     expect(content).toBe("Next refresh <t:1200:R>");
   });
+
+  it("keeps custom mail text in posted content", () => {
+    const content = buildWarMailPostedContentForTest("123456789", 0, {
+      pingRole: true,
+      planText: "Custom war mail line 1\nCustom war mail line 2",
+    });
+    expect(content).toBe(
+      "<@&123456789>\n\nCustom war mail line 1\nCustom war mail line 2\n\nNext refresh <t:1200:R>"
+    );
+  });
 });

--- a/tests/warPlanText.test.ts
+++ b/tests/warPlanText.test.ts
@@ -1,7 +1,12 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { prisma } from "../src/prisma";
 import { WarEventHistoryService } from "../src/services/war-events/history";
 
 describe("WarEventHistoryService.buildWarPlanText", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("returns exact WIN plan lines", async () => {
     const svc = new WarEventHistoryService({} as never);
     const out = await svc.buildWarPlanText("FWA", "WIN", "ABC123", "OPPONENT_NAME");
@@ -41,6 +46,50 @@ describe("WarEventHistoryService.buildWarPlanText", () => {
         "⏳ Last 12hrs: ★ ★ ☆ -> any",
         "🎯 Do NOT surpass 100 ★",
       ].join("\n")
+    );
+  });
+
+  it("prefers clan custom plan text for guild-scoped lookups", async () => {
+    const svc = new WarEventHistoryService({} as never);
+    const planSpy = vi.spyOn(prisma.clanWarPlan, "findFirst");
+    planSpy.mockResolvedValueOnce({ planText: "MM custom plan vs {opponent}" } as any);
+
+    const out = await svc.buildWarPlanText("123456789012345678", "MM", null, "ABC123", "OPPONENT_NAME");
+
+    expect(out).toBe("MM custom plan vs OPPONENT_NAME");
+    expect(planSpy).toHaveBeenCalledTimes(1);
+    expect(planSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          guildId: "123456789012345678",
+          scope: "CUSTOM",
+          matchType: "MM",
+          outcome: "ANY",
+        }),
+      })
+    );
+  });
+
+  it("falls back to editable guild default when clan custom is missing", async () => {
+    const svc = new WarEventHistoryService({} as never);
+    const planSpy = vi.spyOn(prisma.clanWarPlan, "findFirst");
+    planSpy
+      .mockResolvedValueOnce(null as any)
+      .mockResolvedValueOnce({ planText: "BL default plan vs {opponent}" } as any);
+
+    const out = await svc.buildWarPlanText("123456789012345678", "BL", null, "ABC123", "OPPONENT_NAME");
+
+    expect(out).toBe("BL default plan vs OPPONENT_NAME");
+    expect(planSpy).toHaveBeenCalledTimes(2);
+    expect(planSpy.mock.calls[1]?.[0]).toEqual(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          guildId: "123456789012345678",
+          scope: "DEFAULT",
+          matchType: "BL",
+          outcome: "ANY",
+        }),
+      })
     );
   });
 });


### PR DESCRIPTION
- render warplan text in message content so formatting/media links persist
- align war-mail embed with notify-style status/stats fields
- resolve emoji shortcodes from guild and client emoji caches
- add tests for guild custom/default plan lookup and mail content formatting