### PR TITLE
fix(points): enforce war-scoped snapshot reuse

### DIFF
--- a/src/services/PointsDirectFetchGateService.ts
+++ b/src/services/PointsDirectFetchGateService.ts
@@ -19,6 +19,7 @@ export type PointsDirectFetchCaller = "command" | "poller" | "service";
 
 export type PointsDirectFetchDecisionCode =
   | "manual_force_bypass"
+  | "reused_war_snapshot"
   | "not_tracked"
   | "locked_active_war"
   | "locked_between_wars_until_presync"
@@ -58,6 +59,7 @@ type PointsLockRuntimeSnapshot = {
   lifecycle: PointsLifecycleState | null;
   latestKnownPoints: number | null;
   postedSyncAtMs: number | null;
+  hasReusableWarSnapshot: boolean;
 };
 
 export type EvaluatePointsDirectFetchInput = {
@@ -503,6 +505,23 @@ function buildDecisionFromState(input: {
     };
   }
 
+  if (input.runtime.hasReusableWarSnapshot) {
+    return {
+      allowed: false,
+      outcome: "blocked",
+      decisionCode: "reused_war_snapshot",
+      reason: "Current-war snapshot already exists; reuse persisted sync data instead of direct fetch.",
+      clanTag: input.runtime.clanTag,
+      guildId: input.runtime.guildId,
+      fetchReason: input.fetchReason,
+      caller: input.caller,
+      lockState: input.state.lifecycleState,
+      lockUntilMs: input.state.lockUntilMs,
+      postedSyncAtMs: input.state.postedSyncAtMs,
+      manualForceBypass: false,
+    };
+  }
+
   if (!input.runtime.tracked) {
     return {
       allowed: true,
@@ -777,6 +796,13 @@ export class PointsDirectFetchGateService {
             ],
           })
         : null;
+    const hasReusableWarSnapshot = Boolean(
+      syncRow &&
+        syncRow.needsValidation === false &&
+        Number.isFinite(syncRow.clanPoints) &&
+        Number.isFinite(syncRow.opponentPoints) &&
+        (warId !== null || warStartTime !== null)
+    );
     const mailLifecycleRow =
       guildId !== null && warId !== null
         ? await prisma.warMailLifecycle.findUnique({
@@ -847,6 +873,7 @@ export class PointsDirectFetchGateService {
         previousBaseline: null,
       }),
       postedSyncAtMs,
+      hasReusableWarSnapshot,
     };
   }
 

--- a/src/services/PointsProjectionService.ts
+++ b/src/services/PointsProjectionService.ts
@@ -32,6 +32,24 @@ type Snapshot = {
   fetchedAtMs: number;
 };
 
+type CurrentWarContext = {
+  guildId: string;
+  clanTag: string;
+  opponentTag: string | null;
+  warId: string | null;
+  warStartTime: Date;
+};
+
+type WarScopedSyncRow = {
+  syncNum: number;
+  clanPoints: number;
+  opponentPoints: number;
+  isFwa: boolean;
+  opponentTag: string;
+  syncFetchedAt: Date;
+  lastSuccessfulPointsApiFetchAt: Date | null;
+};
+
 /** Purpose: normalize tag. */
 function normalizeTag(input: string): string {
   return input.trim().toUpperCase().replace(/^#/, "");
@@ -160,6 +178,11 @@ function formatPoints(value: number | null): string {
   return Intl.NumberFormat("en-US").format(value);
 }
 
+/** Purpose: normalize optional integers for persisted snapshot materialization. */
+function toOptionalInt(value: number | null | undefined): number | null {
+  return value !== null && value !== undefined && Number.isFinite(value) ? Math.trunc(value) : null;
+}
+
 export class PointsProjectionService {
   /** Purpose: initialize service dependencies. */
   constructor(
@@ -179,11 +202,29 @@ export class PointsProjectionService {
     const normalizedTag = normalizeTag(tag);
     const reason = options?.reason ?? "war_event_projection";
     const caller = options?.caller ?? "poller";
+    const manualForceBypass = options?.manualForceBypass ?? false;
+
+    if (!manualForceBypass) {
+      const warScopedPersisted = await this.getWarScopedPersistedSnapshot(normalizedTag);
+      if (warScopedPersisted) {
+        recordFetchEvent({
+          namespace: "points",
+          operation: "projection_fetch",
+          source: "cache_hit",
+          detail: `tag=${normalizedTag} reason=${reason} caller=${caller} reuse=war_scoped_persisted`,
+        });
+        console.info(
+          `[points-fetch] source=persisted tag=${normalizedTag} reason=${reason} reuse=war_scoped_persisted`
+        );
+        return warScopedPersisted;
+      }
+    }
+
     const gateDecision = await this.directFetchGate.evaluateFetchAccess({
       clanTag: normalizedTag,
       fetchReason: reason,
       caller,
-      manualForceBypass: options?.manualForceBypass ?? false,
+      manualForceBypass,
     });
     if (!gateDecision.allowed) {
       recordFetchEvent({
@@ -283,6 +324,174 @@ export class PointsProjectionService {
       winnerBoxSync,
       winnerBoxTags,
       fetchedAtMs,
+    };
+  }
+
+  /** Purpose: reuse war-scoped persisted sync data before web fetches during active wars. */
+  private async getWarScopedPersistedSnapshot(tag: string): Promise<Snapshot | null> {
+    const normalizedTag = normalizeTag(tag);
+
+    const directContext = await this.findCurrentWarContextByClanTag(normalizedTag);
+    if (directContext) {
+      const row = await this.findWarScopedSyncRow(directContext);
+      if (row) {
+        return this.buildSnapshotFromWarScopedSyncRow({
+          requestedTag: normalizedTag,
+          context: directContext,
+          row,
+          perspective: "primary",
+        });
+      }
+    }
+
+    const inverseContext = await this.findCurrentWarContextByOpponentTag(normalizedTag);
+    if (inverseContext) {
+      const row = await this.findWarScopedSyncRow(inverseContext);
+      if (row) {
+        return this.buildSnapshotFromWarScopedSyncRow({
+          requestedTag: normalizedTag,
+          context: inverseContext,
+          row,
+          perspective: "opponent",
+        });
+      }
+    }
+
+    return null;
+  }
+
+  /** Purpose: resolve current-war context for a tracked clan tag. */
+  private async findCurrentWarContextByClanTag(tag: string): Promise<CurrentWarContext | null> {
+    const row = await prisma.currentWar.findFirst({
+      where: {
+        clanTag: `#${normalizeTag(tag)}`,
+        startTime: { not: null },
+        state: { in: ["preparation", "inWar"] },
+      },
+      orderBy: { updatedAt: "desc" },
+      select: {
+        guildId: true,
+        clanTag: true,
+        opponentTag: true,
+        warId: true,
+        startTime: true,
+      },
+    });
+    if (!row?.startTime) return null;
+    const normalizedOpponentTag = normalizeTag(row.opponentTag ?? "");
+    return {
+      guildId: row.guildId,
+      clanTag: normalizeTag(row.clanTag),
+      opponentTag: normalizedOpponentTag || null,
+      warId: row.warId !== null && row.warId !== undefined ? String(Math.trunc(row.warId)) : null,
+      warStartTime: row.startTime,
+    };
+  }
+
+  /** Purpose: resolve current-war context by matching a tag as the active opponent. */
+  private async findCurrentWarContextByOpponentTag(tag: string): Promise<CurrentWarContext | null> {
+    const row = await prisma.currentWar.findFirst({
+      where: {
+        opponentTag: `#${normalizeTag(tag)}`,
+        startTime: { not: null },
+        state: { in: ["preparation", "inWar"] },
+      },
+      orderBy: { updatedAt: "desc" },
+      select: {
+        guildId: true,
+        clanTag: true,
+        opponentTag: true,
+        warId: true,
+        startTime: true,
+      },
+    });
+    if (!row?.startTime) return null;
+    const normalizedOpponentTag = normalizeTag(row.opponentTag ?? "");
+    return {
+      guildId: row.guildId,
+      clanTag: normalizeTag(row.clanTag),
+      opponentTag: normalizedOpponentTag || null,
+      warId: row.warId !== null && row.warId !== undefined ? String(Math.trunc(row.warId)) : null,
+      warStartTime: row.startTime,
+    };
+  }
+
+  /** Purpose: load war-scoped sync row used to materialize persisted snapshots. */
+  private async findWarScopedSyncRow(context: CurrentWarContext): Promise<WarScopedSyncRow | null> {
+    const warIdentity = [
+      ...(context.warId ? [{ warId: context.warId }] : []),
+      { warStartTime: context.warStartTime },
+    ];
+    const row = await prisma.clanPointsSync.findFirst({
+      where: {
+        guildId: context.guildId,
+        clanTag: `#${context.clanTag}`,
+        needsValidation: false,
+        OR: warIdentity,
+      },
+      select: {
+        syncNum: true,
+        clanPoints: true,
+        opponentPoints: true,
+        isFwa: true,
+        opponentTag: true,
+        syncFetchedAt: true,
+        lastSuccessfulPointsApiFetchAt: true,
+      },
+      orderBy: [
+        { syncFetchedAt: "desc" },
+        { lastSuccessfulPointsApiFetchAt: "desc" },
+        { updatedAt: "desc" },
+      ],
+    });
+    if (!row) return null;
+    if (
+      !Number.isFinite(row.syncNum) ||
+      !Number.isFinite(row.clanPoints) ||
+      !Number.isFinite(row.opponentPoints)
+    ) {
+      return null;
+    }
+    return {
+      syncNum: Math.trunc(row.syncNum),
+      clanPoints: Math.trunc(row.clanPoints),
+      opponentPoints: Math.trunc(row.opponentPoints),
+      isFwa: Boolean(row.isFwa),
+      opponentTag: normalizeTag(row.opponentTag),
+      syncFetchedAt: row.syncFetchedAt,
+      lastSuccessfulPointsApiFetchAt: row.lastSuccessfulPointsApiFetchAt ?? null,
+    };
+  }
+
+  /** Purpose: convert a war-scoped sync row into a projection snapshot shape. */
+  private buildSnapshotFromWarScopedSyncRow(input: {
+    requestedTag: string;
+    context: CurrentWarContext;
+    row: WarScopedSyncRow;
+    perspective: "primary" | "opponent";
+  }): Snapshot {
+    const fetchedAtMs =
+      toOptionalInt(input.row.lastSuccessfulPointsApiFetchAt?.getTime()) ??
+      toOptionalInt(input.row.syncFetchedAt.getTime()) ??
+      Date.now();
+    const winnerTags = [input.context.clanTag];
+    if (input.context.opponentTag) winnerTags.push(input.context.opponentTag);
+
+    const balance =
+      input.perspective === "primary"
+        ? toOptionalInt(input.row.clanPoints)
+        : toOptionalInt(input.row.opponentPoints);
+    return {
+      tag: normalizeTag(input.requestedTag),
+      clanName: null,
+      balance,
+      activeFwa: input.row.isFwa,
+      notFound: false,
+      effectiveSync: toOptionalInt(input.row.syncNum),
+      syncMode: getSyncMode(toOptionalInt(input.row.syncNum)),
+      winnerBoxSync: toOptionalInt(input.row.syncNum),
+      winnerBoxTags: winnerTags,
+      fetchedAtMs: fetchedAtMs ?? Date.now(),
     };
   }
 

--- a/src/services/WarEventLogService.ts
+++ b/src/services/WarEventLogService.ts
@@ -547,8 +547,16 @@ export class WarEventLogService {
     let outcome = normalizeOutcome(sub.outcome);
     if (params.source === "current" && opponentTag) {
       const [a, b] = await Promise.all([
-        this.points.fetchSnapshot(clanTag, { reason: "manual_refresh" }),
-        this.points.fetchSnapshot(opponentTag, { reason: "manual_refresh" }),
+        this.points.fetchSnapshot(clanTag, {
+          reason: "manual_refresh",
+          caller: "command",
+          manualForceBypass: true,
+        }),
+        this.points.fetchSnapshot(opponentTag, {
+          reason: "manual_refresh",
+          caller: "command",
+          manualForceBypass: true,
+        }),
       ]);
       fwaPoints = a.balance;
       opponentFwaPoints = b.balance;
@@ -1222,8 +1230,14 @@ export class WarEventLogService {
       const projectionOpponentTag = nextOpponentTag || normalizeTag(sub.opponentTag ?? "");
       const projectionReason = gateDecision.fetchReason ?? "war_event_projection";
       const [a, b] = await Promise.all([
-        this.points.fetchSnapshot(projectionClanTag, { reason: projectionReason }),
-        this.points.fetchSnapshot(projectionOpponentTag, { reason: projectionReason }),
+        this.points.fetchSnapshot(projectionClanTag, {
+          reason: projectionReason,
+          caller: "poller",
+        }),
+        this.points.fetchSnapshot(projectionOpponentTag, {
+          reason: projectionReason,
+          caller: "poller",
+        }),
       ]);
       liveOpponentResolution = inferMatchTypeFromOpponentPoints({
         available: true,

--- a/src/services/war-events/pointsSync.ts
+++ b/src/services/war-events/pointsSync.ts
@@ -121,6 +121,7 @@ export class WarStartPointsSyncService {
     try {
       const primary = await this.points.fetchSnapshot(clanTag, {
         reason: "post_war_reconciliation",
+        caller: "service",
       });
       const siteUpdated = primary.winnerBoxTags.map((t) => normalizeTag(t)).includes(opponentTag);
       const trackedDb = sub.fwaPoints ?? null;
@@ -134,7 +135,7 @@ export class WarStartPointsSyncService {
       let opponentNotFound = job.siteOpponentNotFound;
       if (!opponentChecked) {
         const opp = await this.points
-          .fetchSnapshot(opponentTag, { reason: "post_war_reconciliation" })
+          .fetchSnapshot(opponentTag, { reason: "post_war_reconciliation", caller: "service" })
           .catch(() => null);
         opponentChecked = true;
         const liveResolution = inferMatchTypeFromOpponentPoints({

--- a/tests/pointsDirectFetchGate.service.test.ts
+++ b/tests/pointsDirectFetchGate.service.test.ts
@@ -30,6 +30,7 @@ function buildRuntime(overrides?: Record<string, unknown>) {
     },
     latestKnownPoints: 1200,
     postedSyncAtMs: null,
+    hasReusableWarSnapshot: false,
     ...overrides,
   };
 }
@@ -81,6 +82,24 @@ describe("PointsDirectFetchGate lifecycle", () => {
     expect(blocked.decisionCode).toBe("locked_active_war");
     expect(bypass.allowed).toBe(true);
     expect(bypass.decisionCode).toBe("manual_force_bypass");
+  });
+
+  it("blocks routine direct fetches when a reusable war snapshot already exists", () => {
+    const runtime = buildRuntime({
+      warState: "inWar",
+      hasReusableWarSnapshot: true,
+    });
+    const state = buildState({ lifecycleState: "unlocked" });
+    const decision = buildPointsDirectFetchDecisionForTest({
+      runtime,
+      state,
+      caller: "poller",
+      fetchReason: "post_war_reconciliation",
+      manualForceBypass: false,
+    });
+
+    expect(decision.allowed).toBe(false);
+    expect(decision.decisionCode).toBe("reused_war_snapshot");
   });
 
   it("re-locks non-MM between wars after point value changes when posted sync exists", () => {


### PR DESCRIPTION
- reuse current-war ClanPointsSync snapshots before projection web fetches
- reuse inverse opponent snapshots via CurrentWar.opponentTag mapping
- block direct fetch when a reusable war snapshot exists unless manual bypass is set
- set explicit caller/bypass flags for poller, service, and manual refresh paths
- add regression coverage for reusable-snapshot gate decisions