### PR TITLE
fix(fwa-mail): place plan text before role mention in posts

### DIFF
--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -3997,13 +3997,22 @@ async function showWarMailPreview(
   const previewSummary = enabled
     ? "Review mail preview and confirm send."
     : ["Cannot send yet.", ...warnings].join("\n");
+  const previewMentionRoleId = normalizeDiscordRoleId(rendered.clanRoleId);
+  const previewMailText = buildWarMailPostedContent(previewMentionRoleId, undefined, {
+    pingRole: true,
+    planText: rendered.planText,
+    includeNextRefresh: !rendered.freezeRefresh,
+  });
   const content = limitDiscordContent(
-    [previewSummary, "", "**Mail Text Preview**", rendered.planText].filter((part) => part.trim().length > 0).join("\n")
+    [previewSummary, "", "**Mail Text Preview**", previewMailText]
+      .filter((part) => part.trim().length > 0)
+      .join("\n")
   );
 
   if (interaction.isButton()) {
     await interaction.update({
       content,
+      allowedMentions: { parse: [] },
       embeds: [rendered.embed],
       components: buildWarMailPreviewComponents({
         userId,
@@ -4017,6 +4026,7 @@ async function showWarMailPreview(
 
   await interaction.editReply({
     content,
+    allowedMentions: { parse: [] },
     embeds: [rendered.embed],
     components: buildWarMailPreviewComponents({
       userId,


### PR DESCRIPTION
- reorder posted mail content to `plan -> mention -> refresh`
- preserve visible role mention on refresh for both new and legacy post layouts
- align preview body composition with posted content ordering
- suppress preview mention pings with non-parsing allowedMentions
- update downstream logic tests for ordering and legacy refresh compatibility

- update `phase2-validate-staged-corrections.js` to accept dynamic target sets via:
  - `--target-file <path>`
  - `--target-war-ids <csv>`
- keep validator fail-closed membership checks (exact set, no duplicates, strict row validation)
- update `phase2-apply-archive-corrections.js` with the same target-set parameterization
- preserve apply safety rails:
  - dry-run default
  - no writes unless `--apply`
  - strict staged-file validation
  - strict DB invariant checks
  - backup export and post-apply verification
- add target config artifacts:
  - `scripts/phase2-targets-staging.json`
  - `scripts/phase2-targets-production.json` (`1000026..1000033`)
- maintain staging usability via default target config while enabling safe production targeting