### PR TITLE
refactor(fwa): extract command helper modules from Fwa.ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,4 @@ npm start
 
 ## Development
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development guidelines and architecture documentation.
+FWA command internals are split under `src/commands/fwa/` helper modules to keep `Fwa.ts` orchestration-focused and unit-testable.

--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -59,28 +59,84 @@ import {
   type PointsApiFetchReason,
 } from "../services/PointsFetchPolicyService";
 import { PointsSyncService } from "../services/PointsSyncService";
+import {
+  buildFwaMailBackCustomId,
+  buildFwaMailConfirmCustomId,
+  buildFwaMailConfirmNoPingCustomId,
+  buildFwaMailRefreshCustomId,
+  buildFwaMatchAllianceCustomId,
+  buildFwaMatchCopyCustomId,
+  buildFwaMatchSelectCustomId,
+  buildFwaMatchSendMailCustomId,
+  buildMatchSkipSyncActionCustomId,
+  buildMatchSkipSyncConfirmCustomId,
+  buildMatchSkipSyncUndoCustomId,
+  buildMatchSyncActionCustomId,
+  buildMatchTypeActionCustomId,
+  buildMatchTypeEditCustomId,
+  buildOutcomeActionCustomId,
+  buildPointsPostButtonCustomId,
+  createTransientFwaKey,
+  parseFwaMailBackCustomId,
+  parseFwaMailConfirmCustomId,
+  parseFwaMailConfirmNoPingCustomId,
+  parseFwaMailRefreshCustomId,
+  parseFwaMatchAllianceCustomId,
+  parseFwaMatchCopyCustomId,
+  parseFwaMatchSelectCustomId,
+  parseFwaMatchSendMailCustomId,
+  parseMatchSkipSyncActionCustomId,
+  parseMatchSkipSyncConfirmCustomId,
+  parseMatchSkipSyncUndoCustomId,
+  parseMatchSyncActionCustomId,
+  parseMatchTypeActionCustomId,
+  parseMatchTypeEditCustomId,
+  parseOutcomeActionCustomId,
+  parsePointsPostButtonCustomId,
+} from "./fwa/customIds";
+import {
+  extractActiveFwa,
+  extractField,
+  extractMatchupBalances,
+  extractMatchupHeader,
+  extractPointBalance,
+  extractSyncNumber,
+  extractTagsFromText,
+  extractTopSectionText,
+  extractWinnerBoxText,
+  parseCocApiTime,
+  sanitizeClanName,
+  toPlainText,
+} from "./fwa/dataParsers";
+import {
+  buildLimitedMessage,
+  compareTagsForTiebreak,
+  formatPoints,
+  getSyncMode,
+  limitDiscordContent,
+} from "./fwa/matchUtils";
 export { isMissedSyncClanForTest } from "./fwa/matchState";
+export {
+  isFwaMailBackButtonCustomId,
+  isFwaMailConfirmButtonCustomId,
+  isFwaMailConfirmNoPingButtonCustomId,
+  isFwaMailRefreshButtonCustomId,
+  isFwaMatchAllianceButtonCustomId,
+  isFwaMatchCopyButtonCustomId,
+  isFwaMatchSelectCustomId,
+  isFwaMatchSendMailButtonCustomId,
+  isFwaMatchSkipSyncActionButtonCustomId,
+  isFwaMatchSkipSyncConfirmButtonCustomId,
+  isFwaMatchSkipSyncUndoButtonCustomId,
+  isFwaMatchSyncActionButtonCustomId,
+  isFwaMatchTypeActionButtonCustomId,
+  isFwaMatchTypeEditButtonCustomId,
+  isFwaOutcomeActionButtonCustomId,
+  isPointsPostButtonCustomId,
+} from "./fwa/customIds";
 const POINTS_BASE_URL = "https://points.fwafarm.com/clan?tag=";
-const TIEBREAK_ORDER = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
-const DISCORD_CONTENT_MAX = 2000;
 const POINTS_CACHE_VERSION = 5;
 const POINTS_SNAPSHOT_CACHE_TTL_MS = 90 * 1000;
-const POINTS_POST_BUTTON_PREFIX = "points-post-channel";
-const FWA_MATCH_COPY_BUTTON_PREFIX = "fwa-match-copy";
-const FWA_MATCH_TYPE_ACTION_PREFIX = "fwa-match-type-action";
-const FWA_MATCH_TYPE_EDIT_PREFIX = "fwa-match-type-edit";
-const FWA_OUTCOME_ACTION_PREFIX = "fwa-outcome-action";
-const FWA_MATCH_SYNC_ACTION_PREFIX = "fwa-match-sync-action";
-const FWA_MATCH_SKIP_SYNC_ACTION_PREFIX = "fwa-match-skip-sync-action";
-const FWA_MATCH_SKIP_SYNC_CONFIRM_PREFIX = "fwa-match-skip-sync-confirm";
-const FWA_MATCH_SKIP_SYNC_UNDO_PREFIX = "fwa-match-skip-sync-undo";
-const FWA_MATCH_SELECT_PREFIX = "fwa-match-select";
-const FWA_MATCH_ALLIANCE_PREFIX = "fwa-match-alliance";
-const FWA_MAIL_CONFIRM_PREFIX = "fwa-mail-confirm";
-const FWA_MAIL_CONFIRM_NO_PING_PREFIX = "fwa-mail-confirm-no-ping";
-const FWA_MAIL_BACK_PREFIX = "fwa-mail-back";
-const FWA_MAIL_REFRESH_PREFIX = "fwa-mail-refresh";
-const FWA_MATCH_SEND_MAIL_PREFIX = "fwa-match-send-mail";
 const WAR_MAIL_REFRESH_MS = 20 * 60 * 1000;
 const MAILBOX_SENT_EMOJI = "📬";
 const MAILBOX_NOT_SENT_EMOJI = "📭";
@@ -222,21 +278,6 @@ function logFwaMatchTelemetry(event: string, detail: string): void {
   console.log(`[telemetry-fwa-match] event=${event} ${detail}`);
 }
 
-function buildPointsPostButtonCustomId(userId: string): string {
-  return `${POINTS_POST_BUTTON_PREFIX}:${userId}`;
-}
-
-function parsePointsPostButtonCustomId(customId: string): { userId: string } | null {
-  const parts = customId.split(":");
-  if (parts.length !== 2 || parts[0] !== POINTS_POST_BUTTON_PREFIX) return null;
-  const userId = parts[1]?.trim() ?? "";
-  return userId ? { userId } : null;
-}
-
-export function isPointsPostButtonCustomId(customId: string): boolean {
-  return customId.startsWith(`${POINTS_POST_BUTTON_PREFIX}:`);
-}
-
 type MatchView = {
   embed: EmbedBuilder;
   copyText: string;
@@ -299,306 +340,6 @@ const fwaMailPostedPayloads = new Map<string, FwaMailPostedPayload>();
 const fwaMailPollers = new Map<string, ReturnType<typeof setInterval>>();
 const pointsSnapshotCache = new Map<string, PointsSnapshotCacheEntry>();
 const pointsSnapshotInFlight = new Map<string, Promise<PointsSnapshot>>();
-
-function createTransientFwaKey(): string {
-  return `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
-}
-
-function buildFwaMatchCopyCustomId(
-  userId: string,
-  key: string,
-  mode: "copy" | "embed"
-): string {
-  return `${FWA_MATCH_COPY_BUTTON_PREFIX}:${userId}:${key}:${mode}`;
-}
-
-function buildFwaMatchSelectCustomId(userId: string, key: string): string {
-  return `${FWA_MATCH_SELECT_PREFIX}:${userId}:${key}`;
-}
-
-function parseFwaMatchSelectCustomId(customId: string): { userId: string; key: string } | null {
-  const parts = customId.split(":");
-  if (parts.length !== 3 || parts[0] !== FWA_MATCH_SELECT_PREFIX) return null;
-  const userId = parts[1]?.trim() ?? "";
-  const key = parts[2]?.trim() ?? "";
-  if (!userId || !key) return null;
-  return { userId, key };
-}
-
-function buildFwaMatchAllianceCustomId(userId: string, key: string): string {
-  return `${FWA_MATCH_ALLIANCE_PREFIX}:${userId}:${key}`;
-}
-
-function parseFwaMatchAllianceCustomId(customId: string): { userId: string; key: string } | null {
-  const parts = customId.split(":");
-  if (parts.length !== 3 || parts[0] !== FWA_MATCH_ALLIANCE_PREFIX) return null;
-  const userId = parts[1]?.trim() ?? "";
-  const key = parts[2]?.trim() ?? "";
-  if (!userId || !key) return null;
-  return { userId, key };
-}
-
-function parseFwaMatchCopyCustomId(
-  customId: string
-): { userId: string; key: string; mode: "copy" | "embed" } | null {
-  const parts = customId.split(":");
-  if (parts.length !== 4 || parts[0] !== FWA_MATCH_COPY_BUTTON_PREFIX) return null;
-  const userId = parts[1]?.trim() ?? "";
-  const key = parts[2]?.trim() ?? "";
-  const mode = parts[3] === "copy" || parts[3] === "embed" ? parts[3] : null;
-  if (!userId || !key || !mode) return null;
-  return { userId, key, mode };
-}
-
-export function isFwaMatchCopyButtonCustomId(customId: string): boolean {
-  return customId.startsWith(`${FWA_MATCH_COPY_BUTTON_PREFIX}:`);
-}
-
-type MatchTypeActionParams = {
-  userId: string;
-  tag: string;
-  targetType: "FWA" | "BL" | "MM";
-};
-
-function buildMatchTypeActionCustomId(params: MatchTypeActionParams): string {
-  return `${FWA_MATCH_TYPE_ACTION_PREFIX}:${params.userId}:${normalizeTag(params.tag)}:${params.targetType}`;
-}
-
-function parseMatchTypeActionCustomId(customId: string): MatchTypeActionParams | null {
-  const parts = customId.split(":");
-  if (parts.length !== 4 || parts[0] !== FWA_MATCH_TYPE_ACTION_PREFIX) return null;
-  const userId = parts[1]?.trim() ?? "";
-  const tag = normalizeTag(parts[2] ?? "");
-  const targetType = parts[3] === "FWA" || parts[3] === "BL" || parts[3] === "MM" ? parts[3] : null;
-  if (!userId || !tag || !targetType) return null;
-  return { userId, tag, targetType };
-}
-
-export function isFwaMatchTypeActionButtonCustomId(customId: string): boolean {
-  return customId.startsWith(`${FWA_MATCH_TYPE_ACTION_PREFIX}:`);
-}
-
-type MatchTypeEditParams = { userId: string; key: string };
-
-function buildMatchTypeEditCustomId(params: MatchTypeEditParams): string {
-  return `${FWA_MATCH_TYPE_EDIT_PREFIX}:${params.userId}:${params.key}`;
-}
-
-function parseMatchTypeEditCustomId(customId: string): MatchTypeEditParams | null {
-  const parts = customId.split(":");
-  if (parts.length !== 3 || parts[0] !== FWA_MATCH_TYPE_EDIT_PREFIX) return null;
-  const userId = parts[1]?.trim() ?? "";
-  const key = parts[2]?.trim() ?? "";
-  if (!userId || !key) return null;
-  return { userId, key };
-}
-
-export function isFwaMatchTypeEditButtonCustomId(customId: string): boolean {
-  return customId.startsWith(`${FWA_MATCH_TYPE_EDIT_PREFIX}:`);
-}
-
-type OutcomeActionParams = {
-  userId: string;
-  tag: string;
-  currentOutcome: "WIN" | "LOSE";
-};
-
-function buildOutcomeActionCustomId(params: OutcomeActionParams): string {
-  return `${FWA_OUTCOME_ACTION_PREFIX}:${params.userId}:${normalizeTag(params.tag)}:${params.currentOutcome}`;
-}
-
-function parseOutcomeActionCustomId(customId: string): OutcomeActionParams | null {
-  const parts = customId.split(":");
-  if (parts.length !== 4 || parts[0] !== FWA_OUTCOME_ACTION_PREFIX) return null;
-  const userId = parts[1]?.trim() ?? "";
-  const tag = normalizeTag(parts[2] ?? "");
-  const currentOutcome = parts[3] === "WIN" || parts[3] === "LOSE" ? parts[3] : null;
-  if (!userId || !tag || !currentOutcome) return null;
-  return { userId, tag, currentOutcome };
-}
-
-export function isFwaOutcomeActionButtonCustomId(customId: string): boolean {
-  return customId.startsWith(`${FWA_OUTCOME_ACTION_PREFIX}:`);
-}
-
-type MatchSyncActionParams = {
-  userId: string;
-  key: string;
-  tag: string;
-};
-
-function buildMatchSyncActionCustomId(params: MatchSyncActionParams): string {
-  return `${FWA_MATCH_SYNC_ACTION_PREFIX}:${params.userId}:${params.key}:${normalizeTag(params.tag)}`;
-}
-
-function parseMatchSyncActionCustomId(customId: string): MatchSyncActionParams | null {
-  const parts = customId.split(":");
-  if (parts.length !== 4 || parts[0] !== FWA_MATCH_SYNC_ACTION_PREFIX) return null;
-  const userId = parts[1]?.trim() ?? "";
-  const key = parts[2]?.trim() ?? "";
-  const tag = normalizeTag(parts[3] ?? "");
-  if (!userId || !key || !tag) return null;
-  return { userId, key, tag };
-}
-
-export function isFwaMatchSyncActionButtonCustomId(customId: string): boolean {
-  return customId.startsWith(`${FWA_MATCH_SYNC_ACTION_PREFIX}:`);
-}
-
-type MatchSkipSyncActionParams = {
-  userId: string;
-  key: string;
-  tag: string;
-};
-
-function buildMatchSkipSyncActionCustomId(params: MatchSkipSyncActionParams): string {
-  return `${FWA_MATCH_SKIP_SYNC_ACTION_PREFIX}:${params.userId}:${params.key}:${normalizeTag(params.tag)}`;
-}
-
-function parseMatchSkipSyncActionCustomId(customId: string): MatchSkipSyncActionParams | null {
-  const parts = customId.split(":");
-  if (parts.length !== 4 || parts[0] !== FWA_MATCH_SKIP_SYNC_ACTION_PREFIX) return null;
-  const userId = parts[1]?.trim() ?? "";
-  const key = parts[2]?.trim() ?? "";
-  const tag = normalizeTag(parts[3] ?? "");
-  if (!userId || !key || !tag) return null;
-  return { userId, key, tag };
-}
-
-export function isFwaMatchSkipSyncActionButtonCustomId(customId: string): boolean {
-  return customId.startsWith(`${FWA_MATCH_SKIP_SYNC_ACTION_PREFIX}:`);
-}
-
-function buildMatchSkipSyncConfirmCustomId(params: MatchSkipSyncActionParams): string {
-  return `${FWA_MATCH_SKIP_SYNC_CONFIRM_PREFIX}:${params.userId}:${params.key}:${normalizeTag(params.tag)}`;
-}
-
-function parseMatchSkipSyncConfirmCustomId(customId: string): MatchSkipSyncActionParams | null {
-  const parts = customId.split(":");
-  if (parts.length !== 4 || parts[0] !== FWA_MATCH_SKIP_SYNC_CONFIRM_PREFIX) return null;
-  const userId = parts[1]?.trim() ?? "";
-  const key = parts[2]?.trim() ?? "";
-  const tag = normalizeTag(parts[3] ?? "");
-  if (!userId || !key || !tag) return null;
-  return { userId, key, tag };
-}
-
-export function isFwaMatchSkipSyncConfirmButtonCustomId(customId: string): boolean {
-  return customId.startsWith(`${FWA_MATCH_SKIP_SYNC_CONFIRM_PREFIX}:`);
-}
-
-function buildMatchSkipSyncUndoCustomId(params: MatchSkipSyncActionParams): string {
-  return `${FWA_MATCH_SKIP_SYNC_UNDO_PREFIX}:${params.userId}:${params.key}:${normalizeTag(params.tag)}`;
-}
-
-function parseMatchSkipSyncUndoCustomId(customId: string): MatchSkipSyncActionParams | null {
-  const parts = customId.split(":");
-  if (parts.length !== 4 || parts[0] !== FWA_MATCH_SKIP_SYNC_UNDO_PREFIX) return null;
-  const userId = parts[1]?.trim() ?? "";
-  const key = parts[2]?.trim() ?? "";
-  const tag = normalizeTag(parts[3] ?? "");
-  if (!userId || !key || !tag) return null;
-  return { userId, key, tag };
-}
-
-export function isFwaMatchSkipSyncUndoButtonCustomId(customId: string): boolean {
-  return customId.startsWith(`${FWA_MATCH_SKIP_SYNC_UNDO_PREFIX}:`);
-}
-
-export function isFwaMatchSelectCustomId(customId: string): boolean {
-  return customId.startsWith(`${FWA_MATCH_SELECT_PREFIX}:`);
-}
-
-export function isFwaMatchAllianceButtonCustomId(customId: string): boolean {
-  return customId.startsWith(`${FWA_MATCH_ALLIANCE_PREFIX}:`);
-}
-
-function buildFwaMailConfirmCustomId(userId: string, key: string): string {
-  return `${FWA_MAIL_CONFIRM_PREFIX}:${userId}:${key}`;
-}
-
-function parseFwaMailConfirmCustomId(customId: string): { userId: string; key: string } | null {
-  const parts = customId.split(":");
-  if (parts.length !== 3 || parts[0] !== FWA_MAIL_CONFIRM_PREFIX) return null;
-  const userId = parts[1]?.trim() ?? "";
-  const key = parts[2]?.trim() ?? "";
-  if (!userId || !key) return null;
-  return { userId, key };
-}
-
-export function isFwaMailConfirmButtonCustomId(customId: string): boolean {
-  return customId.startsWith(`${FWA_MAIL_CONFIRM_PREFIX}:`);
-}
-
-function buildFwaMailConfirmNoPingCustomId(userId: string, key: string): string {
-  return `${FWA_MAIL_CONFIRM_NO_PING_PREFIX}:${userId}:${key}`;
-}
-
-function parseFwaMailConfirmNoPingCustomId(customId: string): { userId: string; key: string } | null {
-  const parts = customId.split(":");
-  if (parts.length !== 3 || parts[0] !== FWA_MAIL_CONFIRM_NO_PING_PREFIX) return null;
-  const userId = parts[1]?.trim() ?? "";
-  const key = parts[2]?.trim() ?? "";
-  if (!userId || !key) return null;
-  return { userId, key };
-}
-
-export function isFwaMailConfirmNoPingButtonCustomId(customId: string): boolean {
-  return customId.startsWith(`${FWA_MAIL_CONFIRM_NO_PING_PREFIX}:`);
-}
-
-function buildFwaMailBackCustomId(userId: string, key: string): string {
-  return `${FWA_MAIL_BACK_PREFIX}:${userId}:${key}`;
-}
-
-function parseFwaMailBackCustomId(customId: string): { userId: string; key: string } | null {
-  const parts = customId.split(":");
-  if (parts.length !== 3 || parts[0] !== FWA_MAIL_BACK_PREFIX) return null;
-  const userId = parts[1]?.trim() ?? "";
-  const key = parts[2]?.trim() ?? "";
-  if (!userId || !key) return null;
-  return { userId, key };
-}
-
-export function isFwaMailBackButtonCustomId(customId: string): boolean {
-  return customId.startsWith(`${FWA_MAIL_BACK_PREFIX}:`);
-}
-
-function buildFwaMailRefreshCustomId(key: string): string {
-  return `${FWA_MAIL_REFRESH_PREFIX}:${key}`;
-}
-
-function parseFwaMailRefreshCustomId(customId: string): { key: string } | null {
-  const parts = customId.split(":");
-  if (parts.length !== 2 || parts[0] !== FWA_MAIL_REFRESH_PREFIX) return null;
-  const key = parts[1]?.trim() ?? "";
-  if (!key) return null;
-  return { key };
-}
-
-export function isFwaMailRefreshButtonCustomId(customId: string): boolean {
-  return customId.startsWith(`${FWA_MAIL_REFRESH_PREFIX}:`);
-}
-
-function buildFwaMatchSendMailCustomId(userId: string, key: string, tag: string): string {
-  return `${FWA_MATCH_SEND_MAIL_PREFIX}:${userId}:${key}:${tag}`;
-}
-
-function parseFwaMatchSendMailCustomId(
-  customId: string
-): { userId: string; key: string; tag: string } | null {
-  const parts = customId.split(":");
-  if (parts.length !== 4 || parts[0] !== FWA_MATCH_SEND_MAIL_PREFIX) return null;
-  const userId = parts[1]?.trim() ?? "";
-  const key = parts[2]?.trim() ?? "";
-  const tag = normalizeTag(parts[3] ?? "");
-  if (!userId || !key || !tag) return null;
-  return { userId, key, tag };
-}
-
-export function isFwaMatchSendMailButtonCustomId(customId: string): boolean {
-  return customId.startsWith(`${FWA_MATCH_SEND_MAIL_PREFIX}:`);
-}
 
 function updateSingleViewMatchType(
   view: MatchView,
@@ -4030,109 +3771,6 @@ export async function handlePointsPostButton(interaction: ButtonInteraction): Pr
   }
 }
 
-function toPlainText(html: string): string {
-  return html
-    .replace(/<script[\s\S]*?<\/script>/gi, " ")
-    .replace(/<style[\s\S]*?<\/style>/gi, " ")
-    .replace(/<[^>]+>/g, " ")
-    .replace(/&nbsp;/gi, " ")
-    .replace(/\s+/g, " ")
-    .trim();
-}
-
-function extractField(text: string, label: string): string | null {
-  const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const regex = new RegExp(
-    `${escaped}\\s*:\\s*(.+?)(?=\\s+[A-Za-z][A-Za-z0-9\\s]{1,40}:|$)`,
-    "i"
-  );
-  const match = text.match(regex);
-  if (!match?.[1]) return null;
-  return match[1].trim().slice(0, 120);
-}
-
-function extractPointBalance(html: string): number | null {
-  const directMatch = html.match(/(?:Point Balance|Current Point Balance)\s*:\s*([+-]?\d+)/i);
-  if (directMatch?.[1]) return Number(directMatch[1]);
-
-  const plain = toPlainText(html);
-  const textMatch = plain.match(/(?:Point Balance|Current Point Balance)\s*:\s*([+-]?\d+)/i);
-  if (!textMatch?.[1]) return null;
-  return Number(textMatch[1]);
-}
-
-function extractActiveFwa(...texts: Array<string | null | undefined>): boolean | null {
-  const raw = texts
-    .map((text) =>
-      text
-        ? text.match(/Active FWA\s*:\s*(Yes|No)\b/i)?.[1] ??
-          extractField(text, "Active FWA")?.match(/^(Yes|No)\b/i)?.[1] ??
-          null
-        : null
-    )
-    .find((value) => value);
-  if (!raw) return null;
-  if (/^yes$/i.test(raw)) return true;
-  if (/^no$/i.test(raw)) return false;
-  return null;
-}
-
-function extractWinnerBoxText(html: string): string | null {
-  const match = html.match(
-    /<p[^>]*class=["'][^"']*winner-box[^"']*["'][^>]*>([\s\S]*?)<\/p>/i
-  );
-  if (!match?.[1]) return null;
-  return toPlainText(match[1]);
-}
-
-function extractTopSectionText(html: string): string {
-  const plain = toPlainText(html);
-  const marker = plain.search(/Last Known War State\s*:/i);
-  if (marker < 0) return plain;
-  return plain.slice(0, marker).trim();
-}
-
-function extractTagsFromText(text: string): string[] {
-  const tags = new Set<string>();
-  const hashMatches = text.matchAll(/#([0-9A-Z]{4,})/gi);
-  for (const match of hashMatches) {
-    if (match[1]) tags.add(normalizeTag(match[1]));
-  }
-  const parenMatches = text.matchAll(/\(\s*([0-9A-Z]{4,})\s*\)/gi);
-  for (const match of parenMatches) {
-    if (match[1]) tags.add(normalizeTag(match[1]));
-  }
-  return [...tags];
-}
-
-function extractSyncNumber(text: string): number | null {
-  const match = text.match(/sync\s*#\s*(\d+)/i);
-  if (!match?.[1]) return null;
-  const value = Number(match[1]);
-  return Number.isFinite(value) ? value : null;
-}
-
-function extractMatchupBalances(text: string): {
-  primaryBalance: number | null;
-  opponentBalance: number | null;
-} {
-  const match = text.match(/\(\s*([+-]?\d+)\s*([<>=])\s*([+-]?\d+)(?:,|\))/i);
-  if (!match?.[1] || !match?.[3]) {
-    return { primaryBalance: null, opponentBalance: null };
-  }
-  const primary = Number(match[1]);
-  const opponent = Number(match[3]);
-  return {
-    primaryBalance: Number.isFinite(primary) ? primary : null,
-    opponentBalance: Number.isFinite(opponent) ? opponent : null,
-  };
-}
-
-function getSyncMode(syncNumber: number | null): "low" | "high" | null {
-  if (syncNumber === null) return null;
-  return syncNumber % 2 === 0 ? "high" : "low";
-}
-
 async function getSourceOfTruthSync(
   _settings: SettingsService,
   _guildId?: string | null
@@ -4446,47 +4084,6 @@ function applySourceSync(snapshot: PointsSnapshot, sourceSync: number | null): P
   };
 }
 
-function rankChar(ch: string): number {
-  const idx = TIEBREAK_ORDER.indexOf(ch);
-  return idx >= 0 ? idx : Number.MAX_SAFE_INTEGER;
-}
-
-function compareTagsForTiebreak(primaryTag: string, opponentTag: string): number {
-  const a = normalizeTag(primaryTag);
-  const b = normalizeTag(opponentTag);
-  const maxLen = Math.max(a.length, b.length);
-
-  for (let i = 0; i < maxLen; i += 1) {
-    const ra = rankChar(a[i] ?? "");
-    const rb = rankChar(b[i] ?? "");
-    if (ra === rb) continue;
-    return ra - rb;
-  }
-
-  return 0;
-}
-
-function formatPoints(value: number): string {
-  return Intl.NumberFormat("en-US").format(value);
-}
-
-function sanitizeClanName(input: string | null | undefined): string | null {
-  if (!input) return null;
-  const trimmed = input.trim();
-  if (!trimmed) return null;
-  if (trimmed.length > 80) return null;
-  if (/Clan Tag|Point Balance|Sync #|Winner|War State/i.test(trimmed)) return null;
-  return trimmed;
-}
-
-type MatchupHeader = {
-  syncNumber: number | null;
-  primaryName: string | null;
-  primaryTag: string | null;
-  opponentName: string | null;
-  opponentTag: string | null;
-};
-
 type ActualSheetClanSnapshot = {
   totalWeight: string | null;
   weightCompo: string | null;
@@ -4567,90 +4164,11 @@ async function getActualSheetSnapshotCached(
   return snapshot;
 }
 
-function extractMatchupHeader(topText: string): MatchupHeader {
-  const regex =
-    /Sync\s*#\s*(\d+)\s+(.+?)\s*\(\s*([0-9A-Z]{4,})\s*\)\s+vs\.\s+(.+?)\s*\(\s*([0-9A-Z]{4,})\s*\)/i;
-  const match = topText.match(regex);
-  if (!match) {
-    return {
-      syncNumber: extractSyncNumber(topText),
-      primaryName: null,
-      primaryTag: null,
-      opponentName: null,
-      opponentTag: null,
-    };
-  }
-
-  return {
-    syncNumber: Number(match[1]),
-    primaryName: sanitizeClanName(match[2]) ?? null,
-    primaryTag: normalizeTag(match[3]),
-    opponentName: sanitizeClanName(match[4]) ?? null,
-    opponentTag: normalizeTag(match[5]),
-  };
-}
-
-
-function limitDiscordContent(content: string): string {
-  return truncateDiscordContent(content, DISCORD_CONTENT_MAX);
-}
-
-function buildLimitedMessage(header: string, lines: string[], summary: string): string {
-  let message = `${header}\n\n`;
-  let included = 0;
-
-  for (const line of lines) {
-    const candidate = `${message}${line}\n`;
-    if ((candidate + summary).length > DISCORD_CONTENT_MAX) break;
-    message = candidate;
-    included += 1;
-  }
-
-  if (included < lines.length) {
-    const omittedNote = `\n...and ${lines.length - included} more clan(s).`;
-    if ((message + omittedNote + summary).length <= DISCORD_CONTENT_MAX) {
-      message += omittedNote;
-    }
-  }
-
-  // If the first line alone is too long, still show a shortened version.
-  if (included === 0 && lines.length > 0) {
-    const firstLineBudget = Math.max(0, DISCORD_CONTENT_MAX - message.length - summary.length - 40);
-    const shortened = firstLineBudget > 0 ? `${lines[0].slice(0, firstLineBudget)}...` : "";
-    if (shortened) {
-      message += `${shortened}\n`;
-      if (lines.length > 1) {
-        const omittedNote = `...and ${lines.length - 1} more clan(s).`;
-        if ((message + omittedNote + summary).length <= DISCORD_CONTENT_MAX) {
-          message += omittedNote;
-        }
-      }
-    }
-  }
-
-  if ((message + summary).length > DISCORD_CONTENT_MAX) {
-    const allowed = Math.max(0, DISCORD_CONTENT_MAX - message.length);
-    return `${message}${summary.slice(0, allowed)}`;
-  }
-
-  return `${message}${summary}`;
-}
-
 function getHttpStatus(err: unknown): number | null {
   const status =
     (err as { status?: number } | null | undefined)?.status ??
     (err as { response?: { status?: number } } | null | undefined)?.response?.status;
   return typeof status === "number" ? status : null;
-}
-
-function parseCocApiTime(input: string | null | undefined): number | null {
-  if (!input) return null;
-  const match = input.match(
-    /^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})\.\d{3}Z$/
-  );
-  if (!match) return null;
-  const [, y, m, d, hh, mm, ss] = match;
-  return Date.UTC(Number(y), Number(m) - 1, Number(d), Number(hh), Number(mm), Number(ss));
 }
 
 type CurrentWarResult = Awaited<ReturnType<CoCService["getCurrentWar"]>>;

--- a/src/commands/fwa/customIds.ts
+++ b/src/commands/fwa/customIds.ts
@@ -1,0 +1,361 @@
+const POINTS_POST_BUTTON_PREFIX = "points-post-channel";
+const FWA_MATCH_COPY_BUTTON_PREFIX = "fwa-match-copy";
+const FWA_MATCH_TYPE_ACTION_PREFIX = "fwa-match-type-action";
+const FWA_MATCH_TYPE_EDIT_PREFIX = "fwa-match-type-edit";
+const FWA_OUTCOME_ACTION_PREFIX = "fwa-outcome-action";
+const FWA_MATCH_SYNC_ACTION_PREFIX = "fwa-match-sync-action";
+const FWA_MATCH_SKIP_SYNC_ACTION_PREFIX = "fwa-match-skip-sync-action";
+const FWA_MATCH_SKIP_SYNC_CONFIRM_PREFIX = "fwa-match-skip-sync-confirm";
+const FWA_MATCH_SKIP_SYNC_UNDO_PREFIX = "fwa-match-skip-sync-undo";
+const FWA_MATCH_SELECT_PREFIX = "fwa-match-select";
+const FWA_MATCH_ALLIANCE_PREFIX = "fwa-match-alliance";
+const FWA_MAIL_CONFIRM_PREFIX = "fwa-mail-confirm";
+const FWA_MAIL_CONFIRM_NO_PING_PREFIX = "fwa-mail-confirm-no-ping";
+const FWA_MAIL_BACK_PREFIX = "fwa-mail-back";
+const FWA_MAIL_REFRESH_PREFIX = "fwa-mail-refresh";
+const FWA_MATCH_SEND_MAIL_PREFIX = "fwa-match-send-mail";
+
+export type MatchTypeActionParams = {
+  userId: string;
+  tag: string;
+  targetType: "FWA" | "BL" | "MM";
+};
+
+export type MatchTypeEditParams = {
+  userId: string;
+  key: string;
+};
+
+export type OutcomeActionParams = {
+  userId: string;
+  tag: string;
+  currentOutcome: "WIN" | "LOSE";
+};
+
+export type MatchSyncActionParams = {
+  userId: string;
+  key: string;
+  tag: string;
+};
+
+export type MatchSkipSyncActionParams = {
+  userId: string;
+  key: string;
+  tag: string;
+};
+
+/** Purpose: normalize incoming clan tags to the internal uppercase/hashless form. */
+function normalizeTag(input: string): string {
+  return input.trim().toUpperCase().replace(/^#/, "");
+}
+
+/** Purpose: parse a fixed custom-id format with prefix validation and non-empty parts. */
+function parseCustomIdParts(
+  customId: string,
+  prefix: string,
+  expectedParts: number
+): string[] | null {
+  const parts = customId.split(":");
+  if (parts.length !== expectedParts || parts[0] !== prefix) return null;
+  const values = parts.slice(1).map((part) => part.trim());
+  if (values.some((value) => !value)) return null;
+  return values;
+}
+
+/** Purpose: generate an opaque short-lived key for interaction payload maps. */
+export function createTransientFwaKey(): string {
+  return `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
+}
+
+/** Purpose: build custom-id for posting points output into a channel. */
+export function buildPointsPostButtonCustomId(userId: string): string {
+  return `${POINTS_POST_BUTTON_PREFIX}:${userId}`;
+}
+
+/** Purpose: parse points-post button custom-id payload. */
+export function parsePointsPostButtonCustomId(customId: string): { userId: string } | null {
+  const values = parseCustomIdParts(customId, POINTS_POST_BUTTON_PREFIX, 2);
+  if (!values) return null;
+  return { userId: values[0] };
+}
+
+/** Purpose: detect points-post button custom-id prefix. */
+export function isPointsPostButtonCustomId(customId: string): boolean {
+  return customId.startsWith(`${POINTS_POST_BUTTON_PREFIX}:`);
+}
+
+/** Purpose: build custom-id for copy/embed toggle button in fwa match results. */
+export function buildFwaMatchCopyCustomId(
+  userId: string,
+  key: string,
+  mode: "copy" | "embed"
+): string {
+  return `${FWA_MATCH_COPY_BUTTON_PREFIX}:${userId}:${key}:${mode}`;
+}
+
+/** Purpose: parse fwa match copy-toggle custom-id payload. */
+export function parseFwaMatchCopyCustomId(
+  customId: string
+): { userId: string; key: string; mode: "copy" | "embed" } | null {
+  const values = parseCustomIdParts(customId, FWA_MATCH_COPY_BUTTON_PREFIX, 4);
+  if (!values) return null;
+  const [userId, key, rawMode] = values;
+  const mode = rawMode === "copy" || rawMode === "embed" ? rawMode : null;
+  if (!mode) return null;
+  return { userId, key, mode };
+}
+
+/** Purpose: detect fwa match copy-toggle button custom-id prefix. */
+export function isFwaMatchCopyButtonCustomId(customId: string): boolean {
+  return customId.startsWith(`${FWA_MATCH_COPY_BUTTON_PREFIX}:`);
+}
+
+/** Purpose: build custom-id for fwa match clan selector menu. */
+export function buildFwaMatchSelectCustomId(userId: string, key: string): string {
+  return `${FWA_MATCH_SELECT_PREFIX}:${userId}:${key}`;
+}
+
+/** Purpose: parse fwa match clan selector custom-id payload. */
+export function parseFwaMatchSelectCustomId(customId: string): { userId: string; key: string } | null {
+  const values = parseCustomIdParts(customId, FWA_MATCH_SELECT_PREFIX, 3);
+  if (!values) return null;
+  return { userId: values[0], key: values[1] };
+}
+
+/** Purpose: detect fwa match selector custom-id prefix. */
+export function isFwaMatchSelectCustomId(customId: string): boolean {
+  return customId.startsWith(`${FWA_MATCH_SELECT_PREFIX}:`);
+}
+
+/** Purpose: build custom-id for fwa match alliance-view button. */
+export function buildFwaMatchAllianceCustomId(userId: string, key: string): string {
+  return `${FWA_MATCH_ALLIANCE_PREFIX}:${userId}:${key}`;
+}
+
+/** Purpose: parse fwa match alliance-view custom-id payload. */
+export function parseFwaMatchAllianceCustomId(customId: string): { userId: string; key: string } | null {
+  const values = parseCustomIdParts(customId, FWA_MATCH_ALLIANCE_PREFIX, 3);
+  if (!values) return null;
+  return { userId: values[0], key: values[1] };
+}
+
+/** Purpose: detect fwa match alliance-view button custom-id prefix. */
+export function isFwaMatchAllianceButtonCustomId(customId: string): boolean {
+  return customId.startsWith(`${FWA_MATCH_ALLIANCE_PREFIX}:`);
+}
+
+/** Purpose: build custom-id for match-type override action button. */
+export function buildMatchTypeActionCustomId(params: MatchTypeActionParams): string {
+  return `${FWA_MATCH_TYPE_ACTION_PREFIX}:${params.userId}:${normalizeTag(params.tag)}:${params.targetType}`;
+}
+
+/** Purpose: parse match-type override action custom-id payload. */
+export function parseMatchTypeActionCustomId(customId: string): MatchTypeActionParams | null {
+  const values = parseCustomIdParts(customId, FWA_MATCH_TYPE_ACTION_PREFIX, 4);
+  if (!values) return null;
+  const [userId, rawTag, rawTargetType] = values;
+  const targetType = rawTargetType === "FWA" || rawTargetType === "BL" || rawTargetType === "MM"
+    ? rawTargetType
+    : null;
+  if (!targetType) return null;
+  return { userId, tag: normalizeTag(rawTag), targetType };
+}
+
+/** Purpose: detect match-type override action button prefix. */
+export function isFwaMatchTypeActionButtonCustomId(customId: string): boolean {
+  return customId.startsWith(`${FWA_MATCH_TYPE_ACTION_PREFIX}:`);
+}
+
+/** Purpose: build custom-id for match-type edit entry button. */
+export function buildMatchTypeEditCustomId(params: MatchTypeEditParams): string {
+  return `${FWA_MATCH_TYPE_EDIT_PREFIX}:${params.userId}:${params.key}`;
+}
+
+/** Purpose: parse match-type edit entry custom-id payload. */
+export function parseMatchTypeEditCustomId(customId: string): MatchTypeEditParams | null {
+  const values = parseCustomIdParts(customId, FWA_MATCH_TYPE_EDIT_PREFIX, 3);
+  if (!values) return null;
+  return { userId: values[0], key: values[1] };
+}
+
+/** Purpose: detect match-type edit entry button prefix. */
+export function isFwaMatchTypeEditButtonCustomId(customId: string): boolean {
+  return customId.startsWith(`${FWA_MATCH_TYPE_EDIT_PREFIX}:`);
+}
+
+/** Purpose: build custom-id for expected-outcome action button. */
+export function buildOutcomeActionCustomId(params: OutcomeActionParams): string {
+  return `${FWA_OUTCOME_ACTION_PREFIX}:${params.userId}:${normalizeTag(params.tag)}:${params.currentOutcome}`;
+}
+
+/** Purpose: parse expected-outcome action custom-id payload. */
+export function parseOutcomeActionCustomId(customId: string): OutcomeActionParams | null {
+  const values = parseCustomIdParts(customId, FWA_OUTCOME_ACTION_PREFIX, 4);
+  if (!values) return null;
+  const [userId, rawTag, rawOutcome] = values;
+  const currentOutcome = rawOutcome === "WIN" || rawOutcome === "LOSE" ? rawOutcome : null;
+  if (!currentOutcome) return null;
+  return { userId, tag: normalizeTag(rawTag), currentOutcome };
+}
+
+/** Purpose: detect expected-outcome action button prefix. */
+export function isFwaOutcomeActionButtonCustomId(customId: string): boolean {
+  return customId.startsWith(`${FWA_OUTCOME_ACTION_PREFIX}:`);
+}
+
+/** Purpose: build custom-id for sync data action button. */
+export function buildMatchSyncActionCustomId(params: MatchSyncActionParams): string {
+  return `${FWA_MATCH_SYNC_ACTION_PREFIX}:${params.userId}:${params.key}:${normalizeTag(params.tag)}`;
+}
+
+/** Purpose: parse sync data action custom-id payload. */
+export function parseMatchSyncActionCustomId(customId: string): MatchSyncActionParams | null {
+  const values = parseCustomIdParts(customId, FWA_MATCH_SYNC_ACTION_PREFIX, 4);
+  if (!values) return null;
+  return { userId: values[0], key: values[1], tag: normalizeTag(values[2]) };
+}
+
+/** Purpose: detect sync data action button prefix. */
+export function isFwaMatchSyncActionButtonCustomId(customId: string): boolean {
+  return customId.startsWith(`${FWA_MATCH_SYNC_ACTION_PREFIX}:`);
+}
+
+/** Purpose: build custom-id for skip-sync action button. */
+export function buildMatchSkipSyncActionCustomId(params: MatchSkipSyncActionParams): string {
+  return `${FWA_MATCH_SKIP_SYNC_ACTION_PREFIX}:${params.userId}:${params.key}:${normalizeTag(params.tag)}`;
+}
+
+/** Purpose: parse skip-sync action custom-id payload. */
+export function parseMatchSkipSyncActionCustomId(customId: string): MatchSkipSyncActionParams | null {
+  const values = parseCustomIdParts(customId, FWA_MATCH_SKIP_SYNC_ACTION_PREFIX, 4);
+  if (!values) return null;
+  return { userId: values[0], key: values[1], tag: normalizeTag(values[2]) };
+}
+
+/** Purpose: detect skip-sync action button prefix. */
+export function isFwaMatchSkipSyncActionButtonCustomId(customId: string): boolean {
+  return customId.startsWith(`${FWA_MATCH_SKIP_SYNC_ACTION_PREFIX}:`);
+}
+
+/** Purpose: build custom-id for skip-sync confirmation button. */
+export function buildMatchSkipSyncConfirmCustomId(params: MatchSkipSyncActionParams): string {
+  return `${FWA_MATCH_SKIP_SYNC_CONFIRM_PREFIX}:${params.userId}:${params.key}:${normalizeTag(params.tag)}`;
+}
+
+/** Purpose: parse skip-sync confirmation custom-id payload. */
+export function parseMatchSkipSyncConfirmCustomId(customId: string): MatchSkipSyncActionParams | null {
+  const values = parseCustomIdParts(customId, FWA_MATCH_SKIP_SYNC_CONFIRM_PREFIX, 4);
+  if (!values) return null;
+  return { userId: values[0], key: values[1], tag: normalizeTag(values[2]) };
+}
+
+/** Purpose: detect skip-sync confirmation button prefix. */
+export function isFwaMatchSkipSyncConfirmButtonCustomId(customId: string): boolean {
+  return customId.startsWith(`${FWA_MATCH_SKIP_SYNC_CONFIRM_PREFIX}:`);
+}
+
+/** Purpose: build custom-id for skip-sync undo button. */
+export function buildMatchSkipSyncUndoCustomId(params: MatchSkipSyncActionParams): string {
+  return `${FWA_MATCH_SKIP_SYNC_UNDO_PREFIX}:${params.userId}:${params.key}:${normalizeTag(params.tag)}`;
+}
+
+/** Purpose: parse skip-sync undo custom-id payload. */
+export function parseMatchSkipSyncUndoCustomId(customId: string): MatchSkipSyncActionParams | null {
+  const values = parseCustomIdParts(customId, FWA_MATCH_SKIP_SYNC_UNDO_PREFIX, 4);
+  if (!values) return null;
+  return { userId: values[0], key: values[1], tag: normalizeTag(values[2]) };
+}
+
+/** Purpose: detect skip-sync undo button prefix. */
+export function isFwaMatchSkipSyncUndoButtonCustomId(customId: string): boolean {
+  return customId.startsWith(`${FWA_MATCH_SKIP_SYNC_UNDO_PREFIX}:`);
+}
+
+/** Purpose: build custom-id for war-mail send confirmation button. */
+export function buildFwaMailConfirmCustomId(userId: string, key: string): string {
+  return `${FWA_MAIL_CONFIRM_PREFIX}:${userId}:${key}`;
+}
+
+/** Purpose: parse war-mail send confirmation custom-id payload. */
+export function parseFwaMailConfirmCustomId(customId: string): { userId: string; key: string } | null {
+  const values = parseCustomIdParts(customId, FWA_MAIL_CONFIRM_PREFIX, 3);
+  if (!values) return null;
+  return { userId: values[0], key: values[1] };
+}
+
+/** Purpose: detect war-mail send confirmation button prefix. */
+export function isFwaMailConfirmButtonCustomId(customId: string): boolean {
+  return customId.startsWith(`${FWA_MAIL_CONFIRM_PREFIX}:`);
+}
+
+/** Purpose: build custom-id for no-ping mail confirmation button. */
+export function buildFwaMailConfirmNoPingCustomId(userId: string, key: string): string {
+  return `${FWA_MAIL_CONFIRM_NO_PING_PREFIX}:${userId}:${key}`;
+}
+
+/** Purpose: parse no-ping mail confirmation custom-id payload. */
+export function parseFwaMailConfirmNoPingCustomId(
+  customId: string
+): { userId: string; key: string } | null {
+  const values = parseCustomIdParts(customId, FWA_MAIL_CONFIRM_NO_PING_PREFIX, 3);
+  if (!values) return null;
+  return { userId: values[0], key: values[1] };
+}
+
+/** Purpose: detect no-ping mail confirmation button prefix. */
+export function isFwaMailConfirmNoPingButtonCustomId(customId: string): boolean {
+  return customId.startsWith(`${FWA_MAIL_CONFIRM_NO_PING_PREFIX}:`);
+}
+
+/** Purpose: build custom-id for returning from mail preview to match view. */
+export function buildFwaMailBackCustomId(userId: string, key: string): string {
+  return `${FWA_MAIL_BACK_PREFIX}:${userId}:${key}`;
+}
+
+/** Purpose: parse back-to-match custom-id payload. */
+export function parseFwaMailBackCustomId(customId: string): { userId: string; key: string } | null {
+  const values = parseCustomIdParts(customId, FWA_MAIL_BACK_PREFIX, 3);
+  if (!values) return null;
+  return { userId: values[0], key: values[1] };
+}
+
+/** Purpose: detect back-to-match button prefix. */
+export function isFwaMailBackButtonCustomId(customId: string): boolean {
+  return customId.startsWith(`${FWA_MAIL_BACK_PREFIX}:`);
+}
+
+/** Purpose: build custom-id for manual war-mail refresh button. */
+export function buildFwaMailRefreshCustomId(key: string): string {
+  return `${FWA_MAIL_REFRESH_PREFIX}:${key}`;
+}
+
+/** Purpose: parse manual war-mail refresh custom-id payload. */
+export function parseFwaMailRefreshCustomId(customId: string): { key: string } | null {
+  const values = parseCustomIdParts(customId, FWA_MAIL_REFRESH_PREFIX, 2);
+  if (!values) return null;
+  return { key: values[0] };
+}
+
+/** Purpose: detect manual war-mail refresh button prefix. */
+export function isFwaMailRefreshButtonCustomId(customId: string): boolean {
+  return customId.startsWith(`${FWA_MAIL_REFRESH_PREFIX}:`);
+}
+
+/** Purpose: build custom-id for sending war-mail from the /fwa match card. */
+export function buildFwaMatchSendMailCustomId(userId: string, key: string, tag: string): string {
+  return `${FWA_MATCH_SEND_MAIL_PREFIX}:${userId}:${key}:${tag}`;
+}
+
+/** Purpose: parse send-mail-from-match custom-id payload. */
+export function parseFwaMatchSendMailCustomId(
+  customId: string
+): { userId: string; key: string; tag: string } | null {
+  const values = parseCustomIdParts(customId, FWA_MATCH_SEND_MAIL_PREFIX, 4);
+  if (!values) return null;
+  return { userId: values[0], key: values[1], tag: normalizeTag(values[2]) };
+}
+
+/** Purpose: detect send-mail-from-match button prefix. */
+export function isFwaMatchSendMailButtonCustomId(customId: string): boolean {
+  return customId.startsWith(`${FWA_MATCH_SEND_MAIL_PREFIX}:`);
+}

--- a/src/commands/fwa/dataParsers.ts
+++ b/src/commands/fwa/dataParsers.ts
@@ -1,0 +1,164 @@
+/** Purpose: normalize incoming clan tags to the internal uppercase/hashless form. */
+function normalizeTag(input: string): string {
+  return input.trim().toUpperCase().replace(/^#/, "");
+}
+
+/** Purpose: strip HTML to compact text for regex-based parsing. */
+export function toPlainText(html: string): string {
+  return html
+    .replace(/<script[\s\S]*?<\/script>/gi, " ")
+    .replace(/<style[\s\S]*?<\/style>/gi, " ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/gi, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/** Purpose: extract a labeled field from flattened text content. */
+export function extractField(text: string, label: string): string | null {
+  const escaped = label.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const regex = new RegExp(
+    `${escaped}\\s*:\\s*(.+?)(?=\\s+[A-Za-z][A-Za-z0-9\\s]{1,40}:|$)`,
+    "i"
+  );
+  const match = text.match(regex);
+  if (!match?.[1]) return null;
+  return match[1].trim().slice(0, 120);
+}
+
+/** Purpose: parse clan point balance from raw HTML or normalized text fallback. */
+export function extractPointBalance(html: string): number | null {
+  const directMatch = html.match(/(?:Point Balance|Current Point Balance)\s*:\s*([+-]?\d+)/i);
+  if (directMatch?.[1]) return Number(directMatch[1]);
+
+  const plain = toPlainText(html);
+  const textMatch = plain.match(/(?:Point Balance|Current Point Balance)\s*:\s*([+-]?\d+)/i);
+  if (!textMatch?.[1]) return null;
+  return Number(textMatch[1]);
+}
+
+/** Purpose: parse Active FWA Yes/No state from multiple candidate text sources. */
+export function extractActiveFwa(...texts: Array<string | null | undefined>): boolean | null {
+  const raw = texts
+    .map((text) =>
+      text
+        ? text.match(/Active FWA\s*:\s*(Yes|No)\b/i)?.[1] ??
+          extractField(text, "Active FWA")?.match(/^(Yes|No)\b/i)?.[1] ??
+          null
+        : null
+    )
+    .find((value) => value);
+  if (!raw) return null;
+  if (/^yes$/i.test(raw)) return true;
+  if (/^no$/i.test(raw)) return false;
+  return null;
+}
+
+/** Purpose: extract winner-box paragraph text from points HTML. */
+export function extractWinnerBoxText(html: string): string | null {
+  const match = html.match(
+    /<p[^>]*class=["'][^"']*winner-box[^"']*["'][^>]*>([\s\S]*?)<\/p>/i
+  );
+  if (!match?.[1]) return null;
+  return toPlainText(match[1]);
+}
+
+/** Purpose: isolate top section text before the Last Known War State block. */
+export function extractTopSectionText(html: string): string {
+  const plain = toPlainText(html);
+  const marker = plain.search(/Last Known War State\s*:/i);
+  if (marker < 0) return plain;
+  return plain.slice(0, marker).trim();
+}
+
+/** Purpose: parse clan tags from both hash-tag and parenthesized forms. */
+export function extractTagsFromText(text: string): string[] {
+  const tags = new Set<string>();
+  const hashMatches = text.matchAll(/#([0-9A-Z]{4,})/gi);
+  for (const match of hashMatches) {
+    if (match[1]) tags.add(normalizeTag(match[1]));
+  }
+  const parenMatches = text.matchAll(/\(\s*([0-9A-Z]{4,})\s*\)/gi);
+  for (const match of parenMatches) {
+    if (match[1]) tags.add(normalizeTag(match[1]));
+  }
+  return [...tags];
+}
+
+/** Purpose: extract sync number from freeform text. */
+export function extractSyncNumber(text: string): number | null {
+  const match = text.match(/sync\s*#\s*(\d+)/i);
+  if (!match?.[1]) return null;
+  const value = Number(match[1]);
+  return Number.isFinite(value) ? value : null;
+}
+
+/** Purpose: parse (primary vs opponent) balances from points summary text. */
+export function extractMatchupBalances(text: string): {
+  primaryBalance: number | null;
+  opponentBalance: number | null;
+} {
+  const match = text.match(/\(\s*([+-]?\d+)\s*([<>=])\s*([+-]?\d+)(?:,|\))/i);
+  if (!match?.[1] || !match?.[3]) {
+    return { primaryBalance: null, opponentBalance: null };
+  }
+  const primary = Number(match[1]);
+  const opponent = Number(match[3]);
+  return {
+    primaryBalance: Number.isFinite(primary) ? primary : null,
+    opponentBalance: Number.isFinite(opponent) ? opponent : null,
+  };
+}
+
+/** Purpose: sanitize scraped clan names to avoid noisy/invalid labels in output. */
+export function sanitizeClanName(input: string | null | undefined): string | null {
+  if (!input) return null;
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+  if (trimmed.length > 80) return null;
+  if (/Clan Tag|Point Balance|Sync #|Winner|War State/i.test(trimmed)) return null;
+  return trimmed;
+}
+
+export type MatchupHeader = {
+  syncNumber: number | null;
+  primaryName: string | null;
+  primaryTag: string | null;
+  opponentName: string | null;
+  opponentTag: string | null;
+};
+
+/** Purpose: parse matchup header row from points top-section text. */
+export function extractMatchupHeader(topText: string): MatchupHeader {
+  const regex =
+    /Sync\s*#\s*(\d+)\s+(.+?)\s*\(\s*([0-9A-Z]{4,})\s*\)\s+vs\.\s+(.+?)\s*\(\s*([0-9A-Z]{4,})\s*\)/i;
+  const match = topText.match(regex);
+  if (!match) {
+    return {
+      syncNumber: extractSyncNumber(topText),
+      primaryName: null,
+      primaryTag: null,
+      opponentName: null,
+      opponentTag: null,
+    };
+  }
+
+  return {
+    syncNumber: Number(match[1]),
+    primaryName: sanitizeClanName(match[2]) ?? null,
+    primaryTag: normalizeTag(match[3]),
+    opponentName: sanitizeClanName(match[4]) ?? null,
+    opponentTag: normalizeTag(match[5]),
+  };
+}
+
+/** Purpose: parse Clash API timestamp format (`yyyyMMddTHHmmss.SSSZ`) into epoch ms. */
+export function parseCocApiTime(input: string | null | undefined): number | null {
+  if (!input) return null;
+  const match = input.match(
+    /^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})\.\d{3}Z$/
+  );
+  if (!match) return null;
+  const [, y, m, d, hh, mm, ss] = match;
+  return Date.UTC(Number(y), Number(m) - 1, Number(d), Number(hh), Number(mm), Number(ss));
+}

--- a/src/commands/fwa/matchUtils.ts
+++ b/src/commands/fwa/matchUtils.ts
@@ -1,0 +1,89 @@
+import { truncateDiscordContent } from "../../helper/discordContent";
+
+const TIEBREAK_ORDER = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+const DISCORD_CONTENT_MAX = 2000;
+
+/** Purpose: normalize incoming clan tags to the internal uppercase/hashless form. */
+function normalizeTag(input: string): string {
+  return input.trim().toUpperCase().replace(/^#/, "");
+}
+
+/** Purpose: derive low/high sync mode from an absolute sync number. */
+export function getSyncMode(syncNumber: number | null): "low" | "high" | null {
+  if (syncNumber === null) return null;
+  return syncNumber % 2 === 0 ? "high" : "low";
+}
+
+/** Purpose: rank tag characters using FWA sync tiebreak ordering. */
+function rankChar(ch: string): number {
+  const idx = TIEBREAK_ORDER.indexOf(ch);
+  return idx >= 0 ? idx : Number.MAX_SAFE_INTEGER;
+}
+
+/** Purpose: compare clan tags using deterministic FWA tiebreak ordering. */
+export function compareTagsForTiebreak(primaryTag: string, opponentTag: string): number {
+  const a = normalizeTag(primaryTag);
+  const b = normalizeTag(opponentTag);
+  const maxLen = Math.max(a.length, b.length);
+
+  for (let i = 0; i < maxLen; i += 1) {
+    const ra = rankChar(a[i] ?? "");
+    const rb = rankChar(b[i] ?? "");
+    if (ra === rb) continue;
+    return ra - rb;
+  }
+
+  return 0;
+}
+
+/** Purpose: format numeric points using Discord-friendly U.S. grouping. */
+export function formatPoints(value: number): string {
+  return Intl.NumberFormat("en-US").format(value);
+}
+
+/** Purpose: enforce Discord message limit with shared truncation behavior. */
+export function limitDiscordContent(content: string): string {
+  return truncateDiscordContent(content, DISCORD_CONTENT_MAX);
+}
+
+/** Purpose: build a bounded message with graceful truncation and omitted-count summary. */
+export function buildLimitedMessage(header: string, lines: string[], summary: string): string {
+  let message = `${header}\n\n`;
+  let included = 0;
+
+  for (const line of lines) {
+    const candidate = `${message}${line}\n`;
+    if ((candidate + summary).length > DISCORD_CONTENT_MAX) break;
+    message = candidate;
+    included += 1;
+  }
+
+  if (included < lines.length) {
+    const omittedNote = `\n...and ${lines.length - included} more clan(s).`;
+    if ((message + omittedNote + summary).length <= DISCORD_CONTENT_MAX) {
+      message += omittedNote;
+    }
+  }
+
+  // If the first line alone is too long, still show a shortened version.
+  if (included === 0 && lines.length > 0) {
+    const firstLineBudget = Math.max(0, DISCORD_CONTENT_MAX - message.length - summary.length - 40);
+    const shortened = firstLineBudget > 0 ? `${lines[0].slice(0, firstLineBudget)}...` : "";
+    if (shortened) {
+      message += `${shortened}\n`;
+      if (lines.length > 1) {
+        const omittedNote = `...and ${lines.length - 1} more clan(s).`;
+        if ((message + omittedNote + summary).length <= DISCORD_CONTENT_MAX) {
+          message += omittedNote;
+        }
+      }
+    }
+  }
+
+  if ((message + summary).length > DISCORD_CONTENT_MAX) {
+    const allowed = Math.max(0, DISCORD_CONTENT_MAX - message.length);
+    return `${message}${summary.slice(0, allowed)}`;
+  }
+
+  return `${message}${summary}`;
+}

--- a/tests/fwaCustomIds.logic.test.ts
+++ b/tests/fwaCustomIds.logic.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildFwaMatchSendMailCustomId,
+  buildMatchTypeActionCustomId,
+  buildPointsPostButtonCustomId,
+  createTransientFwaKey,
+  isFwaMatchSendMailButtonCustomId,
+  isPointsPostButtonCustomId,
+  parseFwaMatchSendMailCustomId,
+  parseMatchTypeActionCustomId,
+  parsePointsPostButtonCustomId,
+} from "../src/commands/fwa/customIds";
+
+describe("fwa custom-id helpers", () => {
+  it("round-trips match-type action ids and normalizes tag", () => {
+    const customId = buildMatchTypeActionCustomId({
+      userId: "123",
+      tag: "#ab12cd",
+      targetType: "FWA",
+    });
+
+    expect(parseMatchTypeActionCustomId(customId)).toEqual({
+      userId: "123",
+      tag: "AB12CD",
+      targetType: "FWA",
+    });
+  });
+
+  it("rejects malformed match-type action ids", () => {
+    expect(parseMatchTypeActionCustomId("fwa-match-type-action:123:ABC:BAD")).toBeNull();
+    expect(parseMatchTypeActionCustomId("fwa-match-type-action:123:ABC")).toBeNull();
+  });
+
+  it("round-trips send-mail ids and supports selector checks", () => {
+    const customId = buildFwaMatchSendMailCustomId("321", "payload", "#qwerty");
+
+    expect(isFwaMatchSendMailButtonCustomId(customId)).toBe(true);
+    expect(parseFwaMatchSendMailCustomId(customId)).toEqual({
+      userId: "321",
+      key: "payload",
+      tag: "QWERTY",
+    });
+  });
+
+  it("round-trips points-post ids and supports selector checks", () => {
+    const customId = buildPointsPostButtonCustomId("777");
+
+    expect(isPointsPostButtonCustomId(customId)).toBe(true);
+    expect(parsePointsPostButtonCustomId(customId)).toEqual({ userId: "777" });
+  });
+
+  it("creates transient payload keys", () => {
+    const keyA = createTransientFwaKey();
+    const keyB = createTransientFwaKey();
+
+    expect(keyA.length).toBeGreaterThan(6);
+    expect(keyB.length).toBeGreaterThan(6);
+    expect(keyA).not.toBe(keyB);
+  });
+});

--- a/tests/fwaDataParsers.logic.test.ts
+++ b/tests/fwaDataParsers.logic.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+import {
+  extractActiveFwa,
+  extractMatchupBalances,
+  extractMatchupHeader,
+  extractPointBalance,
+  extractTagsFromText,
+  parseCocApiTime,
+  sanitizeClanName,
+} from "../src/commands/fwa/dataParsers";
+
+describe("fwa data parsers", () => {
+  it("extracts point balance from html content", () => {
+    const html = "<div><strong>Current Point Balance: 12345</strong></div>";
+    expect(extractPointBalance(html)).toBe(12345);
+  });
+
+  it("extracts active FWA values across text candidates", () => {
+    expect(extractActiveFwa("Active FWA: Yes")).toBe(true);
+    expect(extractActiveFwa("Active FWA: No")).toBe(false);
+    expect(extractActiveFwa("No matching field")).toBeNull();
+  });
+
+  it("parses matchup header and sync number", () => {
+    const header = extractMatchupHeader("Sync #74 Alpha (Q2AAA) vs. Bravo (P3BBB)");
+    expect(header).toEqual({
+      syncNumber: 74,
+      primaryName: "Alpha",
+      primaryTag: "Q2AAA",
+      opponentName: "Bravo",
+      opponentTag: "P3BBB",
+    });
+  });
+
+  it("extracts tags and matchup balances from summary text", () => {
+    const text = "Winner: #Q2AAA (Q2AAA) (1200 > 1180, high sync)";
+    expect(extractTagsFromText(text)).toEqual(["Q2AAA"]);
+    expect(extractMatchupBalances(text)).toEqual({
+      primaryBalance: 1200,
+      opponentBalance: 1180,
+    });
+  });
+
+  it("parses Clash API timestamps to epoch milliseconds", () => {
+    expect(parseCocApiTime("20260308T123456.000Z")).toBe(
+      Date.UTC(2026, 2, 8, 12, 34, 56)
+    );
+  });
+
+  it("sanitizes noisy clan names", () => {
+    expect(sanitizeClanName("Clan Tag: #ABC")).toBeNull();
+    expect(sanitizeClanName("  Legit Clan  ")).toBe("Legit Clan");
+  });
+});

--- a/tests/fwaMatchUtils.logic.test.ts
+++ b/tests/fwaMatchUtils.logic.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildLimitedMessage,
+  compareTagsForTiebreak,
+  formatPoints,
+  getSyncMode,
+} from "../src/commands/fwa/matchUtils";
+
+describe("fwa match utils", () => {
+  it("derives sync mode from sync number parity", () => {
+    expect(getSyncMode(10)).toBe("high");
+    expect(getSyncMode(11)).toBe("low");
+    expect(getSyncMode(null)).toBeNull();
+  });
+
+  it("compares tags using deterministic tiebreak order", () => {
+    expect(compareTagsForTiebreak("A000", "B000")).toBeLessThan(0);
+    expect(compareTagsForTiebreak("Z000", "A000")).toBeGreaterThan(0);
+    expect(compareTagsForTiebreak("#Q2AAA", "Q2AAA")).toBe(0);
+  });
+
+  it("formats points for display", () => {
+    expect(formatPoints(1234567)).toBe("1,234,567");
+  });
+
+  it("builds bounded messages and adds omitted-count note when truncated", () => {
+    const lines = Array.from({ length: 120 }, (_, index) => `Clan ${index} ${"x".repeat(40)}`);
+    const message = buildLimitedMessage("Header", lines, "\nSummary");
+
+    expect(message.length).toBeLessThanOrEqual(2000);
+    expect(message).toContain("...and ");
+  });
+});


### PR DESCRIPTION
- move custom-id builders/parsers/selectors to src/commands/fwa/customIds.ts
- move points/war parsing helpers to src/commands/fwa/dataParsers.ts
- move sync-mode, tiebreak, and message-limit helpers to src/commands/fwa/matchUtils.ts
- keep Fwa command behavior intact via imported helpers and re-exports
- add focused unit tests for custom-id, parser, and match utility logic