### PR TITLE
fix(startup): harden command registration against REST timeouts

### DIFF
--- a/src/ClashCookies.ts
+++ b/src/ClashCookies.ts
@@ -2,7 +2,11 @@ import { Client, GatewayIntentBits } from "discord.js";
 import ready from "./listeners/ready";
 import interactionCreate from "./listeners/interactionCreate";
 import { CoCService } from "./services/CoCService";
+import { getDiscordRestTimeoutMsFromEnv } from "./services/StartupCommandRegistrationService";
 import "dotenv/config";
+
+const discordRestTimeoutMs = getDiscordRestTimeoutMsFromEnv(process.env);
+console.log(`[startup:discord-rest] timeout_ms=${discordRestTimeoutMs}`);
 
 const client = new Client({
   intents: [
@@ -10,6 +14,9 @@ const client = new Client({
     GatewayIntentBits.GuildMembers,
     GatewayIntentBits.GuildMessages,
   ],
+  rest: {
+    timeout: discordRestTimeoutMs,
+  },
 });
 
 const cocService = new CoCService();

--- a/src/listeners/ready.ts
+++ b/src/listeners/ready.ts
@@ -17,6 +17,10 @@ import { TelemetryIngestService } from "../services/telemetry/ingest";
 import { startTelemetryScheduleLoop } from "../services/telemetry/schedule";
 import { refreshAllTrackedWarMailPosts } from "../commands/Fwa";
 import {
+  getCommandRegistrationConfigFromEnv,
+  registerGuildCommandsWithRetry,
+} from "../services/StartupCommandRegistrationService";
+import {
   setNextNotifyRefreshAtMs,
   setNextWarMailRefreshAtMs,
 } from "../services/refreshSchedule";
@@ -178,10 +182,20 @@ export default (client: Client, cocService: CoCService): void => {
 
     // Register ONLY guild commands
     const commandsWithVisibility = Commands.map((cmd) => injectVisibilityOptions(cmd));
-    try {
-      await guild.commands.set(commandsWithVisibility);
-    } catch (err) {
-      console.error(`Guild command registration failed: ${formatError(err)}`);
+    const registrationConfig = getCommandRegistrationConfigFromEnv(process.env);
+    const registrationResult = await registerGuildCommandsWithRetry({
+      guild,
+      commands: commandsWithVisibility,
+      config: registrationConfig,
+      logger: console,
+    });
+    if (registrationResult.status === "success") {
+      console.log(`[startup:commands] registration complete count=${Commands.length}`);
+    } else if (registrationResult.status === "skipped") {
+      console.warn(
+        `[startup:commands] registration skipped by config. payload_count=${Commands.length}`
+      );
+    } else {
       console.error(
         "Command registration payload summary:",
         commandsWithVisibility.map((c: any) => ({
@@ -189,9 +203,11 @@ export default (client: Client, cocService: CoCService): void => {
           optionCount: Array.isArray(c?.options) ? c.options.length : 0,
         }))
       );
-      throw err;
+      console.warn(
+        `[startup:commands] registration unavailable after ${registrationResult.attempts} attempt(s); startup continuing.`
+      );
     }
-    console.log(`✅ Guild commands registered (${Commands.length})`);
+
     TelemetryIngestService.getInstance().startAutoFlush();
     startTelemetryScheduleLoop(client);
     console.log("Telemetry ingest + schedule loops enabled.");

--- a/src/services/StartupCommandRegistrationService.ts
+++ b/src/services/StartupCommandRegistrationService.ts
@@ -1,0 +1,155 @@
+type LoggerLike = {
+  info?: (message: string, ...args: unknown[]) => void;
+  warn?: (message: string, ...args: unknown[]) => void;
+  error?: (message: string, ...args: unknown[]) => void;
+};
+
+type GuildCommandRegistrar = {
+  commands: {
+    set: (commands: any[]) => Promise<unknown>;
+  };
+};
+
+export type CommandRegistrationConfig = {
+  enabled: boolean;
+  maxAttempts: number;
+  baseBackoffMs: number;
+};
+
+export type CommandRegistrationResult =
+  | { status: "skipped" }
+  | { status: "success"; attempts: number }
+  | { status: "failed"; attempts: number; error: unknown };
+
+export type RegisterGuildCommandsInput = {
+  guild: GuildCommandRegistrar;
+  commands: unknown[];
+  config: CommandRegistrationConfig;
+  logger?: LoggerLike;
+  sleep?: (ms: number) => Promise<void>;
+};
+
+const DEFAULT_REST_TIMEOUT_MS = 30_000;
+const DEFAULT_REGISTRATION_MAX_ATTEMPTS = 3;
+const DEFAULT_REGISTRATION_BASE_BACKOFF_MS = 2_000;
+
+/** Purpose: parse an env flag into a deterministic boolean. */
+function parseBoolean(input: string | undefined, fallback: boolean): boolean {
+  const normalized = String(input ?? "")
+    .trim()
+    .toLowerCase();
+  if (!normalized) return fallback;
+  if (["1", "true", "yes", "on"].includes(normalized)) return true;
+  if (["0", "false", "no", "off"].includes(normalized)) return false;
+  return fallback;
+}
+
+/** Purpose: parse a positive integer from env with deterministic fallback. */
+function parsePositiveInt(input: string | undefined, fallback: number): number {
+  const parsed = Number(input ?? "");
+  if (!Number.isFinite(parsed)) return fallback;
+  if (parsed <= 0) return fallback;
+  return Math.floor(parsed);
+}
+
+/** Purpose: classify timeout/network aborts as retryable registration errors. */
+export function isTransientRegistrationError(error: unknown): boolean {
+  const code = String((error as { code?: string } | null | undefined)?.code ?? "").trim();
+  const name = String((error as { name?: string } | null | undefined)?.name ?? "").trim();
+  const message = String((error as { message?: string } | null | undefined)?.message ?? "").trim();
+  const codeUpper = code.toUpperCase();
+  const nameUpper = name.toUpperCase();
+  const messageLower = message.toLowerCase();
+
+  if (
+    ["UND_ERR_ABORTED", "ETIMEDOUT", "ECONNRESET", "ECONNREFUSED", "EAI_AGAIN", "ENOTFOUND"].includes(
+      codeUpper
+    )
+  ) {
+    return true;
+  }
+  if (nameUpper.includes("ABORT") || nameUpper.includes("TIMEOUT")) return true;
+  if (
+    messageLower.includes("request aborted") ||
+    messageLower.includes("aborterror") ||
+    messageLower.includes("timed out") ||
+    messageLower.includes("socket hang up")
+  ) {
+    return true;
+  }
+  return false;
+}
+
+/** Purpose: load command registration retry config from process env. */
+export function getCommandRegistrationConfigFromEnv(
+  env: NodeJS.ProcessEnv
+): CommandRegistrationConfig {
+  return {
+    enabled: parseBoolean(env.STARTUP_REGISTER_GUILD_COMMANDS, true),
+    maxAttempts: parsePositiveInt(
+      env.STARTUP_COMMAND_REGISTRATION_MAX_ATTEMPTS,
+      DEFAULT_REGISTRATION_MAX_ATTEMPTS
+    ),
+    baseBackoffMs: parsePositiveInt(
+      env.STARTUP_COMMAND_REGISTRATION_BASE_BACKOFF_MS,
+      DEFAULT_REGISTRATION_BASE_BACKOFF_MS
+    ),
+  };
+}
+
+/** Purpose: load Discord REST timeout from env with safe fallback. */
+export function getDiscordRestTimeoutMsFromEnv(env: NodeJS.ProcessEnv): number {
+  return parsePositiveInt(env.DISCORD_REST_TIMEOUT_MS, DEFAULT_REST_TIMEOUT_MS);
+}
+
+/** Purpose: perform bounded retry registration and return a non-throwing result. */
+export async function registerGuildCommandsWithRetry(
+  input: RegisterGuildCommandsInput
+): Promise<CommandRegistrationResult> {
+  const logger = input.logger ?? console;
+  const sleep =
+    input.sleep ??
+    ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, Math.max(0, ms))));
+
+  if (!input.config.enabled) {
+    logger.warn?.("[startup:commands] registration skipped (STARTUP_REGISTER_GUILD_COMMANDS=false)");
+    return { status: "skipped" };
+  }
+
+  logger.info?.(
+    `[startup:commands] registration start attempts=${input.config.maxAttempts} payload_count=${input.commands.length}`
+  );
+
+  for (let attempt = 1; attempt <= input.config.maxAttempts; attempt += 1) {
+    try {
+      await input.guild.commands.set(input.commands);
+      logger.info?.(`[startup:commands] registration success attempt=${attempt}`);
+      return { status: "success", attempts: attempt };
+    } catch (error) {
+      const transient = isTransientRegistrationError(error);
+      logger.error?.(
+        `[startup:commands] registration failed attempt=${attempt}/${input.config.maxAttempts} transient=${
+          transient ? 1 : 0
+        } error=${error instanceof Error ? error.message : String(error)}`
+      );
+
+      const finalAttempt = attempt >= input.config.maxAttempts;
+      if (!transient || finalAttempt) {
+        logger.warn?.(
+          "[startup:commands] continuing startup in degraded mode (command registration unavailable)"
+        );
+        return { status: "failed", attempts: attempt, error };
+      }
+
+      const backoffMs = input.config.baseBackoffMs * Math.pow(2, attempt - 1);
+      logger.warn?.(
+        `[startup:commands] retrying registration in ${backoffMs}ms attempt=${attempt + 1}`
+      );
+      await sleep(backoffMs);
+    }
+  }
+
+  const fallbackError = new Error("Registration failed without explicit error.");
+  logger.warn?.("[startup:commands] continuing startup in degraded mode (fallback terminal path)");
+  return { status: "failed", attempts: input.config.maxAttempts, error: fallbackError };
+}

--- a/tests/startupCommandRegistration.service.test.ts
+++ b/tests/startupCommandRegistration.service.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  getCommandRegistrationConfigFromEnv,
+  getDiscordRestTimeoutMsFromEnv,
+  isTransientRegistrationError,
+  registerGuildCommandsWithRetry,
+} from "../src/services/StartupCommandRegistrationService";
+
+describe("StartupCommandRegistrationService config", () => {
+  it("uses deterministic defaults when env is missing or invalid", () => {
+    expect(getCommandRegistrationConfigFromEnv({} as NodeJS.ProcessEnv)).toEqual({
+      enabled: true,
+      maxAttempts: 3,
+      baseBackoffMs: 2000,
+    });
+    expect(
+      getCommandRegistrationConfigFromEnv({
+        STARTUP_REGISTER_GUILD_COMMANDS: "banana",
+        STARTUP_COMMAND_REGISTRATION_MAX_ATTEMPTS: "-2",
+        STARTUP_COMMAND_REGISTRATION_BASE_BACKOFF_MS: "abc",
+      } as NodeJS.ProcessEnv)
+    ).toEqual({
+      enabled: true,
+      maxAttempts: 3,
+      baseBackoffMs: 2000,
+    });
+    expect(getDiscordRestTimeoutMsFromEnv({} as NodeJS.ProcessEnv)).toBe(30000);
+    expect(
+      getDiscordRestTimeoutMsFromEnv({
+        DISCORD_REST_TIMEOUT_MS: "xyz",
+      } as NodeJS.ProcessEnv)
+    ).toBe(30000);
+  });
+
+  it("parses valid env config values", () => {
+    expect(
+      getCommandRegistrationConfigFromEnv({
+        STARTUP_REGISTER_GUILD_COMMANDS: "false",
+        STARTUP_COMMAND_REGISTRATION_MAX_ATTEMPTS: "5",
+        STARTUP_COMMAND_REGISTRATION_BASE_BACKOFF_MS: "1500",
+      } as NodeJS.ProcessEnv)
+    ).toEqual({
+      enabled: false,
+      maxAttempts: 5,
+      baseBackoffMs: 1500,
+    });
+    expect(
+      getDiscordRestTimeoutMsFromEnv({
+        DISCORD_REST_TIMEOUT_MS: "45000",
+      } as NodeJS.ProcessEnv)
+    ).toBe(45000);
+  });
+});
+
+describe("StartupCommandRegistrationService retries", () => {
+  it("skips registration when disabled", async () => {
+    const setMock = vi.fn();
+    const result = await registerGuildCommandsWithRetry({
+      guild: { commands: { set: setMock } },
+      commands: [{ name: "a" }],
+      config: { enabled: false, maxAttempts: 3, baseBackoffMs: 2000 },
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      sleep: vi.fn(),
+    });
+
+    expect(result).toEqual({ status: "skipped" });
+    expect(setMock).not.toHaveBeenCalled();
+  });
+
+  it("retries transient failures and succeeds", async () => {
+    const setMock = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error("Request aborted"), { code: "UND_ERR_ABORTED" }))
+      .mockResolvedValueOnce(undefined);
+    const sleepMock = vi.fn().mockResolvedValue(undefined);
+
+    const result = await registerGuildCommandsWithRetry({
+      guild: { commands: { set: setMock } },
+      commands: [{ name: "a" }],
+      config: { enabled: true, maxAttempts: 3, baseBackoffMs: 2000 },
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      sleep: sleepMock,
+    });
+
+    expect(result).toEqual({ status: "success", attempts: 2 });
+    expect(setMock).toHaveBeenCalledTimes(2);
+    expect(sleepMock).toHaveBeenCalledTimes(1);
+    expect(sleepMock).toHaveBeenCalledWith(2000);
+  });
+
+  it("does not retry non-transient failures", async () => {
+    const setMock = vi.fn().mockRejectedValueOnce(new Error("Invalid Form Body"));
+    const sleepMock = vi.fn().mockResolvedValue(undefined);
+
+    const result = await registerGuildCommandsWithRetry({
+      guild: { commands: { set: setMock } },
+      commands: [{ name: "a" }],
+      config: { enabled: true, maxAttempts: 3, baseBackoffMs: 2000 },
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      sleep: sleepMock,
+    });
+
+    expect(result.status).toBe("failed");
+    expect(setMock).toHaveBeenCalledTimes(1);
+    expect(sleepMock).not.toHaveBeenCalled();
+  });
+
+  it("returns failed after max transient retries", async () => {
+    const setMock = vi
+      .fn()
+      .mockRejectedValue(
+        Object.assign(new Error("Request aborted"), { code: "UND_ERR_ABORTED", name: "AbortError" })
+      );
+    const sleepMock = vi.fn().mockResolvedValue(undefined);
+
+    const result = await registerGuildCommandsWithRetry({
+      guild: { commands: { set: setMock } },
+      commands: [{ name: "a" }],
+      config: { enabled: true, maxAttempts: 2, baseBackoffMs: 1000 },
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      sleep: sleepMock,
+    });
+
+    expect(result.status).toBe("failed");
+    expect(result.attempts).toBe(2);
+    expect(setMock).toHaveBeenCalledTimes(2);
+    expect(sleepMock).toHaveBeenCalledTimes(1);
+    expect(sleepMock).toHaveBeenCalledWith(1000);
+  });
+});
+
+describe("StartupCommandRegistrationService transient classifier", () => {
+  it("classifies abort/timeout signatures as transient", () => {
+    expect(isTransientRegistrationError({ code: "UND_ERR_ABORTED" })).toBe(true);
+    expect(isTransientRegistrationError({ name: "AbortError" })).toBe(true);
+    expect(isTransientRegistrationError({ message: "Request aborted" })).toBe(true);
+    expect(isTransientRegistrationError({ message: "Invalid Form Body" })).toBe(false);
+  });
+});


### PR DESCRIPTION
- add startup command registration service with bounded retry/backoff
- treat registration failures as degraded-mode continuation instead of crash
- add env-configurable Discord REST timeout and registration gate
- add unit tests for retry policy, transient detection, and env parsing