### PR TITLE
fix(startup): retry Discord bootstrap on transient REST aborts

### DIFF
--- a/src/ClashCookies.ts
+++ b/src/ClashCookies.ts
@@ -2,7 +2,12 @@ import { Client, GatewayIntentBits } from "discord.js";
 import ready from "./listeners/ready";
 import interactionCreate from "./listeners/interactionCreate";
 import { CoCService } from "./services/CoCService";
-import { getDiscordRestTimeoutMsFromEnv } from "./services/StartupCommandRegistrationService";
+import {
+  getDiscordRestTimeoutMsFromEnv,
+  getStartupLoginRetryConfigFromEnv,
+  isTransientRegistrationError,
+  runWithTransientRetry,
+} from "./services/StartupCommandRegistrationService";
 import "dotenv/config";
 
 const discordRestTimeoutMs = getDiscordRestTimeoutMsFromEnv(process.env);
@@ -21,8 +26,56 @@ const client = new Client({
 
 const cocService = new CoCService();
 
-// ✅ Register listeners ONCE
+// Register listeners once before login attempts.
 interactionCreate(client, cocService);
 ready(client, cocService);
 
-client.login(process.env.DISCORD_TOKEN);
+async function loginWithRetry(): Promise<void> {
+  const retryConfig = getStartupLoginRetryConfigFromEnv(process.env);
+  console.log(
+    `[startup:login] start base_backoff_ms=${retryConfig.baseBackoffMs} max_backoff_ms=${retryConfig.maxBackoffMs}`
+  );
+
+  const result = await runWithTransientRetry<string>({
+    execute: async () => {
+      const token = String(process.env.DISCORD_TOKEN ?? "").trim();
+      if (!token) {
+        throw new Error("MISSING_DISCORD_TOKEN");
+      }
+      return client.login(token);
+    },
+    config: retryConfig,
+    isTransientError: isTransientRegistrationError,
+    onFailure: (context) => {
+      const errorMessage =
+        context.error instanceof Error ? context.error.message : String(context.error);
+      if (context.willRetry && context.backoffMs !== null) {
+        console.warn(
+          `[startup:login] retry attempt=${context.attempt + 1} backoff_ms=${context.backoffMs} transient=${
+            context.transient ? 1 : 0
+          } error=${errorMessage}`
+        );
+        return;
+      }
+
+      console.error(
+        `[startup:login] fatal_non_transient attempt=${context.attempt} transient=${
+          context.transient ? 1 : 0
+        } error=${errorMessage}`
+      );
+    },
+  });
+
+  if (result.status === "success") {
+    console.log(`[startup:login] success attempt=${result.attempts}`);
+    return;
+  }
+
+  process.exit(1);
+}
+
+void loginWithRetry().catch((error) => {
+  const errorMessage = error instanceof Error ? error.message : String(error);
+  console.error(`[startup:login] fatal_non_transient error=${errorMessage}`);
+  process.exit(1);
+});

--- a/src/listeners/ready.ts
+++ b/src/listeners/ready.ts
@@ -18,7 +18,10 @@ import { startTelemetryScheduleLoop } from "../services/telemetry/schedule";
 import { refreshAllTrackedWarMailPosts } from "../commands/Fwa";
 import {
   getCommandRegistrationConfigFromEnv,
+  getStartupBootstrapRetryConfigFromEnv,
+  isTransientRegistrationError,
   registerGuildCommandsWithRetry,
+  runWithTransientRetry,
 } from "../services/StartupCommandRegistrationService";
 import {
   setNextNotifyRefreshAtMs,
@@ -152,9 +155,44 @@ export default (client: Client, cocService: CoCService): void => {
 
     console.log("ClashCookies is starting...");
 
-    const guildId = process.env.GUILD_ID!;
-    const guild = await client.guilds.fetch(guildId);
-    const me = await guild.members.fetch(client.user!.id);
+    const bootstrapConfig = getStartupBootstrapRetryConfigFromEnv(process.env);
+    console.log(
+      `[startup:bootstrap] start base_backoff_ms=${bootstrapConfig.baseBackoffMs} max_backoff_ms=${bootstrapConfig.maxBackoffMs}`
+    );
+    const bootstrap = await runWithTransientRetry({
+      execute: async () => {
+        const guildIdRaw = String(process.env.GUILD_ID ?? "").trim();
+        if (!guildIdRaw) {
+          throw new Error("MISSING_GUILD_ID");
+        }
+        const guild = await client.guilds.fetch(guildIdRaw);
+        const me = await guild.members.fetch(client.user!.id);
+        return { guildId: guildIdRaw, guild, me };
+      },
+      config: bootstrapConfig,
+      isTransientError: isTransientRegistrationError,
+      onFailure: (context) => {
+        const errorMessage =
+          context.error instanceof Error ? context.error.message : String(context.error);
+        if (context.willRetry && context.backoffMs !== null) {
+          console.warn(
+            `[startup:bootstrap] retry attempt=${context.attempt + 1} backoff_ms=${context.backoffMs} transient=${context.transient ? 1 : 0} error=${errorMessage}`
+          );
+          return;
+        }
+
+        console.error(
+          `[startup:bootstrap] fatal_non_transient attempt=${context.attempt} transient=${context.transient ? 1 : 0} error=${errorMessage}`
+        );
+      },
+    });
+    if (bootstrap.status !== "success") {
+      process.exit(1);
+      return;
+    }
+
+    console.log(`[startup:bootstrap] success attempt=${bootstrap.attempts}`);
+    const { guildId, guild, me } = bootstrap.value;
     const guildPerms = me.permissions;
     const maybePinMessagesBit = (PermissionFlagsBits as Record<string, bigint>).PinMessages;
     const requiredGuildPerms: Array<[bigint, string]> = [

--- a/src/services/StartupCommandRegistrationService.ts
+++ b/src/services/StartupCommandRegistrationService.ts
@@ -29,9 +29,40 @@ export type RegisterGuildCommandsInput = {
   sleep?: (ms: number) => Promise<void>;
 };
 
+export type TransientRetryConfig = {
+  baseBackoffMs: number;
+  maxBackoffMs: number;
+  maxAttempts?: number;
+};
+
+export type TransientRetryFailureContext = {
+  attempt: number;
+  transient: boolean;
+  willRetry: boolean;
+  backoffMs: number | null;
+  maxAttempts?: number;
+  error: unknown;
+};
+
+export type RunWithTransientRetryInput<T> = {
+  execute: () => Promise<T>;
+  config: TransientRetryConfig;
+  isTransientError?: (error: unknown) => boolean;
+  sleep?: (ms: number) => Promise<void>;
+  onFailure?: (context: TransientRetryFailureContext) => void;
+};
+
+export type RunWithTransientRetryResult<T> =
+  | { status: "success"; attempts: number; value: T }
+  | { status: "failed"; attempts: number; transient: boolean; error: unknown };
+
 const DEFAULT_REST_TIMEOUT_MS = 30_000;
 const DEFAULT_REGISTRATION_MAX_ATTEMPTS = 3;
 const DEFAULT_REGISTRATION_BASE_BACKOFF_MS = 2_000;
+const DEFAULT_STARTUP_LOGIN_BASE_BACKOFF_MS = 2_000;
+const DEFAULT_STARTUP_LOGIN_MAX_BACKOFF_MS = 60_000;
+const DEFAULT_STARTUP_BOOTSTRAP_BASE_BACKOFF_MS = 2_000;
+const DEFAULT_STARTUP_BOOTSTRAP_MAX_BACKOFF_MS = 60_000;
 
 /** Purpose: parse an env flag into a deterministic boolean. */
 function parseBoolean(input: string | undefined, fallback: boolean): boolean {
@@ -52,7 +83,7 @@ function parsePositiveInt(input: string | undefined, fallback: number): number {
   return Math.floor(parsed);
 }
 
-/** Purpose: classify timeout/network aborts as retryable registration errors. */
+/** Purpose: classify timeout/network aborts as retryable Discord REST errors. */
 export function isTransientRegistrationError(error: unknown): boolean {
   const code = String((error as { code?: string } | null | undefined)?.code ?? "").trim();
   const name = String((error as { name?: string } | null | undefined)?.name ?? "").trim();
@@ -80,6 +111,59 @@ export function isTransientRegistrationError(error: unknown): boolean {
   return false;
 }
 
+/** Purpose: compute exponential backoff with a deterministic cap. */
+function computeBackoffMs(config: TransientRetryConfig, attempt: number): number {
+  const exponent = Math.max(0, attempt - 1);
+  const candidate = config.baseBackoffMs * Math.pow(2, exponent);
+  return Math.min(config.maxBackoffMs, Math.floor(candidate));
+}
+
+/** Purpose: run one async operation with transient-aware retry policy. */
+export async function runWithTransientRetry<T>(
+  input: RunWithTransientRetryInput<T>
+): Promise<RunWithTransientRetryResult<T>> {
+  const sleep =
+    input.sleep ??
+    ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, Math.max(0, ms))));
+  const isTransient = input.isTransientError ?? isTransientRegistrationError;
+  const maxAttempts =
+    typeof input.config.maxAttempts === "number" && Number.isFinite(input.config.maxAttempts)
+      ? Math.max(1, Math.floor(input.config.maxAttempts))
+      : undefined;
+
+  for (let attempt = 1; ; attempt += 1) {
+    try {
+      const value = await input.execute();
+      return { status: "success", attempts: attempt, value };
+    } catch (error) {
+      const transient = isTransient(error);
+      const exhausted = typeof maxAttempts === "number" && attempt >= maxAttempts;
+      const willRetry = transient && !exhausted;
+      const backoffMs = willRetry ? computeBackoffMs(input.config, attempt) : null;
+
+      input.onFailure?.({
+        attempt,
+        transient,
+        willRetry,
+        backoffMs,
+        maxAttempts,
+        error,
+      });
+
+      if (!willRetry) {
+        return {
+          status: "failed",
+          attempts: attempt,
+          transient,
+          error,
+        };
+      }
+
+      await sleep(backoffMs ?? 0);
+    }
+  }
+}
+
 /** Purpose: load command registration retry config from process env. */
 export function getCommandRegistrationConfigFromEnv(
   env: NodeJS.ProcessEnv
@@ -97,6 +181,40 @@ export function getCommandRegistrationConfigFromEnv(
   };
 }
 
+/** Purpose: load startup login retry backoff config from env. */
+export function getStartupLoginRetryConfigFromEnv(env: NodeJS.ProcessEnv): TransientRetryConfig {
+  const baseBackoffMs = parsePositiveInt(
+    env.STARTUP_LOGIN_BASE_BACKOFF_MS,
+    DEFAULT_STARTUP_LOGIN_BASE_BACKOFF_MS
+  );
+  const maxBackoffMs = parsePositiveInt(
+    env.STARTUP_LOGIN_MAX_BACKOFF_MS,
+    DEFAULT_STARTUP_LOGIN_MAX_BACKOFF_MS
+  );
+  return {
+    baseBackoffMs,
+    maxBackoffMs: Math.max(baseBackoffMs, maxBackoffMs),
+  };
+}
+
+/** Purpose: load startup bootstrap retry backoff config from env. */
+export function getStartupBootstrapRetryConfigFromEnv(
+  env: NodeJS.ProcessEnv
+): TransientRetryConfig {
+  const baseBackoffMs = parsePositiveInt(
+    env.STARTUP_BOOTSTRAP_BASE_BACKOFF_MS,
+    DEFAULT_STARTUP_BOOTSTRAP_BASE_BACKOFF_MS
+  );
+  const maxBackoffMs = parsePositiveInt(
+    env.STARTUP_BOOTSTRAP_MAX_BACKOFF_MS,
+    DEFAULT_STARTUP_BOOTSTRAP_MAX_BACKOFF_MS
+  );
+  return {
+    baseBackoffMs,
+    maxBackoffMs: Math.max(baseBackoffMs, maxBackoffMs),
+  };
+}
+
 /** Purpose: load Discord REST timeout from env with safe fallback. */
 export function getDiscordRestTimeoutMsFromEnv(env: NodeJS.ProcessEnv): number {
   return parsePositiveInt(env.DISCORD_REST_TIMEOUT_MS, DEFAULT_REST_TIMEOUT_MS);
@@ -107,9 +225,6 @@ export async function registerGuildCommandsWithRetry(
   input: RegisterGuildCommandsInput
 ): Promise<CommandRegistrationResult> {
   const logger = input.logger ?? console;
-  const sleep =
-    input.sleep ??
-    ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, Math.max(0, ms))));
 
   if (!input.config.enabled) {
     logger.warn?.("[startup:commands] registration skipped (STARTUP_REGISTER_GUILD_COMMANDS=false)");
@@ -120,36 +235,41 @@ export async function registerGuildCommandsWithRetry(
     `[startup:commands] registration start attempts=${input.config.maxAttempts} payload_count=${input.commands.length}`
   );
 
-  for (let attempt = 1; attempt <= input.config.maxAttempts; attempt += 1) {
-    try {
-      await input.guild.commands.set(input.commands);
-      logger.info?.(`[startup:commands] registration success attempt=${attempt}`);
-      return { status: "success", attempts: attempt };
-    } catch (error) {
-      const transient = isTransientRegistrationError(error);
+  const maxBackoffMs = input.config.baseBackoffMs * Math.pow(2, Math.max(0, input.config.maxAttempts - 1));
+  const result = await runWithTransientRetry<unknown>({
+    execute: () => input.guild.commands.set(input.commands),
+    config: {
+      baseBackoffMs: input.config.baseBackoffMs,
+      maxBackoffMs,
+      maxAttempts: input.config.maxAttempts,
+    },
+    sleep: input.sleep,
+    isTransientError: isTransientRegistrationError,
+    onFailure: (context) => {
+      const errorMessage =
+        context.error instanceof Error ? context.error.message : String(context.error);
       logger.error?.(
-        `[startup:commands] registration failed attempt=${attempt}/${input.config.maxAttempts} transient=${
-          transient ? 1 : 0
-        } error=${error instanceof Error ? error.message : String(error)}`
+        `[startup:commands] registration failed attempt=${context.attempt}/${context.maxAttempts ?? "inf"} transient=${
+          context.transient ? 1 : 0
+        } error=${errorMessage}`
       );
-
-      const finalAttempt = attempt >= input.config.maxAttempts;
-      if (!transient || finalAttempt) {
+      if (context.willRetry && context.backoffMs !== null) {
         logger.warn?.(
-          "[startup:commands] continuing startup in degraded mode (command registration unavailable)"
+          `[startup:commands] retrying registration in ${context.backoffMs}ms attempt=${
+            context.attempt + 1
+          }`
         );
-        return { status: "failed", attempts: attempt, error };
       }
+    },
+  });
 
-      const backoffMs = input.config.baseBackoffMs * Math.pow(2, attempt - 1);
-      logger.warn?.(
-        `[startup:commands] retrying registration in ${backoffMs}ms attempt=${attempt + 1}`
-      );
-      await sleep(backoffMs);
-    }
+  if (result.status === "success") {
+    logger.info?.(`[startup:commands] registration success attempt=${result.attempts}`);
+    return { status: "success", attempts: result.attempts };
   }
 
-  const fallbackError = new Error("Registration failed without explicit error.");
-  logger.warn?.("[startup:commands] continuing startup in degraded mode (fallback terminal path)");
-  return { status: "failed", attempts: input.config.maxAttempts, error: fallbackError };
+  logger.warn?.(
+    "[startup:commands] continuing startup in degraded mode (command registration unavailable)"
+  );
+  return { status: "failed", attempts: result.attempts, error: result.error };
 }

--- a/tests/startupCommandRegistration.service.test.ts
+++ b/tests/startupCommandRegistration.service.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, it, vi } from "vitest";
 import {
   getCommandRegistrationConfigFromEnv,
   getDiscordRestTimeoutMsFromEnv,
+  getStartupBootstrapRetryConfigFromEnv,
+  getStartupLoginRetryConfigFromEnv,
   isTransientRegistrationError,
   registerGuildCommandsWithRetry,
+  runWithTransientRetry,
 } from "../src/services/StartupCommandRegistrationService";
 
 describe("StartupCommandRegistrationService config", () => {
@@ -30,6 +33,14 @@ describe("StartupCommandRegistrationService config", () => {
         DISCORD_REST_TIMEOUT_MS: "xyz",
       } as NodeJS.ProcessEnv)
     ).toBe(30000);
+    expect(getStartupLoginRetryConfigFromEnv({} as NodeJS.ProcessEnv)).toEqual({
+      baseBackoffMs: 2000,
+      maxBackoffMs: 60000,
+    });
+    expect(getStartupBootstrapRetryConfigFromEnv({} as NodeJS.ProcessEnv)).toEqual({
+      baseBackoffMs: 2000,
+      maxBackoffMs: 60000,
+    });
   });
 
   it("parses valid env config values", () => {
@@ -49,6 +60,24 @@ describe("StartupCommandRegistrationService config", () => {
         DISCORD_REST_TIMEOUT_MS: "45000",
       } as NodeJS.ProcessEnv)
     ).toBe(45000);
+    expect(
+      getStartupLoginRetryConfigFromEnv({
+        STARTUP_LOGIN_BASE_BACKOFF_MS: "1500",
+        STARTUP_LOGIN_MAX_BACKOFF_MS: "45000",
+      } as NodeJS.ProcessEnv)
+    ).toEqual({
+      baseBackoffMs: 1500,
+      maxBackoffMs: 45000,
+    });
+    expect(
+      getStartupBootstrapRetryConfigFromEnv({
+        STARTUP_BOOTSTRAP_BASE_BACKOFF_MS: "2500",
+        STARTUP_BOOTSTRAP_MAX_BACKOFF_MS: "30000",
+      } as NodeJS.ProcessEnv)
+    ).toEqual({
+      baseBackoffMs: 2500,
+      maxBackoffMs: 30000,
+    });
   });
 });
 
@@ -135,5 +164,66 @@ describe("StartupCommandRegistrationService transient classifier", () => {
     expect(isTransientRegistrationError({ name: "AbortError" })).toBe(true);
     expect(isTransientRegistrationError({ message: "Request aborted" })).toBe(true);
     expect(isTransientRegistrationError({ message: "Invalid Form Body" })).toBe(false);
+  });
+});
+
+describe("StartupCommandRegistrationService shared retry helper", () => {
+  it("retries transient failures and succeeds with capped backoff", async () => {
+    const execute = vi
+      .fn()
+      .mockRejectedValueOnce(Object.assign(new Error("Request aborted"), { code: "UND_ERR_ABORTED" }))
+      .mockResolvedValueOnce("ok");
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    const failures: Array<{ willRetry: boolean; backoffMs: number | null }> = [];
+
+    const result = await runWithTransientRetry({
+      execute,
+      config: { baseBackoffMs: 2000, maxBackoffMs: 2500 },
+      sleep,
+      onFailure: (context) => {
+        failures.push({ willRetry: context.willRetry, backoffMs: context.backoffMs });
+      },
+    });
+
+    expect(result).toEqual({ status: "success", attempts: 2, value: "ok" });
+    expect(execute).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledTimes(1);
+    expect(sleep).toHaveBeenCalledWith(2000);
+    expect(failures).toEqual([{ willRetry: true, backoffMs: 2000 }]);
+  });
+
+  it("fails immediately on non-transient errors", async () => {
+    const execute = vi.fn().mockRejectedValue(new Error("TOKEN_INVALID"));
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    const result = await runWithTransientRetry({
+      execute,
+      config: { baseBackoffMs: 1000, maxBackoffMs: 5000 },
+      sleep,
+    });
+
+    expect(result.status).toBe("failed");
+    expect(result.attempts).toBe(1);
+    expect(result.transient).toBe(false);
+    expect(sleep).not.toHaveBeenCalled();
+  });
+
+  it("honors maxAttempts for transient failures", async () => {
+    const execute = vi
+      .fn()
+      .mockRejectedValue(Object.assign(new Error("Request aborted"), { code: "UND_ERR_ABORTED" }));
+    const sleep = vi.fn().mockResolvedValue(undefined);
+
+    const result = await runWithTransientRetry({
+      execute,
+      config: { baseBackoffMs: 1000, maxBackoffMs: 5000, maxAttempts: 2 },
+      sleep,
+    });
+
+    expect(result.status).toBe("failed");
+    expect(result.attempts).toBe(2);
+    expect(result.transient).toBe(true);
+    expect(sleep).toHaveBeenCalledTimes(1);
+    expect(sleep).toHaveBeenCalledWith(1000);
   });
 });


### PR DESCRIPTION
- add shared transient retry helper with capped exponential backoff
- wrap login and ready bootstrap fetches with retry + fatal non-transient exit
- add env-driven startup retry backoff config and startup service tests