### PR TITLE
refactor(fwa): suppress steady-state poll info log spam

### DIFF
--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -18,6 +18,10 @@ import { Command } from "../Command";
 import { truncateDiscordContent } from "../helper/discordContent";
 import { recordFetchEvent } from "../helper/fetchTelemetry";
 import { formatError } from "../helper/formatError";
+import {
+  resolveSteadyStateLogLevel,
+  SteadyStateLogGate,
+} from "../helper/steadyStateLogGate";
 import { prisma } from "../prisma";
 import { CoCService } from "../services/CoCService";
 import { listPlayerLinksForClanMembers } from "../services/PlayerLinkService";
@@ -83,6 +87,7 @@ import {
 } from "../services/MatchTypeResolutionService";
 import {
   PointsDirectFetchGateService,
+  type PollerPointsFetchDecision,
   type PointsDirectFetchCaller,
   PointsDirectFetchBlockedError,
   isPointsDirectFetchBlockedError,
@@ -700,9 +705,107 @@ function logFwaMatchTelemetry(event: string, detail: string): void {
   console.log(`[telemetry-fwa-match] event=${event} ${detail}`);
 }
 
+type MatchTypeResolutionLogStage = "mail_embed" | "alliance_view" | "single_view";
+
+/** Purpose: build stable match-type log identity for one clan+war+stage. */
+function buildMatchTypeResolutionLogIdentity(params: {
+  stage: MatchTypeResolutionLogStage;
+  clanTag: string;
+  warId: number | null | undefined;
+}): string {
+  const warIdText =
+    params.warId !== null &&
+    params.warId !== undefined &&
+    Number.isFinite(params.warId)
+      ? String(Math.trunc(params.warId))
+      : "unknown";
+  return `matchtype|stage=${params.stage}|clan=${normalizeTag(params.clanTag)}|war=${warIdText}`;
+}
+
+/** Purpose: build match-type state signature used for steady-state info suppression. */
+function buildMatchTypeResolutionLogSignature(params: {
+  source: MatchTypeResolutionSource;
+  matchType: "FWA" | "BL" | "MM" | "SKIP";
+  inferred: boolean;
+  confirmed: boolean;
+}): string {
+  return `source=${params.source}|match_type=${params.matchType}|inferred=${params.inferred ? "1" : "0"}|confirmed=${params.confirmed ? "1" : "0"}`;
+}
+
+/** Purpose: emit info only when match-type state changes for the same clan+war+stage identity. */
+function resolveMatchTypeResolutionLogLevel(params: {
+  stage: MatchTypeResolutionLogStage;
+  clanTag: string;
+  warId: number | null | undefined;
+  source: MatchTypeResolutionSource;
+  matchType: "FWA" | "BL" | "MM" | "SKIP";
+  inferred: boolean;
+  confirmed: boolean;
+}): "info" | "debug" {
+  return resolveSteadyStateLogLevel({
+    gate: fwaMatchTypeResolutionLogGate,
+    identity: buildMatchTypeResolutionLogIdentity({
+      stage: params.stage,
+      clanTag: params.clanTag,
+      warId: params.warId,
+    }),
+    signature: buildMatchTypeResolutionLogSignature({
+      source: params.source,
+      matchType: params.matchType,
+      inferred: params.inferred,
+      confirmed: params.confirmed,
+    }),
+  });
+}
+
+/** Purpose: build stable routine blocked-fetch identity for one guild+clan+fetch reason. */
+function buildRoutineBlockedPointsFetchLogIdentity(params: {
+  guildId: string;
+  clanTag: string;
+  fetchReason: PointsApiFetchReason;
+}): string {
+  return `points_skip|guild=${params.guildId}|clan=${normalizeTag(params.clanTag)}|fetch_reason=${params.fetchReason}`;
+}
+
+/** Purpose: build routine blocked-fetch state signature for steady-state suppression. */
+function buildRoutineBlockedPointsFetchLogSignature(params: {
+  outcome: PollerPointsFetchDecision["outcome"];
+  decisionCode: PollerPointsFetchDecision["decisionCode"];
+}): string {
+  return `outcome=${params.outcome}|code=${params.decisionCode}`;
+}
+
+/** Purpose: emit info only when routine blocked-fetch state changes for one guild+clan reason. */
+function resolveRoutineBlockedPointsFetchSkipLogLevel(params: {
+  guildId: string;
+  clanTag: string;
+  fetchReason: PointsApiFetchReason;
+  outcome: PollerPointsFetchDecision["outcome"];
+  decisionCode: PollerPointsFetchDecision["decisionCode"];
+}): "info" | "debug" {
+  return resolveSteadyStateLogLevel({
+    gate: fwaRoutinePointsSkipLogGate,
+    identity: buildRoutineBlockedPointsFetchLogIdentity({
+      guildId: params.guildId,
+      clanTag: params.clanTag,
+      fetchReason: params.fetchReason,
+    }),
+    signature: buildRoutineBlockedPointsFetchLogSignature({
+      outcome: params.outcome,
+      decisionCode: params.decisionCode,
+    }),
+  });
+}
+
+/** Purpose: clear in-memory steady-state log trackers for deterministic tests. */
+function resetFwaSteadyStateLogTrackers(): void {
+  fwaMatchTypeResolutionLogGate.clear();
+  fwaRoutinePointsSkipLogGate.clear();
+}
+
 /** Purpose: emit structured logs for match-type source/inference/confirmation decisions. */
 function logMatchTypeResolution(params: {
-  stage: "mail_embed" | "alliance_view" | "single_view";
+  stage: MatchTypeResolutionLogStage;
   clanTag: string;
   opponentTag: string | null;
   warId: number | null | undefined;
@@ -718,9 +821,21 @@ function logMatchTypeResolution(params: {
       ? String(Math.trunc(params.warId))
       : "unknown";
   const opponent = normalizeTag(String(params.opponentTag ?? ""));
-  console.info(
-    `[fwa-matchtype] stage=${params.stage} clan=#${normalizeTag(params.clanTag)} opponent=${opponent ? `#${opponent}` : "unknown"} war_id=${warIdText} source=${params.source} match_type=${params.matchType} inferred=${params.inferred ? "1" : "0"} confirmed=${params.confirmed ? "1" : "0"}`,
-  );
+  const line = `[fwa-matchtype] stage=${params.stage} clan=#${normalizeTag(params.clanTag)} opponent=${opponent ? `#${opponent}` : "unknown"} war_id=${warIdText} source=${params.source} match_type=${params.matchType} inferred=${params.inferred ? "1" : "0"} confirmed=${params.confirmed ? "1" : "0"}`;
+  const logLevel = resolveMatchTypeResolutionLogLevel({
+    stage: params.stage,
+    clanTag: params.clanTag,
+    warId: params.warId,
+    source: params.source,
+    matchType: params.matchType,
+    inferred: params.inferred,
+    confirmed: params.confirmed,
+  });
+  if (logLevel === "info") {
+    console.info(line);
+    return;
+  }
+  console.debug(line);
 }
 
 type MatchView = {
@@ -814,6 +929,8 @@ const fwaComplianceViewPayloads = new Map<string, FwaComplianceViewPayload>();
 const fwaMailPollers = new Map<string, ReturnType<typeof setInterval>>();
 const pointsSnapshotCache = new Map<string, PointsSnapshotCacheEntry>();
 const pointsSnapshotInFlight = new Map<string, Promise<PointsSnapshot>>();
+const fwaMatchTypeResolutionLogGate = new SteadyStateLogGate();
+const fwaRoutinePointsSkipLogGate = new SteadyStateLogGate();
 
 /** Purpose: normalize any war id input to a comparable string key. */
 function normalizeWarIdText(
@@ -1943,9 +2060,19 @@ async function buildWarMailEmbedForTag(
     routineDecision.fetchReason ??
     (options?.routine ? "mail_refresh" : "mail_preview");
   if (options?.routine && !routineDecision.allowed) {
-    console.info(
-      `[fwa-mail] points fetch skipped guild=${guildId} clan=#${normalizedTag} outcome=${routineDecision.outcome} code=${routineDecision.decisionCode} reason=${routineDecision.reason}`,
-    );
+    const line = `[fwa-mail] points fetch skipped guild=${guildId} clan=#${normalizedTag} outcome=${routineDecision.outcome} code=${routineDecision.decisionCode} reason=${routineDecision.reason}`;
+    const logLevel = resolveRoutineBlockedPointsFetchSkipLogLevel({
+      guildId,
+      clanTag: normalizedTag,
+      fetchReason,
+      outcome: routineDecision.outcome,
+      decisionCode: routineDecision.decisionCode,
+    });
+    if (logLevel === "info") {
+      console.info(line);
+    } else {
+      console.debug(line);
+    }
   }
 
   let primaryBalance: number | null = null;
@@ -6426,6 +6553,12 @@ export const hasSameWarExplicitFwaConfirmationForTest =
   hasSameWarExplicitFwaConfirmation;
 export const applyExplicitOpponentNotFoundFallbackGuardForTest =
   applyExplicitOpponentNotFoundFallbackGuard;
+export const resolveMatchTypeResolutionLogLevelForTest =
+  resolveMatchTypeResolutionLogLevel;
+export const resolveRoutineBlockedPointsFetchSkipLogLevelForTest =
+  resolveRoutineBlockedPointsFetchSkipLogLevel;
+export const resetFwaSteadyStateLogTrackersForTest =
+  resetFwaSteadyStateLogTrackers;
 
 /** Purpose: infer match type strictly from opponent points-site signals. */
 function inferMatchTypeFromPointsSnapshots(

--- a/src/helper/steadyStateLogGate.ts
+++ b/src/helper/steadyStateLogGate.ts
@@ -1,0 +1,45 @@
+export type SteadyStateLogLevel = "info" | "debug";
+
+/** Purpose: track last-emitted signatures and suppress repeated steady-state info logs. */
+export class SteadyStateLogGate {
+  private readonly lastSignatureByIdentity = new Map<string, string>();
+
+  /** Purpose: initialize bounded in-memory signature storage for logging-only dedupe. */
+  constructor(private readonly maxIdentities: number = 2000) {}
+
+  /** Purpose: return true when the identity's signature is new or changed since last emit. */
+  shouldEmitInfo(identity: string, signature: string): boolean {
+    const normalizedIdentity = identity.trim();
+    const normalizedSignature = signature.trim();
+    const previous = this.lastSignatureByIdentity.get(normalizedIdentity);
+    if (previous === normalizedSignature) return false;
+    this.lastSignatureByIdentity.set(normalizedIdentity, normalizedSignature);
+    this.pruneOverflow();
+    return true;
+  }
+
+  /** Purpose: clear tracked signatures for deterministic tests or lifecycle resets. */
+  clear(): void {
+    this.lastSignatureByIdentity.clear();
+  }
+
+  /** Purpose: evict oldest identities to keep log-only dedupe memory bounded. */
+  private pruneOverflow(): void {
+    while (this.lastSignatureByIdentity.size > this.maxIdentities) {
+      const oldestKey = this.lastSignatureByIdentity.keys().next().value;
+      if (typeof oldestKey !== "string") break;
+      this.lastSignatureByIdentity.delete(oldestKey);
+    }
+  }
+}
+
+/** Purpose: classify steady-state logs into info for changes and debug for repeats. */
+export function resolveSteadyStateLogLevel(params: {
+  gate: SteadyStateLogGate;
+  identity: string;
+  signature: string;
+}): SteadyStateLogLevel {
+  return params.gate.shouldEmitInfo(params.identity, params.signature)
+    ? "info"
+    : "debug";
+}

--- a/src/services/WarMailLifecycleService.ts
+++ b/src/services/WarMailLifecycleService.ts
@@ -165,19 +165,29 @@ export class WarMailLifecycleService {
   /** Purpose: persist lifecycle status=POSTED for one clan and one war. */
   async markPosted(input: UpsertPostedLifecycleInput): Promise<void> {
     const clanTag = normalizeTag(input.clanTag);
+    const warId = Math.trunc(input.warId);
     const postedAt = input.postedAt ?? new Date();
+    const existing = await prisma.warMailLifecycle.findUnique({
+      where: {
+        guildId_clanTag_warId: {
+          guildId: input.guildId,
+          clanTag,
+          warId,
+        },
+      },
+    });
     await prisma.warMailLifecycle.upsert({
       where: {
         guildId_clanTag_warId: {
           guildId: input.guildId,
           clanTag,
-          warId: Math.trunc(input.warId),
+          warId,
         },
       },
       create: {
         guildId: input.guildId,
         clanTag,
-        warId: Math.trunc(input.warId),
+        warId,
         status: WarMailLifecycleStatus.POSTED,
         channelId: input.channelId,
         messageId: input.messageId,
@@ -192,9 +202,17 @@ export class WarMailLifecycleService {
         deletedAt: null,
       },
     });
-    console.info(
-      `[mail-lifecycle] guild=${input.guildId} clan=${clanTag} war=${Math.trunc(input.warId)} status=POSTED`
-    );
+    const isTransitionToPosted =
+      !existing || existing.status !== WarMailLifecycleStatus.POSTED;
+    const postedIdentityChanged =
+      existing?.channelId !== input.channelId ||
+      existing?.messageId !== input.messageId;
+    const logLine = `[mail-lifecycle] guild=${input.guildId} clan=${clanTag} war=${warId} status=POSTED`;
+    if (isTransitionToPosted || postedIdentityChanged) {
+      console.info(logLine);
+      return;
+    }
+    console.debug(`${logLine} outcome=noop_reasserted`);
   }
 
   /** Purpose: persist lifecycle status=DELETED for one clan and one war. */

--- a/src/services/fwa-feeds/FwaFeedSchedulerService.ts
+++ b/src/services/fwa-feeds/FwaFeedSchedulerService.ts
@@ -1,5 +1,6 @@
 import { recordFetchEvent, runFetchTelemetryBatch } from "../../helper/fetchTelemetry";
 import { formatError } from "../../helper/formatError";
+import { SteadyStateLogGate } from "../../helper/steadyStateLogGate";
 import { FwaClansCatalogSyncService } from "./FwaClansCatalogSyncService";
 import { FwaClanMembersSyncService } from "./FwaClanMembersSyncService";
 import { FwaWarMembersSyncService } from "./FwaWarMembersSyncService";
@@ -23,6 +24,13 @@ type SchedulerConfig = {
   jitterMs: number;
 };
 
+type TrackedClanWarsWatchSummary = {
+  trackedClanCount: number;
+  activeClanCount: number;
+  polledClanCount: number;
+  updateAcquiredCount: number;
+};
+
 function toBool(input: string | undefined, fallback: boolean): boolean {
   if (input === undefined) return fallback;
   const normalized = input.trim().toLowerCase();
@@ -40,6 +48,36 @@ function minutesToMsWithMin(valueMinutes: number, minMinutes: number): number {
   return Math.max(minMinutes, valueMinutes) * 60 * 1000;
 }
 
+/** Purpose: serialize tracked-clan watch summary into a deterministic comparison key. */
+function buildTrackedClanWarsWatchSummaryKey(summary: TrackedClanWarsWatchSummary): string {
+  return `tracked=${summary.trackedClanCount}|active=${summary.activeClanCount}|polled=${summary.polledClanCount}|acquired=${summary.updateAcquiredCount}`;
+}
+
+/** Purpose: flag whether a tracked-clan watch summary represents actual polling work. */
+function hasTrackedClanWarsWatchActivity(summary: TrackedClanWarsWatchSummary): boolean {
+  return (
+    summary.activeClanCount > 0 ||
+    summary.polledClanCount > 0 ||
+    summary.updateAcquiredCount > 0
+  );
+}
+
+/** Purpose: keep watch summaries at info for work/changes, and demote repeated no-op states to debug. */
+function resolveTrackedClanWarsWatchSummaryLogLevel(params: {
+  summary: TrackedClanWarsWatchSummary;
+  summaryChanged: boolean;
+}): "info" | "debug" {
+  if (hasTrackedClanWarsWatchActivity(params.summary) || params.summaryChanged) {
+    return "info";
+  }
+  return "debug";
+}
+
+export const buildTrackedClanWarsWatchSummaryKeyForTest =
+  buildTrackedClanWarsWatchSummaryKey;
+export const resolveTrackedClanWarsWatchSummaryLogLevelForTest =
+  resolveTrackedClanWarsWatchSummaryLogLevel;
+
 /** Purpose: orchestrate bounded fwastats feed scheduler jobs with explicit cadence and cost controls. */
 export class FwaFeedSchedulerService {
   private readonly config: SchedulerConfig;
@@ -55,6 +93,7 @@ export class FwaFeedSchedulerService {
   private warMembersInProgress = false;
   private watchInProgress = false;
   private globalWarsInProgress = false;
+  private readonly trackedClanWarsWatchSummaryLogGate = new SteadyStateLogGate();
 
   /** Purpose: initialize scheduler config from env with safe minimum intervals and bounded defaults. */
   constructor() {
@@ -324,9 +363,20 @@ export class FwaFeedSchedulerService {
           },
           now,
         );
-        console.info(
-          `[fwa-feed] job=tracked_clan_wars_watch tracked=${summary.trackedClanCount} active=${summary.activeClanCount} polled=${summary.polledClanCount} acquired=${summary.updateAcquiredCount} duration_ms=${Date.now() - startedAt}`,
+        const summaryChanged = this.trackedClanWarsWatchSummaryLogGate.shouldEmitInfo(
+          "tracked_clan_wars_watch",
+          buildTrackedClanWarsWatchSummaryKey(summary),
         );
+        const logLevel = resolveTrackedClanWarsWatchSummaryLogLevel({
+          summary,
+          summaryChanged,
+        });
+        const line = `[fwa-feed] job=tracked_clan_wars_watch tracked=${summary.trackedClanCount} active=${summary.activeClanCount} polled=${summary.polledClanCount} acquired=${summary.updateAcquiredCount} duration_ms=${Date.now() - startedAt}`;
+        if (logLevel === "info") {
+          console.info(line);
+        } else {
+          console.debug(line);
+        }
       });
     } catch (error) {
       await this.syncState.recordFailure(

--- a/tests/fwaSteadyStateLogs.logic.test.ts
+++ b/tests/fwaSteadyStateLogs.logic.test.ts
@@ -1,0 +1,186 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  resetFwaSteadyStateLogTrackersForTest,
+  resolveMatchTypeResolutionLogLevelForTest,
+  resolveRoutineBlockedPointsFetchSkipLogLevelForTest,
+} from "../src/commands/Fwa";
+import { SteadyStateLogGate } from "../src/helper/steadyStateLogGate";
+import {
+  buildTrackedClanWarsWatchSummaryKeyForTest,
+  resolveTrackedClanWarsWatchSummaryLogLevelForTest,
+} from "../src/services/fwa-feeds/FwaFeedSchedulerService";
+
+describe("fwa routine points-skip logging policy", () => {
+  beforeEach(() => {
+    resetFwaSteadyStateLogTrackersForTest();
+  });
+
+  it("demotes repeated validated_active_war_locked routine skips to debug", () => {
+    const first = resolveRoutineBlockedPointsFetchSkipLogLevelForTest({
+      guildId: "guild-1",
+      clanTag: "AAA111",
+      fetchReason: "mail_refresh",
+      outcome: "blocked",
+      decisionCode: "validated_active_war_locked",
+    });
+    const second = resolveRoutineBlockedPointsFetchSkipLogLevelForTest({
+      guildId: "guild-1",
+      clanTag: "AAA111",
+      fetchReason: "mail_refresh",
+      outcome: "blocked",
+      decisionCode: "validated_active_war_locked",
+    });
+
+    expect(first).toBe("info");
+    expect(second).toBe("debug");
+  });
+
+  it("keeps changed blocked-state events at info", () => {
+    const first = resolveRoutineBlockedPointsFetchSkipLogLevelForTest({
+      guildId: "guild-1",
+      clanTag: "AAA111",
+      fetchReason: "mail_refresh",
+      outcome: "blocked",
+      decisionCode: "validated_active_war_locked",
+    });
+    const changed = resolveRoutineBlockedPointsFetchSkipLogLevelForTest({
+      guildId: "guild-1",
+      clanTag: "AAA111",
+      fetchReason: "mail_refresh",
+      outcome: "blocked",
+      decisionCode: "policy_blocked",
+    });
+
+    expect(first).toBe("info");
+    expect(changed).toBe("info");
+  });
+});
+
+describe("fwa match-type logging policy", () => {
+  beforeEach(() => {
+    resetFwaSteadyStateLogTrackersForTest();
+  });
+
+  it("demotes repeated identical match-type confirmations to debug", () => {
+    const first = resolveMatchTypeResolutionLogLevelForTest({
+      stage: "mail_embed",
+      clanTag: "AAA111",
+      warId: 1001,
+      source: "confirmed_current_war",
+      matchType: "FWA",
+      inferred: false,
+      confirmed: true,
+    });
+    const second = resolveMatchTypeResolutionLogLevelForTest({
+      stage: "mail_embed",
+      clanTag: "AAA111",
+      warId: 1001,
+      source: "confirmed_current_war",
+      matchType: "FWA",
+      inferred: false,
+      confirmed: true,
+    });
+
+    expect(first).toBe("info");
+    expect(second).toBe("debug");
+  });
+
+  it("logs source/type/flag changes at info", () => {
+    resolveMatchTypeResolutionLogLevelForTest({
+      stage: "mail_embed",
+      clanTag: "AAA111",
+      warId: 1001,
+      source: "confirmed_current_war",
+      matchType: "FWA",
+      inferred: false,
+      confirmed: true,
+    });
+    const changedSource = resolveMatchTypeResolutionLogLevelForTest({
+      stage: "mail_embed",
+      clanTag: "AAA111",
+      warId: 1001,
+      source: "stored_sync",
+      matchType: "FWA",
+      inferred: true,
+      confirmed: false,
+    });
+    const changedType = resolveMatchTypeResolutionLogLevelForTest({
+      stage: "mail_embed",
+      clanTag: "AAA111",
+      warId: 1001,
+      source: "live_points_active_fwa_no",
+      matchType: "BL",
+      inferred: true,
+      confirmed: false,
+    });
+
+    expect(changedSource).toBe("info");
+    expect(changedType).toBe("info");
+  });
+});
+
+describe("tracked clan wars watch summary logging policy", () => {
+  it("keeps repeated empty/no-op watch summaries out of info", () => {
+    const summary = {
+      trackedClanCount: 9,
+      activeClanCount: 0,
+      polledClanCount: 0,
+      updateAcquiredCount: 0,
+    };
+
+    const gate = new SteadyStateLogGate();
+    const firstChanged = gate.shouldEmitInfo(
+      "tracked_clan_wars_watch",
+      buildTrackedClanWarsWatchSummaryKeyForTest(summary),
+    );
+    const secondChanged = gate.shouldEmitInfo(
+      "tracked_clan_wars_watch",
+      buildTrackedClanWarsWatchSummaryKeyForTest(summary),
+    );
+    const secondLevel = resolveTrackedClanWarsWatchSummaryLogLevelForTest({
+      summary,
+      summaryChanged: secondChanged,
+    });
+
+    expect(firstChanged).toBe(true);
+    expect(secondChanged).toBe(false);
+    expect(secondLevel).toBe("debug");
+  });
+
+  it("logs changed or non-empty watch summaries at info", () => {
+    const noOpSummary = {
+      trackedClanCount: 9,
+      activeClanCount: 0,
+      polledClanCount: 0,
+      updateAcquiredCount: 0,
+    };
+    const changedSummary = {
+      trackedClanCount: 9,
+      activeClanCount: 1,
+      polledClanCount: 1,
+      updateAcquiredCount: 0,
+    };
+    const gate = new SteadyStateLogGate();
+    gate.shouldEmitInfo(
+      "tracked_clan_wars_watch",
+      buildTrackedClanWarsWatchSummaryKeyForTest(noOpSummary),
+    );
+    const changed = gate.shouldEmitInfo(
+      "tracked_clan_wars_watch",
+      buildTrackedClanWarsWatchSummaryKeyForTest(changedSummary),
+    );
+
+    const changedLevel = resolveTrackedClanWarsWatchSummaryLogLevelForTest({
+      summary: noOpSummary,
+      summaryChanged: changed,
+    });
+    const nonEmptyLevel = resolveTrackedClanWarsWatchSummaryLogLevelForTest({
+      summary: changedSummary,
+      summaryChanged: false,
+    });
+
+    expect(changed).toBe(true);
+    expect(changedLevel).toBe("info");
+    expect(nonEmptyLevel).toBe("info");
+  });
+});

--- a/tests/warMailLifecycle.service.test.ts
+++ b/tests/warMailLifecycle.service.test.ts
@@ -171,5 +171,88 @@ describe("WarMailLifecycleService", () => {
     expect(result.status).toBe("posted");
     expect(result.debug.reconciliationOutcome).toBe("channel_inaccessible");
   });
+
+  it("logs POSTED at info for first lifecycle transition", async () => {
+    const findSpy = vi.spyOn(prisma.warMailLifecycle, "findUnique").mockResolvedValueOnce(null as never);
+    const upsertSpy = vi.spyOn(prisma.warMailLifecycle, "upsert").mockResolvedValueOnce({} as never);
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
+    const service = new WarMailLifecycleService();
+
+    await service.markPosted({
+      guildId: "guild-1",
+      clanTag: "AAA111",
+      warId: 1001,
+      channelId: "123",
+      messageId: "456",
+    });
+
+    expect(findSpy).toHaveBeenCalledTimes(1);
+    expect(upsertSpy).toHaveBeenCalledTimes(1);
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    expect(String(infoSpy.mock.calls[0]?.[0] ?? "")).toContain("status=POSTED");
+    expect(debugSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not repeat POSTED info for no-op upserts with same message identity", async () => {
+    vi.spyOn(prisma.warMailLifecycle, "findUnique").mockResolvedValueOnce({
+      guildId: "guild-1",
+      clanTag: "#AAA111",
+      warId: 1001,
+      status: "POSTED",
+      channelId: "123",
+      messageId: "456",
+      postedAt: new Date(),
+      deletedAt: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as never);
+    vi.spyOn(prisma.warMailLifecycle, "upsert").mockResolvedValueOnce({} as never);
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
+    const service = new WarMailLifecycleService();
+
+    await service.markPosted({
+      guildId: "guild-1",
+      clanTag: "AAA111",
+      warId: 1001,
+      channelId: "123",
+      messageId: "456",
+    });
+
+    expect(infoSpy).not.toHaveBeenCalled();
+    expect(debugSpy).toHaveBeenCalledTimes(1);
+    expect(String(debugSpy.mock.calls[0]?.[0] ?? "")).toContain("status=POSTED");
+  });
+
+  it("logs POSTED info when posted message identity changes", async () => {
+    vi.spyOn(prisma.warMailLifecycle, "findUnique").mockResolvedValueOnce({
+      guildId: "guild-1",
+      clanTag: "#AAA111",
+      warId: 1001,
+      status: "POSTED",
+      channelId: "123",
+      messageId: "old-message",
+      postedAt: new Date(),
+      deletedAt: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as never);
+    vi.spyOn(prisma.warMailLifecycle, "upsert").mockResolvedValueOnce({} as never);
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
+    const service = new WarMailLifecycleService();
+
+    await service.markPosted({
+      guildId: "guild-1",
+      clanTag: "AAA111",
+      warId: 1001,
+      channelId: "123",
+      messageId: "new-message",
+    });
+
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    expect(debugSpy).not.toHaveBeenCalled();
+  });
 });
 


### PR DESCRIPTION
- add a bounded steady-state log gate helper for info-vs-debug emission
- demote repeated routine mail-refresh skip and match-type confirmation logs
- log mail lifecycle POSTED at info only for true transitions or message identity changes
- demote repeated no-op tracked-clan watch summaries while keeping changed/non-empty summaries at info
- add targeted tests for log-level transitions and no-op suppression