### PR TITLE
fix(fwa-mail): ping clan role and standardize plan headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Discord bot for Clash of Clans activity tooling.
 - Provides FWA points and matchup tooling.
 - Uses cached `/fwa match` rendering with processing indicators for faster button interactions.
 - Supports tracked-clan mail channel config via `/tracked-clan configure` and send-preview flow via `/fwa mail send`.
+- War mail send paths now mention the tracked clan role (`TrackedClan.clanRoleId`) when pinging is enabled.
 - Supports configurable war plans by match type/outcome via `/warplan set|show|reset`; these templates are used in posted war mail content (including line breaks, emoji, and media links).
 
 ## Quick Start

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -34,8 +34,8 @@
 - `/fwa points [visibility:private|public] [tag:<tag>]` - Fetch current point balance from `https://points.fwafarm.com/clan?tag=<tag-without-#>`. If `tag` is omitted, fetches all tracked clans.
 - `/fwa match [visibility:private|public] tag:<tag>` - Resolve current war opponent from CoC API, render cached matchup state, and project win/lose by points (or sync-based tiebreak on tie). Slow in-message actions now show a processing notice while updates run.
 - `/fwa match-type [visibility:private|public] [tag:<trackedClanTag>] [type:FWA|BL|MM]` - Manually set or view per-clan match type override used by matchup output. If no args, lists overrides for all tracked clans.
-- `/fwa mail send tag:<trackedClanTag>` - Show ephemeral war mail preview with confirm-and-send to the tracked clan mail channel.
-- `/fwa match` single-clan view includes a `Send Mail` button that follows the same access policy as `/fwa mail send`.
+- `/fwa mail send tag:<trackedClanTag>` - Show ephemeral war mail preview with confirm-and-send to the tracked clan mail channel. Confirm-and-send pings `TrackedClan.clanRoleId` when enabled.
+- `/fwa match` single-clan view includes a `Send Mail` button that follows the same access policy as `/fwa mail send` and uses the same role-ping behavior.
 - `/recruitment show platform:discord|reddit|band clan:<tag>` - Render platform-specific recruitment template output for a tracked clan.
 - `/recruitment edit platform:discord|reddit|band clan:<tag>` - Open platform-specific modal:
   - Discord: clan tag, body (max 1024), optional image URL(s)

--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -182,6 +182,14 @@ function normalizeTag(input: string): string {
   return input.trim().toUpperCase().replace(/^#/, "");
 }
 
+/** Purpose: normalize stored role values to a raw Discord role ID. */
+function normalizeDiscordRoleId(input: string | null | undefined): string | null {
+  const raw = String(input ?? "").trim();
+  if (!raw) return null;
+  const idMatch = raw.match(/\d{5,}/);
+  return idMatch?.[0] ?? null;
+}
+
 function buildPointsUrl(tag: string): string {
   const normalizedTag = normalizeTag(tag);
   const proxyBase = (process.env.POINTS_PROXY_URL ?? "").trim();
@@ -750,7 +758,7 @@ async function getTrackedClanMailConfig(tag: string): Promise<{
     tag: normalizeTag(row.tag),
     name: sanitizeClanName(row.name ?? "") ?? null,
     mailChannelId: row.mailChannelId ?? null,
-    clanRoleId: row.clanRoleId ?? null,
+    clanRoleId: normalizeDiscordRoleId(row.clanRoleId ?? null),
   };
 }
 
@@ -1166,24 +1174,25 @@ async function buildWarMailEmbedForTag(
     outcome,
     normalizedTag,
     effectiveOpponentName,
-    hasLiveWar && warState === "inWar" ? "battle" : "prep"
+    hasLiveWar && warState === "inWar" ? "battle" : "prep",
+    clanName
   );
   if (customOrDefaultPlan) {
     planText = customOrDefaultPlan;
   } else if (matchType === "BL") {
     planText = [
-      `**⚫️ BLACKLIST WAR 🆚 ${opponentName} 🏴‍☠️**`,
+      `# ⚫ ${clanName} vs ${effectiveOpponentName} 🏴‍☠️`,
       "Everyone switch to WAR BASES!!",
       "This is our opportunity to gain some extra FWA points!",
       "➕ 30+ people switch to war base = +1 point",
       "➕ 60% total destruction = +1 point",
       "➕ win war = +1 point",
       "---",
-      "If you need war base, check https://clashofclans-layouts.com/ or ⁠bases",
+      "If you need war base, check https://clashofclans-layouts.com/ or bases",
     ].join("\n");
   } else if (matchType === "MM") {
     planText = [
-      `⚪️ MISMATCHED WAR 🆚 ${opponentName} :sob:`,
+      `# ⚪ ${clanName} vs ${effectiveOpponentName} :sob:`,
       "Keep WA base active, attack what you can!",
     ].join("\n");
   }
@@ -1618,23 +1627,32 @@ function buildNextRefreshRelativeLabel(
 function buildWarMailPostedContent(
   roleId?: string | null,
   nowMs?: number,
-  options?: { pingRole?: boolean; planText?: string }
+  options?: { pingRole?: boolean; planText?: string; includeNextRefresh?: boolean }
 ): string {
-  const nextRefresh = buildNextRefreshRelativeLabel(
-    WAR_MAIL_REFRESH_MS,
-    nowMs,
-    getNextWarMailRefreshAtMs()
-  );
+  const normalizedRoleId = normalizeDiscordRoleId(roleId);
+  const includeNextRefresh = options?.includeNextRefresh !== false;
+  const nextRefresh = includeNextRefresh
+    ? buildNextRefreshRelativeLabel(
+        WAR_MAIL_REFRESH_MS,
+        nowMs,
+        getNextWarMailRefreshAtMs()
+      )
+    : "";
   const planText = String(options?.planText ?? "").trim();
   if (!planText) {
-    if (roleId && options?.pingRole !== false) return `<@&${roleId}>\n${nextRefresh}`;
-    return nextRefresh;
+    if (normalizedRoleId && options?.pingRole !== false) {
+      return includeNextRefresh ? `<@&${normalizedRoleId}>\n${nextRefresh}` : `<@&${normalizedRoleId}>`;
+    }
+    return nextRefresh || "War plan unavailable.";
   }
   const sections: string[] = [];
-  if (roleId && options?.pingRole !== false) {
-    sections.push(`<@&${roleId}>`);
+  if (normalizedRoleId && options?.pingRole !== false) {
+    sections.push(`<@&${normalizedRoleId}>`);
   }
-  sections.push(planText, nextRefresh);
+  sections.push(planText);
+  if (nextRefresh) {
+    sections.push(nextRefresh);
+  }
   return limitDiscordContent(sections.join("\n\n"));
 }
 
@@ -3127,15 +3145,15 @@ async function handleFwaMailConfirmAction(
     return;
   }
   const postKey = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
+  const mentionRoleId = normalizeDiscordRoleId(rendered.clanRoleId);
   const sent = await (channel as any).send({
-    content: rendered.freezeRefresh
-      ? undefined
-      : buildWarMailPostedContent(rendered.clanRoleId, undefined, {
-          pingRole: options.pingRole,
-          planText: rendered.planText,
-        }),
+    content: buildWarMailPostedContent(mentionRoleId, undefined, {
+      pingRole: options.pingRole,
+      planText: rendered.planText,
+      includeNextRefresh: !rendered.freezeRefresh,
+    }),
     allowedMentions:
-      options.pingRole && rendered.clanRoleId ? { roles: [rendered.clanRoleId] } : undefined,
+      options.pingRole && mentionRoleId ? { roles: [mentionRoleId] } : undefined,
     embeds: [rendered.embed],
     components: rendered.freezeRefresh ? [] : buildWarMailPostedComponents(postKey),
   });
@@ -7272,9 +7290,4 @@ export const Fwa: Command = {
     await interaction.respond(choices);
   },
 };
-
-
-
-
-
 

--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -218,6 +218,7 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
       "If match type is inferred, `/fwa match` shows a warning and quick verify link, with action buttons to confirm FWA/BL/MM.",
       "Tracked clan mail channel is configured via `/tracked-clan configure ... mail-channel`.",
       "`/fwa mail send` opens an ephemeral war mail preview with confirm/send.",
+      "Confirm-and-send pings the tracked clan role (`TrackedClan.clanRoleId`) when pinging is enabled.",
       "The `/fwa match` single-clan `Send Mail` button uses the same permissions as `/fwa mail send`.",
       "Default access for `/fwa mail send` is FWA leader role + Administrator (or override via `/permission add command:fwa:mail:send`).",
       "`/fwa leader-role` sets the default FWA leader role used by leader-only commands.",

--- a/src/commands/WarPlan.ts
+++ b/src/commands/WarPlan.ts
@@ -145,35 +145,25 @@ async function getDefaultPlanText(
   outcome: PlanOutcome,
   loseStyle: PlanLoseStyle
 ): Promise<string> {
-  if (matchType === "FWA" && (outcome === "WIN" || outcome === "LOSE")) {
-    const clanTagHint = loseStyle === "TRADITIONAL" ? "#LOSETRADITIONAL" : "#LOSETRIPLETOP30";
-    return (
-      (await history.buildWarPlanText(
-        guildId,
-        "FWA",
-        outcome,
-        clanTagHint,
-        "{opponent}",
-        "battle"
-      )) ?? "FWA plan unavailable."
-    );
-  }
-  if (matchType === "BL") {
-    return [
-      "\u26ab\ufe0f BLACKLIST WAR \ud83c\udd9a {opponent} \ud83c\udff4\u200d\u2620\ufe0f ",
-      "Everyone switch to WAR BASES!!",
-      "This is our opportunity to gain some extra FWA points!",
-      "\u2795 30+ people switch to war base = +1 point",
-      "\u2795 60% total destruction = +1 point",
-      "\u2795 win war = +1 point",
-      "---",
-      "If you need war base, check https://clashofclans-layouts.com/ or bases",
-    ].join("\n");
-  }
-  return [
-    "\u26aa\ufe0f MISMATCHED WAR \ud83c\udd9a {opponent} :sob:",
-    "Keep WA base active, attack what you can!",
-  ].join("\n");
+  const clanTagHint =
+    matchType === "FWA" && outcome === "LOSE"
+      ? loseStyle === "TRADITIONAL"
+        ? "#LOSETRADITIONAL"
+        : "#LOSETRIPLETOP30"
+      : "#DEFAULT";
+  const expectedOutcome =
+    matchType === "FWA" && (outcome === "WIN" || outcome === "LOSE") ? outcome : null;
+  return (
+    (await history.buildWarPlanText(
+      guildId,
+      matchType,
+      expectedOutcome,
+      clanTagHint,
+      "{opponent}",
+      "battle",
+      "{clan}"
+    )) ?? `${matchType} plan unavailable.`
+  );
 }
 
 async function getCurrentOrDefaultPlanText(params: {

--- a/src/services/WarEventLogService.ts
+++ b/src/services/WarEventLogService.ts
@@ -693,7 +693,8 @@ export class WarEventLogService {
         payload.outcome,
         payload.clanTag,
         payload.opponentName,
-        "battle"
+        "battle",
+        payload.clanName
       );
       if (battlePlanText) {
         embed.addFields({
@@ -751,7 +752,8 @@ export class WarEventLogService {
         payload.outcome,
         payload.clanTag,
         payload.opponentName,
-        "prep"
+        "prep",
+        payload.clanName
       );
       if (prepPlanText) {
         embed.addFields({
@@ -1679,7 +1681,8 @@ export class WarEventLogService {
         payload.outcome,
         payload.clanTag,
         payload.opponentName,
-        "battle"
+        "battle",
+        payload.clanName
       );
       if (battlePlanText) {
         embed.addFields({
@@ -1737,7 +1740,8 @@ export class WarEventLogService {
         payload.outcome,
         payload.clanTag,
         payload.opponentName,
-        "prep"
+        "prep",
+        payload.clanName
       );
       if (prepPlanText) {
         embed.addFields({
@@ -2321,7 +2325,8 @@ export class WarEventLogService {
       payload.outcome,
       payload.clanTag,
       payload.opponentName,
-      "battle"
+      "battle",
+      payload.clanName
     );
     if (battlePlanText) {
       embed.addFields({
@@ -2423,7 +2428,8 @@ export class WarEventLogService {
       payload.outcome,
       payload.clanTag,
       payload.opponentName,
-      "prep"
+      "prep",
+      payload.clanName
     );
     if (prepPlanText) {
       embed.addFields({

--- a/src/services/war-events/history.ts
+++ b/src/services/war-events/history.ts
@@ -87,7 +87,8 @@ export class WarEventHistoryService {
     expectedOutcomeOrClanTag: "WIN" | "LOSE" | string | null,
     clanTagOrOpponentName?: string | null,
     opponentNameInput?: string | null,
-    _phase: "prep" | "battle" = "battle"
+    _phase: "prep" | "battle" = "battle",
+    clanNameInput?: string | null
   ): Promise<string | null> {
     let guildId: string | null | undefined = guildIdOrMatchType;
     let matchType = matchTypeOrExpectedOutcome as MatchType;
@@ -108,8 +109,11 @@ export class WarEventHistoryService {
     }
 
     const normalizedClanTag = normalizeTag(clanTag);
-    const normalizedClanTagHash = normalizedClanTag ? `#${normalizedClanTag}` : "";
+    const normalizedClanTagHash = normalizedClanTag || "";
     const opponentName = String(opponentNameInputResolved ?? "").trim() || "Unknown";
+    const clanName = String(clanNameInput ?? "").trim() || normalizedClanTagHash || "Our Clan";
+    const applyPlaceholders = (planText: string): string =>
+      planText.replace(/\{opponent\}/gi, opponentName).replace(/\{clan\}/gi, clanName);
     let loseStyleCache: FwaLoseStyle | null = null;
     const getLoseStyle = async (): Promise<FwaLoseStyle> => {
       if (!loseStyleCache) {
@@ -151,7 +155,7 @@ export class WarEventHistoryService {
           },
         });
         if (customPlan?.planText && customPlan.planText.trim().length > 0) {
-          return customPlan.planText.replace(/\{opponent\}/gi, opponentName);
+          return applyPlaceholders(customPlan.planText);
         }
 
         const defaultPlan = await prisma.clanWarPlan.findFirst({
@@ -169,7 +173,7 @@ export class WarEventHistoryService {
           },
         });
         if (defaultPlan?.planText && defaultPlan.planText.trim().length > 0) {
-          return defaultPlan.planText.replace(/\{opponent\}/gi, opponentName);
+          return applyPlaceholders(defaultPlan.planText);
         }
       } catch (error) {
         if (
@@ -183,7 +187,7 @@ export class WarEventHistoryService {
 
     if (matchType === "BL") {
       return [
-        `\u26ab\ufe0f BLACKLIST WAR \ud83c\udd9a ${opponentName} \ud83c\udff4\u200d\u2620\ufe0f `,
+        `# \u26ab\ufe0f ${clanName} vs ${opponentName} \ud83c\udff4\u200d\u2620\ufe0f`,
         "Everyone switch to WAR BASES!!",
         "This is our opportunity to gain some extra FWA points!",
         "\u2795 30+ people switch to war base = +1 point",
@@ -196,7 +200,7 @@ export class WarEventHistoryService {
 
     if (matchType === "MM") {
       return [
-        `\u26aa\ufe0f MISMATCHED WAR \ud83c\udd9a ${opponentName} :sob:`,
+        `# \u26aa\ufe0f ${clanName} vs ${opponentName} :sob:`,
         "Keep WA base active, attack what you can!",
       ].join("\n");
     }
@@ -204,7 +208,7 @@ export class WarEventHistoryService {
     if (matchType !== "FWA") return null;
     if (expectedOutcome === "WIN") {
       return [
-        `**\ud83d\udc9a WIN WAR \ud83c\udd9a ${opponentName} \ud83d\udfe2 **`,
+        `# \ud83d\udfe2 ${clanName} vs ${opponentName} \ud83d\udc9a`,
         "\ud83d\udde1\ufe0f 1st Attack: \u2605 \u2605 \u2605 -> Mirror",
         "\ud83d\udde1\ufe0f 2nd Attack: \u2605 \u2605 \u2606 -> any",
         "\u231b\ufe0f Only after 101+ stars -> Attack ANY base",
@@ -214,14 +218,14 @@ export class WarEventHistoryService {
       const loseStyle = await getLoseStyle();
       if (loseStyle === "TRIPLE_TOP_30") {
         return [
-          `**\u2764\ufe0f LOSE WAR \ud83c\udd9a ${opponentName} \ud83d\udd34**`,
+          `# \ud83d\udd34 ${clanName} vs ${opponentName} \u2764\ufe0f`,
           "\ud83d\udde1\ufe0f Attack any of the top 30 bases for 1-3 stars",
           "\ud83d\udeab Do NOT attack the bottom 20 bases",
           "\ud83c\udfaf Goal is 90 stars (do not cross)",
         ].join("\n");
       }
       return [
-        `**\u2764\ufe0f LOSE WAR \ud83c\udd9a ${opponentName} \ud83d\udd34**`,
+        `# \ud83d\udd34 ${clanName} vs ${opponentName} \u2764\ufe0f`,
         "\ud83d\udde1\ufe0f 1st Attack: \u2605 \u2605 \u2606 -> Mirror",
         "\ud83d\udde1\ufe0f 2nd Attack: \u2605 \u2606 \u2606 -> any",
         "\u23f3 Last 12hrs: \u2605 \u2605 \u2606 -> any",

--- a/tests/fwaMailDownstream.logic.test.ts
+++ b/tests/fwaMailDownstream.logic.test.ts
@@ -64,4 +64,21 @@ describe("fwa war-mail posted content", () => {
       "<@&123456789>\n\nCustom war mail line 1\nCustom war mail line 2\n\nNext refresh <t:1200:R>"
     );
   });
+
+  it("normalizes mention-style stored role ids before pinging", () => {
+    const content = buildWarMailPostedContentForTest("<@&123456789>", 0, {
+      pingRole: true,
+      planText: "Plan body",
+    });
+    expect(content).toBe("<@&123456789>\n\nPlan body\n\nNext refresh <t:1200:R>");
+  });
+
+  it("can omit next-refresh line for frozen mail posts", () => {
+    const content = buildWarMailPostedContentForTest("123456789", 0, {
+      pingRole: true,
+      planText: "Plan body",
+      includeNextRefresh: false,
+    });
+    expect(content).toBe("<@&123456789>\n\nPlan body");
+  });
 });

--- a/tests/warPlanText.test.ts
+++ b/tests/warPlanText.test.ts
@@ -7,56 +7,119 @@ describe("WarEventHistoryService.buildWarPlanText", () => {
     vi.restoreAllMocks();
   });
 
-  it("returns exact WIN plan lines", async () => {
+  it("returns WIN plan with header and expected instructions", async () => {
     const svc = new WarEventHistoryService({} as never);
-    const out = await svc.buildWarPlanText("FWA", "WIN", "ABC123", "OPPONENT_NAME");
-    expect(out).toBe(
-      [
-        "**💚 WIN WAR 🆚 OPPONENT_NAME 🟢 **",
-        "🗡️ 1st Attack: ★ ★ ★ -> Mirror",
-        "🗡️ 2nd Attack: ★ ★ ☆ -> any",
-        "⌛️ Only after 101+ stars -> Attack ANY base",
-      ].join("\n")
+    const out = await svc.buildWarPlanText(
+      "FWA",
+      "WIN",
+      "ABC123",
+      "OPPONENT_NAME",
+      undefined,
+      "battle",
+      "CLAN_NAME"
     );
+    expect(out).toBeTruthy();
+    const lines = String(out).split("\n");
+    expect(lines[0]).toContain("# ");
+    expect(lines[0]).toContain("CLAN_NAME vs OPPONENT_NAME");
+    expect(out).toContain("1st Attack");
+    expect(out).toContain("2nd Attack");
+    expect(out).toContain("Only after 101+ stars");
   });
 
-  it("returns exact LOSE TRIPLE_TOP_30 plan lines", async () => {
+  it("returns LOSE TRIPLE_TOP_30 plan with header and expected instructions", async () => {
     const svc = new WarEventHistoryService({} as never);
     (svc as any).getLoseStyleForClan = vi.fn().mockResolvedValue("TRIPLE_TOP_30");
-    const out = await svc.buildWarPlanText("FWA", "LOSE", "ABC123", "OPPONENT_NAME");
-    expect(out).toBe(
-      [
-        "**❤️ LOSE WAR 🆚 OPPONENT_NAME 🔴**",
-        "🗡️ Attack any of the top 30 bases for 1-3 stars",
-        "🚫 Do NOT attack the bottom 20 bases",
-        "🎯 Goal is 90 stars (do not cross)",
-      ].join("\n")
+    const out = await svc.buildWarPlanText(
+      "FWA",
+      "LOSE",
+      "ABC123",
+      "OPPONENT_NAME",
+      undefined,
+      "battle",
+      "CLAN_NAME"
     );
+    expect(out).toBeTruthy();
+    const lines = String(out).split("\n");
+    expect(lines[0]).toContain("# ");
+    expect(lines[0]).toContain("CLAN_NAME vs OPPONENT_NAME");
+    expect(out).toContain("top 30");
+    expect(out).toContain("Do NOT attack the bottom 20 bases");
+    expect(out).toContain("Goal is 90 stars");
   });
 
-  it("returns exact LOSE TRADITIONAL plan lines", async () => {
+  it("returns LOSE TRADITIONAL plan with header and expected instructions", async () => {
     const svc = new WarEventHistoryService({} as never);
     (svc as any).getLoseStyleForClan = vi.fn().mockResolvedValue("TRADITIONAL");
-    const out = await svc.buildWarPlanText("FWA", "LOSE", "ABC123", "OPPONENT_NAME");
-    expect(out).toBe(
-      [
-        "**❤️ LOSE WAR 🆚 OPPONENT_NAME 🔴**",
-        "🗡️ 1st Attack: ★ ★ ☆ -> Mirror",
-        "🗡️ 2nd Attack: ★ ☆ ☆ -> any",
-        "⏳ Last 12hrs: ★ ★ ☆ -> any",
-        "🎯 Do NOT surpass 100 ★",
-      ].join("\n")
+    const out = await svc.buildWarPlanText(
+      "FWA",
+      "LOSE",
+      "ABC123",
+      "OPPONENT_NAME",
+      undefined,
+      "battle",
+      "CLAN_NAME"
     );
+    expect(out).toBeTruthy();
+    const lines = String(out).split("\n");
+    expect(lines[0]).toContain("# ");
+    expect(lines[0]).toContain("CLAN_NAME vs OPPONENT_NAME");
+    expect(out).toContain("1st Attack");
+    expect(out).toContain("2nd Attack");
+    expect(out).toContain("Last 12hrs");
+    expect(out).toContain("Do NOT surpass 100");
+  });
+
+  it("returns BL default with header format in first line", async () => {
+    const svc = new WarEventHistoryService({} as never);
+    const out = await svc.buildWarPlanText(
+      "BL",
+      null,
+      "ABC123",
+      "OPPONENT_NAME",
+      undefined,
+      "battle",
+      "CLAN_NAME"
+    );
+
+    expect(out).toBeTruthy();
+    const firstLine = String(out).split("\n")[0] ?? "";
+    expect(firstLine).toContain("# ");
+    expect(firstLine).toContain("CLAN_NAME vs OPPONENT_NAME");
+  });
+
+  it("returns MM default with header format in first line", async () => {
+    const svc = new WarEventHistoryService({} as never);
+    const out = await svc.buildWarPlanText(
+      "MM",
+      null,
+      "ABC123",
+      "OPPONENT_NAME",
+      undefined,
+      "battle",
+      "CLAN_NAME"
+    );
+
+    expect(out).toBeTruthy();
+    const firstLine = String(out).split("\n")[0] ?? "";
+    expect(firstLine).toContain("# ");
+    expect(firstLine).toContain("CLAN_NAME vs OPPONENT_NAME");
   });
 
   it("prefers clan custom plan text for guild-scoped lookups", async () => {
     const svc = new WarEventHistoryService({} as never);
     const planSpy = vi.spyOn(prisma.clanWarPlan, "findFirst");
-    planSpy.mockResolvedValueOnce({ planText: "MM custom plan vs {opponent}" } as any);
+    planSpy.mockResolvedValueOnce({ planText: "MM custom plan {clan} vs {opponent}" } as any);
 
-    const out = await svc.buildWarPlanText("123456789012345678", "MM", null, "ABC123", "OPPONENT_NAME");
+    const out = await svc.buildWarPlanText(
+      "123456789012345678",
+      "MM",
+      null,
+      "ABC123",
+      "OPPONENT_NAME"
+    );
 
-    expect(out).toBe("MM custom plan vs OPPONENT_NAME");
+    expect(out).toBe("MM custom plan #ABC123 vs OPPONENT_NAME");
     expect(planSpy).toHaveBeenCalledTimes(1);
     expect(planSpy).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -75,11 +138,17 @@ describe("WarEventHistoryService.buildWarPlanText", () => {
     const planSpy = vi.spyOn(prisma.clanWarPlan, "findFirst");
     planSpy
       .mockResolvedValueOnce(null as any)
-      .mockResolvedValueOnce({ planText: "BL default plan vs {opponent}" } as any);
+      .mockResolvedValueOnce({ planText: "BL default plan {clan} vs {opponent}" } as any);
 
-    const out = await svc.buildWarPlanText("123456789012345678", "BL", null, "ABC123", "OPPONENT_NAME");
+    const out = await svc.buildWarPlanText(
+      "123456789012345678",
+      "BL",
+      null,
+      "ABC123",
+      "OPPONENT_NAME"
+    );
 
-    expect(out).toBe("BL default plan vs OPPONENT_NAME");
+    expect(out).toBe("BL default plan #ABC123 vs OPPONENT_NAME");
     expect(planSpy).toHaveBeenCalledTimes(2);
     expect(planSpy.mock.calls[1]?.[0]).toEqual(
       expect.objectContaining({


### PR DESCRIPTION
- normalize TrackedClan.clanRoleId before mentions/allowedMentions
- ensure mail send paths include role ping and shared plan content behavior
- use # header first line for default BL/MM/FWA plans with clan vs opponent
- refactor default plan sourcing through WarEventHistoryService
- add/update tests for role ping normalization and plan text behavior