### PR TITLE
fix(war-events): persist expected war-end points and reconcile mismat…

### DIFF
--- a/src/helper/fetchTelemetry.ts
+++ b/src/helper/fetchTelemetry.ts
@@ -1,5 +1,5 @@
 import { AsyncLocalStorage } from "node:async_hooks";
-import { prisma } from "../prisma";
+import { hasInitializedPrismaClient, prisma } from "../prisma";
 import { TelemetryIngestService } from "../services/telemetry/ingest";
 
 type FetchSource = "api" | "web" | "cache_hit" | "cache_miss" | "fallback_cache";
@@ -27,6 +27,7 @@ const telemetryBatchStorage = new AsyncLocalStorage<{
   startedAtMs: number;
   operationTotals: Map<string, Totals>;
 }>();
+let apiUsagePersistenceDisabled = false;
 
 function makeEmptyTotals(): Totals {
   return {
@@ -59,9 +60,18 @@ function getOrCreateTotals(map: Map<string, Totals>, key: string): Totals {
   return created;
 }
 
+/** Purpose: determine whether a value supports Promise-style rejection handling. */
+function isPromiseLike(value: unknown): value is Promise<unknown> {
+  if (typeof value !== "object" || value === null) return false;
+  return typeof (value as { then?: unknown }).then === "function";
+}
+
 function trackApiUsage(endpoint: string, incrementBy: number): void {
-  void prisma.apiUsage
-    .upsert({
+  if (apiUsagePersistenceDisabled) return;
+  if (!hasInitializedPrismaClient()) return;
+
+  try {
+    const maybePromise = prisma.apiUsage.upsert({
       where: { endpoint },
       create: {
         endpoint,
@@ -72,8 +82,15 @@ function trackApiUsage(endpoint: string, incrementBy: number): void {
         lastCall: new Date(),
         callCount: { increment: incrementBy },
       },
-    })
-    .catch(() => undefined);
+    });
+    if (isPromiseLike(maybePromise)) {
+      void maybePromise.catch(() => undefined);
+    }
+  } catch (error) {
+    apiUsagePersistenceDisabled = true;
+    const message = String((error as { message?: string } | null)?.message ?? error);
+    console.warn(`[telemetry] apiUsage persistence disabled reason=${message}`);
+  }
 }
 
 export async function runFetchTelemetryBatch<T>(

--- a/src/prisma.ts
+++ b/src/prisma.ts
@@ -57,6 +57,11 @@ export function getPrismaClient(): PrismaClient {
   }
 }
 
+/** Purpose: expose whether Prisma has already been initialized without forcing initialization. */
+export function hasInitializedPrismaClient(): boolean {
+  return prismaClient !== null;
+}
+
 /** Purpose: resolve a nested Prisma path into the owning object and target value. */
 function resolvePrismaPath(root: unknown, path: PrismaPath): { owner: unknown; value: unknown } {
   if (path.length === 0) {

--- a/src/services/FwaStatsWeightService.ts
+++ b/src/services/FwaStatsWeightService.ts
@@ -34,6 +34,9 @@ type WeightCacheEntry = {
 
 const SUCCESS_CACHE_TTL_MS = 10 * 60 * 1000;
 const PARSE_ERROR_CACHE_TTL_MS = 2 * 60 * 1000;
+const WEIGHT_AGE_UNIT_PATTERN =
+  "(d|day|days|h|hr|hrs|hour|hours|m|min|mins|minute|minutes|w|wk|wks|week|weeks|mo|mon|month|months|y|yr|yrs|year|years)";
+const WEIGHT_AGE_TOKEN_PATTERN = `(\\d+(?:\\.\\d+)?)\\s*${WEIGHT_AGE_UNIT_PATTERN}\\b`;
 
 /** Purpose: normalize clan tags to canonical #UPPER format. */
 function normalizeClanTag(input: string): string {
@@ -60,12 +63,49 @@ export function isFwaStatsLoginPage(html: string): boolean {
 
 /** Purpose: extract weight age token from HTML content. */
 export function extractWeightAgeToken(html: string): string | null {
-  const normalized = String(html ?? "").replace(/\s+/g, " ");
-  if (!normalized) return null;
-  const match = normalized.match(/Clan weight submitted\s+(.+?)\s+ago\b/i);
-  const raw = String(match?.[1] ?? "").trim();
-  if (!raw) return null;
-  return raw.replace(/[. ]+$/g, "").trim() || null;
+  const normalizedHtml = String(html ?? "").replace(/\s+/g, " ").trim();
+  if (!normalizedHtml) return null;
+
+  const normalizeMatch = (value: string | null | undefined): string | null => {
+    const raw = String(value ?? "")
+      .replace(/<[^>]+>/g, " ")
+      .replace(/&nbsp;/gi, " ")
+      .replace(/\bago\b/gi, " ")
+      .replace(/\s+/g, " ")
+      .replace(/[. ]+$/g, "")
+      .trim();
+    if (!raw) return null;
+    return parseWeightAgeDays(raw) === null ? null : raw;
+  };
+
+  const strictPatterns = [
+    /Clan weight submitted\s+(.+?)\s+ago\b/i,
+    /(?:last\s+)?(?:clan\s+)?weight(?:\s+\w+){0,3}\s+submitted\s*[:-]?\s+(.+?)\s+ago\b/i,
+    /(?:last\s+)?weight(?:\s+\w+){0,3}\s+submission\s*[:-]?\s+(.+?)\s+ago\b/i,
+    /weight\s+age\s*[:-]?\s+(.+?)\s+ago\b/i,
+  ];
+  for (const pattern of strictPatterns) {
+    const match = normalizedHtml.match(pattern);
+    const token = normalizeMatch(match?.[1]);
+    if (token) return token;
+  }
+
+  const textOnly = normalizedHtml.replace(/<[^>]+>/g, " ").replace(/&nbsp;/gi, " ").trim();
+  if (!/\bweight\b/i.test(textOnly)) return null;
+
+  const contextualAgoPattern = new RegExp(
+    `(?:weight|submitted)[^\\r\\n]{0,80}?(${WEIGHT_AGE_TOKEN_PATTERN})\\s+ago\\b`,
+    "i"
+  );
+  const contextualToken = normalizeMatch(textOnly.match(contextualAgoPattern)?.[1]);
+  if (contextualToken) return contextualToken;
+
+  const fallbackAgoPattern = new RegExp(`${WEIGHT_AGE_TOKEN_PATTERN}\\s+ago\\b`, "gi");
+  for (const match of textOnly.matchAll(fallbackAgoPattern)) {
+    const token = normalizeMatch(match[1]);
+    if (token) return token;
+  }
+  return null;
 }
 
 /** Purpose: convert human-readable weight age token to day units for health scoring. */
@@ -73,9 +113,7 @@ export function parseWeightAgeDays(token: string | null | undefined): number | n
   const normalized = String(token ?? "").trim().toLowerCase();
   if (!normalized) return null;
 
-  const match = normalized.match(
-    /(\d+(?:\.\d+)?)\s*(d|day|days|h|hr|hrs|hour|hours|m|min|mins|minute|minutes|w|wk|wks|week|weeks|mo|mon|month|months|y|yr|yrs|year|years)\b/
-  );
+  const match = normalized.match(new RegExp(WEIGHT_AGE_TOKEN_PATTERN, "i"));
   if (!match) return null;
 
   const value = Number(match[1]);
@@ -344,7 +382,7 @@ export class FwaStatsWeightService {
             status: "parse_error",
             httpStatus: response.status,
             fromCache: false,
-            error: "Could not find 'Clan weight submitted ... ago' in page HTML.",
+            error: "Could not find weight age text in page HTML.",
             authErrorCode: null,
           };
           recordFetchEvent({

--- a/src/services/WarEventLogService.ts
+++ b/src/services/WarEventLogService.ts
@@ -15,8 +15,9 @@ import { CoCService } from "./CoCService";
 import { PointsProjectionService } from "./PointsProjectionService";
 import { PostedMessageService } from "./PostedMessageService";
 import { PointsSyncService } from "./PointsSyncService";
-import { PointsFetchPolicyService } from "./PointsFetchPolicyService";
+import { PointsFetchPolicyService, type PointsApiFetchReason } from "./PointsFetchPolicyService";
 import { SettingsService } from "./SettingsService";
+import { CommandPermissionService } from "./CommandPermissionService";
 import {
   chooseMatchTypeResolution,
   inferMatchTypeFromOpponentPoints,
@@ -33,6 +34,7 @@ import {
   type MatchType,
   type WarEndResultSnapshot,
   type WarState,
+  computeExpectedWarEndPointsForTest,
   deriveExpectedOutcome,
   deriveState,
   eventTitle,
@@ -55,6 +57,7 @@ const COC_WAR_OUTAGE_FAILURE_THRESHOLD = 2;
 const COC_WAR_OUTAGE_RECOVERY_THRESHOLD = 2;
 const battleDayPostByGuildTag = new Map<string, { channelId: string; messageId: string }>();
 const NOTIFY_UNKNOWN_OPPONENT = "Unknown Opponent";
+const WAR_END_DISCREPANCY_MARKER = "war_end_discrepancy";
 
 function buildNextRefreshRelativeLabel(
   intervalMs: number,
@@ -147,6 +150,73 @@ function buildBattleDayRefreshEditPayload(
 }
 
 export const buildBattleDayRefreshEditPayloadForTest = buildBattleDayRefreshEditPayload;
+
+/** Purpose: normalize and persist discrepancy fingerprint data on tracked notify rows. */
+function parseWarEndDiscrepancyFingerprint(configHash: string | null | undefined): string | null {
+  const raw = String(configHash ?? "");
+  const match = raw.match(new RegExp(`(?:^|\\|)${WAR_END_DISCREPANCY_MARKER}:([^|]+)$`));
+  return match?.[1] ? match[1] : null;
+}
+
+/** Purpose: write discrepancy fingerprint while preserving the existing notify config hash payload. */
+function writeWarEndDiscrepancyFingerprint(
+  configHash: string | null | undefined,
+  fingerprint: string
+): string {
+  const raw = String(configHash ?? "");
+  const stripped = raw.replace(
+    new RegExp(`(?:^|\\|)${WAR_END_DISCREPANCY_MARKER}:[^|]+$`),
+    ""
+  );
+  if (!stripped) return `${WAR_END_DISCREPANCY_MARKER}:${fingerprint}`;
+  return `${stripped}|${WAR_END_DISCREPANCY_MARKER}:${fingerprint}`;
+}
+
+/** Purpose: build canonical mismatch fingerprint for idempotent war-end discrepancy alerts. */
+function buildWarEndDiscrepancyFingerprint(
+  warId: number,
+  expectedPoints: number,
+  actualPoints: number
+): string {
+  return `${Math.trunc(warId)}:${Math.trunc(expectedPoints)}:${Math.trunc(actualPoints)}`;
+}
+
+/** Purpose: build visible warning content for war-end points reconciliation mismatches. */
+function buildWarEndDiscrepancyContent(params: {
+  existingPostedContent: string | null | undefined;
+  opponentName: string | null | undefined;
+  expectedPoints: number;
+  actualPoints: number;
+  fwaLeaderRoleId: string | null;
+}): {
+  content: string;
+  allowedMentions: { parse: []; roles?: string[] };
+} {
+  const existingMentionRoleId = extractPostedNotifyMentionRoleId(params.existingPostedContent);
+  const baseContent = buildNotifyEventPostedContent({
+    eventType: "war_ended",
+    opponentName: params.opponentName,
+    notifyRoleId: existingMentionRoleId,
+    includeRoleMention: Boolean(existingMentionRoleId),
+  });
+  const warningLines = [
+    "⚠️ War-end points mismatch detected.",
+    `Expected points: ${Math.trunc(params.expectedPoints)}`,
+    `Actual points: ${Math.trunc(params.actualPoints)}`,
+  ];
+  if (params.fwaLeaderRoleId) {
+    warningLines.push(`<@&${params.fwaLeaderRoleId}>`);
+  }
+  return {
+    content: [baseContent, ...warningLines].join("\n"),
+    allowedMentions: params.fwaLeaderRoleId
+      ? { parse: [], roles: [params.fwaLeaderRoleId] }
+      : { parse: [] },
+  };
+}
+
+export const buildWarEndDiscrepancyContentForTest = buildWarEndDiscrepancyContent;
+export const buildWarEndDiscrepancyFingerprintForTest = buildWarEndDiscrepancyFingerprint;
 
 /** Purpose: keep notify-event embed colors stable and centralized across render paths. */
 export function resolveNotifyEventEmbedColor(eventType: EventType): number {
@@ -667,6 +737,7 @@ export class WarEventLogService {
   private readonly pointsSync: WarStartPointsSyncService;
   private readonly currentSyncs: PointsSyncService;
   private readonly pointsPolicy: PointsFetchPolicyService;
+  private readonly commandPermissions: CommandPermissionService;
   private readonly history: WarEventHistoryService;
   private readonly postedMessages: PostedMessageService;
   private readonly cocWarOutageByClanTag = new Map<string, CocWarOutageState>();
@@ -677,6 +748,7 @@ export class WarEventLogService {
     this.pointsSync = new WarStartPointsSyncService(this.points, new SettingsService());
     this.currentSyncs = new PointsSyncService();
     this.pointsPolicy = new PointsFetchPolicyService();
+    this.commandPermissions = new CommandPermissionService();
     this.history = new WarEventHistoryService(coc);
     this.postedMessages = new PostedMessageService();
   }
@@ -979,24 +1051,22 @@ export class WarEventLogService {
             resultLabel: deriveResultLabelFromStars(currentClanStars, currentOpponentStars),
           }
         : null;
-    const testWarStartFwaPoints =
-      params.source === "current" ? sub.warStartFwaPoints ?? fwaPoints : sub.warStartFwaPoints;
+    const testWarStartFwaPoints = this.resolveWarEndBeforePoints({
+      warStartFwaPoints: sub.warStartFwaPoints,
+      fwaPoints: sub.fwaPoints,
+    });
     let testWarEndFwaPoints = sub.warEndFwaPoints;
-    if (params.source === "current" && params.eventType === "war_ended") {
-      if (sub.matchType === "BL" && testFinalResultOverride) {
-        const before = testWarStartFwaPoints ?? fwaPoints;
-        const delta = this.computeBlPointsDelta(testFinalResultOverride);
-        testWarEndFwaPoints = before !== null && Number.isFinite(before) ? before + delta : null;
-      } else if (sub.matchType === "FWA" && testFinalResultOverride) {
-        const before = testWarStartFwaPoints ?? fwaPoints;
-        const delta = this.computeTestFwaPointsDelta(testFinalResultOverride);
-        testWarEndFwaPoints = before !== null && Number.isFinite(before) ? before + delta : null;
-      } else if (sub.matchType === "MM") {
-        const before = testWarStartFwaPoints ?? fwaPoints;
-        testWarEndFwaPoints = before !== null && Number.isFinite(before) ? before : fwaPoints;
-      } else {
-        testWarEndFwaPoints = fwaPoints;
-      }
+    if (params.source === "current" && params.eventType === "war_ended" && testFinalResultOverride) {
+      const before = this.resolveWarEndBeforePoints({
+        warStartFwaPoints: sub.warStartFwaPoints,
+        fwaPoints: sub.fwaPoints,
+      });
+      testWarEndFwaPoints = this.computeExpectedWarEndPoints({
+        matchType: sub.matchType,
+        before,
+        finalResult: testFinalResultOverride,
+        outcome,
+      });
     }
 
     return {
@@ -1080,7 +1150,7 @@ export class WarEventLogService {
     embed.addFields(
       {
         name: "Opponent",
-        value: `${payload.opponentName} (${opponentTag ? `#${opponentTag}` : "unknown"})`,
+        value: `${payload.opponentName} (${opponentTag || "unknown"})`,
         inline: false,
       },
       {
@@ -1349,17 +1419,33 @@ export class WarEventLogService {
     return Boolean(existing?.warId);
   }
 
-  /** Purpose: compute bl points delta. */
-  private computeBlPointsDelta(finalResult: WarEndResultSnapshot): number {
-    if (finalResult.resultLabel === "WIN") return 3;
-    if ((finalResult.clanDestruction ?? 0) >= 60) return 2;
-    return 1;
+  /** Purpose: resolve canonical war-end "before points" source with explicit precedence. */
+  private resolveWarEndBeforePoints(sub: {
+    warStartFwaPoints: number | null;
+    fwaPoints: number | null;
+  }): number | null {
+    if (sub.warStartFwaPoints !== null && Number.isFinite(sub.warStartFwaPoints)) {
+      return Math.trunc(sub.warStartFwaPoints);
+    }
+    if (sub.fwaPoints !== null && Number.isFinite(sub.fwaPoints)) {
+      return Math.trunc(sub.fwaPoints);
+    }
+    return null;
   }
 
-  private computeTestFwaPointsDelta(finalResult: WarEndResultSnapshot): number {
-    if (finalResult.resultLabel === "WIN") return -1;
-    if (finalResult.resultLabel === "LOSE") return 1;
-    return 0;
+  /** Purpose: compute expected post-war points for persisted war-end canonical output. */
+  private computeExpectedWarEndPoints(input: {
+    matchType: MatchType;
+    before: number | null;
+    finalResult: WarEndResultSnapshot;
+    outcome: "WIN" | "LOSE" | null;
+  }): number | null {
+    return computeExpectedWarEndPointsForTest({
+      matchType: input.matchType,
+      before: input.before,
+      finalResult: input.finalResult,
+      outcome: input.outcome,
+    });
   }
 
   /** Purpose: fetch current war while preserving upstream-failure classification. */
@@ -1756,9 +1842,6 @@ export class WarEventLogService {
       if (eventType === "war_started") {
         nextWarStartFwaPoints = a.balance;
       }
-      if (eventType === "war_ended") {
-        nextWarEndFwaPoints = a.balance;
-      }
     }
     const resolvedMatchType = chooseMatchTypeResolution({
       confirmedCurrent: currentWarResolution.confirmed,
@@ -1769,7 +1852,7 @@ export class WarEventLogService {
     let nextMatchType = resolvedMatchType?.matchType ?? sub.matchType;
     let nextInferredMatchType = resolvedMatchType?.inferred ?? sub.inferredMatchType;
 
-    if (eventType === "war_ended" && nextMatchType === "BL") {
+    if (eventType === "war_ended") {
       const finalResult = await this.history.getWarEndResultSnapshot({
         clanTag: sub.clanTag,
         opponentTag: nextOpponentTag || normalizeTag(sub.opponentTag ?? ""),
@@ -1777,18 +1860,22 @@ export class WarEventLogService {
         fallbackOpponentStars: nextOpponentStars,
         warStartTime: nextWarStartTime,
       });
-      const delta = this.computeBlPointsDelta(finalResult);
-      const before =
-        nextWarStartFwaPoints !== null && Number.isFinite(nextWarStartFwaPoints)
-          ? nextWarStartFwaPoints
-          : nextFwaPoints !== null && Number.isFinite(nextFwaPoints)
-            ? nextFwaPoints
-            : null;
-      if (before !== null) {
-        const after = before + delta;
-        nextWarEndFwaPoints = after;
-        nextFwaPoints = after;
+      const before = this.resolveWarEndBeforePoints({
+        warStartFwaPoints: sub.warStartFwaPoints,
+        fwaPoints: sub.fwaPoints,
+      });
+      if (
+        (nextWarStartFwaPoints === null || nextWarStartFwaPoints === undefined) &&
+        before !== null
+      ) {
+        nextWarStartFwaPoints = before;
       }
+      nextWarEndFwaPoints = this.computeExpectedWarEndPoints({
+        matchType: nextMatchType,
+        before,
+        finalResult,
+        outcome: normalizeOutcome(nextOutcome),
+      });
     }
 
     const resolvedWarId = await this.ensureCurrentWarId({
@@ -1889,6 +1976,21 @@ export class WarEventLogService {
         sub,
         payload: detectedEventPayload,
         resolvedWarId,
+      });
+    }
+    if (currentState === "notInWar" && eventType !== "war_ended") {
+      await this.reconcileWarEndedPointsDiscrepancy({
+        guildId: sub.guildId,
+        clanTag: sub.clanTag,
+        fallbackOpponentName: nextOpponentName || sub.opponentName || null,
+        allowProviderFetch: gateDecision.allowed,
+        fetchReason: gateDecision.fetchReason ?? "post_war_reconciliation",
+      }).catch((err) => {
+        console.error(
+          `[war-events] reconcile war-end points failed guild=${sub.guildId} clan=${sub.clanTag} error=${formatError(
+            err
+          )}`
+        );
       });
     }
     return eventType === "war_ended";
@@ -2043,6 +2145,127 @@ export class WarEventLogService {
       params.resolvedWarId,
       params.sub
     );
+  }
+
+  /** Purpose: reconcile ended-war provider points against persisted expected points and alert once per mismatch fingerprint. */
+  private async reconcileWarEndedPointsDiscrepancy(params: {
+    guildId: string;
+    clanTag: string;
+    fallbackOpponentName: string | null;
+    allowProviderFetch: boolean;
+    fetchReason: PointsApiFetchReason;
+  }): Promise<void> {
+    const clanTag = normalizeTag(params.clanTag);
+    if (!clanTag) return;
+
+    const trackedMessage = await prisma.clanPostedMessage.findFirst({
+      where: {
+        guildId: params.guildId,
+        clanTag,
+        type: "notify",
+        event: "war_ended",
+        warId: { not: null },
+      },
+      orderBy: { createdAt: "desc" },
+    });
+    if (!trackedMessage?.warId) return;
+
+    const warId = Number(trackedMessage.warId);
+    if (!Number.isFinite(warId)) return;
+
+    const historyRow = await prisma.clanWarHistory.findFirst({
+      where: {
+        warId: Math.trunc(warId),
+        clanTag,
+      },
+      select: {
+        pointsAfterWar: true,
+        clanName: true,
+        opponentName: true,
+      },
+    });
+    const expectedPoints =
+      historyRow?.pointsAfterWar !== null &&
+      historyRow?.pointsAfterWar !== undefined &&
+      Number.isFinite(Number(historyRow.pointsAfterWar))
+        ? Math.trunc(Number(historyRow.pointsAfterWar))
+        : null;
+    if (expectedPoints === null) return;
+    if (!params.allowProviderFetch) return;
+
+    const providerSnapshot = await this.points
+      .fetchSnapshot(clanTag, {
+        reason: params.fetchReason,
+        caller: "poller",
+      })
+      .catch(() => null);
+    const actualPoints =
+      providerSnapshot?.balance !== null &&
+      providerSnapshot?.balance !== undefined &&
+      Number.isFinite(Number(providerSnapshot.balance))
+        ? Math.trunc(Number(providerSnapshot.balance))
+        : null;
+    if (actualPoints === null) return;
+    if (actualPoints === expectedPoints) return;
+
+    const fingerprint = buildWarEndDiscrepancyFingerprint(warId, expectedPoints, actualPoints);
+    const previousFingerprint = parseWarEndDiscrepancyFingerprint(trackedMessage.configHash);
+    if (previousFingerprint === fingerprint) return;
+
+    const fwaLeaderRoleId = await this.commandPermissions
+      .getFwaLeaderRoleId(params.guildId)
+      .catch(() => null);
+    const allowedMentions = fwaLeaderRoleId
+      ? ({ parse: [], roles: [fwaLeaderRoleId] } as const)
+      : ({ parse: [] } as const);
+    const warningContent =
+      `⚠️ War-end points mismatch detected for ${historyRow?.clanName ?? clanTag} (War ID: ${Math.trunc(warId)}).\n` +
+      `Expected points: ${expectedPoints}\n` +
+      `Actual points: ${actualPoints}` +
+      (fwaLeaderRoleId ? `\n<@&${fwaLeaderRoleId}>` : "");
+
+    let alerted = false;
+    const channel = await this.client.channels.fetch(trackedMessage.channelId).catch(() => null);
+    if (channel && channel.isTextBased()) {
+      const message = await (channel as any).messages.fetch(trackedMessage.messageId).catch(() => null);
+      if (message) {
+        const edited = buildWarEndDiscrepancyContent({
+          existingPostedContent: String(message.content ?? ""),
+          opponentName: historyRow?.opponentName ?? params.fallbackOpponentName,
+          expectedPoints,
+          actualPoints,
+          fwaLeaderRoleId,
+        });
+        const editedOk = await message
+          .edit({
+            content: edited.content,
+            allowedMentions: edited.allowedMentions,
+          })
+          .then(() => true)
+          .catch(() => false);
+        alerted = editedOk;
+      }
+    }
+
+    if (!alerted && channel && channel.isTextBased()) {
+      const sent = await (channel as any)
+        .send({
+          content: warningContent,
+          allowedMentions,
+        })
+        .catch(() => null);
+      alerted = Boolean(sent);
+    }
+    if (!alerted) return;
+
+    await prisma.clanPostedMessage
+      .update({
+        where: { id: trackedMessage.id },
+        data: {
+          configHash: writeWarEndDiscrepancyFingerprint(trackedMessage.configHash, fingerprint),
+        },
+      })
+      .catch(() => null);
   }
 
   private async tryCreateEventGuard(
@@ -2212,7 +2435,7 @@ export class WarEventLogService {
 
     embed.addFields({
       name: "Opponent",
-      value: `${payload.opponentName} (${opponentTag ? `#${opponentTag}` : "unknown"})`,
+      value: `${payload.opponentName} (${opponentTag || "unknown"})`,
       inline: false,
     });
     embed.addFields({
@@ -2872,7 +3095,7 @@ export class WarEventLogService {
       .setTimestamp(new Date());
     embed.addFields({
       name: "Opponent",
-      value: `${payload.opponentName} (${opponentTag ? `#${opponentTag}` : "unknown"})`,
+      value: `${payload.opponentName} (${opponentTag || "unknown"})`,
       inline: false,
     });
     embed.addFields({
@@ -2976,7 +3199,7 @@ export class WarEventLogService {
       .setTimestamp(new Date());
     embed.addFields({
       name: "Opponent",
-      value: `${payload.opponentName} (${opponentTag ? `#${opponentTag}` : "unknown"})`,
+      value: `${payload.opponentName} (${opponentTag || "unknown"})`,
       inline: false,
     });
     embed.addFields({

--- a/src/services/war-events/core.ts
+++ b/src/services/war-events/core.ts
@@ -14,6 +14,8 @@ export type WarEndResultSnapshot = {
   resultLabel: "WIN" | "LOSE" | "TIE" | "UNKNOWN";
 };
 
+type ResolvedWarEndOutcome = "WIN" | "LOSE" | "TIE" | "UNKNOWN";
+
 export type WarComplianceSnapshot = {
   missedBoth: string[];
   notFollowingPlan: string[];
@@ -167,23 +169,56 @@ export function computeWarPointsDeltaForTest(input: {
   after: number | null;
   finalResult: WarEndResultSnapshot;
 }): number | null {
+  const before = input.before !== null && Number.isFinite(input.before) ? input.before : null;
+  if (before === null) return null;
+  const expectedAfter = computeExpectedWarEndPointsForTest({
+    matchType: input.matchType,
+    before,
+    finalResult: input.finalResult,
+    outcome: null,
+  });
+  if (expectedAfter === null || !Number.isFinite(expectedAfter)) return null;
+  return expectedAfter - before;
+}
+
+/** Purpose: compute expected post-war points using persisted before-points and match rules. */
+export function computeExpectedWarEndPointsForTest(input: {
+  matchType: MatchType;
+  before: number | null;
+  finalResult: WarEndResultSnapshot;
+  outcome: "WIN" | "LOSE" | null;
+}): number | null {
+  const before = input.before !== null && Number.isFinite(input.before) ? Math.trunc(input.before) : null;
+  if (before === null) return null;
+
+  const resolvedOutcome = resolveWarEndOutcome(input.finalResult, input.outcome);
+  if (resolvedOutcome === "UNKNOWN") return before;
+
+  if (input.matchType === "MM") return before;
+  if (input.matchType === "FWA") {
+    if (resolvedOutcome === "WIN") return before - 1;
+    if (resolvedOutcome === "LOSE") return before + 1;
+    return before;
+  }
   if (input.matchType === "BL") {
-    if (input.finalResult.resultLabel === "WIN") return 3;
-    if ((input.finalResult.clanDestruction ?? 0) >= 60) return 2;
-    return 1;
+    if (resolvedOutcome === "WIN") return before + 3;
+    if (Number(input.finalResult.clanDestruction ?? 0) > 60) return before + 2;
+    return before + 1;
   }
-  if (input.matchType === "MM") {
-    return 0;
+
+  return before;
+}
+
+/** Purpose: resolve best-available war-end outcome from CoC result and stored expected outcome. */
+function resolveWarEndOutcome(
+  finalResult: WarEndResultSnapshot,
+  outcome: "WIN" | "LOSE" | null
+): ResolvedWarEndOutcome {
+  if (finalResult.resultLabel === "WIN" || finalResult.resultLabel === "LOSE" || finalResult.resultLabel === "TIE") {
+    return finalResult.resultLabel;
   }
-  if (
-    input.before !== null &&
-    Number.isFinite(input.before) &&
-    input.after !== null &&
-    Number.isFinite(input.after)
-  ) {
-    return input.after - input.before;
-  }
-  return null;
+  if (outcome === "WIN" || outcome === "LOSE") return outcome;
+  return "UNKNOWN";
 }
 
 /** Purpose: compute missed/violating members for war-plan compliance checks. */

--- a/src/services/war-events/history.ts
+++ b/src/services/war-events/history.ts
@@ -33,52 +33,31 @@ export class WarEventHistoryService {
     },
     finalResult: WarEndResultSnapshot
   ): string {
-    const before = payload.warStartFwaPoints;
-    const delta = this.computeWarPointsDelta({
-      matchType: payload.matchType,
-      before,
-      after: payload.warEndFwaPoints,
-      finalResult,
-    });
-
+    const _finalResult = finalResult;
+    void _finalResult;
+    const before =
+      payload.warStartFwaPoints !== null && Number.isFinite(payload.warStartFwaPoints)
+        ? Math.trunc(payload.warStartFwaPoints)
+        : null;
+    const after =
+      payload.warEndFwaPoints !== null && Number.isFinite(payload.warEndFwaPoints)
+        ? Math.trunc(payload.warEndFwaPoints)
+        : null;
+    if (before === null && after === null) {
+      return `${payload.clanName}: unknown -> unknown (expected post-war points unavailable)`;
+    }
+    if (before === null || after === null) {
+      return `${payload.clanName}: ${before ?? "unknown"} -> ${after ?? "unknown"}`;
+    }
+    const delta = after - before;
+    const deltaText = delta >= 0 ? `+${delta}` : String(delta);
     if (payload.matchType === "BL") {
-      const afterFromRow = payload.warEndFwaPoints;
-      const after =
-        afterFromRow !== null && Number.isFinite(afterFromRow)
-          ? afterFromRow
-          : before !== null && Number.isFinite(before) && delta !== null
-            ? before + delta
-            : null;
-      const resolvedBefore =
-        before !== null && Number.isFinite(before)
-          ? before
-          : after !== null && Number.isFinite(after) && delta !== null
-            ? after - delta
-            : null;
-      return `${payload.clanName}: ${resolvedBefore ?? "unknown"} -> ${after ?? "unknown"} (${delta !== null && delta >= 0 ? `+${delta}` : String(delta ?? "unknown")}) [BL]`;
+      return `${payload.clanName}: ${before} -> ${after} (${deltaText}) [BL]`;
     }
-
     if (payload.matchType === "MM") {
-      const resolvedBefore =
-        before !== null && Number.isFinite(before)
-          ? before
-          : payload.warEndFwaPoints !== null && Number.isFinite(payload.warEndFwaPoints)
-            ? payload.warEndFwaPoints
-            : null;
-      const resolvedAfter = resolvedBefore;
-      return `${payload.clanName}: ${resolvedBefore ?? "unknown"} -> ${resolvedAfter ?? "unknown"} (+0) [MM]`;
+      return `${payload.clanName}: ${before} -> ${after} (+0) [MM]`;
     }
-
-    const after = payload.warEndFwaPoints;
-    if (
-      before !== null &&
-      Number.isFinite(before) &&
-      after !== null &&
-      Number.isFinite(after)
-    ) {
-      return `${payload.clanName}: ${before} -> ${after} (${delta !== null && delta >= 0 ? `+${delta}` : String(delta ?? after - before)})`;
-    }
-    return `${payload.clanName}: ${before ?? "unknown"} -> ${after ?? "unknown"}`;
+    return `${payload.clanName}: ${before} -> ${after} (${deltaText})`;
   }
 
   /** Purpose: build per-clan war-plan instruction text for start/battle embeds. */

--- a/tests/fetchTelemetry.test.ts
+++ b/tests/fetchTelemetry.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("fetch telemetry persistence guards", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+    vi.doUnmock("../src/prisma");
+    vi.doUnmock("../src/services/telemetry/ingest");
+  });
+
+  it("skips apiUsage writes when Prisma is not initialized", async () => {
+    const upsert = vi.fn();
+    const recordFetchEventTelemetry = vi.fn();
+
+    vi.doMock("../src/prisma", () => ({
+      prisma: {
+        apiUsage: { upsert },
+      },
+      hasInitializedPrismaClient: () => false,
+    }));
+    vi.doMock("../src/services/telemetry/ingest", () => ({
+      TelemetryIngestService: {
+        getInstance: () => ({
+          recordFetchEventTelemetry,
+        }),
+      },
+    }));
+
+    const { recordFetchEvent } = await import("../src/helper/fetchTelemetry");
+    recordFetchEvent({
+      namespace: "fwastats_weight",
+      operation: "weight_age_fetch",
+      source: "api",
+    });
+
+    expect(upsert).not.toHaveBeenCalled();
+    expect(recordFetchEventTelemetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables apiUsage persistence after synchronous Prisma write failure", async () => {
+    const upsert = vi.fn(() => {
+      throw new Error("sync failure");
+    });
+    const recordFetchEventTelemetry = vi.fn();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    vi.doMock("../src/prisma", () => ({
+      prisma: {
+        apiUsage: { upsert },
+      },
+      hasInitializedPrismaClient: () => true,
+    }));
+    vi.doMock("../src/services/telemetry/ingest", () => ({
+      TelemetryIngestService: {
+        getInstance: () => ({
+          recordFetchEventTelemetry,
+        }),
+      },
+    }));
+
+    const { recordFetchEvent } = await import("../src/helper/fetchTelemetry");
+    recordFetchEvent({
+      namespace: "fwastats_weight",
+      operation: "weight_age_fetch",
+      source: "api",
+    });
+    recordFetchEvent({
+      namespace: "fwastats_weight",
+      operation: "weight_age_fetch",
+      source: "api",
+    });
+
+    expect(upsert).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(recordFetchEventTelemetry).toHaveBeenCalledTimes(2);
+  });
+});

--- a/tests/fwaWeight.commandOutput.test.ts
+++ b/tests/fwaWeight.commandOutput.test.ts
@@ -15,6 +15,7 @@ const prismaMock = vi.hoisted(() => ({
 
 vi.mock("../src/prisma", () => ({
   prisma: prismaMock,
+  hasInitializedPrismaClient: () => false,
 }));
 
 import { Fwa } from "../src/commands/Fwa";

--- a/tests/fwaWeight.service.test.ts
+++ b/tests/fwaWeight.service.test.ts
@@ -29,6 +29,24 @@ describe("FwaStatsWeightService helpers", () => {
     expect(extractWeightAgeToken(html)).toBe("22d");
   });
 
+  it("extracts weight age token from alternate submission wording", () => {
+    const html = `
+      <div class="alert alert-success">
+        Last weight submission: 3 days ago
+      </div>
+    `;
+    expect(extractWeightAgeToken(html)).toBe("3 days");
+  });
+
+  it("extracts weight age token when value is wrapped in nested markup", () => {
+    const html = `
+      <div>
+        <span>Weight submitted:</span> <strong>12h</strong> ago
+      </div>
+    `;
+    expect(extractWeightAgeToken(html)).toBe("12h");
+  });
+
   it("detects login page HTML", () => {
     const html = "<html><head><title>Login FWA Stats</title></head></html>";
     expect(isFwaStatsLoginPage(html)).toBe(true);

--- a/tests/warEventLog.logic.test.ts
+++ b/tests/warEventLog.logic.test.ts
@@ -34,7 +34,7 @@ describe("WarEventLogService.computeWarPointsDeltaForTest", () => {
     expect(delta).toBe(3);
   });
 
-  it("BL war: returns +2 points when not a win but clan destruction is >= 60%", () => {
+  it("BL war: returns +2 points when not a win but clan destruction is > 60%", () => {
     const delta = computeWarPointsDeltaForTest({
       matchType: "BL",
       before: 100,
@@ -42,7 +42,7 @@ describe("WarEventLogService.computeWarPointsDeltaForTest", () => {
       finalResult: {
         clanStars: 90,
         opponentStars: 100,
-        clanDestruction: 60,
+        clanDestruction: 60.01,
         opponentDestruction: 70,
         warEndTime: null,
         resultLabel: "LOSE",
@@ -68,22 +68,22 @@ describe("WarEventLogService.computeWarPointsDeltaForTest", () => {
     expect(delta).toBe(1);
   });
 
-  it("FWA war: returns arithmetic delta (after - before) when both values are present", () => {
+  it("FWA war: returns -1 on WIN", () => {
     expect(
       computeWarPointsDeltaForTest({
         matchType: "FWA",
         before: 1200,
         after: 1205,
         finalResult: {
-          clanStars: null,
-          opponentStars: null,
+          clanStars: 100,
+          opponentStars: 99,
           clanDestruction: null,
           opponentDestruction: null,
           warEndTime: null,
-          resultLabel: "UNKNOWN",
+          resultLabel: "WIN",
         },
       })
-    ).toBe(5);
+    ).toBe(-1);
   });
 
   it("MM war: always returns 0 points delta at war end", () => {
@@ -104,7 +104,41 @@ describe("WarEventLogService.computeWarPointsDeltaForTest", () => {
     ).toBe(0);
   });
 
-  it("FWA/MM war: returns null when before/after values are incomplete", () => {
+  it("FWA war: returns +1 on LOSE", () => {
+    const delta = computeWarPointsDeltaForTest({
+      matchType: "FWA",
+      before: 100,
+      after: 100,
+      finalResult: {
+        clanStars: 99,
+        opponentStars: 100,
+        clanDestruction: null,
+        opponentDestruction: null,
+        warEndTime: null,
+        resultLabel: "LOSE",
+      },
+    });
+    expect(delta).toBe(1);
+  });
+
+  it("FWA war: returns 0 on TIE", () => {
+    const delta = computeWarPointsDeltaForTest({
+      matchType: "FWA",
+      before: 100,
+      after: 100,
+      finalResult: {
+        clanStars: 100,
+        opponentStars: 100,
+        clanDestruction: null,
+        opponentDestruction: null,
+        warEndTime: null,
+        resultLabel: "TIE",
+      },
+    });
+    expect(delta).toBe(0);
+  });
+
+  it("FWA/MM war: returns null when before is unknown", () => {
     const delta = computeWarPointsDeltaForTest({
       matchType: "FWA",
       before: null,
@@ -256,43 +290,43 @@ describe("WarEventHistoryService.buildWarEndPointsLine", () => {
     resultLabel: "WIN" as const,
   };
 
-  it("BL win: derives +3 and renders before->after even when after is missing", () => {
+  it("BL win: renders persisted expected +3", () => {
     const line = history.buildWarEndPointsLine(
       {
         clanName: "Alpha",
         matchType: "BL",
         warStartFwaPoints: 100,
-        warEndFwaPoints: null,
+        warEndFwaPoints: 103,
       },
       baseResult
     );
     expect(line).toBe("Alpha: 100 -> 103 (+3) [BL]");
   });
 
-  it("BL lose with 60%+ destruction: derives +2", () => {
+  it("BL lose with 60%+ destruction: renders persisted expected +2", () => {
     const line = history.buildWarEndPointsLine(
       {
         clanName: "Alpha",
         matchType: "BL",
         warStartFwaPoints: 100,
-        warEndFwaPoints: null,
+        warEndFwaPoints: 102,
       },
       {
         ...baseResult,
         resultLabel: "LOSE",
-        clanDestruction: 60,
+        clanDestruction: 60.01,
       }
     );
     expect(line).toBe("Alpha: 100 -> 102 (+2) [BL]");
   });
 
-  it("BL lose below 60% destruction: derives +1", () => {
+  it("BL lose below 60% destruction: renders persisted expected +1", () => {
     const line = history.buildWarEndPointsLine(
       {
         clanName: "Alpha",
         matchType: "BL",
         warStartFwaPoints: 100,
-        warEndFwaPoints: null,
+        warEndFwaPoints: 101,
       },
       {
         ...baseResult,
@@ -303,24 +337,22 @@ describe("WarEventHistoryService.buildWarEndPointsLine", () => {
     expect(line).toBe("Alpha: 100 -> 101 (+1) [BL]");
   });
 
-  it("FWA war: renders arithmetic delta using stored before/after", () => {
+  it("FWA win: renders persisted expected post-war points", () => {
     const line = history.buildWarEndPointsLine(
       {
         clanName: "Alpha",
         matchType: "FWA",
         warStartFwaPoints: 1200,
-        warEndFwaPoints: 1205,
+        warEndFwaPoints: 1199,
       },
       {
         ...baseResult,
-        resultLabel: "UNKNOWN",
-        clanStars: null,
-        opponentStars: null,
+        resultLabel: "WIN",
         clanDestruction: null,
         opponentDestruction: null,
       }
     );
-    expect(line).toBe("Alpha: 1200 -> 1205 (+5)");
+    expect(line).toBe("Alpha: 1200 -> 1199 (-1)");
   });
 
   it("MM war: renders no points change at war end", () => {
@@ -329,7 +361,7 @@ describe("WarEventHistoryService.buildWarEndPointsLine", () => {
         clanName: "Alpha",
         matchType: "MM",
         warStartFwaPoints: 1200,
-        warEndFwaPoints: 1197,
+        warEndFwaPoints: 1200,
       },
       {
         ...baseResult,
@@ -341,6 +373,22 @@ describe("WarEventHistoryService.buildWarEndPointsLine", () => {
       }
     );
     expect(line).toBe("Alpha: 1200 -> 1200 (+0) [MM]");
+  });
+
+  it("renders explicit unknown output when both before and expected are unknown", () => {
+    const line = history.buildWarEndPointsLine(
+      {
+        clanName: "Alpha",
+        matchType: "FWA",
+        warStartFwaPoints: null,
+        warEndFwaPoints: null,
+      },
+      {
+        ...baseResult,
+        resultLabel: "UNKNOWN",
+      }
+    );
+    expect(line).toBe("Alpha: unknown -> unknown (expected post-war points unavailable)");
   });
 });
 

--- a/tests/warEventLog.warEndPointsReconcile.test.ts
+++ b/tests/warEventLog.warEndPointsReconcile.test.ts
@@ -1,0 +1,588 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { Client } from "discord.js";
+import { ChannelType } from "discord.js";
+import { prisma } from "../src/prisma";
+import {
+  WarEventLogService,
+  buildWarEndDiscrepancyFingerprintForTest,
+} from "../src/services/WarEventLogService";
+
+function buildBasePayload(overrides?: Partial<Record<string, unknown>>) {
+  return {
+    eventType: "war_started" as const,
+    clanTag: "#AAA111",
+    clanName: "Alpha",
+    opponentTag: "#OPP123",
+    opponentName: "Enemy",
+    syncNumber: 123,
+    notifyRole: "555",
+    pingRole: true,
+    fwaPoints: 1000,
+    opponentFwaPoints: 1001,
+    outcome: "WIN" as const,
+    matchType: "FWA" as const,
+    warStartFwaPoints: 1000,
+    warEndFwaPoints: 999,
+    clanStars: 100,
+    opponentStars: 99,
+    prepStartTime: new Date("2026-03-11T00:00:00.000Z"),
+    warStartTime: new Date("2026-03-12T00:00:00.000Z"),
+    warEndTime: new Date("2026-03-13T00:00:00.000Z"),
+    clanAttacks: 1,
+    opponentAttacks: 1,
+    teamSize: 50,
+    attacksPerMember: 2,
+    clanDestruction: 70,
+    opponentDestruction: 69,
+    ...overrides,
+  };
+}
+
+function makeSubscription(
+  overrides?: Partial<Record<string, unknown>>
+): Record<string, unknown> {
+  return {
+    guildId: "guild-1",
+    clanTag: "#AAA111",
+    warId: 1001,
+    syncNum: 10,
+    channelId: "chan-1",
+    notify: true,
+    pingRole: true,
+    embedEnabled: true,
+    inferredMatchType: false,
+    notifyRole: "555",
+    fwaPoints: 1200,
+    opponentFwaPoints: 1201,
+    outcome: "WIN",
+    matchType: "FWA",
+    warStartFwaPoints: 1200,
+    warEndFwaPoints: null,
+    clanStars: 100,
+    opponentStars: 99,
+    state: "inWar",
+    prepStartTime: new Date("2026-03-11T00:00:00.000Z"),
+    startTime: new Date("2026-03-12T00:00:00.000Z"),
+    endTime: new Date("2026-03-12T01:00:00.000Z"),
+    opponentTag: "#OPP123",
+    opponentName: "Enemy",
+    clanName: "Alpha",
+    pointsConfirmedByClanMail: false,
+    pointsNeedsValidation: true,
+    pointsLastSuccessfulFetchAt: null,
+    pointsLastKnownSyncNumber: null,
+    pointsLastKnownPoints: null,
+    pointsLastKnownMatchType: null,
+    pointsLastKnownOutcome: null,
+    pointsWarId: null,
+    pointsOpponentTag: null,
+    pointsWarStartTime: null,
+    ...overrides,
+  };
+}
+
+function buildServiceWithHistoryStub(): WarEventLogService {
+  const client = { channels: { fetch: vi.fn() } } as unknown as Client;
+  const service = new WarEventLogService(client, {} as any);
+  const history = (service as any).history;
+  vi.spyOn(history, "buildWarPlanText").mockResolvedValue(null);
+  vi.spyOn(history, "getWarEndResultSnapshot").mockResolvedValue({
+    clanStars: 100,
+    opponentStars: 99,
+    clanDestruction: 70,
+    opponentDestruction: 69,
+    warEndTime: null,
+    resultLabel: "WIN",
+  });
+  vi.spyOn(history, "getWarComplianceSnapshot").mockResolvedValue({
+    missedBoth: [],
+    notFollowingPlan: [],
+  });
+  return service;
+}
+
+describe("War-end opponent tag rendering", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("preview path renders opponent tag with a single leading #", async () => {
+    const service = buildServiceWithHistoryStub();
+    const message = await (service as any).buildEventMessage(buildBasePayload(), "guild-1", {
+      includeRoleMention: false,
+      includeEventComponents: false,
+      warId: 1001,
+    });
+    const fields = message.embeds[0]?.data?.fields ?? [];
+    const opponentField = fields.find((field) => field.name === "Opponent");
+    expect(opponentField?.value).toBe("Enemy (#OPP123)");
+    expect(opponentField?.value).not.toContain("##OPP123");
+  });
+
+  it("live posting path renders opponent tag with a single leading #", async () => {
+    const send = vi.fn().mockResolvedValue({ id: "msg-1" });
+    const client = {
+      channels: {
+        fetch: vi.fn().mockResolvedValue({
+          isTextBased: () => true,
+          type: ChannelType.GuildText,
+          guildId: "guild-1",
+          send,
+        }),
+      },
+    } as unknown as Client;
+    const service = new WarEventLogService(client, {} as any);
+    (service as any).history = {
+      buildWarPlanText: vi.fn().mockResolvedValue(null),
+      getWarEndResultSnapshot: vi.fn().mockResolvedValue({
+        clanStars: 100,
+        opponentStars: 99,
+        clanDestruction: 70,
+        opponentDestruction: 69,
+        warEndTime: null,
+        resultLabel: "WIN",
+      }),
+      getWarComplianceSnapshot: vi.fn().mockResolvedValue({
+        missedBoth: [],
+        notFollowingPlan: [],
+      }),
+    };
+    await (service as any).emitEvent("chan-1", buildBasePayload(), 1001, undefined);
+    expect(send).toHaveBeenCalledTimes(1);
+    const sent = send.mock.calls[0]?.[0];
+    const fields = sent?.embeds?.[0]?.data?.fields ?? [];
+    const opponentField = fields.find((field: any) => field.name === "Opponent");
+    expect(opponentField?.value).toBe("Enemy (#OPP123)");
+    expect(opponentField?.value).not.toContain("##OPP123");
+  });
+
+  it("war-ended embed points line uses persisted expected points", async () => {
+    const service = buildServiceWithHistoryStub();
+    const payload = buildBasePayload({
+      eventType: "war_ended",
+      fwaPoints: 1300,
+      warStartFwaPoints: 1200,
+      warEndFwaPoints: 1199,
+      matchType: "FWA",
+      outcome: "WIN",
+    });
+    const message = await (service as any).buildEventMessage(payload, "guild-1", {
+      includeRoleMention: false,
+      includeEventComponents: false,
+      warId: 1001,
+    });
+    const fields = message.embeds[0]?.data?.fields ?? [];
+    const pointsField = fields.find((field) => field.name === "FWA Points");
+    expect(pointsField?.value).toBe("Alpha: 1200 -> 1199 (-1)");
+  });
+});
+
+describe("War-end expected points persistence via processSubscription", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  async function runProcessSubscriptionCase(input: {
+    subOverrides?: Partial<Record<string, unknown>>;
+    finalResult: {
+      clanStars: number | null;
+      opponentStars: number | null;
+      clanDestruction: number | null;
+      opponentDestruction: number | null;
+      warEndTime: Date | null;
+      resultLabel: "WIN" | "LOSE" | "TIE" | "UNKNOWN";
+    };
+    expectedWarEndFwaPoints: number | null;
+  }): Promise<void> {
+    vi.restoreAllMocks();
+    const service = new WarEventLogService({ channels: { fetch: vi.fn() } } as unknown as Client, {} as any);
+    const sub = makeSubscription(input.subOverrides);
+
+    vi.spyOn(prisma, "$queryRaw").mockResolvedValue([sub] as any);
+    const updateSpy = vi.spyOn(prisma.currentWar, "update").mockResolvedValue({} as any);
+
+    (service as any).getCurrentWarSnapshot = vi.fn().mockResolvedValue({
+      war: null,
+      observation: { kind: "success" },
+    });
+    (service as any).hasWarEndRecorded = vi.fn().mockResolvedValue(false);
+    (service as any).ensureCurrentWarId = vi.fn().mockResolvedValue(1001);
+    (service as any).syncWarAttacksFromWarSnapshot = vi.fn().mockResolvedValue(undefined);
+    (service as any).dispatchDetectedEvent = vi.fn().mockResolvedValue(undefined);
+    (service as any).reconcileWarEndedPointsDiscrepancy = vi.fn().mockResolvedValue(undefined);
+    (service as any).pointsPolicy = {
+      evaluatePollerFetch: vi.fn().mockReturnValue({
+        allowed: false,
+        fetchReason: "post_war_reconciliation",
+      }),
+    };
+    (service as any).pointsSync = {
+      resetWarStartPointsJob: vi.fn().mockResolvedValue(undefined),
+      maybeRunWarStartPointsCheck: vi.fn().mockResolvedValue(undefined),
+      getPreviousSyncNum: vi.fn().mockResolvedValue(10),
+    };
+    (service as any).currentSyncs = {
+      markNeedsValidation: vi.fn().mockResolvedValue(undefined),
+      getCurrentSyncForClan: vi.fn().mockResolvedValue(null),
+    };
+    (service as any).history = {
+      getWarEndResultSnapshot: vi.fn().mockResolvedValue(input.finalResult),
+    };
+
+    await (service as any).processSubscription("guild-1", "#AAA111", {
+      previousSync: 10,
+      activeSync: 11,
+    });
+
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+    const updateData = updateSpy.mock.calls[0]?.[0]?.data;
+    expect(updateData?.warEndFwaPoints).toBe(input.expectedWarEndFwaPoints);
+  }
+
+  it("persists FWA WIN/LOSE/TIE expected points using war-start before points", async () => {
+    await runProcessSubscriptionCase({
+      subOverrides: { matchType: "FWA", warStartFwaPoints: 100, fwaPoints: 777 },
+      finalResult: {
+        clanStars: 100,
+        opponentStars: 99,
+        clanDestruction: 60,
+        opponentDestruction: 50,
+        warEndTime: null,
+        resultLabel: "WIN",
+      },
+      expectedWarEndFwaPoints: 99,
+    });
+    await runProcessSubscriptionCase({
+      subOverrides: { matchType: "FWA", warStartFwaPoints: 100, fwaPoints: 777 },
+      finalResult: {
+        clanStars: 99,
+        opponentStars: 100,
+        clanDestruction: 60,
+        opponentDestruction: 50,
+        warEndTime: null,
+        resultLabel: "LOSE",
+      },
+      expectedWarEndFwaPoints: 101,
+    });
+    await runProcessSubscriptionCase({
+      subOverrides: { matchType: "FWA", warStartFwaPoints: 100, fwaPoints: 777 },
+      finalResult: {
+        clanStars: 100,
+        opponentStars: 100,
+        clanDestruction: 60,
+        opponentDestruction: 50,
+        warEndTime: null,
+        resultLabel: "TIE",
+      },
+      expectedWarEndFwaPoints: 100,
+    });
+  });
+
+  it("persists MM expected points as +0", async () => {
+    await runProcessSubscriptionCase({
+      subOverrides: { matchType: "MM", warStartFwaPoints: 350 },
+      finalResult: {
+        clanStars: 100,
+        opponentStars: 90,
+        clanDestruction: 70,
+        opponentDestruction: 60,
+        warEndTime: null,
+        resultLabel: "WIN",
+      },
+      expectedWarEndFwaPoints: 350,
+    });
+  });
+
+  it("persists BL expected points as +3 / +2 / +1 with strict >60 threshold", async () => {
+    await runProcessSubscriptionCase({
+      subOverrides: { matchType: "BL", warStartFwaPoints: 500 },
+      finalResult: {
+        clanStars: 100,
+        opponentStars: 99,
+        clanDestruction: 55,
+        opponentDestruction: 60,
+        warEndTime: null,
+        resultLabel: "WIN",
+      },
+      expectedWarEndFwaPoints: 503,
+    });
+    await runProcessSubscriptionCase({
+      subOverrides: { matchType: "BL", warStartFwaPoints: 500 },
+      finalResult: {
+        clanStars: 90,
+        opponentStars: 100,
+        clanDestruction: 60.01,
+        opponentDestruction: 70,
+        warEndTime: null,
+        resultLabel: "LOSE",
+      },
+      expectedWarEndFwaPoints: 502,
+    });
+    await runProcessSubscriptionCase({
+      subOverrides: { matchType: "BL", warStartFwaPoints: 500 },
+      finalResult: {
+        clanStars: 90,
+        opponentStars: 100,
+        clanDestruction: 60,
+        opponentDestruction: 70,
+        warEndTime: null,
+        resultLabel: "LOSE",
+      },
+      expectedWarEndFwaPoints: 501,
+    });
+  });
+
+  it("uses before unchanged when war-end outcome is unknown", async () => {
+    await runProcessSubscriptionCase({
+      subOverrides: { matchType: "FWA", warStartFwaPoints: 222, outcome: null },
+      finalResult: {
+        clanStars: null,
+        opponentStars: null,
+        clanDestruction: null,
+        opponentDestruction: null,
+        warEndTime: null,
+        resultLabel: "UNKNOWN",
+      },
+      expectedWarEndFwaPoints: 222,
+    });
+  });
+
+  it("persists null expected points when before points are unknown", async () => {
+    await runProcessSubscriptionCase({
+      subOverrides: {
+        matchType: "FWA",
+        warStartFwaPoints: null,
+        fwaPoints: null,
+        outcome: null,
+      },
+      finalResult: {
+        clanStars: null,
+        opponentStars: null,
+        clanDestruction: null,
+        opponentDestruction: null,
+        warEndTime: null,
+        resultLabel: "UNKNOWN",
+      },
+      expectedWarEndFwaPoints: null,
+    });
+  });
+});
+
+describe("War-end points reconciliation", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function buildReconcileService(channelMock: unknown): WarEventLogService {
+    const client = {
+      channels: {
+        fetch: vi.fn().mockResolvedValue(channelMock),
+      },
+    } as unknown as Client;
+    const service = new WarEventLogService(client, {} as any);
+    (service as any).points = {
+      fetchSnapshot: vi.fn().mockResolvedValue({ balance: 100 }),
+    };
+    (service as any).commandPermissions = {
+      getFwaLeaderRoleId: vi.fn().mockResolvedValue("777"),
+    };
+    return service;
+  }
+
+  it("equal expected/actual points produce no warning output", async () => {
+    const channelFetch = vi.fn();
+    const service = new WarEventLogService(
+      { channels: { fetch: channelFetch } } as unknown as Client,
+      {} as any
+    );
+    (service as any).points = {
+      fetchSnapshot: vi.fn().mockResolvedValue({ balance: 100 }),
+    };
+    vi.spyOn(prisma.clanPostedMessage, "findFirst").mockResolvedValue({
+      id: "pm-1",
+      guildId: "guild-1",
+      clanTag: "#AAA111",
+      type: "notify",
+      event: "war_ended",
+      channelId: "chan-1",
+      messageId: "msg-1",
+      messageUrl: "",
+      warId: "1001",
+      syncNum: null,
+      configHash: "cfg",
+      createdAt: new Date(),
+    } as any);
+    vi.spyOn(prisma.clanWarHistory, "findFirst").mockResolvedValue({
+      pointsAfterWar: 100,
+      clanName: "Alpha",
+      opponentName: "Enemy",
+    } as any);
+    const updateSpy = vi.spyOn(prisma.clanPostedMessage, "update").mockResolvedValue({} as any);
+
+    await (service as any).reconcileWarEndedPointsDiscrepancy({
+      guildId: "guild-1",
+      clanTag: "#AAA111",
+      fallbackOpponentName: "Enemy",
+      allowProviderFetch: true,
+      fetchReason: "post_war_reconciliation",
+    });
+
+    expect(channelFetch).not.toHaveBeenCalled();
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  it("mismatch edits original message with visible warning and fwa leader role ping", async () => {
+    const edit = vi.fn().mockResolvedValue({});
+    const channel = {
+      isTextBased: () => true,
+      messages: {
+        fetch: vi.fn().mockResolvedValue({
+          content: "War ended against Enemy\n<@&555>",
+          edit,
+        }),
+      },
+      send: vi.fn(),
+    };
+    const service = buildReconcileService(channel);
+    (service as any).points = {
+      fetchSnapshot: vi.fn().mockResolvedValue({ balance: 99 }),
+    };
+
+    vi.spyOn(prisma.clanPostedMessage, "findFirst").mockResolvedValue({
+      id: "pm-1",
+      guildId: "guild-1",
+      clanTag: "#AAA111",
+      type: "notify",
+      event: "war_ended",
+      channelId: "chan-1",
+      messageId: "msg-1",
+      messageUrl: "",
+      warId: "1001",
+      syncNum: null,
+      configHash: "cfg",
+      createdAt: new Date(),
+    } as any);
+    vi.spyOn(prisma.clanWarHistory, "findFirst").mockResolvedValue({
+      pointsAfterWar: 100,
+      clanName: "Alpha",
+      opponentName: "Enemy",
+    } as any);
+    const updateSpy = vi.spyOn(prisma.clanPostedMessage, "update").mockResolvedValue({} as any);
+
+    await (service as any).reconcileWarEndedPointsDiscrepancy({
+      guildId: "guild-1",
+      clanTag: "#AAA111",
+      fallbackOpponentName: "Enemy",
+      allowProviderFetch: true,
+      fetchReason: "post_war_reconciliation",
+    });
+
+    expect(edit).toHaveBeenCalledTimes(1);
+    const editPayload = edit.mock.calls[0]?.[0];
+    expect(editPayload.content).toContain("⚠️ War-end points mismatch detected.");
+    expect(editPayload.content).toContain("Expected points: 100");
+    expect(editPayload.content).toContain("Actual points: 99");
+    expect(editPayload.content).toContain("<@&777>");
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("idempotency skips repeated alerts for unchanged mismatch fingerprint", async () => {
+    const edit = vi.fn().mockResolvedValue({});
+    const channel = {
+      isTextBased: () => true,
+      messages: {
+        fetch: vi.fn().mockResolvedValue({
+          content: "War ended against Enemy\n<@&555>",
+          edit,
+        }),
+      },
+      send: vi.fn(),
+    };
+    const service = buildReconcileService(channel);
+    (service as any).points = {
+      fetchSnapshot: vi.fn().mockResolvedValue({ balance: 99 }),
+    };
+    const fingerprint = buildWarEndDiscrepancyFingerprintForTest(1001, 100, 99);
+
+    vi.spyOn(prisma.clanPostedMessage, "findFirst").mockResolvedValue({
+      id: "pm-1",
+      guildId: "guild-1",
+      clanTag: "#AAA111",
+      type: "notify",
+      event: "war_ended",
+      channelId: "chan-1",
+      messageId: "msg-1",
+      messageUrl: "",
+      warId: "1001",
+      syncNum: null,
+      configHash: `cfg|war_end_discrepancy:${fingerprint}`,
+      createdAt: new Date(),
+    } as any);
+    vi.spyOn(prisma.clanWarHistory, "findFirst").mockResolvedValue({
+      pointsAfterWar: 100,
+      clanName: "Alpha",
+      opponentName: "Enemy",
+    } as any);
+    const updateSpy = vi.spyOn(prisma.clanPostedMessage, "update").mockResolvedValue({} as any);
+
+    await (service as any).reconcileWarEndedPointsDiscrepancy({
+      guildId: "guild-1",
+      clanTag: "#AAA111",
+      fallbackOpponentName: "Enemy",
+      allowProviderFetch: true,
+      fetchReason: "post_war_reconciliation",
+    });
+
+    expect(edit).not.toHaveBeenCalled();
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+
+  it("falls back to a follow-up message when editing the original message is not possible", async () => {
+    const send = vi.fn().mockResolvedValue({ id: "fallback-msg" });
+    const channel = {
+      isTextBased: () => true,
+      messages: {
+        fetch: vi.fn().mockResolvedValue(null),
+      },
+      send,
+    };
+    const service = buildReconcileService(channel);
+    (service as any).points = {
+      fetchSnapshot: vi.fn().mockResolvedValue({ balance: 99 }),
+    };
+
+    vi.spyOn(prisma.clanPostedMessage, "findFirst").mockResolvedValue({
+      id: "pm-1",
+      guildId: "guild-1",
+      clanTag: "#AAA111",
+      type: "notify",
+      event: "war_ended",
+      channelId: "chan-1",
+      messageId: "msg-1",
+      messageUrl: "",
+      warId: "1001",
+      syncNum: null,
+      configHash: "cfg",
+      createdAt: new Date(),
+    } as any);
+    vi.spyOn(prisma.clanWarHistory, "findFirst").mockResolvedValue({
+      pointsAfterWar: 100,
+      clanName: "Alpha",
+      opponentName: "Enemy",
+    } as any);
+    const updateSpy = vi.spyOn(prisma.clanPostedMessage, "update").mockResolvedValue({} as any);
+
+    await (service as any).reconcileWarEndedPointsDiscrepancy({
+      guildId: "guild-1",
+      clanTag: "#AAA111",
+      fallbackOpponentName: "Enemy",
+      allowProviderFetch: true,
+      fetchReason: "post_war_reconciliation",
+    });
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send.mock.calls[0]?.[0]?.content).toContain("Expected points: 100");
+    expect(send.mock.calls[0]?.[0]?.content).toContain("Actual points: 99");
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
…ches

- compute and persist canonical expected post-war points at war close using FWA/MM/BL rules and before-point precedence
- use persisted expected war-end points for initial war-ended embed output and explicit unknown-points rendering when before is unavailable
- reconcile later provider points against persisted expected values, edit the tracked war-ended message on mismatch, and ping /fwa leader-role
- add persisted mismatch fingerprint idempotency and fallback follow-up messaging when edits cannot be applied
- fix opponent tag rendering to avoid double # in live notify posting and preview paths
- add regression tests for render, expected-point persistence rules, reconciliation behavior, and idempotency