### PR TITLE
fix(fwa-match): suppress false needs-validation for clan-not-found

### DIFF
--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -4928,6 +4928,7 @@ function buildSyncValidationState(input: {
     isFwa: boolean | null;
     lastKnownMatchType?: string | null;
   } | null;
+  currentWarId?: string | number | null;
   currentWarStartTime: Date | null;
   siteCurrent: boolean;
   syncNum: number | null;
@@ -4952,9 +4953,20 @@ function buildSyncValidationState(input: {
     };
   }
 
+  const suppressMissingPersistedRowDifference =
+    input.syncRow === null &&
+    input.opponentNotFound === true &&
+    input.syncNum !== null &&
+    Number.isFinite(input.syncNum) &&
+    (input.opponentPoints === null || !Number.isFinite(input.opponentPoints)) &&
+    (normalizeWarIdText(input.currentWarId) !== null ||
+      (input.currentWarStartTime instanceof Date &&
+        Number.isFinite(input.currentWarStartTime.getTime())));
   const differences: string[] = [];
   if (!input.syncRow) {
-    differences.push("- Missing persisted sync validation row for this war");
+    if (!suppressMissingPersistedRowDifference) {
+      differences.push("- Missing persisted sync validation row for this war");
+    }
   } else {
     const currentSyncLabel =
       input.syncNum !== null && Number.isFinite(input.syncNum)
@@ -5022,11 +5034,11 @@ function buildSyncValidationState(input: {
     syncRowMissing: input.syncRow === null,
     differences,
     statusLine:
-      differences.length > 0
-        ? showNotFoundStatus
-          ? POINTS_CLAN_NOT_FOUND_STATUS_LINE
-          : ":warning: Data not fully synced with points.fwafarm"
-        : "✅ Data is in sync with points.fwafarm",
+      showNotFoundStatus && (differences.length > 0 || suppressMissingPersistedRowDifference)
+        ? POINTS_CLAN_NOT_FOUND_STATUS_LINE
+        : differences.length > 0
+          ? ":warning: Data not fully synced with points.fwafarm"
+          : "✅ Data is in sync with points.fwafarm",
   };
 }
 function buildStoredSyncSummary(input: {
@@ -6929,6 +6941,7 @@ async function buildTrackedMatchOverview(
     });
     const validationState = buildSyncValidationState({
       syncRow,
+      currentWarId: sub?.warId ?? null,
       currentWarStartTime: warStartTimeForSync,
       siteCurrent: siteUpdatedForAlert,
       syncNum: siteSyncObservedForWrite,
@@ -9753,6 +9766,7 @@ export const Fwa: Command = {
         });
         const validationState = buildSyncValidationState({
           syncRow,
+          currentWarId: subscription?.warId ?? null,
           currentWarStartTime: warStartTimeForSync,
           siteCurrent: siteUpdated,
           syncNum: siteSyncObservedForWrite,

--- a/tests/fwaMatchNeedsValidation.logic.test.ts
+++ b/tests/fwaMatchNeedsValidation.logic.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+
+import { buildSyncValidationStateForTest } from "../src/commands/Fwa";
+import { buildActionableSyncStateLine } from "../src/commands/fwa/syncDisplay";
+
+describe("fwa match needs-validation state contract", () => {
+  it("does not mark needs-validation when explicit clan-not-found has trusted same-war sync and no persisted row", () => {
+    const validation = buildSyncValidationStateForTest({
+      syncRow: null,
+      currentWarId: "2001",
+      currentWarStartTime: new Date("2026-03-11T08:00:00.000Z"),
+      siteCurrent: true,
+      syncNum: 475,
+      opponentTag: "2OPP",
+      clanPoints: 1200,
+      opponentPoints: null,
+      outcome: null,
+      isFwa: false,
+      opponentNotFound: true,
+    });
+
+    expect(validation.differences).toEqual([]);
+    expect(validation.statusLine).toBe(":interrobang: Clan not found on points.fwafarm");
+    expect(
+      buildActionableSyncStateLine({
+        syncRow: null,
+        siteCurrent: validation.siteCurrent,
+        differenceCount: validation.differences.length,
+      })
+    ).toBe("");
+  });
+
+  it("keeps missing-row validation active for normal non-not-found flows", () => {
+    const validation = buildSyncValidationStateForTest({
+      syncRow: null,
+      currentWarId: "2001",
+      currentWarStartTime: new Date("2026-03-11T08:00:00.000Z"),
+      siteCurrent: true,
+      syncNum: 475,
+      opponentTag: "2OPP",
+      clanPoints: 1200,
+      opponentPoints: 1000,
+      outcome: null,
+      isFwa: false,
+      opponentNotFound: false,
+    });
+
+    expect(validation.differences).toEqual(["- Missing persisted sync validation row for this war"]);
+    expect(
+      buildActionableSyncStateLine({
+        syncRow: null,
+        siteCurrent: validation.siteCurrent,
+        differenceCount: validation.differences.length,
+      })
+    ).toBe("State: Needs validation");
+  });
+
+  it("keeps missing-row validation active when war identity is not known", () => {
+    const validation = buildSyncValidationStateForTest({
+      syncRow: null,
+      currentWarId: null,
+      currentWarStartTime: null,
+      siteCurrent: true,
+      syncNum: 475,
+      opponentTag: "2OPP",
+      clanPoints: 1200,
+      opponentPoints: null,
+      outcome: null,
+      isFwa: false,
+      opponentNotFound: true,
+    });
+
+    expect(validation.differences).toEqual(["- Missing persisted sync validation row for this war"]);
+    expect(
+      buildActionableSyncStateLine({
+        syncRow: null,
+        siteCurrent: validation.siteCurrent,
+        differenceCount: validation.differences.length,
+      })
+    ).toBe("State: Needs validation");
+  });
+});


### PR DESCRIPTION
- treat missing same-war persisted sync row as non-actionable only when opponent lookup is explicitly not found and trusted same-war observed sync exists
- keep ClanPointsSync and schema invariants unchanged (no nullable opponentPoints and no CurrentWar.syncNum authority)
- preserve normal points-backed missing-row validation behavior
- add deterministic regression tests for explicit not-found, identity-scoped suppression, and unchanged normal flows