### PR TITLE
fix(war-events): keep heading first line in embed war plan text

### DIFF
--- a/src/services/WarEventLogService.ts
+++ b/src/services/WarEventLogService.ts
@@ -370,12 +370,18 @@ function buildWarStatsLines(stats: EmbedWarStats): string[] {
   ];
 }
 
-/** Purpose: omit markdown heading lines from war-plan text for embed rendering only. */
+/** Purpose: normalize markdown heading prefixes from war-plan text for embed rendering only. */
 function sanitizeWarPlanForEmbed(planText: string | null | undefined): string | null {
   if (!planText) return null;
-  const filtered = planText.split(/\r?\n/).filter((line) => !/^\s*#/.test(line));
-  if (filtered.length === 0) return null;
-  return filtered.join("\n");
+  const normalized = planText.split(/\r?\n/).map((line) => {
+    const headingMatch = line.match(/^(\s*)#{1,6}(?:\s+|$)(.*)$/);
+    if (!headingMatch) return line;
+    const leading = headingMatch[1] ?? "";
+    const remainder = headingMatch[2] ?? "";
+    return `${leading}${remainder}`;
+  });
+  if (!normalized.some((line) => line.trim().length > 0)) return null;
+  return normalized.join("\n");
 }
 
 export const sanitizeWarPlanForEmbedForTest = sanitizeWarPlanForEmbed;

--- a/tests/warEventLog.logic.test.ts
+++ b/tests/warEventLog.logic.test.ts
@@ -395,7 +395,7 @@ describe("WarEventLogService.computeWarComplianceForTest", () => {
 });
 
 describe("WarEventLogService.sanitizeWarPlanForEmbedForTest", () => {
-  it("omits heading-style lines and keeps non-heading lines in order", () => {
+  it("normalizes heading-style prefixes and keeps line order", () => {
     const text = [
       "# Title",
       "Line 1",
@@ -408,7 +408,15 @@ describe("WarEventLogService.sanitizeWarPlanForEmbedForTest", () => {
 
     const sanitized = sanitizeWarPlanForEmbedForTest(text);
 
-    expect(sanitized?.split("\n")).toEqual(["Line 1", "", "  - Keep this", "Line 2"]);
+    expect(sanitized?.split("\n")).toEqual([
+      "Title",
+      "Line 1",
+      "  Subtitle",
+      "",
+      "  - Keep this",
+      "   Internal Header",
+      "Line 2",
+    ]);
   });
 
   it("keeps plans without heading lines unchanged", () => {
@@ -419,10 +427,16 @@ describe("WarEventLogService.sanitizeWarPlanForEmbedForTest", () => {
     expect(sanitized).toBe(text);
   });
 
-  it("returns null when all lines are heading-style lines", () => {
-    const text = ["# Title", "  ## Subtitle", "   ### More"].join("\n");
+  it("returns null when heading-only lines sanitize to empty content", () => {
+    const text = ["#   ", "  ##   ", "   ###"].join("\n");
 
     expect(sanitizeWarPlanForEmbedForTest(text)).toBeNull();
+  });
+
+  it("does not alter # characters that are not markdown heading prefixes", () => {
+    const text = ["Line #1", "  - # keep", "#not-a-heading", "foo #bar baz"].join("\n");
+    const sanitized = sanitizeWarPlanForEmbedForTest(text);
+    expect(sanitized).toBe(text);
   });
 });
 


### PR DESCRIPTION
- change war-plan sanitizer to strip leading markdown heading prefixes
- preserve heading line content instead of dropping full lines
- keep non-heading `#` usage untouched
- update sanitizer regression tests for normalized heading behavior