### PR TITLE
feat(fwa): add paginated embed views for /fwa compliance

### DIFF
--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -26,7 +26,10 @@ import {
 } from "../services/CommandPermissionService";
 import { GoogleSheetsService } from "../services/GoogleSheetsService";
 import { SettingsService } from "../services/SettingsService";
-import { WarComplianceService } from "../services/WarComplianceService";
+import {
+  WarComplianceService,
+  type WarComplianceIssue,
+} from "../services/WarComplianceService";
 import { WarEventLogService } from "../services/WarEventLogService";
 import { FwaStatsWeightService } from "../services/FwaStatsWeightService";
 import { FwaStatsWeightCookieService } from "../services/FwaStatsWeightCookieService";
@@ -84,6 +87,7 @@ import {
 } from "../services/PointsDirectFetchGateService";
 import {
   buildFwaMailBackCustomId,
+  createTransientFwaKey,
   buildFwaMailConfirmCustomId,
   buildFwaMailConfirmNoPingCustomId,
   buildFwaMailRefreshCustomId,
@@ -100,6 +104,7 @@ import {
   buildOutcomeActionCustomId,
   buildPointsPostButtonCustomId,
   parseFwaMailBackCustomId,
+  parseFwaComplianceViewCustomId,
   parseFwaMailConfirmCustomId,
   parseFwaMailConfirmNoPingCustomId,
   parseFwaMailRefreshCustomId,
@@ -146,7 +151,10 @@ import {
   type WarMailExpectedOutcome,
   type WarMailMatchType,
 } from "./fwa/mailEmbedColor";
-import { buildWarComplianceReportLines } from "./fwa/complianceView";
+import {
+  buildFwaComplianceEmbedView,
+  type FwaComplianceActiveView,
+} from "./fwa/complianceEmbedView";
 import {
   WEIGHT_SEVERE_STALE_DAYS,
   WEIGHT_STALE_DAYS,
@@ -167,6 +175,7 @@ import {
 } from "./fwa/warScopedReuse";
 export { isMissedSyncClanForTest } from "./fwa/matchState";
 export {
+  isFwaComplianceViewButtonCustomId,
   isFwaMailBackButtonCustomId,
   isFwaMailConfirmButtonCustomId,
   isFwaMailConfirmNoPingButtonCustomId,
@@ -344,6 +353,39 @@ function parseComplianceWarTarget(input: string | null | undefined):
   };
 }
 
+/** Purpose: render a stored compliance-view payload into message-safe embed/components. */
+function renderComplianceViewPayload(input: {
+  key: string;
+  payload: FwaComplianceViewPayload;
+}): {
+  embeds: EmbedBuilder[];
+  components: ActionRowBuilder<ButtonBuilder>[];
+} {
+  const rendered = buildFwaComplianceEmbedView({
+    userId: input.payload.userId,
+    key: input.key,
+    isFwa: input.payload.isFwa,
+    clanName: input.payload.clanName,
+    warId: input.payload.warId,
+    expectedOutcome: input.payload.expectedOutcome,
+    warStartTime: input.payload.warStartTime,
+    warEndTime: input.payload.warEndTime,
+    participantsCount: input.payload.participantsCount,
+    attacksCount: input.payload.attacksCount,
+    missedBoth: input.payload.missedBoth,
+    notFollowingPlan: input.payload.notFollowingPlan,
+    activeView: input.payload.activeView,
+    mainPage: input.payload.mainPage,
+    missedPage: input.payload.missedPage,
+  });
+  input.payload.mainPage = rendered.mainPage;
+  input.payload.missedPage = rendered.missedPage;
+  return {
+    embeds: [rendered.embed],
+    components: rendered.components,
+  };
+}
+
 /** Purpose: normalize stored role values to a raw Discord role ID. */
 function normalizeDiscordRoleId(input: string | null | undefined): string | null {
   const raw = String(input ?? "").trim();
@@ -462,8 +504,28 @@ type FwaMailPreviewPayload = {
   revisionOverride?: MatchRevisionFields | null;
 };
 
+type FwaComplianceViewPayload = {
+  userId: string;
+  guildId: string;
+  clanName: string;
+  clanTag: string;
+  isFwa: boolean;
+  warId: number | null;
+  expectedOutcome: "WIN" | "LOSE" | null;
+  warStartTime: Date | null;
+  warEndTime: Date | null;
+  participantsCount: number;
+  attacksCount: number;
+  missedBoth: WarComplianceIssue[];
+  notFollowingPlan: WarComplianceIssue[];
+  activeView: FwaComplianceActiveView;
+  mainPage: number;
+  missedPage: number;
+};
+
 const fwaMatchCopyPayloads = new Map<string, FwaMatchCopyPayload>();
 const fwaMailPreviewPayloads = new Map<string, FwaMailPreviewPayload>();
+const fwaComplianceViewPayloads = new Map<string, FwaComplianceViewPayload>();
 const fwaMailPollers = new Map<string, ReturnType<typeof setInterval>>();
 const pointsSnapshotCache = new Map<string, PointsSnapshotCacheEntry>();
 const pointsSnapshotInFlight = new Map<string, Promise<PointsSnapshot>>();
@@ -2939,6 +3001,60 @@ function buildFwaMatchCopyComponents(
     }
   }
   return rows;
+}
+
+export async function handleFwaComplianceViewButton(
+  interaction: ButtonInteraction
+): Promise<void> {
+  const parsed = parseFwaComplianceViewCustomId(interaction.customId);
+  if (!parsed) return;
+  if (interaction.user.id !== parsed.userId) {
+    await interaction.reply({
+      ephemeral: true,
+      content: "Only the command requester can use this button.",
+    });
+    return;
+  }
+
+  const payload = fwaComplianceViewPayloads.get(parsed.key);
+  if (!payload) {
+    await interaction.reply({
+      ephemeral: true,
+      content: "This compliance view expired. Please run /fwa compliance again.",
+    });
+    return;
+  }
+
+  if (parsed.action === "open_missed") {
+    payload.activeView = "missed";
+  } else if (parsed.action === "open_main") {
+    if (payload.isFwa) {
+      payload.activeView = "fwa_main";
+    }
+  } else if (parsed.action === "prev") {
+    if (payload.activeView === "fwa_main") {
+      payload.mainPage = Math.max(0, payload.mainPage - 1);
+    } else {
+      payload.missedPage = Math.max(0, payload.missedPage - 1);
+    }
+  } else if (parsed.action === "next") {
+    if (payload.activeView === "fwa_main") {
+      payload.mainPage += 1;
+    } else {
+      payload.missedPage += 1;
+    }
+  }
+
+  const rendered = renderComplianceViewPayload({
+    key: parsed.key,
+    payload,
+  });
+  fwaComplianceViewPayloads.set(parsed.key, payload);
+  await interaction.update({
+    content: undefined,
+    embeds: rendered.embeds,
+    components: rendered.components,
+  });
 }
 
 export async function handleFwaMatchCopyButton(interaction: ButtonInteraction): Promise<void> {
@@ -8934,16 +9050,34 @@ export const Fwa: Command = {
       }
 
       if (evaluation.status === "not_applicable") {
-        await editReplySafe(
-          [
-            `War compliance for **${clanDisplayName}** (#${tag})`,
-            `War: **${evaluation.warId ?? "unknown"}** | Started ${startedLabel} | Ended ${endedLabel}`,
-            `Match type: **${evaluation.matchType ?? "UNKNOWN"}** | Expected outcome: **${evaluation.expectedOutcome ?? "UNKNOWN"}**`,
-            "War-plan compliance checks are only enforced for FWA wars.",
-          ].join("\n")
-        );
+        const key = createTransientFwaKey();
+        const payload: FwaComplianceViewPayload = {
+          userId: interaction.user.id,
+          guildId: interaction.guildId,
+          clanName: clanDisplayName,
+          clanTag: tag,
+          isFwa: false,
+          warId: evaluation.warId,
+          expectedOutcome: evaluation.expectedOutcome,
+          warStartTime: evaluation.warStartTime,
+          warEndTime: evaluation.warEndTime,
+          participantsCount: evaluation.participantsCount,
+          attacksCount: evaluation.attacksCount,
+          missedBoth: evaluation.report?.missedBoth ?? [],
+          notFollowingPlan: [],
+          activeView: "missed",
+          mainPage: 0,
+          missedPage: 0,
+        };
+        const rendered = renderComplianceViewPayload({ key, payload });
+        fwaComplianceViewPayloads.set(key, payload);
+        await editReplySafe({
+          content: undefined,
+          embeds: rendered.embeds,
+          components: rendered.components,
+        });
         console.info(
-          `[fwa-compliance] event=complete guild=${interaction.guildId} user=${interaction.user.id} clan=#${tag} scope=${evaluation.scope} source=${evaluation.source ?? "none"} war_resolution_source=${evaluation.warResolutionSource ?? "none"} war_id=${evaluation.warId ?? "unknown"} status=not_applicable match_type=${evaluation.matchType ?? "UNKNOWN"} duration_ms=${Date.now() - startedAtMs}`
+          `[fwa-compliance] event=complete guild=${interaction.guildId} user=${interaction.user.id} clan=#${tag} scope=${evaluation.scope} source=${evaluation.source ?? "none"} war_resolution_source=${evaluation.warResolutionSource ?? "none"} war_id=${evaluation.warId ?? "unknown"} status=not_applicable match_type=${evaluation.matchType ?? "UNKNOWN"} missed_both=${payload.missedBoth.length} duration_ms=${Date.now() - startedAtMs}`
         );
         return;
       }
@@ -8962,12 +9096,32 @@ export const Fwa: Command = {
         return;
       }
 
-      const lines = buildWarComplianceReportLines({
+      const key = createTransientFwaKey();
+      const payload: FwaComplianceViewPayload = {
+        userId: interaction.user.id,
+        guildId: interaction.guildId,
         clanName: clanDisplayName,
         clanTag: tag,
-        report: evaluation.report,
+        isFwa: true,
+        warId: evaluation.report.warId ?? evaluation.warId,
+        expectedOutcome: evaluation.report.expectedOutcome ?? evaluation.expectedOutcome,
+        warStartTime: evaluation.report.warStartTime ?? evaluation.warStartTime,
+        warEndTime: evaluation.report.warEndTime ?? evaluation.warEndTime,
+        participantsCount: evaluation.report.participantsCount,
+        attacksCount: evaluation.report.attacksCount,
+        missedBoth: evaluation.report.missedBoth,
+        notFollowingPlan: evaluation.report.notFollowingPlan,
+        activeView: "fwa_main",
+        mainPage: 0,
+        missedPage: 0,
+      };
+      const rendered = renderComplianceViewPayload({ key, payload });
+      fwaComplianceViewPayloads.set(key, payload);
+      await editReplySafe({
+        content: undefined,
+        embeds: rendered.embeds,
+        components: rendered.components,
       });
-      await editReplySafe(lines.join("\n"));
       console.info(
         `[fwa-compliance] event=complete guild=${interaction.guildId} user=${interaction.user.id} clan=#${tag} scope=${evaluation.scope} source=${evaluation.source ?? "none"} war_resolution_source=${evaluation.warResolutionSource ?? "none"} war_id=${evaluation.report.warId ?? evaluation.warId ?? "unknown"} status=ok missed_both=${evaluation.report.missedBoth.length} not_following=${evaluation.report.notFollowingPlan.length} participants=${evaluation.report.participantsCount} attacks=${evaluation.report.attacksCount} war_end_time=${evaluation.timingInputs.warEndTimeIso ?? "unknown"} first_attack_seen_at=${evaluation.timingInputs.firstAttackSeenAtIso ?? "unknown"} last_attack_seen_at=${evaluation.timingInputs.lastAttackSeenAtIso ?? "unknown"} duration_ms=${Date.now() - startedAtMs}`
       );

--- a/src/commands/fwa/complianceEmbedView.ts
+++ b/src/commands/fwa/complianceEmbedView.ts
@@ -1,0 +1,484 @@
+import {
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  EmbedBuilder,
+  type APIEmbed,
+} from "discord.js";
+import { type WarComplianceIssue } from "../../services/WarComplianceService";
+import { buildFwaComplianceViewCustomId } from "./customIds";
+
+export type FwaComplianceActiveView = "fwa_main" | "missed";
+
+export type FwaComplianceEmbedRenderInput = {
+  userId: string;
+  key: string;
+  isFwa: boolean;
+  clanName: string;
+  warId: number | null;
+  expectedOutcome: "WIN" | "LOSE" | null;
+  warStartTime: Date | null;
+  warEndTime: Date | null;
+  participantsCount: number;
+  attacksCount: number;
+  missedBoth: WarComplianceIssue[];
+  notFollowingPlan: WarComplianceIssue[];
+  activeView: FwaComplianceActiveView;
+  mainPage: number;
+  missedPage: number;
+};
+
+export type FwaComplianceEmbedRenderOutput = {
+  embed: EmbedBuilder;
+  components: ActionRowBuilder<ButtonBuilder>[];
+  mainPage: number;
+  missedPage: number;
+  mainPageCount: number;
+  missedPageCount: number;
+};
+
+type ParsedActualBehavior = {
+  targets: string;
+  reason: string;
+  strictContext: string | null;
+};
+
+const FIELD_LIMIT = 1024;
+const PAGE_CONTENT_LIMIT = 980;
+
+/** Purpose: sort compliance rows by roster position first for deterministic paging. */
+function sortIssuesDeterministically(issues: WarComplianceIssue[]): WarComplianceIssue[] {
+  return [...issues].sort((a, b) => {
+    const posA = Number.isFinite(Number(a.playerPosition))
+      ? Number(a.playerPosition)
+      : Number.MAX_SAFE_INTEGER;
+    const posB = Number.isFinite(Number(b.playerPosition))
+      ? Number(b.playerPosition)
+      : Number.MAX_SAFE_INTEGER;
+    if (posA !== posB) return posA - posB;
+    const nameA = String(a.playerName ?? "").trim() || String(a.playerTag ?? "").trim();
+    const nameB = String(b.playerName ?? "").trim() || String(b.playerTag ?? "").trim();
+    const nameDelta = nameA.localeCompare(nameB);
+    if (nameDelta !== 0) return nameDelta;
+    return String(a.playerTag ?? "").localeCompare(String(b.playerTag ?? ""));
+  });
+}
+
+/** Purpose: keep pagination bounded to valid page indexes. */
+function clampPage(page: number, pageCount: number): number {
+  if (!Number.isFinite(page)) return 0;
+  if (pageCount <= 1) return 0;
+  return Math.max(0, Math.min(Math.trunc(page), pageCount - 1));
+}
+
+/** Purpose: paginate variable-size text blocks without relying on silent truncation. */
+function paginateBlocks(blocks: string[]): string[] {
+  if (blocks.length === 0) return ["No entries."];
+  const pages: string[] = [];
+  let current = "";
+
+  for (const rawBlock of blocks) {
+    const block = String(rawBlock ?? "").trim();
+    if (!block) continue;
+    const next = current ? `${current}\n\n${block}` : block;
+    if (next.length <= PAGE_CONTENT_LIMIT) {
+      current = next;
+      continue;
+    }
+    if (current) {
+      pages.push(current);
+      current = "";
+    }
+    if (block.length <= PAGE_CONTENT_LIMIT) {
+      current = block;
+      continue;
+    }
+    pages.push(`${block.slice(0, PAGE_CONTENT_LIMIT - 12)}\n(+truncated)`);
+  }
+
+  if (current) {
+    pages.push(current);
+  }
+
+  return pages.length > 0 ? pages : ["No entries."];
+}
+
+/** Purpose: transform persisted violation behavior text into embed-friendly block lines. */
+function parseActualBehavior(actualBehavior: string): ParsedActualBehavior {
+  const raw = String(actualBehavior ?? "").trim();
+  if (!raw) {
+    return {
+      targets: "No targets logged.",
+      reason: "No details available.",
+      strictContext: null,
+    };
+  }
+
+  const separatorIndex = raw.indexOf(" : ");
+  if (separatorIndex <= -1) {
+    return {
+      targets: raw,
+      reason: "No details available.",
+      strictContext: null,
+    };
+  }
+
+  const targetsRaw = raw.slice(0, separatorIndex).trim();
+  const reasonRaw = raw.slice(separatorIndex + 3).trim();
+  const reasonParts = reasonRaw
+    .split("|")
+    .map((part) => part.trim())
+    .filter(Boolean);
+
+  const targets = targetsRaw
+    .split(",")
+    .map((chunk) =>
+      chunk
+        .replace(/\(\s*([^)]*?)\s*\)/g, "$1")
+        .replace(/\s+/g, " ")
+        .trim()
+    )
+    .filter(Boolean)
+    .join(" | ");
+
+  return {
+    targets: targets || "No targets logged.",
+    reason: reasonParts[0] ?? "No details available.",
+    strictContext: reasonParts.length > 1 ? reasonParts.slice(1).join(" | ") : null,
+  };
+}
+
+/** Purpose: render one not-following issue into the required multi-line violation block. */
+function renderViolationBlock(issue: WarComplianceIssue): string {
+  const parsed = parseActualBehavior(issue.actualBehavior);
+  const name = String(issue.playerName ?? "").trim() || "Unknown member";
+  const pos = Number.isFinite(Number(issue.playerPosition))
+    ? `#${Math.trunc(Number(issue.playerPosition))}`
+    : "#?";
+  const lines = [`${pos} ${name}`, `→ ${parsed.targets}`, parsed.reason];
+  if (parsed.strictContext) {
+    lines.push(parsed.strictContext);
+  }
+  return lines.join("\n");
+}
+
+/** Purpose: render one missed-both issue line in `Name (#TAG)` format. */
+function renderMissedLine(issue: WarComplianceIssue): string {
+  const name = String(issue.playerName ?? "").trim() || "Unknown member";
+  const tag = String(issue.playerTag ?? "").trim();
+  if (!tag || tag === "UNKNOWN") return name;
+  return `${name} (${tag})`;
+}
+
+/** Purpose: build deterministic summary text for the main FWA compliance embed. */
+function buildSummaryFieldValue(input: {
+  participantsCount: number;
+  attacksCount: number;
+  missedCount: number;
+  violationCount: number;
+}): string {
+  return [
+    `👥 Participants: ${input.participantsCount}`,
+    `⚔️ Attacks Logged: ${input.attacksCount}`,
+    "---",
+    `❌ Missed Both Attacks: ${input.missedCount}`,
+    `⚠️ Didn't Follow Plan: ${input.violationCount}`,
+  ].join("\n");
+}
+
+/** Purpose: safely build the war description with unknown fallbacks required by command contract. */
+function buildWarDescription(input: {
+  warId: number | null;
+  expectedOutcome: "WIN" | "LOSE" | null;
+  warStartTime: Date | null;
+  warEndTime: Date | null;
+}): string {
+  const warIdLabel = input.warId ?? "unknown";
+  const expected = input.expectedOutcome ?? "UNKNOWN";
+  const startLine =
+    input.warStartTime instanceof Date
+      ? `Start <t:${Math.floor(input.warStartTime.getTime() / 1000)}:f>`
+      : "Start unknown";
+  const endLine =
+    input.warEndTime instanceof Date
+      ? `End <t:${Math.floor(input.warEndTime.getTime() / 1000)}:R>`
+      : "End unknown";
+  return [`War #${warIdLabel} • Expected: ${expected}`, startLine, endLine].join("\n");
+}
+
+/** Purpose: build the paged FWA-main compliance embed (summary + plan violations). */
+function buildMainEmbed(input: {
+  clanName: string;
+  warId: number | null;
+  expectedOutcome: "WIN" | "LOSE" | null;
+  warStartTime: Date | null;
+  warEndTime: Date | null;
+  participantsCount: number;
+  attacksCount: number;
+  missedBoth: WarComplianceIssue[];
+  violations: WarComplianceIssue[];
+  page: number;
+}): { embed: EmbedBuilder; page: number; pageCount: number } {
+  const sortedViolations = sortIssuesDeterministically(input.violations);
+  const violationPages = paginateBlocks(sortedViolations.map(renderViolationBlock));
+  const page = clampPage(input.page, violationPages.length);
+  const value = violationPages[page] ?? "No plan violations found.";
+  const safeValue = value.length <= FIELD_LIMIT ? value : `${value.slice(0, FIELD_LIMIT - 12)}\n(+truncated)`;
+
+  const embed = new EmbedBuilder()
+    .setTitle(`FWA War Compliance — ${input.clanName}`)
+    .setDescription(
+      buildWarDescription({
+        warId: input.warId,
+        expectedOutcome: input.expectedOutcome,
+        warStartTime: input.warStartTime,
+        warEndTime: input.warEndTime,
+      })
+    )
+    .addFields(
+      {
+        name: "Summary",
+        value: buildSummaryFieldValue({
+          participantsCount: input.participantsCount,
+          attacksCount: input.attacksCount,
+          missedCount: input.missedBoth.length,
+          violationCount: input.violations.length,
+        }),
+      },
+      {
+        name: "Plan Violations",
+        value: safeValue || "No plan violations found.",
+      }
+    )
+    .setFooter({ text: `Page ${page + 1}/${violationPages.length}` });
+
+  return {
+    embed,
+    page,
+    pageCount: violationPages.length,
+  };
+}
+
+/** Purpose: build the paged missed-attacks embed used by both FWA and non-FWA flows. */
+function buildMissedEmbed(input: {
+  clanName: string;
+  warId: number | null;
+  missedBoth: WarComplianceIssue[];
+  page: number;
+}): { embed: EmbedBuilder; page: number; pageCount: number } {
+  const sortedMissed = sortIssuesDeterministically(input.missedBoth);
+  const missedLines =
+    sortedMissed.length > 0
+      ? sortedMissed.map(renderMissedLine)
+      : ["No players missed both attacks."];
+  const missedPages = paginateBlocks(missedLines);
+  const page = clampPage(input.page, missedPages.length);
+  const value = missedPages[page] ?? "No players missed both attacks.";
+  const safeValue = value.length <= FIELD_LIMIT ? value : `${value.slice(0, FIELD_LIMIT - 12)}\n(+truncated)`;
+  const warIdLabel = input.warId ?? "unknown";
+
+  const embed = new EmbedBuilder()
+    .setTitle(`Missed Attacks — ${input.clanName}`)
+    .setDescription(`War #${warIdLabel} • Missed Both Attacks: ${sortedMissed.length}`)
+    .addFields({
+      name: "Players",
+      value: safeValue || "No players missed both attacks.",
+    })
+    .setFooter({ text: `Page ${page + 1}/${missedPages.length}` });
+
+  return {
+    embed,
+    page,
+    pageCount: missedPages.length,
+  };
+}
+
+/** Purpose: attach deterministic navigation controls for the active compliance view/page. */
+function buildComponents(input: {
+  userId: string;
+  key: string;
+  isFwa: boolean;
+  activeView: FwaComplianceActiveView;
+  missedCount: number;
+  mainPage: number;
+  mainPageCount: number;
+  missedPage: number;
+  missedPageCount: number;
+}): ActionRowBuilder<ButtonBuilder>[] {
+  const rows: ActionRowBuilder<ButtonBuilder>[] = [];
+  if (input.activeView === "fwa_main") {
+    rows.push(
+      new ActionRowBuilder<ButtonBuilder>().addComponents(
+        new ButtonBuilder()
+          .setCustomId(
+            buildFwaComplianceViewCustomId({
+              userId: input.userId,
+              key: input.key,
+              action: "open_missed",
+            })
+          )
+          .setLabel("Missed Attacks")
+          .setStyle(ButtonStyle.Secondary)
+          .setDisabled(input.missedCount <= 0)
+      )
+    );
+    rows.push(
+      new ActionRowBuilder<ButtonBuilder>().addComponents(
+        new ButtonBuilder()
+          .setCustomId(
+            buildFwaComplianceViewCustomId({
+              userId: input.userId,
+              key: input.key,
+              action: "prev",
+            })
+          )
+          .setLabel("Prev")
+          .setStyle(ButtonStyle.Secondary)
+          .setDisabled(input.mainPage <= 0),
+        new ButtonBuilder()
+          .setCustomId(
+            buildFwaComplianceViewCustomId({
+              userId: input.userId,
+              key: input.key,
+              action: "next",
+            })
+          )
+          .setLabel("Next")
+          .setStyle(ButtonStyle.Secondary)
+          .setDisabled(input.mainPage >= input.mainPageCount - 1)
+      )
+    );
+    return rows;
+  }
+
+  rows.push(
+    new ActionRowBuilder<ButtonBuilder>().addComponents(
+      new ButtonBuilder()
+        .setCustomId(
+          buildFwaComplianceViewCustomId({
+            userId: input.userId,
+            key: input.key,
+            action: "open_main",
+          })
+        )
+        .setLabel(input.isFwa ? "Back to FWA Compliance" : "FWA Compliance")
+        .setStyle(ButtonStyle.Secondary)
+        .setDisabled(!input.isFwa)
+    )
+  );
+  rows.push(
+    new ActionRowBuilder<ButtonBuilder>().addComponents(
+      new ButtonBuilder()
+        .setCustomId(
+          buildFwaComplianceViewCustomId({
+            userId: input.userId,
+            key: input.key,
+            action: "prev",
+          })
+        )
+        .setLabel("Prev")
+        .setStyle(ButtonStyle.Secondary)
+        .setDisabled(input.missedPage <= 0),
+      new ButtonBuilder()
+        .setCustomId(
+          buildFwaComplianceViewCustomId({
+            userId: input.userId,
+            key: input.key,
+            action: "next",
+          })
+        )
+        .setLabel("Next")
+        .setStyle(ButtonStyle.Secondary)
+        .setDisabled(input.missedPage >= input.missedPageCount - 1)
+    )
+  );
+  return rows;
+}
+
+/** Purpose: render the active compliance view embed + components while keeping page bounds consistent. */
+export function buildFwaComplianceEmbedView(
+  input: FwaComplianceEmbedRenderInput
+): FwaComplianceEmbedRenderOutput {
+  if (input.activeView === "fwa_main") {
+    const main = buildMainEmbed({
+      clanName: input.clanName,
+      warId: input.warId,
+      expectedOutcome: input.expectedOutcome,
+      warStartTime: input.warStartTime,
+      warEndTime: input.warEndTime,
+      participantsCount: input.participantsCount,
+      attacksCount: input.attacksCount,
+      missedBoth: input.missedBoth,
+      violations: input.notFollowingPlan,
+      page: input.mainPage,
+    });
+    const missed = buildMissedEmbed({
+      clanName: input.clanName,
+      warId: input.warId,
+      missedBoth: input.missedBoth,
+      page: input.missedPage,
+    });
+
+    return {
+      embed: main.embed,
+      components: buildComponents({
+        userId: input.userId,
+        key: input.key,
+        isFwa: input.isFwa,
+        activeView: input.activeView,
+        missedCount: input.missedBoth.length,
+        mainPage: main.page,
+        mainPageCount: main.pageCount,
+        missedPage: missed.page,
+        missedPageCount: missed.pageCount,
+      }),
+      mainPage: main.page,
+      missedPage: missed.page,
+      mainPageCount: main.pageCount,
+      missedPageCount: missed.pageCount,
+    };
+  }
+
+  const missed = buildMissedEmbed({
+    clanName: input.clanName,
+    warId: input.warId,
+    missedBoth: input.missedBoth,
+    page: input.missedPage,
+  });
+  const main = buildMainEmbed({
+    clanName: input.clanName,
+    warId: input.warId,
+    expectedOutcome: input.expectedOutcome,
+    warStartTime: input.warStartTime,
+    warEndTime: input.warEndTime,
+    participantsCount: input.participantsCount,
+    attacksCount: input.attacksCount,
+    missedBoth: input.missedBoth,
+    violations: input.notFollowingPlan,
+    page: input.mainPage,
+  });
+
+  return {
+    embed: missed.embed,
+    components: buildComponents({
+      userId: input.userId,
+      key: input.key,
+      isFwa: input.isFwa,
+      activeView: input.activeView,
+      missedCount: input.missedBoth.length,
+      mainPage: main.page,
+      mainPageCount: main.pageCount,
+      missedPage: missed.page,
+      missedPageCount: missed.pageCount,
+    }),
+    mainPage: main.page,
+    missedPage: missed.page,
+    mainPageCount: main.pageCount,
+    missedPageCount: missed.pageCount,
+  };
+}
+
+/** Purpose: expose embed JSON for unit tests without coupling tests to message builders. */
+export function toEmbedJson(embed: EmbedBuilder): APIEmbed {
+  return embed.toJSON();
+}

--- a/src/commands/fwa/customIds.ts
+++ b/src/commands/fwa/customIds.ts
@@ -14,6 +14,7 @@ const FWA_MAIL_CONFIRM_NO_PING_PREFIX = "fwa-mail-confirm-no-ping";
 const FWA_MAIL_BACK_PREFIX = "fwa-mail-back";
 const FWA_MAIL_REFRESH_PREFIX = "fwa-mail-refresh";
 const FWA_MATCH_SEND_MAIL_PREFIX = "fwa-match-send-mail";
+const FWA_COMPLIANCE_VIEW_PREFIX = "fwa-compliance-view";
 
 export type MatchTypeActionParams = {
   userId: string;
@@ -42,6 +43,13 @@ export type MatchSkipSyncActionParams = {
   userId: string;
   key: string;
   tag: string;
+};
+
+export type FwaComplianceViewAction = "open_missed" | "open_main" | "prev" | "next";
+export type FwaComplianceViewParams = {
+  userId: string;
+  key: string;
+  action: FwaComplianceViewAction;
 };
 
 /** Purpose: normalize incoming clan tags to the internal uppercase/hashless form. */
@@ -358,4 +366,32 @@ export function parseFwaMatchSendMailCustomId(
 /** Purpose: detect send-mail-from-match button prefix. */
 export function isFwaMatchSendMailButtonCustomId(customId: string): boolean {
   return customId.startsWith(`${FWA_MATCH_SEND_MAIL_PREFIX}:`);
+}
+
+/** Purpose: build custom-id for /fwa compliance embed view buttons. */
+export function buildFwaComplianceViewCustomId(params: FwaComplianceViewParams): string {
+  return `${FWA_COMPLIANCE_VIEW_PREFIX}:${params.userId}:${params.key}:${params.action}`;
+}
+
+/** Purpose: parse /fwa compliance embed view button custom-id payload. */
+export function parseFwaComplianceViewCustomId(
+  customId: string
+): FwaComplianceViewParams | null {
+  const values = parseCustomIdParts(customId, FWA_COMPLIANCE_VIEW_PREFIX, 4);
+  if (!values) return null;
+  const [userId, key, rawAction] = values;
+  const action: FwaComplianceViewAction | null =
+    rawAction === "open_missed" ||
+    rawAction === "open_main" ||
+    rawAction === "prev" ||
+    rawAction === "next"
+      ? rawAction
+      : null;
+  if (!action) return null;
+  return { userId, key, action };
+}
+
+/** Purpose: detect /fwa compliance embed view button custom-id prefix. */
+export function isFwaComplianceViewButtonCustomId(customId: string): boolean {
+  return customId.startsWith(`${FWA_COMPLIANCE_VIEW_PREFIX}:`);
 }

--- a/src/listeners/interactionCreate.ts
+++ b/src/listeners/interactionCreate.ts
@@ -29,6 +29,7 @@ import {
   handleFwaMatchSkipSyncActionButton,
   handleFwaMatchSkipSyncConfirmButton,
   handleFwaMatchSkipSyncUndoButton,
+  handleFwaComplianceViewButton,
   handleFwaMailConfirmButton,
   handleFwaMailConfirmNoPingButton,
   handleFwaMailBackButton,
@@ -48,6 +49,7 @@ import {
   isFwaOutcomeActionButtonCustomId,
   isFwaMatchSelectCustomId,
   isFwaMatchTypeActionButtonCustomId,
+  isFwaComplianceViewButtonCustomId,
   handlePointsPostButton,
   isFwaMatchCopyButtonCustomId,
   isPointsPostButtonCustomId,
@@ -317,6 +319,21 @@ const handleButtonInteraction = async (
         });
       }
     }
+  }
+
+  if (isFwaComplianceViewButtonCustomId(interaction.customId)) {
+    try {
+      await handleFwaComplianceViewButton(interaction);
+    } catch (err) {
+      console.error(`FWA compliance view button failed: ${formatError(err)}`);
+      if (!interaction.replied && !interaction.deferred) {
+        await interaction.reply({
+          ephemeral: true,
+          content: "Failed to update compliance view.",
+        });
+      }
+    }
+    return;
   }
 
   if (isFwaMatchCopyButtonCustomId(interaction.customId)) {

--- a/src/services/WarComplianceService.ts
+++ b/src/services/WarComplianceService.ts
@@ -357,6 +357,22 @@ function mapNamesToIssues(input: {
   });
 }
 
+/** Purpose: build missed-both issues for non-FWA contexts so UI can show missed-attacks view. */
+function buildMissedBothIssuesFromParticipants(
+  participants: WarComplianceParticipant[]
+): WarComplianceIssue[] {
+  return participants
+    .filter((row) => Number(row.attacksUsed ?? 0) <= 0)
+    .map((row) => ({
+      playerTag: normalizeTag(row.playerTag) || "UNKNOWN",
+      playerName: getParticipantLabel({ playerName: row.playerName, playerTag: row.playerTag }),
+      playerPosition: row.playerPosition ?? null,
+      ruleType: "missed_both" as const,
+      expectedBehavior: "Use both attacks for the war.",
+      actualBehavior: "",
+    }));
+}
+
 /** Purpose: normalize persisted match-type text to command-safe enum values. */
 function normalizeMatchType(input: string | null | undefined): MatchType {
   const value = String(input ?? "").trim().toUpperCase();
@@ -702,6 +718,20 @@ export class WarComplianceService {
     });
 
     if (context.matchType !== "FWA") {
+      const loseStyle = await getLoseStyleForClan(context.clanTag);
+      const report: WarComplianceReport = {
+        clanTag: context.clanTag,
+        warId: context.warId,
+        warStartTime: context.warStartTime,
+        warEndTime: context.warEndTime,
+        matchType: context.matchType,
+        expectedOutcome: context.expectedOutcome,
+        loseStyle,
+        missedBoth: buildMissedBothIssuesFromParticipants(context.participants),
+        notFollowingPlan: [],
+        participantsCount: context.participants.length,
+        attacksCount: context.attacks.length,
+      };
       return buildResult({
         status: "not_applicable",
         source: context.source,
@@ -711,6 +741,7 @@ export class WarComplianceService {
         warEndTime: context.warEndTime,
         matchType: context.matchType,
         expectedOutcome: context.expectedOutcome,
+        report,
         participantsCount: context.participants.length,
         attacksCount: context.attacks.length,
         timingInputs,

--- a/tests/fwaComplianceEmbedView.logic.test.ts
+++ b/tests/fwaComplianceEmbedView.logic.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it } from "vitest";
+import { type APIActionRowComponent, type APIButtonComponent } from "discord.js";
+import {
+  buildFwaComplianceEmbedView,
+  toEmbedJson,
+} from "../src/commands/fwa/complianceEmbedView";
+import { type WarComplianceIssue } from "../src/services/WarComplianceService";
+
+function makeViolation(position: number, name: string, actualBehavior: string): WarComplianceIssue {
+  return {
+    playerTag: `#P${position}`,
+    playerName: name,
+    playerPosition: position,
+    ruleType: "not_following_plan",
+    expectedBehavior: "Mirror triple in strict window; avoid off-mirror triples/zeros.",
+    actualBehavior,
+  };
+}
+
+function makeMissed(position: number, name: string): WarComplianceIssue {
+  return {
+    playerTag: `#M${position}`,
+    playerName: name,
+    playerPosition: position,
+    ruleType: "missed_both",
+    expectedBehavior: "Use both attacks for the war.",
+    actualBehavior: "",
+  };
+}
+
+function flattenButtons(components: ReturnType<typeof buildFwaComplianceEmbedView>["components"]) {
+  const rows = components.map((row) => row.toJSON() as APIActionRowComponent<APIButtonComponent>);
+  return rows.flatMap((row) => row.components);
+}
+
+describe("buildFwaComplianceEmbedView", () => {
+  it("renders main FWA compliance embed with summary and violations", () => {
+    const rendered = buildFwaComplianceEmbedView({
+      userId: "123",
+      key: "payload",
+      isFwa: true,
+      clanName: "Rocky Road",
+      warId: 777,
+      expectedOutcome: "WIN",
+      warStartTime: new Date("2026-03-12T00:00:00.000Z"),
+      warEndTime: new Date("2026-03-13T00:00:00.000Z"),
+      participantsCount: 50,
+      attacksCount: 53,
+      missedBoth: [makeMissed(10, "Missed One")],
+      notFollowingPlan: [
+        makeViolation(
+          5,
+          "lotus",
+          "#5 (★ ★ ★), #14 (★ ★ ★) : tripled non-mirror in strict window | 56★ | 22h 1m left"
+        ),
+      ],
+      activeView: "fwa_main",
+      mainPage: 0,
+      missedPage: 0,
+    });
+
+    const embed = toEmbedJson(rendered.embed);
+    expect(embed.title).toBe("FWA War Compliance — Rocky Road");
+    expect(embed.description).toContain("War #777 • Expected: WIN");
+    expect(embed.fields?.[0]?.name).toBe("Summary");
+    expect(embed.fields?.[1]?.name).toBe("Plan Violations");
+    expect(embed.fields?.[1]?.value).toContain("#5 lotus");
+    expect(embed.fields?.[1]?.value).toContain("→ #5 ★ ★ ★ | #14 ★ ★ ★");
+    expect(embed.fields?.[1]?.value).toContain("tripled non-mirror in strict window");
+    expect(embed.fields?.[1]?.value).toContain("56★ | 22h 1m left");
+
+    const buttons = flattenButtons(rendered.components);
+    const missedToggle = buttons.find((button) => button.label === "Missed Attacks");
+    expect(missedToggle).toBeTruthy();
+    expect(missedToggle?.disabled).toBe(false);
+  });
+
+  it("disables missed-attacks toggle when there are no missed-both players", () => {
+    const rendered = buildFwaComplianceEmbedView({
+      userId: "123",
+      key: "payload",
+      isFwa: true,
+      clanName: "Rocky Road",
+      warId: 777,
+      expectedOutcome: "WIN",
+      warStartTime: null,
+      warEndTime: null,
+      participantsCount: 50,
+      attacksCount: 53,
+      missedBoth: [],
+      notFollowingPlan: [],
+      activeView: "fwa_main",
+      mainPage: 0,
+      missedPage: 0,
+    });
+
+    const buttons = flattenButtons(rendered.components);
+    const missedToggle = buttons.find((button) => button.label === "Missed Attacks");
+    expect(missedToggle).toBeTruthy();
+    expect(missedToggle?.disabled).toBe(true);
+  });
+
+  it("renders non-FWA missed view with disabled FWA compliance button and empty state", () => {
+    const rendered = buildFwaComplianceEmbedView({
+      userId: "123",
+      key: "payload",
+      isFwa: false,
+      clanName: "Rocky Road",
+      warId: 888,
+      expectedOutcome: null,
+      warStartTime: null,
+      warEndTime: null,
+      participantsCount: 50,
+      attacksCount: 20,
+      missedBoth: [],
+      notFollowingPlan: [],
+      activeView: "missed",
+      mainPage: 0,
+      missedPage: 0,
+    });
+
+    const embed = toEmbedJson(rendered.embed);
+    expect(embed.title).toBe("Missed Attacks — Rocky Road");
+    expect(embed.fields?.[0]?.name).toBe("Players");
+    expect(embed.fields?.[0]?.value).toContain("No players missed both attacks.");
+
+    const buttons = flattenButtons(rendered.components);
+    const fwaButton = buttons.find((button) => button.label === "FWA Compliance");
+    expect(fwaButton).toBeTruthy();
+    expect(fwaButton?.disabled).toBe(true);
+  });
+
+  it("paginates violations and players with deterministic ordering", () => {
+    const notFollowing = Array.from({ length: 28 }, (_, idx) =>
+      makeViolation(
+        idx + 1,
+        `P${idx + 1}`,
+        `#${idx + 1} (★ ★ ☆), #${idx + 2} (★ ★ ★) : didn't triple mirror in strict window with extended reason text ${"x".repeat(48)} | ${20 + idx}★ | 21h 0m left`
+      )
+    );
+    const missed = Array.from({ length: 140 }, (_, idx) => makeMissed(idx + 1, `M${idx + 1}`));
+
+    const mainPageOne = buildFwaComplianceEmbedView({
+      userId: "123",
+      key: "payload",
+      isFwa: true,
+      clanName: "Rocky Road",
+      warId: 999,
+      expectedOutcome: "WIN",
+      warStartTime: null,
+      warEndTime: null,
+      participantsCount: 50,
+      attacksCount: 54,
+      missedBoth: missed,
+      notFollowingPlan: notFollowing,
+      activeView: "fwa_main",
+      mainPage: 0,
+      missedPage: 0,
+    });
+
+    const mainPageTwo = buildFwaComplianceEmbedView({
+      userId: "123",
+      key: "payload",
+      isFwa: true,
+      clanName: "Rocky Road",
+      warId: 999,
+      expectedOutcome: "WIN",
+      warStartTime: null,
+      warEndTime: null,
+      participantsCount: 50,
+      attacksCount: 54,
+      missedBoth: missed,
+      notFollowingPlan: notFollowing,
+      activeView: "fwa_main",
+      mainPage: 1,
+      missedPage: 0,
+    });
+
+    const mainOne = toEmbedJson(mainPageOne.embed);
+    const mainTwo = toEmbedJson(mainPageTwo.embed);
+    expect(mainPageOne.mainPageCount).toBeGreaterThan(1);
+    expect(mainOne.footer?.text).toMatch(/^Page 1\/\d+$/);
+    expect(mainTwo.footer?.text).toMatch(/^Page 2\/\d+$/);
+    expect(mainOne.fields?.[1]?.value).toContain("#1 P1");
+    expect(mainTwo.fields?.[1]?.value).not.toContain("#1 P1");
+
+    const missedPageTwo = buildFwaComplianceEmbedView({
+      userId: "123",
+      key: "payload",
+      isFwa: true,
+      clanName: "Rocky Road",
+      warId: 999,
+      expectedOutcome: "WIN",
+      warStartTime: null,
+      warEndTime: null,
+      participantsCount: 50,
+      attacksCount: 54,
+      missedBoth: missed,
+      notFollowingPlan: notFollowing,
+      activeView: "missed",
+      mainPage: 0,
+      missedPage: 1,
+    });
+    const missedTwo = toEmbedJson(missedPageTwo.embed);
+    expect(missedPageTwo.missedPageCount).toBeGreaterThan(1);
+    expect(missedTwo.footer?.text).toMatch(/^Page 2\/\d+$/);
+  });
+});

--- a/tests/fwaCustomIds.logic.test.ts
+++ b/tests/fwaCustomIds.logic.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildFwaComplianceViewCustomId,
   buildFwaMatchSendMailCustomId,
   buildMatchTypeActionCustomId,
   buildPointsPostButtonCustomId,
   createTransientFwaKey,
+  isFwaComplianceViewButtonCustomId,
   isFwaMatchSendMailButtonCustomId,
   isPointsPostButtonCustomId,
+  parseFwaComplianceViewCustomId,
   parseFwaMatchSendMailCustomId,
   parseMatchTypeActionCustomId,
   parsePointsPostButtonCustomId,
@@ -56,5 +59,20 @@ describe("fwa custom-id helpers", () => {
     expect(keyA.length).toBeGreaterThan(6);
     expect(keyB.length).toBeGreaterThan(6);
     expect(keyA).not.toBe(keyB);
+  });
+
+  it("round-trips fwa compliance view custom ids", () => {
+    const customId = buildFwaComplianceViewCustomId({
+      userId: "444",
+      key: "abc123",
+      action: "open_missed",
+    });
+
+    expect(isFwaComplianceViewButtonCustomId(customId)).toBe(true);
+    expect(parseFwaComplianceViewCustomId(customId)).toEqual({
+      userId: "444",
+      key: "abc123",
+      action: "open_missed",
+    });
   });
 });

--- a/tests/warCompliance.service.test.ts
+++ b/tests/warCompliance.service.test.ts
@@ -217,6 +217,62 @@ describe("WarComplianceService", () => {
     expect(babyPk?.actualBehavior).toContain("| 3★ | 22h 0m left");
   });
 
+  it("does not flag strict-window non-mirror triples when trueStars is zero", async () => {
+    const warStartTime = new Date("2026-02-01T00:00:00.000Z");
+    const warEndTime = new Date("2026-02-02T00:00:00.000Z");
+    const participants = [
+      { playerName: "Alice", playerTag: "#A1", attacksUsed: 2, playerPosition: 1 },
+      { playerName: "Bob", playerTag: "#B1", attacksUsed: 0, playerPosition: 2 },
+    ];
+    const attacks = [
+      {
+        playerTag: "#A1",
+        playerName: "Alice",
+        playerPosition: 1,
+        defenderPosition: 2,
+        stars: 3,
+        trueStars: 0,
+        attackSeenAt: new Date("2026-02-01T01:00:00.000Z"),
+        warEndTime,
+        attackOrder: 1,
+      },
+      {
+        playerTag: "#A1",
+        playerName: "Alice",
+        playerPosition: 1,
+        defenderPosition: 1,
+        stars: 3,
+        trueStars: 3,
+        attackSeenAt: new Date("2026-02-01T02:00:00.000Z"),
+        warEndTime,
+        attackOrder: 2,
+      },
+    ];
+
+    vi.spyOn(prisma.warAttacks, "findFirst").mockResolvedValue({
+      warStartTime,
+      warEndTime,
+      warId: 999,
+    } as any);
+    vi.spyOn(prisma.warAttacks, "findMany")
+      .mockResolvedValueOnce(participants as any)
+      .mockResolvedValueOnce(attacks as any);
+    vi.spyOn(prisma.trackedClan, "findFirst").mockResolvedValue({
+      loseStyle: "TRIPLE_TOP_30",
+    } as any);
+
+    const service = new WarComplianceService();
+    const report = await service.getComplianceReport({
+      clanTag: "#TEST",
+      preferredWarStartTime: warStartTime,
+      matchType: "FWA",
+      expectedOutcome: "WIN",
+    });
+
+    expect(report).not.toBeNull();
+    expect(report?.notFollowingPlan).toHaveLength(0);
+  });
+
   it("returns null report for BL/MM checks without hitting DB", async () => {
     const findFirstSpy = vi.spyOn(prisma.warAttacks, "findFirst");
     const service = new WarComplianceService();
@@ -452,6 +508,53 @@ describe("WarComplianceService", () => {
     });
 
     expect(result.status).toBe("no_active_war");
+  });
+
+  it("returns non-FWA missed-both details for not-applicable evaluations", async () => {
+    const warStartTime = new Date("2026-02-01T00:00:00.000Z");
+    const warEndTime = new Date("2026-02-02T00:00:00.000Z");
+    vi.spyOn(prisma.currentWar, "findFirst").mockResolvedValue({
+      warId: 4001,
+      startTime: warStartTime,
+      endTime: warEndTime,
+      matchType: "BL",
+      outcome: "WIN",
+    } as any);
+    vi.spyOn(prisma.warAttacks, "findMany")
+      .mockResolvedValueOnce([
+        {
+          playerName: "Alice",
+          playerTag: "#A",
+          attacksUsed: 0,
+          playerPosition: 1,
+          warStartTime,
+        },
+        {
+          playerName: "Bob",
+          playerTag: "#B",
+          attacksUsed: 2,
+          playerPosition: 2,
+          warStartTime,
+        },
+      ] as any)
+      .mockResolvedValueOnce([] as any);
+    vi.spyOn(prisma.trackedClan, "findFirst").mockResolvedValue({
+      loseStyle: "TRADITIONAL",
+    } as any);
+
+    const service = new WarComplianceService();
+    const result = await service.evaluateComplianceForCommand({
+      guildId: "guild-1",
+      clanTag: "#TEST",
+      scope: "current",
+    });
+
+    expect(result.status).toBe("not_applicable");
+    expect(result.matchType).toBe("BL");
+    expect(result.report).toBeTruthy();
+    expect(result.report?.missedBoth).toHaveLength(1);
+    expect(result.report?.missedBoth[0]?.playerName).toBe("Alice");
+    expect(result.report?.notFollowingPlan).toHaveLength(0);
   });
 
   it("returns insufficient_data when historical participation implies attacks but no attack rows exist", async () => {


### PR DESCRIPTION
- replace text-only compliance output with embed-based FWA main + missed-attacks views
- add invoker-locked button routing for view toggles and prev/next pagination
- default non-FWA wars to missed-attacks view with disabled FWA compliance toggle
- keep strict-window non-mirror infractions gated on positive trueStars
- include non-FWA missed-both details in evaluation payloads for UI rendering
- add regression tests for custom ids, embed rendering/pagination, and rule behavior