### PR TITLE
fix(fwa-mail): place plan text before role mention in posts

### DIFF
--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -2448,10 +2448,10 @@ function buildWarMailPostedContent(
     return nextRefresh || "War plan unavailable.";
   }
   const sections: string[] = [];
+  sections.push(planText);
   if (normalizedRoleId && options?.pingRole !== false) {
     sections.push(`<@&${normalizedRoleId}>`);
   }
-  sections.push(planText);
   if (nextRefresh) {
     sections.push(nextRefresh);
   }
@@ -2470,8 +2470,7 @@ function extractPostedWarMailMentionRoleId(
     const trimmed = line.trim();
     if (!trimmed) continue;
     const match = trimmed.match(/^<@&(\d{5,})>$/);
-    if (!match?.[1]) return null;
-    return normalizeDiscordRoleId(match[1]);
+    if (match?.[1]) return normalizeDiscordRoleId(match[1]);
   }
   return null;
 }

--- a/tests/fwaMailDownstream.logic.test.ts
+++ b/tests/fwaMailDownstream.logic.test.ts
@@ -55,7 +55,7 @@ describe("fwa war-mail posted content", () => {
       planText: "Custom war mail line 1\nCustom war mail line 2",
     });
     expect(content).toBe(
-      "<@&123456789>\n\nCustom war mail line 1\nCustom war mail line 2\n\nNext refresh <t:1200:R>"
+      "Custom war mail line 1\nCustom war mail line 2\n\n<@&123456789>\n\nNext refresh <t:1200:R>"
     );
   });
 
@@ -64,7 +64,7 @@ describe("fwa war-mail posted content", () => {
       pingRole: true,
       planText: "Plan body",
     });
-    expect(content).toBe("<@&123456789>\n\nPlan body\n\nNext refresh <t:1200:R>");
+    expect(content).toBe("Plan body\n\n<@&123456789>\n\nNext refresh <t:1200:R>");
   });
 
   it("can omit next-refresh line for frozen mail posts", () => {
@@ -73,19 +73,29 @@ describe("fwa war-mail posted content", () => {
       planText: "Plan body",
       includeNextRefresh: false,
     });
-    expect(content).toBe("<@&123456789>\n\nPlan body");
+    expect(content).toBe("Plan body\n\n<@&123456789>");
   });
 });
 
 describe("fwa war-mail refresh edit payload", () => {
   it("preserves existing visible role mention in refreshed content", () => {
     const payload = buildWarMailRefreshEditPayloadForTest(
+      "Old plan\n\n<@&123456789>\n\nNext refresh <t:999:R>",
+      "New plan",
+      0
+    );
+
+    expect(payload.content).toBe("New plan\n\n<@&123456789>\n\nNext refresh <t:1200:R>");
+  });
+
+  it("preserves mention in refresh edits for legacy mention-first content", () => {
+    const payload = buildWarMailRefreshEditPayloadForTest(
       "<@&123456789>\n\nOld plan\n\nNext refresh <t:999:R>",
       "New plan",
       0
     );
 
-    expect(payload.content).toBe("<@&123456789>\n\nNew plan\n\nNext refresh <t:1200:R>");
+    expect(payload.content).toBe("New plan\n\n<@&123456789>\n\nNext refresh <t:1200:R>");
   });
 
   it("uses non-pinging allowedMentions on refresh edits", () => {


### PR DESCRIPTION
- reorder posted mail content to `plan -> mention -> refresh`
- preserve visible role mention on refresh for both new and legacy post layouts
- update downstream logic tests for ordering and legacy refresh compatibility

- update `phase2-validate-staged-corrections.js` to accept dynamic target sets via:
  - `--target-file <path>`
  - `--target-war-ids <csv>`
- keep validator fail-closed membership checks (exact set, no duplicates, strict row validation)
- update `phase2-apply-archive-corrections.js` with the same target-set parameterization
- preserve apply safety rails:
  - dry-run default
  - no writes unless `--apply`
  - strict staged-file validation
  - strict DB invariant checks
  - backup export and post-apply verification
- add target config artifacts:
  - `scripts/phase2-targets-staging.json`
  - `scripts/phase2-targets-production.json` (`1000026..1000033`)
- maintain staging usability via default target config while enabling safe production targeting