### PR TITLE
feat(clan-health): add leadership snapshot command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Discord bot for Clash of Clans activity tooling.
 - War-mail embeds now use state-coded sidebars (BL=black, MM=white, FWA WIN=green, FWA LOSE=red, unresolved=gray) and refresh/update paths keep color aligned with current match type/outcome.
 - `/remaining war` now supports alliance-wide aggregate mode (no tag) with dominant-cluster mean remaining time, spread, and outlier clan reporting.
 - Telemetry now records command lifecycle/API/stage aggregates and supports `/telemetry report` plus scheduled Discord report posting.
+- `/clan-health` now provides a DB-only leadership snapshot per tracked clan (last-30 match/win rates, inactivity counts, and missing Discord links).
 
 ## Quick Start
 ```bash

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -12,6 +12,7 @@
 - `/lastseen tag:<playerTag>` - Show a player's last seen activity, with drill-down button for tracked signal timestamps.
 - `/inactive days:<number>` - List players inactive for N days.
 - `/inactive wars:<number>` - List tracked-clan members who used 0/2 attacks in each of the last N ended wars (requires war-history tracking window).
+- `/clan-health [visibility:private|public] tag:<trackedClanTag>` - Leadership snapshot from persisted data only: match rate and win rate (last 30 ended wars), inactive counts (missed-both in last 3 ended FWA wars + last-seen >=7d), and missing Discord links among observed members.
 - `/role-users role:<discordRole>` - List users in a role with pagination.
 - `/tracked-clan configure tag:<tag> [lose-style:triple-top-30|traditional] [mail-channel:<discordChannel>] [log-channel:<discordChannel>] [clan-role:<discordRole>] [clan-badge:<emoji>] [short-name:<abbr>]` - Add/update tracked clan settings.
 - `/tracked-clan remove tag:<tag>` - Remove tracked clan.

--- a/src/Commands.ts
+++ b/src/Commands.ts
@@ -18,6 +18,7 @@ import { Force } from "./commands/Force";
 import { Remaining } from "./commands/Remaining";
 import { WarPlan } from "./commands/WarPlan";
 import { Telemetry } from "./commands/Telemetry";
+import { ClanHealth } from "./commands/ClanHealth";
 
 // ...existing code...
 export const Commands = [
@@ -38,6 +39,7 @@ export const Commands = [
   Recruitment,
   KickList,
   Telemetry,
+  ClanHealth,
   Force,
   Post,
   CommandRole,

--- a/src/commands/ClanHealth.ts
+++ b/src/commands/ClanHealth.ts
@@ -1,0 +1,161 @@
+import {
+  ApplicationCommandOptionType,
+  AutocompleteInteraction,
+  ChatInputCommandInteraction,
+  Client,
+  EmbedBuilder,
+} from "discord.js";
+import { Command } from "../Command";
+import { prisma } from "../prisma";
+import { CoCService } from "../services/CoCService";
+import { ClanHealthSnapshotService, type ClanHealthSnapshot } from "../services/ClanHealthSnapshotService";
+
+const clanHealthSnapshotService = new ClanHealthSnapshotService();
+
+/** Purpose: normalize clan tags to uppercase with optional leading '#'. */
+function normalizeClanTag(input: string): string {
+  const bare = String(input ?? "").trim().toUpperCase().replace(/^#/, "");
+  return bare ? `#${bare}` : "";
+}
+
+/** Purpose: render rates with percentage + numerator/denominator for leadership readability. */
+function formatRate(numerator: number, denominator: number): string {
+  if (!Number.isFinite(denominator) || denominator <= 0) return "n/a (0/0)";
+  const pct = (numerator / denominator) * 100;
+  return `${pct.toFixed(1)}% (${numerator}/${denominator})`;
+}
+
+/** Purpose: build response embed for a clan-health snapshot. */
+function buildClanHealthEmbed(snapshot: ClanHealthSnapshot): EmbedBuilder {
+  const warSampleSuffix =
+    snapshot.warMetrics.endedWarSampleSize < snapshot.warMetrics.windowSize
+      ? ` (sample ${snapshot.warMetrics.endedWarSampleSize}/${snapshot.warMetrics.windowSize} ended wars)`
+      : "";
+  const inactiveWarSampleSuffix =
+    snapshot.inactiveWars.warsAvailable < snapshot.inactiveWars.windowSize
+      ? ` (sample ${snapshot.inactiveWars.warsSampled}/${snapshot.inactiveWars.windowSize} wars)`
+      : "";
+
+  return new EmbedBuilder()
+    .setTitle(`Clan Health: ${snapshot.clanName}`)
+    .setDescription("Leadership snapshot from persisted data only (no live API calls in command path).")
+    .addFields(
+      {
+        name: "War Performance",
+        value: [
+          `Match rate (last ${snapshot.warMetrics.windowSize} ended wars): **${formatRate(
+            snapshot.warMetrics.fwaMatchCount,
+            snapshot.warMetrics.endedWarSampleSize
+          )}**${warSampleSuffix}`,
+          `Win rate (same window): **${formatRate(
+            snapshot.warMetrics.winCount,
+            snapshot.warMetrics.endedWarSampleSize
+          )}**`,
+        ].join("\n"),
+        inline: false,
+      },
+      {
+        name: "Inactivity",
+        value: [
+          `Inactive (wars, last ${snapshot.inactiveWars.windowSize} ended FWA wars): **${snapshot.inactiveWars.inactivePlayerCount}**${inactiveWarSampleSuffix}`,
+          `Inactive (days, >=${snapshot.inactiveDays.thresholdDays}d): **${snapshot.inactiveDays.inactivePlayerCount}**`,
+          `Observed members (updated in last ${snapshot.inactiveDays.staleHours}h): **${snapshot.inactiveDays.observedMemberCount}**`,
+        ].join("\n"),
+        inline: false,
+      },
+      {
+        name: "Discord Links",
+        value: `Missing links: **${snapshot.missingLinks.missingMemberCount}/${snapshot.missingLinks.observedMemberCount}** observed member(s)`,
+        inline: false,
+      }
+    )
+    .setFooter({ text: `${snapshot.clanTag} • Deterministic DB snapshot` });
+}
+
+export const ClanHealth: Command = {
+  name: "clan-health",
+  description: "Leadership snapshot: rates, inactivity, and missing Discord links",
+  options: [
+    {
+      name: "visibility",
+      description: "Response visibility",
+      type: ApplicationCommandOptionType.String,
+      required: false,
+      choices: [
+        { name: "private", value: "private" },
+        { name: "public", value: "public" },
+      ],
+    },
+    {
+      name: "tag",
+      description: "Tracked clan tag (with or without #)",
+      type: ApplicationCommandOptionType.String,
+      required: true,
+      autocomplete: true,
+    },
+  ],
+  run: async (
+    _client: Client,
+    interaction: ChatInputCommandInteraction,
+    _cocService: CoCService
+  ) => {
+    await interaction.deferReply({ ephemeral: true });
+
+    if (!interaction.guildId) {
+      await interaction.editReply("This command can only be used in a server.");
+      return;
+    }
+
+    const tagInput = interaction.options.getString("tag", true);
+    const normalizedTag = normalizeClanTag(tagInput);
+    if (!normalizedTag) {
+      await interaction.editReply("Invalid clan tag.");
+      return;
+    }
+
+    const snapshot = await clanHealthSnapshotService.getSnapshot({
+      guildId: interaction.guildId,
+      clanTag: normalizedTag,
+    });
+
+    if (!snapshot) {
+      await interaction.editReply(`Clan ${normalizedTag} is not in tracked clans.`);
+      return;
+    }
+
+    await interaction.editReply({
+      embeds: [buildClanHealthEmbed(snapshot)],
+    });
+  },
+  autocomplete: async (interaction: AutocompleteInteraction) => {
+    const focused = interaction.options.getFocused(true);
+    if (focused.name !== "tag") {
+      await interaction.respond([]);
+      return;
+    }
+
+    const query = normalizeClanTag(String(focused.value ?? "")).replace(/^#/, "").toLowerCase();
+    const tracked = await prisma.trackedClan.findMany({
+      orderBy: { createdAt: "asc" },
+      select: { name: true, tag: true },
+    });
+
+    const choices = tracked
+      .map((clan) => {
+        const normalized = normalizeClanTag(clan.tag);
+        const bare = normalized.replace(/^#/, "");
+        const label = clan.name?.trim() ? `${clan.name.trim()} (${normalized})` : normalized;
+        return { name: label.slice(0, 100), value: bare };
+      })
+      .filter((choice) => {
+        const name = choice.name.toLowerCase();
+        const value = choice.value.toLowerCase();
+        return name.includes(query) || value.includes(query);
+      })
+      .slice(0, 25);
+
+    await interaction.respond(choices);
+  },
+};
+
+export const buildClanHealthEmbedForTest = buildClanHealthEmbed;

--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -79,6 +79,16 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
     ],
     examples: ["/inactive days:7", "/inactive days:30", "/inactive wars:3"],
   },
+  "clan-health": {
+    summary: "Leadership snapshot for one tracked clan using persisted data only.",
+    details: [
+      "Shows match rate and win rate from the last 30 ended wars.",
+      "Shows inactivity counts from two signals: missed both attacks in last 3 ended FWA wars, and last-seen inactivity >= 7 days.",
+      "Shows missing Discord links among observed clan members updated within the configured stale window.",
+      "Command path is DB-only (no live CoC/points HTTP calls).",
+    ],
+    examples: ["/clan-health tag:2QG2C08UP", "/clan-health tag:2QG2C08UP visibility:public"],
+  },
   "role-users": {
     summary: "Show members in a role with paging controls.",
     details: [

--- a/src/services/ClanHealthSnapshotService.ts
+++ b/src/services/ClanHealthSnapshotService.ts
@@ -1,0 +1,265 @@
+import { prisma } from "../prisma";
+
+export type ClanHealthSnapshot = {
+  clanTag: string;
+  clanName: string;
+  warMetrics: {
+    windowSize: number;
+    endedWarSampleSize: number;
+    fwaMatchCount: number;
+    winCount: number;
+  };
+  inactiveWars: {
+    windowSize: number;
+    warsAvailable: number;
+    warsSampled: number;
+    inactivePlayerCount: number;
+  };
+  inactiveDays: {
+    thresholdDays: number;
+    staleHours: number;
+    observedMemberCount: number;
+    inactivePlayerCount: number;
+  };
+  missingLinks: {
+    observedMemberCount: number;
+    linkedMemberCount: number;
+    missingMemberCount: number;
+  };
+  telemetry: {
+    warRows: number;
+    participationRows: number;
+    activityRows: number;
+    linkRows: number;
+    durationMs: number;
+  };
+};
+
+type WarHistoryMetricRow = {
+  matchType: string | null;
+  actualOutcome: string | null;
+};
+
+type ParticipationMetricRow = {
+  playerTag: string;
+  missedBoth: boolean;
+};
+
+type ActivityMetricRow = {
+  tag: string;
+  lastSeenAt: Date;
+};
+
+const DEFAULT_WAR_WINDOW_SIZE = 30;
+const DEFAULT_INACTIVE_WAR_WINDOW_SIZE = 3;
+const DEFAULT_INACTIVE_DAYS_THRESHOLD = 7;
+const DEFAULT_INACTIVE_STALE_HOURS = 6;
+
+/** Purpose: normalize clan tags into canonical uppercase + leading-# format. */
+function normalizeClanTag(input: string): string {
+  const raw = String(input ?? "").trim().toUpperCase().replace(/^#/, "");
+  return raw ? `#${raw}` : "";
+}
+
+/** Purpose: derive ended-war rate metrics from the most recent history window. */
+function computeWarMetrics(rows: WarHistoryMetricRow[], windowSize: number) {
+  const endedWarSampleSize = rows.length;
+  const fwaMatchCount = rows.filter((row) => String(row.matchType ?? "").toUpperCase() === "FWA").length;
+  const winCount = rows.filter((row) => String(row.actualOutcome ?? "").toUpperCase() === "WIN").length;
+  return { windowSize, endedWarSampleSize, fwaMatchCount, winCount };
+}
+
+/** Purpose: count players with at least one missed-both war in the selected recent window. */
+function computeInactiveWarsPlayerCount(rows: ParticipationMetricRow[]): number {
+  const missedByPlayer = new Map<string, boolean>();
+  for (const row of rows) {
+    const tag = String(row.playerTag ?? "").trim().toUpperCase();
+    if (!tag) continue;
+    if (row.missedBoth) missedByPlayer.set(tag, true);
+    else if (!missedByPlayer.has(tag)) missedByPlayer.set(tag, false);
+  }
+  let total = 0;
+  for (const missed of missedByPlayer.values()) {
+    if (missed) total += 1;
+  }
+  return total;
+}
+
+/** Purpose: compute inactivity and link counts from observed member rows and linked tags. */
+function computeActivityAndLinkMetrics(input: {
+  rows: ActivityMetricRow[];
+  linkedTags: Set<string>;
+  inactiveCutoff: Date;
+  thresholdDays: number;
+  staleHours: number;
+}) {
+  const uniqueRowsByTag = new Map<string, ActivityMetricRow>();
+  for (const row of input.rows) {
+    const normalizedTag = String(row.tag ?? "").trim().toUpperCase();
+    if (!normalizedTag) continue;
+    uniqueRowsByTag.set(normalizedTag, row);
+  }
+
+  let inactivePlayerCount = 0;
+  let linkedMemberCount = 0;
+  for (const [tag, row] of uniqueRowsByTag.entries()) {
+    if (row.lastSeenAt.getTime() < input.inactiveCutoff.getTime()) inactivePlayerCount += 1;
+    if (input.linkedTags.has(tag)) linkedMemberCount += 1;
+  }
+
+  const observedMemberCount = uniqueRowsByTag.size;
+  const missingMemberCount = Math.max(0, observedMemberCount - linkedMemberCount);
+  return {
+    inactiveDays: {
+      thresholdDays: input.thresholdDays,
+      staleHours: input.staleHours,
+      observedMemberCount,
+      inactivePlayerCount,
+    },
+    missingLinks: {
+      observedMemberCount,
+      linkedMemberCount,
+      missingMemberCount,
+    },
+  };
+}
+
+export const computeWarMetricsForTest = computeWarMetrics;
+export const computeInactiveWarsPlayerCountForTest = computeInactiveWarsPlayerCount;
+export const computeActivityAndLinkMetricsForTest = computeActivityAndLinkMetrics;
+
+export class ClanHealthSnapshotService {
+  /** Purpose: load a single-clan leadership snapshot from persisted DB state only. */
+  async getSnapshot(input: {
+    guildId: string;
+    clanTag: string;
+    warWindowSize?: number;
+    inactiveWarWindowSize?: number;
+    inactiveDaysThreshold?: number;
+    inactiveStaleHours?: number;
+  }): Promise<ClanHealthSnapshot | null> {
+    const startedAtMs = Date.now();
+    const warWindowSize = Math.max(1, Math.trunc(input.warWindowSize ?? DEFAULT_WAR_WINDOW_SIZE));
+    const inactiveWarWindowSize = Math.max(
+      1,
+      Math.trunc(input.inactiveWarWindowSize ?? DEFAULT_INACTIVE_WAR_WINDOW_SIZE)
+    );
+    const inactiveDaysThreshold = Math.max(
+      1,
+      Math.trunc(input.inactiveDaysThreshold ?? DEFAULT_INACTIVE_DAYS_THRESHOLD)
+    );
+    const inactiveStaleHours = Math.max(
+      1,
+      Math.trunc(input.inactiveStaleHours ?? Number(process.env.INACTIVE_STALE_HOURS ?? DEFAULT_INACTIVE_STALE_HOURS))
+    );
+
+    const normalizedTag = normalizeClanTag(input.clanTag);
+    if (!normalizedTag) return null;
+
+    const trackedClan = await prisma.trackedClan.findFirst({
+      where: { tag: { equals: normalizedTag, mode: "insensitive" } },
+      select: { tag: true, name: true },
+    });
+    if (!trackedClan) return null;
+
+    const canonicalClanTag = normalizeClanTag(trackedClan.tag);
+    const canonicalClanName = String(trackedClan.name ?? "").trim() || canonicalClanTag;
+    const staleCutoff = new Date(Date.now() - inactiveStaleHours * 60 * 60 * 1000);
+    const inactiveCutoff = new Date(Date.now() - inactiveDaysThreshold * 24 * 60 * 60 * 1000);
+
+    const [warRows, distinctFwaWars, activityRows] = await Promise.all([
+      prisma.clanWarHistory.findMany({
+        where: {
+          clanTag: canonicalClanTag,
+          warEndTime: { not: null },
+        },
+        orderBy: [{ warEndTime: "desc" }, { warStartTime: "desc" }],
+        take: warWindowSize,
+        select: { matchType: true, actualOutcome: true },
+      }),
+      prisma.clanWarParticipation.findMany({
+        where: {
+          guildId: input.guildId,
+          clanTag: canonicalClanTag,
+          matchType: "FWA",
+        },
+        select: { warId: true, warStartTime: true },
+        orderBy: [{ warStartTime: "desc" }, { createdAt: "desc" }],
+        distinct: ["warId"],
+      }),
+      prisma.playerActivity.findMany({
+        where: {
+          guildId: input.guildId,
+          clanTag: canonicalClanTag,
+          updatedAt: { gte: staleCutoff },
+        },
+        select: { tag: true, lastSeenAt: true },
+      }),
+    ]);
+
+    const selectedWarIds = distinctFwaWars
+      .slice(0, inactiveWarWindowSize)
+      .map((row) => String(row.warId ?? "").trim())
+      .filter((warId) => warId.length > 0);
+
+    const [participationRows, linkedRows] = await Promise.all([
+      selectedWarIds.length > 0
+        ? prisma.clanWarParticipation.findMany({
+            where: {
+              guildId: input.guildId,
+              clanTag: canonicalClanTag,
+              warId: { in: selectedWarIds },
+            },
+            select: { playerTag: true, missedBoth: true },
+          })
+        : Promise.resolve([] as ParticipationMetricRow[]),
+      activityRows.length > 0
+        ? prisma.playerLink.findMany({
+            where: { playerTag: { in: activityRows.map((row) => row.tag) } },
+            select: { playerTag: true },
+          })
+        : Promise.resolve([] as Array<{ playerTag: string }>),
+    ]);
+
+    const linkedTags = new Set(
+      linkedRows
+        .map((row) => String(row.playerTag ?? "").trim().toUpperCase())
+        .filter((tag) => tag.length > 0)
+    );
+    const activityAndLinks = computeActivityAndLinkMetrics({
+      rows: activityRows,
+      linkedTags,
+      inactiveCutoff,
+      thresholdDays: inactiveDaysThreshold,
+      staleHours: inactiveStaleHours,
+    });
+    const warMetrics = computeWarMetrics(warRows, warWindowSize);
+    const inactivePlayerCount = computeInactiveWarsPlayerCount(participationRows);
+    const durationMs = Date.now() - startedAtMs;
+
+    console.info(
+      `[clan-health] guild=${input.guildId} clan=${canonicalClanTag} war_rows=${warRows.length} participation_rows=${participationRows.length} activity_rows=${activityRows.length} link_rows=${linkedRows.length} duration_ms=${durationMs}`
+    );
+
+    return {
+      clanTag: canonicalClanTag,
+      clanName: canonicalClanName,
+      warMetrics,
+      inactiveWars: {
+        windowSize: inactiveWarWindowSize,
+        warsAvailable: distinctFwaWars.length,
+        warsSampled: selectedWarIds.length,
+        inactivePlayerCount,
+      },
+      inactiveDays: activityAndLinks.inactiveDays,
+      missingLinks: activityAndLinks.missingLinks,
+      telemetry: {
+        warRows: warRows.length,
+        participationRows: participationRows.length,
+        activityRows: activityRows.length,
+        linkRows: linkedRows.length,
+        durationMs,
+      },
+    };
+  }
+}

--- a/src/services/CommandPermissionService.ts
+++ b/src/services/CommandPermissionService.ts
@@ -40,6 +40,7 @@ export const COMMAND_PERMISSION_TARGETS = [
   "force:mail:update",
   "remaining",
   "remaining:war",
+  "clan-health",
   "telemetry",
   "telemetry:report",
   "telemetry:schedule:set",
@@ -108,6 +109,7 @@ const FWA_LEADER_DEFAULT_TARGETS = new Set<string>([
   "sync:time:post",
   "sync:post:status",
   "inactive",
+  "clan-health",
 ]);
 
 /** Purpose: command roles key. */

--- a/tests/clanHealth.command.test.ts
+++ b/tests/clanHealth.command.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const serviceMock = vi.hoisted(() => ({
+  getSnapshot: vi.fn(),
+}));
+
+const prismaMock = vi.hoisted(() => ({
+  trackedClan: {
+    findMany: vi.fn(),
+  },
+}));
+
+vi.mock("../src/services/ClanHealthSnapshotService", () => ({
+  ClanHealthSnapshotService: class {
+    getSnapshot = serviceMock.getSnapshot;
+  },
+}));
+
+vi.mock("../src/prisma", () => ({
+  prisma: prismaMock,
+}));
+
+import { ClanHealth } from "../src/commands/ClanHealth";
+
+function makeInteraction(tagValue: string) {
+  const deferReply = vi.fn().mockResolvedValue(undefined);
+  const editReply = vi.fn().mockResolvedValue(undefined);
+  return {
+    guildId: "guild-1",
+    deferReply,
+    editReply,
+    options: {
+      getString: vi.fn((name: string, required?: boolean) => {
+        if (name === "tag") return tagValue;
+        if (name === "visibility") return "private";
+        if (required) return tagValue;
+        return null;
+      }),
+      getFocused: vi.fn().mockReturnValue({ name: "tag", value: "alp" }),
+    },
+    respond: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe("/clan-health command", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders leadership metrics and does not call external CoC API", async () => {
+    serviceMock.getSnapshot.mockResolvedValue({
+      clanTag: "#AAA111",
+      clanName: "Alpha",
+      warMetrics: {
+        windowSize: 30,
+        endedWarSampleSize: 20,
+        fwaMatchCount: 14,
+        winCount: 11,
+      },
+      inactiveWars: {
+        windowSize: 3,
+        warsAvailable: 3,
+        warsSampled: 3,
+        inactivePlayerCount: 2,
+      },
+      inactiveDays: {
+        thresholdDays: 7,
+        staleHours: 6,
+        observedMemberCount: 40,
+        inactivePlayerCount: 5,
+      },
+      missingLinks: {
+        observedMemberCount: 40,
+        linkedMemberCount: 35,
+        missingMemberCount: 5,
+      },
+      telemetry: {
+        warRows: 20,
+        participationRows: 100,
+        activityRows: 40,
+        linkRows: 35,
+        durationMs: 7,
+      },
+    });
+
+    const interaction = makeInteraction("AAA111");
+    const cocService = { getCurrentWar: vi.fn(), getClan: vi.fn(), getPlayerRaw: vi.fn() };
+    await ClanHealth.run({} as any, interaction as any, cocService as any);
+
+    expect(cocService.getCurrentWar).not.toHaveBeenCalled();
+    expect(cocService.getClan).not.toHaveBeenCalled();
+    expect(interaction.editReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        embeds: expect.any(Array),
+      })
+    );
+    const payload = interaction.editReply.mock.calls[0]?.[0];
+    const embedJson = payload.embeds[0].toJSON();
+    expect(embedJson.title).toContain("Clan Health");
+    expect(embedJson.fields.map((field: any) => field.name)).toEqual([
+      "War Performance",
+      "Inactivity",
+      "Discord Links",
+    ]);
+  });
+
+  it("supports tracked-clan autocomplete for tag", async () => {
+    prismaMock.trackedClan.findMany.mockResolvedValue([
+      { name: "Alpha", tag: "#AAA111" },
+      { name: "Bravo", tag: "#BBB222" },
+    ]);
+    const interaction = makeInteraction("AAA111");
+    interaction.options.getFocused.mockReturnValue({ name: "tag", value: "alp" });
+
+    await ClanHealth.autocomplete?.(interaction as any);
+
+    expect(interaction.respond).toHaveBeenCalledWith([
+      { name: "Alpha (#AAA111)", value: "AAA111" },
+    ]);
+  });
+});

--- a/tests/clanHealthSnapshot.service.test.ts
+++ b/tests/clanHealthSnapshot.service.test.ts
@@ -1,0 +1,146 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const prismaMock = vi.hoisted(() => ({
+  trackedClan: {
+    findFirst: vi.fn(),
+  },
+  clanWarHistory: {
+    findMany: vi.fn(),
+  },
+  clanWarParticipation: {
+    findMany: vi.fn(),
+  },
+  playerActivity: {
+    findMany: vi.fn(),
+  },
+  playerLink: {
+    findMany: vi.fn(),
+  },
+}));
+
+vi.mock("../src/prisma", () => ({
+  prisma: prismaMock,
+}));
+
+import { ClanHealthSnapshotService } from "../src/services/ClanHealthSnapshotService";
+
+describe("ClanHealthSnapshotService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-09T12:00:00.000Z"));
+  });
+
+  it("returns null for non-tracked clan", async () => {
+    prismaMock.trackedClan.findFirst.mockResolvedValue(null);
+    const service = new ClanHealthSnapshotService();
+
+    const snapshot = await service.getSnapshot({
+      guildId: "guild-1",
+      clanTag: "#MISSING",
+    });
+
+    expect(snapshot).toBeNull();
+    expect(prismaMock.clanWarHistory.findMany).not.toHaveBeenCalled();
+    expect(prismaMock.playerActivity.findMany).not.toHaveBeenCalled();
+  });
+
+  it("computes rates, inactivity, and missing links for partial war samples", async () => {
+    prismaMock.trackedClan.findFirst.mockResolvedValue({
+      tag: "#AAA111",
+      name: "Alpha",
+    });
+    prismaMock.clanWarHistory.findMany.mockResolvedValue([
+      { matchType: "FWA", actualOutcome: "WIN" },
+      { matchType: "BL", actualOutcome: "LOSE" },
+      { matchType: "FWA", actualOutcome: "WIN" },
+    ]);
+    prismaMock.clanWarParticipation.findMany
+      .mockResolvedValueOnce([
+        { warId: "w3", warStartTime: new Date("2026-03-08T00:00:00.000Z") },
+        { warId: "w2", warStartTime: new Date("2026-03-07T00:00:00.000Z") },
+      ])
+      .mockResolvedValueOnce([
+        { playerTag: "#P1", missedBoth: false },
+        { playerTag: "#P1", missedBoth: true },
+        { playerTag: "#P2", missedBoth: false },
+      ]);
+    prismaMock.playerActivity.findMany.mockResolvedValue([
+      { tag: "#P1", lastSeenAt: new Date("2026-03-01T00:00:00.000Z") },
+      { tag: "#P2", lastSeenAt: new Date("2026-03-08T23:00:00.000Z") },
+      { tag: "#P3", lastSeenAt: new Date("2026-03-01T00:00:00.000Z") },
+    ]);
+    prismaMock.playerLink.findMany.mockResolvedValue([{ playerTag: "#P1" }, { playerTag: "#P2" }]);
+
+    const service = new ClanHealthSnapshotService();
+    const snapshot = await service.getSnapshot({
+      guildId: "guild-1",
+      clanTag: "aaa111",
+      warWindowSize: 30,
+      inactiveWarWindowSize: 3,
+      inactiveDaysThreshold: 7,
+      inactiveStaleHours: 6,
+    });
+
+    expect(snapshot).not.toBeNull();
+    expect(snapshot?.clanTag).toBe("#AAA111");
+    expect(snapshot?.warMetrics.endedWarSampleSize).toBe(3);
+    expect(snapshot?.warMetrics.fwaMatchCount).toBe(2);
+    expect(snapshot?.warMetrics.winCount).toBe(2);
+    expect(snapshot?.inactiveWars.warsAvailable).toBe(2);
+    expect(snapshot?.inactiveWars.warsSampled).toBe(2);
+    expect(snapshot?.inactiveWars.inactivePlayerCount).toBe(1);
+    expect(snapshot?.inactiveDays.inactivePlayerCount).toBe(2);
+    expect(snapshot?.missingLinks.missingMemberCount).toBe(1);
+    expect(snapshot?.missingLinks.observedMemberCount).toBe(3);
+  });
+
+  it("handles no-war and all-linked edge case", async () => {
+    prismaMock.trackedClan.findFirst.mockResolvedValue({
+      tag: "#BBB222",
+      name: "Bravo",
+    });
+    prismaMock.clanWarHistory.findMany.mockResolvedValue([]);
+    prismaMock.clanWarParticipation.findMany.mockResolvedValueOnce([]);
+    prismaMock.playerActivity.findMany.mockResolvedValue([
+      { tag: "#P1", lastSeenAt: new Date("2026-03-08T22:00:00.000Z") },
+      { tag: "#P2", lastSeenAt: new Date("2026-03-08T21:00:00.000Z") },
+    ]);
+    prismaMock.playerLink.findMany.mockResolvedValue([{ playerTag: "#P1" }, { playerTag: "#P2" }]);
+
+    const service = new ClanHealthSnapshotService();
+    const snapshot = await service.getSnapshot({
+      guildId: "guild-1",
+      clanTag: "#BBB222",
+    });
+
+    expect(snapshot?.warMetrics.endedWarSampleSize).toBe(0);
+    expect(snapshot?.inactiveWars.warsAvailable).toBe(0);
+    expect(snapshot?.inactiveWars.inactivePlayerCount).toBe(0);
+    expect(snapshot?.missingLinks.missingMemberCount).toBe(0);
+  });
+
+  it("handles all-unlinked edge case", async () => {
+    prismaMock.trackedClan.findFirst.mockResolvedValue({
+      tag: "#CCC333",
+      name: "Charlie",
+    });
+    prismaMock.clanWarHistory.findMany.mockResolvedValue([]);
+    prismaMock.clanWarParticipation.findMany.mockResolvedValueOnce([]);
+    prismaMock.playerActivity.findMany.mockResolvedValue([
+      { tag: "#P1", lastSeenAt: new Date("2026-03-01T00:00:00.000Z") },
+      { tag: "#P2", lastSeenAt: new Date("2026-03-01T00:00:00.000Z") },
+    ]);
+    prismaMock.playerLink.findMany.mockResolvedValue([]);
+
+    const service = new ClanHealthSnapshotService();
+    const snapshot = await service.getSnapshot({
+      guildId: "guild-1",
+      clanTag: "#CCC333",
+    });
+
+    expect(snapshot?.missingLinks.observedMemberCount).toBe(2);
+    expect(snapshot?.missingLinks.missingMemberCount).toBe(2);
+    expect(snapshot?.missingLinks.linkedMemberCount).toBe(0);
+  });
+});


### PR DESCRIPTION
- add /clan-health with DB-only snapshot metrics for one tracked clan
- add ClanHealthSnapshotService with deterministic war/inactivity/link aggregation
- add permission target wiring and help/docs discoverability updates
- add unit/command tests for metrics, edge cases, and DB-only command behavior