### PR TITLE
fix(fwa-feeds): enforce non-null sync-state scope identities

### DIFF
--- a/prisma/migrations/20260319132000_fix_fwafeed_syncstate_scopekey_identity/migration.sql
+++ b/prisma/migrations/20260319132000_fix_fwafeed_syncstate_scopekey_identity/migration.sql
@@ -1,0 +1,59 @@
+-- Remove legacy NULL-scope rows that are superseded by existing resolved keys.
+DELETE FROM "FwaFeedSyncState" AS legacy
+USING "FwaFeedSyncState" AS resolved
+WHERE legacy."scopeKey" IS NULL
+  AND legacy."scopeType" = 'GLOBAL'
+  AND resolved."feedType" = legacy."feedType"
+  AND resolved."scopeType" = legacy."scopeType"
+  AND resolved."scopeKey" = '__global__';
+
+DELETE FROM "FwaFeedSyncState" AS legacy
+USING "FwaFeedSyncState" AS resolved
+WHERE legacy."scopeKey" IS NULL
+  AND legacy."scopeType" = 'TRACKED_CLANS'
+  AND resolved."feedType" = legacy."feedType"
+  AND resolved."scopeType" = legacy."scopeType"
+  AND resolved."scopeKey" = '__tracked_clans__';
+
+-- Collapse duplicate NULL identities before mapping to deterministic scope keys.
+WITH ranked AS (
+  SELECT
+    "id",
+    ROW_NUMBER() OVER (
+      PARTITION BY "feedType", "scopeType"
+      ORDER BY "updatedAt" DESC, "createdAt" DESC, "id" DESC
+    ) AS rn
+  FROM "FwaFeedSyncState"
+  WHERE "scopeKey" IS NULL
+    AND "scopeType" IN ('GLOBAL', 'TRACKED_CLANS')
+)
+DELETE FROM "FwaFeedSyncState" AS row
+USING ranked
+WHERE row."id" = ranked."id"
+  AND ranked.rn > 1;
+
+-- Backfill deterministic non-null identities.
+UPDATE "FwaFeedSyncState"
+SET "scopeKey" = '__global__'
+WHERE "scopeKey" IS NULL
+  AND "scopeType" = 'GLOBAL';
+
+UPDATE "FwaFeedSyncState"
+SET "scopeKey" = '__tracked_clans__'
+WHERE "scopeKey" IS NULL
+  AND "scopeType" = 'TRACKED_CLANS';
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM "FwaFeedSyncState"
+    WHERE "scopeKey" IS NULL
+  ) THEN
+    RAISE EXCEPTION 'FwaFeedSyncState.scopeKey migration failed: unresolved NULL scopeKey rows remain';
+  END IF;
+END $$;
+
+ALTER TABLE "FwaFeedSyncState"
+ALTER COLUMN "scopeKey" SET NOT NULL;
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -651,7 +651,7 @@ model FwaFeedSyncState {
   id                  String            @id @default(cuid())
   feedType            FwaFeedType
   scopeType           FwaFeedScopeType
-  scopeKey            String?
+  scopeKey            String
   lastAttemptAt       DateTime?
   lastSuccessAt       DateTime?
   lastStatus          FwaFeedSyncStatus @default(IDLE)

--- a/src/services/fwa-feeds/FwaFeedSyncStateService.ts
+++ b/src/services/fwa-feeds/FwaFeedSyncStateService.ts
@@ -1,5 +1,6 @@
 import type { FwaFeedScopeType, FwaFeedSyncStatus, FwaFeedType } from "@prisma/client";
 import { prisma } from "../../prisma";
+import { resolveFwaFeedScopeKey } from "./scopeKey";
 
 type SyncScope = {
   feedType: FwaFeedType;
@@ -27,12 +28,20 @@ export class FwaFeedSyncStateService {
     return prisma.fwaFeedSyncState as any;
   }
 
+  private resolveScope(scope: SyncScope): SyncScope & { scopeKey: string } {
+    return {
+      ...scope,
+      scopeKey: resolveFwaFeedScopeKey(scope),
+    };
+  }
+
   private buildCompoundScopeWhere(scope: SyncScope) {
+    const resolved = this.resolveScope(scope);
     return {
       feedType_scopeType_scopeKey: {
-        feedType: scope.feedType,
-        scopeType: scope.scopeType,
-        scopeKey: scope.scopeKey,
+        feedType: resolved.feedType,
+        scopeType: resolved.scopeType,
+        scopeKey: resolved.scopeKey,
       },
     };
   }
@@ -40,17 +49,18 @@ export class FwaFeedSyncStateService {
   /** Purpose: load current sync-state metadata row for one feed/scope identity. */
   async getState(scope: SyncScope) {
     const delegate = this.getDelegate();
+    const resolved = this.resolveScope(scope);
     if (typeof delegate.findFirst === "function") {
       return delegate.findFirst({
         where: {
-          feedType: scope.feedType,
-          scopeType: scope.scopeType,
-          scopeKey: scope.scopeKey,
+          feedType: resolved.feedType,
+          scopeType: resolved.scopeType,
+          scopeKey: resolved.scopeKey,
         },
       });
     }
     return delegate.findUnique({
-      where: this.buildCompoundScopeWhere(scope),
+      where: this.buildCompoundScopeWhere(resolved),
     });
   }
 
@@ -72,12 +82,13 @@ export class FwaFeedSyncStateService {
   /** Purpose: persist sync-attempt timestamps before fetch/parse work starts. */
   async recordAttempt(scope: SyncScope, nextEligibleAt: Date | null, now: Date = new Date()): Promise<void> {
     const delegate = this.getDelegate();
+    const resolved = this.resolveScope(scope);
     await delegate.upsert({
-      where: this.buildCompoundScopeWhere(scope),
+      where: this.buildCompoundScopeWhere(resolved),
       create: {
-        feedType: scope.feedType,
-        scopeType: scope.scopeType,
-        scopeKey: scope.scopeKey,
+        feedType: resolved.feedType,
+        scopeType: resolved.scopeType,
+        scopeKey: resolved.scopeKey,
         lastAttemptAt: now,
         nextEligibleAt,
       },
@@ -91,12 +102,13 @@ export class FwaFeedSyncStateService {
   /** Purpose: persist successful sync metadata including content hash and row counts. */
   async recordSuccess(params: RecordSuccessParams, now: Date = new Date()): Promise<void> {
     const delegate = this.getDelegate();
+    const resolved = this.resolveScope(params);
     await delegate.upsert({
-      where: this.buildCompoundScopeWhere(params),
+      where: this.buildCompoundScopeWhere(resolved),
       create: {
-        feedType: params.feedType,
-        scopeType: params.scopeType,
-        scopeKey: params.scopeKey,
+        feedType: resolved.feedType,
+        scopeType: resolved.scopeType,
+        scopeKey: resolved.scopeKey,
         lastAttemptAt: now,
         lastSuccessAt: now,
         lastStatus: params.status,
@@ -124,12 +136,13 @@ export class FwaFeedSyncStateService {
   /** Purpose: persist failed sync metadata and concise error diagnostics for one scope. */
   async recordFailure(params: RecordFailureParams, now: Date = new Date()): Promise<void> {
     const delegate = this.getDelegate();
+    const resolved = this.resolveScope(params);
     await delegate.upsert({
-      where: this.buildCompoundScopeWhere(params),
+      where: this.buildCompoundScopeWhere(resolved),
       create: {
-        feedType: params.feedType,
-        scopeType: params.scopeType,
-        scopeKey: params.scopeKey,
+        feedType: resolved.feedType,
+        scopeType: resolved.scopeType,
+        scopeKey: resolved.scopeKey,
         lastAttemptAt: now,
         lastStatus: "FAILURE",
         lastErrorCode: params.errorCode,

--- a/src/services/fwa-feeds/scopeKey.ts
+++ b/src/services/fwa-feeds/scopeKey.ts
@@ -1,0 +1,27 @@
+import type { FwaFeedScopeType } from "@prisma/client";
+import { normalizeFwaTag } from "./normalize";
+
+export const FWA_FEED_SCOPE_KEY_GLOBAL = "__global__";
+export const FWA_FEED_SCOPE_KEY_TRACKED_CLANS = "__tracked_clans__";
+
+type ScopeKeyInput = {
+  scopeType: FwaFeedScopeType;
+  scopeKey: string | null;
+};
+
+/** Purpose: resolve a deterministic non-null scope identity key for feed-sync state rows. */
+export function resolveFwaFeedScopeKey(input: ScopeKeyInput): string {
+  if (input.scopeType === "GLOBAL") {
+    return FWA_FEED_SCOPE_KEY_GLOBAL;
+  }
+  if (input.scopeType === "TRACKED_CLANS") {
+    return FWA_FEED_SCOPE_KEY_TRACKED_CLANS;
+  }
+
+  const normalized = normalizeFwaTag(input.scopeKey);
+  if (!normalized) {
+    throw new Error("scopeKey is required when scopeType is CLAN_TAG");
+  }
+  return normalized;
+}
+

--- a/tests/fwaFeed.syncState.service.test.ts
+++ b/tests/fwaFeed.syncState.service.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { FwaFeedSyncStateService } from "../src/services/fwa-feeds/FwaFeedSyncStateService";
+import {
+  FWA_FEED_SCOPE_KEY_GLOBAL,
+  FWA_FEED_SCOPE_KEY_TRACKED_CLANS,
+} from "../src/services/fwa-feeds/scopeKey";
 
 const prismaMock = vi.hoisted(() => ({
   fwaFeedSyncState: {
@@ -26,6 +30,15 @@ describe("FwaFeedSyncStateService", () => {
       new Date("2026-03-19T10:00:00.000Z"),
     );
     expect(eligible).toBe(true);
+    expect(prismaMock.fwaFeedSyncState.findUnique).toHaveBeenCalledWith({
+      where: {
+        feedType_scopeType_scopeKey: {
+          feedType: "CLANS",
+          scopeType: "GLOBAL",
+          scopeKey: FWA_FEED_SCOPE_KEY_GLOBAL,
+        },
+      },
+    });
   });
 
   it("blocks runs before nextEligibleAt", async () => {
@@ -63,7 +76,107 @@ describe("FwaFeedSyncStateService", () => {
           lastContentHash: "abc123",
           lastStatus: "SUCCESS",
         }),
+        where: {
+          feedType_scopeType_scopeKey: {
+            feedType: "WAR_MEMBERS",
+            scopeType: "GLOBAL",
+            scopeKey: FWA_FEED_SCOPE_KEY_GLOBAL,
+          },
+        },
       }),
     );
+  });
+
+  it("TRACKED_CLANS upsert resolves to sentinel scopeKey", async () => {
+    prismaMock.fwaFeedSyncState.upsert.mockResolvedValue(undefined);
+    const service = new FwaFeedSyncStateService();
+
+    await service.recordAttempt(
+      {
+        feedType: "CLAN_MEMBERS",
+        scopeType: "TRACKED_CLANS",
+        scopeKey: null,
+      },
+      new Date("2026-03-19T10:15:00.000Z"),
+      new Date("2026-03-19T10:00:00.000Z"),
+    );
+
+    expect(prismaMock.fwaFeedSyncState.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          feedType_scopeType_scopeKey: {
+            feedType: "CLAN_MEMBERS",
+            scopeType: "TRACKED_CLANS",
+            scopeKey: FWA_FEED_SCOPE_KEY_TRACKED_CLANS,
+          },
+        },
+        create: expect.objectContaining({
+          scopeKey: FWA_FEED_SCOPE_KEY_TRACKED_CLANS,
+        }),
+      }),
+    );
+  });
+
+  it("CLAN_TAG upsert resolves to normalized clan tag scopeKey", async () => {
+    prismaMock.fwaFeedSyncState.upsert.mockResolvedValue(undefined);
+    const service = new FwaFeedSyncStateService();
+
+    await service.recordAttempt(
+      {
+        feedType: "CLAN_WARS",
+        scopeType: "CLAN_TAG",
+        scopeKey: " aaa111 ",
+      },
+      new Date("2026-03-19T10:15:00.000Z"),
+      new Date("2026-03-19T10:00:00.000Z"),
+    );
+
+    expect(prismaMock.fwaFeedSyncState.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          feedType_scopeType_scopeKey: {
+            feedType: "CLAN_WARS",
+            scopeType: "CLAN_TAG",
+            scopeKey: "#AAA111",
+          },
+        },
+        create: expect.objectContaining({
+          scopeKey: "#AAA111",
+        }),
+      }),
+    );
+  });
+
+  it("throws when CLAN_TAG scopeKey is missing", async () => {
+    const service = new FwaFeedSyncStateService();
+    await expect(
+      service.recordAttempt(
+        {
+          feedType: "CLAN_WARS",
+          scopeType: "CLAN_TAG",
+          scopeKey: null,
+        },
+        new Date("2026-03-19T10:15:00.000Z"),
+      ),
+    ).rejects.toThrow("scopeKey is required when scopeType is CLAN_TAG");
+    expect(prismaMock.fwaFeedSyncState.upsert).not.toHaveBeenCalled();
+  });
+
+  it("never writes null scopeKey in any upsert payload", async () => {
+    prismaMock.fwaFeedSyncState.upsert.mockResolvedValue(undefined);
+    const service = new FwaFeedSyncStateService();
+
+    await service.recordFailure({
+      feedType: "CLAN_MEMBERS",
+      scopeType: "TRACKED_CLANS",
+      scopeKey: null,
+      errorCode: "ERR",
+      errorSummary: "failed",
+      nextEligibleAt: null,
+    });
+
+    const upsertArg = prismaMock.fwaFeedSyncState.upsert.mock.calls.at(-1)?.[0];
+    expect(upsertArg.create.scopeKey).not.toBeNull();
+    expect(upsertArg.where.feedType_scopeType_scopeKey.scopeKey).not.toBeNull();
   });
 });


### PR DESCRIPTION
- add shared scope-key resolver for GLOBAL, TRACKED_CLANS, and CLAN_TAG scopes
- route all FwaFeedSyncState read/write upserts through resolved non-null scope keys
- make FwaFeedSyncState.scopeKey required and add migration to backfill null identities
- add sync-state tests for global/tracked/clan upserts, missing CLAN_TAG errors, and null-write prevention