### PR TITLE
fix(warplan): honor lose-style defaults in set modal prefill

### DIFF
--- a/src/commands/WarPlan.ts
+++ b/src/commands/WarPlan.ts
@@ -145,23 +145,22 @@ async function getDefaultPlanText(
   outcome: PlanOutcome,
   loseStyle: PlanLoseStyle
 ): Promise<string> {
-  const clanTagHint =
-    matchType === "FWA" && outcome === "LOSE"
-      ? loseStyle === "TRADITIONAL"
-        ? "#LOSETRADITIONAL"
-        : "#LOSETRIPLETOP30"
-      : "#DEFAULT";
   const expectedOutcome =
     matchType === "FWA" && (outcome === "WIN" || outcome === "LOSE") ? outcome : null;
+  const forcedLoseStyle =
+    matchType === "FWA" && outcome === "LOSE" && (loseStyle === "TRADITIONAL" || loseStyle === "TRIPLE_TOP_30")
+      ? loseStyle
+      : null;
   return (
     (await history.buildWarPlanText(
       guildId,
       matchType,
       expectedOutcome,
-      clanTagHint,
+      "",
       "{opponent}",
       "battle",
-      "{clan}"
+      "{clan}",
+      { forcedLoseStyle }
     )) ?? `${matchType} plan unavailable.`
   );
 }

--- a/src/services/war-events/history.ts
+++ b/src/services/war-events/history.ts
@@ -89,7 +89,8 @@ export class WarEventHistoryService {
     clanTagOrOpponentName?: string | null,
     opponentNameInput?: string | null,
     _phase: "prep" | "battle" = "battle",
-    clanNameInput?: string | null
+    clanNameInput?: string | null,
+    options?: { forcedLoseStyle?: FwaLoseStyle | null }
   ): Promise<string | null> {
     let guildId: string | null | undefined = guildIdOrMatchType;
     let matchType = matchTypeOrExpectedOutcome as MatchType;
@@ -116,8 +117,13 @@ export class WarEventHistoryService {
     const clanName = String(clanNameInput ?? "").trim() || normalizedClanTagWithHash || "Our Clan";
     const applyPlaceholders = (planText: string): string =>
       planText.replace(/\{opponent\}/gi, opponentName).replace(/\{clan\}/gi, clanName);
+    const forcedLoseStyle =
+      options?.forcedLoseStyle === "TRADITIONAL" || options?.forcedLoseStyle === "TRIPLE_TOP_30"
+        ? options.forcedLoseStyle
+        : null;
     let loseStyleCache: FwaLoseStyle | null = null;
     const getLoseStyle = async (): Promise<FwaLoseStyle> => {
+      if (forcedLoseStyle) return forcedLoseStyle;
       if (!loseStyleCache) {
         loseStyleCache = await this.getLoseStyleForClan(normalizedClanTag);
       }

--- a/tests/warPlanText.test.ts
+++ b/tests/warPlanText.test.ts
@@ -161,4 +161,110 @@ describe("WarEventHistoryService.buildWarPlanText", () => {
       })
     );
   });
+
+  it("uses forced traditional lose style for editable default lookup", async () => {
+    const svc = new WarEventHistoryService({} as never);
+    const planSpy = vi.spyOn(prisma.clanWarPlan, "findFirst");
+    planSpy
+      .mockResolvedValueOnce(null as any)
+      .mockResolvedValueOnce({ planText: "Traditional default {clan} vs {opponent}" } as any);
+
+    const out = await svc.buildWarPlanText(
+      "123456789012345678",
+      "FWA",
+      "LOSE",
+      "",
+      "OPPONENT_NAME",
+      "battle",
+      "CLAN_NAME",
+      { forcedLoseStyle: "TRADITIONAL" }
+    );
+
+    expect(out).toBe("Traditional default CLAN_NAME vs OPPONENT_NAME");
+    expect(planSpy).toHaveBeenCalledTimes(2);
+    expect(planSpy.mock.calls[1]?.[0]).toEqual(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          guildId: "123456789012345678",
+          scope: "DEFAULT",
+          matchType: "FWA",
+          outcome: "LOSE",
+          loseStyle: { in: ["TRADITIONAL", "ANY"] },
+        }),
+      })
+    );
+  });
+
+  it("uses forced triple-top-30 lose style for editable default lookup", async () => {
+    const svc = new WarEventHistoryService({} as never);
+    const planSpy = vi.spyOn(prisma.clanWarPlan, "findFirst");
+    planSpy
+      .mockResolvedValueOnce(null as any)
+      .mockResolvedValueOnce({ planText: "Triple default {clan} vs {opponent}" } as any);
+
+    const out = await svc.buildWarPlanText(
+      "123456789012345678",
+      "FWA",
+      "LOSE",
+      "",
+      "OPPONENT_NAME",
+      "battle",
+      "CLAN_NAME",
+      { forcedLoseStyle: "TRIPLE_TOP_30" }
+    );
+
+    expect(out).toBe("Triple default CLAN_NAME vs OPPONENT_NAME");
+    expect(planSpy).toHaveBeenCalledTimes(2);
+    expect(planSpy.mock.calls[1]?.[0]).toEqual(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          guildId: "123456789012345678",
+          scope: "DEFAULT",
+          matchType: "FWA",
+          outcome: "LOSE",
+          loseStyle: { in: ["TRIPLE_TOP_30", "ANY"] },
+        }),
+      })
+    );
+  });
+
+  it("uses forced traditional lose style for built-in fallback when no db plan exists", async () => {
+    const svc = new WarEventHistoryService({} as never);
+    const planSpy = vi.spyOn(prisma.clanWarPlan, "findFirst");
+    planSpy.mockResolvedValueOnce(null as any).mockResolvedValueOnce(null as any);
+
+    const out = await svc.buildWarPlanText(
+      "123456789012345678",
+      "FWA",
+      "LOSE",
+      "",
+      "OPPONENT_NAME",
+      "battle",
+      "CLAN_NAME",
+      { forcedLoseStyle: "TRADITIONAL" }
+    );
+
+    expect(out).toContain("Last 12hrs");
+    expect(out).toContain("Do NOT surpass 100");
+  });
+
+  it("uses forced triple-top-30 lose style for built-in fallback when no db plan exists", async () => {
+    const svc = new WarEventHistoryService({} as never);
+    const planSpy = vi.spyOn(prisma.clanWarPlan, "findFirst");
+    planSpy.mockResolvedValueOnce(null as any).mockResolvedValueOnce(null as any);
+
+    const out = await svc.buildWarPlanText(
+      "123456789012345678",
+      "FWA",
+      "LOSE",
+      "",
+      "OPPONENT_NAME",
+      "battle",
+      "CLAN_NAME",
+      { forcedLoseStyle: "TRIPLE_TOP_30" }
+    );
+
+    expect(out).toContain("top 30");
+    expect(out).toContain("Do NOT attack the bottom 20 bases");
+  });
 });


### PR DESCRIPTION
- remove sentinel clan-tag fallback for default prefill resolution
- add explicit forced lose-style override in war-plan text resolver
- ensure `/warplan set` prefill resolves latest FWA lose default variants
- add regression tests for traditional/triple defaults and built-in fallback

- update `phase2-validate-staged-corrections.js` to accept dynamic target sets via:
  - `--target-file <path>`
  - `--target-war-ids <csv>`
- keep validator fail-closed membership checks (exact set, no duplicates, strict row validation)
- update `phase2-apply-archive-corrections.js` with the same target-set parameterization
- preserve apply safety rails:
  - dry-run default
  - no writes unless `--apply`
  - strict staged-file validation
  - strict DB invariant checks
  - backup export and post-apply verification
- add target config artifacts:
  - `scripts/phase2-targets-staging.json`
  - `scripts/phase2-targets-production.json` (`1000026..1000033`)
- maintain staging usability via default target config while enabling safe production targeting