### PR TITLE
feat(compo): add inline state/place refresh actions

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -22,8 +22,8 @@
 - `/sheet unlink [mode:actual|war]` - Remove one mode link or all links.
 - `/sheet refresh mode:actual|war` - Trigger mode-specific Apps Script raw feed refresh.
 - `/compo advice clan:<tracked-clan> [mode:actual|war]` - Pull advice using mode-specific sheet link.
-- `/compo state [mode:actual|war]` - Render AllianceDashboard state as an attached PNG image with mode label.
-- `/compo place weight:<value>` - Suggest placement options from ACTUAL state (vacancy + composition fit). Accepts formats like `145000`, `145,000`, or `145k` and maps to TH weight buckets.
+- `/compo state [mode:actual|war]` - Render AllianceDashboard state as an attached PNG image with mode label. Includes an inline `Refresh Data` button that triggers the shared sheet-refresh flow and rerenders in place.
+- `/compo place weight:<value>` - Suggest placement options from ACTUAL state (vacancy + composition fit). Accepts formats like `145000`, `145,000`, or `145k` and maps to TH weight buckets. Includes an inline `Refresh Data` button that triggers the shared sheet-refresh flow and rerenders in place.
 - `/cc player tag:<tag>` - Build `https://cc.fwafarm.com/cc_n/member.php?tag=<tag>`.
 - `/cc clan tag:<tag>` - Build `https://cc.fwafarm.com/cc_n/clan.php?tag=<tag>`.
 - `/notify war clan-tag:<tag> target-channel:<channel> [role:<discordRole>]` - Enable war-state event logs (war start, battle day, war end) for a clan in a selected channel. Optional role is pinged when event logs are posted.

--- a/src/commands/Compo.ts
+++ b/src/commands/Compo.ts
@@ -1,8 +1,15 @@
 import {
+  ActionRowBuilder,
+  APIActionRowComponent,
+  APIMessageActionRowComponent,
   ApplicationCommandOptionType,
   AutocompleteInteraction,
+  ButtonBuilder,
+  ButtonInteraction,
+  ButtonStyle,
   ChatInputCommandInteraction,
   Client,
+  ComponentType,
   EmbedBuilder,
 } from "discord.js";
 import { Command } from "../Command";
@@ -11,6 +18,12 @@ import { normalizeCompoClanDisplayName } from "../helper/compoDisplay";
 import { prisma } from "../prisma";
 import { safeReply } from "../helper/safeReply";
 import { CoCService } from "../services/CoCService";
+import {
+  getSheetRefreshErrorHint,
+  mapSheetRefreshFlowErrorToMessage,
+  SheetRefreshFlowError,
+  triggerSharedSheetRefresh,
+} from "../services/SheetRefreshService";
 import {
   GoogleSheetMode,
   GoogleSheetReadError,
@@ -72,6 +85,9 @@ const FIXED_LAYOUT_RANGE = "AllianceDashboard!A6:BD500";
 const FIXED_LAYOUT_RANGE_START_ROW = 6;
 const STATE_HEADERS = ["Clan", "Total", "Missing", "TH18", "TH17", "TH16", "TH15", "TH14", "<=TH13"];
 const LOOKUP_REFRESH_RANGE = "Lookup!B10:B10";
+const COMPO_REFRESH_PREFIX = "compo-refresh";
+const COMPO_REFRESH_LABEL = "Refresh Data";
+const COMPO_REFRESH_LOADING_LABEL = "Refreshing...";
 const COMPO_ERROR_MESSAGE_BY_CODE: Record<GoogleSheetReadErrorCode, string> = {
   SHEET_LINK_MISSING: "No compo sheet is linked for this server.",
   SHEET_PROXY_UNAUTHORIZED:
@@ -83,6 +99,92 @@ const COMPO_ERROR_MESSAGE_BY_CODE: Record<GoogleSheetReadErrorCode, string> = {
   SHEET_READ_FAILURE:
     "The compo sheet could not be read due to a sheet service error.",
 };
+
+type CompoRefreshPayload =
+  | {
+      kind: "state";
+      userId: string;
+      mode: GoogleSheetMode;
+    }
+  | {
+      kind: "place";
+      userId: string;
+      weight: number;
+    };
+
+function buildCompoRefreshCustomId(payload: CompoRefreshPayload): string {
+  if (payload.kind === "state") {
+    return `${COMPO_REFRESH_PREFIX}:state:${payload.userId}:${payload.mode}`;
+  }
+  return `${COMPO_REFRESH_PREFIX}:place:${payload.userId}:${Math.trunc(payload.weight)}`;
+}
+
+function parseCompoRefreshCustomId(customId: string): CompoRefreshPayload | null {
+  const parts = String(customId ?? "").split(":");
+  if (parts.length !== 4 || parts[0] !== COMPO_REFRESH_PREFIX) return null;
+  const [, kind, userId, value] = parts;
+  if (!userId || !value) return null;
+  if (kind === "state") {
+    if (value !== "actual" && value !== "war") return null;
+    return {
+      kind: "state",
+      userId,
+      mode: value,
+    };
+  }
+  if (kind === "place") {
+    const weight = Number(value);
+    if (!Number.isFinite(weight) || weight <= 0) return null;
+    return {
+      kind: "place",
+      userId,
+      weight: Math.trunc(weight),
+    };
+  }
+  return null;
+}
+
+export function isCompoRefreshButtonCustomId(customId: string): boolean {
+  return String(customId ?? "").startsWith(`${COMPO_REFRESH_PREFIX}:`);
+}
+
+function buildCompoRefreshActionRow(
+  customId: string,
+  options?: { loading?: boolean }
+): ActionRowBuilder<ButtonBuilder> {
+  const loading = options?.loading ?? false;
+  return new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder()
+      .setCustomId(customId)
+      .setLabel(loading ? COMPO_REFRESH_LOADING_LABEL : COMPO_REFRESH_LABEL)
+      .setStyle(ButtonStyle.Secondary)
+      .setDisabled(loading)
+  );
+}
+
+function extractSupplementalRowsFromMessage(
+  interaction: ButtonInteraction
+): Array<APIActionRowComponent<APIMessageActionRowComponent>> {
+  return interaction.message.components
+    .map((row) => row.toJSON() as APIActionRowComponent<APIMessageActionRowComponent>)
+    .filter(
+      (row) =>
+        !row.components.some(
+          (component) =>
+            component.type === ComponentType.Button &&
+            "custom_id" in component &&
+            typeof component.custom_id === "string" &&
+            isCompoRefreshButtonCustomId(component.custom_id)
+        )
+    );
+}
+
+function buildRefreshLine(refreshCell: string[][]): string {
+  const rawRefresh = refreshCell[0]?.[0]?.trim();
+  return rawRefresh && /^\d+$/.test(rawRefresh)
+    ? `RAW Data last refreshed: <t:${rawRefresh}:F>`
+    : "RAW Data last refreshed: (not available)";
+}
 
 function normalizeTag(value: string): string {
   return value.trim().toUpperCase().replace(/^#/, "");
@@ -344,6 +446,128 @@ function buildCompoStateRows(modeRows: SheetIndexedRow[]): string[][] {
     STATE_HEADERS,
     ...contentRows,
   ];
+}
+
+type CompoRenderPayload = {
+  content?: string;
+  embeds?: EmbedBuilder[];
+  files?: Array<{
+    attachment: Buffer;
+    name: string;
+  }>;
+};
+
+type CompoSheetSnapshot = {
+  linked: Awaited<ReturnType<GoogleSheetsService["getCompoLinkedSheet"]>>;
+  rows: string[][];
+  modeRows: SheetIndexedRow[];
+  refreshLine: string;
+};
+
+async function readCompoSheetSnapshot(mode: GoogleSheetMode): Promise<CompoSheetSnapshot> {
+  const settings = new SettingsService();
+  const sheets = new GoogleSheetsService(settings);
+  const linked = await sheets.getCompoLinkedSheet(FIXED_LAYOUT_RANGE);
+  const [rows, refreshCell] = await Promise.all([
+    sheets.readCompoLinkedValues(FIXED_LAYOUT_RANGE, linked),
+    sheets.readCompoLinkedValues(LOOKUP_REFRESH_RANGE, linked),
+  ]);
+  return {
+    linked,
+    rows,
+    modeRows: getModeRows(rows, mode),
+    refreshLine: buildRefreshLine(refreshCell),
+  };
+}
+
+function buildCompoStatePayload(input: {
+  mode: GoogleSheetMode;
+  modeRows: SheetIndexedRow[];
+  refreshLine: string;
+}): CompoRenderPayload {
+  const stateRows = buildCompoStateRows(input.modeRows);
+  return {
+    content: [`Mode Displayed: **${input.mode.toUpperCase()}**`, input.refreshLine].join("\n"),
+    files: [
+      {
+        attachment: renderStatePng(input.mode, stateRows),
+        name: `compo-state-${input.mode}.png`,
+      },
+    ],
+  };
+}
+
+async function buildCompoPlacePayload(input: {
+  inputWeight: number;
+  bucket: WeightBucket;
+  actualRows: SheetIndexedRow[];
+  cocService: CoCService;
+  refreshLine: string;
+}): Promise<{
+  payload: CompoRenderPayload;
+  candidateCount: number;
+  recommendedCount: number;
+  vacancyCount: number;
+  compositionCount: number;
+}> {
+  const candidates = readPlacementCandidates(input.actualRows);
+  if (candidates.length === 0) {
+    return {
+      payload: {
+        content: "No placement data found in ACTUAL rows from AllianceDashboard!A6:BD500.",
+      },
+      candidateCount: 0,
+      recommendedCount: 0,
+      vacancyCount: 0,
+      compositionCount: 0,
+    };
+  }
+
+  const candidatesWithLiveVacancy = await enrichCandidatesWithLiveVacancy(
+    candidates,
+    input.cocService
+  );
+  const vacancyChoice = candidatesWithLiveVacancy
+    .filter((c) => c.hasVacancy)
+    .sort((a, b) => {
+      if (b.vacancySlots !== a.vacancySlots)
+        return b.vacancySlots - a.vacancySlots;
+      return Math.abs(a.remainingToTarget - input.inputWeight) - Math.abs(b.remainingToTarget - input.inputWeight);
+    });
+
+  const compositionNeeds = candidatesWithLiveVacancy
+    .map((c) => {
+      const key = normalize(`${input.bucket}-delta`);
+      const delta = c.bucketDeltaByHeader[key] ?? 0;
+      return { ...c, delta };
+    })
+    .filter((c) => c.delta < 0)
+    .sort((a, b) => {
+      if (a.delta !== b.delta) return a.delta - b.delta;
+      return b.missingCount - a.missingCount;
+    });
+
+  const recommended = compositionNeeds.filter((c) => c.hasVacancy);
+  const vacancyList = vacancyChoice;
+  const compositionList = compositionNeeds;
+  const embed = buildCompoPlaceEmbed({
+    inputWeight: input.inputWeight,
+    bucket: input.bucket,
+    recommended,
+    vacancyList,
+    compositionList,
+    refreshLine: input.refreshLine,
+  });
+  return {
+    payload: {
+      content: "",
+      embeds: [embed],
+    },
+    candidateCount: candidates.length,
+    recommendedCount: recommended.length,
+    vacancyCount: vacancyList.length,
+    compositionCount: compositionList.length,
+  };
 }
 
 type PlacementCandidate = {
@@ -638,6 +862,120 @@ function renderStatePng(mode: GoogleSheetMode, rows: string[][]): Buffer {
   return PNG.sync.write(png);
 }
 
+function buildCompoRefreshComponents(input: {
+  customId: string;
+  loading: boolean;
+  supplementalRows?: Array<APIActionRowComponent<APIMessageActionRowComponent>>;
+}): Array<ActionRowBuilder<ButtonBuilder> | APIActionRowComponent<APIMessageActionRowComponent>> {
+  const components: Array<ActionRowBuilder<ButtonBuilder> | APIActionRowComponent<APIMessageActionRowComponent>> = [
+    buildCompoRefreshActionRow(input.customId, { loading: input.loading }),
+  ];
+  if (input.supplementalRows && input.supplementalRows.length > 0) {
+    components.push(...input.supplementalRows);
+  }
+  return components.slice(0, 5);
+}
+
+function mapCompoRefreshErrorToMessage(err: unknown): string {
+  if (err instanceof SheetRefreshFlowError) {
+    return mapSheetRefreshFlowErrorToMessage(err);
+  }
+  if (err instanceof GoogleSheetReadError) {
+    return mapCompoSheetErrorToMessage(err);
+  }
+  const refreshHint = getSheetRefreshErrorHint(err);
+  return `Failed to refresh compo view. ${refreshHint}`;
+}
+
+export async function handleCompoRefreshButton(
+  interaction: ButtonInteraction,
+  cocService: CoCService
+): Promise<void> {
+  const parsed = parseCompoRefreshCustomId(interaction.customId);
+  if (!parsed) {
+    if (!interaction.replied && !interaction.deferred) {
+      await interaction.reply({ ephemeral: true, content: "Invalid refresh action." });
+    }
+    return;
+  }
+  if (interaction.user.id !== parsed.userId) {
+    await interaction.reply({
+      ephemeral: true,
+      content: "Only the command requester can use this refresh button.",
+    });
+    return;
+  }
+
+  const supplementalRows = extractSupplementalRowsFromMessage(interaction);
+  await interaction.update({
+    components: buildCompoRefreshComponents({
+      customId: interaction.customId,
+      loading: true,
+      supplementalRows,
+    }),
+  });
+
+  try {
+    const refreshMode = parsed.kind === "state" ? parsed.mode : "actual";
+    await triggerSharedSheetRefresh({
+      guildId: interaction.guildId ?? null,
+      mode: refreshMode,
+    });
+
+    if (parsed.kind === "state") {
+      const snapshot = await readCompoSheetSnapshot(parsed.mode);
+      const payload = buildCompoStatePayload({
+        mode: parsed.mode,
+        modeRows: snapshot.modeRows,
+        refreshLine: snapshot.refreshLine,
+      });
+      await interaction.editReply({
+        ...payload,
+        components: buildCompoRefreshComponents({
+          customId: interaction.customId,
+          loading: false,
+          supplementalRows,
+        }),
+      });
+      return;
+    }
+
+    const bucket = getWeightBucket(parsed.weight);
+    if (!bucket) {
+      throw new Error("Invalid placement bucket for refresh.");
+    }
+    const snapshot = await readCompoSheetSnapshot("actual");
+    const placeResult = await buildCompoPlacePayload({
+      inputWeight: parsed.weight,
+      bucket,
+      actualRows: snapshot.modeRows,
+      cocService,
+      refreshLine: snapshot.refreshLine,
+    });
+    await interaction.editReply({
+      ...placeResult.payload,
+      components: buildCompoRefreshComponents({
+        customId: interaction.customId,
+        loading: false,
+        supplementalRows,
+      }),
+    });
+  } catch (err) {
+    console.error(`compo refresh button failed: ${formatError(err)}`);
+    await interaction.editReply({
+      components: buildCompoRefreshComponents({
+        customId: interaction.customId,
+        loading: false,
+        supplementalRows,
+      }),
+    });
+    await interaction.followUp({
+      ephemeral: true,
+      content: mapCompoRefreshErrorToMessage(err),
+    });
+  }
+}
+
 export const Compo: Command = {
   name: "compo",
   description: "Composition tools",
@@ -796,60 +1134,51 @@ export const Compo: Command = {
 
       if (subcommand === "state") {
         logCompoStage(interaction, "computation_start", { mode });
-        const settings = new SettingsService();
-        const sheets = new GoogleSheetsService(settings);
-        const linked = await sheets.getCompoLinkedSheet(FIXED_LAYOUT_RANGE);
+        const snapshot = await readCompoSheetSnapshot(mode);
         logCompoStage(interaction, "db_fetch", {
           entity: "sheet_link",
           mode,
-          result: linked.sheetId ? "found" : "missing",
-          sheetIdPresent: Boolean(linked.sheetId),
-          resolutionSource: linked.source,
+          result: snapshot.linked.sheetId ? "found" : "missing",
+          sheetIdPresent: Boolean(snapshot.linked.sheetId),
+          resolutionSource: snapshot.linked.source,
         });
         logCompoStage(interaction, "read_dispatch", {
           range: FIXED_LAYOUT_RANGE,
-          resolutionSource: linked.source,
+          resolutionSource: snapshot.linked.source,
         });
         logCompoStage(interaction, "read_dispatch", {
           range: LOOKUP_REFRESH_RANGE,
-          resolutionSource: linked.source,
+          resolutionSource: snapshot.linked.source,
         });
-        const [rows, refreshCell] = await Promise.all([
-          sheets.readCompoLinkedValues(FIXED_LAYOUT_RANGE, linked),
-          sheets.readCompoLinkedValues(LOOKUP_REFRESH_RANGE, linked),
-        ]);
-        const modeRows = getModeRows(rows, mode);
         logCompoStage(interaction, "db_fetch", {
           entity: "sheet_rows",
           mode,
-          result: rows.length > 0 ? "found" : "missing",
-          totalRows: rows.length,
-          modeRows: modeRows.length,
+          result: snapshot.rows.length > 0 ? "found" : "missing",
+          totalRows: snapshot.rows.length,
+          modeRows: snapshot.modeRows.length,
         });
-        const stateRows = buildCompoStateRows(modeRows);
-
-        const rawRefresh = refreshCell[0]?.[0]?.trim();
-        const refreshLine =
-          rawRefresh && /^\d+$/.test(rawRefresh)
-            ? `RAW Data last refreshed: <t:${rawRefresh}:F>`
-            : "RAW Data last refreshed: (not available)";
+        const payload = buildCompoStatePayload({
+          mode,
+          modeRows: snapshot.modeRows,
+          refreshLine: snapshot.refreshLine,
+        });
+        const refreshCustomId = buildCompoRefreshCustomId({
+          kind: "state",
+          userId: interaction.user.id,
+          mode,
+        });
 
         logCompoStage(interaction, "computation_complete", {
           result: "state_rendered",
-          modeRows: modeRows.length,
+          modeRows: snapshot.modeRows.length,
         });
-        const content = [`Mode Displayed: **${mode.toUpperCase()}**`, refreshLine].join("\n");
-        const png = renderStatePng(mode, stateRows);
-
         logCompoStage(interaction, "response_build", { reason: "state_png" });
         await interaction.editReply({
-          content,
-          files: [
-            {
-              attachment: png,
-              name: `compo-state-${mode}.png`,
-            },
-          ],
+          ...payload,
+          components: buildCompoRefreshComponents({
+            customId: refreshCustomId,
+            loading: false,
+          }),
         });
         logCompoStage(interaction, "response_sent", { reason: "state_png" });
         return;
@@ -889,107 +1218,64 @@ export const Compo: Command = {
         }
 
         const stateMode: GoogleSheetMode = "actual";
-        const settings = new SettingsService();
-        const sheets = new GoogleSheetsService(settings);
-        const linked = await sheets.getCompoLinkedSheet(FIXED_LAYOUT_RANGE);
+        const snapshot = await readCompoSheetSnapshot(stateMode);
         logCompoStage(interaction, "db_fetch", {
           entity: "sheet_link",
           mode: stateMode,
-          result: linked.sheetId ? "found" : "missing",
-          sheetIdPresent: Boolean(linked.sheetId),
-          resolutionSource: linked.source,
+          result: snapshot.linked.sheetId ? "found" : "missing",
+          sheetIdPresent: Boolean(snapshot.linked.sheetId),
+          resolutionSource: snapshot.linked.source,
         });
         logCompoStage(interaction, "read_dispatch", {
           range: FIXED_LAYOUT_RANGE,
-          resolutionSource: linked.source,
+          resolutionSource: snapshot.linked.source,
         });
         logCompoStage(interaction, "read_dispatch", {
           range: LOOKUP_REFRESH_RANGE,
-          resolutionSource: linked.source,
+          resolutionSource: snapshot.linked.source,
         });
-
-        const [rows, refreshCell] = await Promise.all([
-          sheets.readCompoLinkedValues(FIXED_LAYOUT_RANGE, linked),
-          sheets.readCompoLinkedValues(LOOKUP_REFRESH_RANGE, linked),
-        ]);
-        const actualRows = getModeRows(rows, stateMode);
         logCompoStage(interaction, "db_fetch", {
           entity: "sheet_rows",
           mode: stateMode,
-          result: rows.length > 0 ? "found" : "missing",
-          totalRows: rows.length,
-          modeRows: actualRows.length,
+          result: snapshot.rows.length > 0 ? "found" : "missing",
+          totalRows: snapshot.rows.length,
+          modeRows: snapshot.modeRows.length,
         });
 
-        const candidates = readPlacementCandidates(actualRows);
-        logCompoStage(interaction, "computation_complete", {
-          result: "placement_candidates",
-          candidates: candidates.length,
-          bucket,
-        });
-
-        if (candidates.length === 0) {
-          logCompoStage(interaction, "response_build", { reason: "no_candidates" });
-          await safeReply(interaction, {
-            ephemeral: true,
-            content: "No placement data found in ACTUAL rows from AllianceDashboard!A6:BD500.",
-          });
-          logCompoStage(interaction, "response_sent", { reason: "no_candidates" });
-          return;
-        }
-
-        const candidatesWithLiveVacancy = await enrichCandidatesWithLiveVacancy(
-          candidates,
-          cocService
-        );
-        const vacancyChoice = candidatesWithLiveVacancy
-          .filter((c) => c.hasVacancy)
-          .sort((a, b) => {
-            if (b.vacancySlots !== a.vacancySlots)
-              return b.vacancySlots - a.vacancySlots;
-            return Math.abs(a.remainingToTarget - inputWeight) - Math.abs(b.remainingToTarget - inputWeight);
-          });
-
-        const compositionNeeds = candidatesWithLiveVacancy
-          .map((c) => {
-            const key = normalize(`${bucket}-delta`);
-            const delta = c.bucketDeltaByHeader[key] ?? 0;
-            return { ...c, delta };
-          })
-          .filter((c) => c.delta < 0)
-          .sort((a, b) => {
-            if (a.delta !== b.delta) return a.delta - b.delta;
-            return b.missingCount - a.missingCount;
-          });
-
-        const recommended = compositionNeeds.filter((c) => c.hasVacancy);
-        const vacancyList = vacancyChoice;
-        const compositionList = compositionNeeds;
-        const rawRefresh = refreshCell[0]?.[0]?.trim();
-        const refreshLine =
-          rawRefresh && /^\d+$/.test(rawRefresh)
-            ? `RAW Data last refreshed: <t:${rawRefresh}:F>`
-            : "RAW Data last refreshed: (not available)";
-
-        logCompoStage(interaction, "response_build", {
-          reason: "placement_result",
-          recommended: recommended.length,
-          vacancy: vacancyList.length,
-          composition: compositionList.length,
-        });
-        const embed = buildCompoPlaceEmbed({
+        const placeResult = await buildCompoPlacePayload({
           inputWeight,
           bucket,
-          recommended,
-          vacancyList,
-          compositionList,
-          refreshLine,
+          actualRows: snapshot.modeRows,
+          cocService,
+          refreshLine: snapshot.refreshLine,
+        });
+        logCompoStage(interaction, "computation_complete", {
+          result: "placement_candidates",
+          candidates: placeResult.candidateCount,
+          bucket,
+        });
+
+        const refreshCustomId = buildCompoRefreshCustomId({
+          kind: "place",
+          userId: interaction.user.id,
+          weight: inputWeight,
+        });
+        logCompoStage(interaction, "response_build", {
+          reason: placeResult.candidateCount === 0 ? "no_candidates" : "placement_result",
+          recommended: placeResult.recommendedCount,
+          vacancy: placeResult.vacancyCount,
+          composition: placeResult.compositionCount,
         });
         await interaction.editReply({
-          content: "",
-          embeds: [embed],
+          ...placeResult.payload,
+          components: buildCompoRefreshComponents({
+            customId: refreshCustomId,
+            loading: false,
+          }),
         });
-        logCompoStage(interaction, "response_sent", { reason: "placement_result" });
+        logCompoStage(interaction, "response_sent", {
+          reason: placeResult.candidateCount === 0 ? "no_candidates" : "placement_result",
+        });
         return;
       }
 
@@ -1059,4 +1345,6 @@ export const buildCompoStateRowsForTest = buildCompoStateRows;
 export const getModeRowsForTest = getModeRows;
 export const getAbsoluteSheetRowNumberForTest = getAbsoluteSheetRowNumber;
 export const mapCompoSheetErrorToMessageForTest = mapCompoSheetErrorToMessage;
+export const buildCompoRefreshCustomIdForTest = buildCompoRefreshCustomId;
+export const parseCompoRefreshCustomIdForTest = parseCompoRefreshCustomId;
 

--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -130,8 +130,8 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
     summary: "Composition tools backed by the AllianceDashboard sheet.",
     details: [
       "`advice`: fetch clan-specific adjustment notes.",
-      "`state`: render state table as an image.",
-      "`place`: suggest placement by war weight.",
+      "`state`: render state table as an image (with inline refresh button).",
+      "`place`: suggest placement by war weight (with inline refresh button).",
     ],
     examples: [
       "/compo advice tag:#2QG2C08UP mode:actual",

--- a/src/commands/Sheet.ts
+++ b/src/commands/Sheet.ts
@@ -1,4 +1,3 @@
-import axios from "axios";
 import {
   ApplicationCommandOptionType,
   ChatInputCommandInteraction,
@@ -6,10 +5,15 @@ import {
 } from "discord.js";
 import { Command } from "../Command";
 import { formatError } from "../helper/formatError";
-import { recordFetchEvent } from "../helper/fetchTelemetry";
 import { safeReply } from "../helper/safeReply";
 import { CoCService } from "../services/CoCService";
 import { GoogleSheetsService } from "../services/GoogleSheetsService";
+import {
+  getSheetRefreshErrorHint,
+  mapSheetRefreshFlowErrorToMessage,
+  SheetRefreshFlowError,
+  triggerSharedSheetRefresh,
+} from "../services/SheetRefreshService";
 import { SettingsService } from "../services/SettingsService";
 
 function extractSheetId(input: string): string {
@@ -54,34 +58,10 @@ function getSheetErrorHint(err: unknown): string {
   return "Check credentials, sharing, sheet ID, and optional tab/range.";
 }
 
-function getRefreshErrorHint(err: unknown): string {
-  const message = formatError(err).toLowerCase();
-  if (message.includes("econnaborted") || message.includes("timeout")) {
-    return "Apps Script refresh timed out. The refresh may still be running; try again in a few minutes.";
-  }
-  if (message.includes("unauthorized") || message.includes("401")) {
-    return "Apps Script rejected the shared secret/token. Re-check *_APPS_SCRIPT_SHARED_SECRET.";
-  }
-  if (message.includes("403")) {
-    return "Apps Script endpoint denied access. Re-check web app deployment access and secret.";
-  }
-  if (message.includes("404")) {
-    return "Apps Script webhook URL was not found. Re-check GS_WEBHOOK_URL.";
-  }
-  if (message.includes("500")) {
-    return "Apps Script returned a server error. Check Apps Script execution logs.";
-  }
-
-  return "Could not trigger Apps Script refresh. Check webhook URL, shared secret, deployment access, and Apps Script logs.";
-}
-
 const SHEET_REFRESH_MODE_CHOICES = [
   { name: "Actual", value: "actual" },
   { name: "War", value: "war" },
 ];
-const SHEET_REFRESH_COOLDOWN_MS = 5 * 60 * 1000;
-const SHEET_REFRESH_TIMEOUT_MS = 120000;
-const lastRefreshAtMsByGuild = new Map<string, number>();
 const SHEET_LINK_PREREQUISITES = [
   "Prerequisites:",
   "1. Share the sheet with Google service account as Editor: `clashcookies-serviceaccount@project-61d5243b-bd8a-4eae-b4f.iam.gserviceaccount.com`",
@@ -89,56 +69,6 @@ const SHEET_LINK_PREREQUISITES = [
   "3. Set that same key in bot env var `GS_WEBHOOK_SHARED_SECRET`.",
   "4. In Apps Script, deploy a Web App and set its URL in bot env var `GS_WEBHOOK_URL`.",
 ].join("\n");
-
-async function postRefreshWebhook(
-  url: string,
-  token: string | null,
-  action: "refreshMembers" | "refreshWar"
-): Promise<string> {
-  const payload: Record<string, string> = { action };
-  if (token) payload.token = token;
-  const makeRequest = () =>
-    axios.post<string>(
-      url,
-      payload,
-      {
-        headers: { "Content-Type": "application/json" },
-        timeout: SHEET_REFRESH_TIMEOUT_MS,
-        responseType: "text",
-      }
-    );
-
-  try {
-    const response = await makeRequest();
-    recordFetchEvent({
-      namespace: "google_sheets",
-      operation: "apps_script_refresh",
-      source: "web",
-      detail: `action=${action} status=${response.status}`,
-    });
-    return String(response.data ?? "").trim();
-  } catch (firstErr) {
-    const hint = formatError(firstErr).toLowerCase();
-    const retryable =
-      hint.includes("timeout") ||
-      hint.includes("econnaborted") ||
-      hint.includes("socket hang up") ||
-      hint.includes("502") ||
-      hint.includes("503") ||
-      hint.includes("504");
-
-    if (!retryable) throw firstErr;
-
-    const second = await makeRequest();
-    recordFetchEvent({
-      namespace: "google_sheets",
-      operation: "apps_script_refresh",
-      source: "web",
-      detail: `action=${action} status=${second.status} retry=true`,
-    });
-    return String(second.data ?? "").trim();
-  }
-}
 
 export const Sheet: Command = {
   name: "sheet",
@@ -250,52 +180,31 @@ export const Sheet: Command = {
           return;
         }
 
-        const guildKey = `${interaction.guildId ?? "dm"}`;
-        const now = Date.now();
-        const lastRun = lastRefreshAtMsByGuild.get(guildKey);
-        if (lastRun && now - lastRun < SHEET_REFRESH_COOLDOWN_MS) {
-          const availableAt = Math.floor(
-            (lastRun + SHEET_REFRESH_COOLDOWN_MS) / 1000
-          );
-          await safeReply(interaction, {
-            ephemeral: true,
-            content: `Refresh cooldown active. Try again <t:${availableAt}:R>.`,
+        let refreshResult: Awaited<
+          ReturnType<typeof triggerSharedSheetRefresh>
+        >;
+        try {
+          refreshResult = await triggerSharedSheetRefresh({
+            guildId: interaction.guildId ?? null,
+            mode: refreshMode,
           });
-          return;
+        } catch (err) {
+          if (err instanceof SheetRefreshFlowError) {
+            await safeReply(interaction, {
+              ephemeral: true,
+              content: mapSheetRefreshFlowErrorToMessage(err),
+            });
+            return;
+          }
+          throw err;
         }
 
-        const config = {
-          url: process.env.GS_WEBHOOK_URL?.trim(),
-          token: process.env.GS_WEBHOOK_SHARED_SECRET?.trim() ?? null,
-          action: refreshMode === "actual" ? "refreshMembers" : "refreshWar",
-        } as const;
-
-        if (!config.url) {
-          await safeReply(interaction, {
-            ephemeral: true,
-            content: "Missing GS_WEBHOOK_URL.",
-          });
-          return;
-        }
-
-        const refreshStartedAtMs = Date.now();
-        const resultText = await postRefreshWebhook(
-          config.url,
-          config.token,
-          config.action as "refreshMembers" | "refreshWar"
-        );
-        const refreshDurationSeconds = (
-          (Date.now() - refreshStartedAtMs) /
-          1000
-        ).toFixed(2);
-
-        lastRefreshAtMsByGuild.set(guildKey, now);
         await safeReply(interaction, {
           ephemeral: true,
           content:
-            resultText.length > 0
-              ? `Refresh triggered for **${refreshMode.toUpperCase()}** mode in **${refreshDurationSeconds}s**.\n${resultText}`
-              : `Refresh triggered for **${refreshMode.toUpperCase()}** mode in **${refreshDurationSeconds}s**.`,
+            refreshResult.resultText.length > 0
+              ? `Refresh triggered for **${refreshMode.toUpperCase()}** mode in **${refreshResult.durationSeconds}s**.\n${refreshResult.resultText}`
+              : `Refresh triggered for **${refreshMode.toUpperCase()}** mode in **${refreshResult.durationSeconds}s**.`,
         });
         return;
       }
@@ -309,7 +218,7 @@ export const Sheet: Command = {
       console.error(`sheet command failed: ${formatError(err)}`);
       const hint =
         subcommand === "refresh"
-          ? getRefreshErrorHint(err)
+          ? getSheetRefreshErrorHint(err)
           : getSheetErrorHint(err);
       await safeReply(interaction, {
         ephemeral: true,

--- a/src/listeners/interactionCreate.ts
+++ b/src/listeners/interactionCreate.ts
@@ -63,6 +63,10 @@ import {
   isNotifyWarPreviewPostButtonCustomId,
 } from "../commands/Notify";
 import {
+  handleCompoRefreshButton,
+  isCompoRefreshButtonCustomId,
+} from "../commands/Compo";
+import {
   handleNotifyWarRefreshButton,
   isNotifyWarRefreshButtonCustomId,
 } from "../services/WarEventLogService";
@@ -534,6 +538,20 @@ const handleButtonInteraction = async (
         await interaction.reply({
           ephemeral: true,
           content: "Failed to post previewed war embed.",
+        });
+      }
+    }
+  }
+
+  if (isCompoRefreshButtonCustomId(interaction.customId)) {
+    try {
+      await handleCompoRefreshButton(interaction, cocService);
+    } catch (err) {
+      console.error(`Compo refresh button failed: ${formatError(err)}`);
+      if (!interaction.replied && !interaction.deferred) {
+        await interaction.reply({
+          ephemeral: true,
+          content: "Failed to refresh compo output.",
         });
       }
     }

--- a/src/services/SheetRefreshService.ts
+++ b/src/services/SheetRefreshService.ts
@@ -1,0 +1,148 @@
+import axios from "axios";
+import { formatError } from "../helper/formatError";
+import { recordFetchEvent } from "../helper/fetchTelemetry";
+
+export type SheetRefreshMode = "actual" | "war";
+type SheetRefreshAction = "refreshMembers" | "refreshWar";
+
+const SHEET_REFRESH_COOLDOWN_MS = 5 * 60 * 1000;
+const SHEET_REFRESH_TIMEOUT_MS = 120000;
+const lastRefreshAtMsByGuild = new Map<string, number>();
+
+type SheetRefreshFlowErrorCode = "INVALID_MODE" | "COOLDOWN_ACTIVE" | "MISSING_WEBHOOK_URL";
+
+export class SheetRefreshFlowError extends Error {
+  readonly code: SheetRefreshFlowErrorCode;
+  readonly retryAtEpochSeconds: number | null;
+
+  constructor(
+    code: SheetRefreshFlowErrorCode,
+    message: string,
+    options?: {
+      retryAtEpochSeconds?: number | null;
+    }
+  ) {
+    super(message);
+    this.name = "SheetRefreshFlowError";
+    this.code = code;
+    this.retryAtEpochSeconds =
+      options?.retryAtEpochSeconds !== undefined ? options.retryAtEpochSeconds : null;
+  }
+}
+
+function resolveSheetRefreshAction(mode: SheetRefreshMode): SheetRefreshAction {
+  return mode === "actual" ? "refreshMembers" : "refreshWar";
+}
+
+async function postRefreshWebhook(
+  url: string,
+  token: string | null,
+  action: SheetRefreshAction
+): Promise<string> {
+  const payload: Record<string, string> = { action };
+  if (token) payload.token = token;
+  const makeRequest = () =>
+    axios.post<string>(url, payload, {
+      headers: { "Content-Type": "application/json" },
+      timeout: SHEET_REFRESH_TIMEOUT_MS,
+      responseType: "text",
+    });
+
+  try {
+    const response = await makeRequest();
+    recordFetchEvent({
+      namespace: "google_sheets",
+      operation: "apps_script_refresh",
+      source: "web",
+      detail: `action=${action} status=${response.status}`,
+    });
+    return String(response.data ?? "").trim();
+  } catch (firstErr) {
+    const hint = formatError(firstErr).toLowerCase();
+    const retryable =
+      hint.includes("timeout") ||
+      hint.includes("econnaborted") ||
+      hint.includes("socket hang up") ||
+      hint.includes("502") ||
+      hint.includes("503") ||
+      hint.includes("504");
+
+    if (!retryable) throw firstErr;
+
+    const second = await makeRequest();
+    recordFetchEvent({
+      namespace: "google_sheets",
+      operation: "apps_script_refresh",
+      source: "web",
+      detail: `action=${action} status=${second.status} retry=true`,
+    });
+    return String(second.data ?? "").trim();
+  }
+}
+
+export function mapSheetRefreshFlowErrorToMessage(err: SheetRefreshFlowError): string {
+  if (err.code === "INVALID_MODE") return "Invalid mode. Use actual or war.";
+  if (err.code === "MISSING_WEBHOOK_URL") return "Missing GS_WEBHOOK_URL.";
+  if (err.code === "COOLDOWN_ACTIVE" && err.retryAtEpochSeconds) {
+    return `Refresh cooldown active. Try again <t:${err.retryAtEpochSeconds}:R>.`;
+  }
+  return "Failed to trigger refresh.";
+}
+
+export function getSheetRefreshErrorHint(err: unknown): string {
+  const message = formatError(err).toLowerCase();
+  if (message.includes("econnaborted") || message.includes("timeout")) {
+    return "Apps Script refresh timed out. The refresh may still be running; try again in a few minutes.";
+  }
+  if (message.includes("unauthorized") || message.includes("401")) {
+    return "Apps Script rejected the shared secret/token. Re-check *_APPS_SCRIPT_SHARED_SECRET.";
+  }
+  if (message.includes("403")) {
+    return "Apps Script endpoint denied access. Re-check web app deployment access and secret.";
+  }
+  if (message.includes("404")) {
+    return "Apps Script webhook URL was not found. Re-check GS_WEBHOOK_URL.";
+  }
+  if (message.includes("500")) {
+    return "Apps Script returned a server error. Check Apps Script execution logs.";
+  }
+  return "Could not trigger Apps Script refresh. Check webhook URL, shared secret, deployment access, and Apps Script logs.";
+}
+
+export async function triggerSharedSheetRefresh(input: {
+  guildId: string | null | undefined;
+  mode: SheetRefreshMode;
+}): Promise<{ mode: SheetRefreshMode; resultText: string; durationSeconds: string }> {
+  const mode = input.mode;
+  if (mode !== "actual" && mode !== "war") {
+    throw new SheetRefreshFlowError("INVALID_MODE", "invalid mode");
+  }
+
+  const guildKey = `${input.guildId ?? "dm"}`;
+  const now = Date.now();
+  const lastRun = lastRefreshAtMsByGuild.get(guildKey);
+  if (lastRun && now - lastRun < SHEET_REFRESH_COOLDOWN_MS) {
+    const availableAt = Math.floor((lastRun + SHEET_REFRESH_COOLDOWN_MS) / 1000);
+    throw new SheetRefreshFlowError("COOLDOWN_ACTIVE", "cooldown active", {
+      retryAtEpochSeconds: availableAt,
+    });
+  }
+
+  const url = process.env.GS_WEBHOOK_URL?.trim();
+  if (!url) {
+    throw new SheetRefreshFlowError("MISSING_WEBHOOK_URL", "missing GS_WEBHOOK_URL");
+  }
+
+  const token = process.env.GS_WEBHOOK_SHARED_SECRET?.trim() ?? null;
+  const action = resolveSheetRefreshAction(mode);
+  const refreshStartedAtMs = Date.now();
+  const resultText = await postRefreshWebhook(url, token, action);
+  const durationSeconds = ((Date.now() - refreshStartedAtMs) / 1000).toFixed(2);
+
+  lastRefreshAtMsByGuild.set(guildKey, now);
+  return {
+    mode,
+    resultText,
+    durationSeconds,
+  };
+}

--- a/tests/compo.commandSheetRead.test.ts
+++ b/tests/compo.commandSheetRead.test.ts
@@ -73,6 +73,32 @@ function makeReadError(code: GoogleSheetReadErrorCode): GoogleSheetReadError {
   });
 }
 
+function getComponentCustomIds(payload: unknown): string[] {
+  if (!payload || typeof payload !== "object") return [];
+  const rows = Array.isArray((payload as { components?: unknown[] }).components)
+    ? ((payload as { components: unknown[] }).components as unknown[])
+    : [];
+  return rows.flatMap((row) => {
+    const normalized =
+      row && typeof (row as { toJSON?: () => unknown }).toJSON === "function"
+        ? (row as { toJSON: () => unknown }).toJSON()
+        : row;
+    if (!normalized || typeof normalized !== "object") return [];
+    const components = Array.isArray((normalized as { components?: unknown[] }).components)
+      ? ((normalized as { components: unknown[] }).components as unknown[])
+      : [];
+    return components
+      .map((component) =>
+        String(
+          (component as { custom_id?: unknown; customId?: unknown }).custom_id ??
+            (component as { custom_id?: unknown; customId?: unknown }).customId ??
+            ""
+        )
+      )
+      .filter((value) => value.length > 0);
+  });
+}
+
 describe("/compo strict sheet read path", () => {
   const linkedSheet = {
     sheetId: "sheet-1",
@@ -176,6 +202,38 @@ describe("/compo strict sheet read path", () => {
     const payload = interaction.editReply.mock.calls.at(-1)?.[0];
     expect(String(payload?.content ?? "")).toContain("**DARK EMPIRE** (`#LQQ99UV8`)");
     expect(String(payload?.content ?? "")).not.toContain("-actual");
+  });
+
+  it("adds inline refresh buttons for /compo state and /compo place outputs", async () => {
+    vi.spyOn(GoogleSheetsService.prototype, "getCompoLinkedSheet").mockResolvedValue(linkedSheet);
+    vi.spyOn(GoogleSheetsService.prototype, "readCompoLinkedValues").mockImplementation(
+      async (range: string) => {
+        if (range === LOOKUP_REFRESH_RANGE) return [["1709900000"]];
+        return makeRows();
+      }
+    );
+
+    const stateInteraction = makeInteraction({ subcommand: "state", mode: "war" });
+    await Compo.run({} as any, stateInteraction as any, {
+      getClan: vi.fn().mockResolvedValue({
+        memberList: Array.from({ length: 49 }, () => ({ tag: "#P" })),
+      }),
+    } as any);
+    const statePayload = stateInteraction.editReply.mock.calls.at(-1)?.[0];
+    expect(getComponentCustomIds(statePayload).some((id) => id.startsWith("compo-refresh:state:"))).toBe(
+      true
+    );
+
+    const placeInteraction = makeInteraction({ subcommand: "place", weight: "151k" });
+    await Compo.run({} as any, placeInteraction as any, {
+      getClan: vi.fn().mockResolvedValue({
+        memberList: Array.from({ length: 47 }, () => ({ tag: "#P" })),
+      }),
+    } as any);
+    const placePayload = placeInteraction.editReply.mock.calls.at(-1)?.[0];
+    expect(getComponentCustomIds(placePayload).some((id) => id.startsWith("compo-refresh:place:"))).toBe(
+      true
+    );
   });
 });
 

--- a/tests/compoRefresh.logic.test.ts
+++ b/tests/compoRefresh.logic.test.ts
@@ -1,0 +1,163 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  buildCompoRefreshCustomIdForTest,
+  handleCompoRefreshButton,
+} from "../src/commands/Compo";
+import { GoogleSheetsService } from "../src/services/GoogleSheetsService";
+import * as SheetRefreshService from "../src/services/SheetRefreshService";
+
+function makeMessageRow(customId: string, label: string, disabled = false): { toJSON: () => unknown } {
+  return {
+    toJSON: () => ({
+      type: 1,
+      components: [
+        {
+          type: 2,
+          style: 2,
+          label,
+          custom_id: customId,
+          disabled,
+        },
+      ],
+    }),
+  };
+}
+
+function readFirstButton(payload: unknown): { label: string; disabled: boolean } | null {
+  if (!payload || typeof payload !== "object") return null;
+  const rows = Array.isArray((payload as { components?: unknown[] }).components)
+    ? ((payload as { components: unknown[] }).components as unknown[])
+    : [];
+  const firstRow = rows[0];
+  const normalized =
+    firstRow && typeof (firstRow as { toJSON?: () => unknown }).toJSON === "function"
+      ? (firstRow as { toJSON: () => unknown }).toJSON()
+      : firstRow;
+  if (!normalized || typeof normalized !== "object") return null;
+  const firstComponent = Array.isArray((normalized as { components?: unknown[] }).components)
+    ? (normalized as { components: unknown[] }).components[0]
+    : null;
+  if (!firstComponent || typeof firstComponent !== "object") return null;
+  return {
+    label: String((firstComponent as { label?: unknown }).label ?? ""),
+    disabled: Boolean((firstComponent as { disabled?: unknown }).disabled),
+  };
+}
+
+function makeInteraction(customId: string) {
+  const interaction: any = {
+    customId,
+    guildId: "guild-1",
+    channelId: "channel-1",
+    user: { id: "user-1" },
+    message: {
+      id: "message-1",
+      components: [
+        makeMessageRow(customId, "Refresh Data"),
+        makeMessageRow("post-channel:user-1", "Post to Channel"),
+      ],
+    },
+    replied: false,
+    deferred: false,
+    update: vi.fn(async () => {
+      interaction.deferred = true;
+    }),
+    editReply: vi.fn().mockResolvedValue(undefined),
+    followUp: vi.fn().mockResolvedValue(undefined),
+    reply: vi.fn().mockResolvedValue(undefined),
+  };
+  return interaction;
+}
+
+describe("compo refresh button behavior", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("shows loading state, routes through shared sheet refresh, and rerenders state output", async () => {
+    vi.spyOn(SheetRefreshService, "triggerSharedSheetRefresh").mockResolvedValue({
+      mode: "war",
+      resultText: "ok",
+      durationSeconds: "0.10",
+    });
+    vi.spyOn(GoogleSheetsService.prototype, "getCompoLinkedSheet").mockResolvedValue({
+      sheetId: "sheet-1",
+      tabName: "AllianceDashboard",
+      source: "google_sheet_id",
+    });
+    vi.spyOn(GoogleSheetsService.prototype, "readCompoLinkedValues").mockImplementation(
+      async (range: string) => {
+        if (range === "Lookup!B10:B10") return [["1709900000"]];
+        const rows = Array.from({ length: 8 }, () => Array.from({ length: 56 }, () => ""));
+        rows[2][0] = "WAR CLAN";
+        rows[2][3] = "1,500,000";
+        rows[2][20] = "2";
+        rows[2][21] = "0";
+        rows[2][22] = "0";
+        rows[2][23] = "-1";
+        rows[2][24] = "0";
+        rows[2][25] = "0";
+        rows[2][26] = "0";
+        return rows;
+      }
+    );
+
+    const customId = buildCompoRefreshCustomIdForTest({
+      kind: "state",
+      userId: "user-1",
+      mode: "war",
+    });
+    const interaction = makeInteraction(customId);
+
+    await handleCompoRefreshButton(interaction as any, {} as any);
+
+    expect(SheetRefreshService.triggerSharedSheetRefresh).toHaveBeenCalledWith({
+      guildId: "guild-1",
+      mode: "war",
+    });
+    const loadingPayload = interaction.update.mock.calls[0]?.[0];
+    expect(readFirstButton(loadingPayload)).toEqual({
+      label: "Refreshing...",
+      disabled: true,
+    });
+    const refreshedPayload = interaction.editReply.mock.calls.at(-1)?.[0];
+    expect(readFirstButton(refreshedPayload)).toEqual({
+      label: "Refresh Data",
+      disabled: false,
+    });
+    expect(Array.isArray(refreshedPayload.files)).toBe(true);
+    expect(interaction.followUp).not.toHaveBeenCalled();
+  });
+
+  it("restores non-loading state and keeps previous output on refresh failure", async () => {
+    vi.spyOn(SheetRefreshService, "triggerSharedSheetRefresh").mockRejectedValue(
+      new Error("boom")
+    );
+    const customId = buildCompoRefreshCustomIdForTest({
+      kind: "state",
+      userId: "user-1",
+      mode: "actual",
+    });
+    const interaction = makeInteraction(customId);
+
+    await handleCompoRefreshButton(interaction as any, {} as any);
+
+    const loadingPayload = interaction.update.mock.calls[0]?.[0];
+    expect(readFirstButton(loadingPayload)).toEqual({
+      label: "Refreshing...",
+      disabled: true,
+    });
+    const recoveryPayload = interaction.editReply.mock.calls.at(-1)?.[0];
+    expect(readFirstButton(recoveryPayload)).toEqual({
+      label: "Refresh Data",
+      disabled: false,
+    });
+    expect(Object.prototype.hasOwnProperty.call(recoveryPayload, "content")).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(recoveryPayload, "embeds")).toBe(false);
+    expect(Object.prototype.hasOwnProperty.call(recoveryPayload, "files")).toBe(false);
+    expect(interaction.followUp).toHaveBeenCalledTimes(1);
+    expect(String(interaction.followUp.mock.calls[0]?.[0]?.content ?? "")).toContain(
+      "Failed to refresh compo view."
+    );
+  });
+});

--- a/tests/sheetRefresh.command.test.ts
+++ b/tests/sheetRefresh.command.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Sheet } from "../src/commands/Sheet";
+import * as SheetRefreshService from "../src/services/SheetRefreshService";
+
+function makeInteraction(mode: "actual" | "war") {
+  const interaction: any = {
+    commandName: "sheet",
+    guildId: "guild-1",
+    user: { id: "user-1", tag: "User#0001" },
+    deferred: false,
+    replied: false,
+    deferReply: vi.fn(async () => {
+      interaction.deferred = true;
+    }),
+    editReply: vi.fn().mockResolvedValue(undefined),
+    reply: vi.fn().mockResolvedValue(undefined),
+    options: {
+      getSubcommand: vi.fn(() => "refresh"),
+      getString: vi.fn((name: string) => (name === "mode" ? mode : null)),
+    },
+  };
+  return interaction;
+}
+
+describe("sheet refresh shared pathway", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("routes /sheet refresh through shared refresh service", async () => {
+    vi.spyOn(SheetRefreshService, "triggerSharedSheetRefresh").mockResolvedValue({
+      mode: "actual",
+      resultText: "OK",
+      durationSeconds: "0.12",
+    });
+    const interaction = makeInteraction("actual");
+
+    await Sheet.run({} as any, interaction as any, {} as any);
+
+    expect(SheetRefreshService.triggerSharedSheetRefresh).toHaveBeenCalledWith({
+      guildId: "guild-1",
+      mode: "actual",
+    });
+    const payload = interaction.editReply.mock.calls.at(-1)?.[0];
+    expect(String(payload?.content ?? "")).toContain("Refresh triggered for **ACTUAL** mode");
+  });
+});


### PR DESCRIPTION
- add `Refresh Data` button to `/compo state` and `/compo place`
- reuse shared Apps Script refresh pathway via new SheetRefreshService
- show immediate loading state and rerender compo output in place on success
- restore non-loading button state and preserve prior output on refresh failure
- wire interaction routing for compo refresh button custom IDs
- add regression tests for button presence, shared routing, loading, success, and failure paths