### PR TITLE
fix(fwa): auto-reconcile deleted mail during match rendering

### DIFF
--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -1338,6 +1338,14 @@ type ResolvedLiveWarMailStatus = {
   debug: WarMailLifecycleStatusDebugInfo;
 };
 
+type FwaMatchMailStatusDebugRow = {
+  clanTag: string;
+  clanName: string;
+  warId: number | null;
+  status: WarMailLifecycleNormalizedStatus;
+  debug: WarMailLifecycleStatusDebugInfo;
+};
+
 type WarMailDebugTrackedTarget = {
   warId: string | null;
   channelId: string;
@@ -1446,6 +1454,83 @@ function buildMailStatusDebugLines(debug: WarMailLifecycleStatusDebugInfo): stri
   return lines;
 }
 
+/** Purpose: collect lifecycle-only debug rows for `/fwa match debug-mail-status` without running heavy match flows. */
+async function collectFwaMatchMailStatusDebugRows(params: {
+  client: Client | null | undefined;
+  guildId: string;
+  tag: string;
+}): Promise<FwaMatchMailStatusDebugRow[]> {
+  const tracked = await prisma.trackedClan.findMany({
+    where: params.tag
+      ? {
+          OR: [
+            { tag: { equals: `#${params.tag}`, mode: "insensitive" } },
+            { tag: { equals: params.tag, mode: "insensitive" } },
+          ],
+        }
+      : undefined,
+    orderBy: { createdAt: "asc" },
+    select: { tag: true, name: true },
+  });
+  if (tracked.length === 0) return [];
+  const normalizedTags = tracked.map((row) => normalizeTag(row.tag));
+  const currentWars = await prisma.currentWar.findMany({
+    where: {
+      guildId: params.guildId,
+      clanTag: { in: normalizedTags.map((tag) => `#${tag}`) },
+    },
+    select: { clanTag: true, warId: true },
+  });
+  const warIdByTag = new Map(
+    currentWars.map((row) => [
+      normalizeTag(row.clanTag),
+      row.warId !== null && row.warId !== undefined && Number.isFinite(row.warId)
+        ? Math.trunc(row.warId)
+        : null,
+    ])
+  );
+
+  const rows = await Promise.all(
+    tracked.map(async (row) => {
+      const normalizedTag = normalizeTag(row.tag);
+      const warId = warIdByTag.get(normalizedTag) ?? null;
+      const resolved = await resolveLiveWarMailStatus({
+        client: params.client,
+        guildId: params.guildId,
+        tag: normalizedTag,
+        warId,
+        emitDebugLog: true,
+      });
+      return {
+        clanTag: normalizedTag,
+        clanName: sanitizeClanName(row.name) ?? `#${normalizedTag}`,
+        warId,
+        status: resolved.status,
+        debug: resolved.debug,
+      };
+    })
+  );
+
+  return rows;
+}
+
+/** Purpose: render concise lifecycle diagnostics for `/fwa match debug-mail-status`. */
+function buildFwaMatchMailStatusDebugSummaryLines(
+  rows: FwaMatchMailStatusDebugRow[]
+): string[] {
+  return rows.flatMap((row) => [
+    `${row.clanName} (#${row.clanTag})`,
+    `- war_id=${row.warId ?? "none"}`,
+    `- status=${row.status}`,
+    `- message_id=${row.debug.trackedMessageId ?? "none"}`,
+    `- channel_id=${row.debug.trackedChannelId ?? "none"}`,
+    `- message_exists=${row.debug.trackedMessageExists}`,
+    `- reconciliation=${row.debug.reconciliationOutcome}`,
+    `- action=${row.debug.trackingCleared ? "mark_deleted" : "no_change"}`,
+    "",
+  ]);
+}
+
 /** Purpose: reconcile tracked war-mail state with live Discord message existence and return normalized status. */
 async function resolveLiveWarMailStatus(
   params: ResolveLiveWarMailStatusParams
@@ -1517,6 +1602,8 @@ function buildWarMailRevisionLines(params: {
 }
 
 export const buildWarMailRevisionLinesForTest = buildWarMailRevisionLines;
+export const buildFwaMatchMailStatusDebugSummaryLinesForTest =
+  buildFwaMatchMailStatusDebugSummaryLines;
 
 function buildSupersededWarMailDescription(params: {
   changedAtMs: number;
@@ -7551,6 +7638,42 @@ export const Fwa: Command = {
           return;
         }
       }
+      if (debugMailStatusRequested) {
+        if (!matchMailStatusDebugEnabled) {
+          await editReplySafe(
+            "You do not have permission to use `/fwa match debug-mail-status` in this server."
+          );
+          return;
+        }
+        if (!interaction.inGuild() || !interaction.guildId) {
+          await editReplySafe("This command can only be used in a server.");
+          return;
+        }
+        const debugRows = await collectFwaMatchMailStatusDebugRows({
+          client: interaction.client,
+          guildId: interaction.guildId,
+          tag,
+        });
+        if (debugRows.length === 0) {
+          await editReplySafe(
+            tag
+              ? `Clan #${tag} is not in tracked clans.`
+              : "No tracked clans configured. Use `/tracked-clan configure` first."
+          );
+          return;
+        }
+        const debugLines = buildFwaMatchMailStatusDebugSummaryLines(debugRows);
+        await editReplySafe(
+          buildLimitedMessage(
+            `FWA Mail Lifecycle Debug (${debugRows.length})`,
+            debugLines,
+            "Lifecycle-only diagnostics (no points/war API fetches)."
+          ),
+          [],
+          []
+        );
+        return;
+      }
       logFwaMatchTelemetry(
         "command",
         `user=${interaction.user.id} guild=${interaction.guildId ?? "dm"} scope=${tag ? "single" : "alliance"} tag=${tag ?? "all"} visibility=${isPublic ? "public" : "private"} source_sync=${sourceSync ?? "unknown"}`
@@ -7562,6 +7685,7 @@ export const Fwa: Command = {
         warLookupCache,
         interaction.client,
         {
+          onlyClanTags: tag ? [tag] : undefined,
           mailStatusDebugEnabled: matchMailStatusDebugEnabled,
         }
       );

--- a/src/services/WarMailLifecycleService.ts
+++ b/src/services/WarMailLifecycleService.ts
@@ -315,11 +315,18 @@ export class WarMailLifecycleService {
     }
 
     if (!row.channelId || !row.messageId) {
-      await this.markDeleted({
+      const trackingCleared = await this.markDeleted({
         guildId: params.guildId,
         clanTag: normalizedTag,
         warId,
-      }).catch(() => undefined);
+      }).catch(() => false);
+      this.logReconcile({
+        guildId: params.guildId,
+        clanTag: normalizedTag,
+        warId,
+        outcome: "message_missing_confirmed",
+        action: trackingCleared ? "mark_deleted" : "no_change",
+      });
       const debug = this.buildDebugInfo({
         currentWarId: String(warId),
         trackedWarId: String(row.warId),
@@ -327,7 +334,7 @@ export class WarMailLifecycleService {
         messageId: row.messageId ?? null,
         status: "deleted",
         outcome: "message_missing_confirmed",
-        trackingCleared: true,
+        trackingCleared,
       });
       this.logDebug(params, normalizedTag, debug);
       return {
@@ -351,6 +358,13 @@ export class WarMailLifecycleService {
         clanTag: normalizedTag,
         warId,
       }).catch(() => false);
+      this.logReconcile({
+        guildId: params.guildId,
+        clanTag: normalizedTag,
+        warId,
+        outcome: reconciliation,
+        action: trackingCleared ? "mark_deleted" : "no_change",
+      });
       const debug = this.buildDebugInfo({
         currentWarId: String(warId),
         trackedWarId: String(row.warId),
@@ -376,6 +390,13 @@ export class WarMailLifecycleService {
       status: "posted",
       outcome: reconciliation,
       trackingCleared: false,
+    });
+    this.logReconcile({
+      guildId: params.guildId,
+      clanTag: normalizedTag,
+      warId,
+      outcome: reconciliation,
+      action: "no_change",
     });
     this.logDebug(params, normalizedTag, debug);
     return {
@@ -471,6 +492,26 @@ export class WarMailLifecycleService {
     if (!params.emitDebugLog || !params.guildId) return;
     console.info(
       `[fwa-mail-status-debug] guild=${params.guildId} clan=${normalizedTag} current_war_id=${debug.currentWarId ?? "unknown"} tracked_war_id=${debug.trackedMailWarId ?? "none"} tracked_channel_id=${debug.trackedChannelId ?? "none"} tracked_message_id=${debug.trackedMessageId ?? "none"} tracked_exists=${debug.trackedMessageExists} source=${debug.winningSource} normalized_status=${debug.finalNormalizedStatus} reconciliation=${debug.reconciliationOutcome} certainty=${debug.reconciliationCertainty} reason_code=${debug.debugReasonCode} tracking_cleared=${debug.trackingCleared ? "1" : "0"}`
+    );
+  }
+
+  /** Purpose: emit lightweight reconciliation telemetry for POSTED lifecycle checks. */
+  private logReconcile(input: {
+    guildId: string;
+    clanTag: string;
+    warId: number;
+    outcome: WarMailLifecycleReconciliationOutcome;
+    action: "mark_deleted" | "no_change";
+  }): void {
+    const messageExists =
+      input.outcome === "exists"
+        ? "true"
+        : input.outcome === "message_missing_confirmed" ||
+            input.outcome === "channel_missing_confirmed"
+          ? "false"
+          : "unknown";
+    console.info(
+      `[mail-lifecycle-reconcile] guild=${input.guildId} clan=${input.clanTag} war_id=${input.warId} message_exists=${messageExists} outcome=${input.outcome} action=${input.action}`
     );
   }
 }

--- a/tests/fwaMatchMailDebug.logic.test.ts
+++ b/tests/fwaMatchMailDebug.logic.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildFwaMatchMailStatusDebugSummaryLinesForTest,
   buildMailStatusDebugLinesForTest,
   buildWarMailStatusDebugSnapshotForTest,
 } from "../src/commands/Fwa";
@@ -91,5 +92,43 @@ describe("fwa match mail-status debug lines", () => {
     expect(lines).toContain("Current war/config matches tracked: yes");
     expect(lines).toContain("Winning source: WarMailLifecycle");
     expect(lines).toContain("Final normalized status: posted");
+  });
+});
+
+describe("fwa match lifecycle debug summary", () => {
+  it("renders lightweight lifecycle-only diagnostic rows", () => {
+    const lines = buildFwaMatchMailStatusDebugSummaryLinesForTest([
+      {
+        clanTag: "AAA111",
+        clanName: "Alpha",
+        warId: 1001,
+        status: "deleted",
+        debug: {
+          currentWarId: "1001",
+          trackedMailWarId: "1001",
+          trackedChannelId: "123",
+          trackedMessageId: "456",
+          trackedMessageExists: "no",
+          currentWarConfigMatchesTrackedMessage: true,
+          winningSource: "WarMailLifecycle",
+          finalNormalizedStatus: "deleted",
+          reconciliationOutcome: "message_missing_confirmed",
+          reconciliationCertainty: "definitive",
+          debugReasonCode: "tracked_post_missing_message",
+          debugReason: "Tracked lifecycle message missing.",
+          environmentMismatchSignal: false,
+          trackingCleared: true,
+        },
+      },
+    ]).join("\n");
+
+    expect(lines).toContain("Alpha (#AAA111)");
+    expect(lines).toContain("war_id=1001");
+    expect(lines).toContain("status=deleted");
+    expect(lines).toContain("message_id=456");
+    expect(lines).toContain("channel_id=123");
+    expect(lines).toContain("message_exists=no");
+    expect(lines).toContain("reconciliation=message_missing_confirmed");
+    expect(lines).toContain("action=mark_deleted");
   });
 });


### PR DESCRIPTION
- reconcile POSTED lifecycle rows during `/fwa match` and mark missing messages DELETED
- route `/fwa match debug-mail-status` through a lightweight lifecycle-only path
- add reconcile telemetry logs and tests for debug summary output