### PR TITLE
Clean up script_of_scripts.md by removing conflict markers

### DIFF
--- a/scripts/script_of_scripts.md
+++ b/scripts/script_of_scripts.md
@@ -64,14 +64,11 @@ When making changes:
 
 If necessary, refactor existing code to support the new feature.
 
-<<<<<<< Updated upstream
-=======
 Before considering the task complete:
 * Run relevant validation commands (lint/tests) for the affected scope
 * Fix CI-blocking lint errors
 * Do not leave touched files with avoidable lint issues
 
->>>>>>> Stashed changes
 ---
 
 # Step 5 — Generate Conventional Commit Message


### PR DESCRIPTION
Removed merge conflict markers from the documentation.