### PR TITLE
fix(fwa-mail): preserve role mention on refresh edits

### DIFF
--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -2450,6 +2450,41 @@ function buildWarMailPostedContent(
 export const buildWarMailPostedContentForTest = buildWarMailPostedContent;
 export const buildWarMailNextRefreshLabelForTest = buildNextRefreshRelativeLabel;
 
+/** Purpose: keep an already-visible role mention on refresh edits without deriving new mention state. */
+function extractPostedWarMailMentionRoleId(
+  existingPostedContent: string | null | undefined
+): string | null {
+  const lines = String(existingPostedContent ?? "").split(/\r?\n/);
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const match = trimmed.match(/^<@&(\d{5,})>$/);
+    if (!match?.[1]) return null;
+    return normalizeDiscordRoleId(match[1]);
+  }
+  return null;
+}
+
+/** Purpose: build refresh edit payload while preserving visible mention text and suppressing re-pings. */
+function buildWarMailRefreshEditPayload(
+  existingPostedContent: string | null | undefined,
+  planText: string | null | undefined,
+  nowMs?: number
+): {
+  content: string;
+  allowedMentions: { parse: [] };
+} {
+  const persistedMentionRoleId = extractPostedWarMailMentionRoleId(existingPostedContent);
+  return {
+    content: buildWarMailPostedContent(persistedMentionRoleId, nowMs, {
+      planText: String(planText ?? ""),
+    }),
+    allowedMentions: { parse: [] },
+  };
+}
+
+export const buildWarMailRefreshEditPayloadForTest = buildWarMailRefreshEditPayload;
+
 function hasWarIdentityShifted(params: {
   postedWarId?: string | null;
   postedWarStartMs?: number | null;
@@ -2634,14 +2669,12 @@ async function refreshWarMailPostByResolvedTarget(params: {
       normalizedTag,
       nextWarIdText && Number.isFinite(Number(nextWarIdText)) ? Number(nextWarIdText) : null
     );
+  const refreshEditPayload = rendered.freezeRefresh
+    ? null
+    : buildWarMailRefreshEditPayload(String(message?.content ?? ""), rendered.planText);
   await message.edit({
-    content:
-      rendered.freezeRefresh
-        ? undefined
-        : buildWarMailPostedContent(undefined, undefined, {
-            pingRole: false,
-            planText: rendered.planText,
-          }),
+    content: rendered.freezeRefresh ? undefined : refreshEditPayload?.content,
+    allowedMentions: rendered.freezeRefresh ? undefined : refreshEditPayload?.allowedMentions,
     embeds: [rendered.embed],
     components: rendered.freezeRefresh ? [] : buildWarMailPostedComponents(refreshKey),
   });

--- a/tests/fwaMailDownstream.logic.test.ts
+++ b/tests/fwaMailDownstream.logic.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildWarMailPostedContentForTest,
+  buildWarMailRefreshEditPayloadForTest,
   hasWarIdentityShiftedForTest,
 } from "../src/commands/Fwa";
 
@@ -73,5 +74,37 @@ describe("fwa war-mail posted content", () => {
       includeNextRefresh: false,
     });
     expect(content).toBe("<@&123456789>\n\nPlan body");
+  });
+});
+
+describe("fwa war-mail refresh edit payload", () => {
+  it("preserves existing visible role mention in refreshed content", () => {
+    const payload = buildWarMailRefreshEditPayloadForTest(
+      "<@&123456789>\n\nOld plan\n\nNext refresh <t:999:R>",
+      "New plan",
+      0
+    );
+
+    expect(payload.content).toBe("<@&123456789>\n\nNew plan\n\nNext refresh <t:1200:R>");
+  });
+
+  it("uses non-pinging allowedMentions on refresh edits", () => {
+    const payload = buildWarMailRefreshEditPayloadForTest(
+      "<@&123456789>\n\nOld plan\n\nNext refresh <t:999:R>",
+      "New plan",
+      0
+    );
+
+    expect(payload.allowedMentions).toEqual({ parse: [] });
+  });
+
+  it("does not add a role mention when existing posted message has none", () => {
+    const payload = buildWarMailRefreshEditPayloadForTest(
+      "Old plan\n\nNext refresh <t:999:R>",
+      "New plan",
+      0
+    );
+
+    expect(payload.content).toBe("New plan\n\nNext refresh <t:1200:R>");
   });
 });


### PR DESCRIPTION
- preserve visible role mention text from existing posted mail content during refresh edits
- apply non-pinging allowed mentions on refresh edits to prevent re-notification
- add regression tests for mentioned/no-mention refresh behavior while keeping send-content expectations