### PR TITLE
Fix war-mail refresh edits to preserve visible mention without re-pinging

### DIFF
--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -2450,6 +2450,41 @@ function buildWarMailPostedContent(
 export const buildWarMailPostedContentForTest = buildWarMailPostedContent;
 export const buildWarMailNextRefreshLabelForTest = buildNextRefreshRelativeLabel;
 
+/** Purpose: keep an already-visible role mention on refresh edits without deriving new mention state. */
+function extractPostedWarMailMentionRoleId(
+  existingPostedContent: string | null | undefined
+): string | null {
+  const lines = String(existingPostedContent ?? "").split(/\r?\n/);
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const match = trimmed.match(/^<@&(\d{5,})>$/);
+    if (!match?.[1]) return null;
+    return normalizeDiscordRoleId(match[1]);
+  }
+  return null;
+}
+
+/** Purpose: build refresh edit payload while preserving visible mention text and suppressing re-pings. */
+function buildWarMailRefreshEditPayload(
+  existingPostedContent: string | null | undefined,
+  planText: string | null | undefined,
+  nowMs?: number
+): {
+  content: string;
+  allowedMentions: { parse: [] };
+} {
+  const persistedMentionRoleId = extractPostedWarMailMentionRoleId(existingPostedContent);
+  return {
+    content: buildWarMailPostedContent(persistedMentionRoleId, nowMs, {
+      planText: String(planText ?? ""),
+    }),
+    allowedMentions: { parse: [] },
+  };
+}
+
+export const buildWarMailRefreshEditPayloadForTest = buildWarMailRefreshEditPayload;
+
 function hasWarIdentityShifted(params: {
   postedWarId?: string | null;
   postedWarStartMs?: number | null;
@@ -2634,14 +2669,12 @@ async function refreshWarMailPostByResolvedTarget(params: {
       normalizedTag,
       nextWarIdText && Number.isFinite(Number(nextWarIdText)) ? Number(nextWarIdText) : null
     );
+  const refreshEditPayload = rendered.freezeRefresh
+    ? null
+    : buildWarMailRefreshEditPayload(String(message?.content ?? ""), rendered.planText);
   await message.edit({
-    content:
-      rendered.freezeRefresh
-        ? undefined
-        : buildWarMailPostedContent(undefined, undefined, {
-            pingRole: false,
-            planText: rendered.planText,
-          }),
+    content: rendered.freezeRefresh ? undefined : refreshEditPayload?.content,
+    allowedMentions: rendered.freezeRefresh ? undefined : refreshEditPayload?.allowedMentions,
     embeds: [rendered.embed],
     components: rendered.freezeRefresh ? [] : buildWarMailPostedComponents(refreshKey),
   });

--- a/tests/fwaMailDownstream.logic.test.ts
+++ b/tests/fwaMailDownstream.logic.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildWarMailPostedContentForTest,
+  buildWarMailRefreshEditPayloadForTest,
   hasWarIdentityShiftedForTest,
 } from "../src/commands/Fwa";
 
@@ -73,5 +74,37 @@ describe("fwa war-mail posted content", () => {
       includeNextRefresh: false,
     });
     expect(content).toBe("<@&123456789>\n\nPlan body");
+  });
+});
+
+describe("fwa war-mail refresh edit payload", () => {
+  it("preserves existing visible role mention in refreshed content", () => {
+    const payload = buildWarMailRefreshEditPayloadForTest(
+      "<@&123456789>\n\nOld plan\n\nNext refresh <t:999:R>",
+      "New plan",
+      0
+    );
+
+    expect(payload.content).toBe("<@&123456789>\n\nNew plan\n\nNext refresh <t:1200:R>");
+  });
+
+  it("uses non-pinging allowedMentions on refresh edits", () => {
+    const payload = buildWarMailRefreshEditPayloadForTest(
+      "<@&123456789>\n\nOld plan\n\nNext refresh <t:999:R>",
+      "New plan",
+      0
+    );
+
+    expect(payload.allowedMentions).toEqual({ parse: [] });
+  });
+
+  it("does not add a role mention when existing posted message has none", () => {
+    const payload = buildWarMailRefreshEditPayloadForTest(
+      "Old plan\n\nNext refresh <t:999:R>",
+      "New plan",
+      0
+    );
+
+    expect(payload.content).toBe("New plan\n\nNext refresh <t:1200:R>");
   });
 });


### PR DESCRIPTION
## PR Title
`fix(fwa-mail): preserve visible role mention on refresh edits`

## PR Notes (`origin/main..origin/dev`)
- Scope: `2 commits`, `2 files changed`, `73 insertions`, `7 deletions`.
- Commits:
1. `eb7d590` Merge pull request #485 from `feature/war-mail-refresh-mention`
2. `b14970b` fix(fwa-mail): preserve role mention on refresh edits

## Summary
- Fixes war-mail refresh so an already-visible clan role mention stays visible after refresh edits.
- Prevents refresh edits from causing a new ping by forcing non-pinging edit mentions.
- Keeps no-ping posts unchanged: if the existing message has no role mention, refresh still does not add one.

## What Changed
- Added mention extraction from existing posted content and reused it only for refresh edits.
- Added a dedicated refresh edit payload builder with `allowedMentions: { parse: [] }`.
- Updated refresh edit path to use this payload while preserving freeze-refresh behavior.

## Tests
- Added deterministic coverage for:
1. Mentioned post remains mentioned after refresh edit.
2. Refresh edit uses non-pinging `allowedMentions`.
3. No-mention post remains no-mention after refresh.

## Changed Files
- [src/commands/Fwa.ts](c:/Projects/ClashCookies/src/commands/Fwa.ts)
- [tests/fwaMailDownstream.logic.test.ts](c:/Projects/ClashCookies/tests/fwaMailDownstream.logic.test.ts)