### PR TITLE
fix(link): chunk /link list responses to avoid 2000-char failures

### DIFF
--- a/src/commands/Link.ts
+++ b/src/commands/Link.ts
@@ -6,6 +6,7 @@ import {
   PermissionFlagsBits,
 } from "discord.js";
 import { Command } from "../Command";
+import { DISCORD_CONTENT_LIMIT, truncateDiscordContent } from "../helper/discordContent";
 import { prisma } from "../prisma";
 import { CoCService } from "../services/CoCService";
 import { CommandPermissionService } from "../services/CommandPermissionService";
@@ -69,6 +70,33 @@ function normalizeClanMemberOrder(rawMembers: unknown[]): string[] {
     ordered.push(row.tag);
   }
   return ordered;
+}
+
+function buildChunkedLinkListMessages(header: string, rows: string[]): string[] {
+  const safeHeader =
+    header.length > DISCORD_CONTENT_LIMIT
+      ? truncateDiscordContent(header, DISCORD_CONTENT_LIMIT)
+      : header;
+  const chunks: string[] = [];
+  let current = safeHeader;
+
+  for (const row of rows) {
+    const safeRow =
+      row.length > DISCORD_CONTENT_LIMIT
+        ? truncateDiscordContent(row, DISCORD_CONTENT_LIMIT)
+        : row;
+    const candidate = `${current}\n${safeRow}`;
+    if (candidate.length <= DISCORD_CONTENT_LIMIT) {
+      current = candidate;
+      continue;
+    }
+
+    chunks.push(current);
+    current = safeRow;
+  }
+
+  chunks.push(current);
+  return chunks;
 }
 
 export const Link: Command = {
@@ -280,9 +308,14 @@ export const Link: Command = {
       (row) =>
         `- ${row.playerTag} | <@${row.discordUserId}> (${row.discordUserId}) | linkedAt ${formatLinkedAtUtc(row.linkedAt)}`
     );
-    await interaction.editReply(
-      [`linked_players: ${links.length} for ${normalizedClanTag}`, ...lines].join("\n")
+    const chunks = buildChunkedLinkListMessages(
+      `linked_players: ${links.length} for ${normalizedClanTag}`,
+      lines
     );
+    await interaction.editReply(chunks[0] ?? "empty_list: no linked players found.");
+    for (const chunk of chunks.slice(1)) {
+      await interaction.followUp({ content: chunk });
+    }
   },
   autocomplete: async (interaction: AutocompleteInteraction) => {
     const focused = interaction.options.getFocused(true);

--- a/tests/link.command.run.test.ts
+++ b/tests/link.command.run.test.ts
@@ -46,6 +46,7 @@ function makeInteraction(input: InteractionInput) {
     },
     deferReply: vi.fn().mockResolvedValue(undefined),
     editReply: vi.fn().mockResolvedValue(undefined),
+    followUp: vi.fn().mockResolvedValue(undefined),
     reply: vi.fn().mockResolvedValue(undefined),
   };
 }
@@ -165,5 +166,74 @@ describe("/link run", () => {
         "- #QGRJ2222 | <@222222222222222222> (222222222222222222) | linkedAt 2026-03-15 09:07 UTC",
       ].join("\n")
     );
+    expect(interaction.followUp).not.toHaveBeenCalled();
+  });
+
+  it("chunks /link list output when message content exceeds Discord limit", async () => {
+    const createdAt = new Date("2026-03-15T09:07:00.000Z");
+    const alphabet = "PYLQGRJCUV0289";
+    const makeValidTag = (index: number): string => {
+      const a = alphabet[Math.floor(index / alphabet.length) % alphabet.length];
+      const b = alphabet[index % alphabet.length];
+      return `#PY${a}${b}${a}${b}`;
+    };
+    const records = Array.from({ length: 45 }, (_, i) => {
+      return {
+        playerTag: makeValidTag(i),
+        discordUserId: `11111111111111${String(i).padStart(4, "0")}`,
+        createdAt,
+      };
+    });
+    prismaMock.playerLink.findMany.mockResolvedValue(records);
+    const interaction = makeInteraction({
+      subcommand: "list",
+      clanTag: "#PQL0289",
+    });
+    const cocService = {
+      getClan: vi.fn().mockResolvedValue({
+        members: records.map((row, index) => ({
+          tag: row.playerTag,
+          mapPosition: index + 1,
+        })),
+      }),
+    };
+
+    await Link.run({} as any, interaction as any, cocService as any);
+
+    const first = String(interaction.editReply.mock.calls[0]?.[0] ?? "");
+    const followUps = interaction.followUp.mock.calls.map((call) =>
+      String(call[0]?.content ?? "")
+    );
+    const allMessages = [first, ...followUps];
+
+    expect(interaction.editReply).toHaveBeenCalledTimes(1);
+    expect(interaction.followUp).toHaveBeenCalled();
+    expect(allMessages.every((content) => content.length <= 2000)).toBe(true);
+    expect(first).toContain("linked_players: 45 for #PQL0289");
+    expect(allMessages.join("\n")).toContain(records[records.length - 1]?.playerTag ?? "");
+  });
+
+  it("keeps output valid when a single line would exceed Discord limit", async () => {
+    const createdAt = new Date("2026-03-15T09:07:00.000Z");
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      { playerTag: "#PYLQ0289", discordUserId: "1".repeat(2500), createdAt },
+    ]);
+    const interaction = makeInteraction({
+      subcommand: "list",
+      clanTag: "#PQL0289",
+    });
+    const cocService = {
+      getClan: vi.fn().mockResolvedValue({
+        members: [{ tag: "#PYLQ0289", mapPosition: 1 }],
+      }),
+    };
+
+    await Link.run({} as any, interaction as any, cocService as any);
+
+    const first = String(interaction.editReply.mock.calls[0]?.[0] ?? "");
+    const second = String(interaction.followUp.mock.calls[0]?.[0]?.content ?? "");
+    expect(first.length).toBeLessThanOrEqual(2000);
+    expect(second.length).toBeLessThanOrEqual(2000);
+    expect(second).toContain("...truncated");
   });
 });


### PR DESCRIPTION
- split large /link list output into message-safe chunks
- send first chunk via editReply and remaining chunks via followUp
- add tests for chunking and long-line truncation safety