### PR TITLE
fix(compo): enforce single-sheet reads and classify sheet errors

### DIFF
--- a/src/commands/Compo.ts
+++ b/src/commands/Compo.ts
@@ -10,7 +10,12 @@ import { formatError } from "../helper/formatError";
 import { prisma } from "../prisma";
 import { safeReply } from "../helper/safeReply";
 import { CoCService } from "../services/CoCService";
-import { GoogleSheetMode, GoogleSheetsService } from "../services/GoogleSheetsService";
+import {
+  GoogleSheetMode,
+  GoogleSheetReadError,
+  GoogleSheetReadErrorCode,
+  GoogleSheetsService,
+} from "../services/GoogleSheetsService";
 import { SettingsService } from "../services/SettingsService";
 
 function normalize(value: string): string {
@@ -65,6 +70,18 @@ const COL_ADJUSTMENT = 53; // BB
 const FIXED_LAYOUT_RANGE = "AllianceDashboard!A6:BD500";
 const FIXED_LAYOUT_RANGE_START_ROW = 6;
 const STATE_HEADERS = ["Clan", "Total", "Missing", "TH18", "TH17", "TH16", "TH15", "TH14", "<=TH13"];
+const LOOKUP_REFRESH_RANGE = "Lookup!B10:B10";
+const COMPO_ERROR_MESSAGE_BY_CODE: Record<GoogleSheetReadErrorCode, string> = {
+  SHEET_LINK_MISSING: "No compo sheet is linked for this server.",
+  SHEET_PROXY_UNAUTHORIZED:
+    "The linked compo sheet could not be accessed because the sheet proxy is not authorized.",
+  SHEET_ACCESS_DENIED:
+    "The linked compo sheet exists, but this bot does not currently have access to read it.",
+  SHEET_RANGE_INVALID:
+    "The linked compo sheet does not contain the expected AllianceDashboard layout.",
+  SHEET_READ_FAILURE:
+    "The compo sheet could not be read due to a sheet service error.",
+};
 
 function normalizeTag(value: string): string {
   return value.trim().toUpperCase().replace(/^#/, "");
@@ -77,6 +94,13 @@ type SheetIndexedRow = {
 
 function getAbsoluteSheetRowNumber(rangeRelativeIndex: number): number {
   return FIXED_LAYOUT_RANGE_START_ROW + rangeRelativeIndex;
+}
+
+function mapCompoSheetErrorToMessage(err: unknown): string {
+  if (err instanceof GoogleSheetReadError) {
+    return COMPO_ERROR_MESSAGE_BY_CODE[err.code] ?? COMPO_ERROR_MESSAGE_BY_CODE.SHEET_READ_FAILURE;
+  }
+  return COMPO_ERROR_MESSAGE_BY_CODE.SHEET_READ_FAILURE;
 }
 
 function isActualSheetRow(sheetRowNumber: number): boolean {
@@ -669,14 +693,19 @@ export const Compo: Command = {
 
         const settings = new SettingsService();
         const sheets = new GoogleSheetsService(settings);
-        const linked = await sheets.getLinkedSheet();
+        const linked = await sheets.getCompoLinkedSheet(FIXED_LAYOUT_RANGE);
         logCompoStage(interaction, "db_fetch", {
           entity: "sheet_link",
           mode,
           result: linked.sheetId ? "found" : "missing",
           sheetIdPresent: Boolean(linked.sheetId),
+          resolutionSource: linked.source,
         });
-        const rows = await sheets.readLinkedValues(FIXED_LAYOUT_RANGE);
+        logCompoStage(interaction, "read_dispatch", {
+          range: FIXED_LAYOUT_RANGE,
+          resolutionSource: linked.source,
+        });
+        const rows = await sheets.readCompoLinkedValues(FIXED_LAYOUT_RANGE, linked);
         const modeRows = getModeRows(rows, mode);
         logCompoStage(interaction, "db_fetch", {
           entity: "sheet_rows",
@@ -745,16 +774,25 @@ export const Compo: Command = {
         logCompoStage(interaction, "computation_start", { mode });
         const settings = new SettingsService();
         const sheets = new GoogleSheetsService(settings);
-        const linked = await sheets.getLinkedSheet();
+        const linked = await sheets.getCompoLinkedSheet(FIXED_LAYOUT_RANGE);
         logCompoStage(interaction, "db_fetch", {
           entity: "sheet_link",
           mode,
           result: linked.sheetId ? "found" : "missing",
           sheetIdPresent: Boolean(linked.sheetId),
+          resolutionSource: linked.source,
+        });
+        logCompoStage(interaction, "read_dispatch", {
+          range: FIXED_LAYOUT_RANGE,
+          resolutionSource: linked.source,
+        });
+        logCompoStage(interaction, "read_dispatch", {
+          range: LOOKUP_REFRESH_RANGE,
+          resolutionSource: linked.source,
         });
         const [rows, refreshCell] = await Promise.all([
-          sheets.readLinkedValues(FIXED_LAYOUT_RANGE),
-          sheets.readLinkedValues("Lookup!B10:B10"),
+          sheets.readCompoLinkedValues(FIXED_LAYOUT_RANGE, linked),
+          sheets.readCompoLinkedValues(LOOKUP_REFRESH_RANGE, linked),
         ]);
         const modeRows = getModeRows(rows, mode);
         logCompoStage(interaction, "db_fetch", {
@@ -842,17 +880,26 @@ export const Compo: Command = {
         const stateMode: GoogleSheetMode = "actual";
         const settings = new SettingsService();
         const sheets = new GoogleSheetsService(settings);
-        const linked = await sheets.getLinkedSheet();
+        const linked = await sheets.getCompoLinkedSheet(FIXED_LAYOUT_RANGE);
         logCompoStage(interaction, "db_fetch", {
           entity: "sheet_link",
           mode: stateMode,
           result: linked.sheetId ? "found" : "missing",
           sheetIdPresent: Boolean(linked.sheetId),
+          resolutionSource: linked.source,
+        });
+        logCompoStage(interaction, "read_dispatch", {
+          range: FIXED_LAYOUT_RANGE,
+          resolutionSource: linked.source,
+        });
+        logCompoStage(interaction, "read_dispatch", {
+          range: LOOKUP_REFRESH_RANGE,
+          resolutionSource: linked.source,
         });
 
         const [rows, refreshCell] = await Promise.all([
-          sheets.readLinkedValues(FIXED_LAYOUT_RANGE),
-          sheets.readLinkedValues("Lookup!B10:B10"),
+          sheets.readCompoLinkedValues(FIXED_LAYOUT_RANGE, linked),
+          sheets.readCompoLinkedValues(LOOKUP_REFRESH_RANGE, linked),
         ]);
         const actualRows = getModeRows(rows, stateMode);
         logCompoStage(interaction, "db_fetch", {
@@ -947,11 +994,17 @@ export const Compo: Command = {
       console.error(
         `[compo-command-error] stage=run_catch subcommand=${getSubcommandSafe(interaction)} error=${formatError(err)}`
       );
-      logCompoStage(interaction, "response_build", { reason: "run_catch" });
+      logCompoStage(interaction, "response_build", {
+        reason: "run_catch",
+        normalizedCode: err instanceof GoogleSheetReadError ? err.code : "",
+        normalizedStatus: err instanceof GoogleSheetReadError ? err.meta.httpStatus ?? "" : "",
+        normalizedRange: err instanceof GoogleSheetReadError ? err.meta.range : "",
+        resolutionSource:
+          err instanceof GoogleSheetReadError ? err.meta.resolutionSource ?? "" : "",
+      });
       await safeReply(interaction, {
         ephemeral: true,
-        content:
-          "Failed to read compo sheet data. Check linked sheet access for the selected mode and AllianceDashboard layout.",
+        content: mapCompoSheetErrorToMessage(err),
       });
       logCompoStage(interaction, "response_sent", { reason: "run_catch" });
     }
@@ -993,3 +1046,4 @@ export const readPlacementCandidatesForTest = readPlacementCandidates;
 export const buildCompoPlaceEmbedForTest = buildCompoPlaceEmbed;
 export const getModeRowsForTest = getModeRows;
 export const getAbsoluteSheetRowNumberForTest = getAbsoluteSheetRowNumber;
+export const mapCompoSheetErrorToMessageForTest = mapCompoSheetErrorToMessage;

--- a/src/services/GoogleSheetsService.ts
+++ b/src/services/GoogleSheetsService.ts
@@ -12,8 +12,85 @@ export const SHEET_SETTING_WAR_ID_KEY = "google_sheet_war_id";
 export const SHEET_SETTING_WAR_TAB_KEY = "google_sheet_war_tab";
 const GOOGLE_API_TIMEOUT_MS = 20000;
 const APPS_SCRIPT_PROXY_TIMEOUT_MS = 30000;
+const PROXY_UNAUTHORIZED_SIGNALS = [
+  "unauthorized",
+  "forbidden",
+  "invalid signature",
+  "bad secret",
+  "shared secret",
+  "token",
+];
+const ACCESS_DENIED_SIGNALS = [
+  "permission",
+  "access denied",
+  "not shared",
+  "cannot open spreadsheet",
+  "spreadsheet access",
+  "insufficient permissions",
+];
+const RANGE_INVALID_SIGNALS = [
+  "unable to parse range",
+  "invalid range",
+  "range not found",
+  "cannot find range",
+  "requested entity was not found",
+  "exceeds grid limits",
+  "cannot find sheet",
+  "no grid with id",
+  "alliancedashboard",
+];
 
 export type GoogleSheetMode = "actual" | "war";
+export type GoogleSheetReadErrorCode =
+  | "SHEET_LINK_MISSING"
+  | "SHEET_PROXY_UNAUTHORIZED"
+  | "SHEET_ACCESS_DENIED"
+  | "SHEET_RANGE_INVALID"
+  | "SHEET_READ_FAILURE";
+
+export type GoogleSheetReadErrorMeta = {
+  action: "readValues";
+  range: string;
+  resolutionSource?: "google_sheet_id";
+  sheetId?: string;
+  source?: "proxy" | "api";
+  httpStatus?: number;
+  details?: string;
+};
+
+export class GoogleSheetReadError extends Error {
+  readonly code: GoogleSheetReadErrorCode;
+  readonly meta: GoogleSheetReadErrorMeta;
+
+  constructor(code: GoogleSheetReadErrorCode, message: string, meta: GoogleSheetReadErrorMeta) {
+    super(message);
+    this.name = "GoogleSheetReadError";
+    this.code = code;
+    this.meta = meta;
+  }
+}
+
+type GoogleSheetTransportErrorMeta = {
+  source: "proxy" | "api";
+  status?: number;
+  responseText?: string;
+};
+
+class GoogleSheetTransportError extends Error {
+  readonly meta: GoogleSheetTransportErrorMeta;
+
+  constructor(message: string, meta: GoogleSheetTransportErrorMeta) {
+    super(message);
+    this.name = "GoogleSheetTransportError";
+    this.meta = meta;
+  }
+}
+
+export type CompoLinkedSheet = {
+  sheetId: string;
+  tabName: string | null;
+  source: "google_sheet_id";
+};
 
 type AccessTokenCache = {
   token: string;
@@ -100,6 +177,47 @@ export class GoogleSheetsService {
     return this.readValues(sheetId, effectiveRange);
   }
 
+  async getCompoLinkedSheet(range: string): Promise<CompoLinkedSheet> {
+    const sheetId = await this.settings.get(SHEET_SETTING_ID_KEY);
+    const tabName = await this.settings.get(SHEET_SETTING_TAB_KEY);
+    if (!sheetId || !sheetId.trim()) {
+      throw new GoogleSheetReadError(
+        "SHEET_LINK_MISSING",
+        "No compo sheet is linked for this server.",
+        {
+          action: "readValues",
+          range,
+          resolutionSource: "google_sheet_id",
+          source: this.getReadSource(),
+        }
+      );
+    }
+
+    return {
+      sheetId: sheetId.trim(),
+      tabName,
+      source: "google_sheet_id",
+    };
+  }
+
+  async readCompoLinkedValues(
+    range: string,
+    linkedSheet?: CompoLinkedSheet
+  ): Promise<string[][]> {
+    const linked = linkedSheet ?? (await this.getCompoLinkedSheet(range));
+    try {
+      return await this.readValues(linked.sheetId, range);
+    } catch (err) {
+      throw this.normalizeCompoReadError(err, {
+        action: "readValues",
+        range,
+        resolutionSource: linked.source,
+        sheetId: linked.sheetId,
+        source: this.getReadSource(),
+      });
+    }
+  }
+
   /** Purpose: read values. */
   async readValues(sheetId: string, range: string): Promise<string[][]> {
     const proxyUrl = process.env.GS_WEBHOOK_URL?.trim();
@@ -142,7 +260,14 @@ export class GoogleSheetsService {
         errorCode: failure.errorCode,
         timeout: failure.timeout,
       });
-      throw err;
+      throw new GoogleSheetTransportError(
+        this.errorMessageFromUnknown(err, "Google Sheets API request failed."),
+        {
+          source: "api",
+          status: this.readStatusFromUnknown(err),
+          responseText: this.errorTextFromUnknown(err),
+        }
+      );
     }
   }
 
@@ -159,18 +284,50 @@ export class GoogleSheetsService {
       range,
     };
     if (token) payload.token = token;
-
-    const response = await axios.post<{
-      values?: unknown;
-      ok?: boolean;
-      error?: unknown;
-      message?: unknown;
-      result?: { values?: unknown };
-    }>(url, payload, {
-      headers: { "Content-Type": "application/json" },
-      timeout: APPS_SCRIPT_PROXY_TIMEOUT_MS,
-      validateStatus: () => true,
-    });
+    let response: {
+      status: number;
+      data?: {
+        values?: unknown;
+        ok?: boolean;
+        error?: unknown;
+        message?: unknown;
+        result?: { values?: unknown };
+      };
+    };
+    try {
+      response = await axios.post<{
+        values?: unknown;
+        ok?: boolean;
+        error?: unknown;
+        message?: unknown;
+        result?: { values?: unknown };
+      }>(url, payload, {
+        headers: { "Content-Type": "application/json" },
+        timeout: APPS_SCRIPT_PROXY_TIMEOUT_MS,
+        validateStatus: () => true,
+      });
+    } catch (err) {
+      const failure = toFailureTelemetry(err);
+      recordFetchEvent({
+        namespace: "google_sheets",
+        operation: "apps_script_proxy",
+        source: "web",
+        detail: "action=readValues status=request_error",
+        durationMs: Date.now() - startedAtMs,
+        status: "failure",
+        errorCategory: failure.errorCategory,
+        errorCode: failure.errorCode,
+        timeout: failure.timeout,
+      });
+      throw new GoogleSheetTransportError(
+        this.errorMessageFromUnknown(err, "Apps Script proxy request failed."),
+        {
+          source: "proxy",
+          status: this.readStatusFromUnknown(err),
+          responseText: this.errorTextFromUnknown(err),
+        }
+      );
+    }
 
     if (response.status >= 400) {
       recordFetchEvent({
@@ -189,7 +346,11 @@ export class GoogleSheetsService {
           : typeof response.data?.message === "string"
             ? response.data.message
             : `Apps Script proxy returned HTTP ${response.status}`;
-      throw new Error(message);
+      throw new GoogleSheetTransportError(message, {
+        source: "proxy",
+        status: response.status,
+        responseText: this.compactUnknown(response.data),
+      });
     }
     recordFetchEvent({
       namespace: "google_sheets",
@@ -210,6 +371,124 @@ export class GoogleSheetsService {
       if (!Array.isArray(row)) return [];
       return row.map((cell) => String(cell ?? ""));
     });
+  }
+
+  private getReadSource(): "proxy" | "api" {
+    return process.env.GS_WEBHOOK_URL?.trim() ? "proxy" : "api";
+  }
+
+  private normalizeCompoReadError(
+    err: unknown,
+    meta: GoogleSheetReadErrorMeta
+  ): GoogleSheetReadError {
+    if (err instanceof GoogleSheetReadError) return err;
+
+    const transportMeta =
+      err instanceof GoogleSheetTransportError
+        ? err.meta
+        : {
+            source: meta.source,
+            status: this.readStatusFromUnknown(err),
+            responseText: this.errorTextFromUnknown(err),
+          };
+
+    const mergedMeta: GoogleSheetReadErrorMeta = {
+      ...meta,
+      source: transportMeta.source ?? meta.source,
+      httpStatus: transportMeta.status,
+      details: transportMeta.responseText,
+    };
+    const code = this.classifyCompoReadErrorCode(mergedMeta);
+    const message = this.errorMessageForCode(code);
+    return new GoogleSheetReadError(code, message, mergedMeta);
+  }
+
+  private classifyCompoReadErrorCode(
+    meta: GoogleSheetReadErrorMeta
+  ): GoogleSheetReadErrorCode {
+    const source = meta.source ?? "api";
+    const status = meta.httpStatus;
+    const details = String(meta.details ?? "").toLowerCase();
+
+    if (this.containsSignal(details, RANGE_INVALID_SIGNALS)) {
+      return "SHEET_RANGE_INVALID";
+    }
+
+    if (source === "proxy") {
+      if (status === 401) return "SHEET_PROXY_UNAUTHORIZED";
+      if (status === 403) {
+        if (this.containsSignal(details, PROXY_UNAUTHORIZED_SIGNALS)) {
+          return "SHEET_PROXY_UNAUTHORIZED";
+        }
+        if (this.containsSignal(details, ACCESS_DENIED_SIGNALS)) {
+          return "SHEET_ACCESS_DENIED";
+        }
+        return "SHEET_READ_FAILURE";
+      }
+    }
+
+    if (source === "api") {
+      if (status === 403) {
+        if (
+          this.containsSignal(details, ACCESS_DENIED_SIGNALS) ||
+          !this.containsSignal(details, PROXY_UNAUTHORIZED_SIGNALS)
+        ) {
+          return "SHEET_ACCESS_DENIED";
+        }
+      }
+    }
+
+    return "SHEET_READ_FAILURE";
+  }
+
+  private containsSignal(input: string, signals: string[]): boolean {
+    return signals.some((signal) => input.includes(signal));
+  }
+
+  private errorMessageForCode(code: GoogleSheetReadErrorCode): string {
+    switch (code) {
+      case "SHEET_LINK_MISSING":
+        return "No compo sheet is linked for this server.";
+      case "SHEET_PROXY_UNAUTHORIZED":
+        return "Sheet proxy authorization failed while reading compo data.";
+      case "SHEET_ACCESS_DENIED":
+        return "The linked sheet could not be accessed.";
+      case "SHEET_RANGE_INVALID":
+        return "The linked sheet does not contain the expected AllianceDashboard layout.";
+      default:
+        return "The compo sheet could not be read due to a sheet service error.";
+    }
+  }
+
+  private readStatusFromUnknown(err: unknown): number | undefined {
+    const status = (err as { response?: { status?: unknown } })?.response?.status;
+    return typeof status === "number" ? status : undefined;
+  }
+
+  private errorMessageFromUnknown(err: unknown, fallback: string): string {
+    if (typeof err === "string" && err.trim()) return err.trim();
+    if (err instanceof Error && err.message.trim()) return err.message.trim();
+    return fallback;
+  }
+
+  private errorTextFromUnknown(err: unknown): string | undefined {
+    const responseData = (err as { response?: { data?: unknown } })?.response?.data;
+    const compactResponse = this.compactUnknown(responseData);
+    if (compactResponse) return compactResponse;
+    if (typeof err === "string" && err.trim()) return err.trim();
+    if (err instanceof Error && err.message.trim()) return err.message.trim();
+    return undefined;
+  }
+
+  private compactUnknown(value: unknown): string | undefined {
+    if (value === null || value === undefined) return undefined;
+    if (typeof value === "string") return value.trim() || undefined;
+    try {
+      const text = JSON.stringify(value);
+      return text && text.length > 0 ? text : undefined;
+    } catch {
+      return undefined;
+    }
   }
 
   /** Purpose: get access token. */

--- a/tests/compo.commandSheetRead.test.ts
+++ b/tests/compo.commandSheetRead.test.ts
@@ -1,0 +1,190 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Compo, mapCompoSheetErrorToMessageForTest } from "../src/commands/Compo";
+import {
+  GoogleSheetReadError,
+  GoogleSheetReadErrorCode,
+  GoogleSheetsService,
+} from "../src/services/GoogleSheetsService";
+
+const FIXED_LAYOUT_RANGE = "AllianceDashboard!A6:BD500";
+const LOOKUP_REFRESH_RANGE = "Lookup!B10:B10";
+
+function makeRows(): string[][] {
+  const rows = Array.from({ length: 8 }, () => Array.from({ length: 56 }, () => ""));
+  const actualRow = rows[1];
+  actualRow[0] = "DARK EMPIRE";
+  actualRow[1] = "#LQQ99UV8";
+  actualRow[3] = "1,470,000";
+  actualRow[20] = "1";
+  actualRow[21] = "0";
+  actualRow[22] = "0";
+  actualRow[23] = "-1";
+  actualRow[24] = "0";
+  actualRow[25] = "0";
+  actualRow[26] = "0";
+  actualRow[48] = "1,500,000";
+  actualRow[53] = "Add 1x TH16";
+  return rows;
+}
+
+function makeInteraction(params: {
+  subcommand: "advice" | "state" | "place";
+  tag?: string;
+  mode?: string | null;
+  weight?: string;
+}) {
+  const interaction: any = {
+    commandName: "compo",
+    guildId: "guild-1",
+    user: { id: "user-1" },
+    deferred: false,
+    replied: false,
+    deferReply: vi.fn(async () => {
+      interaction.deferred = true;
+    }),
+    editReply: vi.fn().mockResolvedValue(undefined),
+    reply: vi.fn().mockResolvedValue(undefined),
+    options: {
+      getSubcommand: vi.fn(() => params.subcommand),
+      getString: vi.fn((name: string) => {
+        if (name === "tag") return params.tag ?? null;
+        if (name === "mode") return params.mode ?? null;
+        if (name === "weight") return params.weight ?? null;
+        return null;
+      }),
+    },
+  };
+  return interaction;
+}
+
+function makeReadError(code: GoogleSheetReadErrorCode): GoogleSheetReadError {
+  return new GoogleSheetReadError(code, code, {
+    action: "readValues",
+    range: FIXED_LAYOUT_RANGE,
+    resolutionSource: "google_sheet_id",
+    source: "proxy",
+    httpStatus: 403,
+  });
+}
+
+describe("/compo strict sheet read path", () => {
+  const linkedSheet = {
+    sheetId: "sheet-1",
+    tabName: "AllianceDashboard",
+    source: "google_sheet_id" as const,
+  };
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it.each([
+    {
+      subcommand: "advice" as const,
+      tag: "#LQQ99UV8",
+      expectedRanges: [FIXED_LAYOUT_RANGE],
+    },
+    {
+      subcommand: "state" as const,
+      expectedRanges: [FIXED_LAYOUT_RANGE, LOOKUP_REFRESH_RANGE],
+    },
+    {
+      subcommand: "place" as const,
+      weight: "151k",
+      expectedRanges: [FIXED_LAYOUT_RANGE, LOOKUP_REFRESH_RANGE],
+    },
+  ])("uses strict canonical resolver for /compo $subcommand", async (testCase) => {
+    const getCompoLinkedSheetSpy = vi
+      .spyOn(GoogleSheetsService.prototype, "getCompoLinkedSheet")
+      .mockResolvedValue(linkedSheet);
+    const readCompoLinkedValuesSpy = vi
+      .spyOn(GoogleSheetsService.prototype, "readCompoLinkedValues")
+      .mockImplementation(async (range: string) => {
+        if (range === LOOKUP_REFRESH_RANGE) return [["1709900000"]];
+        return makeRows();
+      });
+
+    const interaction = makeInteraction(testCase);
+    const cocService = {
+      getClan: vi.fn().mockResolvedValue({
+        memberList: Array.from({ length: 49 }, () => ({ tag: "#P" })),
+      }),
+    };
+
+    await Compo.run({} as any, interaction as any, cocService as any);
+
+    expect(getCompoLinkedSheetSpy).toHaveBeenCalledTimes(1);
+    expect(getCompoLinkedSheetSpy).toHaveBeenCalledWith(FIXED_LAYOUT_RANGE);
+    const ranges = readCompoLinkedValuesSpy.mock.calls.map((call) => String(call[0] ?? ""));
+    expect(ranges).toEqual(testCase.expectedRanges);
+    for (const call of readCompoLinkedValuesSpy.mock.calls) {
+      expect(call[1]).toBe(linkedSheet);
+    }
+  });
+
+  it.each([
+    { subcommand: "advice" as const, tag: "#LQQ99UV8" },
+    { subcommand: "state" as const },
+    { subcommand: "place" as const, weight: "151k" },
+  ])(
+    "maps normalized sheet errors consistently for /compo $subcommand",
+    async (testCase) => {
+      vi.spyOn(GoogleSheetsService.prototype, "getCompoLinkedSheet").mockResolvedValue(
+        linkedSheet
+      );
+      vi.spyOn(GoogleSheetsService.prototype, "readCompoLinkedValues").mockRejectedValue(
+        makeReadError("SHEET_PROXY_UNAUTHORIZED")
+      );
+
+      const interaction = makeInteraction(testCase);
+      const cocService = { getClan: vi.fn() };
+
+      await Compo.run({} as any, interaction as any, cocService as any);
+
+      const payload = interaction.editReply.mock.calls.at(-1)?.[0];
+      expect(String(payload?.content ?? "")).toBe(
+        "The linked compo sheet could not be accessed because the sheet proxy is not authorized."
+      );
+    }
+  );
+});
+
+describe("/compo error message mapping", () => {
+  it("maps all normalized sheet codes to stable user messages", () => {
+    const cases: Array<{ code: GoogleSheetReadErrorCode; message: string }> = [
+      {
+        code: "SHEET_LINK_MISSING",
+        message: "No compo sheet is linked for this server.",
+      },
+      {
+        code: "SHEET_PROXY_UNAUTHORIZED",
+        message:
+          "The linked compo sheet could not be accessed because the sheet proxy is not authorized.",
+      },
+      {
+        code: "SHEET_ACCESS_DENIED",
+        message:
+          "The linked compo sheet exists, but this bot does not currently have access to read it.",
+      },
+      {
+        code: "SHEET_RANGE_INVALID",
+        message:
+          "The linked compo sheet does not contain the expected AllianceDashboard layout.",
+      },
+      {
+        code: "SHEET_READ_FAILURE",
+        message: "The compo sheet could not be read due to a sheet service error.",
+      },
+    ];
+
+    for (const testCase of cases) {
+      const err = makeReadError(testCase.code);
+      expect(mapCompoSheetErrorToMessageForTest(err)).toBe(testCase.message);
+    }
+
+    expect(mapCompoSheetErrorToMessageForTest(new Error("boom"))).toBe(
+      "The compo sheet could not be read due to a sheet service error."
+    );
+  });
+});
+

--- a/tests/googleSheets.compo.service.test.ts
+++ b/tests/googleSheets.compo.service.test.ts
@@ -1,0 +1,193 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import axios from "axios";
+import {
+  GoogleSheetReadError,
+  GoogleSheetsService,
+  SHEET_SETTING_ACTUAL_ID_KEY,
+  SHEET_SETTING_ID_KEY,
+  SHEET_SETTING_TAB_KEY,
+  SHEET_SETTING_WAR_ID_KEY,
+} from "../src/services/GoogleSheetsService";
+import { SettingsService } from "../src/services/SettingsService";
+
+vi.mock("axios", () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+}));
+
+type AxiosMock = {
+  get: ReturnType<typeof vi.fn>;
+  post: ReturnType<typeof vi.fn>;
+};
+
+type SettingsStubMap = Record<string, string | null>;
+
+function makeSettingsStub(map: SettingsStubMap): SettingsService {
+  return {
+    get: vi.fn(async (key: string) => map[key] ?? null),
+    set: vi.fn(),
+    delete: vi.fn(),
+  } as unknown as SettingsService;
+}
+
+const RANGE = "AllianceDashboard!A6:BD500";
+
+describe("GoogleSheetsService /compo strict read path", () => {
+  const mockedAxios = axios as unknown as AxiosMock;
+  const originalWebhookUrl = process.env.GS_WEBHOOK_URL;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mockedAxios.get.mockReset();
+    mockedAxios.post.mockReset();
+    delete process.env.GS_WEBHOOK_URL;
+  });
+
+  afterEach(() => {
+    if (typeof originalWebhookUrl === "string") {
+      process.env.GS_WEBHOOK_URL = originalWebhookUrl;
+    } else {
+      delete process.env.GS_WEBHOOK_URL;
+    }
+  });
+
+  it("uses google_sheet_id only and does not fall back to legacy keys", async () => {
+    const settings = makeSettingsStub({
+      [SHEET_SETTING_ID_KEY]: null,
+      [SHEET_SETTING_TAB_KEY]: "AllianceDashboard",
+      [SHEET_SETTING_ACTUAL_ID_KEY]: "legacy-actual",
+      [SHEET_SETTING_WAR_ID_KEY]: "legacy-war",
+    });
+    const service = new GoogleSheetsService(settings);
+
+    await expect(service.getCompoLinkedSheet(RANGE)).rejects.toMatchObject({
+      name: "GoogleSheetReadError",
+      code: "SHEET_LINK_MISSING",
+    });
+
+    const getSpy = settings.get as unknown as ReturnType<typeof vi.fn>;
+    expect(getSpy).toHaveBeenCalledWith(SHEET_SETTING_ID_KEY);
+    expect(getSpy).toHaveBeenCalledWith(SHEET_SETTING_TAB_KEY);
+    expect(getSpy).not.toHaveBeenCalledWith(SHEET_SETTING_ACTUAL_ID_KEY);
+    expect(getSpy).not.toHaveBeenCalledWith(SHEET_SETTING_WAR_ID_KEY);
+  });
+
+  it("classifies proxy 403 auth/signature failures as SHEET_PROXY_UNAUTHORIZED", async () => {
+    process.env.GS_WEBHOOK_URL = "https://proxy.example.com";
+    mockedAxios.post.mockResolvedValue({
+      status: 403,
+      data: { error: "invalid signature" },
+    });
+    const service = new GoogleSheetsService(
+      makeSettingsStub({
+        [SHEET_SETTING_ID_KEY]: "sheet-1",
+        [SHEET_SETTING_TAB_KEY]: "AllianceDashboard",
+      })
+    );
+
+    await expect(service.readCompoLinkedValues(RANGE)).rejects.toMatchObject({
+      name: "GoogleSheetReadError",
+      code: "SHEET_PROXY_UNAUTHORIZED",
+    });
+  });
+
+  it("classifies proxy 403 access failures as SHEET_ACCESS_DENIED", async () => {
+    process.env.GS_WEBHOOK_URL = "https://proxy.example.com";
+    mockedAxios.post.mockResolvedValue({
+      status: 403,
+      data: { message: "cannot open spreadsheet: not shared" },
+    });
+    const service = new GoogleSheetsService(
+      makeSettingsStub({
+        [SHEET_SETTING_ID_KEY]: "sheet-1",
+      })
+    );
+
+    await expect(service.readCompoLinkedValues(RANGE)).rejects.toMatchObject({
+      name: "GoogleSheetReadError",
+      code: "SHEET_ACCESS_DENIED",
+    });
+  });
+
+  it("classifies range/layout failures as SHEET_RANGE_INVALID", async () => {
+    process.env.GS_WEBHOOK_URL = "https://proxy.example.com";
+    mockedAxios.post.mockResolvedValue({
+      status: 400,
+      data: { error: "Unable to parse range: AllianceDashboard!A6:BD500" },
+    });
+    const service = new GoogleSheetsService(
+      makeSettingsStub({
+        [SHEET_SETTING_ID_KEY]: "sheet-1",
+      })
+    );
+
+    await expect(service.readCompoLinkedValues(RANGE)).rejects.toMatchObject({
+      name: "GoogleSheetReadError",
+      code: "SHEET_RANGE_INVALID",
+    });
+  });
+
+  it("classifies unclear proxy 403 failures as SHEET_READ_FAILURE", async () => {
+    process.env.GS_WEBHOOK_URL = "https://proxy.example.com";
+    mockedAxios.post.mockResolvedValue({
+      status: 403,
+      data: { message: "upstream blocked request" },
+    });
+    const service = new GoogleSheetsService(
+      makeSettingsStub({
+        [SHEET_SETTING_ID_KEY]: "sheet-1",
+      })
+    );
+
+    await expect(service.readCompoLinkedValues(RANGE)).rejects.toMatchObject({
+      name: "GoogleSheetReadError",
+      code: "SHEET_READ_FAILURE",
+    });
+  });
+
+  it("classifies direct API permission failures as SHEET_ACCESS_DENIED", async () => {
+    mockedAxios.get.mockRejectedValue({
+      message: "Request failed with status code 403",
+      response: {
+        status: 403,
+        data: { error: { message: "The caller does not have permission" } },
+      },
+    });
+    const service = new GoogleSheetsService(
+      makeSettingsStub({
+        [SHEET_SETTING_ID_KEY]: "sheet-1",
+      })
+    );
+    vi.spyOn(service as any, "getAccessToken").mockResolvedValue("token-1");
+
+    await expect(service.readCompoLinkedValues(RANGE)).rejects.toMatchObject({
+      name: "GoogleSheetReadError",
+      code: "SHEET_ACCESS_DENIED",
+    });
+  });
+
+  it("returns normalized GoogleSheetReadError objects for /compo failures", async () => {
+    process.env.GS_WEBHOOK_URL = "https://proxy.example.com";
+    mockedAxios.post.mockResolvedValue({
+      status: 403,
+      data: { error: "invalid signature" },
+    });
+    const service = new GoogleSheetsService(
+      makeSettingsStub({
+        [SHEET_SETTING_ID_KEY]: "sheet-1",
+      })
+    );
+
+    try {
+      await service.readCompoLinkedValues(RANGE);
+      throw new Error("expected rejection");
+    } catch (err) {
+      expect(err).toBeInstanceOf(GoogleSheetReadError);
+      expect((err as GoogleSheetReadError).meta.range).toBe(RANGE);
+      expect((err as GoogleSheetReadError).meta.resolutionSource).toBe("google_sheet_id");
+    }
+  });
+});
+


### PR DESCRIPTION
- make /compo advice/state/place resolve from google_sheet_id only
- add strict /compo GoogleSheetsService read path with normalized error codes
- classify proxy/direct 403 failures into unauthorized vs access-denied vs fallback
- map normalized sheet errors to stable user-facing /compo messages
- add tests for strict resolver behavior, error classification, and command mapping