### PR TITLE
fix(fwa-match): block FWA fallback on explicit not-found

### DIFF
--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -1548,11 +1548,22 @@ async function buildWarMailEmbedForTag(
         ...activeWarInference,
       })
     );
+    const guardedFallbackResolution = applyExplicitOpponentNotFoundFallbackGuard({
+      fallbackResolution,
+      opponentNotFoundExplicitly: opponentSnapshot?.notFound === true,
+      hasSameWarExplicitFwaConfirmation: hasSameWarExplicitFwaConfirmation({
+        fallbackResolution,
+        currentWarStartTime: subscription?.startTime ?? null,
+        currentWarOpponentTag: subscription?.opponentTag ?? null,
+        activeWarStartTime: getWarStartDateForSync(null, war),
+        activeOpponentTag: opponentTag,
+      }),
+    });
     appliedResolution = chooseMatchTypeResolution({
-      confirmedCurrent: fallbackResolution.confirmedCurrent,
+      confirmedCurrent: guardedFallbackResolution.confirmedCurrent,
       liveOpponent: pointsInference,
-      storedSync: fallbackResolution.storedSync,
-      unconfirmedCurrent: fallbackResolution.unconfirmedCurrent,
+      storedSync: guardedFallbackResolution.storedSync,
+      unconfirmedCurrent: guardedFallbackResolution.unconfirmedCurrent,
     });
     inferredMatchType = appliedResolution?.inferred ?? Boolean(subscription?.inferredMatchType);
     matchType =
@@ -5333,6 +5344,56 @@ type MatchTypeFallbackResolution = {
   unconfirmedCurrent: MatchTypeResolution | null;
 };
 
+/** Purpose: verify confirmed FWA fallback comes from the same live-war identity. */
+function hasSameWarExplicitFwaConfirmation(input: {
+  fallbackResolution: MatchTypeFallbackResolution;
+  currentWarStartTime: Date | null | undefined;
+  currentWarOpponentTag: string | null | undefined;
+  activeWarStartTime: Date | null | undefined;
+  activeOpponentTag: string | null | undefined;
+}): boolean {
+  const confirmed = input.fallbackResolution.confirmedCurrent;
+  if (!confirmed || confirmed.matchType !== "FWA" || confirmed.confirmed !== true) return false;
+  const persistedOpponentTag = normalizeTag(String(input.currentWarOpponentTag ?? ""));
+  const activeOpponentTag = normalizeTag(String(input.activeOpponentTag ?? ""));
+  if (!persistedOpponentTag || !activeOpponentTag || persistedOpponentTag !== activeOpponentTag) {
+    return false;
+  }
+  const persistedWarStartMs =
+    input.currentWarStartTime instanceof Date && Number.isFinite(input.currentWarStartTime.getTime())
+      ? input.currentWarStartTime.getTime()
+      : null;
+  const activeWarStartMs =
+    input.activeWarStartTime instanceof Date && Number.isFinite(input.activeWarStartTime.getTime())
+      ? input.activeWarStartTime.getTime()
+      : null;
+  if (persistedWarStartMs === null || activeWarStartMs === null) return false;
+  return persistedWarStartMs === activeWarStartMs;
+}
+
+/** Purpose: block fallback FWA-family auto-selection on explicit opponent not-found unless same-war confirmation exists. */
+function applyExplicitOpponentNotFoundFallbackGuard(input: {
+  fallbackResolution: MatchTypeFallbackResolution;
+  opponentNotFoundExplicitly: boolean;
+  hasSameWarExplicitFwaConfirmation: boolean;
+}): MatchTypeFallbackResolution {
+  if (!input.opponentNotFoundExplicitly || input.hasSameWarExplicitFwaConfirmation) {
+    return input.fallbackResolution;
+  }
+  const dropFallbackFwa = (
+    resolution: MatchTypeResolution | null
+  ): MatchTypeResolution | null => {
+    if (!resolution) return null;
+    if (resolution.matchType !== "FWA") return resolution;
+    return null;
+  };
+  return {
+    confirmedCurrent: dropFallbackFwa(input.fallbackResolution.confirmedCurrent),
+    storedSync: dropFallbackFwa(input.fallbackResolution.storedSync),
+    unconfirmedCurrent: dropFallbackFwa(input.fallbackResolution.unconfirmedCurrent),
+  };
+}
+
 export const getMailBlockedReasonFromStatusForTest = getMailBlockedReasonFromStatus;
 export const getMailBlockedReasonFromRevisionStateForTest = getMailBlockedReasonFromRevisionState;
 export const resolveWarMailFreshnessStatusForTest = resolveWarMailFreshnessStatus;
@@ -5361,6 +5422,9 @@ export const shouldHydrateAlliancePayloadForTest = shouldHydrateAlliancePayload;
 export const resolveMatchTypeFromStoredSyncRowForTest = resolveMatchTypeFromStoredSyncRow;
 export const buildSyncValidationStateForTest = buildSyncValidationState;
 export const resolveRenderedSyncNumberForStoredSummaryForTest = resolveRenderedSyncNumberForStoredSummary;
+export const hasSameWarExplicitFwaConfirmationForTest = hasSameWarExplicitFwaConfirmation;
+export const applyExplicitOpponentNotFoundFallbackGuardForTest =
+  applyExplicitOpponentNotFoundFallbackGuard;
 
 /** Purpose: infer match type strictly from opponent points-site signals. */
 function inferMatchTypeFromPointsSnapshots(
@@ -5573,11 +5637,11 @@ function buildOpponentSnapshotFromTrackedClanFallback(params: {
       ...trackedSnapshot,
       tag: requestedOpponentTag,
       snapshotSource: "tracked_clan_fallback",
-      lookupState: "ok",
+      lookupState: "clan_not_found",
       clanName: extractedOpponentName ?? trackedSnapshot.clanName ?? null,
       balance: Math.trunc(opponentBalance),
       activeFwa: null,
-      notFound: false,
+      notFound: true,
       fallbackCurrentForWar: true,
       fallbackExtractedOpponentTag: extractedOpponentTag,
       winnerBoxText: normalizedWinnerBoxText,
@@ -6351,6 +6415,7 @@ async function buildTrackedMatchOverview(
       clanTag: true,
       warId: true,
       startTime: true,
+      opponentTag: true,
       matchType: true,
       inferredMatchType: true,
       outcome: true,
@@ -6753,11 +6818,22 @@ async function buildTrackedMatchOverview(
       }
     );
     const pointsResolution = toMatchTypeResolutionFromPointsInference(inferredFromPointsType);
+    const guardedFallbackResolution = applyExplicitOpponentNotFoundFallbackGuard({
+      fallbackResolution,
+      opponentNotFoundExplicitly: opponentPoints?.notFound === true,
+      hasSameWarExplicitFwaConfirmation: hasSameWarExplicitFwaConfirmation({
+        fallbackResolution,
+        currentWarStartTime: sub?.startTime ?? null,
+        currentWarOpponentTag: sub?.opponentTag ?? null,
+        activeWarStartTime: getWarStartDateForSync(null, war),
+        activeOpponentTag: opponentTag,
+      }),
+    });
     const appliedResolution = chooseMatchTypeResolution({
-      confirmedCurrent: fallbackResolution.confirmedCurrent,
+      confirmedCurrent: guardedFallbackResolution.confirmedCurrent,
       liveOpponent: pointsResolution,
-      storedSync: fallbackResolution.storedSync,
-      unconfirmedCurrent: fallbackResolution.unconfirmedCurrent,
+      storedSync: guardedFallbackResolution.storedSync,
+      unconfirmedCurrent: guardedFallbackResolution.unconfirmedCurrent,
     });
     if (!appliedResolution) {
       continue;
@@ -9341,6 +9417,7 @@ export const Fwa: Command = {
                 state: true,
                 warId: true,
                 startTime: true,
+                opponentTag: true,
                 matchType: true,
                 inferredMatchType: true,
                 outcome: true,
@@ -9646,11 +9723,22 @@ export const Fwa: Command = {
           ...activeWarInference,
         });
         const pointsResolution = toMatchTypeResolutionFromPointsInference(inferredFromPointsType);
+        const guardedFallbackResolution = applyExplicitOpponentNotFoundFallbackGuard({
+          fallbackResolution,
+          opponentNotFoundExplicitly: opponent.notFound === true,
+          hasSameWarExplicitFwaConfirmation: hasSameWarExplicitFwaConfirmation({
+            fallbackResolution,
+            currentWarStartTime: subscription?.startTime ?? null,
+            currentWarOpponentTag: subscription?.opponentTag ?? null,
+            activeWarStartTime: getWarStartDateForSync(null, war),
+            activeOpponentTag: opponentTag,
+          }),
+        });
         const appliedResolution = chooseMatchTypeResolution({
-          confirmedCurrent: fallbackResolution.confirmedCurrent,
+          confirmedCurrent: guardedFallbackResolution.confirmedCurrent,
           liveOpponent: pointsResolution,
-          storedSync: fallbackResolution.storedSync,
-          unconfirmedCurrent: fallbackResolution.unconfirmedCurrent,
+          storedSync: guardedFallbackResolution.storedSync,
+          unconfirmedCurrent: guardedFallbackResolution.unconfirmedCurrent,
         });
         if (!appliedResolution) {
           await editReplySafe("Unable to resolve match type from current data.");

--- a/tests/fwaMatchInference.logic.test.ts
+++ b/tests/fwaMatchInference.logic.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
+  applyExplicitOpponentNotFoundFallbackGuardForTest,
+  hasSameWarExplicitFwaConfirmationForTest,
   getMailBlockedReasonFromStatusForTest,
   inferMatchTypeFromPointsSnapshotsForTest,
   resolveMatchTypeFromStoredSyncRowForTest,
@@ -282,6 +284,152 @@ describe("fwa match precedence", () => {
       inferred: false,
       confirmed: true,
       syncIsFwa: false,
+    });
+  });
+});
+
+describe("fwa explicit opponent-not-found fallback guard", () => {
+  it("drops fallback FWA current-war resolution when explicit not-found has no same-war confirmation", () => {
+    const current = resolveCurrentWarMatchTypeSignal({
+      matchType: "FWA",
+      inferredMatchType: false,
+    });
+    const fallback = {
+      confirmedCurrent: current.confirmed,
+      storedSync: null,
+      unconfirmedCurrent: current.unconfirmed,
+    };
+    const sameWarConfirmed = hasSameWarExplicitFwaConfirmationForTest({
+      fallbackResolution: fallback,
+      currentWarStartTime: new Date("2026-03-10T01:00:00.000Z"),
+      currentWarOpponentTag: "#2Y2U9VRCR",
+      activeWarStartTime: new Date("2026-03-11T01:00:00.000Z"),
+      activeOpponentTag: "#2Y2U9VRCR",
+    });
+    const guarded = applyExplicitOpponentNotFoundFallbackGuardForTest({
+      fallbackResolution: fallback,
+      opponentNotFoundExplicitly: true,
+      hasSameWarExplicitFwaConfirmation: sameWarConfirmed,
+    });
+    const resolved = chooseMatchTypeResolution({
+      confirmedCurrent: guarded.confirmedCurrent,
+      liveOpponent: null,
+      storedSync: guarded.storedSync,
+      unconfirmedCurrent: guarded.unconfirmedCurrent,
+    });
+
+    expect(sameWarConfirmed).toBe(false);
+    expect(resolved).toBeNull();
+  });
+
+  it("keeps same-war explicit FWA confirmation when intentionally confirmed", () => {
+    const current = resolveCurrentWarMatchTypeSignal({
+      matchType: "FWA",
+      inferredMatchType: false,
+    });
+    const fallback = {
+      confirmedCurrent: current.confirmed,
+      storedSync: null,
+      unconfirmedCurrent: current.unconfirmed,
+    };
+    const sameWarConfirmed = hasSameWarExplicitFwaConfirmationForTest({
+      fallbackResolution: fallback,
+      currentWarStartTime: new Date("2026-03-11T01:00:00.000Z"),
+      currentWarOpponentTag: "#2Y2U9VRCR",
+      activeWarStartTime: new Date("2026-03-11T01:00:00.000Z"),
+      activeOpponentTag: "#2Y2U9VRCR",
+    });
+    const guarded = applyExplicitOpponentNotFoundFallbackGuardForTest({
+      fallbackResolution: fallback,
+      opponentNotFoundExplicitly: true,
+      hasSameWarExplicitFwaConfirmation: sameWarConfirmed,
+    });
+    const resolved = chooseMatchTypeResolution({
+      confirmedCurrent: guarded.confirmedCurrent,
+      liveOpponent: null,
+      storedSync: guarded.storedSync,
+      unconfirmedCurrent: guarded.unconfirmedCurrent,
+    });
+
+    expect(sameWarConfirmed).toBe(true);
+    expect(resolved).toMatchObject({
+      matchType: "FWA",
+      source: "confirmed_current_war",
+      inferred: false,
+      confirmed: true,
+      syncIsFwa: true,
+    });
+  });
+
+  it("still allows MM/BL non-FWA inference when battle evidence supports it", () => {
+    const current = resolveCurrentWarMatchTypeSignal({
+      matchType: "FWA",
+      inferredMatchType: false,
+    });
+    const fallback = {
+      confirmedCurrent: current.confirmed,
+      storedSync: null,
+      unconfirmedCurrent: current.unconfirmed,
+    };
+    const guarded = applyExplicitOpponentNotFoundFallbackGuardForTest({
+      fallbackResolution: fallback,
+      opponentNotFoundExplicitly: true,
+      hasSameWarExplicitFwaConfirmation: false,
+    });
+    const live = inferMatchTypeFromPointsSnapshotsForTest(
+      { activeFwa: true },
+      { balance: null, activeFwa: null, notFound: true },
+      {
+        currentWarState: "inWar",
+        currentWarClanAttacksUsed: 4,
+        currentWarClanStars: 9,
+        currentWarOpponentStars: 3,
+      }
+    );
+    const resolved = chooseMatchTypeResolution({
+      confirmedCurrent: guarded.confirmedCurrent,
+      liveOpponent: live,
+      storedSync: guarded.storedSync,
+      unconfirmedCurrent: guarded.unconfirmedCurrent,
+    });
+
+    expect(resolved).toMatchObject({
+      matchType: "MM",
+      source: "active_war_non_fwa_mismatch",
+      inferred: true,
+      confirmed: false,
+      syncIsFwa: false,
+    });
+  });
+
+  it("leaves normal opponent-page-present flows unchanged", () => {
+    const current = resolveCurrentWarMatchTypeSignal({
+      matchType: "FWA",
+      inferredMatchType: false,
+    });
+    const fallback = {
+      confirmedCurrent: current.confirmed,
+      storedSync: null,
+      unconfirmedCurrent: current.unconfirmed,
+    };
+    const guarded = applyExplicitOpponentNotFoundFallbackGuardForTest({
+      fallbackResolution: fallback,
+      opponentNotFoundExplicitly: false,
+      hasSameWarExplicitFwaConfirmation: false,
+    });
+    const resolved = chooseMatchTypeResolution({
+      confirmedCurrent: guarded.confirmedCurrent,
+      liveOpponent: null,
+      storedSync: guarded.storedSync,
+      unconfirmedCurrent: guarded.unconfirmedCurrent,
+    });
+
+    expect(resolved).toMatchObject({
+      matchType: "FWA",
+      source: "confirmed_current_war",
+      inferred: false,
+      confirmed: true,
+      syncIsFwa: true,
     });
   });
 });

--- a/tests/fwaMatchRevisionDraft.logic.test.ts
+++ b/tests/fwaMatchRevisionDraft.logic.test.ts
@@ -760,6 +760,8 @@ describe("fwa tracked-clan fallback snapshot", () => {
     expect(resolved.snapshot?.tag).toBe("2OPP");
     expect(resolved.snapshot?.balance).toBe(980);
     expect(resolved.snapshot?.clanName).toBe("Opponent Clan");
+    expect(resolved.snapshot?.lookupState).toBe("clan_not_found");
+    expect(resolved.snapshot?.notFound).toBe(true);
     expect(resolved.snapshot?.winnerBoxText).toBe("Not marked as an FWA match.");
   });
 


### PR DESCRIPTION
- preserve explicit opponent clan-not-found provenance in tracked-clan fallback snapshots
- block fallback FWA resolution sources when opponent not-found is explicit and same-war FWA confirmation is absent
- add deterministic regression tests for not-found fallback guarding and unchanged MM/BL/normal flows