### PR TITLE
feat(emoji): add app-emoji resolver and /emoji browser

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,6 +1,7 @@
 # Commands Reference
 
 - `/help [command:<name>] [visibility:private|public]` - List command docs/examples. Default visibility is private.
+- `/emoji [name:<emoji_name>]` - Resolve one bot application emoji by name, or browse a paginated list of all bot application emojis when `name` is omitted.
 - `/telemetry report [period:24h|7d|30d] [timezone:<ianaTz>]` - Show aggregate telemetry report (usage, latency, failures, API health) for the selected window.
 - `/telemetry schedule set target-channel:<channel> cadence-hours:<n> [timezone:<ianaTz>] [enabled:true|false]` - Configure scheduled telemetry report posting.
 - `/telemetry schedule show` - Show current telemetry schedule config and last posted window.

--- a/src/Commands.ts
+++ b/src/Commands.ts
@@ -1,4 +1,5 @@
 import { Help } from "./commands/Help";
+import { Emoji } from "./commands/Emoji";
 import { LastSeen } from "./commands/LastSeen";
 import { Inactive } from "./commands/Inactive";
 import { RoleUsers } from "./commands/RoleUsers";
@@ -26,6 +27,7 @@ import { Layout } from "./commands/Layout";
 // ...existing code...
 export const Commands = [
   Help,
+  Emoji,
   LastSeen,
   Inactive,
   RoleUsers,

--- a/src/commands/Emoji.ts
+++ b/src/commands/Emoji.ts
@@ -1,0 +1,295 @@
+import {
+  ActionRowBuilder,
+  ApplicationCommandOptionType,
+  ButtonBuilder,
+  ButtonInteraction,
+  ButtonStyle,
+  ChatInputCommandInteraction,
+  Client,
+  ComponentType,
+  EmbedBuilder,
+} from "discord.js";
+import { Command } from "../Command";
+import { formatError } from "../helper/formatError";
+import {
+  emojiResolverService,
+  normalizeEmojiLookupName,
+  type EmojiResolverService,
+  type ResolvedApplicationEmoji,
+} from "../services/emoji/EmojiResolverService";
+import { CoCService } from "../services/CoCService";
+
+type EmojiResolverPort = Pick<
+  EmojiResolverService,
+  "listApplicationEmojis" | "resolveByName"
+>;
+
+const EMOJI_PAGE_SIZE = 20;
+const EMOJI_PAGINATOR_TIMEOUT_MS = 10 * 60 * 1000;
+
+let activeEmojiResolver: EmojiResolverPort = emojiResolverService;
+
+/** Purpose: convert one resolved emoji into compact list-display text. */
+function formatEmojiListLine(emoji: ResolvedApplicationEmoji): string {
+  return `${emoji.rendered} \`${emoji.shortcode}\``;
+}
+
+/** Purpose: split emoji list output into deterministic page chunks for embed display. */
+function paginateEmojiLines(
+  emojis: ResolvedApplicationEmoji[],
+  pageSize: number = EMOJI_PAGE_SIZE,
+): string[] {
+  if (emojis.length === 0) return [];
+  const pages: string[] = [];
+  for (let i = 0; i < emojis.length; i += pageSize) {
+    const slice = emojis.slice(i, i + pageSize);
+    pages.push(slice.map(formatEmojiListLine).join("\n"));
+  }
+  return pages;
+}
+
+/** Purpose: apply previous/next pagination input while keeping page index bounded. */
+function applyEmojiPageAction(params: {
+  action: "prev" | "next";
+  page: number;
+  totalPages: number;
+}): number {
+  if (params.totalPages <= 0) return 0;
+  if (params.action === "prev") return Math.max(0, params.page - 1);
+  return Math.min(params.totalPages - 1, params.page + 1);
+}
+
+/** Purpose: build paginated list embed for current bot application emoji inventory. */
+function buildEmojiListEmbed(params: {
+  emojis: ResolvedApplicationEmoji[];
+  pages: string[];
+  page: number;
+}): EmbedBuilder {
+  if (params.emojis.length === 0) {
+    return new EmbedBuilder()
+      .setTitle("Bot Application Emojis")
+      .setDescription("No application emojis are currently available for this bot.")
+      .setFooter({ text: "Total 0 emojis" })
+      .setColor(0x5865f2);
+  }
+  return new EmbedBuilder()
+    .setTitle("Bot Application Emojis")
+    .setDescription(params.pages[params.page] ?? "")
+    .setFooter({
+      text: `Page ${params.page + 1}/${params.pages.length} • Total ${params.emojis.length} emojis`,
+    })
+    .setColor(0x5865f2);
+}
+
+/** Purpose: build prev/next paginator buttons with proper boundary and timeout disabled states. */
+function buildEmojiListRow(params: {
+  prefix: string;
+  page: number;
+  totalPages: number;
+  forceDisabled?: boolean;
+}): ActionRowBuilder<ButtonBuilder> {
+  const disabled = Boolean(params.forceDisabled);
+  return new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder()
+      .setCustomId(`${params.prefix}:prev`)
+      .setLabel("Previous")
+      .setStyle(ButtonStyle.Secondary)
+      .setDisabled(disabled || params.page <= 0),
+    new ButtonBuilder()
+      .setCustomId(`${params.prefix}:next`)
+      .setLabel("Next")
+      .setStyle(ButtonStyle.Secondary)
+      .setDisabled(disabled || params.page >= params.totalPages - 1),
+  );
+}
+
+/** Purpose: build resolve-mode embed for one shortcode-to-rendered-emoji mapping. */
+function buildEmojiResolveEmbed(emoji: ResolvedApplicationEmoji): EmbedBuilder {
+  return new EmbedBuilder()
+    .setTitle("Emoji Resolved")
+    .setDescription(`${emoji.rendered}  ${emoji.shortcode}`)
+    .addFields({ name: "Raw token", value: `\`${emoji.rendered}\`` })
+    .setColor(0x57f287);
+}
+
+/** Purpose: derive lightweight same-command suggestions for close emoji-name misses. */
+function buildEmojiNameSuggestions(
+  input: string,
+  emojis: ResolvedApplicationEmoji[],
+): string[] {
+  const query = input.toLowerCase();
+  if (!query) return [];
+  return emojis
+    .filter((emoji) => emoji.name.toLowerCase().includes(query))
+    .slice(0, 5)
+    .map((emoji) => emoji.shortcode);
+}
+
+/** Purpose: allow tests to inject a resolver and assert command behavior deterministically. */
+export function setEmojiResolverForTest(resolver: EmojiResolverPort): void {
+  activeEmojiResolver = resolver;
+}
+
+/** Purpose: restore production resolver after test injection. */
+export function resetEmojiResolverForTest(): void {
+  activeEmojiResolver = emojiResolverService;
+}
+
+export const applyEmojiPageActionForTest = applyEmojiPageAction;
+export const paginateEmojiLinesForTest = paginateEmojiLines;
+export const buildEmojiListEmbedForTest = buildEmojiListEmbed;
+export const buildEmojiListRowForTest = buildEmojiListRow;
+export const normalizeEmojiLookupNameInputForTest = normalizeEmojiLookupName;
+
+export const Emoji: Command = {
+  name: "emoji",
+  description: "Resolve and browse bot application emojis",
+  options: [
+    {
+      name: "name",
+      description: "Emoji name or shortcode (for example: arrow_arrow or :arrow_arrow:)",
+      type: ApplicationCommandOptionType.String,
+      required: false,
+    },
+  ],
+  run: async (
+    _client: Client,
+    interaction: ChatInputCommandInteraction,
+    _cocService: CoCService,
+  ) => {
+    await interaction.deferReply({ ephemeral: true });
+    const rawName = interaction.options.getString("name", false);
+    const requestedName = normalizeEmojiLookupName(rawName ?? "");
+
+    try {
+      if (requestedName) {
+        const resolved = await activeEmojiResolver.resolveByName(
+          interaction.client,
+          requestedName,
+        );
+        if (resolved) {
+          await interaction.editReply({
+            embeds: [buildEmojiResolveEmbed(resolved)],
+          });
+          return;
+        }
+
+        const all = await activeEmojiResolver.listApplicationEmojis(
+          interaction.client,
+        );
+        const suggestions = buildEmojiNameSuggestions(requestedName, all);
+        const suggestionText = suggestions.length
+          ? `\nDid you mean: ${suggestions.join(", ")}`
+          : "";
+        await interaction.editReply({
+          content: `No application emoji found for \`:${requestedName}:\`.${suggestionText}`,
+          embeds: [],
+          components: [],
+        });
+        return;
+      }
+
+      const emojis = await activeEmojiResolver.listApplicationEmojis(
+        interaction.client,
+      );
+      const pages = paginateEmojiLines(emojis);
+      let page = 0;
+      const paginatorPrefix = `emoji-list:${interaction.id}`;
+
+      await interaction.editReply({
+        embeds: [
+          buildEmojiListEmbed({
+            emojis,
+            pages,
+            page,
+          }),
+        ],
+        components:
+          pages.length > 1
+            ? [
+                buildEmojiListRow({
+                  prefix: paginatorPrefix,
+                  page,
+                  totalPages: pages.length,
+                }),
+              ]
+            : [],
+      });
+
+      if (pages.length <= 1) return;
+
+      const message = await interaction.fetchReply();
+      const collector = message.createMessageComponentCollector({
+        componentType: ComponentType.Button,
+        time: EMOJI_PAGINATOR_TIMEOUT_MS,
+      });
+
+      collector.on("collect", async (button: ButtonInteraction) => {
+        if (button.user.id !== interaction.user.id) {
+          await button.reply({
+            ephemeral: true,
+            content: "Only the command user can control this paginator.",
+          });
+          return;
+        }
+        if (
+          button.customId !== `${paginatorPrefix}:prev` &&
+          button.customId !== `${paginatorPrefix}:next`
+        ) {
+          return;
+        }
+        page = applyEmojiPageAction({
+          action: button.customId.endsWith(":prev") ? "prev" : "next",
+          page,
+          totalPages: pages.length,
+        });
+        await button.update({
+          embeds: [
+            buildEmojiListEmbed({
+              emojis,
+              pages,
+              page,
+            }),
+          ],
+          components: [
+            buildEmojiListRow({
+              prefix: paginatorPrefix,
+              page,
+              totalPages: pages.length,
+            }),
+          ],
+        });
+      });
+
+      collector.on("end", async () => {
+        await interaction
+          .editReply({
+            embeds: [
+              buildEmojiListEmbed({
+                emojis,
+                pages,
+                page,
+              }),
+            ],
+            components: [
+              buildEmojiListRow({
+                prefix: paginatorPrefix,
+                page,
+                totalPages: pages.length,
+                forceDisabled: true,
+              }),
+            ],
+          })
+          .catch(() => undefined);
+      });
+    } catch (error) {
+      console.error(`[emoji] command failed: ${formatError(error)}`);
+      await interaction.editReply({
+        content:
+          "Could not load bot application emojis right now. Please try again later.",
+        embeds: [],
+        components: [],
+      });
+    }
+  },
+};

--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -64,6 +64,15 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
     ],
     examples: ["/help", "/help command:sheet", "/help visibility:public"],
   },
+  emoji: {
+    summary: "Resolve or browse bot-owned application emojis by shortcode name.",
+    details: [
+      "Use `/emoji name:<emoji_name>` to resolve one emoji and show rendered + raw token output.",
+      "Use `/emoji` with no args to browse a paginated list of all available bot application emojis.",
+      "Emoji resolution is environment-safe by name (application emoji IDs may differ per bot instance).",
+    ],
+    examples: ["/emoji", "/emoji name:arrow_arrow", "/emoji name::arrow_arrow:"],
+  },
   lastseen: {
     summary: "Estimate when a player was last active.",
     details: [

--- a/src/commands/WarPlan.ts
+++ b/src/commands/WarPlan.ts
@@ -19,6 +19,10 @@ import {
   type WarPlanComplianceConfig,
 } from "../services/warPlanComplianceConfig";
 import { WarEventHistoryService } from "../services/war-events/history";
+import {
+  emojiResolverService,
+  type EmojiResolverService,
+} from "../services/emoji/EmojiResolverService";
 
 type PlanMatchType = "FWA" | "BL" | "MM";
 type PlanOutcome = "WIN" | "LOSE" | "ANY";
@@ -105,54 +109,18 @@ function buildComplianceConfigLine(input: {
   return `Compliance gate: nonMirrorTripleMinClanStars=${input.nonMirrorTripleMinClanStars}, allBasesOpenHoursLeft=${input.allBasesOpenHoursLeft}h${applicability}`;
 }
 
-async function resolveCustomEmojiShortcodes(
-  text: string,
-  interaction: ChatInputCommandInteraction,
-): Promise<string> {
-  const exact = new Map<string, string>();
-  const lowercase = new Map<string, string>();
-  const pushEmoji = (name: string | null | undefined, token: string): void => {
-    if (!name) return;
-    if (!exact.has(name)) {
-      exact.set(name, token);
-    }
-    const lowered = name.toLowerCase();
-    if (!lowercase.has(lowered)) {
-      lowercase.set(lowered, token);
-    }
-  };
+type EmojiShortcodeResolver = Pick<EmojiResolverService, "replaceShortcodes">;
 
-  const guild = interaction.guild;
-  if (guild) {
-    try {
-      await guild.emojis.fetch();
-    } catch {
-      // Keep going; we can still use cached/global emojis.
-    }
-    for (const emoji of guild.emojis.cache.values()) {
-      pushEmoji(
-        emoji.name,
-        `<${emoji.animated ? "a" : ""}:${emoji.name}:${emoji.id}>`,
-      );
-    }
-  }
-
-  for (const emoji of interaction.client.emojis.cache.values()) {
-    pushEmoji(
-      emoji.name,
-      `<${emoji.animated ? "a" : ""}:${emoji.name}:${emoji.id}>`,
-    );
-  }
-
-  return text.replace(
-    /(^|[\s([{"']):([a-zA-Z0-9_]{2,32}):(?=$|[\s)\]}".,!?:;'"-])/g,
-    (full, prefix: string, emojiName: string) => {
-      const token =
-        exact.get(emojiName) ?? lowercase.get(emojiName.toLowerCase());
-      if (!token) return full;
-      return `${prefix}${token}`;
-    },
-  );
+/** Purpose: normalize warplan shortcode text via shared application-emoji resolver. */
+async function resolveWarPlanEmojiShortcodes(params: {
+  text: string;
+  client: Client;
+  resolver?: EmojiShortcodeResolver;
+}): Promise<string> {
+  const resolver = params.resolver ?? emojiResolverService;
+  return resolver
+    .replaceShortcodes(params.client, params.text)
+    .catch(() => params.text);
 }
 
 function formatKeyLabel(
@@ -387,6 +355,9 @@ async function getCurrentOrDefaultPlanData(params: {
     allBasesOpenHoursLeft: modalDefaults.allBasesOpenHoursLeft,
   };
 }
+
+export const resolveWarPlanEmojiShortcodesForTest =
+  resolveWarPlanEmojiShortcodes;
 
 export const WarPlan: Command = {
   name: "warplan",
@@ -644,10 +615,10 @@ export const WarPlan: Command = {
           return;
         }
 
-        const planText = await resolveCustomEmojiShortcodes(
-          normalizedPlanText,
-          interaction,
-        );
+        const planText = await resolveWarPlanEmojiShortcodes({
+          text: normalizedPlanText,
+          client: interaction.client,
+        });
         if (!planText.length) {
           await submitted.reply({
             ephemeral: true,

--- a/src/services/CommandPermissionService.ts
+++ b/src/services/CommandPermissionService.ts
@@ -10,6 +10,7 @@ export const FWA_LEADER_ROLE_SETTING_KEY = "fwa_leader_role";
 
 export const COMMAND_PERMISSION_TARGETS = [
   "help",
+  "emoji",
   "lastseen",
   "inactive",
   "role-users",

--- a/src/services/emoji/EmojiResolverService.ts
+++ b/src/services/emoji/EmojiResolverService.ts
@@ -1,0 +1,194 @@
+import { Client } from "discord.js";
+
+export type ResolvedApplicationEmoji = {
+  id: string;
+  name: string;
+  shortcode: string;
+  rendered: string;
+  animated: boolean;
+};
+
+type EmojiSnapshot = {
+  fetchedAtMs: number;
+  entries: ResolvedApplicationEmoji[];
+  exactByName: Map<string, ResolvedApplicationEmoji>;
+  lowercaseByName: Map<string, ResolvedApplicationEmoji>;
+};
+
+type ApplicationEmojiFetchOwner = {
+  emojis?: {
+    fetch?: () => Promise<Map<string, any> | { values: () => Iterable<any> }>;
+  };
+};
+
+const SHORTCODE_REPLACE_PATTERN =
+  /(^|[\s([{"']):([a-zA-Z0-9_]{2,32}):(?=$|[\s)\]}".,!?:;'"-])/g;
+
+/** Purpose: normalize user-provided emoji-name input while preserving name-based environment stability. */
+export function normalizeEmojiLookupName(input: string): string {
+  const trimmed = String(input ?? "").trim();
+  if (!trimmed) return "";
+  const inner = trimmed.replace(/^:/, "").replace(/:$/, "");
+  return inner.trim();
+}
+
+/** Purpose: sort emoji entries deterministically for stable command output across runs. */
+function sortResolvedEmojis(
+  values: ResolvedApplicationEmoji[],
+): ResolvedApplicationEmoji[] {
+  return [...values].sort((a, b) => {
+    const byLower = a.name.toLowerCase().localeCompare(b.name.toLowerCase());
+    if (byLower !== 0) return byLower;
+    const byExact = a.name.localeCompare(b.name);
+    if (byExact !== 0) return byExact;
+    return a.id.localeCompare(b.id);
+  });
+}
+
+/** Purpose: resolve bot-owned application emojis by name and replace shortcode text safely. */
+export class EmojiResolverService {
+  private snapshot: EmojiSnapshot | null = null;
+
+  /** Purpose: configure refreshable in-memory cache TTL for resolver lookups. */
+  constructor(private readonly cacheTtlMs: number = 30_000) {}
+
+  /** Purpose: force-refresh the application emoji snapshot from Discord. */
+  async refresh(client: Client): Promise<void> {
+    this.snapshot = await this.fetchSnapshot(client);
+  }
+
+  /** Purpose: resolve one emoji by name (case-insensitive) from bot application emojis. */
+  async resolveByName(
+    client: Client,
+    name: string,
+    options?: { forceRefresh?: boolean },
+  ): Promise<ResolvedApplicationEmoji | null> {
+    const normalizedName = normalizeEmojiLookupName(name);
+    if (!normalizedName) return null;
+    const snapshot = await this.getSnapshot(client, options?.forceRefresh ?? false);
+    return (
+      snapshot.exactByName.get(normalizedName) ??
+      snapshot.lowercaseByName.get(normalizedName.toLowerCase()) ??
+      null
+    );
+  }
+
+  /** Purpose: replace valid `:emoji_name:` shortcodes with application emoji render tokens. */
+  async replaceShortcodes(
+    client: Client,
+    text: string,
+    options?: { forceRefresh?: boolean },
+  ): Promise<string> {
+    const source = String(text ?? "");
+    if (!source.includes(":")) return source;
+    const snapshot = await this.getSnapshot(client, options?.forceRefresh ?? false);
+    if (snapshot.entries.length === 0) return source;
+    return source.replace(
+      SHORTCODE_REPLACE_PATTERN,
+      (full, prefix: string, emojiName: string) => {
+        const resolved =
+          snapshot.exactByName.get(emojiName) ??
+          snapshot.lowercaseByName.get(emojiName.toLowerCase());
+        if (!resolved) return full;
+        return `${prefix}${resolved.rendered}`;
+      },
+    );
+  }
+
+  /** Purpose: list all available bot application emojis in deterministic order. */
+  async listApplicationEmojis(
+    client: Client,
+    options?: { forceRefresh?: boolean },
+  ): Promise<ResolvedApplicationEmoji[]> {
+    const snapshot = await this.getSnapshot(client, options?.forceRefresh ?? false);
+    return [...snapshot.entries];
+  }
+
+  /** Purpose: fetch cached snapshot when fresh, otherwise rebuild from current bot application emojis. */
+  private async getSnapshot(
+    client: Client,
+    forceRefresh: boolean,
+  ): Promise<EmojiSnapshot> {
+    const nowMs = Date.now();
+    if (
+      !forceRefresh &&
+      this.snapshot &&
+      nowMs - this.snapshot.fetchedAtMs <= this.cacheTtlMs
+    ) {
+      return this.snapshot;
+    }
+    const next = await this.fetchSnapshot(client);
+    this.snapshot = next;
+    return next;
+  }
+
+  /** Purpose: safely ensure client application hydration before reading application emoji inventory. */
+  private async ensureApplication(client: Client) {
+    if (client.application) {
+      await client.application.fetch().catch(() => undefined);
+      return client.application;
+    }
+    return null;
+  }
+
+  /** Purpose: build a fresh application-emoji snapshot keyed for exact and case-insensitive lookups. */
+  private async fetchSnapshot(client: Client): Promise<EmojiSnapshot> {
+    const application = await this.ensureApplication(client);
+    if (!application) {
+      return {
+        fetchedAtMs: Date.now(),
+        entries: [],
+        exactByName: new Map<string, ResolvedApplicationEmoji>(),
+        lowercaseByName: new Map<string, ResolvedApplicationEmoji>(),
+      };
+    }
+
+    const applicationWithEmojis = application as unknown as ApplicationEmojiFetchOwner;
+    const emojiFetch = applicationWithEmojis.emojis?.fetch;
+    if (typeof emojiFetch !== "function") {
+      return {
+        fetchedAtMs: Date.now(),
+        entries: [],
+        exactByName: new Map<string, ResolvedApplicationEmoji>(),
+        lowercaseByName: new Map<string, ResolvedApplicationEmoji>(),
+      };
+    }
+
+    const fetched = await emojiFetch();
+    const collected: ResolvedApplicationEmoji[] = [];
+    for (const emoji of fetched.values()) {
+      const name = String(emoji.name ?? "").trim();
+      const rendered = String(emoji.toString?.() ?? "").trim();
+      if (!name || !rendered) continue;
+      collected.push({
+        id: String(emoji.id),
+        name,
+        shortcode: `:${name}:`,
+        rendered,
+        animated: Boolean(emoji.animated),
+      });
+    }
+
+    const entries = sortResolvedEmojis(collected);
+    const exactByName = new Map<string, ResolvedApplicationEmoji>();
+    const lowercaseByName = new Map<string, ResolvedApplicationEmoji>();
+    for (const entry of entries) {
+      if (!exactByName.has(entry.name)) {
+        exactByName.set(entry.name, entry);
+      }
+      const lowered = entry.name.toLowerCase();
+      if (!lowercaseByName.has(lowered)) {
+        lowercaseByName.set(lowered, entry);
+      }
+    }
+
+    return {
+      fetchedAtMs: Date.now(),
+      entries,
+      exactByName,
+      lowercaseByName,
+    };
+  }
+}
+
+export const emojiResolverService = new EmojiResolverService();

--- a/tests/emoji.command.test.ts
+++ b/tests/emoji.command.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ChatInputCommandInteraction, Client } from "discord.js";
+import {
+  Emoji,
+  applyEmojiPageActionForTest,
+  resetEmojiResolverForTest,
+  setEmojiResolverForTest,
+} from "../src/commands/Emoji";
+
+type EmojiResolverStub = {
+  resolveByName: ReturnType<typeof vi.fn>;
+  listApplicationEmojis: ReturnType<typeof vi.fn>;
+};
+
+function buildInteraction(input?: {
+  name?: string | null;
+}): {
+  interaction: ChatInputCommandInteraction;
+  deferReply: ReturnType<typeof vi.fn>;
+  editReply: ReturnType<typeof vi.fn>;
+  fetchReply: ReturnType<typeof vi.fn>;
+} {
+  const deferReply = vi.fn().mockResolvedValue(undefined);
+  const editReply = vi.fn().mockResolvedValue(undefined);
+  const fetchReply = vi.fn().mockResolvedValue({
+    createMessageComponentCollector: vi.fn(),
+  });
+  const interaction = {
+    id: "interaction-1",
+    user: { id: "user-1" },
+    client: {} as Client,
+    options: {
+      getString: vi.fn((name: string) => (name === "name" ? (input?.name ?? null) : null)),
+    },
+    deferReply,
+    editReply,
+    fetchReply,
+  } as unknown as ChatInputCommandInteraction;
+  return { interaction, deferReply, editReply, fetchReply };
+}
+
+function buildResolverStub(): EmojiResolverStub {
+  return {
+    resolveByName: vi.fn(),
+    listApplicationEmojis: vi.fn(),
+  };
+}
+
+describe("/emoji command", () => {
+  afterEach(() => {
+    resetEmojiResolverForTest();
+    vi.restoreAllMocks();
+  });
+
+  it("supports name mode success", async () => {
+    const resolver = buildResolverStub();
+    resolver.resolveByName.mockResolvedValue({
+      id: "1",
+      name: "arrow_arrow",
+      shortcode: ":arrow_arrow:",
+      rendered: "<:arrow_arrow:1>",
+      animated: false,
+    });
+    setEmojiResolverForTest(resolver as any);
+    const { interaction, editReply } = buildInteraction({ name: "arrow_arrow" });
+
+    await Emoji.run({} as Client, interaction, {} as any);
+
+    expect(resolver.resolveByName).toHaveBeenCalledTimes(1);
+    const payload = editReply.mock.calls[0]?.[0] ?? {};
+    const embed = payload.embeds?.[0];
+    const json = typeof embed?.toJSON === "function" ? embed.toJSON() : embed?.data ?? {};
+    expect(String(json.description ?? "")).toContain(":arrow_arrow:");
+  });
+
+  it("supports name mode not found", async () => {
+    const resolver = buildResolverStub();
+    resolver.resolveByName.mockResolvedValue(null);
+    resolver.listApplicationEmojis.mockResolvedValue([
+      {
+        id: "1",
+        name: "arrow_arrow",
+        shortcode: ":arrow_arrow:",
+        rendered: "<:arrow_arrow:1>",
+        animated: false,
+      },
+    ]);
+    setEmojiResolverForTest(resolver as any);
+    const { interaction, editReply } = buildInteraction({ name: "not_real" });
+
+    await Emoji.run({} as Client, interaction, {} as any);
+
+    const payload = editReply.mock.calls[0]?.[0] ?? {};
+    expect(String(payload.content ?? "")).toContain("No application emoji found");
+  });
+
+  it("renders list mode first page", async () => {
+    const resolver = buildResolverStub();
+    resolver.listApplicationEmojis.mockResolvedValue([
+      {
+        id: "1",
+        name: "alpha",
+        shortcode: ":alpha:",
+        rendered: "<:alpha:1>",
+        animated: false,
+      },
+      {
+        id: "2",
+        name: "bravo",
+        shortcode: ":bravo:",
+        rendered: "<:bravo:2>",
+        animated: false,
+      },
+    ]);
+    setEmojiResolverForTest(resolver as any);
+    const { interaction, editReply, fetchReply } = buildInteraction();
+
+    await Emoji.run({} as Client, interaction, {} as any);
+
+    const payload = editReply.mock.calls[0]?.[0] ?? {};
+    const embed = payload.embeds?.[0];
+    const json = typeof embed?.toJSON === "function" ? embed.toJSON() : embed?.data ?? {};
+    expect(json.title).toBe("Bot Application Emojis");
+    expect(String(json.description ?? "")).toContain(":alpha:");
+    expect(fetchReply).not.toHaveBeenCalled();
+  });
+
+  it("supports pagination next/previous behavior", () => {
+    expect(
+      applyEmojiPageActionForTest({
+        action: "next",
+        page: 0,
+        totalPages: 3,
+      }),
+    ).toBe(1);
+    expect(
+      applyEmojiPageActionForTest({
+        action: "prev",
+        page: 1,
+        totalPages: 3,
+      }),
+    ).toBe(0);
+    expect(
+      applyEmojiPageActionForTest({
+        action: "next",
+        page: 2,
+        totalPages: 3,
+      }),
+    ).toBe(2);
+  });
+
+  it("renders list mode empty state when no emojis are available", async () => {
+    const resolver = buildResolverStub();
+    resolver.listApplicationEmojis.mockResolvedValue([]);
+    setEmojiResolverForTest(resolver as any);
+    const { interaction, editReply } = buildInteraction();
+
+    await Emoji.run({} as Client, interaction, {} as any);
+
+    const payload = editReply.mock.calls[0]?.[0] ?? {};
+    const embed = payload.embeds?.[0];
+    const json = typeof embed?.toJSON === "function" ? embed.toJSON() : embed?.data ?? {};
+    expect(String(json.description ?? "")).toContain(
+      "No application emojis are currently available",
+    );
+    expect(payload.components ?? []).toEqual([]);
+  });
+});

--- a/tests/emojiResolver.service.test.ts
+++ b/tests/emojiResolver.service.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Client } from "discord.js";
+import { EmojiResolverService } from "../src/services/emoji/EmojiResolverService";
+
+type FakeAppEmoji = {
+  id: string;
+  name: string;
+  animated: boolean;
+  toString: () => string;
+};
+
+function buildFakeEmoji(input: {
+  id: string;
+  name: string;
+  animated?: boolean;
+}): FakeAppEmoji {
+  const animated = Boolean(input.animated);
+  return {
+    id: input.id,
+    name: input.name,
+    animated,
+    toString: () =>
+      `<${animated ? "a" : ""}:${input.name}:${input.id}>`,
+  };
+}
+
+function buildClientWithApplicationEmojis(
+  emojis: FakeAppEmoji[],
+): {
+  client: Client;
+  fetchApplication: ReturnType<typeof vi.fn>;
+  fetchEmojis: ReturnType<typeof vi.fn>;
+} {
+  const fetchEmojis = vi.fn().mockResolvedValue(
+    new Map(emojis.map((emoji) => [emoji.id, emoji])),
+  );
+  const fetchApplication = vi.fn().mockResolvedValue(undefined);
+  const client = {
+    application: {
+      fetch: fetchApplication,
+      emojis: {
+        fetch: fetchEmojis,
+      },
+    },
+  } as unknown as Client;
+  return { client, fetchApplication, fetchEmojis };
+}
+
+describe("EmojiResolverService", () => {
+  it("resolves exact-name match", async () => {
+    const resolver = new EmojiResolverService(0);
+    const { client } = buildClientWithApplicationEmojis([
+      buildFakeEmoji({ id: "1", name: "arrow_arrow" }),
+    ]);
+
+    const resolved = await resolver.resolveByName(client, "arrow_arrow");
+
+    expect(resolved?.shortcode).toBe(":arrow_arrow:");
+    expect(resolved?.rendered).toBe("<:arrow_arrow:1>");
+  });
+
+  it("resolves case-insensitive match", async () => {
+    const resolver = new EmojiResolverService(0);
+    const { client } = buildClientWithApplicationEmojis([
+      buildFakeEmoji({ id: "1", name: "arrow_arrow" }),
+    ]);
+
+    const resolved = await resolver.resolveByName(client, "ArRoW_ArRoW");
+
+    expect(resolved?.rendered).toBe("<:arrow_arrow:1>");
+  });
+
+  it("replaces multiple shortcodes in one text body", async () => {
+    const resolver = new EmojiResolverService(0);
+    const { client } = buildClientWithApplicationEmojis([
+      buildFakeEmoji({ id: "1", name: "arrow_arrow" }),
+      buildFakeEmoji({ id: "2", name: "check_mark" }),
+    ]);
+
+    const out = await resolver.replaceShortcodes(
+      client,
+      "Top :arrow_arrow: and :check_mark: done",
+    );
+
+    expect(out).toBe("Top <:arrow_arrow:1> and <:check_mark:2> done");
+  });
+
+  it("leaves unknown shortcodes unchanged", async () => {
+    const resolver = new EmojiResolverService(0);
+    const { client } = buildClientWithApplicationEmojis([
+      buildFakeEmoji({ id: "1", name: "arrow_arrow" }),
+    ]);
+
+    const out = await resolver.replaceShortcodes(
+      client,
+      "Known :arrow_arrow: unknown :not_real:",
+    );
+
+    expect(out).toBe("Known <:arrow_arrow:1> unknown :not_real:");
+  });
+
+  it("handles empty emoji collections", async () => {
+    const resolver = new EmojiResolverService(0);
+    const { client } = buildClientWithApplicationEmojis([]);
+
+    const list = await resolver.listApplicationEmojis(client);
+    const resolved = await resolver.resolveByName(client, "arrow_arrow");
+    const replaced = await resolver.replaceShortcodes(client, "Plan :arrow_arrow:");
+
+    expect(list).toEqual([]);
+    expect(resolved).toBeNull();
+    expect(replaced).toBe("Plan :arrow_arrow:");
+  });
+
+  it("keeps static and animated emoji render tokens as returned by Discord", async () => {
+    const resolver = new EmojiResolverService(0);
+    const { client } = buildClientWithApplicationEmojis([
+      buildFakeEmoji({ id: "1", name: "static_icon", animated: false }),
+      buildFakeEmoji({ id: "2", name: "animated_icon", animated: true }),
+    ]);
+
+    const staticResolved = await resolver.resolveByName(client, "static_icon");
+    const animatedResolved = await resolver.resolveByName(client, "animated_icon");
+
+    expect(staticResolved?.rendered).toBe("<:static_icon:1>");
+    expect(animatedResolved?.rendered).toBe("<a:animated_icon:2>");
+  });
+});

--- a/tests/warPlanEmojiNormalization.logic.test.ts
+++ b/tests/warPlanEmojiNormalization.logic.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Client } from "discord.js";
+import { resolveWarPlanEmojiShortcodesForTest } from "../src/commands/WarPlan";
+import { EmojiResolverService } from "../src/services/emoji/EmojiResolverService";
+
+describe("warplan emoji shortcode normalization", () => {
+  it("uses shared emoji resolver service for shortcode replacement", async () => {
+    const replaceShortcodes = vi
+      .fn()
+      .mockResolvedValue("Plan <:arrow_arrow:123>");
+    const client = {} as Client;
+    const out = await resolveWarPlanEmojiShortcodesForTest({
+      text: "Plan :arrow_arrow:",
+      client,
+      resolver: { replaceShortcodes } as any,
+    });
+
+    expect(replaceShortcodes).toHaveBeenCalledWith(
+      client,
+      "Plan :arrow_arrow:",
+    );
+    expect(out).toBe("Plan <:arrow_arrow:123>");
+  });
+
+  it("preserves unknown shortcodes", async () => {
+    const resolver = new EmojiResolverService(0);
+    const client = {
+      application: {
+        fetch: vi.fn().mockResolvedValue(undefined),
+        emojis: {
+          fetch: vi.fn().mockResolvedValue(new Map()),
+        },
+      },
+    } as unknown as Client;
+
+    const out = await resolveWarPlanEmojiShortcodesForTest({
+      text: "Unknown stays :not_real:",
+      client,
+      resolver,
+    });
+
+    expect(out).toBe("Unknown stays :not_real:");
+  });
+});


### PR DESCRIPTION
- add shared application-emoji resolver service with case-insensitive name lookup, shortcode replacement, deterministic listing, and refreshable cache
- refactor /warplan set modal submit to normalize shortcode text through shared resolver
- add new /emoji command with name-resolve mode and invoker-scoped paginated list mode
- update command registration, help docs, permission target coverage, and docs/commands reference
- add resolver, command, and warplan shortcode tests plus command coverage validation