### PR TITLE
test(fwa-weight): isolate service tests from Prisma settings lookup

### DIFF
--- a/tests/fwaWeight.service.test.ts
+++ b/tests/fwaWeight.service.test.ts
@@ -7,6 +7,7 @@ import {
   parseWeightAgeDays,
 } from "../src/services/FwaStatsWeightService";
 import { FwaStatsWeightCookieService } from "../src/services/FwaStatsWeightCookieService";
+import { SettingsService } from "../src/services/SettingsService";
 
 vi.mock("axios", () => ({
   default: {
@@ -47,8 +48,10 @@ describe("FwaStatsWeightService", () => {
   const originalCookie = process.env.FWASTATS_WEIGHT_COOKIE;
 
   beforeEach(() => {
+    vi.restoreAllMocks();
     mockedAxios.get.mockReset();
     delete process.env.FWASTATS_WEIGHT_COOKIE;
+    vi.spyOn(SettingsService.prototype, "get").mockResolvedValue(null);
   });
 
   afterEach(() => {


### PR DESCRIPTION
- mock SettingsService.get in fwa weight service tests to avoid DB access
- keep cookie/header behavior assertions intact in DB-less CI environments
- prevent DATABASE_URL-dependent test failures when .env is absent