### PR TITLE
fix(fwa-compliance): improve not-following plan output details

### DIFF
--- a/src/commands/fwa/complianceView.ts
+++ b/src/commands/fwa/complianceView.ts
@@ -8,13 +8,25 @@ function formatMemberLabel(issue: WarComplianceIssue): string {
   return `${name} (${tag})`;
 }
 
+/** Purpose: build compact not-following labels with participant position and no tag. */
+function formatNotFollowingLabel(issue: WarComplianceIssue): string {
+  const name = String(issue.playerName ?? "").trim() || "Unknown member";
+  const posRaw = Number(issue.playerPosition ?? NaN);
+  if (Number.isFinite(posRaw) && posRaw > 0) {
+    return `#${Math.trunc(posRaw)}. ${name}`;
+  }
+  return name;
+}
+
 /** Purpose: format compliance issues into bounded output lines for Discord replies. */
 function formatIssueLines(issues: WarComplianceIssue[], limit = 12): string[] {
   const visible = issues.slice(0, limit);
   const lines = visible.map((issue) => {
-    const member = formatMemberLabel(issue);
     const actual = String(issue.actualBehavior ?? "").trim() || "No details available.";
-    return `- ${member}: ${actual}`;
+    if (issue.ruleType === "not_following_plan") {
+      return `- ${formatNotFollowingLabel(issue)} --> ${actual}`;
+    }
+    return `- ${formatMemberLabel(issue)}: ${actual}`;
   });
   const hidden = issues.length - visible.length;
   if (hidden > 0) {

--- a/src/services/WarComplianceService.ts
+++ b/src/services/WarComplianceService.ts
@@ -14,6 +14,7 @@ import {
 export type WarComplianceIssue = {
   playerTag: string;
   playerName: string;
+  playerPosition?: number | null;
   ruleType: "missed_both" | "not_following_plan";
   expectedBehavior: string;
   actualBehavior: string;
@@ -127,6 +128,138 @@ function getParticipantLabel(input: { playerName: string | null; playerTag: stri
   return name || input.playerTag;
 }
 
+type AttackContext = {
+  starsBeforeAttack: number;
+  hoursRemaining: number | null;
+  isStrictWindow: boolean;
+  isMirror: boolean;
+};
+
+/** Purpose: format numeric stars as the visual triplet required by compliance output. */
+function formatStarTriplet(stars: number | null | undefined): string {
+  const normalized = Math.max(0, Math.min(3, Number(stars ?? 0)));
+  if (normalized >= 3) return "★ ★ ★";
+  if (normalized >= 2) return "★ ★ ☆";
+  if (normalized >= 1) return "★ ☆ ☆";
+  return "☆ ☆ ☆";
+}
+
+/** Purpose: format strict-window timing as `Xh Ym left` for deterministic output. */
+function formatTimeRemaining(hoursRemaining: number | null): string {
+  if (hoursRemaining === null || !Number.isFinite(hoursRemaining)) return "unknown left";
+  const totalMinutes = Math.max(0, Math.floor(hoursRemaining * 60));
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return `${hours}h ${minutes}m left`;
+}
+
+/** Purpose: compute strict-window metadata once using the same ordering/rules as compliance checks. */
+function buildAttackContextByAttack(attacks: WarComplianceAttack[]): Map<WarComplianceAttack, AttackContext> {
+  const ordered = [...attacks].sort((a, b) => {
+    const t = a.attackSeenAt.getTime() - b.attackSeenAt.getTime();
+    if (t !== 0) return t;
+    const o = Number(a.attackOrder ?? 0) - Number(b.attackOrder ?? 0);
+    if (o !== 0) return o;
+    return normalizeTag(a.playerTag).localeCompare(normalizeTag(b.playerTag));
+  });
+
+  const result = new Map<WarComplianceAttack, AttackContext>();
+  let cumulativeClanStars = 0;
+  for (const attack of ordered) {
+    const starsBeforeAttack = cumulativeClanStars;
+    const gain = Math.max(0, Number(attack.trueStars ?? 0));
+    cumulativeClanStars += gain;
+
+    const hoursRemaining =
+      attack.warEndTime instanceof Date
+        ? (attack.warEndTime.getTime() - attack.attackSeenAt.getTime()) / (60 * 60 * 1000)
+        : null;
+    const isStrictWindow =
+      hoursRemaining !== null &&
+      Number.isFinite(hoursRemaining) &&
+      hoursRemaining > 12 &&
+      starsBeforeAttack < 100;
+    const playerPos = attack.playerPosition ?? null;
+    const defenderPos = attack.defenderPosition ?? null;
+    const isMirror = playerPos !== null && defenderPos !== null && playerPos === defenderPos;
+
+    result.set(attack, {
+      starsBeforeAttack,
+      hoursRemaining,
+      isStrictWindow,
+      isMirror,
+    });
+  }
+  return result;
+}
+
+type NotFollowingReason = {
+  label: string;
+  strictWindowContext: {
+    starsBeforeAttack: number;
+    timeRemaining: string;
+  } | null;
+};
+
+/** Purpose: compute a user-facing violation reason without changing compliance policy decisions. */
+function describeNotFollowingReason(input: {
+  playerAttacks: WarComplianceAttack[];
+  attackContextByAttack: Map<WarComplianceAttack, AttackContext>;
+  matchType: MatchType;
+  expectedOutcome: "WIN" | "LOSE" | null;
+  loseStyle: FwaLoseStyle;
+}): NotFollowingReason {
+  if (input.matchType === "FWA" && input.expectedOutcome === "WIN") {
+    let strictWindowSeen = false;
+    let mirrorTripleSeen = false;
+    let fallbackStrictContext: NotFollowingReason["strictWindowContext"] = null;
+
+    for (const attack of input.playerAttacks) {
+      const ctx = input.attackContextByAttack.get(attack);
+      if (!ctx?.isStrictWindow) continue;
+      strictWindowSeen = true;
+      const strictContext = {
+        starsBeforeAttack: ctx.starsBeforeAttack,
+        timeRemaining: formatTimeRemaining(ctx.hoursRemaining),
+      };
+      fallbackStrictContext = fallbackStrictContext ?? strictContext;
+
+      const stars = Number(attack.stars ?? 0);
+      const trueStars = Number(attack.trueStars ?? 0);
+      if (ctx.isMirror && stars >= 3) {
+        mirrorTripleSeen = true;
+      }
+      if (!ctx.isMirror && stars === 3 && trueStars > 0) {
+        return {
+          label: "tripled non-mirror in strict window",
+          strictWindowContext: strictContext,
+        };
+      }
+    }
+
+    if (strictWindowSeen && !mirrorTripleSeen) {
+      return {
+        label: "didn't triple mirror",
+        strictWindowContext: fallbackStrictContext,
+      };
+    }
+
+    return {
+      label: "didn't follow win plan",
+      strictWindowContext: fallbackStrictContext,
+    };
+  }
+
+  if (input.matchType === "FWA" && input.expectedOutcome === "LOSE") {
+    if (input.loseStyle === "TRIPLE_TOP_30") {
+      return { label: "attacked outside top-30", strictWindowContext: null };
+    }
+    return { label: "didn't follow lose-style rules", strictWindowContext: null };
+  }
+
+  return { label: "hit non-mirror target", strictWindowContext: null };
+}
+
 /** Purpose: describe expected plan behavior for actionable compliance output lines. */
 function describeExpectedPlanBehavior(input: {
   matchType: MatchType;
@@ -149,25 +282,41 @@ function describeExpectedPlanBehavior(input: {
 
 /** Purpose: summarize observed attack behavior for one player in command output. */
 function describeActualBehaviorForPlayer(
-  playerTag: string,
-  attacksByPlayerTag: Map<string, WarComplianceAttack[]>,
-  attacksUsedByPlayerTag: Map<string, number>
-): string {
-  const normalizedTag = normalizeTag(playerTag);
-  const attacksUsed = attacksUsedByPlayerTag.get(normalizedTag) ?? 0;
-  const playerAttacks = attacksByPlayerTag.get(normalizedTag) ?? [];
-  if (playerAttacks.length === 0) {
-    return `Attacks used: ${attacksUsed}. No attack rows recorded.`;
+  input: {
+    playerTag: string;
+    attacksByPlayerTag: Map<string, WarComplianceAttack[]>;
+    attackContextByAttack: Map<WarComplianceAttack, AttackContext>;
+    matchType: MatchType;
+    expectedOutcome: "WIN" | "LOSE" | null;
+    loseStyle: FwaLoseStyle;
   }
-  const attackSummaries = playerAttacks
+): string {
+  const normalizedTag = normalizeTag(input.playerTag);
+  const playerAttacks = input.attacksByPlayerTag.get(normalizedTag) ?? [];
+  if (playerAttacks.length === 0) {
+    return "No attack rows recorded.";
+  }
+  const orderedAttacks = playerAttacks
     .slice()
     .sort((a, b) => {
       const orderDelta = Number(a.attackOrder ?? 0) - Number(b.attackOrder ?? 0);
       if (orderDelta !== 0) return orderDelta;
       return a.attackSeenAt.getTime() - b.attackSeenAt.getTime();
-    })
-    .map((row) => `#${row.defenderPosition ?? "?"} (${row.stars ?? 0}*)`);
-  return `Attacks used: ${attacksUsed}. Targets: ${attackSummaries.join(", ")}.`;
+    });
+  const attackSummaries = orderedAttacks.map(
+    (row) => `#${row.defenderPosition ?? "?"} (${formatStarTriplet(row.stars)})`
+  );
+  const reason = describeNotFollowingReason({
+    playerAttacks: orderedAttacks,
+    attackContextByAttack: input.attackContextByAttack,
+    matchType: input.matchType,
+    expectedOutcome: input.expectedOutcome,
+    loseStyle: input.loseStyle,
+  });
+  const strictSuffix = reason.strictWindowContext
+    ? ` | ${reason.strictWindowContext.starsBeforeAttack}★ | ${reason.strictWindowContext.timeRemaining}`
+    : "";
+  return `${attackSummaries.join(", ")} : ${reason.label}${strictSuffix}`;
 }
 
 /** Purpose: map rule-engine name output into detailed issues for user-facing command output. */
@@ -177,7 +326,10 @@ function mapNamesToIssues(input: {
   expectedBehavior: string;
   participantByLabel: Map<string, WarComplianceParticipant>;
   attacksByPlayerTag: Map<string, WarComplianceAttack[]>;
-  attacksUsedByPlayerTag: Map<string, number>;
+  attackContextByAttack: Map<WarComplianceAttack, AttackContext>;
+  matchType: MatchType;
+  expectedOutcome: "WIN" | "LOSE" | null;
+  loseStyle: FwaLoseStyle;
 }): WarComplianceIssue[] {
   return input.names.map((name) => {
     const participant = input.participantByLabel.get(name) ?? null;
@@ -185,14 +337,18 @@ function mapNamesToIssues(input: {
     const actualBehavior =
       input.ruleType === "missed_both"
         ? `Attacks used: ${participant?.attacksUsed ?? 0}.`
-        : describeActualBehaviorForPlayer(
+        : describeActualBehaviorForPlayer({
             playerTag,
-            input.attacksByPlayerTag,
-            input.attacksUsedByPlayerTag
-          );
+            attacksByPlayerTag: input.attacksByPlayerTag,
+            attackContextByAttack: input.attackContextByAttack,
+            matchType: input.matchType,
+            expectedOutcome: input.expectedOutcome,
+            loseStyle: input.loseStyle,
+          });
     return {
       playerTag,
       playerName: name,
+      playerPosition: participant?.playerPosition ?? null,
       ruleType: input.ruleType,
       expectedBehavior: input.expectedBehavior,
       actualBehavior,
@@ -1005,7 +1161,7 @@ export class WarComplianceService {
 
     const participantByLabel = new Map<string, WarComplianceParticipant>();
     const attacksByPlayerTag = new Map<string, WarComplianceAttack[]>();
-    const attacksUsedByPlayerTag = new Map<string, number>();
+    const attackContextByAttack = buildAttackContextByAttack(context.attacks);
 
     for (const participant of context.participants) {
       const label = getParticipantLabel({
@@ -1013,10 +1169,6 @@ export class WarComplianceService {
         playerTag: participant.playerTag,
       });
       participantByLabel.set(label, participant);
-      attacksUsedByPlayerTag.set(
-        normalizeTag(participant.playerTag),
-        Number(participant.attacksUsed ?? 0)
-      );
     }
     for (const attack of context.attacks) {
       const tag = normalizeTag(attack.playerTag);
@@ -1045,7 +1197,10 @@ export class WarComplianceService {
         expectedBehavior: "Use both attacks for the war.",
         participantByLabel,
         attacksByPlayerTag,
-        attacksUsedByPlayerTag,
+        attackContextByAttack,
+        matchType: context.matchType,
+        expectedOutcome: context.expectedOutcome,
+        loseStyle,
       }),
       notFollowingPlan: mapNamesToIssues({
         names: snapshot.notFollowingPlan,
@@ -1053,7 +1208,10 @@ export class WarComplianceService {
         expectedBehavior: expectedPlanBehavior,
         participantByLabel,
         attacksByPlayerTag,
-        attacksUsedByPlayerTag,
+        attackContextByAttack,
+        matchType: context.matchType,
+        expectedOutcome: context.expectedOutcome,
+        loseStyle,
       }),
       participantsCount: context.participants.length,
       attacksCount: context.attacks.length,

--- a/tests/fwaComplianceView.logic.test.ts
+++ b/tests/fwaComplianceView.logic.test.ts
@@ -40,6 +40,7 @@ describe("buildWarComplianceReportLines", () => {
         {
           playerTag: "#P1",
           playerName: "Player One",
+          playerPosition: 1,
           ruleType: "missed_both",
           expectedBehavior: "Use both attacks for the war.",
           actualBehavior: "Attacks used: 0.",
@@ -49,9 +50,11 @@ describe("buildWarComplianceReportLines", () => {
         {
           playerTag: "#P2",
           playerName: "Player Two",
+          playerPosition: 2,
           ruleType: "not_following_plan",
           expectedBehavior: "Mirror triple in strict window; avoid off-mirror triples/zeros.",
-          actualBehavior: "Attacks used: 2. Targets: #1 (2*), #4 (3*).",
+          actualBehavior:
+            "#1 (★ ★ ☆), #4 (★ ★ ★) : tripled non-mirror in strict window | 56★ | 22h 1m left",
         },
       ],
     };
@@ -66,7 +69,10 @@ describe("buildWarComplianceReportLines", () => {
     expect(text).toContain("Player One (#P1): Attacks used: 0.");
     expect(text).toContain("Didn't follow war plan:");
     expect(text).toContain("Expected: Mirror triple in strict window; avoid off-mirror triples/zeros.");
-    expect(text).toContain("Player Two (#P2): Attacks used: 2.");
+    expect(text).toContain(
+      "#2. Player Two --> #1 (★ ★ ☆), #4 (★ ★ ★) : tripled non-mirror in strict window"
+    );
+    expect(text).not.toContain("Attacks used: 2.");
   });
 });
 

--- a/tests/warCompliance.service.test.ts
+++ b/tests/warCompliance.service.test.ts
@@ -73,6 +73,80 @@ describe("WarComplianceService", () => {
     expect(snapshot).toEqual(expected);
   });
 
+  it("formats not-following-plan behavior with stars, reason, and strict-window context", async () => {
+    const warStartTime = new Date("2026-02-01T00:00:00.000Z");
+    const warEndTime = new Date("2026-02-02T00:00:00.000Z");
+    const participants = [
+      { playerName: "lotus", playerTag: "#P2", attacksUsed: 2, playerPosition: 5 },
+      { playerName: "mirror", playerTag: "#P1", attacksUsed: 1, playerPosition: 1 },
+    ];
+    const attacks = [
+      {
+        playerTag: "#P1",
+        playerName: "mirror",
+        playerPosition: 1,
+        defenderPosition: 1,
+        stars: 3,
+        trueStars: 3,
+        attackSeenAt: new Date("2026-02-01T01:00:00.000Z"),
+        warEndTime,
+        attackOrder: 1,
+      },
+      {
+        playerTag: "#P2",
+        playerName: "lotus",
+        playerPosition: 5,
+        defenderPosition: 14,
+        stars: 3,
+        trueStars: 3,
+        attackSeenAt: new Date("2026-02-01T02:00:00.000Z"),
+        warEndTime,
+        attackOrder: 2,
+      },
+      {
+        playerTag: "#P2",
+        playerName: "lotus",
+        playerPosition: 5,
+        defenderPosition: 5,
+        stars: 3,
+        trueStars: 3,
+        attackSeenAt: new Date("2026-02-01T03:00:00.000Z"),
+        warEndTime,
+        attackOrder: 3,
+      },
+    ];
+
+    vi.spyOn(prisma.warAttacks, "findFirst").mockResolvedValue({
+      warStartTime,
+      warEndTime,
+      warId: 777,
+    } as any);
+    vi.spyOn(prisma.warAttacks, "findMany")
+      .mockResolvedValueOnce(participants as any)
+      .mockResolvedValueOnce(attacks as any);
+    vi.spyOn(prisma.trackedClan, "findFirst").mockResolvedValue({
+      loseStyle: "TRADITIONAL",
+    } as any);
+
+    const service = new WarComplianceService();
+    const report = await service.getComplianceReport({
+      clanTag: "#TEST",
+      preferredWarStartTime: warStartTime,
+      matchType: "FWA",
+      expectedOutcome: "WIN",
+    });
+
+    expect(report).not.toBeNull();
+    const lotus = report?.notFollowingPlan.find((row) => row.playerName === "lotus");
+    expect(lotus).toBeTruthy();
+    expect(lotus?.playerPosition).toBe(5);
+    expect(lotus?.actualBehavior).toContain("#14 (★ ★ ★)");
+    expect(lotus?.actualBehavior).toContain("#5 (★ ★ ★)");
+    expect(lotus?.actualBehavior).toContain("tripled non-mirror in strict window");
+    expect(lotus?.actualBehavior).toContain("★ |");
+    expect(lotus?.actualBehavior).not.toContain("Attacks used:");
+  });
+
   it("returns null report for BL/MM checks without hitting DB", async () => {
     const findFirstSpy = vi.spyOn(prisma.warAttacks, "findFirst");
     const service = new WarComplianceService();


### PR DESCRIPTION
- switch target stars to visual triplets in not-following-plan lines
- remove redundant attack-count text from not-following-plan details
- format member labels as `#position. name -->` without player tags
- append explicit violation reasons and strict-window context metadata
- add regression coverage for view formatting and service-generated details