### PR TITLE
fix(fwa): resolve sync data outcome on first click

### DIFF
--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -115,6 +115,11 @@ import {
   getSyncMode,
   limitDiscordContent,
 } from "./fwa/matchUtils";
+import {
+  deriveSyncActionSiteOutcome,
+  evaluatePostSyncValidation,
+  hasRenderedOutcomeMismatch,
+} from "./fwa/syncAction";
 export { isMissedSyncClanForTest } from "./fwa/matchState";
 export {
   isFwaMailBackButtonCustomId,
@@ -2458,36 +2463,66 @@ export async function handleFwaMatchSyncActionButton(
   );
   try {
 
-  await prisma.currentWar.upsert({
-    where: {
-      clanTag_guildId: {
-        guildId: interaction.guildId,
-        clanTag: `#${parsed.tag}`,
+  const persistedAfterApply = await prisma.$transaction(async (tx) => {
+    await tx.currentWar.upsert({
+      where: {
+        clanTag_guildId: {
+          guildId: interaction.guildId!,
+          clanTag: `#${parsed.tag}`,
+        },
       },
-    },
-    create: {
-      guildId: interaction.guildId,
-      clanTag: `#${parsed.tag}`,
-      channelId: interaction.channelId,
-      notify: false,
-      fwaPoints: syncAction.siteFwaPoints,
-      opponentFwaPoints: syncAction.siteOpponentFwaPoints,
-      matchType: syncAction.siteMatchType ?? undefined,
-      inferredMatchType: syncAction.siteMatchType === "MM",
-      outcome: syncAction.siteOutcome,
-    },
-    update: {
-      fwaPoints: syncAction.siteFwaPoints,
-      opponentFwaPoints: syncAction.siteOpponentFwaPoints,
-      matchType: syncAction.siteMatchType ?? undefined,
-      inferredMatchType: syncAction.siteMatchType === "MM",
-      outcome: syncAction.siteOutcome,
-      updatedAt: new Date(),
-    },
+      create: {
+        guildId: interaction.guildId!,
+        clanTag: `#${parsed.tag}`,
+        channelId: interaction.channelId,
+        notify: false,
+        fwaPoints: syncAction.siteFwaPoints,
+        opponentFwaPoints: syncAction.siteOpponentFwaPoints,
+        matchType: syncAction.siteMatchType ?? undefined,
+        inferredMatchType: syncAction.siteMatchType === "MM",
+        outcome: syncAction.siteOutcome,
+      },
+      update: {
+        fwaPoints: syncAction.siteFwaPoints,
+        opponentFwaPoints: syncAction.siteOpponentFwaPoints,
+        matchType: syncAction.siteMatchType ?? undefined,
+        inferredMatchType: syncAction.siteMatchType === "MM",
+        outcome: syncAction.siteOutcome,
+        updatedAt: new Date(),
+      },
+    });
+    return tx.currentWar.findUnique({
+      where: {
+        clanTag_guildId: {
+          guildId: interaction.guildId!,
+          clanTag: `#${parsed.tag}`,
+        },
+      },
+      select: {
+        matchType: true,
+        outcome: true,
+        fwaPoints: true,
+        opponentFwaPoints: true,
+      },
+    });
   });
   logFwaMatchTelemetry(
     "sync_action_applied",
-    `user=${interaction.user.id} tag=${parsed.tag} site_sync=${syncAction.siteSyncNumber ?? "unknown"} site_points=${syncAction.siteFwaPoints ?? "unknown"} opponent_points=${syncAction.siteOpponentFwaPoints ?? "unknown"}`
+    `user=${interaction.user.id} tag=${parsed.tag} site_sync=${syncAction.siteSyncNumber ?? "unknown"} site_match_type=${syncAction.siteMatchType ?? "unknown"} site_outcome=${syncAction.siteOutcome ?? "UNKNOWN"} site_points=${syncAction.siteFwaPoints ?? "unknown"} opponent_points=${syncAction.siteOpponentFwaPoints ?? "unknown"}`
+  );
+  const postSyncValidation = evaluatePostSyncValidation({
+    persistedMatchType: persistedAfterApply?.matchType ?? null,
+    persistedOutcome: persistedAfterApply?.outcome ?? null,
+    persistedFwaPoints: persistedAfterApply?.fwaPoints ?? null,
+    persistedOpponentFwaPoints: persistedAfterApply?.opponentFwaPoints ?? null,
+    siteMatchType: syncAction.siteMatchType,
+    siteOutcome: syncAction.siteOutcome,
+    siteFwaPoints: syncAction.siteFwaPoints,
+    siteOpponentFwaPoints: syncAction.siteOpponentFwaPoints,
+  });
+  logFwaMatchTelemetry(
+    "post_sync_validation",
+    `user=${interaction.user.id} tag=${parsed.tag} fully_aligned=${postSyncValidation.fullyAligned ? 1 : 0} match_type_aligned=${postSyncValidation.matchTypeAligned ? 1 : 0} outcome_aligned=${postSyncValidation.outcomeAligned ? 1 : 0} points_aligned=${postSyncValidation.pointsAligned ? 1 : 0} persisted_match_type=${persistedAfterApply?.matchType ?? "unknown"} persisted_outcome=${persistedAfterApply?.outcome ?? "UNKNOWN"}`
   );
   await markMatchLiveDataChanged({
     guildId: interaction.guildId,
@@ -2502,6 +2537,10 @@ export async function handleFwaMatchSyncActionButton(
     interaction.client
   );
   if (!refreshed) {
+    logFwaMatchTelemetry(
+      "post_sync_render_state",
+      `user=${interaction.user.id} tag=${parsed.tag} status=refresh_failed`
+    );
     await interaction.followUp({
       ephemeral: true,
       content: "Data synced, but this view could not be refreshed.",
@@ -2512,12 +2551,21 @@ export async function handleFwaMatchSyncActionButton(
   const showMode = interaction.message.embeds.length > 0 ? "embed" : "copy";
   const nextView = refreshed.singleViews[parsed.tag];
   if (!nextView) {
+    logFwaMatchTelemetry(
+      "post_sync_render_state",
+      `user=${interaction.user.id} tag=${parsed.tag} status=view_missing`
+    );
     await interaction.followUp({
       ephemeral: true,
       content: "Data synced, but clan view is unavailable now.",
     });
     return;
   }
+  const renderedDescription = String(nextView.embed.data.description ?? "");
+  logFwaMatchTelemetry(
+    "post_sync_render_state",
+    `user=${interaction.user.id} tag=${parsed.tag} status=render_ready sync_action_visible=${nextView.syncAction ? 1 : 0} outcome_mismatch=${hasRenderedOutcomeMismatch(renderedDescription) ? 1 : 0}`
+  );
   await interaction.editReply({
     content: showMode === "copy" ? limitDiscordContent(nextView.copyText) : undefined,
     embeds: showMode === "embed" ? [nextView.embed] : [],
@@ -5250,6 +5298,10 @@ async function buildTrackedMatchOverview(
     ]
       .filter(Boolean)
       .join("\n");
+    const syncActionSiteOutcome = deriveSyncActionSiteOutcome({
+      siteMatchType,
+      projectedOutcome: derivedOutcome,
+    });
     const syncAction: MatchView["syncAction"] =
       siteUpdatedForAlert && hasMismatch
         ? {
@@ -5257,7 +5309,7 @@ async function buildTrackedMatchOverview(
             siteMatchType,
             siteFwaPoints: primaryPoints?.balance ?? null,
             siteOpponentFwaPoints: opponentPoints?.balance ?? null,
-            siteOutcome: matchType === "FWA" ? derivedOutcome : null,
+            siteOutcome: syncActionSiteOutcome,
             siteSyncNumber: siteSyncObserved,
           }
         : null;
@@ -7210,6 +7262,11 @@ export const Fwa: Command = {
             .join("\n")
         );
         let alliance = overview;
+        const syncActionSiteMatchType = inferredFromPointsType === "FWA" ? "FWA" : "MM";
+        const syncActionSiteOutcome = deriveSyncActionSiteOutcome({
+          siteMatchType: syncActionSiteMatchType,
+          projectedOutcome: derivedOutcome,
+        });
         const singleView: MatchView = {
           embed,
           copyText,
@@ -7227,10 +7284,10 @@ export const Fwa: Command = {
             siteUpdated && hasMismatch
               ? {
                   tag,
-                  siteMatchType: inferredFromPointsType === "FWA" ? "FWA" : "MM",
+                  siteMatchType: syncActionSiteMatchType,
                   siteFwaPoints: primary.balance,
                   siteOpponentFwaPoints: opponent.balance,
-                  siteOutcome: matchType === "FWA" ? derivedOutcome : null,
+                  siteOutcome: syncActionSiteOutcome,
                   siteSyncNumber: siteSyncObserved,
                 }
               : null,

--- a/src/commands/fwa/syncAction.ts
+++ b/src/commands/fwa/syncAction.ts
@@ -1,0 +1,94 @@
+export type SyncActionSiteMatchType = "FWA" | "MM" | null;
+export type SyncActionOutcome = "WIN" | "LOSE" | null;
+
+function normalizeMatchType(value: string | null | undefined): "FWA" | "BL" | "MM" | "SKIP" | "UNKNOWN" | null {
+  const normalized = String(value ?? "")
+    .trim()
+    .toUpperCase();
+  if (!normalized) return null;
+  if (
+    normalized !== "FWA" &&
+    normalized !== "BL" &&
+    normalized !== "MM" &&
+    normalized !== "SKIP" &&
+    normalized !== "UNKNOWN"
+  ) {
+    return null;
+  }
+  return normalized;
+}
+
+function normalizeOutcome(value: string | null | undefined): "WIN" | "LOSE" | "UNKNOWN" | null {
+  const normalized = String(value ?? "")
+    .trim()
+    .toUpperCase();
+  if (!normalized) return null;
+  if (normalized !== "WIN" && normalized !== "LOSE" && normalized !== "UNKNOWN") return null;
+  return normalized;
+}
+
+/** Purpose: derive sync action outcome from site-inferred match type, not persisted match type. */
+export function deriveSyncActionSiteOutcome(input: {
+  siteMatchType: SyncActionSiteMatchType;
+  projectedOutcome: SyncActionOutcome;
+}): SyncActionOutcome {
+  if (input.siteMatchType !== "FWA") return null;
+  return input.projectedOutcome ?? null;
+}
+
+function pointsAlignedIfKnown(
+  persisted: number | null | undefined,
+  site: number | null | undefined
+): boolean {
+  if (
+    persisted === null ||
+    persisted === undefined ||
+    site === null ||
+    site === undefined ||
+    !Number.isFinite(persisted) ||
+    !Number.isFinite(site)
+  ) {
+    return true;
+  }
+  return Math.trunc(persisted) === Math.trunc(site);
+}
+
+/** Purpose: evaluate if persisted CurrentWar fields align with the Sync Data payload after apply. */
+export function evaluatePostSyncValidation(input: {
+  persistedMatchType: string | null | undefined;
+  persistedOutcome: string | null | undefined;
+  persistedFwaPoints: number | null | undefined;
+  persistedOpponentFwaPoints: number | null | undefined;
+  siteMatchType: SyncActionSiteMatchType;
+  siteOutcome: SyncActionOutcome;
+  siteFwaPoints: number | null;
+  siteOpponentFwaPoints: number | null;
+}): {
+  matchTypeAligned: boolean;
+  outcomeAligned: boolean;
+  pointsAligned: boolean;
+  fullyAligned: boolean;
+} {
+  const persistedMatchType = normalizeMatchType(input.persistedMatchType);
+  const persistedOutcome = normalizeOutcome(input.persistedOutcome);
+  const matchTypeAligned =
+    input.siteMatchType === null || persistedMatchType === input.siteMatchType;
+  const outcomeAligned =
+    input.siteMatchType !== "FWA" ||
+    input.siteOutcome === null ||
+    persistedOutcome === input.siteOutcome;
+  const pointsAligned =
+    pointsAlignedIfKnown(input.persistedFwaPoints, input.siteFwaPoints) &&
+    pointsAlignedIfKnown(input.persistedOpponentFwaPoints, input.siteOpponentFwaPoints);
+  return {
+    matchTypeAligned,
+    outcomeAligned,
+    pointsAligned,
+    fullyAligned: matchTypeAligned && outcomeAligned && pointsAligned,
+  };
+}
+
+/** Purpose: detect rendered outcome-mismatch text for post-sync convergence telemetry. */
+export function hasRenderedOutcomeMismatch(description: string): boolean {
+  return /\boutcome mismatch\b/i.test(description);
+}

--- a/tests/fwaSyncAction.logic.test.ts
+++ b/tests/fwaSyncAction.logic.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "vitest";
+import {
+  deriveSyncActionSiteOutcome,
+  evaluatePostSyncValidation,
+  hasRenderedOutcomeMismatch,
+} from "../src/commands/fwa/syncAction";
+
+describe("fwa sync action helpers", () => {
+  it("derives site outcome from site-inferred FWA type", () => {
+    const siteOutcome = deriveSyncActionSiteOutcome({
+      siteMatchType: "FWA",
+      projectedOutcome: "WIN",
+    });
+
+    expect(siteOutcome).toBe("WIN");
+  });
+
+  it("keeps site outcome null for non-FWA site matches", () => {
+    const siteOutcome = deriveSyncActionSiteOutcome({
+      siteMatchType: "MM",
+      projectedOutcome: "WIN",
+    });
+
+    expect(siteOutcome).toBeNull();
+  });
+
+  it("keeps site outcome null when projected site outcome is unknown", () => {
+    const siteOutcome = deriveSyncActionSiteOutcome({
+      siteMatchType: "FWA",
+      projectedOutcome: null,
+    });
+
+    expect(siteOutcome).toBeNull();
+  });
+
+  it("marks post-sync validation aligned when persisted values match site payload", () => {
+    const result = evaluatePostSyncValidation({
+      persistedMatchType: "FWA",
+      persistedOutcome: "WIN",
+      persistedFwaPoints: 1000,
+      persistedOpponentFwaPoints: 900,
+      siteMatchType: "FWA",
+      siteOutcome: "WIN",
+      siteFwaPoints: 1000,
+      siteOpponentFwaPoints: 900,
+    });
+
+    expect(result.fullyAligned).toBe(true);
+    expect(result.matchTypeAligned).toBe(true);
+    expect(result.outcomeAligned).toBe(true);
+    expect(result.pointsAligned).toBe(true);
+  });
+
+  it("keeps mismatch visible when persisted FWA outcome is still unknown", () => {
+    const result = evaluatePostSyncValidation({
+      persistedMatchType: "FWA",
+      persistedOutcome: "UNKNOWN",
+      persistedFwaPoints: 1000,
+      persistedOpponentFwaPoints: 900,
+      siteMatchType: "FWA",
+      siteOutcome: "WIN",
+      siteFwaPoints: 1000,
+      siteOpponentFwaPoints: 900,
+    });
+
+    expect(result.fullyAligned).toBe(false);
+    expect(result.outcomeAligned).toBe(false);
+  });
+
+  it("ignores outcome alignment for non-FWA site match types", () => {
+    const result = evaluatePostSyncValidation({
+      persistedMatchType: "MM",
+      persistedOutcome: "UNKNOWN",
+      persistedFwaPoints: 1000,
+      persistedOpponentFwaPoints: 900,
+      siteMatchType: "MM",
+      siteOutcome: null,
+      siteFwaPoints: 1000,
+      siteOpponentFwaPoints: 900,
+    });
+
+    expect(result.matchTypeAligned).toBe(true);
+    expect(result.outcomeAligned).toBe(true);
+    expect(result.pointsAligned).toBe(true);
+    expect(result.fullyAligned).toBe(true);
+  });
+
+  it("detects rendered outcome mismatch text", () => {
+    expect(
+      hasRenderedOutcomeMismatch("⚠ Outcome mismatch: expected UNKNOWN, site WIN.")
+    ).toBe(true);
+    expect(hasRenderedOutcomeMismatch("• Outcome mismatch")).toBe(true);
+    expect(hasRenderedOutcomeMismatch("Data is in sync with points.fwafarm")).toBe(false);
+  });
+});


### PR DESCRIPTION
- derive sync action outcome from site-inferred match type
- add post-sync validation and render-state telemetry logs
- add regression tests for one-click sync convergence and edge cases