### PR TITLE
fix(compo): sanitize trailing -actual in display names

### DIFF
--- a/src/commands/Compo.ts
+++ b/src/commands/Compo.ts
@@ -7,6 +7,7 @@ import {
 } from "discord.js";
 import { Command } from "../Command";
 import { formatError } from "../helper/formatError";
+import { normalizeCompoClanDisplayName } from "../helper/compoDisplay";
 import { prisma } from "../prisma";
 import { safeReply } from "../helper/safeReply";
 import { CoCService } from "../services/CoCService";
@@ -314,13 +315,30 @@ function _mergeStateRows(
     const targetBandValue = (targetBand[i] ?? [""])[0] ?? "";
 
     out.push([
-      abbreviateClan((left[i] ?? [""])[0] ?? ""),
+      abbreviateClan(normalizeCompoClanDisplayName((left[i] ?? [""])[0] ?? "")),
       (middle[i] ?? ["", ""])[0] ?? "",
       targetBandValue,
       ...rightRow,
     ]);
   }
   return out;
+}
+
+function buildCompoStateRows(modeRows: SheetIndexedRow[]): string[][] {
+  return [
+    STATE_HEADERS,
+    ...modeRows.map((modeRow) => [
+      clampCell(normalizeCompoClanDisplayName(String(modeRow.row[COL_CLAN_NAME] ?? ""))),
+      clampCell(String(modeRow.row[COL_TOTAL_WEIGHT] ?? "")),
+      clampCell(String(modeRow.row[COL_MISSING_WEIGHT] ?? "")),
+      clampCell(String(modeRow.row[COL_BUCKET_START] ?? "")),
+      clampCell(String(modeRow.row[COL_BUCKET_START + 1] ?? "")),
+      clampCell(String(modeRow.row[COL_BUCKET_START + 2] ?? "")),
+      clampCell(String(modeRow.row[COL_BUCKET_START + 3] ?? "")),
+      clampCell(String(modeRow.row[COL_BUCKET_START + 4] ?? "")),
+      clampCell(String(modeRow.row[COL_BUCKET_END] ?? "")),
+    ]),
+  ];
 }
 
 type PlacementCandidate = {
@@ -438,16 +456,16 @@ function buildCompoPlaceEmbed(params: {
   refreshLine: string;
 }): EmbedBuilder {
   const recommendedRows = params.recommended.map(
-    (c) => `${abbreviateClan(c.clanName)} — needs ${Math.abs(c.delta)} ${params.bucket}`
+    (c) => `${abbreviateClan(normalizeCompoClanDisplayName(c.clanName))} — needs ${Math.abs(c.delta)} ${params.bucket}`
   );
   const vacancyRows = params.vacancyList.map(
     (c) =>
-      `${abbreviateClan(c.clanName)} — ${
+      `${abbreviateClan(normalizeCompoClanDisplayName(c.clanName))} — ${
         c.liveMemberCount !== null ? `${c.liveMemberCount}/50` : "unknown/50"
       }`
   );
   const compositionRows = params.compositionList.map(
-    (c) => `${abbreviateClan(c.clanName)} — ${c.delta}`
+    (c) => `${abbreviateClan(normalizeCompoClanDisplayName(c.clanName))} — ${c.delta}`
   );
 
   return new EmbedBuilder()
@@ -728,6 +746,7 @@ export const Compo: Command = {
         for (const modeRow of modeRows) {
           const row = modeRow.row;
           const clanName = String(row[COL_CLAN_NAME] ?? "").trim();
+          const displayClanName = normalizeCompoClanDisplayName(clanName);
           const clanTag = normalizeTag(String(row[COL_CLAN_TAG] ?? ""));
           const advice = String(row[COL_ADJUSTMENT] ?? "").trim();
           if (!clanName || !clanTag) continue;
@@ -742,8 +761,8 @@ export const Compo: Command = {
               ephemeral: true,
               content:
                 advice && advice.length > 0
-                  ? `Mode: **${mode.toUpperCase()}**\n**${clanName}** (\`#${clanTag}\`) adjustment:\n${advice}`
-                  : `Mode: **${mode.toUpperCase()}**\nFound **${clanName}** (\`#${clanTag}\`), but there is no adjustment text in column BB.`,
+                  ? `Mode: **${mode.toUpperCase()}**\n**${displayClanName}** (\`#${clanTag}\`) adjustment:\n${advice}`
+                  : `Mode: **${mode.toUpperCase()}**\nFound **${displayClanName}** (\`#${clanTag}\`), but there is no adjustment text in column BB.`,
             });
             logCompoStage(interaction, "response_sent", { reason: "target_found" });
             return;
@@ -802,20 +821,7 @@ export const Compo: Command = {
           totalRows: rows.length,
           modeRows: modeRows.length,
         });
-        const stateRows = [
-          STATE_HEADERS,
-          ...modeRows.map((modeRow) => [
-            clampCell(String(modeRow.row[COL_CLAN_NAME] ?? "")),
-            clampCell(String(modeRow.row[COL_TOTAL_WEIGHT] ?? "")),
-            clampCell(String(modeRow.row[COL_MISSING_WEIGHT] ?? "")),
-            clampCell(String(modeRow.row[COL_BUCKET_START] ?? "")),
-            clampCell(String(modeRow.row[COL_BUCKET_START + 1] ?? "")),
-            clampCell(String(modeRow.row[COL_BUCKET_START + 2] ?? "")),
-            clampCell(String(modeRow.row[COL_BUCKET_START + 3] ?? "")),
-            clampCell(String(modeRow.row[COL_BUCKET_START + 4] ?? "")),
-            clampCell(String(modeRow.row[COL_BUCKET_END] ?? "")),
-          ]),
-        ];
+        const stateRows = buildCompoStateRows(modeRows);
 
         const rawRefresh = refreshCell[0]?.[0]?.trim();
         const refreshLine =
@@ -1044,6 +1050,8 @@ export const Compo: Command = {
 
 export const readPlacementCandidatesForTest = readPlacementCandidates;
 export const buildCompoPlaceEmbedForTest = buildCompoPlaceEmbed;
+export const buildCompoStateRowsForTest = buildCompoStateRows;
 export const getModeRowsForTest = getModeRows;
 export const getAbsoluteSheetRowNumberForTest = getAbsoluteSheetRowNumber;
 export const mapCompoSheetErrorToMessageForTest = mapCompoSheetErrorToMessage;
+

--- a/src/helper/compoDisplay.ts
+++ b/src/helper/compoDisplay.ts
@@ -1,0 +1,14 @@
+const ACTUAL_SUFFIX = "-actual";
+
+/**
+ * Normalize sheet naming suffixes for user-facing /compo output only.
+ * This intentionally strips only one trailing "-actual" suffix.
+ */
+export function normalizeCompoClanDisplayName(value: string): string {
+  const trimmedRight = value.trimEnd();
+  if (!trimmedRight.endsWith(ACTUAL_SUFFIX)) {
+    return trimmedRight;
+  }
+
+  return trimmedRight.slice(0, -ACTUAL_SUFFIX.length).trimEnd();
+}

--- a/tests/compo.commandSheetRead.test.ts
+++ b/tests/compo.commandSheetRead.test.ts
@@ -27,6 +27,12 @@ function makeRows(): string[][] {
   return rows;
 }
 
+function makeRowsWithActualSuffix(): string[][] {
+  const rows = makeRows();
+  rows[1][0] = "DARK EMPIRE-actual";
+  return rows;
+}
+
 function makeInteraction(params: {
   subcommand: "advice" | "state" | "place";
   tag?: string;
@@ -147,6 +153,30 @@ describe("/compo strict sheet read path", () => {
       );
     }
   );
+
+  it("sanitizes trailing -actual suffix in /compo advice display output", async () => {
+    vi.spyOn(GoogleSheetsService.prototype, "getCompoLinkedSheet").mockResolvedValue(
+      linkedSheet
+    );
+    vi.spyOn(GoogleSheetsService.prototype, "readCompoLinkedValues").mockImplementation(
+      async (range: string) => {
+        if (range === LOOKUP_REFRESH_RANGE) return [["1709900000"]];
+        return makeRowsWithActualSuffix();
+      }
+    );
+
+    const interaction = makeInteraction({
+      subcommand: "advice",
+      tag: "#LQQ99UV8",
+    });
+    const cocService = { getClan: vi.fn() };
+
+    await Compo.run({} as any, interaction as any, cocService as any);
+
+    const payload = interaction.editReply.mock.calls.at(-1)?.[0];
+    expect(String(payload?.content ?? "")).toContain("**DARK EMPIRE** (`#LQQ99UV8`)");
+    expect(String(payload?.content ?? "")).not.toContain("-actual");
+  });
 });
 
 describe("/compo error message mapping", () => {

--- a/tests/compoDisplayName.helper.test.ts
+++ b/tests/compoDisplayName.helper.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import { normalizeCompoClanDisplayName } from "../src/helper/compoDisplay";
+
+describe("normalizeCompoClanDisplayName", () => {
+  it("removes one trailing -actual suffix for display", () => {
+    expect(normalizeCompoClanDisplayName("Dark Empire-actual")).toBe("Dark Empire");
+    expect(normalizeCompoClanDisplayName("Dark Empire -actual")).toBe("Dark Empire");
+  });
+
+  it("keeps names unchanged when -actual is not a trailing suffix", () => {
+    expect(normalizeCompoClanDisplayName("Actual Warriors")).toBe("Actual Warriors");
+    expect(normalizeCompoClanDisplayName("Dark Empire-actual-alpha")).toBe("Dark Empire-actual-alpha");
+    expect(normalizeCompoClanDisplayName("Dark Empire-Actual")).toBe("Dark Empire-Actual");
+  });
+
+  it("does not replace non-trailing occurrences and only strips the final suffix", () => {
+    expect(normalizeCompoClanDisplayName("Dark-actual Empire-actual")).toBe("Dark-actual Empire");
+    expect(normalizeCompoClanDisplayName("Dark Empire-actual-actual")).toBe("Dark Empire-actual");
+  });
+});

--- a/tests/compoPlace.logic.test.ts
+++ b/tests/compoPlace.logic.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildCompoPlaceEmbedForTest,
+  buildCompoStateRowsForTest,
   getAbsoluteSheetRowNumberForTest,
   getModeRowsForTest,
   readPlacementCandidatesForTest,
@@ -103,7 +104,7 @@ describe("/compo place candidate parsing", () => {
       bucket: "TH16",
       recommended: [
         {
-          clanName: "Red Riders",
+          clanName: "Red Riders-actual",
           clanTag: "R8R8",
           totalWeight: 0,
           targetBand: 0,
@@ -118,7 +119,7 @@ describe("/compo place candidate parsing", () => {
       ],
       vacancyList: [
         {
-          clanName: "Zero Gravity",
+          clanName: "Zero Gravity-actual",
           clanTag: "ZG99",
           totalWeight: 0,
           targetBand: 0,
@@ -132,7 +133,7 @@ describe("/compo place candidate parsing", () => {
       ],
       compositionList: [
         {
-          clanName: "The Winners Club",
+          clanName: "The Winners Club-actual",
           clanTag: "TWC1",
           totalWeight: 0,
           targetBand: 0,
@@ -157,11 +158,37 @@ describe("/compo place candidate parsing", () => {
       "Composition",
     ]);
     expect(embed.fields?.[0]?.value).toContain("Red Riders");
+    expect(embed.fields?.[0]?.value).not.toContain("-actual");
     expect(embed.fields?.[0]?.value).toContain("needs 2 TH16");
     expect(embed.fields?.[1]?.value).toContain("ZG");
     expect(embed.fields?.[1]?.value).toContain("47/50");
     expect(embed.fields?.[2]?.value).toContain("The Winners Club");
+    expect(embed.fields?.[2]?.value).not.toContain("-actual");
     expect(embed.fields?.[2]?.value).toContain("-4");
+  });
+
+  it("sanitizes clan names in state table rows for display-only rendering", () => {
+    const modeRows = [
+      {
+        row: makeRow({
+          0: "Dark Empire-actual",
+          3: "1,470,000",
+          20: "1",
+          21: "0",
+          22: "0",
+          23: "-1",
+          24: "0",
+          25: "0",
+          26: "0",
+        }),
+        sheetRowNumber: 7,
+      },
+    ];
+
+    const stateRows = buildCompoStateRowsForTest(modeRows);
+    expect(stateRows[0][0]).toBe("Clan");
+    expect(stateRows[1][0]).toBe("Dark Empire");
+    expect(stateRows[1][0]).not.toContain("-actual");
   });
 });
 


### PR DESCRIPTION
- add shared /compo display-name normalizer for trailing -actual suffix
- apply display normalization in advice, place embed rows, and state table render rows
- add regression tests for helper edge cases and advice/place/state output coverage