### PR TITLE
fix(fwa): widen non-FWA inference when opponent evidence is stale

### DIFF
--- a/src/services/MatchTypeResolutionService.ts
+++ b/src/services/MatchTypeResolutionService.ts
@@ -172,7 +172,10 @@ export function inferMatchTypeFromOpponentPoints(
     }
   }
   const activeWarNonFwaResolution = resolveNonFwaMatchTypeFromActiveWarEvidence({
-    nonFwaEvidencePresent: winnerBoxFallback || signal.notFound === true,
+    nonFwaEvidencePresent:
+      winnerBoxFallback ||
+      signal.notFound === true ||
+      signal.opponentEvidenceMissingOrNotCurrent === true,
     currentWarState: signal.currentWarState ?? null,
     currentWarClanAttacksUsed: signal.currentWarClanAttacksUsed ?? null,
     currentWarClanStars: signal.currentWarClanStars ?? null,

--- a/tests/fwaMatchInference.logic.test.ts
+++ b/tests/fwaMatchInference.logic.test.ts
@@ -65,6 +65,48 @@ describe("fwa match inference from points snapshots", () => {
     expect(inferred).toBeNull();
   });
 
+  it("infers MM when Active FWA is missing but opponent evidence is flagged missing/not-current and battle evidence exists", () => {
+    const inferred = inferMatchTypeFromPointsSnapshotsForTest(
+      { activeFwa: true },
+      { balance: 1234, activeFwa: null, notFound: false },
+      {
+        opponentEvidenceMissingOrNotCurrent: true,
+        currentWarState: "inWar",
+        currentWarClanAttacksUsed: 3,
+        currentWarClanStars: 6,
+        currentWarOpponentStars: 2,
+      }
+    );
+
+    expect(inferred).toMatchObject({
+      matchType: "MM",
+      source: "active_war_non_fwa_mismatch",
+      inferred: true,
+      syncIsFwa: false,
+    });
+  });
+
+  it("infers BL when Active FWA is missing but opponent evidence is flagged missing/not-current with zero attacks", () => {
+    const inferred = inferMatchTypeFromPointsSnapshotsForTest(
+      { activeFwa: true },
+      { balance: 1234, activeFwa: null, notFound: false },
+      {
+        opponentEvidenceMissingOrNotCurrent: true,
+        currentWarState: "inWar",
+        currentWarClanAttacksUsed: 0,
+        currentWarClanStars: 0,
+        currentWarOpponentStars: 2,
+      }
+    );
+
+    expect(inferred).toMatchObject({
+      matchType: "BL",
+      source: "active_war_non_fwa_blacklist",
+      inferred: true,
+      syncIsFwa: false,
+    });
+  });
+
   it("returns null from winner-box fallback when battle evidence is still insufficient", () => {
     const inferred = inferMatchTypeFromPointsSnapshotsForTest(
       { activeFwa: true },


### PR DESCRIPTION
- treat opponentEvidenceMissingOrNotCurrent as valid non-FWA evidence input
- keep match-type precedence unchanged (confirmed signals still win)
- add MM/BL regression tests for activeFwa=null with battle-day evidence