### PR TITLE
fix(fwa-compliance): use first-breach context for strict-window output

### DIFF
--- a/src/commands/fwa/complianceView.ts
+++ b/src/commands/fwa/complianceView.ts
@@ -22,11 +22,15 @@ function formatNotFollowingLabel(issue: WarComplianceIssue): string {
 function formatIssueLines(issues: WarComplianceIssue[], limit = 12): string[] {
   const visible = issues.slice(0, limit);
   const lines = visible.map((issue) => {
-    const actual = String(issue.actualBehavior ?? "").trim() || "No details available.";
     if (issue.ruleType === "not_following_plan") {
+      const actual = String(issue.actualBehavior ?? "").trim() || "No details available.";
       return `- ${formatNotFollowingLabel(issue)} --> ${actual}`;
     }
-    return `- ${formatMemberLabel(issue)}: ${actual}`;
+    const actual = String(issue.actualBehavior ?? "").trim();
+    if (actual) {
+      return `- ${formatMemberLabel(issue)}: ${actual}`;
+    }
+    return `- ${formatMemberLabel(issue)}`;
   });
   const hidden = issues.length - visible.length;
   if (hidden > 0) {

--- a/src/services/WarComplianceService.ts
+++ b/src/services/WarComplianceService.ts
@@ -135,6 +135,20 @@ type AttackContext = {
   isMirror: boolean;
 };
 
+/** Purpose: ensure all compliance-side attack iteration uses the same deterministic chronology. */
+function compareAttacksForComplianceOrder(a: WarComplianceAttack, b: WarComplianceAttack): number {
+  const timeDelta = a.attackSeenAt.getTime() - b.attackSeenAt.getTime();
+  if (timeDelta !== 0) return timeDelta;
+  const orderDelta = Number(a.attackOrder ?? 0) - Number(b.attackOrder ?? 0);
+  if (orderDelta !== 0) return orderDelta;
+  return normalizeTag(a.playerTag).localeCompare(normalizeTag(b.playerTag));
+}
+
+/** Purpose: sort attacks in the same chronology used by the shared compliance rule engine. */
+function sortAttacksForComplianceOrder(attacks: WarComplianceAttack[]): WarComplianceAttack[] {
+  return [...attacks].sort(compareAttacksForComplianceOrder);
+}
+
 /** Purpose: format numeric stars as the visual triplet required by compliance output. */
 function formatStarTriplet(stars: number | null | undefined): string {
   const normalized = Math.max(0, Math.min(3, Number(stars ?? 0)));
@@ -155,13 +169,7 @@ function formatTimeRemaining(hoursRemaining: number | null): string {
 
 /** Purpose: compute strict-window metadata once using the same ordering/rules as compliance checks. */
 function buildAttackContextByAttack(attacks: WarComplianceAttack[]): Map<WarComplianceAttack, AttackContext> {
-  const ordered = [...attacks].sort((a, b) => {
-    const t = a.attackSeenAt.getTime() - b.attackSeenAt.getTime();
-    if (t !== 0) return t;
-    const o = Number(a.attackOrder ?? 0) - Number(b.attackOrder ?? 0);
-    if (o !== 0) return o;
-    return normalizeTag(a.playerTag).localeCompare(normalizeTag(b.playerTag));
-  });
+  const ordered = sortAttacksForComplianceOrder(attacks);
 
   const result = new Map<WarComplianceAttack, AttackContext>();
   let cumulativeClanStars = 0;
@@ -210,24 +218,23 @@ function describeNotFollowingReason(input: {
   loseStyle: FwaLoseStyle;
 }): NotFollowingReason {
   if (input.matchType === "FWA" && input.expectedOutcome === "WIN") {
-    let strictWindowSeen = false;
-    let mirrorTripleSeen = false;
-    let fallbackStrictContext: NotFollowingReason["strictWindowContext"] = null;
+    const orderedPlayerAttacks = sortAttacksForComplianceOrder(input.playerAttacks);
+    let firstStrictContext: NotFollowingReason["strictWindowContext"] = null;
+    let hasMirrorTripleInStrictWindow = false;
 
-    for (const attack of input.playerAttacks) {
+    for (const attack of orderedPlayerAttacks) {
       const ctx = input.attackContextByAttack.get(attack);
       if (!ctx?.isStrictWindow) continue;
-      strictWindowSeen = true;
       const strictContext = {
         starsBeforeAttack: ctx.starsBeforeAttack,
         timeRemaining: formatTimeRemaining(ctx.hoursRemaining),
       };
-      fallbackStrictContext = fallbackStrictContext ?? strictContext;
+      firstStrictContext = firstStrictContext ?? strictContext;
 
       const stars = Number(attack.stars ?? 0);
       const trueStars = Number(attack.trueStars ?? 0);
       if (ctx.isMirror && stars >= 3) {
-        mirrorTripleSeen = true;
+        hasMirrorTripleInStrictWindow = true;
       }
       if (!ctx.isMirror && stars === 3 && trueStars > 0) {
         return {
@@ -237,16 +244,16 @@ function describeNotFollowingReason(input: {
       }
     }
 
-    if (strictWindowSeen && !mirrorTripleSeen) {
+    if (firstStrictContext && !hasMirrorTripleInStrictWindow) {
       return {
         label: "didn't triple mirror",
-        strictWindowContext: fallbackStrictContext,
+        strictWindowContext: firstStrictContext,
       };
     }
 
     return {
       label: "didn't follow win plan",
-      strictWindowContext: fallbackStrictContext,
+      strictWindowContext: firstStrictContext,
     };
   }
 
@@ -296,13 +303,7 @@ function describeActualBehaviorForPlayer(
   if (playerAttacks.length === 0) {
     return "No attack rows recorded.";
   }
-  const orderedAttacks = playerAttacks
-    .slice()
-    .sort((a, b) => {
-      const orderDelta = Number(a.attackOrder ?? 0) - Number(b.attackOrder ?? 0);
-      if (orderDelta !== 0) return orderDelta;
-      return a.attackSeenAt.getTime() - b.attackSeenAt.getTime();
-    });
+  const orderedAttacks = sortAttacksForComplianceOrder(playerAttacks);
   const attackSummaries = orderedAttacks.map(
     (row) => `#${row.defenderPosition ?? "?"} (${formatStarTriplet(row.stars)})`
   );
@@ -336,7 +337,7 @@ function mapNamesToIssues(input: {
     const playerTag = normalizeTag(participant?.playerTag ?? "") || "UNKNOWN";
     const actualBehavior =
       input.ruleType === "missed_both"
-        ? `Attacks used: ${participant?.attacksUsed ?? 0}.`
+        ? ""
         : describeActualBehaviorForPlayer({
             playerTag,
             attacksByPlayerTag: input.attacksByPlayerTag,

--- a/tests/fwaComplianceView.logic.test.ts
+++ b/tests/fwaComplianceView.logic.test.ts
@@ -43,7 +43,7 @@ describe("buildWarComplianceReportLines", () => {
           playerPosition: 1,
           ruleType: "missed_both",
           expectedBehavior: "Use both attacks for the war.",
-          actualBehavior: "Attacks used: 0.",
+          actualBehavior: "",
         },
       ],
       notFollowingPlan: [
@@ -66,7 +66,8 @@ describe("buildWarComplianceReportLines", () => {
     }).join("\n");
 
     expect(text).toContain("Missed both attacks:");
-    expect(text).toContain("Player One (#P1): Attacks used: 0.");
+    expect(text).toContain("- Player One (#P1)");
+    expect(text).not.toContain("Attacks used: 0.");
     expect(text).toContain("Didn't follow war plan:");
     expect(text).toContain("Expected: Mirror triple in strict window; avoid off-mirror triples/zeros.");
     expect(text).toContain(

--- a/tests/warCompliance.service.test.ts
+++ b/tests/warCompliance.service.test.ts
@@ -73,7 +73,7 @@ describe("WarComplianceService", () => {
     expect(snapshot).toEqual(expected);
   });
 
-  it("formats not-following-plan behavior with stars, reason, and strict-window context", async () => {
+  it("uses the first offending attack context for strict-window non-mirror triples", async () => {
     const warStartTime = new Date("2026-02-01T00:00:00.000Z");
     const warEndTime = new Date("2026-02-02T00:00:00.000Z");
     const participants = [
@@ -101,18 +101,18 @@ describe("WarComplianceService", () => {
         trueStars: 3,
         attackSeenAt: new Date("2026-02-01T02:00:00.000Z"),
         warEndTime,
-        attackOrder: 2,
+        attackOrder: 99,
       },
       {
         playerTag: "#P2",
         playerName: "lotus",
         playerPosition: 5,
-        defenderPosition: 5,
+        defenderPosition: 8,
         stars: 3,
         trueStars: 3,
         attackSeenAt: new Date("2026-02-01T03:00:00.000Z"),
         warEndTime,
-        attackOrder: 3,
+        attackOrder: 1,
       },
     ];
 
@@ -140,11 +140,81 @@ describe("WarComplianceService", () => {
     const lotus = report?.notFollowingPlan.find((row) => row.playerName === "lotus");
     expect(lotus).toBeTruthy();
     expect(lotus?.playerPosition).toBe(5);
-    expect(lotus?.actualBehavior).toContain("#14 (★ ★ ★)");
-    expect(lotus?.actualBehavior).toContain("#5 (★ ★ ★)");
+    expect(lotus?.actualBehavior).toContain("#14");
+    expect(lotus?.actualBehavior).toContain("#8");
     expect(lotus?.actualBehavior).toContain("tripled non-mirror in strict window");
-    expect(lotus?.actualBehavior).toContain("★ |");
+    expect(lotus?.actualBehavior).toContain("| 3★ | 22h 0m left");
     expect(lotus?.actualBehavior).not.toContain("Attacks used:");
+  });
+
+  it("uses explicit first strict-window context for didn't-triple-mirror reason", async () => {
+    const warStartTime = new Date("2026-02-01T00:00:00.000Z");
+    const warEndTime = new Date("2026-02-02T00:00:00.000Z");
+    const participants = [
+      { playerName: "mirror", playerTag: "#P1", attacksUsed: 1, playerPosition: 1 },
+      { playerName: "Baby PK", playerTag: "#P3", attacksUsed: 2, playerPosition: 8 },
+    ];
+    const attacks = [
+      {
+        playerTag: "#P1",
+        playerName: "mirror",
+        playerPosition: 1,
+        defenderPosition: 1,
+        stars: 3,
+        trueStars: 3,
+        attackSeenAt: new Date("2026-02-01T01:00:00.000Z"),
+        warEndTime,
+        attackOrder: 1,
+      },
+      {
+        playerTag: "#P3",
+        playerName: "Baby PK",
+        playerPosition: 8,
+        defenderPosition: 8,
+        stars: 2,
+        trueStars: 2,
+        attackSeenAt: new Date("2026-02-01T02:00:00.000Z"),
+        warEndTime,
+        attackOrder: 50,
+      },
+      {
+        playerTag: "#P3",
+        playerName: "Baby PK",
+        playerPosition: 8,
+        defenderPosition: 9,
+        stars: 2,
+        trueStars: 2,
+        attackSeenAt: new Date("2026-02-01T03:00:00.000Z"),
+        warEndTime,
+        attackOrder: 2,
+      },
+    ];
+
+    vi.spyOn(prisma.warAttacks, "findFirst").mockResolvedValue({
+      warStartTime,
+      warEndTime,
+      warId: 888,
+    } as any);
+    vi.spyOn(prisma.warAttacks, "findMany")
+      .mockResolvedValueOnce(participants as any)
+      .mockResolvedValueOnce(attacks as any);
+    vi.spyOn(prisma.trackedClan, "findFirst").mockResolvedValue({
+      loseStyle: "TRADITIONAL",
+    } as any);
+
+    const service = new WarComplianceService();
+    const report = await service.getComplianceReport({
+      clanTag: "#TEST",
+      preferredWarStartTime: warStartTime,
+      matchType: "FWA",
+      expectedOutcome: "WIN",
+    });
+
+    expect(report).not.toBeNull();
+    const babyPk = report?.notFollowingPlan.find((row) => row.playerName === "Baby PK");
+    expect(babyPk).toBeTruthy();
+    expect(babyPk?.actualBehavior).toContain("didn't triple mirror");
+    expect(babyPk?.actualBehavior).toContain("| 3★ | 22h 0m left");
   });
 
   it("returns null report for BL/MM checks without hitting DB", async () => {


### PR DESCRIPTION
- align per-player breach reasoning to compliance-order attack chronology
- use first offending strict-window event for non-mirror triple context
- use explicit first strict-window context for didn't-triple-mirror lines
- remove redundant `Attacks used: 0` text from missed-both output rows
- add regression tests for first-breach context selection and missed-both formatting