### PR TITLE
feat(fwa): add war-scoped points reuse for match rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Discord bot for Clash of Clans activity tooling.
 - Supports configurable war plans by match type/outcome via `/warplan set|show|reset`; these templates are used in posted war mail content (including line breaks, emoji, and media links).
 - Optimized points polling now tracks lifecycle state in `ClanPointsSync` (`confirmedByClanMail`, `needsValidation`, last-known values) and reduces routine `points.fwafarm` calls after clan-mail confirmation.
 - `/fwa match` now shows actionable sync status (`Needs validation` or `Confirmed and current`) plus the most recent successful external points fetch timestamp tied to verified sync data.
+- `/fwa match` now reuses war-scoped verified points snapshots from persisted sync data for the active war, and `/force sync data` remains the explicit refresh-scrape path.
 - `/remaining war` now supports alliance-wide aggregate mode (no tag) with dominant-cluster mean remaining time, spread, and outlier clan reporting.
 - Telemetry now records command lifecycle/API/stage aggregates and supports `/telemetry report` plus scheduled Discord report posting.
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -37,7 +37,7 @@
 - `/war war-id war-id:<number>` - Export stored war lookup payload for one war ID as CSV.
 - `/accounts [visibility:private|public] [tag:<playerTag>] [discord-id:<snowflake>]` - List linked player accounts grouped by current clan. Default is your own account; provide exactly one of `tag` or `discord-id` to inspect a different linked user.
 - `/fwa points [visibility:private|public] [tag:<tag>]` - Fetch current point balance from `https://points.fwafarm.com/clan?tag=<tag-without-#>`. If `tag` is omitted, fetches all tracked clans.
-- `/fwa match [visibility:private|public] tag:<tag>` - Resolve current war opponent from CoC API, render cached matchup state, and project win/lose by points (or sync-based tiebreak on tie). Slow in-message actions now show a processing notice while updates run. Sync state output is actionable-only (`Needs validation` or `Confirmed and current`) and hides internal lifecycle debug fields. "Current mail is up to date" now requires the same current-war identity (war/opponent/config), so new wars do not inherit prior mail-sent state.
+- `/fwa match [visibility:private|public] tag:<tag>` - Resolve current war opponent from CoC API, render cached matchup state, and project win/lose by points (or sync-based tiebreak on tie). Slow in-message actions now show a processing notice while updates run. After a war snapshot is verified current, match rendering reuses war-scoped persisted sync data instead of short-TTL re-scrapes. Sync state output is actionable-only (`Needs validation` or `Confirmed and current`) and hides internal lifecycle debug fields. "Current mail is up to date" now requires the same current-war identity (war/opponent/config), so new wars do not inherit prior mail-sent state.
 - `/fwa match-type [visibility:private|public] [tag:<trackedClanTag>] [type:FWA|BL|MM]` - Manually set or view per-clan match type override used by matchup output. If no args, lists overrides for all tracked clans.
 - `/fwa mail send tag:<trackedClanTag>` - Show ephemeral war mail preview with confirm-and-send to the tracked clan mail channel. Confirm-and-send pings `TrackedClan.clanRoleId` when enabled.
 - `/fwa match` single-clan view includes a `Send Mail` button that follows the same access policy as `/fwa mail send` and uses the same role-ping behavior.
@@ -56,7 +56,7 @@
 - `/kick-list clear [mode:all|auto|manual]` - Clear kick-list entries.
 - `/sync time post [role:<discordRole>]` - Open modal, compose sync-time message, post it, and pin it.
 - `/sync post status [message-id:<id>]` - Show claimed vs unclaimed clan badge reactions for the active sync-time post, or for a specific message in the channel.
-- `/force sync data tag:<trackedClanTag> [datapoint:points|syncNum]` - Manually force-sync tracked clan points and/or sync number from points.fwafarm.
+- `/force sync data tag:<trackedClanTag> [datapoint:points|syncNum]` - Manually force-sync tracked clan points and/or sync number from points.fwafarm (explicitly bypasses normal war-scoped reuse).
 - `/force sync mail tag:<trackedClanTag> message-type:<mail|notify:war start|notify:battle start|notify:war end> message-id:<id>` - Upsert `CurrentWar.mailConfig` with current match configuration plus a posted message reference.
 - `/force sync warid [tag:<trackedClanTag>]` - Backfill missing war IDs in `ClanWarHistory`, `WarAttacks`, and `CurrentWar` (database-only flow; no external scrape/API calls).
 - `/force mail update tag:<trackedClanTag>` - Refresh an existing sent war-mail embed in place (no re-ping) and resume 20-minute refresh tracking.

--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -121,6 +121,10 @@ import {
   hasRenderedOutcomeMismatch,
 } from "./fwa/syncAction";
 import { buildActionableSyncStateLine } from "./fwa/syncDisplay";
+import {
+  selectWarScopedReuseRow,
+  type WarScopedSyncReuseRow,
+} from "./fwa/warScopedReuse";
 export { isMissedSyncClanForTest } from "./fwa/matchState";
 export {
   isFwaMailBackButtonCustomId,
@@ -4312,7 +4316,100 @@ async function scrapeClanPoints(
 type ClanPointsFetchOptions = {
   requiredOpponentTag?: string | null;
   fetchReason?: PointsApiFetchReason;
+  warScopedSnapshot?: PointsSnapshot | null;
 };
+
+type WarScopedSyncReuseDbRow = WarScopedSyncReuseRow & {
+  clanTag: string;
+};
+
+/** Purpose: bucket reusable sync rows by clan for O(1) lookup in match rendering loops. */
+function groupWarScopedSyncRowsByClanTag(
+  rows: WarScopedSyncReuseDbRow[]
+): Map<string, WarScopedSyncReuseRow[]> {
+  const grouped = new Map<string, WarScopedSyncReuseRow[]>();
+  for (const row of rows) {
+    const tag = normalizeTag(row.clanTag);
+    const list = grouped.get(tag) ?? [];
+    list.push({
+      warId: row.warId ?? null,
+      warStartTime: row.warStartTime,
+      syncNum: row.syncNum,
+      opponentTag: row.opponentTag,
+      clanPoints: row.clanPoints,
+      opponentPoints: row.opponentPoints,
+      isFwa: row.isFwa ?? null,
+      needsValidation: row.needsValidation,
+      lastSuccessfulPointsApiFetchAt: row.lastSuccessfulPointsApiFetchAt ?? null,
+      syncFetchedAt: row.syncFetchedAt,
+    });
+    grouped.set(tag, list);
+  }
+  return grouped;
+}
+
+/** Purpose: build a synthetic points snapshot from a validated war-scoped ClanPointsSync row. */
+function buildPointsSnapshotFromWarScopedSyncRow(input: {
+  clanTag: string;
+  row: WarScopedSyncReuseRow;
+}): PointsSnapshot {
+  const clanTag = normalizeTag(input.clanTag);
+  const opponentTag = normalizeTag(input.row.opponentTag);
+  const fetchedAtMs =
+    input.row.lastSuccessfulPointsApiFetchAt?.getTime?.() ??
+    input.row.syncFetchedAt?.getTime?.() ??
+    Date.now();
+  const resolvedFetchedAtMs =
+    Number.isFinite(fetchedAtMs) && fetchedAtMs > 0 ? Math.trunc(fetchedAtMs) : Date.now();
+  return {
+    version: POINTS_CACHE_VERSION,
+    tag: clanTag,
+    url: buildPointsUrl(clanTag),
+    balance: Math.trunc(input.row.clanPoints),
+    clanName: null,
+    activeFwa: input.row.isFwa ?? null,
+    notFound: false,
+    winnerBoxText: null,
+    winnerBoxTags: [opponentTag, clanTag],
+    winnerBoxSync: Math.trunc(input.row.syncNum),
+    effectiveSync: Math.trunc(input.row.syncNum),
+    syncMode: getSyncMode(Math.trunc(input.row.syncNum)),
+    winnerBoxHasTag: true,
+    headerPrimaryTag: clanTag,
+    headerOpponentTag: opponentTag,
+    headerPrimaryBalance: Math.trunc(input.row.clanPoints),
+    headerOpponentBalance: Math.trunc(input.row.opponentPoints),
+    warEndMs: null,
+    lastWarCheckAtMs: resolvedFetchedAtMs,
+    fetchedAtMs: resolvedFetchedAtMs,
+    refreshedForWarEndMs: null,
+  };
+}
+
+/** Purpose: select and materialize war-scoped persisted points for a clan, when eligible. */
+function resolveWarScopedSnapshotForMatch(input: {
+  rows: WarScopedSyncReuseRow[];
+  clanTag: string;
+  warId: string | null;
+  warStartTime: Date | null;
+  opponentTag: string;
+  currentSyncNumber: number | null;
+  sourceSyncNumber: number | null;
+}): PointsSnapshot | null {
+  const reusableRow = selectWarScopedReuseRow({
+    rows: input.rows,
+    warId: input.warId,
+    warStartTime: input.warStartTime,
+    opponentTag: input.opponentTag,
+    currentSyncNumber: input.currentSyncNumber,
+    sourceSyncNumber: input.sourceSyncNumber,
+  });
+  if (!reusableRow) return null;
+  return buildPointsSnapshotFromWarScopedSyncRow({
+    clanTag: input.clanTag,
+    row: reusableRow,
+  });
+}
 
 async function getClanPointsCached(
   _settings: SettingsService,
@@ -4334,6 +4431,31 @@ async function getClanPointsCached(
       detail: `tag=${normalizedTag} reason=${reason}`,
     });
     return applySourceSync(cached.snapshot, sourceSync);
+  }
+
+  const warScopedSnapshotRaw = options?.warScopedSnapshot ?? null;
+  const requiredOpponentTag = normalizeTag(String(options?.requiredOpponentTag ?? ""));
+  const warScopedSnapshot =
+    warScopedSnapshotRaw &&
+    (!requiredOpponentTag ||
+      normalizeTag(String(warScopedSnapshotRaw.headerOpponentTag ?? "")) === requiredOpponentTag)
+      ? warScopedSnapshotRaw
+      : null;
+  if (warScopedSnapshot) {
+    recordFetchEvent({
+      namespace: "points",
+      operation: "clan_points_snapshot",
+      source: "cache_hit",
+      detail: `tag=${normalizedTag} reason=${reason} reuse=war_scoped_persisted`,
+    });
+    pointsSnapshotCache.set(normalizedTag, {
+      snapshot: warScopedSnapshot,
+      expiresAtMs: now + POINTS_SNAPSHOT_CACHE_TTL_MS,
+    });
+    console.info(
+      `[points-fetch] source=persisted tag=${normalizedTag} reason=${reason} reuse=war_scoped_persisted`
+    );
+    return applySourceSync(warScopedSnapshot, sourceSync);
   }
 
   const existingPending = pointsSnapshotInFlight.get(normalizedTag);
@@ -4618,6 +4740,55 @@ async function buildTrackedMatchOverview(
     ])
   );
   const subByTag = new Map(subscriptions.map((s) => [normalizeTag(s.clanTag), s]));
+  const subscriptionWarIds = [...new Set(
+    subscriptions
+      .map((sub) =>
+        sub.warId !== null && sub.warId !== undefined && Number.isFinite(sub.warId)
+          ? String(Math.trunc(sub.warId))
+          : null
+      )
+      .filter((value): value is string => Boolean(value))
+  )];
+  const subscriptionWarStarts = [...new Set(
+    subscriptions
+      .map((sub) => (sub.startTime instanceof Date ? sub.startTime.toISOString() : null))
+      .filter((value): value is string => Boolean(value))
+  )].map((iso) => new Date(iso));
+  const scopedTrackedTags = scopedTracked.map((clan) => `#${normalizeTag(clan.tag)}`);
+  const reuseIdentityFilters = [
+    subscriptionWarIds.length > 0 ? { warId: { in: subscriptionWarIds } } : null,
+    subscriptionWarStarts.length > 0 ? { warStartTime: { in: subscriptionWarStarts } } : null,
+  ].filter((clause): clause is NonNullable<typeof clause> => clause !== null);
+  const warScopedSyncRows =
+    guildId && scopedTrackedTags.length > 0 && reuseIdentityFilters.length > 0
+    ? await prisma.clanPointsSync.findMany({
+        where: {
+          guildId,
+          clanTag: { in: scopedTrackedTags },
+          needsValidation: false,
+          OR: reuseIdentityFilters,
+        },
+        select: {
+          clanTag: true,
+          warId: true,
+          warStartTime: true,
+          syncNum: true,
+          opponentTag: true,
+          clanPoints: true,
+          opponentPoints: true,
+          isFwa: true,
+          needsValidation: true,
+          lastSuccessfulPointsApiFetchAt: true,
+          syncFetchedAt: true,
+        },
+        orderBy: [
+          { warStartTime: "desc" },
+          { syncFetchedAt: "desc" },
+          { updatedAt: "desc" },
+        ],
+      })
+    : [];
+  const warScopedSyncRowsByClanTag = groupWarScopedSyncRowsByClanTag(warScopedSyncRows);
 
   const warByClanTag = new Map<string, CurrentWarResult | null>();
   const warStateByClanTag = new Map<string, WarStateForSync>();
@@ -4830,13 +5001,31 @@ async function buildTrackedMatchOverview(
     }
 
     const currentSync = getCurrentSyncFromPrevious(sourceSync, warState);
+    const warIdForReuse =
+      sub?.warId !== null && sub?.warId !== undefined && Number.isFinite(sub?.warId)
+        ? String(Math.trunc(sub.warId))
+        : null;
+    const warStartTimeForReuse = getWarStartDateForSync(sub?.startTime ?? null, war);
+    const warScopedSnapshot = resolveWarScopedSnapshotForMatch({
+      rows: warScopedSyncRowsByClanTag.get(clanTag) ?? [],
+      clanTag,
+      warId: warIdForReuse,
+      warStartTime: warStartTimeForReuse,
+      opponentTag,
+      currentSyncNumber: currentSync,
+      sourceSyncNumber: sourceSync,
+    });
     const primaryPoints = await getClanPointsCached(
       settings,
       cocService,
       clanTag,
       currentSync,
       warLookupCache,
-      { requiredOpponentTag: opponentTag }
+      {
+        requiredOpponentTag: opponentTag,
+        fetchReason: "match_render",
+        warScopedSnapshot,
+      }
     ).catch(() => null);
     let opponentPoints: PointsSnapshot | null = null;
     if (primaryPoints) {
@@ -4997,7 +5186,7 @@ async function buildTrackedMatchOverview(
     const siteUpdatedForAlert = Boolean(
       primaryPoints && isPointsSiteUpdatedForOpponent(primaryPoints, opponentTag, sourceSync)
     );
-    const warStartTimeForSync = getWarStartDateForSync(sub?.startTime ?? null, war);
+    const warStartTimeForSync = warStartTimeForReuse;
     await persistClanPointsSyncIfCurrent({
       guildId,
       clanTag,
@@ -6722,6 +6911,47 @@ export const Fwa: Command = {
             })
           : null;
         opponentTag = normalizeTag(String(war?.opponent?.tag ?? ""));
+        const warIdForReuse =
+          subscription?.warId !== null &&
+          subscription?.warId !== undefined &&
+          Number.isFinite(subscription?.warId)
+            ? String(Math.trunc(subscription.warId))
+            : null;
+        const warStartTimeForReuse = getWarStartDateForSync(subscription?.startTime ?? null, war);
+        const warScopedIdentityFilters = [
+          warIdForReuse ? { warId: warIdForReuse } : null,
+          warStartTimeForReuse ? { warStartTime: warStartTimeForReuse } : null,
+        ].filter((clause): clause is NonNullable<typeof clause> => clause !== null);
+        const warScopedSyncRows =
+          interaction.guildId && warScopedIdentityFilters.length > 0
+          ? await prisma.clanPointsSync.findMany({
+              where: {
+                guildId: interaction.guildId,
+                clanTag: `#${tag}`,
+                needsValidation: false,
+                OR: warScopedIdentityFilters,
+              },
+              select: {
+                clanTag: true,
+                warId: true,
+                warStartTime: true,
+                syncNum: true,
+                opponentTag: true,
+                clanPoints: true,
+                opponentPoints: true,
+                isFwa: true,
+                needsValidation: true,
+                lastSuccessfulPointsApiFetchAt: true,
+                syncFetchedAt: true,
+              },
+              orderBy: [
+                { warStartTime: "desc" },
+                { syncFetchedAt: "desc" },
+                { updatedAt: "desc" },
+              ],
+            })
+          : [];
+        const warScopedSyncRowsByClanTag = groupWarScopedSyncRowsByClanTag(warScopedSyncRows);
         if (warState === "notInWar" || !opponentTag || subscription?.state === "notInWar") {
           const clanProfile = await cocService.getClan(`#${tag}`).catch(() => null);
           const memberCount = Array.isArray(clanProfile?.members)
@@ -6826,13 +7056,26 @@ export const Fwa: Command = {
           return;
         }
 
+        const warScopedSnapshot = resolveWarScopedSnapshotForMatch({
+          rows: warScopedSyncRowsByClanTag.get(tag) ?? [],
+          clanTag: tag,
+          warId: warIdForReuse,
+          warStartTime: warStartTimeForReuse,
+          opponentTag,
+          currentSyncNumber: currentSync,
+          sourceSyncNumber: sourceSync,
+        });
         const primary = await getClanPointsCached(
           settings,
           cocService,
           tag,
           currentSync,
           warLookupCache,
-          { requiredOpponentTag: opponentTag }
+          {
+            requiredOpponentTag: opponentTag,
+            fetchReason: "match_render",
+            warScopedSnapshot,
+          }
         );
         let opponent: PointsSnapshot;
         const siteUpdated = isPointsSiteUpdatedForOpponent(primary, opponentTag, sourceSync);

--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -215,6 +215,7 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
     details: [
       "`/fwa points` returns point balances (single clan tag or all tracked if tag omitted).",
       "`/fwa match` auto-resolves current war opponent from CoC API and evaluates win/lose/tiebreak using cached points + persisted sync state.",
+      "After a war's points snapshot is verified current, `/fwa match` reuses war-scoped persisted sync data instead of re-scraping by short TTL; use `/force sync data` for explicit refresh.",
       "`/fwa match` shows actionable sync status only (`State: Needs validation` or `State: Confirmed and current`) and hides internal lifecycle debug fields.",
       "When available, fwastats active-war validation is used by the war poller to promote inferred FWA matches to confirmed FWA.",
       "If match type is inferred, `/fwa match` shows a warning and quick verify link, with action buttons to confirm FWA/BL/MM.",

--- a/src/commands/fwa/warScopedReuse.ts
+++ b/src/commands/fwa/warScopedReuse.ts
@@ -1,0 +1,84 @@
+export type WarScopedSyncReuseRow = {
+  warId: string | null;
+  warStartTime: Date;
+  syncNum: number;
+  opponentTag: string;
+  clanPoints: number;
+  opponentPoints: number;
+  isFwa: boolean | null;
+  needsValidation: boolean;
+  lastSuccessfulPointsApiFetchAt: Date | null;
+  syncFetchedAt: Date;
+};
+
+function normalizeTag(input: string): string {
+  return input.trim().toUpperCase().replace(/^#/, "");
+}
+
+function toSyncNumber(value: number | null | undefined): number | null {
+  if (value === null || value === undefined || !Number.isFinite(value)) return null;
+  return Math.trunc(value);
+}
+
+function isSameWarIdentity(input: {
+  rowWarId: string | null;
+  rowWarStartTime: Date;
+  warId: string | null;
+  warStartTime: Date | null;
+}): boolean {
+  if (input.warId) {
+    return String(input.rowWarId ?? "") === String(input.warId);
+  }
+  if (input.warStartTime instanceof Date) {
+    const targetMs = input.warStartTime.getTime();
+    const rowMs = input.rowWarStartTime.getTime();
+    return Number.isFinite(targetMs) && Number.isFinite(rowMs) && targetMs === rowMs;
+  }
+  return false;
+}
+
+/** Purpose: select a reusable ClanPointsSync row for the active war context and sync cycle. */
+export function selectWarScopedReuseRow(input: {
+  rows: WarScopedSyncReuseRow[];
+  warId: string | null;
+  warStartTime: Date | null;
+  opponentTag: string;
+  currentSyncNumber: number | null;
+  sourceSyncNumber: number | null;
+}): WarScopedSyncReuseRow | null {
+  const opponentTag = normalizeTag(input.opponentTag);
+  if (!opponentTag) return null;
+  const currentSync = toSyncNumber(input.currentSyncNumber);
+  const sourceSync = toSyncNumber(input.sourceSyncNumber);
+  if (currentSync === null && sourceSync === null) return null;
+
+  for (const row of input.rows) {
+    if (row.needsValidation) continue;
+    if (!isSameWarIdentity({
+      rowWarId: row.warId,
+      rowWarStartTime: row.warStartTime,
+      warId: input.warId,
+      warStartTime: input.warStartTime,
+    })) {
+      continue;
+    }
+
+    if (normalizeTag(row.opponentTag) !== opponentTag) continue;
+    const rowSync = toSyncNumber(row.syncNum);
+    const clanPoints = toSyncNumber(row.clanPoints);
+    const opponentPoints = toSyncNumber(row.opponentPoints);
+    if (rowSync === null || clanPoints === null || opponentPoints === null) continue;
+
+    if (currentSync !== null && rowSync !== currentSync) continue;
+    if (currentSync === null && sourceSync !== null && rowSync <= sourceSync) continue;
+
+    return {
+      ...row,
+      syncNum: rowSync,
+      clanPoints,
+      opponentPoints,
+    };
+  }
+
+  return null;
+}

--- a/tests/warScopedPointsReuse.logic.test.ts
+++ b/tests/warScopedPointsReuse.logic.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from "vitest";
+import {
+  selectWarScopedReuseRow,
+  type WarScopedSyncReuseRow,
+} from "../src/commands/fwa/warScopedReuse";
+
+function buildRow(overrides?: Partial<WarScopedSyncReuseRow>): WarScopedSyncReuseRow {
+  return {
+    warId: "1234",
+    warStartTime: new Date("2026-03-08T00:00:00.000Z"),
+    syncNum: 42,
+    opponentTag: "#ABC123",
+    clanPoints: 1111,
+    opponentPoints: 999,
+    isFwa: true,
+    needsValidation: false,
+    lastSuccessfulPointsApiFetchAt: new Date("2026-03-08T01:00:00.000Z"),
+    syncFetchedAt: new Date("2026-03-08T01:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+describe("war scoped points reuse selection", () => {
+  it("selects lock row when war identity, opponent, and sync align", () => {
+    const row = buildRow();
+    const selected = selectWarScopedReuseRow({
+      rows: [row],
+      warId: "1234",
+      warStartTime: row.warStartTime,
+      opponentTag: "abc123",
+      currentSyncNumber: 42,
+      sourceSyncNumber: 41,
+    });
+
+    expect(selected).not.toBeNull();
+    expect(selected?.syncNum).toBe(42);
+    expect(selected?.clanPoints).toBe(1111);
+  });
+
+  it("reuses by sync progression when current sync is unknown but row sync is newer than source", () => {
+    const selected = selectWarScopedReuseRow({
+      rows: [buildRow({ syncNum: 19 })],
+      warId: "1234",
+      warStartTime: new Date("2026-03-08T00:00:00.000Z"),
+      opponentTag: "#ABC123",
+      currentSyncNumber: null,
+      sourceSyncNumber: 18,
+    });
+
+    expect(selected).not.toBeNull();
+    expect(selected?.syncNum).toBe(19);
+  });
+
+  it("does not reuse when lifecycle requires validation", () => {
+    const selected = selectWarScopedReuseRow({
+      rows: [buildRow({ needsValidation: true })],
+      warId: "1234",
+      warStartTime: new Date("2026-03-08T00:00:00.000Z"),
+      opponentTag: "#ABC123",
+      currentSyncNumber: 42,
+      sourceSyncNumber: 41,
+    });
+
+    expect(selected).toBeNull();
+  });
+
+  it("does not reuse when war identity changes", () => {
+    const selected = selectWarScopedReuseRow({
+      rows: [buildRow({ warId: "2222" })],
+      warId: "1234",
+      warStartTime: new Date("2026-03-08T00:00:00.000Z"),
+      opponentTag: "#ABC123",
+      currentSyncNumber: 42,
+      sourceSyncNumber: 41,
+    });
+
+    expect(selected).toBeNull();
+  });
+
+  it("does not reuse when opponent alignment differs", () => {
+    const selected = selectWarScopedReuseRow({
+      rows: [buildRow({ opponentTag: "#ZZZ999" })],
+      warId: "1234",
+      warStartTime: new Date("2026-03-08T00:00:00.000Z"),
+      opponentTag: "#ABC123",
+      currentSyncNumber: 42,
+      sourceSyncNumber: 41,
+    });
+
+    expect(selected).toBeNull();
+  });
+
+  it("does not reuse when sync is stale for the source sync context", () => {
+    const selected = selectWarScopedReuseRow({
+      rows: [buildRow({ syncNum: 17 })],
+      warId: "1234",
+      warStartTime: new Date("2026-03-08T00:00:00.000Z"),
+      opponentTag: "#ABC123",
+      currentSyncNumber: null,
+      sourceSyncNumber: 17,
+    });
+
+    expect(selected).toBeNull();
+  });
+
+  it("does not reuse when sync context is unavailable", () => {
+    const selected = selectWarScopedReuseRow({
+      rows: [buildRow()],
+      warId: "1234",
+      warStartTime: new Date("2026-03-08T00:00:00.000Z"),
+      opponentTag: "#ABC123",
+      currentSyncNumber: null,
+      sourceSyncNumber: null,
+    });
+
+    expect(selected).toBeNull();
+  });
+});


### PR DESCRIPTION
- reuse verified ClanPointsSync snapshots for active-war /fwa match paths
- keep strict war/opponent/sync guards with transition invalidation
- tag telemetry details for persisted reuse vs web scrape reasons
- add war-scoped reuse logic tests and update help/docs text