### PR TITLE
fix(compo): detect shifted delta headers in place suggestions

### DIFF
--- a/src/commands/Compo.ts
+++ b/src/commands/Compo.ts
@@ -286,13 +286,22 @@ type PlacementCandidate = {
   bucketDeltaByHeader: Record<string, number>;
 };
 
+/** Purpose: find the row that contains composition delta headers in the U:AA block. */
+function findDeltaHeaderRowIndex(rightBlock: string[][]): number {
+  const index = rightBlock.findIndex((row) =>
+    row.some((cell) => normalize(cell).includes("delta"))
+  );
+  return index >= 0 ? index : 0;
+}
+
 function readPlacementCandidates(
   clanCol: string[][],
   totalCol: string[][],
   targetBandCol: string[][],
   rightBlock: string[][]
 ): PlacementCandidate[] {
-  const missingHeaderRow = rightBlock[0] ?? [];
+  const headerRowIndex = findDeltaHeaderRowIndex(rightBlock);
+  const missingHeaderRow = rightBlock[headerRowIndex] ?? [];
   const missingIndex = missingHeaderRow.findIndex((v) =>
     normalize(v).includes("missing")
   );
@@ -302,17 +311,17 @@ function readPlacementCandidates(
     const clanName = (clanCol[i]?.[0] ?? "").trim();
     if (!clanName) continue;
 
+    const rightRow = rightBlock[i + headerRowIndex] ?? rightBlock[i] ?? [];
     const totalWeight = parseNumber(totalCol[i]?.[0]);
     const targetBand = parseNumber(targetBandCol[i]?.[0]);
-    const missingRaw =
-      missingIndex >= 0 ? rightBlock[i]?.[missingIndex] : rightBlock[i]?.[0];
+    const missingRaw = missingIndex >= 0 ? rightRow[missingIndex] : rightRow[0];
     const missingCount = parseNumber(missingRaw);
     const remainingToTarget = targetBand - totalWeight;
     const bucketDeltaByHeader: Record<string, number> = {};
     for (let c = 0; c < missingHeaderRow.length; c += 1) {
       const key = normalize(missingHeaderRow[c] ?? "");
       if (!key) continue;
-      bucketDeltaByHeader[key] = parseNumber(rightBlock[i]?.[c]);
+      bucketDeltaByHeader[key] = parseNumber(rightRow[c]);
     }
 
     candidates.push({
@@ -897,3 +906,5 @@ export const Compo: Command = {
     await interaction.respond(filtered);
   },
 };
+
+export const readPlacementCandidatesForTest = readPlacementCandidates;

--- a/tests/compoPlace.logic.test.ts
+++ b/tests/compoPlace.logic.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { readPlacementCandidatesForTest } from "../src/commands/Compo";
+
+function blankRows(count: number, cols: number): string[][] {
+  return Array.from({ length: count }, () => Array.from({ length: cols }, () => ""));
+}
+
+describe("/compo place candidate parsing", () => {
+  it("detects delta headers when the right-block header row is not the first row", () => {
+    const clanCol = [["Clan"], ["Red Riders"], ...blankRows(7, 1)];
+    const totalCol = [["TotalWeight"], ["1,500,000"], ...blankRows(7, 1)];
+    const targetBandCol = [["Target"], ["1,520,000"], ...blankRows(7, 1)];
+    const rightBlock = [
+      ["", "", "", "", "", "", ""],
+      [
+        "Missing Weights",
+        "TH18-delta",
+        "TH17-delta",
+        "TH16-delta",
+        "TH15-delta",
+        "TH14-delta",
+        "<=TH13-delta",
+      ],
+      ["0", "0", "-1", "-2", "0", "0", "-3"],
+      ...blankRows(6, 7),
+    ];
+
+    const candidates = readPlacementCandidatesForTest(
+      clanCol,
+      totalCol,
+      targetBandCol,
+      rightBlock
+    );
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].missingCount).toBe(0);
+    expect(candidates[0].bucketDeltaByHeader["th16-delta"]).toBe(-2);
+    expect(candidates[0].bucketDeltaByHeader["<=th13-delta"]).toBe(-3);
+  });
+
+  it("keeps existing behavior when headers are already on the first row", () => {
+    const clanCol = [["Clan"], ["Zero Gravity"], ...blankRows(7, 1)];
+    const totalCol = [["TotalWeight"], ["1,430,000"], ...blankRows(7, 1)];
+    const targetBandCol = [["Target"], ["1,470,000"], ...blankRows(7, 1)];
+    const rightBlock = [
+      [
+        "Missing Weights",
+        "TH18-delta",
+        "TH17-delta",
+        "TH16-delta",
+        "TH15-delta",
+        "TH14-delta",
+        "<=TH13-delta",
+      ],
+      ["2", "0", "0", "-1", "-2", "0", "0"],
+      ...blankRows(7, 7),
+    ];
+
+    const candidates = readPlacementCandidatesForTest(
+      clanCol,
+      totalCol,
+      targetBandCol,
+      rightBlock
+    );
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0].missingCount).toBe(2);
+    expect(candidates[0].bucketDeltaByHeader["th16-delta"]).toBe(-1);
+    expect(candidates[0].bucketDeltaByHeader["th15-delta"]).toBe(-2);
+  });
+});
+


### PR DESCRIPTION
- detect the `*-delta` header row dynamically in AllianceDashboard U:AA data
- align candidate row reads to detected header index before delta parsing
- keep existing bucket/vacancy/sort/output logic unchanged
- add regression tests for shifted and first-row header layouts