### PR TITLE
fix(points): gate poller fetches behind mail-confirmed lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Discord bot for Clash of Clans activity tooling.
 - `/fwa match` mail status now scopes "already sent" to the current war identity (war/opponent/config), so new wars start unsent and old posts stop refreshing into new wars.
 - Supports configurable war plans by match type/outcome via `/warplan set|show|reset`; these templates are used in posted war mail content (including line breaks, emoji, and media links).
 - Optimized points polling now tracks lifecycle state in `ClanPointsSync` (`confirmedByClanMail`, `needsValidation`, last-known values) and reduces routine `points.fwafarm` calls after clan-mail confirmation.
+- Poller-side points fetches now use a shared gate that enforces an active-war mail-confirmed lock (`confirmedByClanMail=true`, `needsValidation=false`, matching war identity), blocking routine `post_war_reconciliation`/`mail_refresh` calls until an explicit unlock trigger.
 - `/fwa match` now shows actionable sync status only when validation is needed, keeps single-clan sync/fetch timing details, and hides non-actionable lifecycle/debug lines from user-facing output.
 - `/fwa match` now reuses war-scoped verified points snapshots from persisted sync data for the active war, and `/force sync data` remains the explicit refresh-scrape path.
 - War-mail embeds now use state-coded sidebars (BL=black, MM=white, FWA WIN=green, FWA LOSE=red, unresolved=gray) and refresh/update paths keep color aligned with current match type/outcome.

--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -984,28 +984,47 @@ async function buildWarMailEmbedForTag(
             Number.isFinite(syncRow.lastKnownSyncNumber)
               ? Math.trunc(syncRow.lastKnownSyncNumber)
               : null,
+          warId: syncRow.warId ?? null,
+          opponentTag: syncRow.opponentTag ?? null,
+          warStartTime: syncRow.warStartTime ?? null,
         };
   const routineDecision = options?.routine
-    ? pointsFetchPolicy.shouldFetchForRoutine({
+    ? pointsFetchPolicy.evaluatePollerFetch({
+        guildId,
+        clanTag: normalizedTag,
+        pollerSource: "mail_refresh_loop",
+        requestedReason: options?.fetchReason ?? "mail_refresh",
+        preferredAllowedReason: options?.fetchReason ?? "mail_refresh",
         warState,
         warStartTime: subscription?.startTime ?? null,
         warEndTime: subscription?.endTime ?? null,
         currentSyncNumber: currentSync,
         lifecycle,
+        activeWarId:
+          subscription?.warId !== null &&
+          subscription?.warId !== undefined &&
+          Number.isFinite(subscription.warId)
+            ? String(Math.trunc(subscription.warId))
+            : null,
+        activeOpponentTag: effectiveOpponentTag || null,
       })
     : {
-        shouldFetch: true,
-        reason: options?.fetchReason ?? ("mail_preview" as const),
-        skipReason: null,
+        allowed: true,
+        outcome: "allowed" as const,
+        decisionCode: "manual_override" as const,
+        reason: "Manual mail preview fetch.",
+        fetchReason: options?.fetchReason ?? ("mail_preview" as const),
+        policyReason: null,
+        mailConfirmedLockActive: false,
         optimized: true,
       };
   const fetchReason =
     options?.fetchReason ??
-    routineDecision.reason ??
+    routineDecision.fetchReason ??
     (options?.routine ? "mail_refresh" : "mail_preview");
-  if (options?.routine && !routineDecision.shouldFetch) {
+  if (options?.routine && !routineDecision.allowed) {
     console.info(
-      `[fwa-mail] points fetch skipped guild=${guildId} clan=#${normalizedTag} reason=${routineDecision.skipReason ?? "policy_skip"}`
+      `[fwa-mail] points fetch skipped guild=${guildId} clan=#${normalizedTag} outcome=${routineDecision.outcome} code=${routineDecision.decisionCode} reason=${routineDecision.reason}`
     );
   }
 
@@ -1013,7 +1032,7 @@ async function buildWarMailEmbedForTag(
   let opponentBalance: number | null = null;
   let primarySnapshot: PointsSnapshot | null = null;
   let opponentSnapshot: PointsSnapshot | null = null;
-  if (opponentTag && routineDecision.shouldFetch) {
+  if (opponentTag && routineDecision.allowed) {
     primarySnapshot = await getClanPointsCached(settings, cocService, normalizedTag, currentSync, undefined, {
       fetchReason,
     }).catch(() => null);

--- a/src/services/PointsFetchPolicyService.ts
+++ b/src/services/PointsFetchPolicyService.ts
@@ -18,6 +18,9 @@ export type PointsLifecycleState = {
   needsValidation: boolean;
   lastSuccessfulPointsApiFetchAt: Date | null;
   lastKnownSyncNumber: number | null;
+  warId?: string | null;
+  opponentTag?: string | null;
+  warStartTime?: Date | null;
 };
 
 type RoutinePointsFetchInput = {
@@ -27,6 +30,45 @@ type RoutinePointsFetchInput = {
   currentSyncNumber: number | null;
   lifecycle: PointsLifecycleState | null;
   nowMs?: number;
+};
+
+export type PollerPointsFetchSource = "war_event_poll_cycle" | "mail_refresh_loop";
+
+export type PollerPointsFetchOutcome = "allowed" | "blocked" | "not_applicable";
+
+export type PollerPointsFetchDecisionCode =
+  | "manual_override"
+  | "optimized_polling_disabled"
+  | "no_active_opponent"
+  | "inactive_war_for_mail_refresh"
+  | "validation_required"
+  | "sync_number_changed"
+  | "war_identity_changed"
+  | "war_identity_unverifiable"
+  | "locked_mail_confirmed"
+  | "policy_allowed"
+  | "policy_blocked";
+
+export type PollerPointsFetchDecision = {
+  allowed: boolean;
+  outcome: PollerPointsFetchOutcome;
+  decisionCode: PollerPointsFetchDecisionCode;
+  reason: string;
+  fetchReason: PointsApiFetchReason | null;
+  policyReason: PointsApiFetchReason | null;
+  mailConfirmedLockActive: boolean;
+  optimized: boolean;
+};
+
+export type PollerPointsFetchInput = RoutinePointsFetchInput & {
+  guildId: string;
+  clanTag: string;
+  pollerSource: PollerPointsFetchSource;
+  requestedReason: PointsApiFetchReason;
+  preferredAllowedReason?: PointsApiFetchReason | null;
+  activeOpponentTag?: string | null;
+  activeWarId?: string | number | null;
+  manualOverride?: boolean;
 };
 
 type PointsFetchPolicyConfig = {
@@ -78,6 +120,18 @@ function toEpochMs(value: Date | null): number | null {
   return Number.isFinite(ms) ? ms : null;
 }
 
+/** Purpose: normalize clan tags for stable policy comparisons. */
+function normalizeTag(input: string | null | undefined): string | null {
+  const raw = String(input ?? "").trim().toUpperCase().replace(/^#/, "");
+  return raw ? `#${raw}` : null;
+}
+
+/** Purpose: normalize optional war IDs for stable policy comparisons. */
+function normalizeWarId(input: string | number | null | undefined): string | null {
+  const raw = String(input ?? "").trim();
+  return raw ? raw : null;
+}
+
 /** Purpose: build config from defaults + environment overrides. */
 function resolveConfig(overrides?: Partial<PointsFetchPolicyConfig>): PointsFetchPolicyConfig {
   return {
@@ -109,6 +163,7 @@ function resolveConfig(overrides?: Partial<PointsFetchPolicyConfig>): PointsFetc
 }
 
 export class PointsFetchPolicyService {
+  private static readonly pollerDecisionRollups = new Map<string, number>();
   private readonly config: PointsFetchPolicyConfig;
 
   /** Purpose: initialize policy config from env + optional overrides. */
@@ -123,6 +178,240 @@ export class PointsFetchPolicyService {
 
   /** Purpose: decide if routine/background flows should fetch points right now. */
   shouldFetchForRoutine(input: RoutinePointsFetchInput): RoutinePointsFetchDecision {
+    return this.evaluateRoutineDecision(input);
+  }
+
+  /** Purpose: decide poller-side points fetch behavior with explicit lock/identity semantics and audit metadata. */
+  evaluatePollerFetch(input: PollerPointsFetchInput): PollerPointsFetchDecision {
+    const nowMs = input.nowMs ?? Date.now();
+    const lifecycle = input.lifecycle;
+    const activeWar = input.warState !== "notInWar";
+    const activeOpponentTag = normalizeTag(input.activeOpponentTag);
+    const lifecycleOpponentTag = normalizeTag(lifecycle?.opponentTag ?? null);
+    const activeWarId = normalizeWarId(input.activeWarId);
+    const lifecycleWarId = normalizeWarId(lifecycle?.warId ?? null);
+    const activeWarStartMs = toEpochMs(input.warStartTime);
+    const lifecycleWarStartMs = toEpochMs(lifecycle?.warStartTime ?? null);
+    const hasIdentitySignals =
+      (activeWarId !== null && lifecycleWarId !== null) ||
+      (activeOpponentTag !== null && lifecycleOpponentTag !== null) ||
+      (activeWarStartMs !== null && lifecycleWarStartMs !== null);
+    const identityChanged =
+      (activeWarId !== null && lifecycleWarId !== null && activeWarId !== lifecycleWarId) ||
+      (activeOpponentTag !== null &&
+        lifecycleOpponentTag !== null &&
+        activeOpponentTag !== lifecycleOpponentTag) ||
+      (activeWarStartMs !== null &&
+        lifecycleWarStartMs !== null &&
+        activeWarStartMs !== lifecycleWarStartMs);
+
+    if (input.manualOverride) {
+      const decision = this.buildPollerDecision({
+        allowed: true,
+        outcome: "allowed",
+        decisionCode: "manual_override",
+        reason: "Manual override bypasses routine poller lock checks.",
+        fetchReason: input.preferredAllowedReason ?? input.requestedReason,
+        policyReason: null,
+        mailConfirmedLockActive: false,
+        optimized: this.config.optimizedPollingEnabled,
+      });
+      this.logPollerDecision(input, decision);
+      return decision;
+    }
+
+    if (!this.config.optimizedPollingEnabled) {
+      const decision = this.buildPollerDecision({
+        allowed: true,
+        outcome: "allowed",
+        decisionCode: "optimized_polling_disabled",
+        reason: "Optimized polling disabled; routine poller fetches are allowed.",
+        fetchReason: input.preferredAllowedReason ?? input.requestedReason,
+        policyReason: null,
+        mailConfirmedLockActive: false,
+        optimized: false,
+      });
+      this.logPollerDecision(input, decision);
+      return decision;
+    }
+
+    if (input.requestedReason === "mail_refresh" && !activeWar) {
+      const decision = this.buildPollerDecision({
+        allowed: false,
+        outcome: "not_applicable",
+        decisionCode: "inactive_war_for_mail_refresh",
+        reason: "Mail refresh points fetch applies only to active wars.",
+        fetchReason: null,
+        policyReason: null,
+        mailConfirmedLockActive: false,
+        optimized: true,
+      });
+      this.logPollerDecision(input, decision);
+      return decision;
+    }
+
+    if (activeWar && activeOpponentTag === null) {
+      const decision = this.buildPollerDecision({
+        allowed: false,
+        outcome: "not_applicable",
+        decisionCode: "no_active_opponent",
+        reason: "Active war has no resolved opponent tag.",
+        fetchReason: null,
+        policyReason: null,
+        mailConfirmedLockActive: false,
+        optimized: true,
+      });
+      this.logPollerDecision(input, decision);
+      return decision;
+    }
+
+    if (
+      activeWar &&
+      lifecycle &&
+      lifecycle.lastKnownSyncNumber !== null &&
+      input.currentSyncNumber !== null &&
+      Math.trunc(lifecycle.lastKnownSyncNumber) !== Math.trunc(input.currentSyncNumber)
+    ) {
+      const decision = this.buildPollerDecision({
+        allowed: true,
+        outcome: "allowed",
+        decisionCode: "sync_number_changed",
+        reason: "Active sync number changed since last checkpoint; revalidation is required.",
+        fetchReason: input.preferredAllowedReason ?? "pre_fwa_validation",
+        policyReason: "pre_fwa_validation",
+        mailConfirmedLockActive: false,
+        optimized: true,
+      });
+      this.logPollerDecision(input, decision);
+      return decision;
+    }
+
+    if (activeWar && lifecycle?.needsValidation) {
+      const decision = this.buildPollerDecision({
+        allowed: true,
+        outcome: "allowed",
+        decisionCode: "validation_required",
+        reason: "Lifecycle requires validation; routine fetch is re-enabled.",
+        fetchReason:
+          input.preferredAllowedReason ??
+          (input.warState === "preparation" ? "pre_fwa_validation" : input.requestedReason),
+        policyReason: input.warState === "preparation" ? "pre_fwa_validation" : null,
+        mailConfirmedLockActive: false,
+        optimized: true,
+      });
+      this.logPollerDecision(input, decision);
+      return decision;
+    }
+
+    const lockCandidate =
+      activeWar &&
+      Boolean(lifecycle?.confirmedByClanMail) &&
+      !Boolean(lifecycle?.needsValidation);
+    if (lockCandidate && identityChanged) {
+      const decision = this.buildPollerDecision({
+        allowed: true,
+        outcome: "allowed",
+        decisionCode: "war_identity_changed",
+        reason: "War identity changed since mail confirmation; routine fetch is re-enabled.",
+        fetchReason: input.preferredAllowedReason ?? input.requestedReason,
+        policyReason: null,
+        mailConfirmedLockActive: false,
+        optimized: true,
+      });
+      this.logPollerDecision(input, decision);
+      return decision;
+    }
+
+    if (lockCandidate && !hasIdentitySignals) {
+      const decision = this.buildPollerDecision({
+        allowed: true,
+        outcome: "allowed",
+        decisionCode: "war_identity_unverifiable",
+        reason: "War identity could not be verified; lock is not enforced conservatively.",
+        fetchReason: input.preferredAllowedReason ?? input.requestedReason,
+        policyReason: null,
+        mailConfirmedLockActive: false,
+        optimized: true,
+      });
+      this.logPollerDecision(input, decision);
+      return decision;
+    }
+
+    if (lockCandidate) {
+      const decision = this.buildPollerDecision({
+        allowed: false,
+        outcome: "blocked",
+        decisionCode: "locked_mail_confirmed",
+        reason:
+          "Active war mail-confirmed lock is active; routine poller points fetch is suppressed.",
+        fetchReason: null,
+        policyReason: null,
+        mailConfirmedLockActive: true,
+        optimized: true,
+      });
+      this.logPollerDecision(input, decision);
+      return decision;
+    }
+
+    const policyDecision = this.evaluateRoutineDecision({
+      ...input,
+      nowMs,
+    });
+    if (!policyDecision.shouldFetch) {
+      const decision = this.buildPollerDecision({
+        allowed: false,
+        outcome: "blocked",
+        decisionCode: "policy_blocked",
+        reason: policyDecision.skipReason ?? "Routine policy did not trigger a fetch.",
+        fetchReason: null,
+        policyReason: policyDecision.reason,
+        mailConfirmedLockActive: false,
+        optimized: policyDecision.optimized,
+      });
+      this.logPollerDecision(input, decision);
+      return decision;
+    }
+
+    const decision = this.buildPollerDecision({
+      allowed: true,
+      outcome: "allowed",
+      decisionCode: "policy_allowed",
+      reason: "Routine policy trigger allowed poller points fetch.",
+      fetchReason: input.preferredAllowedReason ?? policyDecision.reason ?? input.requestedReason,
+      policyReason: policyDecision.reason,
+      mailConfirmedLockActive: false,
+      optimized: policyDecision.optimized,
+    });
+    this.logPollerDecision(input, decision);
+    return decision;
+  }
+
+  /** Purpose: build a normalized poller decision payload. */
+  private buildPollerDecision(input: PollerPointsFetchDecision): PollerPointsFetchDecision {
+    return {
+      ...input,
+      allowed: Boolean(input.allowed),
+    };
+  }
+
+  /** Purpose: emit standardized decision logs and in-memory rollups for poller points gate behavior. */
+  private logPollerDecision(
+    input: PollerPointsFetchInput,
+    decision: PollerPointsFetchDecision
+  ): void {
+    const normalizedClanTag = normalizeTag(input.clanTag) ?? input.clanTag;
+    const rollupKey = `${input.pollerSource}:${input.requestedReason}:${decision.outcome}`;
+    const nextCount = (PointsFetchPolicyService.pollerDecisionRollups.get(rollupKey) ?? 0) + 1;
+    PointsFetchPolicyService.pollerDecisionRollups.set(rollupKey, nextCount);
+    const activeWarStartMs = toEpochMs(input.warStartTime);
+    const lifecycleWarStartMs = toEpochMs(input.lifecycle?.warStartTime ?? null);
+    console.info(
+      `[points-gate] source=${input.pollerSource} guild=${input.guildId} clan=${normalizedClanTag} requested_reason=${input.requestedReason} outcome=${decision.outcome} code=${decision.decisionCode} allowed=${decision.allowed ? 1 : 0} lock_active=${decision.mailConfirmedLockActive ? 1 : 0} active_war=${input.warState !== "notInWar" ? 1 : 0} fetch_reason=${decision.fetchReason ?? "none"} active_war_id=${normalizeWarId(input.activeWarId) ?? "none"} active_war_start_ms=${activeWarStartMs ?? "none"} active_opponent=${normalizeTag(input.activeOpponentTag) ?? "none"} lifecycle_war_id=${normalizeWarId(input.lifecycle?.warId ?? null) ?? "none"} lifecycle_war_start_ms=${lifecycleWarStartMs ?? "none"} lifecycle_opponent=${normalizeTag(input.lifecycle?.opponentTag ?? null) ?? "none"} rollup=${nextCount} reason=${decision.reason}`
+    );
+  }
+
+  /** Purpose: evaluate base routine triggers independent of poller identity-lock semantics. */
+  private evaluateRoutineDecision(input: RoutinePointsFetchInput): RoutinePointsFetchDecision {
     const nowMs = input.nowMs ?? Date.now();
     if (!this.config.optimizedPollingEnabled) {
       return {

--- a/src/services/WarEventLogService.ts
+++ b/src/services/WarEventLogService.ts
@@ -104,6 +104,9 @@ type SubscriptionRow = {
   pointsLastKnownPoints: number | null;
   pointsLastKnownMatchType: string | null;
   pointsLastKnownOutcome: string | null;
+  pointsWarId: string | null;
+  pointsOpponentTag: string | null;
+  pointsWarStartTime: Date | null;
 };
 
 type PollTarget = {
@@ -916,7 +919,10 @@ export class WarEventLogService {
           cps."lastKnownSyncNumber" AS "pointsLastKnownSyncNumber",
           cps."lastKnownPoints" AS "pointsLastKnownPoints",
           cps."lastKnownMatchType" AS "pointsLastKnownMatchType",
-          cps."lastKnownOutcome" AS "pointsLastKnownOutcome"
+          cps."lastKnownOutcome" AS "pointsLastKnownOutcome",
+          cps."warId" AS "pointsWarId",
+          cps."opponentTag" AS "pointsOpponentTag",
+          cps."warStartTime" AS "pointsWarStartTime"
         FROM "CurrentWar" cw
         LEFT JOIN "TrackedClan" tc
           ON UPPER(REPLACE(tc."tag",'#','')) = UPPER(REPLACE(cw."clanTag",'#',''))
@@ -1042,7 +1048,10 @@ export class WarEventLogService {
           cps."lastKnownSyncNumber" AS "pointsLastKnownSyncNumber",
           cps."lastKnownPoints" AS "pointsLastKnownPoints",
           cps."lastKnownMatchType" AS "pointsLastKnownMatchType",
-          cps."lastKnownOutcome" AS "pointsLastKnownOutcome"
+          cps."lastKnownOutcome" AS "pointsLastKnownOutcome",
+          cps."warId" AS "pointsWarId",
+          cps."opponentTag" AS "pointsOpponentTag",
+          cps."warStartTime" AS "pointsWarStartTime"
         FROM "CurrentWar" cw
         LEFT JOIN "TrackedClan" tc
           ON UPPER(REPLACE(tc."tag",'#','')) = UPPER(REPLACE(cw."clanTag",'#',''))
@@ -1131,23 +1140,30 @@ export class WarEventLogService {
               Number.isFinite(sub.pointsLastKnownSyncNumber)
                 ? Math.trunc(sub.pointsLastKnownSyncNumber)
                 : null,
+            warId: sub.pointsWarId ?? null,
+            opponentTag: sub.pointsOpponentTag ?? null,
+            warStartTime: sub.pointsWarStartTime ?? null,
           };
-    const policyDecision = this.pointsPolicy.shouldFetchForRoutine({
+    const gateDecision = this.pointsPolicy.evaluatePollerFetch({
+      guildId: sub.guildId,
+      clanTag: sub.clanTag,
+      pollerSource: "war_event_poll_cycle",
+      requestedReason: "post_war_reconciliation",
       warState: currentState,
       warStartTime: nextWarStartTime,
       warEndTime: nextWarEndTime ?? sub.endTime ?? null,
       currentSyncNumber: syncContext.activeSync,
       lifecycle: lifecycleState,
+      activeWarId:
+        sub.warId !== null && sub.warId !== undefined && Number.isFinite(sub.warId)
+          ? String(Math.trunc(sub.warId))
+          : null,
+      activeOpponentTag: nextOpponentTag || normalizeTag(sub.opponentTag ?? ""),
     });
-    if (!policyDecision.shouldFetch) {
-      console.info(
-        `[war-events] points fetch skipped guild=${sub.guildId} clan=${sub.clanTag} reason=${policyDecision.skipReason ?? "policy_skip"} confirmed=${lifecycleState?.confirmedByClanMail ? 1 : 0} needsValidation=${lifecycleState?.needsValidation ? 1 : 0}`
-      );
-    }
     if (eventType === "war_started" && nextOpponentTag) {
       await this.pointsSync.resetWarStartPointsJob(sub.clanTag, nextOpponentTag).catch(() => null);
     }
-    if (policyDecision.shouldFetch && currentState !== "notInWar" && nextOpponentTag) {
+    if (gateDecision.allowed && currentState !== "notInWar" && nextOpponentTag) {
       await this.pointsSync.maybeRunWarStartPointsCheck(
         sub,
         nextOpponentTag,
@@ -1198,10 +1214,10 @@ export class WarEventLogService {
     const nextOpponentDestruction = Number.isFinite(Number(war?.opponent?.destructionPercentage))
       ? Number(war?.opponent?.destructionPercentage)
       : null;
-    if (policyDecision.shouldFetch && (nextOpponentTag || normalizeTag(sub.opponentTag ?? ""))) {
+    if (gateDecision.allowed && (nextOpponentTag || normalizeTag(sub.opponentTag ?? ""))) {
       const projectionClanTag = sub.clanTag;
       const projectionOpponentTag = nextOpponentTag || normalizeTag(sub.opponentTag ?? "");
-      const projectionReason = policyDecision.reason ?? "war_event_projection";
+      const projectionReason = gateDecision.fetchReason ?? "war_event_projection";
       const [a, b] = await Promise.all([
         this.points.fetchSnapshot(projectionClanTag, { reason: projectionReason }),
         this.points.fetchSnapshot(projectionOpponentTag, { reason: projectionReason }),

--- a/tests/pointsFetchPolicy.service.test.ts
+++ b/tests/pointsFetchPolicy.service.test.ts
@@ -99,4 +99,175 @@ describe("PointsFetchPolicyService", () => {
     expect(decision.shouldFetch).toBe(true);
     expect(decision.reason).toBe("post_war_check");
   });
+
+  it("blocks post_war_reconciliation under active mail-confirmed lock", () => {
+    const service = new PointsFetchPolicyService();
+    const decision = service.evaluatePollerFetch({
+      guildId: "guild-1",
+      clanTag: "#AAA111",
+      pollerSource: "war_event_poll_cycle",
+      requestedReason: "post_war_reconciliation",
+      warState: "inWar",
+      warStartTime: new Date("2026-03-08T07:00:00.000Z"),
+      warEndTime: new Date("2026-03-09T07:00:00.000Z"),
+      currentSyncNumber: 2001,
+      activeWarId: "777",
+      activeOpponentTag: "#OPP999",
+      lifecycle: {
+        confirmedByClanMail: true,
+        needsValidation: false,
+        lastSuccessfulPointsApiFetchAt: new Date("2026-03-08T07:40:00.000Z"),
+        lastKnownSyncNumber: 2001,
+        warId: "777",
+        opponentTag: "#OPP999",
+        warStartTime: new Date("2026-03-08T07:00:00.000Z"),
+      },
+      nowMs: new Date("2026-03-08T08:00:00.000Z").getTime(),
+    });
+
+    expect(decision.allowed).toBe(false);
+    expect(decision.outcome).toBe("blocked");
+    expect(decision.decisionCode).toBe("locked_mail_confirmed");
+  });
+
+  it("blocks mail_refresh under active mail-confirmed lock", () => {
+    const service = new PointsFetchPolicyService();
+    const decision = service.evaluatePollerFetch({
+      guildId: "guild-1",
+      clanTag: "#AAA111",
+      pollerSource: "mail_refresh_loop",
+      requestedReason: "mail_refresh",
+      preferredAllowedReason: "mail_refresh",
+      warState: "inWar",
+      warStartTime: new Date("2026-03-08T07:00:00.000Z"),
+      warEndTime: new Date("2026-03-09T07:00:00.000Z"),
+      currentSyncNumber: 2001,
+      activeWarId: "777",
+      activeOpponentTag: "#OPP999",
+      lifecycle: {
+        confirmedByClanMail: true,
+        needsValidation: false,
+        lastSuccessfulPointsApiFetchAt: new Date("2026-03-08T07:40:00.000Z"),
+        lastKnownSyncNumber: 2001,
+        warId: "777",
+        opponentTag: "#OPP999",
+        warStartTime: new Date("2026-03-08T07:00:00.000Z"),
+      },
+      nowMs: new Date("2026-03-08T08:00:00.000Z").getTime(),
+    });
+
+    expect(decision.allowed).toBe(false);
+    expect(decision.decisionCode).toBe("locked_mail_confirmed");
+  });
+
+  it("unlocks routine fetch when war identity changed", () => {
+    const service = new PointsFetchPolicyService();
+    const decision = service.evaluatePollerFetch({
+      guildId: "guild-1",
+      clanTag: "#AAA111",
+      pollerSource: "war_event_poll_cycle",
+      requestedReason: "post_war_reconciliation",
+      warState: "inWar",
+      warStartTime: new Date("2026-03-08T07:00:00.000Z"),
+      warEndTime: new Date("2026-03-09T07:00:00.000Z"),
+      currentSyncNumber: 2001,
+      activeWarId: "888",
+      activeOpponentTag: "#NEW123",
+      lifecycle: {
+        confirmedByClanMail: true,
+        needsValidation: false,
+        lastSuccessfulPointsApiFetchAt: new Date("2026-03-08T07:40:00.000Z"),
+        lastKnownSyncNumber: 2001,
+        warId: "777",
+        opponentTag: "#OLD123",
+        warStartTime: new Date("2026-03-08T07:00:00.000Z"),
+      },
+      nowMs: new Date("2026-03-08T08:00:00.000Z").getTime(),
+    });
+
+    expect(decision.allowed).toBe(true);
+    expect(decision.decisionCode).toBe("war_identity_changed");
+  });
+
+  it("unlocks routine fetch when validation is required", () => {
+    const service = new PointsFetchPolicyService();
+    const decision = service.evaluatePollerFetch({
+      guildId: "guild-1",
+      clanTag: "#AAA111",
+      pollerSource: "war_event_poll_cycle",
+      requestedReason: "post_war_reconciliation",
+      warState: "inWar",
+      warStartTime: new Date("2026-03-08T07:00:00.000Z"),
+      warEndTime: new Date("2026-03-09T07:00:00.000Z"),
+      currentSyncNumber: 2001,
+      activeWarId: "777",
+      activeOpponentTag: "#OPP999",
+      lifecycle: {
+        confirmedByClanMail: true,
+        needsValidation: true,
+        lastSuccessfulPointsApiFetchAt: new Date("2026-03-08T07:40:00.000Z"),
+        lastKnownSyncNumber: 2001,
+        warId: "777",
+        opponentTag: "#OPP999",
+        warStartTime: new Date("2026-03-08T07:00:00.000Z"),
+      },
+      nowMs: new Date("2026-03-08T08:00:00.000Z").getTime(),
+    });
+
+    expect(decision.allowed).toBe(true);
+    expect(decision.decisionCode).toBe("validation_required");
+  });
+
+  it("allows manual override even when lock would otherwise block", () => {
+    const service = new PointsFetchPolicyService();
+    const decision = service.evaluatePollerFetch({
+      guildId: "guild-1",
+      clanTag: "#AAA111",
+      pollerSource: "war_event_poll_cycle",
+      requestedReason: "post_war_reconciliation",
+      warState: "inWar",
+      warStartTime: new Date("2026-03-08T07:00:00.000Z"),
+      warEndTime: new Date("2026-03-09T07:00:00.000Z"),
+      currentSyncNumber: 2001,
+      activeWarId: "777",
+      activeOpponentTag: "#OPP999",
+      manualOverride: true,
+      lifecycle: {
+        confirmedByClanMail: true,
+        needsValidation: false,
+        lastSuccessfulPointsApiFetchAt: new Date("2026-03-08T07:40:00.000Z"),
+        lastKnownSyncNumber: 2001,
+        warId: "777",
+        opponentTag: "#OPP999",
+        warStartTime: new Date("2026-03-08T07:00:00.000Z"),
+      },
+      nowMs: new Date("2026-03-08T08:00:00.000Z").getTime(),
+    });
+
+    expect(decision.allowed).toBe(true);
+    expect(decision.decisionCode).toBe("manual_override");
+  });
+
+  it("returns not_applicable for mail_refresh when no active war exists", () => {
+    const service = new PointsFetchPolicyService();
+    const decision = service.evaluatePollerFetch({
+      guildId: "guild-1",
+      clanTag: "#AAA111",
+      pollerSource: "mail_refresh_loop",
+      requestedReason: "mail_refresh",
+      preferredAllowedReason: "mail_refresh",
+      warState: "notInWar",
+      warStartTime: null,
+      warEndTime: null,
+      currentSyncNumber: 2001,
+      activeWarId: null,
+      activeOpponentTag: null,
+      lifecycle: null,
+      nowMs: new Date("2026-03-08T08:00:00.000Z").getTime(),
+    });
+
+    expect(decision.allowed).toBe(false);
+    expect(decision.outcome).toBe("not_applicable");
+    expect(decision.decisionCode).toBe("inactive_war_for_mail_refresh");
+  });
 });


### PR DESCRIPTION
- add structured poller fetch gate decisions with lock/unlock decision codes
- enforce active-war mail-confirmed lock for war poll and mail refresh paths
- unify poller callsites on one gate with standardized decision logging/rollups
- include war identity fields in lifecycle context for lock validation
- add lock/unlock/not-applicable policy tests and keep full suite green
- document poller-side lock behavior in README