### PR TITLE
fix(mail): force REST message checks for lifecycle reconciliation

### DIFF
--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -1899,8 +1899,14 @@ async function refreshWarMailPostByResolvedTarget(params: {
   }
   if (!channel || !channel.isTextBased()) return "missing";
   let message: any = null;
+  let messageVerifiedViaRest = false;
   try {
-    message = await (channel as any).messages.fetch(params.messageId);
+    // Force REST validation so deleted-message checks cannot be satisfied by stale cache.
+    message = await (channel as any).messages.fetch({
+      message: params.messageId,
+      force: true,
+    });
+    messageVerifiedViaRest = true;
   } catch (err) {
     const code = Number((err as { code?: unknown } | null | undefined)?.code ?? NaN);
     if ((code === 10003 || code === 10008) && params.expectedWarId) {
@@ -1970,6 +1976,7 @@ async function refreshWarMailPostByResolvedTarget(params: {
     components: rendered.freezeRefresh ? [] : buildWarMailPostedComponents(refreshKey),
   });
   if (
+    messageVerifiedViaRest &&
     nextWarIdText &&
     Number.isFinite(Number(nextWarIdText)) &&
     params.channelId &&

--- a/src/services/WarMailLifecycleService.ts
+++ b/src/services/WarMailLifecycleService.ts
@@ -438,7 +438,7 @@ export class WarMailLifecycleService {
     }
     const maybeTextChannel = channel as {
       isTextBased?: () => boolean;
-      messages?: { fetch: (messageId: string, options?: { force?: boolean }) => Promise<unknown> };
+      messages?: { fetch: (options: { message: string; force?: boolean }) => Promise<unknown> };
     };
     if (!maybeTextChannel.isTextBased || !maybeTextChannel.isTextBased()) {
       this.logMessageExistenceCheck({
@@ -460,7 +460,10 @@ export class WarMailLifecycleService {
     }
     try {
       // Force REST validation to avoid stale cached-message false positives.
-      const message = await maybeTextChannel.messages.fetch(input.messageId, { force: true });
+      const message = await maybeTextChannel.messages.fetch({
+        message: input.messageId,
+        force: true,
+      });
       const outcome: WarMailLifecycleReconciliationOutcome = message
         ? "exists"
         : "message_missing_confirmed";

--- a/tests/warMailLifecycle.service.test.ts
+++ b/tests/warMailLifecycle.service.test.ts
@@ -98,7 +98,7 @@ describe("WarMailLifecycleService", () => {
     expect(result.status).toBe("posted");
     expect(result.mailStatusEmoji).toBe("S");
     expect(result.debug.reconciliationOutcome).toBe("exists");
-    expect(fetchMessage).toHaveBeenCalledWith("456", { force: true });
+    expect(fetchMessage).toHaveBeenCalledWith({ message: "456", force: true });
   });
 
   it("marks lifecycle deleted when tracked message is definitively missing", async () => {
@@ -136,7 +136,7 @@ describe("WarMailLifecycleService", () => {
     expect(result.status).toBe("deleted");
     expect(result.debug.trackingCleared).toBe(true);
     expect(result.debug.reconciliationOutcome).toBe("message_missing_confirmed");
-    expect(fetchMessage).toHaveBeenCalledWith("456", { force: true });
+    expect(fetchMessage).toHaveBeenCalledWith({ message: "456", force: true });
   });
 
   it("keeps lifecycle posted on channel-inaccessible failures", async () => {


### PR DESCRIPTION
- use Discord.js single-argument fetch options with force=true in lifecycle checks
- force poller refresh message verification and only reassert POSTED after verified fetch
- update lifecycle tests to assert object-form forced message fetch