### PR TITLE
fix(sync): normalize sync timezones to canonical regions

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -65,7 +65,7 @@
 - `/kick-list remove tag:<playerTag>` - Remove a player from kick list.
 - `/kick-list show` - Show current kick-list with reasons.
 - `/kick-list clear [mode:all|auto|manual]` - Clear kick-list entries.
-- `/sync time post [role:<discordRole>]` - Open modal, compose sync-time message, post it, and pin it.
+- `/sync time post [role:<discordRole>]` - Open modal, compose sync-time message, post it, and pin it. Timezone input accepts IANA names like `America/New_York` plus common US aliases such as `EST`, `EDT`, `PST`, and `PDT`.
 - `/sync post status [message-id:<id>]` - Show claimed vs unclaimed clan badge reactions for the active sync-time post, or for a specific message in the channel.
 - `/force sync data tag:<trackedClanTag> [datapoint:points|syncNum]` - Manually force-sync tracked clan points and/or sync number from points.fwafarm (explicitly bypasses points lock and war-scoped reuse).
 - `/force sync mail tag:<trackedClanTag> message-type:<mail|notify:war start|notify:battle start|notify:war end> message-id:<id>` - Upsert `CurrentWar.mailConfig` with current match configuration plus a posted message reference.

--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -309,6 +309,7 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
     summary: "Post structured messages such as sync time announcements.",
     details: [
       "`/sync time post` opens a modal to capture date/time/timezone and role ping.",
+      "Timezone input accepts IANA names like `America/New_York` plus common US aliases such as `EST`, `EDT`, `PST`, and `PDT`.",
       "Creates and pins a sync-time message in the active channel, then adds clan badge reactions.",
       "`/sync post status` shows claimed vs unclaimed clans from the stored active sync post, or a provided message ID.",
       "`sync time` is admin-only by default.",

--- a/src/commands/Post.ts
+++ b/src/commands/Post.ts
@@ -27,6 +27,7 @@ import {
   FWA_LEADER_ROLE_SETTING_KEY,
 } from "../services/CommandPermissionService";
 import { SettingsService } from "../services/SettingsService";
+import { normalizeSyncTimeZone } from "../services/syncTimeZone";
 
 const DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
 const TIME_PATTERN = /^\d{1,2}:\d{2}$/;
@@ -548,19 +549,6 @@ function toEpochSeconds(
   return Math.floor(result / 1000);
 }
 
-function normalizeTimeZone(input: string): string {
-  return input.trim();
-}
-
-function validateTimeZone(timeZone: string): boolean {
-  try {
-    new Intl.DateTimeFormat("en-US", { timeZone });
-    return true;
-  } catch {
-    return false;
-  }
-}
-
 function getDateTimeInTimeZone(
   date: Date,
   timeZone: string
@@ -707,16 +695,15 @@ export async function handlePostModalSubmit(
 
   const dateInput = interaction.fields.getTextInputValue(DATE_INPUT_ID).trim();
   const timeInput = interaction.fields.getTextInputValue(TIME_INPUT_ID).trim();
-  const timezoneInput = normalizeTimeZone(
-    interaction.fields.getTextInputValue(TIMEZONE_INPUT_ID)
-  );
+  const timezoneRawInput = interaction.fields.getTextInputValue(TIMEZONE_INPUT_ID);
+  const timezoneInput = normalizeSyncTimeZone(timezoneRawInput);
   const roleInput = interaction.fields.getTextInputValue(ROLE_INPUT_ID).trim();
   const permissionService = new CommandPermissionService(settings);
   const defaultLeaderRoleId = await permissionService.getFwaLeaderRoleId(interaction.guildId);
 
-  if (!validateTimeZone(timezoneInput)) {
+  if (!timezoneInput) {
     await interaction.editReply(
-      `Invalid timezone. Use a valid IANA timezone like America/New_York.\nReference: ${IANA_TIMEZONE_HELP_URL}`
+      `Invalid timezone. Use a valid IANA timezone like America/New_York, or a supported US alias like EST, EDT, PST, or PDT.\nReference: ${IANA_TIMEZONE_HELP_URL}`
     );
     return;
   }
@@ -1034,16 +1021,21 @@ export const Post: Command = {
     const settings = new SettingsService();
     const role = interaction.options.getRole("role", false);
 
-    const rememberedTimeZone = await settings.get(userTimeZoneKey(interaction.user.id));
-  const rememberedRoleId = await settings.get(guildSyncRoleKey(interaction.guildId));
-  const defaultLeaderRoleId =
-    (await settings.get(`${FWA_LEADER_ROLE_SETTING_KEY}:${interaction.guildId}`)) ?? "";
-  const initialTimeZone =
-    rememberedTimeZone && validateTimeZone(rememberedTimeZone)
-      ? rememberedTimeZone
-      : "UTC";
-  const defaults = getEffectiveDefaults(initialTimeZone);
-  const initialRoleId = role?.id ?? rememberedRoleId ?? defaultLeaderRoleId ?? "";
+    const rememberedTimeZoneRaw = await settings.get(userTimeZoneKey(interaction.user.id));
+    const rememberedTimeZone = normalizeSyncTimeZone(rememberedTimeZoneRaw);
+    if (
+      rememberedTimeZone &&
+      rememberedTimeZoneRaw?.trim() &&
+      rememberedTimeZoneRaw.trim() !== rememberedTimeZone
+    ) {
+      await settings.set(userTimeZoneKey(interaction.user.id), rememberedTimeZone);
+    }
+    const rememberedRoleId = await settings.get(guildSyncRoleKey(interaction.guildId));
+    const defaultLeaderRoleId =
+      (await settings.get(`${FWA_LEADER_ROLE_SETTING_KEY}:${interaction.guildId}`)) ?? "";
+    const initialTimeZone = rememberedTimeZone ?? "UTC";
+    const defaults = getEffectiveDefaults(initialTimeZone);
+    const initialRoleId = role?.id ?? rememberedRoleId ?? defaultLeaderRoleId ?? "";
 
     const modal = new ModalBuilder()
       .setCustomId(buildModalCustomId(interaction.user.id))
@@ -1063,7 +1055,7 @@ export const Post: Command = {
       .setValue(defaults.time);
     const timeZoneInput = new TextInputBuilder()
       .setCustomId(TIMEZONE_INPUT_ID)
-      .setLabel("Timezone (IANA)")
+      .setLabel("Timezone (IANA or US alias)")
       .setStyle(TextInputStyle.Short)
       .setRequired(true)
       .setValue(initialTimeZone);

--- a/src/services/syncTimeZone.ts
+++ b/src/services/syncTimeZone.ts
@@ -1,0 +1,39 @@
+const SYNC_TIMEZONE_ALIAS_MAP = new Map<string, string>([
+  ["ET", "America/New_York"],
+  ["EST", "America/New_York"],
+  ["EDT", "America/New_York"],
+  ["CT", "America/Chicago"],
+  ["CST", "America/Chicago"],
+  ["CDT", "America/Chicago"],
+  ["MT", "America/Denver"],
+  ["MST", "America/Denver"],
+  ["MDT", "America/Denver"],
+  ["PT", "America/Los_Angeles"],
+  ["PST", "America/Los_Angeles"],
+  ["PDT", "America/Los_Angeles"],
+]);
+
+function canonicalizeTimeZone(value: string): string | null {
+  try {
+    return new Intl.DateTimeFormat("en-US", { timeZone: value }).resolvedOptions().timeZone;
+  } catch {
+    return null;
+  }
+}
+
+function isSupportedSyncTimeZone(timeZone: string): boolean {
+  if (timeZone === "UTC") return true;
+  return timeZone.includes("/") && !timeZone.startsWith("Etc/");
+}
+
+/** Purpose: normalize sync-time timezone input into a canonical region timezone or UTC. */
+export function normalizeSyncTimeZone(input: string | null | undefined): string | null {
+  const trimmed = String(input ?? "").trim();
+  if (!trimmed) return null;
+
+  const aliased = SYNC_TIMEZONE_ALIAS_MAP.get(trimmed.toUpperCase()) ?? trimmed;
+  const canonical = canonicalizeTimeZone(aliased);
+  if (!canonical) return null;
+
+  return isSupportedSyncTimeZone(canonical) ? canonical : null;
+}

--- a/tests/syncTimeZone.logic.test.ts
+++ b/tests/syncTimeZone.logic.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { normalizeSyncTimeZone } from "../src/services/syncTimeZone";
+
+describe("sync time zone normalization", () => {
+  it("accepts canonical IANA region timezones", () => {
+    expect(normalizeSyncTimeZone("America/New_York")).toBe("America/New_York");
+    expect(normalizeSyncTimeZone("America/Los_Angeles")).toBe("America/Los_Angeles");
+    expect(normalizeSyncTimeZone("UTC")).toBe("UTC");
+  });
+
+  it("normalizes supported US aliases to canonical region timezones", () => {
+    expect(normalizeSyncTimeZone(" EST ")).toBe("America/New_York");
+    expect(normalizeSyncTimeZone("EDT")).toBe("America/New_York");
+    expect(normalizeSyncTimeZone("PST")).toBe("America/Los_Angeles");
+    expect(normalizeSyncTimeZone("pdt")).toBe("America/Los_Angeles");
+    expect(normalizeSyncTimeZone("CT")).toBe("America/Chicago");
+  });
+
+  it("canonicalizes alternate IANA aliases to region timezones", () => {
+    expect(normalizeSyncTimeZone("US/Eastern")).toBe("America/New_York");
+    expect(normalizeSyncTimeZone("US/Pacific")).toBe("America/Los_Angeles");
+  });
+
+  it("rejects fixed-offset and invalid timezone identifiers", () => {
+    expect(normalizeSyncTimeZone("Etc/GMT+5")).toBeNull();
+    expect(normalizeSyncTimeZone("Bad/Timezone")).toBeNull();
+    expect(normalizeSyncTimeZone("")).toBeNull();
+  });
+});


### PR DESCRIPTION
- map common US timezone aliases to canonical IANA regions for /sync time post
- canonicalize stored sync-time timezone values on read and write
- add tests and docs for supported sync-time timezone input