### PR TITLE
fix(compo): acknowledge interactions before long pre-run checks

### DIFF
--- a/src/commands/Compo.ts
+++ b/src/commands/Compo.ts
@@ -1036,8 +1036,10 @@ export const Compo: Command = {
   ) => {
     try {
       logCompoStage(interaction, "handler_enter");
-      await interaction.deferReply({ ephemeral: true });
-      logCompoStage(interaction, "defer_reply_ok");
+      if (!interaction.deferred && !interaction.replied) {
+        await interaction.deferReply({ ephemeral: true });
+        logCompoStage(interaction, "defer_reply_ok");
+      }
 
       const subcommand = interaction.options.getSubcommand(true);
       const mode = readMode(interaction);

--- a/src/listeners/interactionCreate.ts
+++ b/src/listeners/interactionCreate.ts
@@ -719,6 +719,14 @@ const handleSlashCommand = async (
         interactionId: interaction.id,
       },
       async () => {
+        if (
+          interaction.commandName === "compo" &&
+          !interaction.deferred &&
+          !interaction.replied
+        ) {
+          await interaction.deferReply({ ephemeral: true });
+        }
+
         const permissionStartedAtMs = Date.now();
         const targets = getCommandTargetsFromInteraction(interaction);
         const allowed = await commandPermissionService.canUseAnyTarget(
@@ -741,10 +749,17 @@ const handleSlashCommand = async (
             errorCode: "PERMISSION_DENIED",
             timeout: false,
           });
-          await interaction.reply({
-            content: `You do not have permission to use /${interaction.commandName}.`,
-            ephemeral: true,
-          });
+          const permissionMessage = `You do not have permission to use /${interaction.commandName}.`;
+          if (interaction.deferred || interaction.replied) {
+            await interaction.editReply({
+              content: permissionMessage,
+            });
+          } else {
+            await interaction.reply({
+              content: permissionMessage,
+              ephemeral: true,
+            });
+          }
           return;
         }
 

--- a/tests/compo.commandSheetRead.test.ts
+++ b/tests/compo.commandSheetRead.test.ts
@@ -235,6 +235,28 @@ describe("/compo strict sheet read path", () => {
       true
     );
   });
+
+  it("does not attempt a second defer when /compo is already acknowledged", async () => {
+    vi.spyOn(GoogleSheetsService.prototype, "getCompoLinkedSheet").mockResolvedValue(linkedSheet);
+    vi.spyOn(GoogleSheetsService.prototype, "readCompoLinkedValues").mockImplementation(
+      async (range: string) => {
+        if (range === LOOKUP_REFRESH_RANGE) return [["1709900000"]];
+        return makeRows();
+      }
+    );
+
+    const interaction = makeInteraction({ subcommand: "state" });
+    interaction.deferred = true;
+
+    await Compo.run({} as any, interaction as any, {
+      getClan: vi.fn().mockResolvedValue({
+        memberList: Array.from({ length: 49 }, () => ({ tag: "#P" })),
+      }),
+    } as any);
+
+    expect(interaction.deferReply).not.toHaveBeenCalled();
+    expect(interaction.editReply).toHaveBeenCalled();
+  });
 });
 
 describe("/compo error message mapping", () => {

--- a/tests/interactionCreate.compoAck.test.ts
+++ b/tests/interactionCreate.compoAck.test.ts
@@ -1,0 +1,148 @@
+import type { Client } from "discord.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Command } from "../src/Command";
+
+type ListenerHandler = (interaction: unknown) => Promise<void>;
+
+function makeCompoSlashInteraction() {
+  const interaction: any = {
+    id: "interaction-1",
+    commandName: "compo",
+    guildId: "guild-1",
+    guild: { id: "guild-1", name: "Guild One" },
+    user: { id: "user-1", tag: "tester#0001" },
+    deferred: false,
+    replied: false,
+    inGuild: () => true,
+    memberPermissions: {
+      has: () => false,
+    },
+    member: {
+      roles: ["123"],
+    },
+    isAutocomplete: () => false,
+    isButton: () => false,
+    isStringSelectMenu: () => false,
+    isModalSubmit: () => false,
+    isChatInputCommand: () => true,
+    options: {
+      data: [],
+      getSubcommand: vi.fn(() => "state"),
+      getSubcommandGroup: vi.fn(() => null),
+      getString: vi.fn(() => null),
+    },
+    deferReply: vi.fn(async () => {
+      interaction.deferred = true;
+    }),
+    reply: vi.fn(async () => {
+      interaction.replied = true;
+    }),
+    editReply: vi.fn().mockResolvedValue(undefined),
+    followUp: vi.fn().mockResolvedValue(undefined),
+  };
+  return interaction;
+}
+
+async function loadInteractionHandler(runMock: ReturnType<typeof vi.fn>): Promise<{
+  handler: ListenerHandler;
+  restoreCommand: () => void;
+}> {
+  const { Commands } = await import("../src/Commands");
+  const compoCommand = Commands.find((cmd): cmd is Command => cmd.name === "compo");
+  if (!compoCommand) {
+    throw new Error("Could not find /compo command");
+  }
+  const originalRun = compoCommand.run;
+  compoCommand.run = runMock;
+
+  const { default: registerInteractionCreate } = await import(
+    "../src/listeners/interactionCreate"
+  );
+  const handlers = new Map<string, ListenerHandler>();
+  const client = {
+    on: vi.fn((event: string, callback: ListenerHandler) => {
+      handlers.set(event, callback);
+    }),
+  } as unknown as Client;
+
+  registerInteractionCreate(client, {} as any);
+
+  const handler = handlers.get("interactionCreate");
+  if (!handler) {
+    throw new Error("interactionCreate listener was not registered");
+  }
+
+  return {
+    handler,
+    restoreCommand: () => {
+      compoCommand.run = originalRun;
+    },
+  };
+}
+
+describe("interactionCreate /compo early acknowledgement", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("acknowledges /compo before waiting on permission checks", async () => {
+    const runMock = vi.fn().mockResolvedValue(undefined);
+    const { SettingsService } = await import("../src/services/SettingsService");
+    let resolveSettingsGet: (value: string) => void = () => undefined;
+    const settingsGetPromise = new Promise<string>((resolve) => {
+      resolveSettingsGet = resolve;
+    });
+    const settingsGetSpy = vi
+      .spyOn(SettingsService.prototype, "get")
+      .mockReturnValue(settingsGetPromise as Promise<string | null>);
+    const { handler, restoreCommand } = await loadInteractionHandler(runMock);
+    const interaction = makeCompoSlashInteraction();
+    const deferReplySpy = interaction.deferReply;
+
+    const pending = handler(interaction);
+    for (let i = 0; i < 20 && settingsGetSpy.mock.calls.length === 0; i += 1) {
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    }
+
+    expect(deferReplySpy).toHaveBeenCalledTimes(1);
+    expect(settingsGetSpy).toHaveBeenCalled();
+    expect(deferReplySpy.mock.invocationCallOrder[0]).toBeLessThan(
+      settingsGetSpy.mock.invocationCallOrder[0]
+    );
+    expect(runMock).not.toHaveBeenCalled();
+
+    resolveSettingsGet("123");
+    await pending;
+    restoreCommand();
+    expect(runMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses post-ack error response path when /compo fails after defer", async () => {
+    const { SettingsService } = await import("../src/services/SettingsService");
+    vi.spyOn(SettingsService.prototype, "get").mockResolvedValue("123");
+    const runMock = vi.fn().mockRejectedValue(new Error("boom"));
+    const { handler, restoreCommand } = await loadInteractionHandler(runMock);
+    const interaction = makeCompoSlashInteraction();
+    const deferReplySpy = interaction.deferReply;
+    const editReplySpy = interaction.editReply;
+    const replySpy = interaction.reply;
+
+    await handler(interaction);
+    restoreCommand();
+
+    expect(deferReplySpy).toHaveBeenCalledTimes(1);
+    expect(editReplySpy).toHaveBeenCalled();
+    expect(replySpy).not.toHaveBeenCalled();
+    const payload = editReplySpy.mock.calls.at(-1)?.[0];
+    const message =
+      typeof payload === "string"
+        ? payload
+        : String((payload as { content?: unknown } | undefined)?.content ?? "");
+    expect(message).toContain("Something went wrong.");
+  });
+});


### PR DESCRIPTION
- defer /compo interactions at slash-handler entry before permission work
- keep permission denial responses ACK-safe when interaction is already deferred
- make /compo defer idempotent to avoid double-ack after early defer
- add regression tests for early ACK ordering and post-ACK failure replies