### PR TITLE
feat(fwa-feeds): add FWAStats ingestion scheduler and sync tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Discord bot for Clash of Clans activity tooling.
 - `/fwa weight-age`, `/fwa weight-link`, `/fwa weight-health`, and `/fwa weight-cookie` now provide FWA Stats weight monitoring with cached scraping, stale-weight flags, auth-expiry recovery guidance, and secure cookie status/update flows.
 - `/fwa compliance` now runs the shared war-end compliance engine on demand for a tracked clan (latest ended war by default, optional `war-id` override).
 - `/layout` now supports FWA base layout listing/fetch by Town Hall and admin-only link upserts (with optional `img-url` preview updates), backed by the new `FwaLayouts` table.
+- FWAStats JSON feed ingestion foundation is now DB-backed with dedicated current-state tables, feed-sync metadata ownership (`FwaFeedSyncState`), tracked-clan wars watch state (`FwaClanWarsWatchState`), and bounded scheduler loops.
 
 ## Quick Start
 ```bash
@@ -46,3 +47,41 @@ npm start
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development guidelines and architecture documentation.
 FWA command internals are split under `src/commands/fwa/` helper modules to keep `Fwa.ts` orchestration-focused and unit-testable.
 Run `npm run seed:fwa-layouts` after migrations when you want to upsert the canonical layout seed rows.
+
+## FWAStats Feed Ingestion (Phase 1)
+Endpoints wired:
+- `https://fwastats.com/Clans.json`
+- `https://fwastats.com/Clan/<clan-tag>/Members.json`
+- `https://fwastats.com/Clan/<clan-tag>/WarMembers.json?warNo=1`
+- `https://fwastats.com/Clan/<clan-tag>/Wars.json`
+
+Intentionally omitted:
+- `https://fwastats.com/Weights.json` (not part of this ingestion phase)
+
+Current-state tables:
+- `FwaClanCatalog`
+- `FwaPlayerCatalog`
+- `FwaClanMemberCurrent`
+- `FwaWarMemberCurrent`
+- `FwaClanWarLogCurrent`
+- `FwaFeedSyncState`
+- `FwaClanWarsWatchState`
+- `FwaFeedCursor` (distributed sweep cursor state)
+
+Cadence defaults and cost controls:
+- `Clans.json`: every 6 hours
+- tracked-clan `Members.json`: every 15 minutes (minimum source freshness respected)
+- `WarMembers.json`: distributed sweep ticks every 15 minutes with bounded chunk size/concurrency
+- tracked-clan `Wars.json` watch: 5-minute cadence only inside active per-clan windows, starts 5 minutes before sync time, stops once update is acquired
+- optional global `Wars.json` sweep: disabled by default, configurable and chunked
+- command paths remain DB-first; `/compo` is still sheet-backed in this phase
+
+Manual/dev operations (script tooling):
+```bash
+npm run sync:fwa-feeds -- status
+npm run sync:fwa-feeds -- run --feed=clan-members --tag=#2QG2C08UP
+npm run sync:fwa-feeds -- run --feed=clan-wars --tag=#2QG2C08UP
+npm run sync:fwa-feeds -- run-global --feed=clans
+npm run sync:fwa-feeds -- run-global --feed=war-members
+npm run sync:fwa-feeds -- watch-status --tag=#2QG2C08UP
+```

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -69,3 +69,44 @@ Optional fallback auth (not required for current setup):
 - `GOOGLE_SERVICE_ACCOUNT_JSON_BASE64`
 - `GOOGLE_SERVICE_ACCOUNT_EMAIL`
 - `GOOGLE_SERVICE_ACCOUNT_PRIVATE_KEY`
+
+## Optional FWAStats Feed Ingestion Scheduler
+These control the JSON-feed ingestion foundation for future DB-backed `/compo` migration.
+
+Feed toggles:
+- `FWA_CLANS_SYNC_ENABLED` (default `true`)
+- `FWA_CLAN_MEMBERS_SYNC_ENABLED` (default `true`)
+- `FWA_WAR_MEMBERS_SWEEP_ENABLED` (default `true`)
+- `FWA_TRACKED_CLAN_WARS_WATCH_ENABLED` (default `true`)
+- `FWA_GLOBAL_CLAN_WARS_SWEEP_ENABLED` (default `false`)
+
+Cadence controls:
+- `FWA_CLANS_SYNC_CRON_OR_MINUTES` (default `360`; clamped to minimum 15 minutes)
+- `FWA_CLAN_MEMBERS_SYNC_MINUTES` (default `15`; minimum 15)
+- `FWA_SWEEP_TICK_MINUTES` (default `15`; minimum 15)
+- `FWA_TRACKED_CLAN_WARS_WATCH_TICK_MINUTES` (default `5`; minimum 5)
+
+Sweep chunk controls:
+- `FWA_WAR_MEMBERS_SWEEP_CHUNK_SIZE` (default `6`)
+- `FWA_GLOBAL_CLAN_WARS_SWEEP_CHUNK_SIZE` (default `20`)
+
+Request/concurrency controls:
+- `FWA_FEED_REQUEST_TIMEOUT_MS` (default `5000`)
+- `FWA_FEED_RETRY_COUNT` (default `1`)
+- `FWA_FEED_MAX_CONCURRENCY` (default `4`)
+- `FWA_FEED_JOB_JITTER_MS` (default `30000`)
+
+Operational notes:
+- Normal feed polling is bounded by source freshness (minimum 15 minutes).
+- Tracked-clan `Wars.json` watch is the only 5-minute exception and only runs inside active watch windows.
+- Members polling uses tracked clans only.
+- Global WarMembers / optional global Wars use cursor-based distributed sweeps from `FwaClanCatalog`.
+- `/compo` remains sheet-backed in this phase.
+
+Manual/dev feed operations:
+```bash
+npm run sync:fwa-feeds -- status
+npm run sync:fwa-feeds -- run --feed=clan-members --tag=#2QG2C08UP
+npm run sync:fwa-feeds -- run-global --feed=clans
+npm run sync:fwa-feeds -- watch-status --tag=#2QG2C08UP
+```

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "lint": "eslint \"src/**/*.ts\" \"tests/**/*.ts\"",
     "lint:fix": "eslint \"src/**/*.ts\" \"tests/**/*.ts\" --fix",
     "seed:fwa-layouts": "ts-node src/scripts/seedFwaLayouts.ts",
+    "sync:fwa-feeds": "ts-node src/scripts/fwaFeedSync.ts",
     "start": "prisma migrate deploy && node dist/ClashCookies.js",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/prisma/migrations/20260319120000_add_fwastats_feed_ingestion_tables/migration.sql
+++ b/prisma/migrations/20260319120000_add_fwastats_feed_ingestion_tables/migration.sql
@@ -1,0 +1,255 @@
+-- CreateEnum
+CREATE TYPE "FwaFeedType" AS ENUM ('CLANS', 'CLAN_MEMBERS', 'WAR_MEMBERS', 'CLAN_WARS');
+
+-- CreateEnum
+CREATE TYPE "FwaFeedScopeType" AS ENUM ('GLOBAL', 'TRACKED_CLANS', 'CLAN_TAG');
+
+-- CreateEnum
+CREATE TYPE "FwaFeedSyncStatus" AS ENUM ('IDLE', 'SUCCESS', 'FAILURE', 'NOOP', 'SKIPPED');
+
+-- CreateTable
+CREATE TABLE "FwaClanCatalog" (
+    "clanTag" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "level" INTEGER,
+    "points" INTEGER,
+    "type" TEXT,
+    "location" TEXT,
+    "requiredTrophies" INTEGER,
+    "warFrequency" TEXT,
+    "winStreak" INTEGER,
+    "wins" INTEGER,
+    "ties" INTEGER,
+    "losses" INTEGER,
+    "isWarLogPublic" BOOLEAN,
+    "imageUrl" TEXT,
+    "description" TEXT,
+    "th18Count" INTEGER,
+    "th17Count" INTEGER,
+    "th16Count" INTEGER,
+    "th15Count" INTEGER,
+    "th14Count" INTEGER,
+    "th13Count" INTEGER,
+    "th12Count" INTEGER,
+    "th11Count" INTEGER,
+    "th10Count" INTEGER,
+    "th9Count" INTEGER,
+    "th8Count" INTEGER,
+    "thLowCount" INTEGER,
+    "estimatedWeight" INTEGER,
+    "firstSeenAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastSeenAt" TIMESTAMP(3) NOT NULL,
+    "lastSyncedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "FwaClanCatalog_pkey" PRIMARY KEY ("clanTag")
+);
+
+-- CreateTable
+CREATE TABLE "FwaPlayerCatalog" (
+    "playerTag" TEXT NOT NULL,
+    "latestName" TEXT NOT NULL,
+    "latestTownHall" INTEGER,
+    "latestKnownWeight" INTEGER,
+    "firstSeenAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "lastSeenAt" TIMESTAMP(3) NOT NULL,
+    "lastSyncedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "FwaPlayerCatalog_pkey" PRIMARY KEY ("playerTag")
+);
+
+-- CreateTable
+CREATE TABLE "FwaClanMemberCurrent" (
+    "clanTag" TEXT NOT NULL,
+    "playerTag" TEXT NOT NULL,
+    "playerName" TEXT NOT NULL,
+    "role" TEXT,
+    "level" INTEGER,
+    "donated" INTEGER,
+    "received" INTEGER,
+    "rank" INTEGER,
+    "trophies" INTEGER,
+    "league" TEXT,
+    "townHall" INTEGER,
+    "weight" INTEGER,
+    "inWar" BOOLEAN,
+    "sourceSyncedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "FwaClanMemberCurrent_pkey" PRIMARY KEY ("clanTag","playerTag")
+);
+
+-- CreateTable
+CREATE TABLE "FwaWarMemberCurrent" (
+    "clanTag" TEXT NOT NULL,
+    "playerTag" TEXT NOT NULL,
+    "playerName" TEXT NOT NULL,
+    "position" INTEGER,
+    "townHall" INTEGER,
+    "weight" INTEGER,
+    "opponentTag" TEXT,
+    "opponentName" TEXT,
+    "attacks" INTEGER,
+    "defender1Tag" TEXT,
+    "defender1Name" TEXT,
+    "defender1TownHall" INTEGER,
+    "defender1Position" INTEGER,
+    "stars1" INTEGER,
+    "destructionPercentage1" DOUBLE PRECISION,
+    "defender2Tag" TEXT,
+    "defender2Name" TEXT,
+    "defender2TownHall" INTEGER,
+    "defender2Position" INTEGER,
+    "stars2" INTEGER,
+    "destructionPercentage2" DOUBLE PRECISION,
+    "sourceSyncedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "FwaWarMemberCurrent_pkey" PRIMARY KEY ("clanTag","playerTag")
+);
+
+-- CreateTable
+CREATE TABLE "FwaClanWarLogCurrent" (
+    "id" TEXT NOT NULL,
+    "clanTag" TEXT NOT NULL,
+    "endTime" TIMESTAMP(3) NOT NULL,
+    "searchTime" TIMESTAMP(3),
+    "result" TEXT,
+    "teamSize" INTEGER NOT NULL,
+    "clanName" TEXT,
+    "clanLevel" INTEGER,
+    "clanStars" INTEGER,
+    "clanDestructionPercentage" DOUBLE PRECISION,
+    "clanAttacks" INTEGER,
+    "clanExpEarned" INTEGER,
+    "opponentTag" TEXT NOT NULL,
+    "opponentName" TEXT,
+    "opponentLevel" INTEGER,
+    "opponentStars" INTEGER,
+    "opponentDestructionPercentage" DOUBLE PRECISION,
+    "opponentInfo" TEXT,
+    "synced" BOOLEAN,
+    "matched" BOOLEAN,
+    "sourceSyncedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "FwaClanWarLogCurrent_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "FwaFeedSyncState" (
+    "id" TEXT NOT NULL,
+    "feedType" "FwaFeedType" NOT NULL,
+    "scopeType" "FwaFeedScopeType" NOT NULL,
+    "scopeKey" TEXT,
+    "lastAttemptAt" TIMESTAMP(3),
+    "lastSuccessAt" TIMESTAMP(3),
+    "lastStatus" "FwaFeedSyncStatus" NOT NULL DEFAULT 'IDLE',
+    "lastErrorCode" TEXT,
+    "lastErrorSummary" TEXT,
+    "lastRowCount" INTEGER,
+    "lastChangedRowCount" INTEGER,
+    "lastContentHash" TEXT,
+    "nextEligibleAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "FwaFeedSyncState_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "FwaClanWarsWatchState" (
+    "clanTag" TEXT NOT NULL,
+    "syncTimeSourceMessageId" TEXT,
+    "nextSyncTimeAt" TIMESTAMP(3),
+    "pollWindowStartAt" TIMESTAMP(3),
+    "pollingActive" BOOLEAN NOT NULL DEFAULT false,
+    "lastDetectedWarEndAt" TIMESTAMP(3),
+    "lastAcquiredUpdateAt" TIMESTAMP(3),
+    "lastObservedContentHash" TEXT,
+    "currentWarCycleKey" TEXT,
+    "stopReason" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "FwaClanWarsWatchState_pkey" PRIMARY KEY ("clanTag")
+);
+
+-- CreateTable
+CREATE TABLE "FwaFeedCursor" (
+    "feedType" "FwaFeedType" NOT NULL,
+    "lastScopeKey" TEXT,
+    "lastRunAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "FwaFeedCursor_pkey" PRIMARY KEY ("feedType")
+);
+
+-- CreateIndex
+CREATE INDEX "FwaClanCatalog_lastSeenAt_idx" ON "FwaClanCatalog"("lastSeenAt");
+
+-- CreateIndex
+CREATE INDEX "FwaClanCatalog_lastSyncedAt_idx" ON "FwaClanCatalog"("lastSyncedAt");
+
+-- CreateIndex
+CREATE INDEX "FwaClanCatalog_points_idx" ON "FwaClanCatalog"("points");
+
+-- CreateIndex
+CREATE INDEX "FwaPlayerCatalog_latestTownHall_idx" ON "FwaPlayerCatalog"("latestTownHall");
+
+-- CreateIndex
+CREATE INDEX "FwaPlayerCatalog_lastSeenAt_idx" ON "FwaPlayerCatalog"("lastSeenAt");
+
+-- CreateIndex
+CREATE INDEX "FwaPlayerCatalog_lastSyncedAt_idx" ON "FwaPlayerCatalog"("lastSyncedAt");
+
+-- CreateIndex
+CREATE INDEX "FwaClanMemberCurrent_clanTag_idx" ON "FwaClanMemberCurrent"("clanTag");
+
+-- CreateIndex
+CREATE INDEX "FwaClanMemberCurrent_playerTag_idx" ON "FwaClanMemberCurrent"("playerTag");
+
+-- CreateIndex
+CREATE INDEX "FwaClanMemberCurrent_sourceSyncedAt_idx" ON "FwaClanMemberCurrent"("sourceSyncedAt");
+
+-- CreateIndex
+CREATE INDEX "FwaWarMemberCurrent_clanTag_idx" ON "FwaWarMemberCurrent"("clanTag");
+
+-- CreateIndex
+CREATE INDEX "FwaWarMemberCurrent_playerTag_idx" ON "FwaWarMemberCurrent"("playerTag");
+
+-- CreateIndex
+CREATE INDEX "FwaWarMemberCurrent_opponentTag_idx" ON "FwaWarMemberCurrent"("opponentTag");
+
+-- CreateIndex
+CREATE INDEX "FwaWarMemberCurrent_sourceSyncedAt_idx" ON "FwaWarMemberCurrent"("sourceSyncedAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "FwaClanWarLogCurrent_clanTag_endTime_opponentTag_teamSize_key" ON "FwaClanWarLogCurrent"("clanTag", "endTime", "opponentTag", "teamSize");
+
+-- CreateIndex
+CREATE INDEX "FwaClanWarLogCurrent_clanTag_idx" ON "FwaClanWarLogCurrent"("clanTag");
+
+-- CreateIndex
+CREATE INDEX "FwaClanWarLogCurrent_opponentTag_idx" ON "FwaClanWarLogCurrent"("opponentTag");
+
+-- CreateIndex
+CREATE INDEX "FwaClanWarLogCurrent_endTime_idx" ON "FwaClanWarLogCurrent"("endTime");
+
+-- CreateIndex
+CREATE INDEX "FwaClanWarLogCurrent_sourceSyncedAt_idx" ON "FwaClanWarLogCurrent"("sourceSyncedAt");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "FwaFeedSyncState_feedType_scopeType_scopeKey_key" ON "FwaFeedSyncState"("feedType", "scopeType", "scopeKey");
+
+-- CreateIndex
+CREATE INDEX "FwaFeedSyncState_feedType_scopeType_scopeKey_idx" ON "FwaFeedSyncState"("feedType", "scopeType", "scopeKey");
+
+-- CreateIndex
+CREATE INDEX "FwaFeedSyncState_lastStatus_updatedAt_idx" ON "FwaFeedSyncState"("lastStatus", "updatedAt");
+
+-- CreateIndex
+CREATE INDEX "FwaFeedSyncState_nextEligibleAt_idx" ON "FwaFeedSyncState"("nextEligibleAt");
+
+-- CreateIndex
+CREATE INDEX "FwaClanWarsWatchState_pollingActive_pollWindowStartAt_nextSyncTimeAt_idx" ON "FwaClanWarsWatchState"("pollingActive", "pollWindowStartAt", "nextSyncTimeAt");
+
+-- CreateIndex
+CREATE INDEX "FwaClanWarsWatchState_lastAcquiredUpdateAt_idx" ON "FwaClanWarsWatchState"("lastAcquiredUpdateAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -104,6 +104,27 @@ enum FwaLayoutType {
   ICE
 }
 
+enum FwaFeedType {
+  CLANS
+  CLAN_MEMBERS
+  WAR_MEMBERS
+  CLAN_WARS
+}
+
+enum FwaFeedScopeType {
+  GLOBAL
+  TRACKED_CLANS
+  CLAN_TAG
+}
+
+enum FwaFeedSyncStatus {
+  IDLE
+  SUCCESS
+  FAILURE
+  NOOP
+  SKIPPED
+}
+
 
 enum TrackedMessageFeatureType {
   FWA_BASE_SWAP
@@ -489,6 +510,190 @@ model FwaLayouts {
 
   @@id([Townhall, Type])
   @@index([Type])
+}
+
+model FwaClanCatalog {
+  clanTag           String   @id
+  name              String
+  level             Int?
+  points            Int?
+  type              String?
+  location          String?
+  requiredTrophies  Int?
+  warFrequency      String?
+  winStreak         Int?
+  wins              Int?
+  ties              Int?
+  losses            Int?
+  isWarLogPublic    Boolean?
+  imageUrl          String?
+  description       String?
+  th18Count         Int?
+  th17Count         Int?
+  th16Count         Int?
+  th15Count         Int?
+  th14Count         Int?
+  th13Count         Int?
+  th12Count         Int?
+  th11Count         Int?
+  th10Count         Int?
+  th9Count          Int?
+  th8Count          Int?
+  thLowCount        Int?
+  estimatedWeight   Int?
+  firstSeenAt       DateTime @default(now())
+  lastSeenAt        DateTime
+  lastSyncedAt      DateTime
+
+  @@index([lastSeenAt])
+  @@index([lastSyncedAt])
+  @@index([points])
+}
+
+model FwaPlayerCatalog {
+  playerTag         String   @id
+  latestName        String
+  latestTownHall    Int?
+  latestKnownWeight Int?
+  firstSeenAt       DateTime @default(now())
+  lastSeenAt        DateTime
+  lastSyncedAt      DateTime
+
+  @@index([latestTownHall])
+  @@index([lastSeenAt])
+  @@index([lastSyncedAt])
+}
+
+model FwaClanMemberCurrent {
+  clanTag        String
+  playerTag      String
+  playerName     String
+  role           String?
+  level          Int?
+  donated        Int?
+  received       Int?
+  rank           Int?
+  trophies       Int?
+  league         String?
+  townHall       Int?
+  weight         Int?
+  inWar          Boolean?
+  sourceSyncedAt DateTime
+
+  @@id([clanTag, playerTag])
+  @@index([clanTag])
+  @@index([playerTag])
+  @@index([sourceSyncedAt])
+}
+
+model FwaWarMemberCurrent {
+  clanTag                 String
+  playerTag               String
+  playerName              String
+  position                Int?
+  townHall                Int?
+  weight                  Int?
+  opponentTag             String?
+  opponentName            String?
+  attacks                 Int?
+  defender1Tag            String?
+  defender1Name           String?
+  defender1TownHall       Int?
+  defender1Position       Int?
+  stars1                  Int?
+  destructionPercentage1  Float?
+  defender2Tag            String?
+  defender2Name           String?
+  defender2TownHall       Int?
+  defender2Position       Int?
+  stars2                  Int?
+  destructionPercentage2  Float?
+  sourceSyncedAt          DateTime
+
+  @@id([clanTag, playerTag])
+  @@index([clanTag])
+  @@index([playerTag])
+  @@index([opponentTag])
+  @@index([sourceSyncedAt])
+}
+
+model FwaClanWarLogCurrent {
+  id                          String   @id @default(cuid())
+  clanTag                     String
+  endTime                     DateTime
+  searchTime                  DateTime?
+  result                      String?
+  teamSize                    Int
+  clanName                    String?
+  clanLevel                   Int?
+  clanStars                   Int?
+  clanDestructionPercentage   Float?
+  clanAttacks                 Int?
+  clanExpEarned               Int?
+  opponentTag                 String
+  opponentName                String?
+  opponentLevel               Int?
+  opponentStars               Int?
+  opponentDestructionPercentage Float?
+  opponentInfo                String?
+  synced                      Boolean?
+  matched                     Boolean?
+  sourceSyncedAt              DateTime
+
+  @@unique([clanTag, endTime, opponentTag, teamSize])
+  @@index([clanTag])
+  @@index([opponentTag])
+  @@index([endTime])
+  @@index([sourceSyncedAt])
+}
+
+model FwaFeedSyncState {
+  id                  String            @id @default(cuid())
+  feedType            FwaFeedType
+  scopeType           FwaFeedScopeType
+  scopeKey            String?
+  lastAttemptAt       DateTime?
+  lastSuccessAt       DateTime?
+  lastStatus          FwaFeedSyncStatus @default(IDLE)
+  lastErrorCode       String?
+  lastErrorSummary    String?
+  lastRowCount        Int?
+  lastChangedRowCount Int?
+  lastContentHash     String?
+  nextEligibleAt      DateTime?
+  createdAt           DateTime          @default(now())
+  updatedAt           DateTime          @updatedAt
+
+  @@unique([feedType, scopeType, scopeKey])
+  @@index([feedType, scopeType, scopeKey])
+  @@index([lastStatus, updatedAt])
+  @@index([nextEligibleAt])
+}
+
+model FwaClanWarsWatchState {
+  clanTag                String   @id
+  syncTimeSourceMessageId String?
+  nextSyncTimeAt         DateTime?
+  pollWindowStartAt      DateTime?
+  pollingActive          Boolean  @default(false)
+  lastDetectedWarEndAt   DateTime?
+  lastAcquiredUpdateAt   DateTime?
+  lastObservedContentHash String?
+  currentWarCycleKey     String?
+  stopReason             String?
+  createdAt              DateTime @default(now())
+  updatedAt              DateTime @updatedAt
+
+  @@index([pollingActive, pollWindowStartAt, nextSyncTimeAt])
+  @@index([lastAcquiredUpdateAt])
+}
+
+model FwaFeedCursor {
+  feedType    FwaFeedType @id
+  lastScopeKey String?
+  lastRunAt   DateTime?
+  createdAt   DateTime    @default(now())
+  updatedAt   DateTime    @updatedAt
 }
 
 model ApiUsage {

--- a/src/listeners/ready.ts
+++ b/src/listeners/ready.ts
@@ -33,6 +33,7 @@ import {
   setNextWarMailRefreshAtMs,
 } from "../services/refreshSchedule";
 import { trackedMessageService } from "../services/TrackedMessageService";
+import { FwaFeedSchedulerService } from "../services/fwa-feeds/FwaFeedSchedulerService";
 
 const DEFAULT_OBSERVE_INTERVAL_MINUTES = 30;
 const RECRUITMENT_REMINDER_INTERVAL_MS = 60 * 60 * 1000;
@@ -552,6 +553,10 @@ export default (client: Client, cocService: CoCService): void => {
     console.log(
       `War event poll + refresh loop enabled (every ${warEventPollMinutes} minute(s)).`
     );
+
+    const fwaFeedScheduler = new FwaFeedSchedulerService();
+    fwaFeedScheduler.start();
+    console.log("FWA feed scheduler loops initialized.");
 
     console.log("ClashCookies is online");
   });

--- a/src/scripts/fwaFeedSync.ts
+++ b/src/scripts/fwaFeedSync.ts
@@ -1,0 +1,97 @@
+import "dotenv/config";
+import { FwaFeedOpsService } from "../services/fwa-feeds/FwaFeedOpsService";
+
+type Command =
+  | "status"
+  | "run"
+  | "run-global"
+  | "watch-status"
+  | "run-job";
+
+function readArg(name: string): string | null {
+  const prefix = `--${name}=`;
+  const value = process.argv.find((arg) => arg.startsWith(prefix));
+  if (!value) return null;
+  return value.slice(prefix.length).trim() || null;
+}
+
+/** Purpose: print one JSON payload and terminate with explicit success code. */
+function printJson(payload: unknown): void {
+  process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+}
+
+/** Purpose: run manual fwa feed sync operations for local/dev/staging validation workflows. */
+async function main(): Promise<void> {
+  const command = (process.argv[2] ?? "status").trim() as Command;
+  const ops = new FwaFeedOpsService();
+
+  if (command === "status") {
+    const tag = readArg("tag");
+    const output = await ops.status(tag ?? undefined);
+    printJson(output);
+    return;
+  }
+
+  if (command === "run") {
+    const feed = readArg("feed");
+    const tag = readArg("tag");
+    if (!feed || !tag) {
+      throw new Error("Usage: fwaFeedSync run --feed=clan-members|clan-wars --tag=#CLANTAG");
+    }
+    if (feed !== "clan-members" && feed !== "clan-wars") {
+      throw new Error("feed must be clan-members or clan-wars");
+    }
+    const output = await ops.runTracked(feed, tag);
+    printJson(output);
+    return;
+  }
+
+  if (command === "run-global") {
+    const feed = readArg("feed");
+    if (!feed) throw new Error("Usage: fwaFeedSync run-global --feed=clans|war-members|clan-wars");
+    if (feed !== "clans" && feed !== "war-members" && feed !== "clan-wars") {
+      throw new Error("feed must be clans, war-members, or clan-wars");
+    }
+    const output = await ops.runGlobal(feed);
+    printJson(output);
+    return;
+  }
+
+  if (command === "watch-status") {
+    const tag = readArg("tag");
+    const output = await ops.watchStatus(tag ?? undefined);
+    printJson(output);
+    return;
+  }
+
+  if (command === "run-job") {
+    const job = readArg("job");
+    if (!job) {
+      throw new Error(
+        "Usage: fwaFeedSync run-job --job=clans|clan-members|war-members|tracked-clan-wars-watch|global-clan-wars",
+      );
+    }
+    if (
+      job !== "clans" &&
+      job !== "clan-members" &&
+      job !== "war-members" &&
+      job !== "tracked-clan-wars-watch" &&
+      job !== "global-clan-wars"
+    ) {
+      throw new Error("Invalid job name.");
+    }
+    await ops.runSchedulerJob(job);
+    printJson({ ok: true, job });
+    return;
+  }
+
+  throw new Error(
+    "Usage: fwaFeedSync <status|run|run-global|watch-status|run-job> [--feed=...] [--tag=...] [--job=...]",
+  );
+}
+
+main().catch((error) => {
+  const message = String((error as { message?: string })?.message ?? error);
+  process.stderr.write(`[fwa-feed-sync] ${message}\n`);
+  process.exitCode = 1;
+});

--- a/src/services/FwaStatsService.ts
+++ b/src/services/FwaStatsService.ts
@@ -1,10 +1,5 @@
-import axios from "axios";
-
-type FwaStatsWarRow = {
-  opponentTag?: string | null;
-  matched?: boolean | string | null;
-  synced?: boolean | string | null;
-};
+import { FwaStatsClient } from "./fwa-feeds/FwaStatsClient";
+import { normalizeFwaTag } from "./fwa-feeds/normalize";
 
 type OpponentCacheEntry = {
   fetchedAtMs: number;
@@ -12,28 +7,15 @@ type OpponentCacheEntry = {
   opponents: Set<string>;
 };
 
-/** Purpose: normalize clan tags to #UPPER format. */
-function normalizeTag(input: string): string {
-  return `#${input.trim().toUpperCase().replace(/^#/, "")}`;
-}
-
-/** Purpose: parse boolean-like API values safely. */
-function asBool(value: unknown): boolean | null {
-  if (typeof value === "boolean") return value;
-  if (typeof value !== "string") return null;
-  const normalized = value.trim().toLowerCase();
-  if (normalized === "true" || normalized === "yes" || normalized === "1") return true;
-  if (normalized === "false" || normalized === "no" || normalized === "0") return false;
-  return null;
-}
-
 /** Purpose: read active opponent tags for a clan from fwastats. */
 export class FwaStatsService {
   private static readonly CACHE_TTL_MS = 5 * 60 * 1000;
-  private static readonly REQUEST_TIMEOUT_MS = 2000;
 
   private readonly cache = new Map<string, OpponentCacheEntry>();
   private readonly inFlight = new Map<string, Promise<OpponentCacheEntry>>();
+
+  /** Purpose: initialize fwastats service dependencies. */
+  constructor(private readonly client = new FwaStatsClient()) {}
 
   /** Purpose: clear in-memory cache (tests/maintenance). */
   clearCache(): void {
@@ -46,8 +28,8 @@ export class FwaStatsService {
     clanTag: string,
     opponentTag: string
   ): Promise<boolean | null> {
-    const clan = normalizeTag(clanTag);
-    const opponent = normalizeTag(opponentTag);
+    const clan = normalizeFwaTag(clanTag);
+    const opponent = normalizeFwaTag(opponentTag);
     if (!clan || !opponent) return null;
 
     try {
@@ -84,27 +66,16 @@ export class FwaStatsService {
 
   /** Purpose: fetch active opponent list from fwastats wars endpoint. */
   private async fetchOpponentCache(clanTag: string): Promise<OpponentCacheEntry> {
-    const bare = clanTag.replace(/^#/, "");
-    const url = `https://fwastats.com/Clan/${bare}/Wars.json`;
-    const response = await axios.get<unknown>(url, {
-      timeout: FwaStatsService.REQUEST_TIMEOUT_MS,
-      validateStatus: () => true,
-    });
-
-    if (response.status >= 400) {
-      throw new Error(`fwastats returned ${response.status}`);
-    }
-
-    const rows = Array.isArray(response.data) ? (response.data as FwaStatsWarRow[]) : [];
+    const rows = await this.client.fetchClanWars(clanTag);
     const opponents = new Set<string>();
     for (const row of rows) {
-      const rawOpponent = String(row?.opponentTag ?? "").trim();
-      if (!rawOpponent) continue;
-      const opponent = normalizeTag(rawOpponent);
+      if (!row.opponentTag) continue;
+      const opponent = normalizeFwaTag(row.opponentTag);
+      if (!opponent) continue;
 
       // Prefer wars that are matched/synced; keep unknown rows to avoid false negatives.
-      const matched = asBool(row?.matched);
-      const synced = asBool(row?.synced);
+      const matched = row.matched;
+      const synced = row.synced;
       if (matched === false && synced === false) continue;
 
       opponents.add(opponent);

--- a/src/services/fwa-feeds/FwaClanMembersSyncService.ts
+++ b/src/services/fwa-feeds/FwaClanMembersSyncService.ts
@@ -1,0 +1,206 @@
+import type { FwaFeedType } from "@prisma/client";
+import { prisma } from "../../prisma";
+import { computeFeedContentHash } from "./hash";
+import { normalizeFwaTag } from "./normalize";
+import { FwaStatsClient } from "./FwaStatsClient";
+import { FwaFeedSyncStateService } from "./FwaFeedSyncStateService";
+import { mapWithConcurrency } from "./concurrency";
+import type { FwaSyncResult } from "./types";
+
+type SyncOptions = {
+  force?: boolean;
+  minimumIntervalMs?: number;
+  now?: Date;
+};
+
+/** Purpose: sync tracked-clan authoritative ACTUAL rosters from Members.json into current-state tables. */
+export class FwaClanMembersSyncService {
+  private static readonly FEED_TYPE: FwaFeedType = "CLAN_MEMBERS";
+  private readonly syncState = new FwaFeedSyncStateService();
+
+  /** Purpose: initialize members-sync dependencies. */
+  constructor(private readonly client = new FwaStatsClient()) {}
+
+  /** Purpose: sync all tracked clans using bounded concurrency and tracked-clan authoritative source list. */
+  async syncAllTrackedClans(params?: SyncOptions & { concurrency?: number }): Promise<{
+    clanCount: number;
+    rowCount: number;
+    changedRowCount: number;
+    failedClans: string[];
+  }> {
+    const tracked = await prisma.trackedClan.findMany({
+      orderBy: { createdAt: "asc" },
+      select: { tag: true },
+    });
+    const clanTags = tracked.map((row) => normalizeFwaTag(row.tag)).filter(Boolean);
+    const concurrency = Math.max(1, Math.trunc(params?.concurrency ?? 4));
+    const results = await mapWithConcurrency(clanTags, concurrency, async (clanTag) => {
+      try {
+        const result = await this.syncTrackedClan(clanTag, params);
+        return { clanTag, result, failed: false };
+      } catch {
+        return { clanTag, result: null, failed: true };
+      }
+    });
+
+    return results.reduce(
+      (acc, row) => {
+        if (row.failed || !row.result) {
+          acc.failedClans.push(row.clanTag);
+          return acc;
+        }
+        acc.rowCount += row.result.rowCount;
+        acc.changedRowCount += row.result.changedRowCount;
+        return acc;
+      },
+      {
+        clanCount: clanTags.length,
+        rowCount: 0,
+        changedRowCount: 0,
+        failedClans: [] as string[],
+      },
+    );
+  }
+
+  /** Purpose: sync one tracked clan members scope with stale-row cleanup and player-catalog upserts. */
+  async syncTrackedClan(clanTag: string, options?: SyncOptions): Promise<FwaSyncResult> {
+    const normalizedClanTag = normalizeFwaTag(clanTag);
+    if (!normalizedClanTag) {
+      return { rowCount: 0, changedRowCount: 0, contentHash: null, status: "SKIPPED" };
+    }
+    const now = options?.now ?? new Date();
+    const minimumIntervalMs = Math.max(0, Math.trunc(options?.minimumIntervalMs ?? 0));
+    const scope = {
+      feedType: FwaClanMembersSyncService.FEED_TYPE,
+      scopeType: "CLAN_TAG" as const,
+      scopeKey: normalizedClanTag,
+    };
+    const nextEligibleAt =
+      minimumIntervalMs > 0 ? new Date(now.getTime() + minimumIntervalMs) : null;
+    if (!options?.force && minimumIntervalMs > 0) {
+      const eligible = await this.syncState.isEligible(scope, minimumIntervalMs, now);
+      if (!eligible) {
+        return { rowCount: 0, changedRowCount: 0, contentHash: null, status: "SKIPPED" };
+      }
+    }
+
+    await this.syncState.recordAttempt(scope, nextEligibleAt, now);
+    try {
+      const rows = await this.client.fetchClanMembers(normalizedClanTag);
+      const sortedRows = [...rows].sort((a, b) => a.playerTag.localeCompare(b.playerTag));
+      const contentHash = computeFeedContentHash(sortedRows);
+      const previousState = await this.syncState.getState(scope);
+      if (previousState?.lastContentHash === contentHash) {
+        const result: FwaSyncResult = {
+          rowCount: rows.length,
+          changedRowCount: 0,
+          contentHash,
+          status: "NOOP",
+        };
+        await this.syncState.recordSuccess(
+          { ...scope, ...result, nextEligibleAt },
+          now,
+        );
+        return result;
+      }
+
+      const changedRowCount = await prisma.$transaction(async (tx) => {
+        const playerTags = rows.map((row) => row.playerTag);
+        const staleDelete = await tx.fwaClanMemberCurrent.deleteMany({
+          where: {
+            clanTag: normalizedClanTag,
+            ...(playerTags.length > 0 ? { playerTag: { notIn: playerTags } } : {}),
+          },
+        });
+
+        for (const row of rows) {
+          await tx.fwaClanMemberCurrent.upsert({
+            where: {
+              clanTag_playerTag: {
+                clanTag: normalizedClanTag,
+                playerTag: row.playerTag,
+              },
+            },
+            update: {
+              playerName: row.playerName,
+              role: row.role,
+              level: row.level,
+              donated: row.donated,
+              received: row.received,
+              rank: row.rank,
+              trophies: row.trophies,
+              league: row.league,
+              townHall: row.townHall,
+              weight: row.weight,
+              inWar: row.inWar,
+              sourceSyncedAt: now,
+            },
+            create: {
+              clanTag: normalizedClanTag,
+              playerTag: row.playerTag,
+              playerName: row.playerName,
+              role: row.role,
+              level: row.level,
+              donated: row.donated,
+              received: row.received,
+              rank: row.rank,
+              trophies: row.trophies,
+              league: row.league,
+              townHall: row.townHall,
+              weight: row.weight,
+              inWar: row.inWar,
+              sourceSyncedAt: now,
+            },
+          });
+          await tx.fwaPlayerCatalog.upsert({
+            where: { playerTag: row.playerTag },
+            update: {
+              latestName: row.playerName,
+              latestTownHall: row.townHall,
+              latestKnownWeight: row.weight,
+              lastSeenAt: now,
+              lastSyncedAt: now,
+            },
+            create: {
+              playerTag: row.playerTag,
+              latestName: row.playerName,
+              latestTownHall: row.townHall,
+              latestKnownWeight: row.weight,
+              firstSeenAt: now,
+              lastSeenAt: now,
+              lastSyncedAt: now,
+            },
+          });
+        }
+        return staleDelete.count + rows.length;
+      });
+
+      const result: FwaSyncResult = {
+        rowCount: rows.length,
+        changedRowCount,
+        contentHash,
+        status: "SUCCESS",
+      };
+      await this.syncState.recordSuccess(
+        { ...scope, ...result, nextEligibleAt },
+        now,
+      );
+      return result;
+    } catch (error) {
+      const errorSummary = String((error as { message?: string })?.message ?? "unknown error").slice(
+        0,
+        200,
+      );
+      await this.syncState.recordFailure(
+        {
+          ...scope,
+          errorCode: "SYNC_FAILED",
+          errorSummary,
+          nextEligibleAt,
+        },
+        now,
+      );
+      throw error;
+    }
+  }
+}

--- a/src/services/fwa-feeds/FwaClanWarsSyncService.ts
+++ b/src/services/fwa-feeds/FwaClanWarsSyncService.ts
@@ -1,0 +1,269 @@
+import type { FwaFeedType } from "@prisma/client";
+import { prisma } from "../../prisma";
+import { computeFeedContentHash } from "./hash";
+import { normalizeFwaTag } from "./normalize";
+import { FwaStatsClient } from "./FwaStatsClient";
+import { FwaFeedCursorService } from "./FwaFeedCursorService";
+import { FwaFeedSyncStateService } from "./FwaFeedSyncStateService";
+import { mapWithConcurrency } from "./concurrency";
+import { selectDistributedSweepChunk } from "./sweep";
+import type { FwaSyncResult } from "./types";
+
+type SyncOptions = {
+  force?: boolean;
+  minimumIntervalMs?: number;
+  now?: Date;
+};
+
+function buildWarRowKey(input: { endTime: Date; opponentTag: string; teamSize: number }): string {
+  return `${input.endTime.toISOString()}|${input.opponentTag}|${input.teamSize}`;
+}
+
+/** Purpose: sync Wars.json rows into bounded current-war-log snapshots per clan scope. */
+export class FwaClanWarsSyncService {
+  private static readonly FEED_TYPE: FwaFeedType = "CLAN_WARS";
+  private readonly syncState = new FwaFeedSyncStateService();
+  private readonly cursor = new FwaFeedCursorService();
+
+  /** Purpose: initialize clan-wars sync dependencies. */
+  constructor(private readonly client = new FwaStatsClient()) {}
+
+  /** Purpose: sync one clan war-log scope with bounded stale-row cleanup and content-hash gating. */
+  async syncClan(clanTag: string, options?: SyncOptions): Promise<FwaSyncResult> {
+    const normalizedClanTag = normalizeFwaTag(clanTag);
+    if (!normalizedClanTag) {
+      return { rowCount: 0, changedRowCount: 0, contentHash: null, status: "SKIPPED" };
+    }
+    const now = options?.now ?? new Date();
+    const minimumIntervalMs = Math.max(0, Math.trunc(options?.minimumIntervalMs ?? 0));
+    const scope = {
+      feedType: FwaClanWarsSyncService.FEED_TYPE,
+      scopeType: "CLAN_TAG" as const,
+      scopeKey: normalizedClanTag,
+    };
+    const nextEligibleAt =
+      minimumIntervalMs > 0 ? new Date(now.getTime() + minimumIntervalMs) : null;
+    if (!options?.force && minimumIntervalMs > 0) {
+      const eligible = await this.syncState.isEligible(scope, minimumIntervalMs, now);
+      if (!eligible) {
+        return { rowCount: 0, changedRowCount: 0, contentHash: null, status: "SKIPPED" };
+      }
+    }
+
+    await this.syncState.recordAttempt(scope, nextEligibleAt, now);
+    try {
+      const rows = await this.client.fetchClanWars(normalizedClanTag);
+      const sortedRows = [...rows].sort((a, b) => {
+        const byEnd = b.endTime.getTime() - a.endTime.getTime();
+        if (byEnd !== 0) return byEnd;
+        return a.opponentTag.localeCompare(b.opponentTag);
+      });
+      const contentHash = computeFeedContentHash(sortedRows);
+      const previousState = await this.syncState.getState(scope);
+      if (previousState?.lastContentHash === contentHash) {
+        const result: FwaSyncResult = {
+          rowCount: rows.length,
+          changedRowCount: 0,
+          contentHash,
+          status: "NOOP",
+        };
+        await this.syncState.recordSuccess({ ...scope, ...result, nextEligibleAt }, now);
+        return result;
+      }
+
+      const changedRowCount = await prisma.$transaction(async (tx) => {
+        const incomingKeySet = new Set(
+          rows.map((row) =>
+            buildWarRowKey({
+              endTime: row.endTime,
+              opponentTag: row.opponentTag,
+              teamSize: row.teamSize,
+            }),
+          ),
+        );
+
+        const existing = await tx.fwaClanWarLogCurrent.findMany({
+          where: { clanTag: normalizedClanTag },
+          select: { id: true, endTime: true, opponentTag: true, teamSize: true },
+        });
+        const staleIds = existing
+          .filter(
+            (row) =>
+              !incomingKeySet.has(
+                buildWarRowKey({
+                  endTime: row.endTime,
+                  opponentTag: row.opponentTag,
+                  teamSize: row.teamSize,
+                }),
+              ),
+          )
+          .map((row) => row.id);
+        if (staleIds.length > 0) {
+          await tx.fwaClanWarLogCurrent.deleteMany({
+            where: { id: { in: staleIds } },
+          });
+        }
+
+        for (const row of rows) {
+          await tx.fwaClanWarLogCurrent.upsert({
+            where: {
+              clanTag_endTime_opponentTag_teamSize: {
+                clanTag: normalizedClanTag,
+                endTime: row.endTime,
+                opponentTag: row.opponentTag,
+                teamSize: row.teamSize,
+              },
+            },
+            update: {
+              searchTime: row.searchTime,
+              result: row.result,
+              clanName: row.clanName,
+              clanLevel: row.clanLevel,
+              clanStars: row.clanStars,
+              clanDestructionPercentage: row.clanDestructionPercentage,
+              clanAttacks: row.clanAttacks,
+              clanExpEarned: row.clanExpEarned,
+              opponentName: row.opponentName,
+              opponentLevel: row.opponentLevel,
+              opponentStars: row.opponentStars,
+              opponentDestructionPercentage: row.opponentDestructionPercentage,
+              opponentInfo: row.opponentInfo,
+              synced: row.synced,
+              matched: row.matched,
+              sourceSyncedAt: now,
+            },
+            create: {
+              clanTag: normalizedClanTag,
+              endTime: row.endTime,
+              searchTime: row.searchTime,
+              result: row.result,
+              teamSize: row.teamSize,
+              clanName: row.clanName,
+              clanLevel: row.clanLevel,
+              clanStars: row.clanStars,
+              clanDestructionPercentage: row.clanDestructionPercentage,
+              clanAttacks: row.clanAttacks,
+              clanExpEarned: row.clanExpEarned,
+              opponentTag: row.opponentTag,
+              opponentName: row.opponentName,
+              opponentLevel: row.opponentLevel,
+              opponentStars: row.opponentStars,
+              opponentDestructionPercentage: row.opponentDestructionPercentage,
+              opponentInfo: row.opponentInfo,
+              synced: row.synced,
+              matched: row.matched,
+              sourceSyncedAt: now,
+            },
+          });
+        }
+        return staleIds.length + rows.length;
+      });
+
+      const result: FwaSyncResult = {
+        rowCount: rows.length,
+        changedRowCount,
+        contentHash,
+        status: "SUCCESS",
+      };
+      await this.syncState.recordSuccess({ ...scope, ...result, nextEligibleAt }, now);
+      return result;
+    } catch (error) {
+      const errorSummary = String((error as { message?: string })?.message ?? "unknown error").slice(
+        0,
+        200,
+      );
+      await this.syncState.recordFailure(
+        {
+          ...scope,
+          errorCode: "SYNC_FAILED",
+          errorSummary,
+          nextEligibleAt,
+        },
+        now,
+      );
+      throw error;
+    }
+  }
+
+  /** Purpose: process one bounded cursor-based global clan-wars sweep chunk from catalog tags. */
+  async runDistributedSweep(params: {
+    chunkSize: number;
+    concurrency: number;
+    force?: boolean;
+    minimumIntervalMs?: number;
+    now?: Date;
+  }): Promise<{
+    attemptedClans: number;
+    rowCount: number;
+    changedRowCount: number;
+    failedClans: string[];
+    nextCursor: string | null;
+  }> {
+    const now = params.now ?? new Date();
+    const chunkSize = Math.max(1, Math.trunc(params.chunkSize));
+    const concurrency = Math.max(1, Math.trunc(params.concurrency));
+    const catalog = await prisma.fwaClanCatalog.findMany({
+      orderBy: { clanTag: "asc" },
+      select: { clanTag: true },
+    });
+    const tags = catalog.map((row) => normalizeFwaTag(row.clanTag)).filter(Boolean);
+    if (tags.length === 0) {
+      return {
+        attemptedClans: 0,
+        rowCount: 0,
+        changedRowCount: 0,
+        failedClans: [],
+        nextCursor: null,
+      };
+    }
+
+    const cursor = await this.cursor.getCursor(FwaClanWarsSyncService.FEED_TYPE);
+    const currentCursor = cursor?.lastScopeKey ? normalizeFwaTag(cursor.lastScopeKey) : null;
+    const selected = selectDistributedSweepChunk(tags, currentCursor, chunkSize);
+
+    const outcomes = await mapWithConcurrency(selected, concurrency, async (tag) => {
+      try {
+        const result = await this.syncClan(tag, {
+          force: params.force,
+          minimumIntervalMs: params.minimumIntervalMs,
+          now,
+        });
+        return { tag, result, failed: false };
+      } catch {
+        return { tag, result: null, failed: true };
+      }
+    });
+
+    const summary = outcomes.reduce(
+      (acc, row) => {
+        if (row.failed || !row.result) {
+          acc.failedClans.push(row.tag);
+          return acc;
+        }
+        acc.rowCount += row.result.rowCount;
+        acc.changedRowCount += row.result.changedRowCount;
+        return acc;
+      },
+      {
+        attemptedClans: selected.length,
+        rowCount: 0,
+        changedRowCount: 0,
+        failedClans: [] as string[],
+      },
+    );
+
+    const nextCursor = selected[selected.length - 1] ?? null;
+    await this.cursor.saveCursor({
+      feedType: FwaClanWarsSyncService.FEED_TYPE,
+      lastScopeKey: nextCursor,
+      lastRunAt: now,
+    });
+
+    return {
+      ...summary,
+      nextCursor,
+    };
+  }
+}
+
+export const selectDistributedSweepChunkForTest = selectDistributedSweepChunk;

--- a/src/services/fwa-feeds/FwaClanWarsWatchService.ts
+++ b/src/services/fwa-feeds/FwaClanWarsWatchService.ts
@@ -1,0 +1,237 @@
+import { prisma } from "../../prisma";
+import {
+  TRACKED_MESSAGE_FEATURE_TYPE,
+  TRACKED_MESSAGE_STATUS,
+  parseSyncTimeMetadata,
+} from "../TrackedMessageService";
+import { normalizeFwaTag } from "./normalize";
+import { FwaClanWarsSyncService } from "./FwaClanWarsSyncService";
+import { mapWithConcurrency } from "./concurrency";
+
+type SyncSchedule = {
+  syncTimeSourceMessageId: string;
+  nextSyncTimeAt: Date;
+  pollWindowStartAt: Date;
+  cycleKey: string;
+};
+
+/** Purpose: compute the next daily sync timestamp from a base epoch while preserving hour/minute cadence. */
+function computeNextDailySyncTime(baseMs: number, nowMs: number): number | null {
+  if (!Number.isFinite(baseMs) || !Number.isFinite(nowMs)) return null;
+  let nextSyncMs = Math.trunc(baseMs);
+  while (nextSyncMs <= nowMs) {
+    nextSyncMs += 24 * 60 * 60 * 1000;
+  }
+  return nextSyncMs;
+}
+
+/** Purpose: derive the tracked-clan wars watch window from the next sync timestamp. */
+function buildWatchWindow(nextSyncMs: number): { nextSyncTimeAt: Date; pollWindowStartAt: Date } {
+  return {
+    nextSyncTimeAt: new Date(nextSyncMs),
+    pollWindowStartAt: new Date(nextSyncMs - 5 * 60 * 1000),
+  };
+}
+
+/** Purpose: coordinate per-clan tracked Wars.json watch windows tied to sync-time source data. */
+export class FwaClanWarsWatchService {
+  /** Purpose: initialize tracked wars watch dependencies. */
+  constructor(private readonly clanWarsSync = new FwaClanWarsSyncService()) {}
+
+  /** Purpose: execute one watch tick, activating/deactivating per-clan windows and polling active clans. */
+  async runWatchTick(params?: { now?: Date; concurrency?: number }): Promise<{
+    trackedClanCount: number;
+    activeClanCount: number;
+    polledClanCount: number;
+    updateAcquiredCount: number;
+  }> {
+    const now = params?.now ?? new Date();
+    const nowMs = now.getTime();
+    const tracked = await prisma.trackedClan.findMany({
+      orderBy: { createdAt: "asc" },
+      select: { tag: true },
+    });
+    const trackedTags = [...new Set(tracked.map((row) => normalizeFwaTag(row.tag)).filter(Boolean))];
+    if (trackedTags.length === 0) {
+      return {
+        trackedClanCount: 0,
+        activeClanCount: 0,
+        polledClanCount: 0,
+        updateAcquiredCount: 0,
+      };
+    }
+
+    const schedules = await this.resolveSyncSchedules(now);
+    const existingStates = await prisma.fwaClanWarsWatchState.findMany({
+      where: { clanTag: { in: trackedTags } },
+    });
+    const existingByTag = new Map(existingStates.map((row) => [normalizeFwaTag(row.clanTag), row]));
+
+    const watchUpserts = trackedTags.map(async (clanTag) => {
+      const schedule = schedules.get(clanTag) ?? null;
+      const existing = existingByTag.get(clanTag) ?? null;
+      const cycleKey = schedule?.cycleKey ?? null;
+      const cycleChanged = Boolean(cycleKey && existing?.currentWarCycleKey !== cycleKey);
+      const alreadyAcquired =
+        !cycleChanged &&
+        existing?.currentWarCycleKey === cycleKey &&
+        existing?.stopReason === "update_acquired";
+      const withinWatchWindow =
+        Boolean(schedule) &&
+        nowMs >= schedule!.pollWindowStartAt.getTime() &&
+        nowMs <= schedule!.nextSyncTimeAt.getTime() + 12 * 60 * 60 * 1000;
+      const pollingActive = Boolean(withinWatchWindow && !alreadyAcquired);
+      const stopReason = !schedule
+        ? "missing_sync_time"
+        : alreadyAcquired
+          ? "update_acquired"
+          : withinWatchWindow
+            ? null
+            : nowMs < schedule.pollWindowStartAt.getTime()
+              ? "waiting_for_window"
+              : "window_expired";
+      const lastObservedContentHash = cycleChanged ? null : existing?.lastObservedContentHash ?? null;
+
+      if (!existing?.pollingActive && pollingActive) {
+        console.info(
+          `[fwa-feed] watch_activate clan=${clanTag} cycle=${cycleKey ?? "none"} window_start=${schedule?.pollWindowStartAt?.toISOString() ?? "none"} next_sync=${schedule?.nextSyncTimeAt?.toISOString() ?? "none"}`,
+        );
+      } else if (existing?.pollingActive && !pollingActive) {
+        console.info(
+          `[fwa-feed] watch_stop clan=${clanTag} cycle=${cycleKey ?? "none"} reason=${stopReason ?? "none"}`,
+        );
+      }
+
+      await prisma.fwaClanWarsWatchState.upsert({
+        where: { clanTag },
+        update: {
+          syncTimeSourceMessageId: schedule?.syncTimeSourceMessageId ?? null,
+          nextSyncTimeAt: schedule?.nextSyncTimeAt ?? null,
+          pollWindowStartAt: schedule?.pollWindowStartAt ?? null,
+          pollingActive,
+          currentWarCycleKey: cycleKey,
+          stopReason,
+          ...(cycleChanged ? { lastDetectedWarEndAt: null, lastAcquiredUpdateAt: null } : {}),
+          lastObservedContentHash,
+        },
+        create: {
+          clanTag,
+          syncTimeSourceMessageId: schedule?.syncTimeSourceMessageId ?? null,
+          nextSyncTimeAt: schedule?.nextSyncTimeAt ?? null,
+          pollWindowStartAt: schedule?.pollWindowStartAt ?? null,
+          pollingActive,
+          currentWarCycleKey: cycleKey,
+          stopReason,
+          lastObservedContentHash,
+        },
+      });
+    });
+    await Promise.all(watchUpserts);
+
+    const activeStates = await prisma.fwaClanWarsWatchState.findMany({
+      where: {
+        clanTag: { in: trackedTags },
+        pollingActive: true,
+      },
+      orderBy: { clanTag: "asc" },
+    });
+
+    const concurrency = Math.max(1, Math.trunc(params?.concurrency ?? 3));
+    const pollOutcomes = await mapWithConcurrency(activeStates, concurrency, async (state) => {
+      const syncResult = await this.clanWarsSync.syncClan(state.clanTag, {
+        force: true,
+        minimumIntervalMs: 0,
+        now,
+      });
+      const previousHash = state.lastObservedContentHash ?? null;
+      const nextHash = syncResult.contentHash ?? null;
+      const updateAcquired = Boolean(previousHash && nextHash && previousHash !== nextHash);
+      const latestWarRow = await prisma.fwaClanWarLogCurrent.findFirst({
+        where: { clanTag: state.clanTag },
+        orderBy: { endTime: "desc" },
+        select: { endTime: true },
+      });
+      await prisma.fwaClanWarsWatchState.update({
+        where: { clanTag: state.clanTag },
+        data: {
+          lastObservedContentHash: nextHash,
+          lastDetectedWarEndAt: latestWarRow?.endTime ?? null,
+          ...(updateAcquired
+            ? {
+                pollingActive: false,
+                lastAcquiredUpdateAt: now,
+                stopReason: "update_acquired",
+              }
+            : {}),
+        },
+      });
+      if (updateAcquired) {
+        console.info(
+          `[fwa-feed] watch_update_acquired clan=${state.clanTag} cycle=${state.currentWarCycleKey ?? "none"} latest_end_time=${latestWarRow?.endTime?.toISOString() ?? "none"}`,
+        );
+      }
+      return {
+        clanTag: state.clanTag,
+        updateAcquired,
+      };
+    });
+
+    return {
+      trackedClanCount: trackedTags.length,
+      activeClanCount: activeStates.length,
+      polledClanCount: pollOutcomes.length,
+      updateAcquiredCount: pollOutcomes.filter((row) => row.updateAcquired).length,
+    };
+  }
+
+  /** Purpose: fetch persistent watch-state rows for operational status reporting. */
+  async getWatchStatus(clanTag?: string) {
+    const normalized = clanTag ? normalizeFwaTag(clanTag) : null;
+    return prisma.fwaClanWarsWatchState.findMany({
+      where: normalized ? { clanTag: normalized } : undefined,
+      orderBy: { clanTag: "asc" },
+    });
+  }
+
+  /** Purpose: resolve per-clan sync schedules from the active sync-time tracked-message source of truth. */
+  private async resolveSyncSchedules(now: Date): Promise<Map<string, SyncSchedule>> {
+    const rows = await prisma.trackedMessage.findMany({
+      where: {
+        featureType: TRACKED_MESSAGE_FEATURE_TYPE.SYNC_TIME_POST,
+        status: TRACKED_MESSAGE_STATUS.ACTIVE,
+      },
+      orderBy: [{ createdAt: "desc" }],
+      select: {
+        messageId: true,
+        metadata: true,
+      },
+    });
+    const schedules = new Map<string, SyncSchedule>();
+    for (const row of rows) {
+      const metadata = parseSyncTimeMetadata(row.metadata);
+      if (!metadata) continue;
+      const baseMs =
+        Number.isFinite(metadata.syncEpochSeconds) && metadata.syncEpochSeconds > 0
+          ? metadata.syncEpochSeconds * 1000
+          : Date.parse(metadata.syncTimeIso);
+      const nowMs = now.getTime();
+      const nextSyncMs = computeNextDailySyncTime(baseMs, nowMs);
+      if (nextSyncMs === null) continue;
+      const { nextSyncTimeAt, pollWindowStartAt } = buildWatchWindow(nextSyncMs);
+      for (const clan of metadata.clans) {
+        const clanTag = normalizeFwaTag(clan.clanTag);
+        if (!clanTag || schedules.has(clanTag)) continue;
+        schedules.set(clanTag, {
+          syncTimeSourceMessageId: row.messageId,
+          nextSyncTimeAt,
+          pollWindowStartAt,
+          cycleKey: `${clanTag}:${nextSyncTimeAt.toISOString()}`,
+        });
+      }
+    }
+    return schedules;
+  }
+}
+
+export const computeNextDailySyncTimeForTest = computeNextDailySyncTime;
+export const buildWatchWindowForTest = buildWatchWindow;

--- a/src/services/fwa-feeds/FwaClansCatalogSyncService.ts
+++ b/src/services/fwa-feeds/FwaClansCatalogSyncService.ts
@@ -1,0 +1,174 @@
+import type { FwaFeedType } from "@prisma/client";
+import { prisma } from "../../prisma";
+import { computeFeedContentHash } from "./hash";
+import { FwaStatsClient } from "./FwaStatsClient";
+import { FwaFeedSyncStateService } from "./FwaFeedSyncStateService";
+import type { FwaSyncResult } from "./types";
+
+type SyncOptions = {
+  force?: boolean;
+  minimumIntervalMs?: number;
+  now?: Date;
+};
+
+/** Purpose: sync global active-fwa clan catalog from Clans.json into current-state storage. */
+export class FwaClansCatalogSyncService {
+  private static readonly FEED_TYPE: FwaFeedType = "CLANS";
+  private readonly syncState = new FwaFeedSyncStateService();
+
+  /** Purpose: initialize clan-catalog sync dependencies. */
+  constructor(private readonly client = new FwaStatsClient()) {}
+
+  /** Purpose: execute one idempotent global catalog sync run with sync-state tracking. */
+  async syncGlobalCatalog(options?: SyncOptions): Promise<FwaSyncResult> {
+    const now = options?.now ?? new Date();
+    const minimumIntervalMs = Math.max(0, Math.trunc(options?.minimumIntervalMs ?? 0));
+    const scope = {
+      feedType: FwaClansCatalogSyncService.FEED_TYPE,
+      scopeType: "GLOBAL" as const,
+      scopeKey: null,
+    };
+    const nextEligibleAt =
+      minimumIntervalMs > 0 ? new Date(now.getTime() + minimumIntervalMs) : null;
+    if (!options?.force && minimumIntervalMs > 0) {
+      const eligible = await this.syncState.isEligible(scope, minimumIntervalMs, now);
+      if (!eligible) {
+        return {
+          rowCount: 0,
+          changedRowCount: 0,
+          contentHash: null,
+          status: "SKIPPED",
+        };
+      }
+    }
+
+    await this.syncState.recordAttempt(scope, nextEligibleAt, now);
+    try {
+      const rows = await this.client.fetchClans();
+      const contentHash = computeFeedContentHash(
+        [...rows].sort((a, b) => a.clanTag.localeCompare(b.clanTag)),
+      );
+      const previousState = await this.syncState.getState(scope);
+      if (previousState?.lastContentHash === contentHash) {
+        const result: FwaSyncResult = {
+          rowCount: rows.length,
+          changedRowCount: 0,
+          contentHash,
+          status: "NOOP",
+        };
+        await this.syncState.recordSuccess(
+          {
+            ...scope,
+            ...result,
+            nextEligibleAt,
+          },
+          now,
+        );
+        return result;
+      }
+
+      await prisma.$transaction(async (tx) => {
+        for (const row of rows) {
+          await tx.fwaClanCatalog.upsert({
+            where: { clanTag: row.clanTag },
+            update: {
+              name: row.name,
+              level: row.level,
+              points: row.points,
+              type: row.type,
+              location: row.location,
+              requiredTrophies: row.requiredTrophies,
+              warFrequency: row.warFrequency,
+              winStreak: row.winStreak,
+              wins: row.wins,
+              ties: row.ties,
+              losses: row.losses,
+              isWarLogPublic: row.isWarLogPublic,
+              imageUrl: row.imageUrl,
+              description: row.description,
+              th18Count: row.th18Count,
+              th17Count: row.th17Count,
+              th16Count: row.th16Count,
+              th15Count: row.th15Count,
+              th14Count: row.th14Count,
+              th13Count: row.th13Count,
+              th12Count: row.th12Count,
+              th11Count: row.th11Count,
+              th10Count: row.th10Count,
+              th9Count: row.th9Count,
+              th8Count: row.th8Count,
+              thLowCount: row.thLowCount,
+              estimatedWeight: row.estimatedWeight,
+              lastSeenAt: now,
+              lastSyncedAt: now,
+            },
+            create: {
+              clanTag: row.clanTag,
+              name: row.name,
+              level: row.level,
+              points: row.points,
+              type: row.type,
+              location: row.location,
+              requiredTrophies: row.requiredTrophies,
+              warFrequency: row.warFrequency,
+              winStreak: row.winStreak,
+              wins: row.wins,
+              ties: row.ties,
+              losses: row.losses,
+              isWarLogPublic: row.isWarLogPublic,
+              imageUrl: row.imageUrl,
+              description: row.description,
+              th18Count: row.th18Count,
+              th17Count: row.th17Count,
+              th16Count: row.th16Count,
+              th15Count: row.th15Count,
+              th14Count: row.th14Count,
+              th13Count: row.th13Count,
+              th12Count: row.th12Count,
+              th11Count: row.th11Count,
+              th10Count: row.th10Count,
+              th9Count: row.th9Count,
+              th8Count: row.th8Count,
+              thLowCount: row.thLowCount,
+              estimatedWeight: row.estimatedWeight,
+              firstSeenAt: now,
+              lastSeenAt: now,
+              lastSyncedAt: now,
+            },
+          });
+        }
+      });
+
+      const result: FwaSyncResult = {
+        rowCount: rows.length,
+        changedRowCount: rows.length,
+        contentHash,
+        status: "SUCCESS",
+      };
+      await this.syncState.recordSuccess(
+        {
+          ...scope,
+          ...result,
+          nextEligibleAt,
+        },
+        now,
+      );
+      return result;
+    } catch (error) {
+      const errorSummary = String((error as { message?: string })?.message ?? "unknown error").slice(
+        0,
+        200,
+      );
+      await this.syncState.recordFailure(
+        {
+          ...scope,
+          errorCode: "SYNC_FAILED",
+          errorSummary,
+          nextEligibleAt,
+        },
+        now,
+      );
+      throw error;
+    }
+  }
+}

--- a/src/services/fwa-feeds/FwaFeedCursorService.ts
+++ b/src/services/fwa-feeds/FwaFeedCursorService.ts
@@ -1,0 +1,28 @@
+import type { FwaFeedType } from "@prisma/client";
+import { prisma } from "../../prisma";
+
+/** Purpose: persist distributed-sweep cursor progress for long-running global feed jobs. */
+export class FwaFeedCursorService {
+  /** Purpose: read cursor row for one feed type. */
+  async getCursor(feedType: FwaFeedType) {
+    return prisma.fwaFeedCursor.findUnique({
+      where: { feedType },
+    });
+  }
+
+  /** Purpose: upsert cursor position after each sweep chunk run. */
+  async saveCursor(params: { feedType: FwaFeedType; lastScopeKey: string | null; lastRunAt: Date }): Promise<void> {
+    await prisma.fwaFeedCursor.upsert({
+      where: { feedType: params.feedType },
+      update: {
+        lastScopeKey: params.lastScopeKey,
+        lastRunAt: params.lastRunAt,
+      },
+      create: {
+        feedType: params.feedType,
+        lastScopeKey: params.lastScopeKey,
+        lastRunAt: params.lastRunAt,
+      },
+    });
+  }
+}

--- a/src/services/fwa-feeds/FwaFeedOpsService.ts
+++ b/src/services/fwa-feeds/FwaFeedOpsService.ts
@@ -1,0 +1,99 @@
+import { prisma } from "../../prisma";
+import { normalizeFwaTag } from "./normalize";
+import { FwaClansCatalogSyncService } from "./FwaClansCatalogSyncService";
+import { FwaClanMembersSyncService } from "./FwaClanMembersSyncService";
+import { FwaWarMembersSyncService } from "./FwaWarMembersSyncService";
+import { FwaClanWarsSyncService } from "./FwaClanWarsSyncService";
+import { FwaClanWarsWatchService } from "./FwaClanWarsWatchService";
+import { FwaFeedSchedulerService } from "./FwaFeedSchedulerService";
+
+/** Purpose: expose manual status/run/watch operations for fwa-feed ingestion without command-surface expansion. */
+export class FwaFeedOpsService {
+  private readonly clansSync = new FwaClansCatalogSyncService();
+  private readonly clanMembersSync = new FwaClanMembersSyncService();
+  private readonly warMembersSync = new FwaWarMembersSyncService();
+  private readonly clanWarsSync = new FwaClanWarsSyncService();
+  private readonly watchService = new FwaClanWarsWatchService(this.clanWarsSync);
+  private readonly scheduler = new FwaFeedSchedulerService();
+
+  /** Purpose: return feed sync-state rows for global jobs and optional per-clan scopes. */
+  async status(clanTag?: string) {
+    const normalized = clanTag ? normalizeFwaTag(clanTag) : null;
+    const where = normalized
+      ? {
+          OR: [
+            { scopeType: "GLOBAL" as const },
+            { scopeType: "TRACKED_CLANS" as const },
+            { scopeType: "CLAN_TAG" as const, scopeKey: normalized },
+          ],
+        }
+      : undefined;
+    const syncStateRows = await prisma.fwaFeedSyncState.findMany({
+      where,
+      orderBy: [{ feedType: "asc" }, { scopeType: "asc" }, { scopeKey: "asc" }],
+    });
+    const watchRows = await this.watchService.getWatchStatus(normalized ?? undefined);
+    return {
+      syncStateRows,
+      watchRows,
+    };
+  }
+
+  /** Purpose: run one tracked-clan one-off sync for clan-members or clan-wars feeds. */
+  async runTracked(feed: "clan-members" | "clan-wars", clanTag: string) {
+    const normalized = normalizeFwaTag(clanTag);
+    if (!normalized) throw new Error("Invalid clan tag");
+    if (feed === "clan-members") {
+      return this.clanMembersSync.syncTrackedClan(normalized, { force: true });
+    }
+    return this.clanWarsSync.syncClan(normalized, { force: true });
+  }
+
+  /** Purpose: run one global one-off sync tick for configured feed families. */
+  async runGlobal(feed: "clans" | "war-members" | "clan-wars") {
+    if (feed === "clans") {
+      return this.clansSync.syncGlobalCatalog({ force: true });
+    }
+    if (feed === "war-members") {
+      return this.warMembersSync.runDistributedSweep({
+        chunkSize: 6,
+        concurrency: 4,
+        force: true,
+      });
+    }
+    return this.clanWarsSync.runDistributedSweep({
+      chunkSize: 20,
+      concurrency: 4,
+      force: true,
+    });
+  }
+
+  /** Purpose: run one scheduler job tick manually for debugging operational behavior. */
+  async runSchedulerJob(
+    job: "clans" | "clan-members" | "war-members" | "tracked-clan-wars-watch" | "global-clan-wars",
+  ): Promise<void> {
+    if (job === "clans") {
+      await this.scheduler.runClansJob();
+      return;
+    }
+    if (job === "clan-members") {
+      await this.scheduler.runTrackedClanMembersJob();
+      return;
+    }
+    if (job === "war-members") {
+      await this.scheduler.runWarMembersSweepJob();
+      return;
+    }
+    if (job === "tracked-clan-wars-watch") {
+      await this.scheduler.runTrackedClanWarsWatchJob();
+      return;
+    }
+    await this.scheduler.runGlobalClanWarsSweepJob();
+  }
+
+  /** Purpose: load per-clan tracked watch state for direct watch-status checks. */
+  async watchStatus(clanTag?: string) {
+    const normalized = clanTag ? normalizeFwaTag(clanTag) : null;
+    return this.watchService.getWatchStatus(normalized ?? undefined);
+  }
+}

--- a/src/services/fwa-feeds/FwaFeedSchedulerService.ts
+++ b/src/services/fwa-feeds/FwaFeedSchedulerService.ts
@@ -1,0 +1,417 @@
+import { recordFetchEvent, runFetchTelemetryBatch } from "../../helper/fetchTelemetry";
+import { formatError } from "../../helper/formatError";
+import { FwaClansCatalogSyncService } from "./FwaClansCatalogSyncService";
+import { FwaClanMembersSyncService } from "./FwaClanMembersSyncService";
+import { FwaWarMembersSyncService } from "./FwaWarMembersSyncService";
+import { FwaClanWarsSyncService } from "./FwaClanWarsSyncService";
+import { FwaClanWarsWatchService } from "./FwaClanWarsWatchService";
+import { FwaFeedSyncStateService } from "./FwaFeedSyncStateService";
+
+type SchedulerConfig = {
+  clansEnabled: boolean;
+  clanMembersEnabled: boolean;
+  warMembersSweepEnabled: boolean;
+  trackedClanWarsWatchEnabled: boolean;
+  globalClanWarsSweepEnabled: boolean;
+  clansIntervalMs: number;
+  clanMembersIntervalMs: number;
+  sweepTickIntervalMs: number;
+  trackedClanWarsWatchTickMs: number;
+  warMembersSweepChunkSize: number;
+  globalClanWarsSweepChunkSize: number;
+  maxConcurrency: number;
+  jitterMs: number;
+};
+
+function toBool(input: string | undefined, fallback: boolean): boolean {
+  if (input === undefined) return fallback;
+  const normalized = input.trim().toLowerCase();
+  if (["1", "true", "yes", "on"].includes(normalized)) return true;
+  if (["0", "false", "no", "off"].includes(normalized)) return false;
+  return fallback;
+}
+
+function toInt(input: string | undefined, fallback: number): number {
+  const parsed = Number(input ?? "");
+  return Number.isFinite(parsed) ? Math.trunc(parsed) : fallback;
+}
+
+function minutesToMsWithMin(valueMinutes: number, minMinutes: number): number {
+  return Math.max(minMinutes, valueMinutes) * 60 * 1000;
+}
+
+/** Purpose: orchestrate bounded fwastats feed scheduler jobs with explicit cadence and cost controls. */
+export class FwaFeedSchedulerService {
+  private readonly config: SchedulerConfig;
+  private readonly syncState = new FwaFeedSyncStateService();
+  private readonly clansSync = new FwaClansCatalogSyncService();
+  private readonly membersSync = new FwaClanMembersSyncService();
+  private readonly warMembersSync = new FwaWarMembersSyncService();
+  private readonly clanWarsSync = new FwaClanWarsSyncService();
+  private readonly watchService = new FwaClanWarsWatchService(this.clanWarsSync);
+
+  private clansInProgress = false;
+  private membersInProgress = false;
+  private warMembersInProgress = false;
+  private watchInProgress = false;
+  private globalWarsInProgress = false;
+
+  /** Purpose: initialize scheduler config from env with safe minimum intervals and bounded defaults. */
+  constructor() {
+    const clansMinutesRaw = toInt(process.env.FWA_CLANS_SYNC_CRON_OR_MINUTES, 360);
+    const clanMembersMinutesRaw = toInt(process.env.FWA_CLAN_MEMBERS_SYNC_MINUTES, 15);
+    const sweepTickMinutesRaw = toInt(process.env.FWA_SWEEP_TICK_MINUTES, 15);
+    const trackedWatchMinutesRaw = toInt(process.env.FWA_TRACKED_CLAN_WARS_WATCH_TICK_MINUTES, 5);
+    this.config = {
+      clansEnabled: toBool(process.env.FWA_CLANS_SYNC_ENABLED, true),
+      clanMembersEnabled: toBool(process.env.FWA_CLAN_MEMBERS_SYNC_ENABLED, true),
+      warMembersSweepEnabled: toBool(process.env.FWA_WAR_MEMBERS_SWEEP_ENABLED, true),
+      trackedClanWarsWatchEnabled: toBool(process.env.FWA_TRACKED_CLAN_WARS_WATCH_ENABLED, true),
+      globalClanWarsSweepEnabled: toBool(process.env.FWA_GLOBAL_CLAN_WARS_SWEEP_ENABLED, false),
+      clansIntervalMs: minutesToMsWithMin(clansMinutesRaw, 15),
+      clanMembersIntervalMs: minutesToMsWithMin(clanMembersMinutesRaw, 15),
+      sweepTickIntervalMs: minutesToMsWithMin(sweepTickMinutesRaw, 15),
+      trackedClanWarsWatchTickMs: minutesToMsWithMin(trackedWatchMinutesRaw, 5),
+      warMembersSweepChunkSize: Math.max(1, toInt(process.env.FWA_WAR_MEMBERS_SWEEP_CHUNK_SIZE, 6)),
+      globalClanWarsSweepChunkSize: Math.max(
+        1,
+        toInt(process.env.FWA_GLOBAL_CLAN_WARS_SWEEP_CHUNK_SIZE, 20),
+      ),
+      maxConcurrency: Math.max(1, toInt(process.env.FWA_FEED_MAX_CONCURRENCY, 4)),
+      jitterMs: Math.max(0, toInt(process.env.FWA_FEED_JOB_JITTER_MS, 30_000)),
+    };
+  }
+
+  /** Purpose: start all enabled fwa feed loops with bounded intervals and overlap guards. */
+  start(): void {
+    if (this.config.clansEnabled) {
+      this.runWithJitter(() => this.runClansJob());
+      setInterval(() => {
+        this.runClansJob().catch((error) => {
+          console.error(`[fwa-feed] clans interval failed: ${formatError(error)}`);
+        });
+      }, this.config.clansIntervalMs);
+      console.log(
+        `[fwa-feed] CLANS sync enabled interval_minutes=${Math.round(this.config.clansIntervalMs / 60000)}`,
+      );
+    }
+
+    if (this.config.clanMembersEnabled) {
+      this.runWithJitter(() => this.runTrackedClanMembersJob());
+      setInterval(() => {
+        this.runTrackedClanMembersJob().catch((error) => {
+          console.error(`[fwa-feed] clan-members interval failed: ${formatError(error)}`);
+        });
+      }, this.config.clanMembersIntervalMs);
+      console.log(
+        `[fwa-feed] CLAN_MEMBERS sync enabled interval_minutes=${Math.round(this.config.clanMembersIntervalMs / 60000)}`,
+      );
+    }
+
+    if (this.config.warMembersSweepEnabled) {
+      this.runWithJitter(() => this.runWarMembersSweepJob());
+      setInterval(() => {
+        this.runWarMembersSweepJob().catch((error) => {
+          console.error(`[fwa-feed] war-members sweep interval failed: ${formatError(error)}`);
+        });
+      }, this.config.sweepTickIntervalMs);
+      console.log(
+        `[fwa-feed] WAR_MEMBERS sweep enabled tick_minutes=${Math.round(this.config.sweepTickIntervalMs / 60000)} chunk=${this.config.warMembersSweepChunkSize}`,
+      );
+    }
+
+    if (this.config.trackedClanWarsWatchEnabled) {
+      this.runWithJitter(() => this.runTrackedClanWarsWatchJob());
+      setInterval(() => {
+        this.runTrackedClanWarsWatchJob().catch((error) => {
+          console.error(`[fwa-feed] tracked clan wars watch interval failed: ${formatError(error)}`);
+        });
+      }, this.config.trackedClanWarsWatchTickMs);
+      console.log(
+        `[fwa-feed] tracked CLAN_WARS watch enabled tick_minutes=${Math.round(this.config.trackedClanWarsWatchTickMs / 60000)}`,
+      );
+    }
+
+    if (this.config.globalClanWarsSweepEnabled) {
+      this.runWithJitter(() => this.runGlobalClanWarsSweepJob());
+      setInterval(() => {
+        this.runGlobalClanWarsSweepJob().catch((error) => {
+          console.error(`[fwa-feed] global clan wars sweep interval failed: ${formatError(error)}`);
+        });
+      }, this.config.sweepTickIntervalMs);
+      console.log(
+        `[fwa-feed] global CLAN_WARS sweep enabled tick_minutes=${Math.round(this.config.sweepTickIntervalMs / 60000)} chunk=${this.config.globalClanWarsSweepChunkSize}`,
+      );
+    }
+  }
+
+  /** Purpose: run one global Clans.json sync cycle with overlap guard and aggregate sync-state row. */
+  async runClansJob(): Promise<void> {
+    if (this.clansInProgress) return;
+    this.clansInProgress = true;
+    const now = new Date();
+    const scope = { feedType: "CLANS" as const, scopeType: "GLOBAL" as const, scopeKey: null };
+    try {
+      await runFetchTelemetryBatch("fwa_clans_catalog_sync", async () => {
+        const startedAt = Date.now();
+        const result = await this.clansSync.syncGlobalCatalog({
+          minimumIntervalMs: this.config.clansIntervalMs,
+          now,
+        });
+        console.info(
+          `[fwa-feed] job=clans status=${result.status} rows=${result.rowCount} changed=${result.changedRowCount} duration_ms=${Date.now() - startedAt}`,
+        );
+        recordFetchEvent({
+          namespace: "fwastats_feed",
+          operation: "clans_scheduler",
+          source: "cache_miss",
+          status: "success",
+          detail: `rows=${result.rowCount} changed=${result.changedRowCount} status=${result.status}`,
+        });
+      });
+    } catch (error) {
+      const nextEligibleAt = new Date(now.getTime() + this.config.clansIntervalMs);
+      await this.syncState.recordFailure(
+        {
+          ...scope,
+          errorCode: "SCHEDULER_FAILED",
+          errorSummary: String((error as { message?: string })?.message ?? "unknown error").slice(
+            0,
+            200,
+          ),
+          nextEligibleAt,
+        },
+        now,
+      );
+      throw error;
+    } finally {
+      this.clansInProgress = false;
+    }
+  }
+
+  /** Purpose: run one tracked-clan Members.json sync cycle with bounded concurrency. */
+  async runTrackedClanMembersJob(): Promise<void> {
+    if (this.membersInProgress) return;
+    this.membersInProgress = true;
+    const now = new Date();
+    const scope = {
+      feedType: "CLAN_MEMBERS" as const,
+      scopeType: "TRACKED_CLANS" as const,
+      scopeKey: null,
+    };
+    const nextEligibleAt = new Date(now.getTime() + this.config.clanMembersIntervalMs);
+    try {
+      await this.syncState.recordAttempt(scope, nextEligibleAt, now);
+      await runFetchTelemetryBatch("fwa_clan_members_sync", async () => {
+        const startedAt = Date.now();
+        const result = await this.membersSync.syncAllTrackedClans({
+          minimumIntervalMs: this.config.clanMembersIntervalMs,
+          now,
+          concurrency: this.config.maxConcurrency,
+        });
+        await this.syncState.recordSuccess(
+          {
+            ...scope,
+            rowCount: result.rowCount,
+            changedRowCount: result.changedRowCount,
+            contentHash: null,
+            status: "SUCCESS",
+            nextEligibleAt,
+          },
+          now,
+        );
+        console.info(
+          `[fwa-feed] job=clan_members status=SUCCESS clans=${result.clanCount} rows=${result.rowCount} changed=${result.changedRowCount} failed=${result.failedClans.length} duration_ms=${Date.now() - startedAt}`,
+        );
+      });
+    } catch (error) {
+      await this.syncState.recordFailure(
+        {
+          ...scope,
+          errorCode: "SCHEDULER_FAILED",
+          errorSummary: String((error as { message?: string })?.message ?? "unknown error").slice(
+            0,
+            200,
+          ),
+          nextEligibleAt,
+        },
+        now,
+      );
+      throw error;
+    } finally {
+      this.membersInProgress = false;
+    }
+  }
+
+  /** Purpose: run one cursor-based WAR_MEMBERS sweep tick with bounded per-clan processing. */
+  async runWarMembersSweepJob(): Promise<void> {
+    if (this.warMembersInProgress) return;
+    this.warMembersInProgress = true;
+    const now = new Date();
+    const scope = { feedType: "WAR_MEMBERS" as const, scopeType: "GLOBAL" as const, scopeKey: "SWEEP" };
+    const nextEligibleAt = new Date(now.getTime() + this.config.sweepTickIntervalMs);
+    try {
+      await this.syncState.recordAttempt(scope, nextEligibleAt, now);
+      await runFetchTelemetryBatch("fwa_war_members_sweep", async () => {
+        const startedAt = Date.now();
+        const summary = await this.warMembersSync.runDistributedSweep({
+          chunkSize: this.config.warMembersSweepChunkSize,
+          concurrency: this.config.maxConcurrency,
+          minimumIntervalMs: 0,
+          now,
+        });
+        await this.syncState.recordSuccess(
+          {
+            ...scope,
+            rowCount: summary.rowCount,
+            changedRowCount: summary.changedRowCount,
+            contentHash: summary.nextCursor,
+            status: "SUCCESS",
+            nextEligibleAt,
+          },
+          now,
+        );
+        console.info(
+          `[fwa-feed] job=war_members_sweep clans=${summary.attemptedClans} rows=${summary.rowCount} changed=${summary.changedRowCount} failed=${summary.failedClans.length} next_cursor=${summary.nextCursor ?? "none"} duration_ms=${Date.now() - startedAt}`,
+        );
+      });
+    } catch (error) {
+      await this.syncState.recordFailure(
+        {
+          ...scope,
+          errorCode: "SCHEDULER_FAILED",
+          errorSummary: String((error as { message?: string })?.message ?? "unknown error").slice(
+            0,
+            200,
+          ),
+          nextEligibleAt,
+        },
+        now,
+      );
+      throw error;
+    } finally {
+      this.warMembersInProgress = false;
+    }
+  }
+
+  /** Purpose: run one tracked-clan watch tick for 5-minute Wars.json update-acquisition windows. */
+  async runTrackedClanWarsWatchJob(): Promise<void> {
+    if (this.watchInProgress) return;
+    this.watchInProgress = true;
+    const now = new Date();
+    const scope = {
+      feedType: "CLAN_WARS" as const,
+      scopeType: "TRACKED_CLANS" as const,
+      scopeKey: "WATCH",
+    };
+    const nextEligibleAt = new Date(now.getTime() + this.config.trackedClanWarsWatchTickMs);
+    try {
+      await this.syncState.recordAttempt(scope, nextEligibleAt, now);
+      await runFetchTelemetryBatch("fwa_tracked_clan_wars_watch", async () => {
+        const startedAt = Date.now();
+        const summary = await this.watchService.runWatchTick({
+          now,
+          concurrency: this.config.maxConcurrency,
+        });
+        await this.syncState.recordSuccess(
+          {
+            ...scope,
+            rowCount: summary.polledClanCount,
+            changedRowCount: summary.updateAcquiredCount,
+            contentHash: `${summary.activeClanCount}`,
+            status: "SUCCESS",
+            nextEligibleAt,
+          },
+          now,
+        );
+        console.info(
+          `[fwa-feed] job=tracked_clan_wars_watch tracked=${summary.trackedClanCount} active=${summary.activeClanCount} polled=${summary.polledClanCount} acquired=${summary.updateAcquiredCount} duration_ms=${Date.now() - startedAt}`,
+        );
+      });
+    } catch (error) {
+      await this.syncState.recordFailure(
+        {
+          ...scope,
+          errorCode: "SCHEDULER_FAILED",
+          errorSummary: String((error as { message?: string })?.message ?? "unknown error").slice(
+            0,
+            200,
+          ),
+          nextEligibleAt,
+        },
+        now,
+      );
+      throw error;
+    } finally {
+      this.watchInProgress = false;
+    }
+  }
+
+  /** Purpose: run one optional global clan-wars cursor sweep tick for broader dataset refreshes. */
+  async runGlobalClanWarsSweepJob(): Promise<void> {
+    if (this.globalWarsInProgress) return;
+    this.globalWarsInProgress = true;
+    const now = new Date();
+    const scope = { feedType: "CLAN_WARS" as const, scopeType: "GLOBAL" as const, scopeKey: "SWEEP" };
+    const nextEligibleAt = new Date(now.getTime() + this.config.sweepTickIntervalMs);
+    try {
+      await this.syncState.recordAttempt(scope, nextEligibleAt, now);
+      await runFetchTelemetryBatch("fwa_global_clan_wars_sweep", async () => {
+        const startedAt = Date.now();
+        const summary = await this.clanWarsSync.runDistributedSweep({
+          chunkSize: this.config.globalClanWarsSweepChunkSize,
+          concurrency: this.config.maxConcurrency,
+          minimumIntervalMs: 0,
+          now,
+        });
+        await this.syncState.recordSuccess(
+          {
+            ...scope,
+            rowCount: summary.rowCount,
+            changedRowCount: summary.changedRowCount,
+            contentHash: summary.nextCursor,
+            status: "SUCCESS",
+            nextEligibleAt,
+          },
+          now,
+        );
+        console.info(
+          `[fwa-feed] job=global_clan_wars_sweep clans=${summary.attemptedClans} rows=${summary.rowCount} changed=${summary.changedRowCount} failed=${summary.failedClans.length} next_cursor=${summary.nextCursor ?? "none"} duration_ms=${Date.now() - startedAt}`,
+        );
+      });
+    } catch (error) {
+      await this.syncState.recordFailure(
+        {
+          ...scope,
+          errorCode: "SCHEDULER_FAILED",
+          errorSummary: String((error as { message?: string })?.message ?? "unknown error").slice(
+            0,
+            200,
+          ),
+          nextEligibleAt,
+        },
+        now,
+      );
+      throw error;
+    } finally {
+      this.globalWarsInProgress = false;
+    }
+  }
+
+  /** Purpose: apply one-time startup jitter to spread background load across restarts. */
+  private runWithJitter(run: () => Promise<void>): void {
+    const jitterMs = this.config.jitterMs;
+    if (jitterMs <= 0) {
+      run().catch((error) => {
+        console.error(`[fwa-feed] startup run failed: ${formatError(error)}`);
+      });
+      return;
+    }
+    const delayMs = Math.floor(Math.random() * jitterMs);
+    setTimeout(() => {
+      run().catch((error) => {
+        console.error(`[fwa-feed] startup jitter run failed: ${formatError(error)}`);
+      });
+    }, delayMs);
+  }
+}

--- a/src/services/fwa-feeds/FwaFeedSyncStateService.ts
+++ b/src/services/fwa-feeds/FwaFeedSyncStateService.ts
@@ -1,0 +1,148 @@
+import type { FwaFeedScopeType, FwaFeedSyncStatus, FwaFeedType } from "@prisma/client";
+import { prisma } from "../../prisma";
+
+type SyncScope = {
+  feedType: FwaFeedType;
+  scopeType: FwaFeedScopeType;
+  scopeKey: string | null;
+};
+
+type RecordSuccessParams = SyncScope & {
+  rowCount: number;
+  changedRowCount: number;
+  contentHash: string | null;
+  status: FwaFeedSyncStatus;
+  nextEligibleAt: Date | null;
+};
+
+type RecordFailureParams = SyncScope & {
+  errorCode: string;
+  errorSummary: string;
+  nextEligibleAt: Date | null;
+};
+
+/** Purpose: own persistent sync-state metadata updates for all fwa feed scopes. */
+export class FwaFeedSyncStateService {
+  private getDelegate() {
+    return prisma.fwaFeedSyncState as any;
+  }
+
+  private buildCompoundScopeWhere(scope: SyncScope) {
+    return {
+      feedType_scopeType_scopeKey: {
+        feedType: scope.feedType,
+        scopeType: scope.scopeType,
+        scopeKey: scope.scopeKey,
+      },
+    };
+  }
+
+  /** Purpose: load current sync-state metadata row for one feed/scope identity. */
+  async getState(scope: SyncScope) {
+    const delegate = this.getDelegate();
+    if (typeof delegate.findFirst === "function") {
+      return delegate.findFirst({
+        where: {
+          feedType: scope.feedType,
+          scopeType: scope.scopeType,
+          scopeKey: scope.scopeKey,
+        },
+      });
+    }
+    return delegate.findUnique({
+      where: this.buildCompoundScopeWhere(scope),
+    });
+  }
+
+  /** Purpose: enforce minimum interval / next-eligible guard for one feed scope. */
+  async isEligible(scope: SyncScope, minimumIntervalMs: number, now: Date = new Date()): Promise<boolean> {
+    const state = await this.getState(scope);
+    if (!state) return true;
+    const nowMs = now.getTime();
+    const nextEligibleMs =
+      state.nextEligibleAt instanceof Date && Number.isFinite(state.nextEligibleAt.getTime())
+        ? state.nextEligibleAt.getTime()
+        : null;
+    if (nextEligibleMs !== null && nextEligibleMs > nowMs) return false;
+    if (!state.lastAttemptAt) return true;
+    const elapsedMs = nowMs - state.lastAttemptAt.getTime();
+    return elapsedMs >= minimumIntervalMs;
+  }
+
+  /** Purpose: persist sync-attempt timestamps before fetch/parse work starts. */
+  async recordAttempt(scope: SyncScope, nextEligibleAt: Date | null, now: Date = new Date()): Promise<void> {
+    const delegate = this.getDelegate();
+    await delegate.upsert({
+      where: this.buildCompoundScopeWhere(scope),
+      create: {
+        feedType: scope.feedType,
+        scopeType: scope.scopeType,
+        scopeKey: scope.scopeKey,
+        lastAttemptAt: now,
+        nextEligibleAt,
+      },
+      update: {
+        lastAttemptAt: now,
+        nextEligibleAt,
+      },
+    });
+  }
+
+  /** Purpose: persist successful sync metadata including content hash and row counts. */
+  async recordSuccess(params: RecordSuccessParams, now: Date = new Date()): Promise<void> {
+    const delegate = this.getDelegate();
+    await delegate.upsert({
+      where: this.buildCompoundScopeWhere(params),
+      create: {
+        feedType: params.feedType,
+        scopeType: params.scopeType,
+        scopeKey: params.scopeKey,
+        lastAttemptAt: now,
+        lastSuccessAt: now,
+        lastStatus: params.status,
+        lastErrorCode: null,
+        lastErrorSummary: null,
+        lastRowCount: params.rowCount,
+        lastChangedRowCount: params.changedRowCount,
+        lastContentHash: params.contentHash,
+        nextEligibleAt: params.nextEligibleAt,
+      },
+      update: {
+        lastAttemptAt: now,
+        lastSuccessAt: now,
+        lastStatus: params.status,
+        lastErrorCode: null,
+        lastErrorSummary: null,
+        lastRowCount: params.rowCount,
+        lastChangedRowCount: params.changedRowCount,
+        lastContentHash: params.contentHash,
+        nextEligibleAt: params.nextEligibleAt,
+      },
+    });
+  }
+
+  /** Purpose: persist failed sync metadata and concise error diagnostics for one scope. */
+  async recordFailure(params: RecordFailureParams, now: Date = new Date()): Promise<void> {
+    const delegate = this.getDelegate();
+    await delegate.upsert({
+      where: this.buildCompoundScopeWhere(params),
+      create: {
+        feedType: params.feedType,
+        scopeType: params.scopeType,
+        scopeKey: params.scopeKey,
+        lastAttemptAt: now,
+        lastStatus: "FAILURE",
+        lastErrorCode: params.errorCode,
+        lastErrorSummary: params.errorSummary,
+        nextEligibleAt: params.nextEligibleAt,
+      },
+      update: {
+        lastAttemptAt: now,
+        lastStatus: "FAILURE",
+        lastErrorCode: params.errorCode,
+        lastErrorSummary: params.errorSummary,
+        nextEligibleAt: params.nextEligibleAt,
+      },
+    });
+  }
+}

--- a/src/services/fwa-feeds/FwaStatsClient.ts
+++ b/src/services/fwa-feeds/FwaStatsClient.ts
@@ -1,0 +1,294 @@
+import axios, { AxiosError } from "axios";
+import { recordFetchEvent } from "../../helper/fetchTelemetry";
+import {
+  normalizeFwaTag,
+  normalizeFwaTagBare,
+  normalizeText,
+  toBoolOrNull,
+  toDateOrNull,
+  toFloatOrNull,
+  toIntOrNull,
+} from "./normalize";
+import type {
+  FwaClanMemberFeedRow,
+  FwaClanWarsFeedRow,
+  FwaClansFeedRow,
+  FwaWarMemberFeedRow,
+} from "./types";
+
+type FeedOperation = "clans_json" | "clan_members_json" | "war_members_json" | "clan_wars_json";
+
+type FetchRowsParams = {
+  operation: FeedOperation;
+  url: string;
+  scope: string;
+};
+
+type FetchRowsResult = {
+  rows: unknown[];
+  durationMs: number;
+};
+
+/** Purpose: centralize all fwastats JSON-feed HTTP calls, parsing, retries, and telemetry. */
+export class FwaStatsClient {
+  private readonly timeoutMs: number;
+  private readonly retryCount: number;
+
+  /** Purpose: configure network safety bounds for fwastats feed requests. */
+  constructor(params?: { timeoutMs?: number; retryCount?: number }) {
+    const envTimeout = toIntOrNull(process.env.FWA_FEED_REQUEST_TIMEOUT_MS);
+    const envRetry = toIntOrNull(process.env.FWA_FEED_RETRY_COUNT);
+    const timeoutMs = params?.timeoutMs ?? envTimeout ?? 5000;
+    const retryCount = params?.retryCount ?? envRetry ?? 1;
+    this.timeoutMs = Math.max(1000, timeoutMs);
+    this.retryCount = Math.max(0, Math.min(5, retryCount));
+  }
+
+  /** Purpose: fetch and parse global active FWA clan catalog rows from `Clans.json`. */
+  async fetchClans(): Promise<FwaClansFeedRow[]> {
+    const { rows } = await this.fetchRows({
+      operation: "clans_json",
+      url: "https://fwastats.com/Clans.json",
+      scope: "global",
+    });
+    return rows
+      .map((row) => this.parseClansRow(row))
+      .filter((row): row is FwaClansFeedRow => Boolean(row));
+  }
+
+  /** Purpose: fetch and parse one tracked clan current member roster from `Members.json`. */
+  async fetchClanMembers(clanTag: string): Promise<FwaClanMemberFeedRow[]> {
+    const normalizedTag = normalizeFwaTag(clanTag);
+    const bare = normalizeFwaTagBare(clanTag);
+    if (!normalizedTag || !bare) return [];
+    const { rows } = await this.fetchRows({
+      operation: "clan_members_json",
+      url: `https://fwastats.com/Clan/${bare}/Members.json`,
+      scope: normalizedTag,
+    });
+    return rows
+      .map((row) => this.parseClanMembersRow(normalizedTag, row))
+      .filter((row): row is FwaClanMemberFeedRow => Boolean(row));
+  }
+
+  /** Purpose: fetch and parse one clan active-war roster rows from `WarMembers.json?warNo=1`. */
+  async fetchWarMembers(clanTag: string): Promise<FwaWarMemberFeedRow[]> {
+    const normalizedTag = normalizeFwaTag(clanTag);
+    const bare = normalizeFwaTagBare(clanTag);
+    if (!normalizedTag || !bare) return [];
+    const { rows } = await this.fetchRows({
+      operation: "war_members_json",
+      url: `https://fwastats.com/Clan/${bare}/WarMembers.json?warNo=1`,
+      scope: normalizedTag,
+    });
+    return rows
+      .map((row) => this.parseWarMembersRow(normalizedTag, row))
+      .filter((row): row is FwaWarMemberFeedRow => Boolean(row));
+  }
+
+  /** Purpose: fetch and parse one clan recent war summary rows from `Wars.json`. */
+  async fetchClanWars(clanTag: string): Promise<FwaClanWarsFeedRow[]> {
+    const normalizedTag = normalizeFwaTag(clanTag);
+    const bare = normalizeFwaTagBare(clanTag);
+    if (!normalizedTag || !bare) return [];
+    const { rows } = await this.fetchRows({
+      operation: "clan_wars_json",
+      url: `https://fwastats.com/Clan/${bare}/Wars.json`,
+      scope: normalizedTag,
+    });
+    return rows
+      .map((row) => this.parseClanWarsRow(normalizedTag, row))
+      .filter((row): row is FwaClanWarsFeedRow => Boolean(row));
+  }
+
+  /** Purpose: perform bounded-retry JSON fetches with concise operation telemetry. */
+  private async fetchRows(params: FetchRowsParams): Promise<FetchRowsResult> {
+    const startedAtMs = Date.now();
+    let lastError: unknown = null;
+    const maxAttempts = this.retryCount + 1;
+    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+      try {
+        const response = await axios.get<unknown>(params.url, {
+          timeout: this.timeoutMs,
+          validateStatus: () => true,
+        });
+        const durationMs = Date.now() - startedAtMs;
+        if (response.status >= 200 && response.status < 300) {
+          const rows = Array.isArray(response.data) ? response.data : [];
+          recordFetchEvent({
+            namespace: "fwastats_feed",
+            operation: params.operation,
+            source: "web",
+            detail: `scope=${params.scope} rows=${rows.length} attempt=${attempt}`,
+            durationMs,
+            status: "success",
+          });
+          return { rows, durationMs };
+        }
+        lastError = new Error(`HTTP_${response.status}`);
+        if (response.status < 500 || attempt >= maxAttempts) {
+          throw lastError;
+        }
+      } catch (error) {
+        lastError = error;
+        const status = (error as AxiosError)?.response?.status;
+        const timeout = (error as AxiosError)?.code === "ECONNABORTED";
+        if (attempt < maxAttempts && (timeout || (status !== undefined && status >= 500))) {
+          continue;
+        }
+        const durationMs = Date.now() - startedAtMs;
+        recordFetchEvent({
+          namespace: "fwastats_feed",
+          operation: params.operation,
+          source: "web",
+          detail: `scope=${params.scope} attempt=${attempt}`,
+          durationMs,
+          status: "failure",
+          errorCategory: status !== undefined ? "http" : "network",
+          errorCode: status !== undefined ? `HTTP_${status}` : "REQUEST_FAILED",
+          timeout,
+        });
+        throw error;
+      }
+    }
+    throw lastError ?? new Error("Unknown fwastats fetch failure");
+  }
+
+  /** Purpose: map one `Clans.json` row into normalized catalog shape. */
+  private parseClansRow(input: unknown): FwaClansFeedRow | null {
+    const row = this.asRecord(input);
+    if (!row) return null;
+    const clanTag = normalizeFwaTag(String(row.tag ?? ""));
+    const name = normalizeText(row.name);
+    if (!clanTag || !name) return null;
+    return {
+      clanTag,
+      name,
+      level: toIntOrNull(row.level),
+      points: toIntOrNull(row.points),
+      type: normalizeText(row.type),
+      location: normalizeText(row.location),
+      requiredTrophies: toIntOrNull(row.requiredTrophies),
+      warFrequency: normalizeText(row.warFrequency),
+      winStreak: toIntOrNull(row.winStreak),
+      wins: toIntOrNull(row.wins),
+      ties: toIntOrNull(row.ties),
+      losses: toIntOrNull(row.losses),
+      isWarLogPublic: toBoolOrNull(row.isWarLogPublic),
+      imageUrl: normalizeText(row.image),
+      description: normalizeText(row.description),
+      th18Count: toIntOrNull(row.th18Count),
+      th17Count: toIntOrNull(row.th17Count),
+      th16Count: toIntOrNull(row.th16Count),
+      th15Count: toIntOrNull(row.th15Count),
+      th14Count: toIntOrNull(row.th14Count),
+      th13Count: toIntOrNull(row.th13Count),
+      th12Count: toIntOrNull(row.th12Count),
+      th11Count: toIntOrNull(row.th11Count),
+      th10Count: toIntOrNull(row.th10Count),
+      th9Count: toIntOrNull(row.th9Count),
+      th8Count: toIntOrNull(row.th8Count),
+      thLowCount: toIntOrNull(row.thLowCount),
+      estimatedWeight: toIntOrNull(row.estimatedWeight),
+    };
+  }
+
+  /** Purpose: map one `Members.json` row into normalized tracked-roster shape. */
+  private parseClanMembersRow(clanTag: string, input: unknown): FwaClanMemberFeedRow | null {
+    const row = this.asRecord(input);
+    if (!row) return null;
+    const playerTag = normalizeFwaTag(String(row.tag ?? ""));
+    const playerName = normalizeText(row.name);
+    if (!playerTag || !playerName) return null;
+    return {
+      clanTag,
+      playerTag,
+      playerName,
+      role: normalizeText(row.role),
+      level: toIntOrNull(row.level),
+      donated: toIntOrNull(row.donated),
+      received: toIntOrNull(row.received),
+      rank: toIntOrNull(row.rank),
+      trophies: toIntOrNull(row.trophies),
+      league: normalizeText(row.league),
+      townHall: toIntOrNull(row.townHall),
+      weight: toIntOrNull(row.weight),
+      inWar: toBoolOrNull(row.inWar),
+    };
+  }
+
+  /** Purpose: map one `WarMembers.json` row into normalized war-roster shape. */
+  private parseWarMembersRow(clanTag: string, input: unknown): FwaWarMemberFeedRow | null {
+    const row = this.asRecord(input);
+    if (!row) return null;
+    const playerTag = normalizeFwaTag(String(row.tag ?? ""));
+    const playerName = normalizeText(row.name);
+    if (!playerTag || !playerName) return null;
+    return {
+      clanTag,
+      playerTag,
+      playerName,
+      position: toIntOrNull(row.position),
+      townHall: toIntOrNull(row.townHall),
+      weight: toIntOrNull(row.weight),
+      opponentTag: normalizeText(row.opponentTag)
+        ? normalizeFwaTag(String(row.opponentTag))
+        : null,
+      opponentName: normalizeText(row.opponentName),
+      attacks: toIntOrNull(row.attacks),
+      defender1Tag: normalizeText(row.defender1Tag)
+        ? normalizeFwaTag(String(row.defender1Tag))
+        : null,
+      defender1Name: normalizeText(row.defender1Name),
+      defender1TownHall: toIntOrNull(row.defender1TownHall),
+      defender1Position: toIntOrNull(row.defender1Position),
+      stars1: toIntOrNull(row.stars1),
+      destructionPercentage1: toFloatOrNull(row.destructionPercentage1),
+      defender2Tag: normalizeText(row.defender2Tag)
+        ? normalizeFwaTag(String(row.defender2Tag))
+        : null,
+      defender2Name: normalizeText(row.defender2Name),
+      defender2TownHall: toIntOrNull(row.defender2TownHall),
+      defender2Position: toIntOrNull(row.defender2Position),
+      stars2: toIntOrNull(row.stars2),
+      destructionPercentage2: toFloatOrNull(row.destructionPercentage2),
+    };
+  }
+
+  /** Purpose: map one `Wars.json` row into normalized clan-war-log shape. */
+  private parseClanWarsRow(clanTag: string, input: unknown): FwaClanWarsFeedRow | null {
+    const row = this.asRecord(input);
+    if (!row) return null;
+    const endTime = toDateOrNull(row.endTime);
+    const teamSize = toIntOrNull(row.teamSize);
+    const normalizedOpponent = normalizeFwaTag(String(row.opponentTag ?? ""));
+    if (!endTime || teamSize === null || !normalizedOpponent) return null;
+    return {
+      clanTag: normalizeFwaTag(String(row.clanTag ?? clanTag)) || clanTag,
+      endTime,
+      searchTime: toDateOrNull(row.searchTime),
+      result: normalizeText(row.result),
+      teamSize,
+      clanName: normalizeText(row.clanName),
+      clanLevel: toIntOrNull(row.clanLevel),
+      clanStars: toIntOrNull(row.clanStars),
+      clanDestructionPercentage: toFloatOrNull(row.clanDestructionPercentage),
+      clanAttacks: toIntOrNull(row.clanAttacks),
+      clanExpEarned: toIntOrNull(row.clanExpEarned),
+      opponentTag: normalizedOpponent,
+      opponentName: normalizeText(row.opponentName),
+      opponentLevel: toIntOrNull(row.opponentLevel),
+      opponentStars: toIntOrNull(row.opponentStars),
+      opponentDestructionPercentage: toFloatOrNull(row.opponentDestructionPercentage),
+      opponentInfo: normalizeText(row.opponentInfo),
+      synced: toBoolOrNull(row.synced),
+      matched: toBoolOrNull(row.matched),
+    };
+  }
+
+  /** Purpose: safely narrow unknown JSON values into object records. */
+  private asRecord(input: unknown): Record<string, unknown> | null {
+    if (!input || typeof input !== "object" || Array.isArray(input)) return null;
+    return input as Record<string, unknown>;
+  }
+}

--- a/src/services/fwa-feeds/FwaWarMembersSyncService.ts
+++ b/src/services/fwa-feeds/FwaWarMembersSyncService.ts
@@ -1,0 +1,260 @@
+import type { FwaFeedType } from "@prisma/client";
+import { prisma } from "../../prisma";
+import { computeFeedContentHash } from "./hash";
+import { normalizeFwaTag } from "./normalize";
+import { FwaStatsClient } from "./FwaStatsClient";
+import { FwaFeedCursorService } from "./FwaFeedCursorService";
+import { FwaFeedSyncStateService } from "./FwaFeedSyncStateService";
+import { mapWithConcurrency } from "./concurrency";
+import { selectDistributedSweepChunk } from "./sweep";
+import type { FwaSyncResult } from "./types";
+
+type SyncOptions = {
+  force?: boolean;
+  minimumIntervalMs?: number;
+  now?: Date;
+};
+
+/** Purpose: sync distributed WarMembers.json sweeps into authoritative current-war roster snapshots. */
+export class FwaWarMembersSyncService {
+  private static readonly FEED_TYPE: FwaFeedType = "WAR_MEMBERS";
+  private readonly syncState = new FwaFeedSyncStateService();
+  private readonly cursor = new FwaFeedCursorService();
+
+  /** Purpose: initialize war-members sync dependencies. */
+  constructor(private readonly client = new FwaStatsClient()) {}
+
+  /** Purpose: sync one clan war-members scope with stale-row cleanup and player-catalog updates. */
+  async syncClan(clanTag: string, options?: SyncOptions): Promise<FwaSyncResult> {
+    const normalizedClanTag = normalizeFwaTag(clanTag);
+    if (!normalizedClanTag) {
+      return { rowCount: 0, changedRowCount: 0, contentHash: null, status: "SKIPPED" };
+    }
+    const now = options?.now ?? new Date();
+    const minimumIntervalMs = Math.max(0, Math.trunc(options?.minimumIntervalMs ?? 0));
+    const scope = {
+      feedType: FwaWarMembersSyncService.FEED_TYPE,
+      scopeType: "CLAN_TAG" as const,
+      scopeKey: normalizedClanTag,
+    };
+    const nextEligibleAt =
+      minimumIntervalMs > 0 ? new Date(now.getTime() + minimumIntervalMs) : null;
+    if (!options?.force && minimumIntervalMs > 0) {
+      const eligible = await this.syncState.isEligible(scope, minimumIntervalMs, now);
+      if (!eligible) {
+        return { rowCount: 0, changedRowCount: 0, contentHash: null, status: "SKIPPED" };
+      }
+    }
+
+    await this.syncState.recordAttempt(scope, nextEligibleAt, now);
+    try {
+      const rows = await this.client.fetchWarMembers(normalizedClanTag);
+      const sortedRows = [...rows].sort((a, b) => a.playerTag.localeCompare(b.playerTag));
+      const contentHash = computeFeedContentHash(sortedRows);
+      const previousState = await this.syncState.getState(scope);
+      if (previousState?.lastContentHash === contentHash) {
+        const result: FwaSyncResult = {
+          rowCount: rows.length,
+          changedRowCount: 0,
+          contentHash,
+          status: "NOOP",
+        };
+        await this.syncState.recordSuccess({ ...scope, ...result, nextEligibleAt }, now);
+        return result;
+      }
+
+      const changedRowCount = await prisma.$transaction(async (tx) => {
+        const playerTags = rows.map((row) => row.playerTag);
+        const staleDelete = await tx.fwaWarMemberCurrent.deleteMany({
+          where: {
+            clanTag: normalizedClanTag,
+            ...(playerTags.length > 0 ? { playerTag: { notIn: playerTags } } : {}),
+          },
+        });
+        for (const row of rows) {
+          await tx.fwaWarMemberCurrent.upsert({
+            where: {
+              clanTag_playerTag: {
+                clanTag: normalizedClanTag,
+                playerTag: row.playerTag,
+              },
+            },
+            update: {
+              playerName: row.playerName,
+              position: row.position,
+              townHall: row.townHall,
+              weight: row.weight,
+              opponentTag: row.opponentTag,
+              opponentName: row.opponentName,
+              attacks: row.attacks,
+              defender1Tag: row.defender1Tag,
+              defender1Name: row.defender1Name,
+              defender1TownHall: row.defender1TownHall,
+              defender1Position: row.defender1Position,
+              stars1: row.stars1,
+              destructionPercentage1: row.destructionPercentage1,
+              defender2Tag: row.defender2Tag,
+              defender2Name: row.defender2Name,
+              defender2TownHall: row.defender2TownHall,
+              defender2Position: row.defender2Position,
+              stars2: row.stars2,
+              destructionPercentage2: row.destructionPercentage2,
+              sourceSyncedAt: now,
+            },
+            create: {
+              clanTag: normalizedClanTag,
+              playerTag: row.playerTag,
+              playerName: row.playerName,
+              position: row.position,
+              townHall: row.townHall,
+              weight: row.weight,
+              opponentTag: row.opponentTag,
+              opponentName: row.opponentName,
+              attacks: row.attacks,
+              defender1Tag: row.defender1Tag,
+              defender1Name: row.defender1Name,
+              defender1TownHall: row.defender1TownHall,
+              defender1Position: row.defender1Position,
+              stars1: row.stars1,
+              destructionPercentage1: row.destructionPercentage1,
+              defender2Tag: row.defender2Tag,
+              defender2Name: row.defender2Name,
+              defender2TownHall: row.defender2TownHall,
+              defender2Position: row.defender2Position,
+              stars2: row.stars2,
+              destructionPercentage2: row.destructionPercentage2,
+              sourceSyncedAt: now,
+            },
+          });
+
+          await tx.fwaPlayerCatalog.upsert({
+            where: { playerTag: row.playerTag },
+            update: {
+              latestName: row.playerName,
+              latestTownHall: row.townHall,
+              latestKnownWeight: row.weight,
+              lastSeenAt: now,
+              lastSyncedAt: now,
+            },
+            create: {
+              playerTag: row.playerTag,
+              latestName: row.playerName,
+              latestTownHall: row.townHall,
+              latestKnownWeight: row.weight,
+              firstSeenAt: now,
+              lastSeenAt: now,
+              lastSyncedAt: now,
+            },
+          });
+        }
+        return staleDelete.count + rows.length;
+      });
+
+      const result: FwaSyncResult = {
+        rowCount: rows.length,
+        changedRowCount,
+        contentHash,
+        status: "SUCCESS",
+      };
+      await this.syncState.recordSuccess({ ...scope, ...result, nextEligibleAt }, now);
+      return result;
+    } catch (error) {
+      const errorSummary = String((error as { message?: string })?.message ?? "unknown error").slice(
+        0,
+        200,
+      );
+      await this.syncState.recordFailure(
+        {
+          ...scope,
+          errorCode: "SYNC_FAILED",
+          errorSummary,
+          nextEligibleAt,
+        },
+        now,
+      );
+      throw error;
+    }
+  }
+
+  /** Purpose: process one bounded cursor-based global sweep chunk from FwaClanCatalog. */
+  async runDistributedSweep(params: {
+    chunkSize: number;
+    concurrency: number;
+    force?: boolean;
+    minimumIntervalMs?: number;
+    now?: Date;
+  }): Promise<{
+    attemptedClans: number;
+    rowCount: number;
+    changedRowCount: number;
+    failedClans: string[];
+    nextCursor: string | null;
+  }> {
+    const now = params.now ?? new Date();
+    const chunkSize = Math.max(1, Math.trunc(params.chunkSize));
+    const concurrency = Math.max(1, Math.trunc(params.concurrency));
+    const catalog = await prisma.fwaClanCatalog.findMany({
+      orderBy: { clanTag: "asc" },
+      select: { clanTag: true },
+    });
+    const tags = catalog.map((row) => normalizeFwaTag(row.clanTag)).filter(Boolean);
+    if (tags.length === 0) {
+      return {
+        attemptedClans: 0,
+        rowCount: 0,
+        changedRowCount: 0,
+        failedClans: [],
+        nextCursor: null,
+      };
+    }
+
+    const cursor = await this.cursor.getCursor(FwaWarMembersSyncService.FEED_TYPE);
+    const currentCursor = cursor?.lastScopeKey ? normalizeFwaTag(cursor.lastScopeKey) : null;
+    const selected = selectDistributedSweepChunk(tags, currentCursor, chunkSize);
+
+    const outcomes = await mapWithConcurrency(selected, concurrency, async (tag) => {
+      try {
+        const result = await this.syncClan(tag, {
+          force: params.force,
+          minimumIntervalMs: params.minimumIntervalMs,
+          now,
+        });
+        return { tag, result, failed: false };
+      } catch {
+        return { tag, result: null, failed: true };
+      }
+    });
+
+    const summary = outcomes.reduce(
+      (acc, row) => {
+        if (row.failed || !row.result) {
+          acc.failedClans.push(row.tag);
+          return acc;
+        }
+        acc.rowCount += row.result.rowCount;
+        acc.changedRowCount += row.result.changedRowCount;
+        return acc;
+      },
+      {
+        attemptedClans: selected.length,
+        rowCount: 0,
+        changedRowCount: 0,
+        failedClans: [] as string[],
+      },
+    );
+
+    const nextCursor = selected[selected.length - 1] ?? null;
+    await this.cursor.saveCursor({
+      feedType: FwaWarMembersSyncService.FEED_TYPE,
+      lastScopeKey: nextCursor,
+      lastRunAt: now,
+    });
+
+    return {
+      ...summary,
+      nextCursor,
+    };
+  }
+}
+
+export const selectDistributedSweepChunkForTest = selectDistributedSweepChunk;

--- a/src/services/fwa-feeds/concurrency.ts
+++ b/src/services/fwa-feeds/concurrency.ts
@@ -1,0 +1,24 @@
+/** Purpose: run async work over a list with bounded concurrency and stable ordering. */
+export async function mapWithConcurrency<TInput, TOutput>(
+  items: readonly TInput[],
+  limit: number,
+  worker: (item: TInput, index: number) => Promise<TOutput>,
+): Promise<TOutput[]> {
+  if (items.length === 0) return [];
+  const maxConcurrency = Math.max(1, Math.trunc(limit));
+  const results: TOutput[] = new Array(items.length);
+  let nextIndex = 0;
+
+  const runWorker = async (): Promise<void> => {
+    while (nextIndex < items.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+      if (index >= items.length) continue;
+      results[index] = await worker(items[index], index);
+    }
+  };
+
+  const runners = Array.from({ length: Math.min(maxConcurrency, items.length) }, () => runWorker());
+  await Promise.all(runners);
+  return results;
+}

--- a/src/services/fwa-feeds/hash.ts
+++ b/src/services/fwa-feeds/hash.ts
@@ -1,0 +1,9 @@
+import { createHash } from "node:crypto";
+import { stableHashValue } from "./normalize";
+
+/** Purpose: build a deterministic content hash for normalized feed payloads. */
+export function computeFeedContentHash(rows: readonly unknown[]): string {
+  const normalized = stableHashValue(rows);
+  const serialized = JSON.stringify(normalized);
+  return createHash("sha256").update(serialized).digest("hex");
+}

--- a/src/services/fwa-feeds/normalize.ts
+++ b/src/services/fwa-feeds/normalize.ts
@@ -1,0 +1,79 @@
+import { normalizeTag, normalizeTagBare } from "../war-events/core";
+
+/** Purpose: normalize clan/player tags to canonical #UPPER format. */
+export function normalizeFwaTag(input: string | null | undefined): string {
+  return normalizeTag(input);
+}
+
+/** Purpose: normalize clan/player tags to uppercase without leading '#'. */
+export function normalizeFwaTagBare(input: string | null | undefined): string {
+  return normalizeTagBare(input);
+}
+
+/** Purpose: trim optional text fields and collapse empty values to null. */
+export function normalizeText(input: unknown): string | null {
+  const value = String(input ?? "").trim();
+  return value.length > 0 ? value : null;
+}
+
+/** Purpose: parse finite integer values with null fallback for invalid input. */
+export function toIntOrNull(input: unknown): number | null {
+  if (typeof input === "number" && Number.isFinite(input)) return Math.trunc(input);
+  if (typeof input === "string") {
+    const value = input.trim();
+    if (!value) return null;
+    const parsed = Number(value.replace(/,/g, ""));
+    return Number.isFinite(parsed) ? Math.trunc(parsed) : null;
+  }
+  return null;
+}
+
+/** Purpose: parse finite float values with null fallback for invalid input. */
+export function toFloatOrNull(input: unknown): number | null {
+  if (typeof input === "number" && Number.isFinite(input)) return input;
+  if (typeof input === "string") {
+    const value = input.trim();
+    if (!value) return null;
+    const parsed = Number(value.replace(/,/g, ""));
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+/** Purpose: parse boolean-like values from FWAStats feed rows. */
+export function toBoolOrNull(input: unknown): boolean | null {
+  if (typeof input === "boolean") return input;
+  if (typeof input !== "string") return null;
+  const normalized = input.trim().toLowerCase();
+  if (["true", "yes", "1"].includes(normalized)) return true;
+  if (["false", "no", "0"].includes(normalized)) return false;
+  return null;
+}
+
+/** Purpose: parse date values from feed rows using strict finite-date checks. */
+export function toDateOrNull(input: unknown): Date | null {
+  if (input instanceof Date) {
+    return Number.isFinite(input.getTime()) ? input : null;
+  }
+  if (typeof input !== "string") return null;
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+  const parsed = new Date(trimmed);
+  return Number.isFinite(parsed.getTime()) ? parsed : null;
+}
+
+/** Purpose: format row values into deterministic primitives for hashing and comparison. */
+export function stableHashValue(input: unknown): unknown {
+  if (input instanceof Date) return input.toISOString();
+  if (Array.isArray(input)) return input.map((value) => stableHashValue(value));
+  if (input && typeof input === "object") {
+    const record = input as Record<string, unknown>;
+    const keys = Object.keys(record).sort();
+    const out: Record<string, unknown> = {};
+    for (const key of keys) {
+      out[key] = stableHashValue(record[key]);
+    }
+    return out;
+  }
+  return input ?? null;
+}

--- a/src/services/fwa-feeds/sweep.ts
+++ b/src/services/fwa-feeds/sweep.ts
@@ -1,0 +1,22 @@
+import { normalizeFwaTag } from "./normalize";
+
+/** Purpose: choose a bounded wrap-around chunk from an ordered clan list using a persistent cursor. */
+export function selectDistributedSweepChunk(
+  orderedTags: readonly string[],
+  cursorTag: string | null,
+  chunkSize: number,
+): string[] {
+  const tags = orderedTags.map((tag) => normalizeFwaTag(tag)).filter(Boolean);
+  if (tags.length === 0) return [];
+  const boundedChunkSize = Math.max(1, Math.trunc(chunkSize));
+  const normalizedCursor = cursorTag ? normalizeFwaTag(cursorTag) : null;
+  const startIndex =
+    normalizedCursor && tags.includes(normalizedCursor)
+      ? (tags.indexOf(normalizedCursor) + 1) % tags.length
+      : 0;
+  const selected: string[] = [];
+  for (let i = 0; i < Math.min(boundedChunkSize, tags.length); i += 1) {
+    selected.push(tags[(startIndex + i) % tags.length]);
+  }
+  return selected;
+}

--- a/src/services/fwa-feeds/types.ts
+++ b/src/services/fwa-feeds/types.ts
@@ -1,0 +1,115 @@
+import type { FwaFeedScopeType, FwaFeedSyncStatus, FwaFeedType } from "@prisma/client";
+
+export type FwaClansFeedRow = {
+  clanTag: string;
+  name: string;
+  level: number | null;
+  points: number | null;
+  type: string | null;
+  location: string | null;
+  requiredTrophies: number | null;
+  warFrequency: string | null;
+  winStreak: number | null;
+  wins: number | null;
+  ties: number | null;
+  losses: number | null;
+  isWarLogPublic: boolean | null;
+  imageUrl: string | null;
+  description: string | null;
+  th18Count: number | null;
+  th17Count: number | null;
+  th16Count: number | null;
+  th15Count: number | null;
+  th14Count: number | null;
+  th13Count: number | null;
+  th12Count: number | null;
+  th11Count: number | null;
+  th10Count: number | null;
+  th9Count: number | null;
+  th8Count: number | null;
+  thLowCount: number | null;
+  estimatedWeight: number | null;
+};
+
+export type FwaClanMemberFeedRow = {
+  clanTag: string;
+  playerTag: string;
+  playerName: string;
+  role: string | null;
+  level: number | null;
+  donated: number | null;
+  received: number | null;
+  rank: number | null;
+  trophies: number | null;
+  league: string | null;
+  townHall: number | null;
+  weight: number | null;
+  inWar: boolean | null;
+};
+
+export type FwaWarMemberFeedRow = {
+  clanTag: string;
+  playerTag: string;
+  playerName: string;
+  position: number | null;
+  townHall: number | null;
+  weight: number | null;
+  opponentTag: string | null;
+  opponentName: string | null;
+  attacks: number | null;
+  defender1Tag: string | null;
+  defender1Name: string | null;
+  defender1TownHall: number | null;
+  defender1Position: number | null;
+  stars1: number | null;
+  destructionPercentage1: number | null;
+  defender2Tag: string | null;
+  defender2Name: string | null;
+  defender2TownHall: number | null;
+  defender2Position: number | null;
+  stars2: number | null;
+  destructionPercentage2: number | null;
+};
+
+export type FwaClanWarsFeedRow = {
+  clanTag: string;
+  endTime: Date;
+  searchTime: Date | null;
+  result: string | null;
+  teamSize: number;
+  clanName: string | null;
+  clanLevel: number | null;
+  clanStars: number | null;
+  clanDestructionPercentage: number | null;
+  clanAttacks: number | null;
+  clanExpEarned: number | null;
+  opponentTag: string;
+  opponentName: string | null;
+  opponentLevel: number | null;
+  opponentStars: number | null;
+  opponentDestructionPercentage: number | null;
+  opponentInfo: string | null;
+  synced: boolean | null;
+  matched: boolean | null;
+};
+
+export type FwaFeedScope = {
+  feedType: FwaFeedType;
+  scopeType: FwaFeedScopeType;
+  scopeKey: string | null;
+};
+
+export type FwaSyncResult = {
+  rowCount: number;
+  changedRowCount: number;
+  contentHash: string | null;
+  status: FwaFeedSyncStatus;
+};
+
+export type FwaTrackedWarsWatchDecision = {
+  pollingActive: boolean;
+  nextSyncTimeAt: Date | null;
+  pollWindowStartAt: Date | null;
+  currentWarCycleKey: string | null;
+  stopReason: string | null;
+};

--- a/tests/fwaFeed.clientParsing.test.ts
+++ b/tests/fwaFeed.clientParsing.test.ts
@@ -1,0 +1,181 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import axios from "axios";
+import { FwaStatsClient } from "../src/services/fwa-feeds/FwaStatsClient";
+
+vi.mock("axios");
+
+const mockedAxios = vi.mocked(axios, true);
+
+describe("FwaStatsClient parsing", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("parses Clans.json rows into normalized catalog DTOs", async () => {
+    mockedAxios.get.mockResolvedValueOnce({
+      status: 200,
+      data: [
+        {
+          tag: "2qg2c08up",
+          name: "Rising Dawn",
+          level: "30",
+          points: 1234,
+          requiredTrophies: "1200",
+          isWarLogPublic: "true",
+          th18Count: "2",
+          estimatedWeight: "145000",
+        },
+        { tag: "", name: "" },
+      ],
+    } as any);
+
+    const client = new FwaStatsClient({ retryCount: 0, timeoutMs: 1000 });
+    const rows = await client.fetchClans();
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      clanTag: "#2QG2C08UP",
+      name: "Rising Dawn",
+      level: 30,
+      points: 1234,
+      requiredTrophies: 1200,
+      isWarLogPublic: true,
+      th18Count: 2,
+      estimatedWeight: 145000,
+    });
+  });
+
+  it("parses Members.json rows with tag/number/bool normalization", async () => {
+    mockedAxios.get.mockResolvedValueOnce({
+      status: 200,
+      data: [
+        {
+          tag: "abc123",
+          name: "Player One",
+          role: "leader",
+          level: "250",
+          donated: "12",
+          received: "10",
+          rank: "1",
+          trophies: "5000",
+          league: "Titan",
+          townHall: "18",
+          weight: "145000",
+          inWar: "false",
+        },
+      ],
+    } as any);
+
+    const client = new FwaStatsClient({ retryCount: 0, timeoutMs: 1000 });
+    const rows = await client.fetchClanMembers("#2QG2C08UP");
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      clanTag: "#2QG2C08UP",
+      playerTag: "#ABC123",
+      playerName: "Player One",
+      level: 250,
+      donated: 12,
+      received: 10,
+      rank: 1,
+      trophies: 5000,
+      townHall: 18,
+      weight: 145000,
+      inWar: false,
+    });
+  });
+
+  it("parses WarMembers rows including defender fields", async () => {
+    mockedAxios.get.mockResolvedValueOnce({
+      status: 200,
+      data: [
+        {
+          tag: "abc123",
+          name: "Player One",
+          position: "3",
+          townHall: "17",
+          weight: "140000",
+          opponentTag: "zzz999",
+          opponentName: "Enemy",
+          attacks: "2",
+          defender1Tag: "QWE111",
+          defender1Name: "Def A",
+          defender1TownHall: "17",
+          defender1Position: "5",
+          stars1: "3",
+          destructionPercentage1: "100",
+          defender2Tag: "RTY222",
+          defender2Name: "Def B",
+          defender2TownHall: "16",
+          defender2Position: "7",
+          stars2: "2",
+          destructionPercentage2: "80.5",
+        },
+      ],
+    } as any);
+
+    const client = new FwaStatsClient({ retryCount: 0, timeoutMs: 1000 });
+    const rows = await client.fetchWarMembers("2QG2C08UP");
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      clanTag: "#2QG2C08UP",
+      playerTag: "#ABC123",
+      position: 3,
+      townHall: 17,
+      opponentTag: "#ZZZ999",
+      attacks: 2,
+      defender1Tag: "#QWE111",
+      defender1TownHall: 17,
+      stars1: 3,
+      destructionPercentage2: 80.5,
+    });
+  });
+
+  it("parses Wars.json rows and skips invalid rows", async () => {
+    mockedAxios.get.mockResolvedValueOnce({
+      status: 200,
+      data: [
+        {
+          endTime: "2026-03-19T05:00:00.000Z",
+          searchTime: "2026-03-18T03:00:00.000Z",
+          result: "win",
+          teamSize: "50",
+          clanTag: "2qg2c08up",
+          clanName: "Rising Dawn",
+          clanLevel: "30",
+          clanStars: "95",
+          clanDestructionPercentage: "98.5",
+          clanAttacks: "100",
+          clanExpEarned: "300",
+          opponentTag: "abc999",
+          opponentName: "Enemy Clan",
+          opponentLevel: "25",
+          opponentStars: "90",
+          opponentDestructionPercentage: "95.2",
+          opponentInfo: "some info",
+          synced: "true",
+          matched: "true",
+        },
+        {
+          endTime: "invalid",
+          teamSize: "50",
+          opponentTag: "abc999",
+        },
+      ],
+    } as any);
+
+    const client = new FwaStatsClient({ retryCount: 0, timeoutMs: 1000 });
+    const rows = await client.fetchClanWars("2QG2C08UP");
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatchObject({
+      clanTag: "#2QG2C08UP",
+      teamSize: 50,
+      opponentTag: "#ABC999",
+      synced: true,
+      matched: true,
+    });
+    expect(rows[0].endTime.toISOString()).toBe("2026-03-19T05:00:00.000Z");
+  });
+});

--- a/tests/fwaFeed.membersSync.test.ts
+++ b/tests/fwaFeed.membersSync.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FwaClanMembersSyncService } from "../src/services/fwa-feeds/FwaClanMembersSyncService";
+import { computeFeedContentHash } from "../src/services/fwa-feeds/hash";
+
+const txMock = vi.hoisted(() => ({
+  fwaClanMemberCurrent: {
+    deleteMany: vi.fn(),
+    upsert: vi.fn(),
+  },
+  fwaPlayerCatalog: {
+    upsert: vi.fn(),
+  },
+}));
+
+const prismaMock = vi.hoisted(() => ({
+  trackedClan: {
+    findMany: vi.fn(),
+  },
+  fwaFeedSyncState: {
+    findUnique: vi.fn(),
+    upsert: vi.fn(),
+  },
+  $transaction: vi.fn(async (callback: (tx: typeof txMock) => Promise<unknown>) => callback(txMock)),
+}));
+
+vi.mock("../src/prisma", () => ({
+  prisma: prismaMock,
+}));
+
+describe("FwaClanMembersSyncService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("syncs one tracked clan and removes stale current rows", async () => {
+    const client = {
+      fetchClanMembers: vi.fn().mockResolvedValue([
+        {
+          clanTag: "#AAA111",
+          playerTag: "#P1",
+          playerName: "One",
+          role: "leader",
+          level: 10,
+          donated: 1,
+          received: 2,
+          rank: 1,
+          trophies: 1000,
+          league: "Gold",
+          townHall: 14,
+          weight: 120000,
+          inWar: true,
+        },
+        {
+          clanTag: "#AAA111",
+          playerTag: "#P2",
+          playerName: "Two",
+          role: null,
+          level: 9,
+          donated: 3,
+          received: 4,
+          rank: 2,
+          trophies: 900,
+          league: null,
+          townHall: 13,
+          weight: 110000,
+          inWar: false,
+        },
+      ]),
+    } as any;
+
+    prismaMock.fwaFeedSyncState.findUnique.mockResolvedValue(null);
+    txMock.fwaClanMemberCurrent.deleteMany.mockResolvedValue({ count: 1 });
+
+    const service = new FwaClanMembersSyncService(client);
+    const result = await service.syncTrackedClan("#aaa111", { force: true });
+
+    expect(client.fetchClanMembers).toHaveBeenCalledWith("#AAA111");
+    expect(txMock.fwaClanMemberCurrent.deleteMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          clanTag: "#AAA111",
+          playerTag: { notIn: ["#P1", "#P2"] },
+        }),
+      }),
+    );
+    expect(txMock.fwaClanMemberCurrent.upsert).toHaveBeenCalledTimes(2);
+    expect(txMock.fwaPlayerCatalog.upsert).toHaveBeenCalledTimes(2);
+    expect(result.status).toBe("SUCCESS");
+    expect(result.rowCount).toBe(2);
+    expect(result.changedRowCount).toBe(3);
+  });
+
+  it("returns NOOP when payload hash is unchanged", async () => {
+    const rows = [
+      {
+        clanTag: "#AAA111",
+        playerTag: "#P1",
+        playerName: "One",
+        role: "leader",
+        level: 10,
+        donated: 1,
+        received: 2,
+        rank: 1,
+        trophies: 1000,
+        league: "Gold",
+        townHall: 14,
+        weight: 120000,
+        inWar: true,
+      },
+    ];
+    const hash = computeFeedContentHash(rows);
+    const client = {
+      fetchClanMembers: vi.fn().mockResolvedValue(rows),
+    } as any;
+    prismaMock.fwaFeedSyncState.findUnique.mockResolvedValue({ lastContentHash: hash });
+
+    const service = new FwaClanMembersSyncService(client);
+    const result = await service.syncTrackedClan("#AAA111", { force: true });
+
+    expect(result.status).toBe("NOOP");
+    expect(result.changedRowCount).toBe(0);
+    expect(prismaMock.$transaction).not.toHaveBeenCalled();
+  });
+
+  it("builds all-tracked sync targets from TrackedClan", async () => {
+    prismaMock.trackedClan.findMany.mockResolvedValue([{ tag: "#aaa111" }, { tag: "#bbb222" }]);
+    const service = new FwaClanMembersSyncService({ fetchClanMembers: vi.fn() } as any);
+    const spy = vi
+      .spyOn(service, "syncTrackedClan")
+      .mockResolvedValue({ rowCount: 0, changedRowCount: 0, contentHash: null, status: "SUCCESS" });
+
+    await service.syncAllTrackedClans({ concurrency: 2, force: true });
+
+    expect(prismaMock.trackedClan.findMany).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith("#AAA111", expect.any(Object));
+    expect(spy).toHaveBeenCalledWith("#BBB222", expect.any(Object));
+  });
+});

--- a/tests/fwaFeed.sweepAndWatch.logic.test.ts
+++ b/tests/fwaFeed.sweepAndWatch.logic.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { selectDistributedSweepChunkForTest as selectWarMembersChunk } from "../src/services/fwa-feeds/FwaWarMembersSyncService";
+import { selectDistributedSweepChunkForTest as selectClanWarsChunk } from "../src/services/fwa-feeds/FwaClanWarsSyncService";
+import {
+  buildWatchWindowForTest,
+  computeNextDailySyncTimeForTest,
+} from "../src/services/fwa-feeds/FwaClanWarsWatchService";
+
+describe("fwa feed sweep chunking", () => {
+  it("advances from cursor and wraps around deterministically", () => {
+    const tags = ["#A", "#B", "#C", "#D"];
+    expect(selectWarMembersChunk(tags, "#B", 2)).toEqual(["#C", "#D"]);
+    expect(selectWarMembersChunk(tags, "#D", 2)).toEqual(["#A", "#B"]);
+    expect(selectClanWarsChunk(tags, null, 3)).toEqual(["#A", "#B", "#C"]);
+  });
+});
+
+describe("tracked clan wars watch timing", () => {
+  it("computes next daily sync time in the future", () => {
+    const base = Date.parse("2026-03-19T12:00:00.000Z");
+    const nowBefore = Date.parse("2026-03-19T11:59:00.000Z");
+    const nowAfter = Date.parse("2026-03-19T12:01:00.000Z");
+
+    expect(computeNextDailySyncTimeForTest(base, nowBefore)).toBe(base);
+    expect(computeNextDailySyncTimeForTest(base, nowAfter)).toBe(base + 24 * 60 * 60 * 1000);
+  });
+
+  it("starts watch window five minutes before next sync", () => {
+    const nextSyncMs = Date.parse("2026-03-19T12:00:00.000Z");
+    const window = buildWatchWindowForTest(nextSyncMs);
+    expect(window.nextSyncTimeAt.toISOString()).toBe("2026-03-19T12:00:00.000Z");
+    expect(window.pollWindowStartAt.toISOString()).toBe("2026-03-19T11:55:00.000Z");
+  });
+});

--- a/tests/fwaFeed.syncState.service.test.ts
+++ b/tests/fwaFeed.syncState.service.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FwaFeedSyncStateService } from "../src/services/fwa-feeds/FwaFeedSyncStateService";
+
+const prismaMock = vi.hoisted(() => ({
+  fwaFeedSyncState: {
+    findUnique: vi.fn(),
+    upsert: vi.fn(),
+  },
+}));
+
+vi.mock("../src/prisma", () => ({
+  prisma: prismaMock,
+}));
+
+describe("FwaFeedSyncStateService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("treats missing scope state as eligible", async () => {
+    prismaMock.fwaFeedSyncState.findUnique.mockResolvedValue(null);
+    const service = new FwaFeedSyncStateService();
+    const eligible = await service.isEligible(
+      { feedType: "CLANS", scopeType: "GLOBAL", scopeKey: null },
+      15 * 60 * 1000,
+      new Date("2026-03-19T10:00:00.000Z"),
+    );
+    expect(eligible).toBe(true);
+  });
+
+  it("blocks runs before nextEligibleAt", async () => {
+    prismaMock.fwaFeedSyncState.findUnique.mockResolvedValue({
+      nextEligibleAt: new Date("2026-03-19T10:10:00.000Z"),
+      lastAttemptAt: new Date("2026-03-19T09:55:00.000Z"),
+    });
+    const service = new FwaFeedSyncStateService();
+    const eligible = await service.isEligible(
+      { feedType: "CLAN_MEMBERS", scopeType: "CLAN_TAG", scopeKey: "#AAA111" },
+      15 * 60 * 1000,
+      new Date("2026-03-19T10:00:00.000Z"),
+    );
+    expect(eligible).toBe(false);
+  });
+
+  it("persists success metadata with row counts and hash", async () => {
+    prismaMock.fwaFeedSyncState.upsert.mockResolvedValue(undefined);
+    const service = new FwaFeedSyncStateService();
+    await service.recordSuccess({
+      feedType: "WAR_MEMBERS",
+      scopeType: "GLOBAL",
+      scopeKey: "SWEEP",
+      rowCount: 20,
+      changedRowCount: 5,
+      contentHash: "abc123",
+      status: "SUCCESS",
+      nextEligibleAt: new Date("2026-03-19T10:15:00.000Z"),
+    });
+    expect(prismaMock.fwaFeedSyncState.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({
+          lastRowCount: 20,
+          lastChangedRowCount: 5,
+          lastContentHash: "abc123",
+          lastStatus: "SUCCESS",
+        }),
+      }),
+    );
+  });
+});

--- a/tests/fwaFeed.watchService.test.ts
+++ b/tests/fwaFeed.watchService.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const prismaMock = vi.hoisted(() => ({
+  trackedClan: {
+    findMany: vi.fn(),
+  },
+  trackedMessage: {
+    findMany: vi.fn(),
+  },
+  fwaClanWarsWatchState: {
+    findMany: vi.fn(),
+    upsert: vi.fn(),
+    update: vi.fn(),
+  },
+  fwaClanWarLogCurrent: {
+    findFirst: vi.fn(),
+  },
+}));
+
+vi.mock("../src/prisma", () => ({
+  prisma: prismaMock,
+}));
+
+import { FwaClanWarsWatchService } from "../src/services/fwa-feeds/FwaClanWarsWatchService";
+
+function buildSyncMetadata(params: {
+  syncEpochSeconds: number;
+  clanTags: string[];
+}) {
+  return {
+    syncTimeIso: new Date(params.syncEpochSeconds * 1000).toISOString(),
+    syncEpochSeconds: params.syncEpochSeconds,
+    roleId: "role-1",
+    clans: params.clanTags.map((tag) => ({
+      clanTag: tag,
+      clanName: tag,
+      emojiId: null,
+      emojiName: null,
+      emojiInline: `:${tag}:`,
+    })),
+    reminderSentAt: null,
+  };
+}
+
+describe("FwaClanWarsWatchService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("polls only tracked clans with active watch windows", async () => {
+    const now = new Date("2026-03-19T11:57:00.000Z");
+    const syncEpoch = Math.floor(new Date("2026-03-19T12:00:00.000Z").getTime() / 1000);
+    prismaMock.trackedClan.findMany.mockResolvedValue([{ tag: "#AAA111" }, { tag: "#BBB222" }]);
+    prismaMock.trackedMessage.findMany.mockResolvedValue([
+      {
+        messageId: "sync-msg-1",
+        metadata: buildSyncMetadata({
+          syncEpochSeconds: syncEpoch,
+          clanTags: ["#AAA111", "#BBB222"],
+        }),
+      },
+    ]);
+    prismaMock.fwaClanWarsWatchState.findMany
+      .mockResolvedValueOnce([
+        {
+          clanTag: "#BBB222",
+          pollingActive: false,
+          currentWarCycleKey: "#BBB222:2026-03-19T12:00:00.000Z",
+          stopReason: "update_acquired",
+          lastObservedContentHash: "hash-b",
+        },
+      ])
+      .mockResolvedValueOnce([
+        {
+          clanTag: "#AAA111",
+          pollingActive: true,
+          currentWarCycleKey: "#AAA111:2026-03-19T12:00:00.000Z",
+          stopReason: null,
+          lastObservedContentHash: "oldhash",
+        },
+      ]);
+    prismaMock.fwaClanWarLogCurrent.findFirst.mockResolvedValue({ endTime: new Date("2026-03-19T10:00:00.000Z") });
+
+    const clanWarsSync = {
+      syncClan: vi.fn().mockResolvedValue({
+        rowCount: 3,
+        changedRowCount: 3,
+        contentHash: "oldhash",
+        status: "SUCCESS",
+      }),
+    } as any;
+    const service = new FwaClanWarsWatchService(clanWarsSync);
+
+    const result = await service.runWatchTick({ now, concurrency: 2 });
+
+    expect(clanWarsSync.syncClan).toHaveBeenCalledTimes(1);
+    expect(clanWarsSync.syncClan).toHaveBeenCalledWith("#AAA111", expect.any(Object));
+    expect(result.trackedClanCount).toBe(2);
+    expect(result.activeClanCount).toBe(1);
+    expect(result.polledClanCount).toBe(1);
+  });
+
+  it("stops polling once update is acquired (content hash changed)", async () => {
+    const now = new Date("2026-03-19T11:57:00.000Z");
+    const syncEpoch = Math.floor(new Date("2026-03-19T12:00:00.000Z").getTime() / 1000);
+    prismaMock.trackedClan.findMany.mockResolvedValue([{ tag: "#AAA111" }]);
+    prismaMock.trackedMessage.findMany.mockResolvedValue([
+      {
+        messageId: "sync-msg-1",
+        metadata: buildSyncMetadata({
+          syncEpochSeconds: syncEpoch,
+          clanTags: ["#AAA111"],
+        }),
+      },
+    ]);
+    prismaMock.fwaClanWarsWatchState.findMany
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          clanTag: "#AAA111",
+          pollingActive: true,
+          currentWarCycleKey: "#AAA111:2026-03-19T12:00:00.000Z",
+          stopReason: null,
+          lastObservedContentHash: "oldhash",
+        },
+      ]);
+    prismaMock.fwaClanWarLogCurrent.findFirst.mockResolvedValue({ endTime: new Date("2026-03-19T10:00:00.000Z") });
+
+    const clanWarsSync = {
+      syncClan: vi.fn().mockResolvedValue({
+        rowCount: 3,
+        changedRowCount: 3,
+        contentHash: "newhash",
+        status: "SUCCESS",
+      }),
+    } as any;
+    const service = new FwaClanWarsWatchService(clanWarsSync);
+
+    const result = await service.runWatchTick({ now, concurrency: 1 });
+
+    expect(result.updateAcquiredCount).toBe(1);
+    expect(prismaMock.fwaClanWarsWatchState.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { clanTag: "#AAA111" },
+        data: expect.objectContaining({
+          pollingActive: false,
+          stopReason: "update_acquired",
+        }),
+      }),
+    );
+  });
+});

--- a/tests/fwaStats.service.test.ts
+++ b/tests/fwaStats.service.test.ts
@@ -1,33 +1,19 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import axios from "axios";
 import { FwaStatsService } from "../src/services/FwaStatsService";
 
-vi.mock("axios", () => ({
-  default: {
-    get: vi.fn(),
-  },
-}));
-
-type AxiosMock = {
-  get: ReturnType<typeof vi.fn>;
-};
-
 describe("FwaStatsService", () => {
-  const mockedAxios = axios as unknown as AxiosMock;
+  const fetchClanWars = vi.fn();
 
   beforeEach(() => {
-    mockedAxios.get.mockReset();
+    fetchClanWars.mockReset();
   });
 
   it("returns true when opponent is present in active wars", async () => {
-    mockedAxios.get.mockResolvedValue({
-      status: 200,
-      data: [
+    fetchClanWars.mockResolvedValue([
         { opponentTag: "#ABC123", matched: true, synced: true },
         { opponentTag: "#ZZZ999", matched: true, synced: false },
-      ],
-    });
-    const service = new FwaStatsService();
+      ]);
+    const service = new FwaStatsService({ fetchClanWars } as any);
 
     const result = await service.isOpponentInActiveWars("#TAG1", "#ABC123");
 
@@ -35,11 +21,8 @@ describe("FwaStatsService", () => {
   });
 
   it("ignores rows explicitly not matched and not synced", async () => {
-    mockedAxios.get.mockResolvedValue({
-      status: 200,
-      data: [{ opponentTag: "#ABC123", matched: false, synced: false }],
-    });
-    const service = new FwaStatsService();
+    fetchClanWars.mockResolvedValue([{ opponentTag: "#ABC123", matched: false, synced: false }]);
+    const service = new FwaStatsService({ fetchClanWars } as any);
 
     const result = await service.isOpponentInActiveWars("#TAG1", "#ABC123");
 
@@ -47,26 +30,20 @@ describe("FwaStatsService", () => {
   });
 
   it("uses cached response within ttl", async () => {
-    mockedAxios.get.mockResolvedValue({
-      status: 200,
-      data: [{ opponentTag: "#ABC123", matched: true, synced: true }],
-    });
-    const service = new FwaStatsService();
+    fetchClanWars.mockResolvedValue([{ opponentTag: "#ABC123", matched: true, synced: true }]);
+    const service = new FwaStatsService({ fetchClanWars } as any);
 
     const first = await service.isOpponentInActiveWars("#TAG1", "#ABC123");
     const second = await service.isOpponentInActiveWars("#TAG1", "#ABC123");
 
     expect(first).toBe(true);
     expect(second).toBe(true);
-    expect(mockedAxios.get).toHaveBeenCalledTimes(1);
+    expect(fetchClanWars).toHaveBeenCalledTimes(1);
   });
 
   it("returns null when fwastats request fails", async () => {
-    mockedAxios.get.mockResolvedValue({
-      status: 500,
-      data: [],
-    });
-    const service = new FwaStatsService();
+    fetchClanWars.mockRejectedValue(new Error("boom"));
+    const service = new FwaStatsService({ fetchClanWars } as any);
 
     const result = await service.isOpponentInActiveWars("#TAG1", "#ABC123");
 


### PR DESCRIPTION
- add Prisma models/enums for feed catalog, current snapshots, sync state, watch state, and sweep cursor
- add unified FwaStats client with typed parsing, normalization helpers, retry/timeout controls, and content hashing
- implement idempotent sync services for clans, tracked clan members, war members sweep, and clan wars refresh
- implement persistent tracked-clan wars watch windows tied to sync-time metadata with update-acquired stop logic
- add bounded scheduler wiring, env-configurable cadence/chunking/concurrency controls, and manual sync/status script entrypoints
- update docs and tests for parsing, sync-state behavior, sweep chunking, and tracked watch lifecycle