### PR TITLE
feat(fwa): add paginated embed views for /fwa compliance

### DIFF
--- a/src/commands/fwa/complianceEmbedView.ts
+++ b/src/commands/fwa/complianceEmbedView.ts
@@ -38,13 +38,33 @@ export type FwaComplianceEmbedRenderOutput = {
 };
 
 type ParsedActualBehavior = {
-  targets: string;
+  attacks: Array<{
+    defenderPosition: number | null;
+    stars: number;
+  }>;
   reason: string;
   strictContext: string | null;
 };
 
 const FIELD_LIMIT = 1024;
 const PAGE_CONTENT_LIMIT = 980;
+
+/** Purpose: render numeric stars as spaced triplets to match existing compliance visuals. */
+function formatStarTriplet(stars: number | null | undefined): string {
+  const normalized = Math.max(0, Math.min(3, Number(stars ?? 0)));
+  if (normalized >= 3) return "★ ★ ★";
+  if (normalized >= 2) return "★ ★ ☆";
+  if (normalized >= 1) return "★ ☆ ☆";
+  return "☆ ☆ ☆";
+}
+
+/** Purpose: convert serialized star glyphs into numeric star values for fallback parsing. */
+function parseStarTripletToCount(input: string): number {
+  const text = String(input ?? "");
+  const matches = text.match(/★|â˜…/g);
+  const count = matches ? matches.length : 0;
+  return Math.max(0, Math.min(3, count));
+}
 
 /** Purpose: sort compliance rows by roster position first for deterministic paging. */
 function sortIssuesDeterministically(issues: WarComplianceIssue[]): WarComplianceIssue[] {
@@ -72,7 +92,7 @@ function clampPage(page: number, pageCount: number): number {
 }
 
 /** Purpose: paginate variable-size text blocks without relying on silent truncation. */
-function paginateBlocks(blocks: string[]): string[] {
+function paginateBlocks(blocks: string[], separator = "\n\n"): string[] {
   if (blocks.length === 0) return ["No entries."];
   const pages: string[] = [];
   let current = "";
@@ -80,7 +100,7 @@ function paginateBlocks(blocks: string[]): string[] {
   for (const rawBlock of blocks) {
     const block = String(rawBlock ?? "").trim();
     if (!block) continue;
-    const next = current ? `${current}\n\n${block}` : block;
+    const next = current ? `${current}${separator}${block}` : block;
     if (next.length <= PAGE_CONTENT_LIMIT) {
       current = next;
       continue;
@@ -108,7 +128,7 @@ function parseActualBehavior(actualBehavior: string): ParsedActualBehavior {
   const raw = String(actualBehavior ?? "").trim();
   if (!raw) {
     return {
-      targets: "No targets logged.",
+      attacks: [],
       reason: "No details available.",
       strictContext: null,
     };
@@ -117,7 +137,7 @@ function parseActualBehavior(actualBehavior: string): ParsedActualBehavior {
   const separatorIndex = raw.indexOf(" : ");
   if (separatorIndex <= -1) {
     return {
-      targets: raw,
+      attacks: [],
       reason: "No details available.",
       strictContext: null,
     };
@@ -130,22 +150,67 @@ function parseActualBehavior(actualBehavior: string): ParsedActualBehavior {
     .map((part) => part.trim())
     .filter(Boolean);
 
-  const targets = targetsRaw
+  const attacks = targetsRaw
     .split(",")
-    .map((chunk) =>
-      chunk
-        .replace(/\(\s*([^)]*?)\s*\)/g, "$1")
-        .replace(/\s+/g, " ")
-        .trim()
-    )
+    .map((chunk) => chunk.trim())
     .filter(Boolean)
-    .join(" | ");
+    .map((chunk) => {
+      const match = chunk.match(/^#(\d+)\s*\(([^)]*)\)$/);
+      if (!match) {
+        return {
+          defenderPosition: null,
+          stars: parseStarTripletToCount(chunk),
+        };
+      }
+      return {
+        defenderPosition: Number(match[1]),
+        stars: parseStarTripletToCount(match[2] ?? ""),
+      };
+    });
 
   return {
-    targets: targets || "No targets logged.",
+    attacks,
     reason: reasonParts[0] ?? "No details available.",
     strictContext: reasonParts.length > 1 ? reasonParts.slice(1).join(" | ") : null,
   };
+}
+
+/** Purpose: infer breach markers for legacy parsed rows when structured attackDetails are unavailable. */
+function buildFallbackAttackDetails(
+  issue: WarComplianceIssue,
+  parsed: ParsedActualBehavior
+): Array<{ defenderPosition: number | null; stars: number; isBreach: boolean }> {
+  const details = parsed.attacks.map((row) => ({
+    defenderPosition: row.defenderPosition,
+    stars: row.stars,
+    isBreach: false,
+  }));
+  const reason = String(issue.reasonLabel ?? parsed.reason ?? "").toLowerCase();
+  const playerPos =
+    Number.isFinite(Number(issue.playerPosition)) && Number(issue.playerPosition) > 0
+      ? Number(issue.playerPosition)
+      : null;
+
+  if (reason.includes("tripled non-mirror")) {
+    for (const row of details) {
+      if (row.stars >= 3 && row.defenderPosition !== null && row.defenderPosition !== playerPos) {
+        row.isBreach = true;
+      }
+    }
+  } else if (reason.includes("didn't triple mirror")) {
+    for (const row of details) {
+      const isMirrorTriple =
+        playerPos !== null && row.defenderPosition === playerPos && row.stars >= 3;
+      if (!isMirrorTriple) {
+        row.isBreach = true;
+      }
+    }
+  }
+
+  if (!details.some((row) => row.isBreach) && details.length > 0 && parsed.strictContext) {
+    details[0].isBreach = true;
+  }
+  return details;
 }
 
 /** Purpose: render one not-following issue into the required multi-line violation block. */
@@ -155,9 +220,33 @@ function renderViolationBlock(issue: WarComplianceIssue): string {
   const pos = Number.isFinite(Number(issue.playerPosition))
     ? `#${Math.trunc(Number(issue.playerPosition))}`
     : "#?";
-  const lines = [`${pos} ${name}`, `→ ${parsed.targets}`, parsed.reason];
-  if (parsed.strictContext) {
-    lines.push(parsed.strictContext);
+  const lines = [`${pos} ${name}`];
+
+  const details =
+    issue.attackDetails && issue.attackDetails.length > 0
+      ? issue.attackDetails.map((detail) => ({
+          defenderPosition: detail.defenderPosition ?? null,
+          stars: Math.max(0, Math.min(3, Number(detail.stars ?? 0))),
+          isBreach: Boolean(detail.isBreach),
+        }))
+      : buildFallbackAttackDetails(issue, parsed);
+
+  if (details.length <= 0) {
+    lines.push("→ No targets logged.");
+  } else {
+    for (const detail of details) {
+      const target = detail.defenderPosition !== null ? `#${detail.defenderPosition}` : "#?";
+      lines.push(
+        `→ ${target} ${formatStarTriplet(detail.stars)}${detail.isBreach ? " ⚠️" : ""}`
+      );
+    }
+  }
+
+  const contextLine = issue.breachContext
+    ? `${issue.breachContext.starsAtBreach}★ | ${issue.breachContext.timeRemaining}`
+    : parsed.strictContext;
+  if (contextLine) {
+    lines.push(contextLine);
   }
   return lines.join("\n");
 }
@@ -172,15 +261,12 @@ function renderMissedLine(issue: WarComplianceIssue): string {
 
 /** Purpose: build deterministic summary text for the main FWA compliance embed. */
 function buildSummaryFieldValue(input: {
-  participantsCount: number;
   attacksCount: number;
   missedCount: number;
   violationCount: number;
 }): string {
   return [
-    `👥 Participants: ${input.participantsCount}`,
     `⚔️ Attacks Logged: ${input.attacksCount}`,
-    "---",
     `❌ Missed Both Attacks: ${input.missedCount}`,
     `⚠️ Didn't Follow Plan: ${input.violationCount}`,
   ].join("\n");
@@ -213,7 +299,6 @@ function buildMainEmbed(input: {
   expectedOutcome: "WIN" | "LOSE" | null;
   warStartTime: Date | null;
   warEndTime: Date | null;
-  participantsCount: number;
   attacksCount: number;
   missedBoth: WarComplianceIssue[];
   violations: WarComplianceIssue[];
@@ -239,7 +324,6 @@ function buildMainEmbed(input: {
       {
         name: "Summary",
         value: buildSummaryFieldValue({
-          participantsCount: input.participantsCount,
           attacksCount: input.attacksCount,
           missedCount: input.missedBoth.length,
           violationCount: input.violations.length,
@@ -271,7 +355,7 @@ function buildMissedEmbed(input: {
     sortedMissed.length > 0
       ? sortedMissed.map(renderMissedLine)
       : ["No players missed both attacks."];
-  const missedPages = paginateBlocks(missedLines);
+  const missedPages = paginateBlocks(missedLines, "\n");
   const page = clampPage(input.page, missedPages.length);
   const value = missedPages[page] ?? "No players missed both attacks.";
   const safeValue = value.length <= FIELD_LIMIT ? value : `${value.slice(0, FIELD_LIMIT - 12)}\n(+truncated)`;
@@ -406,7 +490,6 @@ export function buildFwaComplianceEmbedView(
       expectedOutcome: input.expectedOutcome,
       warStartTime: input.warStartTime,
       warEndTime: input.warEndTime,
-      participantsCount: input.participantsCount,
       attacksCount: input.attacksCount,
       missedBoth: input.missedBoth,
       violations: input.notFollowingPlan,
@@ -451,7 +534,6 @@ export function buildFwaComplianceEmbedView(
     expectedOutcome: input.expectedOutcome,
     warStartTime: input.warStartTime,
     warEndTime: input.warEndTime,
-    participantsCount: input.participantsCount,
     attacksCount: input.attacksCount,
     missedBoth: input.missedBoth,
     violations: input.notFollowingPlan,

--- a/src/services/WarComplianceService.ts
+++ b/src/services/WarComplianceService.ts
@@ -18,6 +18,21 @@ export type WarComplianceIssue = {
   ruleType: "missed_both" | "not_following_plan";
   expectedBehavior: string;
   actualBehavior: string;
+  attackDetails?: WarComplianceIssueAttackDetail[];
+  breachContext?: WarComplianceBreachContext | null;
+  reasonLabel?: string | null;
+};
+
+export type WarComplianceIssueAttackDetail = {
+  defenderPosition: number | null;
+  stars: number;
+  attackOrder: number | null;
+  isBreach: boolean;
+};
+
+export type WarComplianceBreachContext = {
+  starsAtBreach: number;
+  timeRemaining: string;
 };
 
 export type WarComplianceReport = {
@@ -207,7 +222,29 @@ type NotFollowingReason = {
     starsBeforeAttack: number;
     timeRemaining: string;
   } | null;
+  breachAttackOrders: number[];
 };
+
+type PlayerBehaviorDetails = {
+  actualBehavior: string;
+  reasonLabel: string;
+  strictWindowContext: NotFollowingReason["strictWindowContext"];
+  attackDetails: WarComplianceIssueAttackDetail[];
+};
+
+/** Purpose: normalize attack-order values so breach markers can be matched deterministically. */
+function normalizeAttackOrder(value: number | null | undefined): number | null {
+  const parsed = Number(value ?? NaN);
+  if (!Number.isFinite(parsed)) return null;
+  return Math.trunc(parsed);
+}
+
+/** Purpose: append a normalized attack-order only once to keep breach markers stable. */
+function pushUniqueAttackOrder(target: number[], value: number | null): void {
+  if (value === null) return;
+  if (target.includes(value)) return;
+  target.push(value);
+}
 
 /** Purpose: compute a user-facing violation reason without changing compliance policy decisions. */
 function describeNotFollowingReason(input: {
@@ -220,7 +257,10 @@ function describeNotFollowingReason(input: {
   if (input.matchType === "FWA" && input.expectedOutcome === "WIN") {
     const orderedPlayerAttacks = sortAttacksForComplianceOrder(input.playerAttacks);
     let firstStrictContext: NotFollowingReason["strictWindowContext"] = null;
+    let firstStrictWindowNonMirrorTripleContext: NotFollowingReason["strictWindowContext"] = null;
     let hasMirrorTripleInStrictWindow = false;
+    const nonMirrorStrictTripleBreachOrders: number[] = [];
+    const strictWindowNonCompliantOrders: number[] = [];
 
     for (const attack of orderedPlayerAttacks) {
       const ctx = input.attackContextByAttack.get(attack);
@@ -230,41 +270,67 @@ function describeNotFollowingReason(input: {
         timeRemaining: formatTimeRemaining(ctx.hoursRemaining),
       };
       firstStrictContext = firstStrictContext ?? strictContext;
+      const attackOrder = normalizeAttackOrder(attack.attackOrder ?? null);
 
       const stars = Number(attack.stars ?? 0);
       const trueStars = Number(attack.trueStars ?? 0);
-      if (ctx.isMirror && stars >= 3) {
+      const isMirrorTriple = ctx.isMirror && stars >= 3;
+      if (isMirrorTriple) {
         hasMirrorTripleInStrictWindow = true;
+      } else {
+        pushUniqueAttackOrder(strictWindowNonCompliantOrders, attackOrder);
       }
       if (!ctx.isMirror && stars === 3 && trueStars > 0) {
-        return {
-          label: "tripled non-mirror in strict window",
-          strictWindowContext: strictContext,
-        };
+        firstStrictWindowNonMirrorTripleContext =
+          firstStrictWindowNonMirrorTripleContext ?? strictContext;
+        pushUniqueAttackOrder(nonMirrorStrictTripleBreachOrders, attackOrder);
       }
+    }
+
+    if (nonMirrorStrictTripleBreachOrders.length > 0) {
+      return {
+        label: "tripled non-mirror in strict window",
+        strictWindowContext:
+          firstStrictWindowNonMirrorTripleContext ?? firstStrictContext,
+        breachAttackOrders: nonMirrorStrictTripleBreachOrders,
+      };
     }
 
     if (firstStrictContext && !hasMirrorTripleInStrictWindow) {
       return {
         label: "didn't triple mirror",
         strictWindowContext: firstStrictContext,
+        breachAttackOrders: strictWindowNonCompliantOrders,
       };
     }
 
     return {
       label: "didn't follow win plan",
       strictWindowContext: firstStrictContext,
+      breachAttackOrders: strictWindowNonCompliantOrders,
     };
   }
 
   if (input.matchType === "FWA" && input.expectedOutcome === "LOSE") {
     if (input.loseStyle === "TRIPLE_TOP_30") {
-      return { label: "attacked outside top-30", strictWindowContext: null };
+      return {
+        label: "attacked outside top-30",
+        strictWindowContext: null,
+        breachAttackOrders: [],
+      };
     }
-    return { label: "didn't follow lose-style rules", strictWindowContext: null };
+    return {
+      label: "didn't follow lose-style rules",
+      strictWindowContext: null,
+      breachAttackOrders: [],
+    };
   }
 
-  return { label: "hit non-mirror target", strictWindowContext: null };
+  return {
+    label: "hit non-mirror target",
+    strictWindowContext: null,
+    breachAttackOrders: [],
+  };
 }
 
 /** Purpose: describe expected plan behavior for actionable compliance output lines. */
@@ -297,11 +363,16 @@ function describeActualBehaviorForPlayer(
     expectedOutcome: "WIN" | "LOSE" | null;
     loseStyle: FwaLoseStyle;
   }
-): string {
+): PlayerBehaviorDetails {
   const normalizedTag = normalizeTag(input.playerTag);
   const playerAttacks = input.attacksByPlayerTag.get(normalizedTag) ?? [];
   if (playerAttacks.length === 0) {
-    return "No attack rows recorded.";
+    return {
+      actualBehavior: "No attack rows recorded.",
+      reasonLabel: "No details available.",
+      strictWindowContext: null,
+      attackDetails: [],
+    };
   }
   const orderedAttacks = sortAttacksForComplianceOrder(playerAttacks);
   const attackSummaries = orderedAttacks.map(
@@ -314,10 +385,26 @@ function describeActualBehaviorForPlayer(
     expectedOutcome: input.expectedOutcome,
     loseStyle: input.loseStyle,
   });
+  const breachOrders = new Set(reason.breachAttackOrders);
+  const attackDetails = orderedAttacks.map((row) => ({
+    defenderPosition: row.defenderPosition ?? null,
+    stars: Math.max(0, Math.min(3, Number(row.stars ?? 0))),
+    attackOrder: normalizeAttackOrder(row.attackOrder ?? null),
+    isBreach: breachOrders.has(normalizeAttackOrder(row.attackOrder ?? null) ?? NaN),
+  }));
+  if (!attackDetails.some((detail) => detail.isBreach) && attackDetails.length > 0) {
+    // Fail-safe: if source rows have missing attackOrder and no marker could be matched, mark the first line.
+    attackDetails[0] = { ...attackDetails[0], isBreach: true };
+  }
   const strictSuffix = reason.strictWindowContext
     ? ` | ${reason.strictWindowContext.starsBeforeAttack}★ | ${reason.strictWindowContext.timeRemaining}`
     : "";
-  return `${attackSummaries.join(", ")} : ${reason.label}${strictSuffix}`;
+  return {
+    actualBehavior: `${attackSummaries.join(", ")} : ${reason.label}${strictSuffix}`,
+    reasonLabel: reason.label,
+    strictWindowContext: reason.strictWindowContext,
+    attackDetails,
+  };
 }
 
 /** Purpose: map rule-engine name output into detailed issues for user-facing command output. */
@@ -335,9 +422,9 @@ function mapNamesToIssues(input: {
   return input.names.map((name) => {
     const participant = input.participantByLabel.get(name) ?? null;
     const playerTag = normalizeTag(participant?.playerTag ?? "") || "UNKNOWN";
-    const actualBehavior =
+    const behavior =
       input.ruleType === "missed_both"
-        ? ""
+        ? null
         : describeActualBehaviorForPlayer({
             playerTag,
             attacksByPlayerTag: input.attacksByPlayerTag,
@@ -352,7 +439,15 @@ function mapNamesToIssues(input: {
       playerPosition: participant?.playerPosition ?? null,
       ruleType: input.ruleType,
       expectedBehavior: input.expectedBehavior,
-      actualBehavior,
+      actualBehavior: behavior?.actualBehavior ?? "",
+      attackDetails: behavior?.attackDetails ?? [],
+      breachContext: behavior?.strictWindowContext
+        ? {
+            starsAtBreach: behavior.strictWindowContext.starsBeforeAttack,
+            timeRemaining: behavior.strictWindowContext.timeRemaining,
+          }
+        : null,
+      reasonLabel: behavior?.reasonLabel ?? null,
     };
   });
 }

--- a/tests/fwaComplianceEmbedView.logic.test.ts
+++ b/tests/fwaComplianceEmbedView.logic.test.ts
@@ -4,16 +4,31 @@ import {
   buildFwaComplianceEmbedView,
   toEmbedJson,
 } from "../src/commands/fwa/complianceEmbedView";
-import { type WarComplianceIssue } from "../src/services/WarComplianceService";
+import {
+  type WarComplianceIssue,
+  type WarComplianceIssueAttackDetail,
+} from "../src/services/WarComplianceService";
 
-function makeViolation(position: number, name: string, actualBehavior: string): WarComplianceIssue {
+function makeViolation(
+  position: number,
+  name: string,
+  options?: {
+    actualBehavior?: string;
+    attackDetails?: WarComplianceIssueAttackDetail[];
+    breachContext?: { starsAtBreach: number; timeRemaining: string } | null;
+    reasonLabel?: string;
+  }
+): WarComplianceIssue {
   return {
     playerTag: `#P${position}`,
     playerName: name,
     playerPosition: position,
     ruleType: "not_following_plan",
     expectedBehavior: "Mirror triple in strict window; avoid off-mirror triples/zeros.",
-    actualBehavior,
+    actualBehavior: options?.actualBehavior ?? "#5 (★ ★ ★), #14 (★ ★ ★) : tripled non-mirror in strict window | 56★ | 22h 1m left",
+    attackDetails: options?.attackDetails,
+    breachContext: options?.breachContext ?? { starsAtBreach: 56, timeRemaining: "22h 1m left" },
+    reasonLabel: options?.reasonLabel ?? "tripled non-mirror in strict window",
   };
 }
 
@@ -34,7 +49,7 @@ function flattenButtons(components: ReturnType<typeof buildFwaComplianceEmbedVie
 }
 
 describe("buildFwaComplianceEmbedView", () => {
-  it("renders main FWA compliance embed with summary and violations", () => {
+  it("renders summary without participants or divider and formats violations as per-attack lines", () => {
     const rendered = buildFwaComplianceEmbedView({
       userId: "123",
       key: "payload",
@@ -48,11 +63,13 @@ describe("buildFwaComplianceEmbedView", () => {
       attacksCount: 53,
       missedBoth: [makeMissed(10, "Missed One")],
       notFollowingPlan: [
-        makeViolation(
-          5,
-          "lotus",
-          "#5 (★ ★ ★), #14 (★ ★ ★) : tripled non-mirror in strict window | 56★ | 22h 1m left"
-        ),
+        makeViolation(5, "lotus", {
+          attackDetails: [
+            { defenderPosition: 5, stars: 3, attackOrder: 1, isBreach: false },
+            { defenderPosition: 14, stars: 3, attackOrder: 2, isBreach: true },
+          ],
+          breachContext: { starsAtBreach: 56, timeRemaining: "22h 1m left" },
+        }),
       ],
       activeView: "fwa_main",
       mainPage: 0,
@@ -60,19 +77,60 @@ describe("buildFwaComplianceEmbedView", () => {
     });
 
     const embed = toEmbedJson(rendered.embed);
+    const summary = embed.fields?.[0]?.value ?? "";
+    const plan = embed.fields?.[1]?.value ?? "";
+
     expect(embed.title).toBe("FWA War Compliance — Rocky Road");
     expect(embed.description).toContain("War #777 • Expected: WIN");
-    expect(embed.fields?.[0]?.name).toBe("Summary");
-    expect(embed.fields?.[1]?.name).toBe("Plan Violations");
-    expect(embed.fields?.[1]?.value).toContain("#5 lotus");
-    expect(embed.fields?.[1]?.value).toContain("→ #5 ★ ★ ★ | #14 ★ ★ ★");
-    expect(embed.fields?.[1]?.value).toContain("tripled non-mirror in strict window");
-    expect(embed.fields?.[1]?.value).toContain("56★ | 22h 1m left");
+    expect(summary).toContain("⚔️ Attacks Logged: 53");
+    expect(summary).toContain("❌ Missed Both Attacks: 1");
+    expect(summary).toContain("⚠️ Didn't Follow Plan: 1");
+    expect(summary).not.toContain("Participants:");
+    expect(summary).not.toContain("---");
+
+    expect(plan).toContain("#5 lotus");
+    expect(plan).toContain("→ #5 ★ ★ ★");
+    expect(plan).toContain("→ #14 ★ ★ ★ ⚠️");
+    expect(plan).toContain("56★ | 22h 1m left");
+    expect(plan).not.toContain("tripled non-mirror in strict window");
+    expect(plan).not.toContain("| #14");
 
     const buttons = flattenButtons(rendered.components);
     const missedToggle = buttons.find((button) => button.label === "Missed Attacks");
-    expect(missedToggle).toBeTruthy();
     expect(missedToggle?.disabled).toBe(false);
+  });
+
+  it("marks both attack lines when both attacks are breaches", () => {
+    const rendered = buildFwaComplianceEmbedView({
+      userId: "123",
+      key: "payload",
+      isFwa: true,
+      clanName: "Rocky Road",
+      warId: 777,
+      expectedOutcome: "WIN",
+      warStartTime: null,
+      warEndTime: null,
+      participantsCount: 50,
+      attacksCount: 53,
+      missedBoth: [],
+      notFollowingPlan: [
+        makeViolation(1, "Kirito", {
+          attackDetails: [
+            { defenderPosition: 1, stars: 3, attackOrder: 1, isBreach: true },
+            { defenderPosition: 2, stars: 3, attackOrder: 2, isBreach: true },
+          ],
+          breachContext: { starsAtBreach: 49, timeRemaining: "21h 27m left" },
+        }),
+      ],
+      activeView: "fwa_main",
+      mainPage: 0,
+      missedPage: 0,
+    });
+
+    const plan = toEmbedJson(rendered.embed).fields?.[1]?.value ?? "";
+    expect(plan).toContain("→ #1 ★ ★ ★ ⚠️");
+    expect(plan).toContain("→ #2 ★ ★ ★ ⚠️");
+    expect(plan).toContain("49★ | 21h 27m left");
   });
 
   it("disables missed-attacks toggle when there are no missed-both players", () => {
@@ -96,11 +154,10 @@ describe("buildFwaComplianceEmbedView", () => {
 
     const buttons = flattenButtons(rendered.components);
     const missedToggle = buttons.find((button) => button.label === "Missed Attacks");
-    expect(missedToggle).toBeTruthy();
     expect(missedToggle?.disabled).toBe(true);
   });
 
-  it("renders non-FWA missed view with disabled FWA compliance button and empty state", () => {
+  it("renders non-FWA missed view with disabled FWA compliance button and compact player spacing", () => {
     const rendered = buildFwaComplianceEmbedView({
       userId: "123",
       key: "payload",
@@ -112,7 +169,11 @@ describe("buildFwaComplianceEmbedView", () => {
       warEndTime: null,
       participantsCount: 50,
       attacksCount: 20,
-      missedBoth: [],
+      missedBoth: [
+        makeMissed(2, "Lucky Luke"),
+        makeMissed(5, "DiamondPro68"),
+        makeMissed(7, "Darkdestyne"),
+      ],
       notFollowingPlan: [],
       activeView: "missed",
       mainPage: 0,
@@ -122,25 +183,31 @@ describe("buildFwaComplianceEmbedView", () => {
     const embed = toEmbedJson(rendered.embed);
     expect(embed.title).toBe("Missed Attacks — Rocky Road");
     expect(embed.fields?.[0]?.name).toBe("Players");
-    expect(embed.fields?.[0]?.value).toContain("No players missed both attacks.");
+    const players = embed.fields?.[0]?.value ?? "";
+    expect(players).toContain("Lucky Luke (#M2)");
+    expect(players).toContain("DiamondPro68 (#M5)");
+    expect(players).toContain("Darkdestyne (#M7)");
+    expect(players).not.toContain("\n\n");
 
     const buttons = flattenButtons(rendered.components);
     const fwaButton = buttons.find((button) => button.label === "FWA Compliance");
-    expect(fwaButton).toBeTruthy();
     expect(fwaButton?.disabled).toBe(true);
   });
 
-  it("paginates violations and players with deterministic ordering", () => {
-    const notFollowing = Array.from({ length: 28 }, (_, idx) =>
-      makeViolation(
-        idx + 1,
-        `P${idx + 1}`,
-        `#${idx + 1} (★ ★ ☆), #${idx + 2} (★ ★ ★) : didn't triple mirror in strict window with extended reason text ${"x".repeat(48)} | ${20 + idx}★ | 21h 0m left`
-      )
+  it("keeps pagination deterministic for violations and missed-attacks lists", () => {
+    const notFollowing = Array.from({ length: 24 }, (_, idx) =>
+      makeViolation(idx + 1, `P${idx + 1}`, {
+        actualBehavior: `#${idx + 1} (★ ★ ★), #${idx + 2} (★ ★ ☆) : didn't triple mirror | ${45 + idx}★ | 21h 10m left`,
+        attackDetails: [
+          { defenderPosition: idx + 1, stars: 3, attackOrder: 1, isBreach: true },
+          { defenderPosition: idx + 2, stars: 2, attackOrder: 2, isBreach: true },
+        ],
+        breachContext: { starsAtBreach: 45 + idx, timeRemaining: "21h 10m left" },
+      })
     );
     const missed = Array.from({ length: 140 }, (_, idx) => makeMissed(idx + 1, `M${idx + 1}`));
 
-    const mainPageOne = buildFwaComplianceEmbedView({
+    const firstMain = buildFwaComplianceEmbedView({
       userId: "123",
       key: "payload",
       isFwa: true,
@@ -157,8 +224,7 @@ describe("buildFwaComplianceEmbedView", () => {
       mainPage: 0,
       missedPage: 0,
     });
-
-    const mainPageTwo = buildFwaComplianceEmbedView({
+    const secondMain = buildFwaComplianceEmbedView({
       userId: "123",
       key: "payload",
       isFwa: true,
@@ -175,16 +241,15 @@ describe("buildFwaComplianceEmbedView", () => {
       mainPage: 1,
       missedPage: 0,
     });
+    const firstMainEmbed = toEmbedJson(firstMain.embed);
+    const secondMainEmbed = toEmbedJson(secondMain.embed);
+    expect(firstMain.mainPageCount).toBeGreaterThan(1);
+    expect(firstMainEmbed.footer?.text).toMatch(/^Page 1\/\d+$/);
+    expect(secondMainEmbed.footer?.text).toMatch(/^Page 2\/\d+$/);
+    expect(firstMainEmbed.fields?.[1]?.value).toContain("#1 P1");
+    expect(secondMainEmbed.fields?.[1]?.value).not.toContain("#1 P1");
 
-    const mainOne = toEmbedJson(mainPageOne.embed);
-    const mainTwo = toEmbedJson(mainPageTwo.embed);
-    expect(mainPageOne.mainPageCount).toBeGreaterThan(1);
-    expect(mainOne.footer?.text).toMatch(/^Page 1\/\d+$/);
-    expect(mainTwo.footer?.text).toMatch(/^Page 2\/\d+$/);
-    expect(mainOne.fields?.[1]?.value).toContain("#1 P1");
-    expect(mainTwo.fields?.[1]?.value).not.toContain("#1 P1");
-
-    const missedPageTwo = buildFwaComplianceEmbedView({
+    const secondMissed = buildFwaComplianceEmbedView({
       userId: "123",
       key: "payload",
       isFwa: true,
@@ -201,8 +266,8 @@ describe("buildFwaComplianceEmbedView", () => {
       mainPage: 0,
       missedPage: 1,
     });
-    const missedTwo = toEmbedJson(missedPageTwo.embed);
-    expect(missedPageTwo.missedPageCount).toBeGreaterThan(1);
-    expect(missedTwo.footer?.text).toMatch(/^Page 2\/\d+$/);
+    const secondMissedEmbed = toEmbedJson(secondMissed.embed);
+    expect(secondMissed.missedPageCount).toBeGreaterThan(1);
+    expect(secondMissedEmbed.footer?.text).toMatch(/^Page 2\/\d+$/);
   });
 });

--- a/tests/warCompliance.service.test.ts
+++ b/tests/warCompliance.service.test.ts
@@ -273,6 +273,62 @@ describe("WarComplianceService", () => {
     expect(report?.notFollowingPlan).toHaveLength(0);
   });
 
+  it("does not flag mirror-first then redundant non-mirror triple on already-tripled base", async () => {
+    const warStartTime = new Date("2026-02-01T00:00:00.000Z");
+    const warEndTime = new Date("2026-02-02T00:00:00.000Z");
+    const participants = [
+      { playerName: "Alice", playerTag: "#A1", attacksUsed: 2, playerPosition: 1 },
+      { playerName: "Bob", playerTag: "#B1", attacksUsed: 0, playerPosition: 2 },
+    ];
+    const attacks = [
+      {
+        playerTag: "#A1",
+        playerName: "Alice",
+        playerPosition: 1,
+        defenderPosition: 1,
+        stars: 3,
+        trueStars: 3,
+        attackSeenAt: new Date("2026-02-01T01:00:00.000Z"),
+        warEndTime,
+        attackOrder: 1,
+      },
+      {
+        playerTag: "#A1",
+        playerName: "Alice",
+        playerPosition: 1,
+        defenderPosition: 2,
+        stars: 3,
+        trueStars: 0,
+        attackSeenAt: new Date("2026-02-01T02:00:00.000Z"),
+        warEndTime,
+        attackOrder: 2,
+      },
+    ];
+
+    vi.spyOn(prisma.warAttacks, "findFirst").mockResolvedValue({
+      warStartTime,
+      warEndTime,
+      warId: 1001,
+    } as any);
+    vi.spyOn(prisma.warAttacks, "findMany")
+      .mockResolvedValueOnce(participants as any)
+      .mockResolvedValueOnce(attacks as any);
+    vi.spyOn(prisma.trackedClan, "findFirst").mockResolvedValue({
+      loseStyle: "TRIPLE_TOP_30",
+    } as any);
+
+    const service = new WarComplianceService();
+    const report = await service.getComplianceReport({
+      clanTag: "#TEST",
+      preferredWarStartTime: warStartTime,
+      matchType: "FWA",
+      expectedOutcome: "WIN",
+    });
+
+    expect(report).not.toBeNull();
+    expect(report?.notFollowingPlan).toHaveLength(0);
+  });
+
   it("returns null report for BL/MM checks without hitting DB", async () => {
     const findFirstSpy = vi.spyOn(prisma.warAttacks, "findFirst");
     const service = new WarComplianceService();


### PR DESCRIPTION
- replace text-only compliance output with embed-based FWA main + missed-attacks views
- add invoker-locked button routing for view toggles and prev/next pagination
- default non-FWA wars to missed-attacks view with disabled FWA compliance toggle
- keep strict-window non-mirror infractions gated on positive trueStars
- include non-FWA missed-both details in evaluation payloads for UI rendering
- add regression tests for custom ids, embed rendering/pagination, and rule behavior fix(fwa): refine compliance violation rendering and breach semantics

- remove participants/divider lines from the compliance summary
- render plan-violation attacks on separate lines with breach markers
- compact missed-attacks player output with no blank line spacing
- carry explicit breach attack metadata for deterministic rendering
- add regression tests for true-stars edge cases and formatting