### PR TITLE
fix(fwa): prioritize live opponent signals over unconfirmed FWA

### DIFF
--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -68,6 +68,14 @@ import {
 } from "../services/PointsFetchPolicyService";
 import { PointsSyncService } from "../services/PointsSyncService";
 import {
+  chooseMatchTypeResolution,
+  inferMatchTypeFromOpponentPoints,
+  resolveCurrentWarMatchTypeSignal,
+  resolveMatchTypeFromStoredSyncRow,
+  type MatchTypeResolution,
+  type MatchTypeResolutionSource,
+} from "../services/MatchTypeResolutionService";
+import {
   PointsDirectFetchGateService,
   type PointsDirectFetchCaller,
   PointsDirectFetchBlockedError,
@@ -348,15 +356,6 @@ const MATCHTYPE_WARNING_LEGEND =
 function logFwaMatchTelemetry(event: string, detail: string): void {
   console.log(`[telemetry-fwa-match] event=${event} ${detail}`);
 }
-
-type MatchTypeResolutionSource =
-  | "current_war"
-  | "stored_sync"
-  | "points_clan_not_found"
-  | "points_active_fwa_yes"
-  | "points_active_fwa_no"
-  | "points_missing_opponent"
-  | "points_unknown_signal";
 
 /** Purpose: emit structured logs for match-type source/inference/confirmation decisions. */
 function logMatchTypeResolution(params: {
@@ -996,11 +995,17 @@ async function buildWarMailEmbedForTag(
       (subscription?.matchType as "FWA" | "BL" | "MM" | "SKIP" | null | undefined) ?? null,
     existingInferredMatchType: subscription?.inferredMatchType ?? null,
   });
-  let inferredMatchType = fallbackResolution?.inferred ?? Boolean(subscription?.inferredMatchType);
+  let appliedResolution = chooseMatchTypeResolution({
+    confirmedCurrent: fallbackResolution.confirmedCurrent,
+    liveOpponent: null,
+    storedSync: fallbackResolution.storedSync,
+    unconfirmedCurrent: fallbackResolution.unconfirmedCurrent,
+  });
+  let inferredMatchType = appliedResolution?.inferred ?? Boolean(subscription?.inferredMatchType);
   let matchType: "FWA" | "BL" | "MM" | "UNKNOWN" =
-    fallbackResolution?.matchType === "SKIP"
+    appliedResolution?.matchType === "SKIP"
       ? "UNKNOWN"
-      : (fallbackResolution?.matchType ?? "UNKNOWN");
+      : (appliedResolution?.matchType ?? "UNKNOWN");
   let outcome = (subscription?.outcome as "WIN" | "LOSE" | null | undefined) ?? null;
   const fallbackOpponentTag = normalizeTag(String(subscription?.opponentTag ?? ""));
   const effectiveOpponentTag = opponentTag || fallbackOpponentTag;
@@ -1087,7 +1092,7 @@ async function buildWarMailEmbedForTag(
   let opponentBalance: number | null = null;
   let primarySnapshot: PointsSnapshot | null = null;
   let opponentSnapshot: PointsSnapshot | null = null;
-  let pointsInference: PointsInferredMatchType | null = null;
+  let pointsInference: MatchTypeResolution | null = null;
   if (opponentTag && routineDecision.allowed) {
     primarySnapshot = await getClanPointsCached(settings, cocService, normalizedTag, currentSync, undefined, {
       fetchReason,
@@ -1102,22 +1107,20 @@ async function buildWarMailEmbedForTag(
     opponentBalance = subscription?.opponentFwaPoints ?? syncRow?.opponentPoints ?? null;
   }
   if (opponentTag) {
-    if (matchType === "UNKNOWN") {
-      pointsInference = inferMatchTypeFromPointsSnapshots(primarySnapshot, opponentSnapshot);
-      matchType = pointsInference.matchType;
-      inferredMatchType = true;
-    }
-    const appliedResolution = fallbackResolution ?? (
-      pointsInference
-        ? {
-          matchType: pointsInference.matchType,
-          source: pointsInference.source,
-          inferred: true,
-          confirmed: false,
-          syncIsFwa: pointsInference.syncIsFwa,
-        }
-        : null
+    pointsInference = toMatchTypeResolutionFromPointsInference(
+      inferMatchTypeFromPointsSnapshots(primarySnapshot, opponentSnapshot)
     );
+    appliedResolution = chooseMatchTypeResolution({
+      confirmedCurrent: fallbackResolution.confirmedCurrent,
+      liveOpponent: pointsInference,
+      storedSync: fallbackResolution.storedSync,
+      unconfirmedCurrent: fallbackResolution.unconfirmedCurrent,
+    });
+    inferredMatchType = appliedResolution?.inferred ?? Boolean(subscription?.inferredMatchType);
+    matchType =
+      appliedResolution?.matchType === "SKIP"
+        ? "UNKNOWN"
+        : (appliedResolution?.matchType ?? "UNKNOWN");
     if (appliedResolution) {
       logMatchTypeResolution({
         stage: "mail_embed",
@@ -1135,7 +1138,7 @@ async function buildWarMailEmbedForTag(
       (matchType === "FWA" ? true : matchType === "BL" ? false : false);
     if (opponentSnapshot) {
       console.info(
-        `[fwa-matchtype] stage=mail_embed_active_fwa clan=#${normalizedTag} opponent=#${opponentTag} parsed_active_fwa=${opponentSnapshot.activeFwa === null ? "unknown" : opponentSnapshot.activeFwa ? "yes" : "no"} not_found=${opponentSnapshot.notFound ? "1" : "0"} source=${appliedResolution?.source ?? "points_unknown_signal"} sync_is_fwa=${syncIsFwaSignal ? "1" : "0"}`
+        `[fwa-matchtype] stage=mail_embed_active_fwa clan=#${normalizedTag} opponent=#${opponentTag} parsed_active_fwa=${opponentSnapshot.activeFwa === null ? "unknown" : opponentSnapshot.activeFwa ? "yes" : "no"} not_found=${opponentSnapshot.notFound ? "1" : "0"} source=${appliedResolution?.source ?? "none"} sync_is_fwa=${syncIsFwaSignal ? "1" : "0"}`
       );
     }
     if (matchType === "FWA" && !outcome) {
@@ -4356,76 +4359,11 @@ async function persistClanPointsSyncIfCurrent(input: {
   });
 }
 
-type MatchTypeResolution = {
-  matchType: "FWA" | "BL" | "MM" | "SKIP";
-  source: MatchTypeResolutionSource;
-  inferred: boolean;
-  confirmed: boolean;
-  syncIsFwa: boolean | null;
+type MatchTypeFallbackResolution = {
+  confirmedCurrent: MatchTypeResolution | null;
+  storedSync: MatchTypeResolution | null;
+  unconfirmedCurrent: MatchTypeResolution | null;
 };
-
-type PointsInferredMatchType = {
-  matchType: "FWA" | "BL" | "MM";
-  source: MatchTypeResolutionSource;
-  syncIsFwa: boolean;
-  parsedActiveFwa: boolean | null;
-};
-
-type StoredSyncMatchTypeRow = {
-  opponentTag: string;
-  isFwa: boolean | null;
-  lastKnownMatchType: string | null;
-};
-
-/** Purpose: normalize persisted match-type strings into known command-domain values. */
-function normalizeStoredMatchType(
-  raw: string | null | undefined
-): "FWA" | "BL" | "MM" | "SKIP" | null {
-  const value = String(raw ?? "").trim().toUpperCase();
-  if (value === "FWA" || value === "BL" || value === "MM" || value === "SKIP") return value;
-  return null;
-}
-
-/** Purpose: map stored sync metadata to fallback match-type when war/opponent context matches. */
-function resolveMatchTypeFromStoredSyncRow(params: {
-  syncRow: StoredSyncMatchTypeRow | null;
-  opponentTag: string;
-}): MatchTypeResolution | null {
-  if (!params.syncRow) return null;
-  const syncOpponent = normalizeTag(params.syncRow.opponentTag ?? "");
-  const requestedOpponent = normalizeTag(params.opponentTag);
-  if (!syncOpponent || syncOpponent !== requestedOpponent) return null;
-
-  const storedType = normalizeStoredMatchType(params.syncRow.lastKnownMatchType);
-  if (storedType) {
-    return {
-      matchType: storedType,
-      source: "stored_sync",
-      inferred: true,
-      confirmed: false,
-      syncIsFwa: params.syncRow.isFwa ?? null,
-    };
-  }
-  if (params.syncRow.isFwa === true) {
-    return {
-      matchType: "FWA",
-      source: "stored_sync",
-      inferred: true,
-      confirmed: false,
-      syncIsFwa: true,
-    };
-  }
-  if (params.syncRow.isFwa === false) {
-    return {
-      matchType: "BL",
-      source: "stored_sync",
-      inferred: true,
-      confirmed: false,
-      syncIsFwa: false,
-    };
-  }
-  return null;
-}
 
 export const getMailBlockedReasonFromStatusForTest = getMailBlockedReasonFromStatus;
 
@@ -4435,64 +4373,22 @@ export const resolveMatchTypeFromStoredSyncRowForTest = resolveMatchTypeFromStor
 function inferMatchTypeFromPointsSnapshots(
   _primaryPoints: Pick<PointsSnapshot, "activeFwa"> | null,
   opponentPoints: Pick<PointsSnapshot, "balance" | "activeFwa" | "notFound"> | null
-): PointsInferredMatchType {
-  if (opponentPoints?.notFound === true) {
-    return {
-      matchType: "MM",
-      source: "points_clan_not_found",
-      syncIsFwa: false,
-      parsedActiveFwa: opponentPoints.activeFwa ?? null,
-    };
-  }
-  const hasOpponentPoints =
-    opponentPoints?.balance !== null &&
-    opponentPoints?.balance !== undefined &&
-    !Number.isNaN(opponentPoints.balance);
-  if (!hasOpponentPoints) {
-    return {
-      matchType: "MM",
-      source: "points_missing_opponent",
-      syncIsFwa: false,
-      parsedActiveFwa: opponentPoints?.activeFwa ?? null,
-    };
-  }
-  if (opponentPoints?.activeFwa === false) {
-    return {
-      matchType: "BL",
-      source: "points_active_fwa_no",
-      syncIsFwa: false,
-      parsedActiveFwa: false,
-    };
-  }
-  if (opponentPoints?.activeFwa === true) {
-    return {
-      matchType: "FWA",
-      source: "points_active_fwa_yes",
-      syncIsFwa: true,
-      parsedActiveFwa: true,
-    };
-  }
-  return {
-    matchType: "FWA",
-    source: "points_unknown_signal",
-    syncIsFwa: true,
-    parsedActiveFwa: null,
-  };
+): MatchTypeResolution | null {
+  return inferMatchTypeFromOpponentPoints({
+    available: opponentPoints !== null,
+    balance: opponentPoints?.balance ?? null,
+    activeFwa: opponentPoints?.activeFwa ?? null,
+    notFound: opponentPoints?.notFound ?? false,
+  });
 }
 
 export const inferMatchTypeFromPointsSnapshotsForTest = inferMatchTypeFromPointsSnapshots;
 
 /** Purpose: normalize points-based inference into the shared resolution shape. */
 function toMatchTypeResolutionFromPointsInference(
-  pointsInference: PointsInferredMatchType
-): MatchTypeResolution {
-  return {
-    matchType: pointsInference.matchType,
-    source: pointsInference.source,
-    inferred: true,
-    confirmed: false,
-    syncIsFwa: pointsInference.syncIsFwa,
-  };
+  pointsInference: MatchTypeResolution | null
+): MatchTypeResolution | null {
+  return pointsInference;
 }
 
 /** Purpose: resolve match type from persisted sync data when live state is unset. */
@@ -4502,19 +4398,7 @@ async function resolveMatchTypeFromStoredSync(params: {
   opponentTag: string;
   warId?: number | null;
   warStartTime?: Date | null;
-  existingMatchType: "FWA" | "BL" | "MM" | "SKIP" | null | undefined;
-  existingInferredMatchType?: boolean | null | undefined;
 }): Promise<MatchTypeResolution | null> {
-  if (params.existingMatchType) {
-    const inferred = Boolean(params.existingInferredMatchType);
-    return {
-      matchType: params.existingMatchType,
-      source: "current_war",
-      inferred,
-      confirmed: !inferred,
-      syncIsFwa: params.existingMatchType === "FWA" ? true : params.existingMatchType === "BL" ? false : null,
-    };
-  }
   if (!params.guildId || !params.opponentTag) return null;
   const warIdText =
     params.warId !== null && params.warId !== undefined && Number.isFinite(params.warId)
@@ -4548,24 +4432,29 @@ async function resolveMatchTypeWithFallback(params: {
   warStartTime?: Date | null;
   existingMatchType: "FWA" | "BL" | "MM" | "SKIP" | null | undefined;
   existingInferredMatchType?: boolean | null | undefined;
-}): Promise<MatchTypeResolution | null> {
+}): Promise<MatchTypeFallbackResolution> {
+  const currentResolution = resolveCurrentWarMatchTypeSignal({
+    matchType: params.existingMatchType ?? null,
+    inferredMatchType: params.existingInferredMatchType ?? true,
+  });
   if (params.warState === "notInWar") {
-    if (!params.existingMatchType) return null;
-    const inferred = Boolean(params.existingInferredMatchType);
     return {
-      matchType: params.existingMatchType,
-      source: "current_war",
-      inferred,
-      confirmed: !inferred,
-      syncIsFwa:
-        params.existingMatchType === "FWA"
-          ? true
-          : params.existingMatchType === "BL"
-            ? false
-            : null,
+      confirmedCurrent: currentResolution.confirmed,
+      storedSync: null,
+      unconfirmedCurrent: currentResolution.unconfirmed,
     };
   }
-  return resolveMatchTypeFromStoredSync(params);
+  return {
+    confirmedCurrent: currentResolution.confirmed,
+    storedSync: await resolveMatchTypeFromStoredSync({
+      guildId: params.guildId,
+      clanTag: params.clanTag,
+      opponentTag: params.opponentTag,
+      warId: params.warId,
+      warStartTime: params.warStartTime,
+    }),
+    unconfirmedCurrent: currentResolution.unconfirmed,
+  };
 }
 
 /** Purpose: apply source-of-truth sync number over a scraped points snapshot. */
@@ -5492,7 +5381,7 @@ async function buildTrackedMatchOverview(
 
     const opponentTag = normalizeTag(String(war?.opponent?.tag ?? ""));
     const opponentName = sanitizeClanName(String(war?.opponent?.name ?? "")) ?? "Unknown";
-    const matchTypeResolved = await resolveMatchTypeWithFallback({
+    const fallbackResolution = await resolveMatchTypeWithFallback({
       guildId,
       clanTag,
       opponentTag,
@@ -5553,7 +5442,7 @@ async function buildTrackedMatchOverview(
         },
         skipSyncAction: sub?.matchType === "SKIP" ? null : { tag: clanTag },
         undoSkipSyncAction: sub?.matchType === "SKIP" ? { tag: clanTag } : null,
-      };
+        };
       continue;
     }
 
@@ -5601,7 +5490,8 @@ async function buildTrackedMatchOverview(
         };
       }
     }
-    if (!opponentPoints || matchTypeResolved === null) {
+    const needsLiveOpponentResolution = fallbackResolution.confirmedCurrent === null;
+    if (!opponentPoints || needsLiveOpponentResolution) {
       opponentPoints = await getClanPointsCached(
         settings,
         cocService,
@@ -5624,7 +5514,15 @@ async function buildTrackedMatchOverview(
       opponentPoints
     );
     const pointsResolution = toMatchTypeResolutionFromPointsInference(inferredFromPointsType);
-    const appliedResolution = matchTypeResolved ?? pointsResolution;
+    const appliedResolution = chooseMatchTypeResolution({
+      confirmedCurrent: fallbackResolution.confirmedCurrent,
+      liveOpponent: pointsResolution,
+      storedSync: fallbackResolution.storedSync,
+      unconfirmedCurrent: fallbackResolution.unconfirmedCurrent,
+    });
+    if (!appliedResolution) {
+      continue;
+    }
     const matchType = appliedResolution.matchType;
     const inferredMatchType = appliedResolution.inferred;
     const syncIsFwaSignal =
@@ -5805,7 +5703,13 @@ async function buildTrackedMatchOverview(
         validationState.differences.length > 0
     );
     const pointsSyncStatus = validationState.statusLine;
-    const siteMatchType = inferredFromPointsType.matchType;
+    const siteMatchType: "FWA" | "BL" | "MM" | null =
+      inferredFromPointsType &&
+      (inferredFromPointsType.matchType === "FWA" ||
+        inferredFromPointsType.matchType === "BL" ||
+        inferredFromPointsType.matchType === "MM")
+        ? inferredFromPointsType.matchType
+        : null;
     const opponentCcUrl = buildCcVerifyUrl(opponentTag);
     const opponentPointsUrl = buildOfficialPointsUrl(opponentTag);
     const mailChannelId = mailChannelByTag.get(clanTag) ?? null;
@@ -8159,7 +8063,7 @@ export const Fwa: Command = {
             warLookupCache
           );
         }
-        const matchTypeResolved = await resolveMatchTypeWithFallback({
+        const fallbackResolution = await resolveMatchTypeWithFallback({
           guildId: interaction.guildId ?? null,
           clanTag: tag,
           opponentTag,
@@ -8169,7 +8073,7 @@ export const Fwa: Command = {
           existingMatchType: subscription?.matchType ?? null,
           existingInferredMatchType: subscription?.inferredMatchType ?? null,
         });
-        if (matchTypeResolved === null) {
+        if (fallbackResolution.confirmedCurrent === null) {
           const opponentForInference = await getClanPointsCached(
             settings,
             cocService,
@@ -8212,7 +8116,16 @@ export const Fwa: Command = {
         }
         const inferredFromPointsType = inferMatchTypeFromPointsSnapshots(primary, opponent);
         const pointsResolution = toMatchTypeResolutionFromPointsInference(inferredFromPointsType);
-        const appliedResolution = matchTypeResolved ?? pointsResolution;
+        const appliedResolution = chooseMatchTypeResolution({
+          confirmedCurrent: fallbackResolution.confirmedCurrent,
+          liveOpponent: pointsResolution,
+          storedSync: fallbackResolution.storedSync,
+          unconfirmedCurrent: fallbackResolution.unconfirmedCurrent,
+        });
+        if (!appliedResolution) {
+          await editReplySafe("Unable to resolve match type from current data.");
+          return;
+        }
         const matchType = appliedResolution.matchType;
         const syncIsFwaSignal =
           appliedResolution.syncIsFwa ??
@@ -8525,7 +8438,13 @@ export const Fwa: Command = {
             .join("\n")
         );
         let alliance = overview;
-        const syncActionSiteMatchType = inferredFromPointsType.matchType;
+        const syncActionSiteMatchType: "FWA" | "BL" | "MM" | null =
+          inferredFromPointsType &&
+          (inferredFromPointsType.matchType === "FWA" ||
+            inferredFromPointsType.matchType === "BL" ||
+            inferredFromPointsType.matchType === "MM")
+            ? inferredFromPointsType.matchType
+            : null;
         const syncActionSiteOutcome = deriveSyncActionSiteOutcome({
           siteMatchType: syncActionSiteMatchType,
           projectedOutcome: derivedOutcome,

--- a/src/services/MatchTypeResolutionService.ts
+++ b/src/services/MatchTypeResolutionService.ts
@@ -1,0 +1,186 @@
+type MatchType = "FWA" | "BL" | "MM" | "SKIP";
+
+export type MatchTypeResolutionSource =
+  | "confirmed_current_war"
+  | "unconfirmed_current_war"
+  | "stored_sync"
+  | "live_points_clan_not_found"
+  | "live_points_active_fwa_yes"
+  | "live_points_active_fwa_no";
+
+export type MatchTypeResolution = {
+  matchType: MatchType;
+  source: MatchTypeResolutionSource;
+  inferred: boolean;
+  confirmed: boolean;
+  syncIsFwa: boolean | null;
+};
+
+export type StoredSyncMatchTypeRow = {
+  opponentTag: string;
+  isFwa: boolean | null;
+  lastKnownMatchType: string | null;
+};
+
+export type OpponentPointsMatchTypeSignal = {
+  available: boolean;
+  balance: number | null | undefined;
+  activeFwa: boolean | null | undefined;
+  notFound?: boolean | null | undefined;
+};
+
+type CurrentWarMatchTypeSignal = {
+  matchType: string | null | undefined;
+  inferredMatchType: boolean | null | undefined;
+};
+
+function normalizeTag(input: string): string {
+  return input.trim().toUpperCase().replace(/^#/, "");
+}
+
+/** Purpose: normalize persisted match-type strings into known values. */
+export function normalizeStoredMatchType(raw: string | null | undefined): MatchType | null {
+  const value = String(raw ?? "").trim().toUpperCase();
+  if (value === "FWA" || value === "BL" || value === "MM" || value === "SKIP") return value;
+  return null;
+}
+
+/** Purpose: derive sync isFwa signal from resolved match type when explicit signal is absent. */
+export function toSyncIsFwa(matchType: MatchType | null): boolean | null {
+  if (matchType === "FWA") return true;
+  if (matchType === "BL" || matchType === "MM") return false;
+  return null;
+}
+
+/** Purpose: split current-war match type into confirmed vs unconfirmed candidates. */
+export function resolveCurrentWarMatchTypeSignal(
+  signal: CurrentWarMatchTypeSignal
+): { confirmed: MatchTypeResolution | null; unconfirmed: MatchTypeResolution | null } {
+  const current = normalizeStoredMatchType(signal.matchType);
+  if (!current) {
+    return { confirmed: null, unconfirmed: null };
+  }
+  const isConfirmed = signal.inferredMatchType === false;
+  const base: Omit<MatchTypeResolution, "source" | "inferred" | "confirmed"> = {
+    matchType: current,
+    syncIsFwa: toSyncIsFwa(current),
+  };
+  if (isConfirmed) {
+    return {
+      confirmed: {
+        ...base,
+        source: "confirmed_current_war",
+        inferred: false,
+        confirmed: true,
+      },
+      unconfirmed: null,
+    };
+  }
+  return {
+    confirmed: null,
+    unconfirmed: {
+      ...base,
+      source: "unconfirmed_current_war",
+      inferred: true,
+      confirmed: false,
+    },
+  };
+}
+
+/** Purpose: map stored sync metadata to fallback match type for matching opponent context. */
+export function resolveMatchTypeFromStoredSyncRow(params: {
+  syncRow: StoredSyncMatchTypeRow | null;
+  opponentTag: string;
+}): MatchTypeResolution | null {
+  if (!params.syncRow) return null;
+  const syncOpponent = normalizeTag(params.syncRow.opponentTag ?? "");
+  const requestedOpponent = normalizeTag(params.opponentTag);
+  if (!syncOpponent || syncOpponent !== requestedOpponent) return null;
+
+  const storedType = normalizeStoredMatchType(params.syncRow.lastKnownMatchType);
+  if (storedType) {
+    return {
+      matchType: storedType,
+      source: "stored_sync",
+      inferred: true,
+      confirmed: false,
+      syncIsFwa: params.syncRow.isFwa ?? toSyncIsFwa(storedType),
+    };
+  }
+  if (params.syncRow.isFwa === true) {
+    return {
+      matchType: "FWA",
+      source: "stored_sync",
+      inferred: true,
+      confirmed: false,
+      syncIsFwa: true,
+    };
+  }
+  if (params.syncRow.isFwa === false) {
+    return {
+      matchType: "BL",
+      source: "stored_sync",
+      inferred: true,
+      confirmed: false,
+      syncIsFwa: false,
+    };
+  }
+  return null;
+}
+
+/** Purpose: infer match type from live opponent points-site signals. */
+export function inferMatchTypeFromOpponentPoints(
+  signal: OpponentPointsMatchTypeSignal
+): MatchTypeResolution | null {
+  if (!signal.available) return null;
+  if (signal.notFound === true) {
+    return {
+      matchType: "MM",
+      source: "live_points_clan_not_found",
+      inferred: true,
+      confirmed: false,
+      syncIsFwa: false,
+    };
+  }
+  const hasOpponentPoints =
+    signal.balance !== null &&
+    signal.balance !== undefined &&
+    !Number.isNaN(Number(signal.balance)) &&
+    Number.isFinite(Number(signal.balance));
+  if (!hasOpponentPoints) return null;
+  if (signal.activeFwa === false) {
+    return {
+      matchType: "BL",
+      source: "live_points_active_fwa_no",
+      inferred: true,
+      confirmed: false,
+      syncIsFwa: false,
+    };
+  }
+  if (signal.activeFwa === true) {
+    return {
+      matchType: "FWA",
+      source: "live_points_active_fwa_yes",
+      inferred: true,
+      confirmed: false,
+      syncIsFwa: true,
+    };
+  }
+  return null;
+}
+
+/** Purpose: apply deterministic precedence across confirmed, live, stored, and unconfirmed signals. */
+export function chooseMatchTypeResolution(input: {
+  confirmedCurrent: MatchTypeResolution | null;
+  liveOpponent: MatchTypeResolution | null;
+  storedSync: MatchTypeResolution | null;
+  unconfirmedCurrent: MatchTypeResolution | null;
+}): MatchTypeResolution | null {
+  return (
+    input.confirmedCurrent ??
+    input.liveOpponent ??
+    input.storedSync ??
+    input.unconfirmedCurrent ??
+    null
+  );
+}

--- a/src/services/PointsProjectionService.ts
+++ b/src/services/PointsProjectionService.ts
@@ -23,6 +23,8 @@ type Snapshot = {
   tag: string;
   clanName: string | null;
   balance: number | null;
+  activeFwa: boolean | null;
+  notFound: boolean;
   effectiveSync: number | null;
   syncMode: "low" | "high" | null;
   winnerBoxSync: number | null;
@@ -74,6 +76,23 @@ function extractField(text: string, label: string): string | null {
   );
   const match = text.match(regex);
   return match?.[1] ? match[1].trim().slice(0, 120) : null;
+}
+
+/** Purpose: parse Active FWA Yes/No from raw or normalized text. */
+function extractActiveFwa(...texts: Array<string | null | undefined>): boolean | null {
+  const raw = texts
+    .map((text) =>
+      text
+        ? text.match(/Active FWA\s*:\s*(Yes|No)\b/i)?.[1] ??
+          extractField(text, "Active FWA")?.match(/^(Yes|No)\b/i)?.[1] ??
+          null
+        : null
+    )
+    .find((value) => value);
+  if (!raw) return null;
+  if (/^yes$/i.test(raw)) return true;
+  if (/^no$/i.test(raw)) return false;
+  return null;
 }
 
 /** Purpose: extract winner box text. */
@@ -190,6 +209,8 @@ export class PointsProjectionService {
         tag: normalizedTag,
         clanName: null,
         balance: null,
+        activeFwa: null,
+        notFound: false,
         effectiveSync: null,
         syncMode: null,
         winnerBoxSync: null,
@@ -218,6 +239,8 @@ export class PointsProjectionService {
         tag: normalizedTag,
         clanName: await this.cocService.getClanName(normalizedTag).catch(() => null),
         balance: null,
+        activeFwa: null,
+        notFound: false,
         effectiveSync: null,
         syncMode: null,
         winnerBoxSync: null,
@@ -230,6 +253,8 @@ export class PointsProjectionService {
     const topSection = extractTopSectionText(html);
     const plain = toPlainText(html);
     const winnerBoxText = extractWinnerBoxText(html);
+    const activeFwa = extractActiveFwa(topSection, plain);
+    const notFound = /not found|unknown clan|no clan/i.test(topSection || plain);
     const winnerBoxTags = extractTagsFromText(topSection || winnerBoxText || "");
     const winnerBoxSync = extractSyncNumber(topSection || winnerBoxText || "");
     const winnerBoxHasTag = winnerBoxTags.includes(normalizedTag);
@@ -251,6 +276,8 @@ export class PointsProjectionService {
         extractField(plain, "Clan Name") ??
         (await this.cocService.getClanName(normalizedTag).catch(() => null)),
       balance,
+      activeFwa,
+      notFound,
       effectiveSync,
       syncMode: getSyncMode(effectiveSync),
       winnerBoxSync,
@@ -281,6 +308,8 @@ export class PointsProjectionService {
       tag: normalizedTag,
       clanName: null,
       balance: Number.isFinite(row.clanPoints) ? Math.trunc(row.clanPoints) : null,
+      activeFwa: null,
+      notFound: false,
       effectiveSync: Number.isFinite(row.syncNum) ? Math.trunc(row.syncNum) : null,
       syncMode: getSyncMode(Number.isFinite(row.syncNum) ? Math.trunc(row.syncNum) : null),
       winnerBoxSync: Number.isFinite(row.syncNum) ? Math.trunc(row.syncNum) : null,

--- a/src/services/WarEventLogService.ts
+++ b/src/services/WarEventLogService.ts
@@ -12,12 +12,18 @@ import { hashMessageConfig } from "../helper/hashConfig";
 import { formatError } from "../helper/formatError";
 import { prisma } from "../prisma";
 import { CoCService } from "./CoCService";
-import { FwaStatsService } from "./FwaStatsService";
 import { PointsProjectionService } from "./PointsProjectionService";
 import { PostedMessageService } from "./PostedMessageService";
 import { PointsSyncService } from "./PointsSyncService";
 import { PointsFetchPolicyService } from "./PointsFetchPolicyService";
 import { SettingsService } from "./SettingsService";
+import {
+  chooseMatchTypeResolution,
+  inferMatchTypeFromOpponentPoints,
+  resolveCurrentWarMatchTypeSignal,
+  toSyncIsFwa,
+  type MatchTypeResolution,
+} from "./MatchTypeResolutionService";
 import { WarEventHistoryService } from "./war-events/history";
 import { WarStartPointsSyncService } from "./war-events/pointsSync";
 import { getNextNotifyRefreshAtMs } from "./refreshSchedule";
@@ -270,7 +276,6 @@ function buildWarStatsLines(stats: EmbedWarStats): string[] {
 
 export class WarEventLogService {
   private readonly points: PointsProjectionService;
-  private readonly fwaStats: FwaStatsService;
   private readonly pointsSync: WarStartPointsSyncService;
   private readonly currentSyncs: PointsSyncService;
   private readonly pointsPolicy: PointsFetchPolicyService;
@@ -280,7 +285,6 @@ export class WarEventLogService {
   /** Purpose: initialize service dependencies. */
   constructor(private readonly client: Client, private readonly coc: CoCService) {
     this.points = new PointsProjectionService(coc);
-    this.fwaStats = new FwaStatsService();
     this.pointsSync = new WarStartPointsSyncService(this.points, new SettingsService());
     this.currentSyncs = new PointsSyncService();
     this.pointsPolicy = new PointsFetchPolicyService();
@@ -1171,19 +1175,18 @@ export class WarEventLogService {
         nextOpponentName
       ).catch(() => null);
     }
-    const fwaStatsValidated =
-      currentState !== "notInWar" && nextOpponentTag
-        ? await this.fwaStats
-            .isOpponentInActiveWars(sub.clanTag, nextOpponentTag)
-            .catch(() => null)
-        : null;
-
     const fallbackSyncNumberForEvent =
       eventType === "war_ended"
         ? syncContext.activeSync
         : currentState === "notInWar"
           ? syncContext.previousSync
           : syncContext.activeSync;
+
+    const currentWarResolution = resolveCurrentWarMatchTypeSignal({
+      matchType: sub.matchType,
+      inferredMatchType: sub.inferredMatchType,
+    });
+    let liveOpponentResolution: MatchTypeResolution | null = null;
 
     let nextFwaPoints = sub.fwaPoints;
     let nextOpponentFwaPoints = sub.opponentFwaPoints;
@@ -1222,6 +1225,12 @@ export class WarEventLogService {
         this.points.fetchSnapshot(projectionClanTag, { reason: projectionReason }),
         this.points.fetchSnapshot(projectionOpponentTag, { reason: projectionReason }),
       ]);
+      liveOpponentResolution = inferMatchTypeFromOpponentPoints({
+        available: true,
+        balance: b.balance,
+        activeFwa: b.activeFwa,
+        notFound: b.notFound,
+      });
       nextFwaPoints = a.balance;
       nextOpponentFwaPoints = b.balance;
       nextOutcome = deriveExpectedOutcome(
@@ -1247,6 +1256,14 @@ export class WarEventLogService {
         b.balance !== null &&
         Number.isFinite(b.balance)
       ) {
+        const syncResolution = chooseMatchTypeResolution({
+          confirmedCurrent: currentWarResolution.confirmed,
+          liveOpponent: liveOpponentResolution,
+          storedSync: null,
+          unconfirmedCurrent: currentWarResolution.unconfirmed,
+        });
+        const syncMatchType = syncResolution?.matchType ?? sub.matchType ?? null;
+        const syncIsFwa = syncResolution?.syncIsFwa ?? toSyncIsFwa(syncMatchType) ?? false;
         await this.currentSyncs
           .upsertPointsSync({
             guildId: sub.guildId,
@@ -1267,10 +1284,10 @@ export class WarEventLogService {
               b.balance,
               observedSync
             ),
-            isFwa: true,
+            isFwa: syncIsFwa,
             fetchedAt: new Date(a.fetchedAtMs),
             fetchReason: projectionReason,
-            matchType: sub.matchType ?? null,
+            matchType: syncMatchType,
             needsValidation: false,
           })
           .catch(() => null);
@@ -1282,38 +1299,14 @@ export class WarEventLogService {
         nextWarEndFwaPoints = a.balance;
       }
     }
-    let nextMatchType = sub.matchType;
-    let nextInferredMatchType = sub.inferredMatchType;
-    if (fwaStatsValidated === true && (nextMatchType === null || nextInferredMatchType)) {
-      nextMatchType = "FWA";
-      nextInferredMatchType = false;
-    }
-    if (eventType === "war_started") {
-      if (
-        nextMatchType === null &&
-        nextOpponentFwaPoints !== null &&
-        Number.isFinite(nextOpponentFwaPoints)
-      ) {
-        nextMatchType = "FWA";
-        nextInferredMatchType = true;
-      } else if (
-        nextMatchType === null &&
-        (nextOpponentFwaPoints === null || !Number.isFinite(nextOpponentFwaPoints))
-      ) {
-        nextMatchType = "MM";
-        nextInferredMatchType = true;
-      }
-    }
-    if (
-      eventType === "war_ended" &&
-      nextMatchType === null &&
-      nextInferredMatchType
-    ) {
-      nextMatchType =
-        nextOpponentFwaPoints !== null && Number.isFinite(nextOpponentFwaPoints)
-          ? "FWA"
-          : "MM";
-    }
+    const resolvedMatchType = chooseMatchTypeResolution({
+      confirmedCurrent: currentWarResolution.confirmed,
+      liveOpponent: liveOpponentResolution,
+      storedSync: null,
+      unconfirmedCurrent: currentWarResolution.unconfirmed,
+    });
+    let nextMatchType = resolvedMatchType?.matchType ?? sub.matchType;
+    let nextInferredMatchType = resolvedMatchType?.inferred ?? sub.inferredMatchType;
 
     if (eventType === "war_ended" && nextMatchType === "BL") {
       const finalResult = await this.history.getWarEndResultSnapshot({

--- a/src/services/war-events/pointsSync.ts
+++ b/src/services/war-events/pointsSync.ts
@@ -1,4 +1,10 @@
 import { prisma } from "../../prisma";
+import {
+  chooseMatchTypeResolution,
+  inferMatchTypeFromOpponentPoints,
+  resolveCurrentWarMatchTypeSignal,
+  toSyncIsFwa,
+} from "../MatchTypeResolutionService";
 import { PointsProjectionService } from "../PointsProjectionService";
 import { PointsSyncService } from "../PointsSyncService";
 import { SettingsService } from "../SettingsService";
@@ -21,6 +27,8 @@ type WarStartPointsCheckJob = {
   siteSyncNumber: number | null;
   siteOpponentTag: string | null;
   siteOpponentBalance: number | null;
+  siteOpponentActiveFwa: boolean | null;
+  siteOpponentNotFound: boolean | null;
   inferredOpponentIsFwa: boolean | null;
   opponentChecked: boolean;
   lastCheckedAtMs: number | null;
@@ -81,6 +89,8 @@ export class WarStartPointsSyncService {
       siteSyncNumber: null,
       siteOpponentTag: null,
       siteOpponentBalance: null,
+      siteOpponentActiveFwa: null,
+      siteOpponentNotFound: null,
       inferredOpponentIsFwa: null,
       opponentChecked: false,
       lastCheckedAtMs: null,
@@ -120,17 +130,26 @@ export class WarStartPointsSyncService {
       let inferredOpponentIsFwa = job.inferredOpponentIsFwa;
       let opponentChecked = job.opponentChecked;
       let opponentBalance = job.siteOpponentBalance;
+      let opponentActiveFwa = job.siteOpponentActiveFwa;
+      let opponentNotFound = job.siteOpponentNotFound;
       if (!opponentChecked) {
         const opp = await this.points
           .fetchSnapshot(opponentTag, { reason: "post_war_reconciliation" })
           .catch(() => null);
         opponentChecked = true;
-        inferredOpponentIsFwa =
-          opp?.balance !== null && opp?.balance !== undefined && Number.isFinite(opp.balance);
+        const liveResolution = inferMatchTypeFromOpponentPoints({
+          available: opp !== null,
+          balance: opp?.balance ?? null,
+          activeFwa: opp?.activeFwa ?? null,
+          notFound: opp?.notFound ?? false,
+        });
+        inferredOpponentIsFwa = liveResolution?.syncIsFwa ?? null;
         opponentBalance =
           opp?.balance !== null && opp?.balance !== undefined && Number.isFinite(opp.balance)
             ? opp.balance
             : null;
+        opponentActiveFwa = opp?.activeFwa ?? null;
+        opponentNotFound = opp?.notFound ?? null;
       }
 
       const mismatch =
@@ -167,6 +186,8 @@ export class WarStartPointsSyncService {
             : null,
         siteOpponentTag: siteUpdated ? opponentTag : null,
         siteOpponentBalance: opponentBalance,
+        siteOpponentActiveFwa: opponentActiveFwa,
+        siteOpponentNotFound: opponentNotFound,
         inferredOpponentIsFwa,
         opponentChecked,
         lastCheckedAtMs: Date.now(),
@@ -183,6 +204,8 @@ export class WarStartPointsSyncService {
             guildId: true,
             warId: true,
             startTime: true,
+            matchType: true,
+            inferredMatchType: true,
           },
         });
         if (
@@ -193,6 +216,24 @@ export class WarStartPointsSyncService {
           primary.winnerBoxSync !== null &&
           Number.isFinite(primary.winnerBoxSync)
         ) {
+          const liveResolution = inferMatchTypeFromOpponentPoints({
+            available: opponentChecked,
+            balance: opponentBalance,
+            activeFwa: opponentActiveFwa,
+            notFound: opponentNotFound,
+          });
+          const currentResolution = resolveCurrentWarMatchTypeSignal({
+            matchType: currentWar.matchType ?? null,
+            inferredMatchType: currentWar.inferredMatchType ?? true,
+          });
+          const appliedResolution = chooseMatchTypeResolution({
+            confirmedCurrent: currentResolution.confirmed,
+            liveOpponent: liveResolution,
+            storedSync: null,
+            unconfirmedCurrent: currentResolution.unconfirmed,
+          });
+          const syncMatchType = appliedResolution?.matchType ?? currentWar.matchType ?? null;
+          const syncIsFwa = appliedResolution?.syncIsFwa ?? toSyncIsFwa(syncMatchType) ?? false;
           await this.pointsSync.upsertPointsSync({
             guildId: currentWar.guildId,
             clanTag,
@@ -212,10 +253,10 @@ export class WarStartPointsSyncService {
               opponentBalance,
               Math.trunc(primary.winnerBoxSync)
             ),
-            isFwa: true,
+            isFwa: syncIsFwa,
             fetchedAt: new Date(primary.fetchedAtMs),
             fetchReason: "post_war_reconciliation",
-            matchType: "FWA",
+            matchType: syncMatchType,
             needsValidation: false,
           });
         }

--- a/tests/fwaMatchInference.logic.test.ts
+++ b/tests/fwaMatchInference.logic.test.ts
@@ -4,20 +4,19 @@ import {
   inferMatchTypeFromPointsSnapshotsForTest,
   resolveMatchTypeFromStoredSyncRowForTest,
 } from "../src/commands/Fwa";
+import {
+  chooseMatchTypeResolution,
+  resolveCurrentWarMatchTypeSignal,
+} from "../src/services/MatchTypeResolutionService";
 
 describe("fwa match inference from points snapshots", () => {
-  it("infers MM when opponent points are unavailable", () => {
+  it("returns null when opponent evidence is unavailable", () => {
     const inferred = inferMatchTypeFromPointsSnapshotsForTest(
       { activeFwa: true },
       { balance: null, activeFwa: null }
     );
 
-    expect(inferred).toMatchObject({
-      matchType: "MM",
-      source: "points_missing_opponent",
-      syncIsFwa: false,
-      parsedActiveFwa: null,
-    });
+    expect(inferred).toBeNull();
   });
 
   it("infers BL when opponent points exist but Active FWA is NO", () => {
@@ -28,9 +27,8 @@ describe("fwa match inference from points snapshots", () => {
 
     expect(inferred).toMatchObject({
       matchType: "BL",
-      source: "points_active_fwa_no",
+      source: "live_points_active_fwa_no",
       syncIsFwa: false,
-      parsedActiveFwa: false,
     });
   });
 
@@ -42,9 +40,8 @@ describe("fwa match inference from points snapshots", () => {
 
     expect(inferred).toMatchObject({
       matchType: "FWA",
-      source: "points_active_fwa_yes",
+      source: "live_points_active_fwa_yes",
       syncIsFwa: true,
-      parsedActiveFwa: true,
     });
   });
 
@@ -56,24 +53,18 @@ describe("fwa match inference from points snapshots", () => {
 
     expect(inferred).toMatchObject({
       matchType: "MM",
-      source: "points_clan_not_found",
+      source: "live_points_clan_not_found",
       syncIsFwa: false,
-      parsedActiveFwa: null,
     });
   });
 
-  it("infers FWA when opponent points exist and Active FWA signal is missing", () => {
+  it("returns null when Active FWA signal is missing", () => {
     const inferred = inferMatchTypeFromPointsSnapshotsForTest(
       { activeFwa: true },
       { balance: 1234, activeFwa: null }
     );
 
-    expect(inferred).toMatchObject({
-      matchType: "FWA",
-      source: "points_unknown_signal",
-      syncIsFwa: true,
-      parsedActiveFwa: null,
-    });
+    expect(inferred).toBeNull();
   });
 });
 
@@ -126,6 +117,41 @@ describe("fwa mail send gating", () => {
     });
 
     expect(reason).toBe("Match type is inferred. Confirm match type before sending war mail.");
+  });
+});
+
+describe("fwa match precedence", () => {
+  it("lets live BL evidence override unconfirmed current/stored FWA", () => {
+    const current = resolveCurrentWarMatchTypeSignal({
+      matchType: "FWA",
+      inferredMatchType: true,
+    });
+    const stored = resolveMatchTypeFromStoredSyncRowForTest({
+      syncRow: {
+        opponentTag: "#2Q80R9PYU",
+        isFwa: true,
+        lastKnownMatchType: "FWA",
+      },
+      opponentTag: "#2Q80R9PYU",
+    });
+    const live = inferMatchTypeFromPointsSnapshotsForTest(
+      { activeFwa: true },
+      { balance: 2, activeFwa: false, notFound: false }
+    );
+    const resolved = chooseMatchTypeResolution({
+      confirmedCurrent: current.confirmed,
+      liveOpponent: live,
+      storedSync: stored,
+      unconfirmedCurrent: current.unconfirmed,
+    });
+
+    expect(resolved).toMatchObject({
+      matchType: "BL",
+      source: "live_points_active_fwa_no",
+      inferred: true,
+      confirmed: false,
+      syncIsFwa: false,
+    });
   });
 });
 


### PR DESCRIPTION
- add shared match-type resolution service with explicit precedence
- make live opponent points signals authoritative for unconfirmed matchups
- stop poller sync paths from force-writing FWA/isFwa=true
- persist sync isFwa from parsed opponent evidence when available
- update inference tests for null-on-ambiguous and stale-loop BL override