### PR TITLE
fix(emoji): stop masking app emoji fetch failures

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
         "@prisma/client": "^5.22.0",
         "axios": "^1.13.5",
         "clashofclans.js": "^3.1.0",
-        "discord.js": "^14.11.0",
+        "discord.js": "^14.25.1",
         "dotenv": "^16.3.1",
         "knockout": "^3.5.1",
         "pngjs": "^7.0.0",
@@ -71,90 +71,125 @@
       }
     },
     "node_modules/@discordjs/builders": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.6.3.tgz",
-      "integrity": "sha512-CTCh8NqED3iecTNuiz49mwSsrc2iQb4d0MjMdmS/8pb69Y4IlzJ/DIy/p5GFlgOrFbNO2WzMHkWKQSiJ3VNXaw==",
-      "license": "Apache-2.0",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.13.1.tgz",
+      "integrity": "sha512-cOU0UDHc3lp/5nKByDxkmRiNZBpdp0kx55aarbiAfakfKJHlxv/yFW1zmIqCAmwH5CRlrH9iMFKJMpvW4DPB+w==",
       "dependencies": {
-        "@discordjs/formatters": "^0.3.1",
-        "@discordjs/util": "^0.3.1",
-        "@sapphire/shapeshift": "^3.8.2",
-        "discord-api-types": "^0.37.41",
+        "@discordjs/formatters": "^0.6.2",
+        "@discordjs/util": "^1.2.0",
+        "@sapphire/shapeshift": "^4.0.0",
+        "discord-api-types": "^0.38.33",
         "fast-deep-equal": "^3.1.3",
-        "ts-mixer": "^6.0.3",
-        "tslib": "^2.5.0"
+        "ts-mixer": "^6.0.4",
+        "tslib": "^2.6.3"
       },
       "engines": {
-        "node": ">=16.9.0"
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
     "node_modules/@discordjs/collection": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.1.tgz",
-      "integrity": "sha512-aWEc9DCf3TMDe9iaJoOnO2+JVAjeRNuRxPZQA6GVvBf+Z3gqUuWYBy2NWh4+5CLYq5uoc3MOvUQ5H5m8CJBqOA==",
-      "license": "Apache-2.0",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.3.tgz",
+      "integrity": "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==",
       "engines": {
-        "node": ">=16.9.0"
+        "node": ">=16.11.0"
       }
     },
     "node_modules/@discordjs/formatters": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.3.1.tgz",
-      "integrity": "sha512-M7X4IGiSeh4znwcRGcs+49B5tBkNDn4k5bmhxJDAUhRxRHTiFAOTVUNQ6yAKySu5jZTnCbSvTYHW3w0rAzV1MA==",
-      "license": "Apache-2.0",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.6.2.tgz",
+      "integrity": "sha512-y4UPwWhH6vChKRkGdMB4odasUbHOUwy7KL+OVwF86PvT6QVOwElx+TiI1/6kcmcEe+g5YRXJFiXSXUdabqZOvQ==",
       "dependencies": {
-        "discord-api-types": "^0.37.41"
+        "discord-api-types": "^0.38.33"
       },
       "engines": {
-        "node": ">=16.9.0"
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
     "node_modules/@discordjs/rest": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-1.7.1.tgz",
-      "integrity": "sha512-Ofa9UqT0U45G/eX86cURQnX7gzOJLG2oC28VhIk/G6IliYgQF7jFByBJEykPSHE4MxPhqCleYvmsrtfKh1nYmQ==",
-      "license": "Apache-2.0",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.6.0.tgz",
+      "integrity": "sha512-RDYrhmpB7mTvmCKcpj+pc5k7POKszS4E2O9TYc+U+Y4iaCP+r910QdO43qmpOja8LRr1RJ0b3U+CqVsnPqzf4w==",
       "dependencies": {
-        "@discordjs/collection": "^1.5.1",
-        "@discordjs/util": "^0.3.0",
-        "@sapphire/async-queue": "^1.5.0",
-        "@sapphire/snowflake": "^3.4.2",
-        "discord-api-types": "^0.37.41",
-        "file-type": "^18.3.0",
-        "tslib": "^2.5.0",
-        "undici": "^5.22.0"
+        "@discordjs/collection": "^2.1.1",
+        "@discordjs/util": "^1.1.1",
+        "@sapphire/async-queue": "^1.5.3",
+        "@sapphire/snowflake": "^3.5.3",
+        "@vladfrangu/async_event_emitter": "^2.4.6",
+        "discord-api-types": "^0.38.16",
+        "magic-bytes.js": "^1.10.0",
+        "tslib": "^2.6.3",
+        "undici": "6.21.3"
       },
       "engines": {
-        "node": ">=16.9.0"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest/node_modules/@discordjs/collection": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
     "node_modules/@discordjs/util": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-0.3.1.tgz",
-      "integrity": "sha512-HxXKYKg7vohx2/OupUN/4Sd02Ev3PBJ5q0gtjdcvXb0ErCva8jNHWfe/v5sU3UKjIB/uxOhc+TDOnhqffj9pRA==",
-      "license": "Apache-2.0",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.2.0.tgz",
+      "integrity": "sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg==",
+      "dependencies": {
+        "discord-api-types": "^0.38.33"
+      },
       "engines": {
-        "node": ">=16.9.0"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
     "node_modules/@discordjs/ws": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-0.8.3.tgz",
-      "integrity": "sha512-hcYtppanjHecbdNyCKQNH2I4RP9UrphDgmRgLYrATEQF1oo4sYSve7ZmGsBEXSzH72MO2tBPdWSThunbxUVk0g==",
-      "license": "Apache-2.0",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.2.3.tgz",
+      "integrity": "sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==",
       "dependencies": {
-        "@discordjs/collection": "^1.5.1",
-        "@discordjs/rest": "^1.7.1",
-        "@discordjs/util": "^0.3.1",
-        "@sapphire/async-queue": "^1.5.0",
-        "@types/ws": "^8.5.4",
-        "@vladfrangu/async_event_emitter": "^2.2.1",
-        "discord-api-types": "^0.37.41",
-        "tslib": "^2.5.0",
-        "ws": "^8.13.0"
+        "@discordjs/collection": "^2.1.0",
+        "@discordjs/rest": "^2.5.1",
+        "@discordjs/util": "^1.1.0",
+        "@sapphire/async-queue": "^1.5.2",
+        "@types/ws": "^8.5.10",
+        "@vladfrangu/async_event_emitter": "^2.2.4",
+        "discord-api-types": "^0.38.1",
+        "tslib": "^2.6.2",
+        "ws": "^8.17.0"
       },
       "engines": {
-        "node": ">=16.9.0"
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/ws/node_modules/@discordjs/collection": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1110,34 +1145,30 @@
       ]
     },
     "node_modules/@sapphire/async-queue": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.0.tgz",
-      "integrity": "sha512-JkLdIsP8fPAdh9ZZjrbHWR/+mZj0wvKS5ICibcLrRI1j84UmLMshx5n9QmL8b95d4onJ2xxiyugTgSAX7AalmA==",
-      "license": "MIT",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.5.tgz",
+      "integrity": "sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==",
       "engines": {
         "node": ">=v14.0.0",
         "npm": ">=7.0.0"
       }
     },
     "node_modules/@sapphire/shapeshift": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.9.2.tgz",
-      "integrity": "sha512-YRbCXWy969oGIdqR/wha62eX8GNHsvyYi0Rfd4rNW6tSVVa8p0ELiMEuOH/k8rgtvRoM+EMV7Csqz77YdwiDpA==",
-      "license": "MIT",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-4.0.0.tgz",
+      "integrity": "sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "lodash": "^4.17.21"
       },
       "engines": {
-        "node": ">=v14.0.0",
-        "npm": ">=7.0.0"
+        "node": ">=v16"
       }
     },
     "node_modules/@sapphire/snowflake": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.1.tgz",
-      "integrity": "sha512-BxcYGzgEsdlG0dKAyOm0ehLGm2CafIrfQTZGWgkfKYbj+pNNsorZ7EotuZukc2MT70E0UbppVbtpBrqpzVzjNA==",
-      "license": "MIT",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.3.tgz",
+      "integrity": "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==",
       "engines": {
         "node": ">=v14.0.0",
         "npm": ">=7.0.0"
@@ -1148,12 +1179,6 @@
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
       "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
       "dev": true
-    },
-    "node_modules/@tokenizer/token": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
-      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
-      "license": "MIT"
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
@@ -1229,10 +1254,9 @@
       "dev": true
     },
     "node_modules/@types/ws": {
-      "version": "8.5.5",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.5.tgz",
-      "integrity": "sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==",
-      "license": "MIT",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
       "dependencies": {
         "@types/node": "*"
       }
@@ -1837,10 +1861,9 @@
       }
     },
     "node_modules/@vladfrangu/async_event_emitter": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.2.2.tgz",
-      "integrity": "sha512-HIzRG7sy88UZjBJamssEczH5q7t5+axva19UbZLO6u0ySbYPrwzWiXBcC0WuHyhKKoeCyneH+FvYzKQq/zTtkQ==",
-      "license": "MIT",
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.7.tgz",
+      "integrity": "sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==",
       "engines": {
         "node": ">=v14.0.0",
         "npm": ">=7.0.0"
@@ -2014,17 +2037,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/busboy": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
-      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-      "dependencies": {
-        "streamsearch": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=10.16.0"
       }
     },
     "node_modules/cac": {
@@ -2302,34 +2314,34 @@
       }
     },
     "node_modules/discord-api-types": {
-      "version": "0.37.49",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.49.tgz",
-      "integrity": "sha512-a2vvjgmE/1cPtXOuOh5zHlLe+qheu0uO625K+FyZVFomoCmpV1xNpadC48S98K30CnQ4/XJyFGnOZLXxAyBbCQ==",
-      "license": "MIT"
+      "version": "0.38.42",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.42.tgz",
+      "integrity": "sha512-qs1kya7S84r5RR8m9kgttywGrmmoHaRifU1askAoi+wkoSefLpZP6aGXusjNw5b0jD3zOg3LTwUa3Tf2iHIceQ=="
     },
     "node_modules/discord.js": {
-      "version": "14.11.0",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.11.0.tgz",
-      "integrity": "sha512-CkueWYFQ28U38YPR8HgsBR/QT35oPpMbEsTNM30Fs8loBIhnA4s70AwQEoy6JvLcpWWJO7GY0y2BUzZmuBMepQ==",
-      "license": "Apache-2.0",
+      "version": "14.25.1",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.25.1.tgz",
+      "integrity": "sha512-2l0gsPOLPs5t6GFZfQZKnL1OJNYFcuC/ETWsW4VtKVD/tg4ICa9x+jb9bkPffkMdRpRpuUaO/fKkHCBeiCKh8g==",
       "dependencies": {
-        "@discordjs/builders": "^1.6.3",
-        "@discordjs/collection": "^1.5.1",
-        "@discordjs/formatters": "^0.3.1",
-        "@discordjs/rest": "^1.7.1",
-        "@discordjs/util": "^0.3.1",
-        "@discordjs/ws": "^0.8.3",
-        "@sapphire/snowflake": "^3.4.2",
-        "@types/ws": "^8.5.4",
-        "discord-api-types": "^0.37.41",
-        "fast-deep-equal": "^3.1.3",
-        "lodash.snakecase": "^4.1.1",
-        "tslib": "^2.5.0",
-        "undici": "^5.22.0",
-        "ws": "^8.13.0"
+        "@discordjs/builders": "^1.13.0",
+        "@discordjs/collection": "1.5.3",
+        "@discordjs/formatters": "^0.6.2",
+        "@discordjs/rest": "^2.6.0",
+        "@discordjs/util": "^1.2.0",
+        "@discordjs/ws": "^1.2.3",
+        "@sapphire/snowflake": "3.5.3",
+        "discord-api-types": "^0.38.33",
+        "fast-deep-equal": "3.1.3",
+        "lodash.snakecase": "4.1.1",
+        "magic-bytes.js": "^1.10.0",
+        "tslib": "^2.6.3",
+        "undici": "6.21.3"
       },
       "engines": {
-        "node": ">=16.9.0"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
     "node_modules/doctrine": {
@@ -2669,23 +2681,6 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
-    "node_modules/file-type": {
-      "version": "18.5.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-18.5.0.tgz",
-      "integrity": "sha512-yvpl5U868+V6PqXHMmsESpg6unQ5GfnPssl4dxdJudBrr9qy7Fddt7EVX1VLlddFfe8Gj9N7goCZH22FXuSQXQ==",
-      "license": "MIT",
-      "dependencies": {
-        "readable-web-to-node-stream": "^3.0.2",
-        "strtok3": "^7.0.0",
-        "token-types": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
-      }
-    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -2976,26 +2971,6 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3051,6 +3026,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/is-binary-path": {
@@ -3266,10 +3242,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "license": "MIT"
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -3291,6 +3266,11 @@
       "dependencies": {
         "get-func-name": "^2.0.1"
       }
+    },
+    "node_modules/magic-bytes.js": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.13.0.tgz",
+      "integrity": "sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg=="
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -3607,19 +3587,6 @@
         "node": "*"
       }
     },
-    "node_modules/peek-readable": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-5.0.0.tgz",
-      "integrity": "sha512-YtCKvLUOvwtMGmrniQPdO7MwPjgkFBtFIrmfSbYmYuq3tKDV/mcfAhBth1+C3ru7uXIZasc/pHnb+YDYNkkj4A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
-      }
-    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -3801,36 +3768,6 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true
     },
-    "node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/readable-web-to-node-stream": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
-      "integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
-      }
-    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -3945,26 +3882,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/semver": {
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
@@ -4055,23 +3972,6 @@
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true
     },
-    "node_modules/streamsearch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -4106,23 +4006,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
-      }
-    },
-    "node_modules/strtok3": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-7.0.0.tgz",
-      "integrity": "sha512-pQ+V+nYQdC5H3Q7qBZAz/MO6lwGhoC2gOAjuouGf/VO0m7vQRh8QNMl2Uf6SwAtzZ9bOw3UIeBukEGNJl5dtXQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@tokenizer/token": "^0.3.0",
-        "peek-readable": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/supports-color": {
@@ -4193,23 +4076,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/token-types": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/token-types/-/token-types-5.0.1.tgz",
-      "integrity": "sha512-Y2fmSnZjQdDb9W4w4r1tswlMHylzWIeOKpx0aZH9BgGtACHhrk3OkT52AzwcuqTRBZtvvnTjDBh8eynMulu8Vg==",
-      "license": "MIT",
-      "dependencies": {
-        "@tokenizer/token": "^0.3.0",
-        "ieee754": "^1.2.1"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
-      }
-    },
     "node_modules/touch": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.1.tgz",
@@ -4225,10 +4091,9 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/ts-mixer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.3.tgz",
-      "integrity": "sha512-k43M7uCG1AkTyxgnmI5MPwKoUvS/bRvLvUb7+Pgpdlmok8AoqmUaZxUUw8zKM5B1lqZrt41GjYgnvAi0fppqgQ==",
-      "license": "MIT"
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
+      "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA=="
     },
     "node_modules/ts-node": {
       "version": "10.9.2",
@@ -4274,10 +4139,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-      "license": "0BSD"
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -4337,15 +4201,11 @@
       "dev": true
     },
     "node_modules/undici": {
-      "version": "5.22.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.22.1.tgz",
-      "integrity": "sha512-Ji2IJhFXZY0x/0tVBXeQwgPlLWw13GVzpsWPQ3rV50IFMMof2I55PZZxtm4P6iNq+L5znYN9nSTAq0ZyE6lSJw==",
-      "license": "MIT",
-      "dependencies": {
-        "busboy": "^1.6.0"
-      },
+      "version": "6.21.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
+      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
       "engines": {
-        "node": ">=14.0"
+        "node": ">=18.17"
       }
     },
     "node_modules/uri-js": {
@@ -4356,12 +4216,6 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "license": "MIT"
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
@@ -4614,10 +4468,9 @@
       "dev": true
     },
     "node_modules/ws": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
-      "license": "MIT",
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "@prisma/client": "^5.22.0",
     "axios": "^1.13.5",
     "clashofclans.js": "^3.1.0",
-    "discord.js": "^14.11.0",
+    "discord.js": "^14.25.1",
     "dotenv": "^16.3.1",
     "knockout": "^3.5.1",
     "pngjs": "^7.0.0",

--- a/src/commands/Compo.ts
+++ b/src/commands/Compo.ts
@@ -1,7 +1,7 @@
 import {
   ActionRowBuilder,
   APIActionRowComponent,
-  APIMessageActionRowComponent,
+  APIComponentInMessageActionRow,
   ApplicationCommandOptionType,
   AutocompleteInteraction,
   ButtonBuilder,
@@ -164,9 +164,9 @@ function buildCompoRefreshActionRow(
 
 function extractSupplementalRowsFromMessage(
   interaction: ButtonInteraction
-): Array<APIActionRowComponent<APIMessageActionRowComponent>> {
+): Array<APIActionRowComponent<APIComponentInMessageActionRow>> {
   return interaction.message.components
-    .map((row) => row.toJSON() as APIActionRowComponent<APIMessageActionRowComponent>)
+    .map((row) => row.toJSON() as APIActionRowComponent<APIComponentInMessageActionRow>)
     .filter(
       (row) =>
         !row.components.some(
@@ -865,9 +865,9 @@ function renderStatePng(mode: GoogleSheetMode, rows: string[][]): Buffer {
 function buildCompoRefreshComponents(input: {
   customId: string;
   loading: boolean;
-  supplementalRows?: Array<APIActionRowComponent<APIMessageActionRowComponent>>;
-}): Array<ActionRowBuilder<ButtonBuilder> | APIActionRowComponent<APIMessageActionRowComponent>> {
-  const components: Array<ActionRowBuilder<ButtonBuilder> | APIActionRowComponent<APIMessageActionRowComponent>> = [
+  supplementalRows?: Array<APIActionRowComponent<APIComponentInMessageActionRow>>;
+}): Array<ActionRowBuilder<ButtonBuilder> | APIActionRowComponent<APIComponentInMessageActionRow>> {
+  const components: Array<ActionRowBuilder<ButtonBuilder> | APIActionRowComponent<APIComponentInMessageActionRow>> = [
     buildCompoRefreshActionRow(input.customId, { loading: input.loading }),
   ];
   if (input.supplementalRows && input.supplementalRows.length > 0) {

--- a/src/commands/Emoji.ts
+++ b/src/commands/Emoji.ts
@@ -14,6 +14,8 @@ import { formatError } from "../helper/formatError";
 import {
   emojiResolverService,
   normalizeEmojiLookupName,
+  type EmojiInventoryFetchResult,
+  type EmojiResolverFailureCode,
   type EmojiResolverService,
   type ResolvedApplicationEmoji,
 } from "../services/emoji/EmojiResolverService";
@@ -21,7 +23,7 @@ import { CoCService } from "../services/CoCService";
 
 type EmojiResolverPort = Pick<
   EmojiResolverService,
-  "listApplicationEmojis" | "resolveByName"
+  "fetchApplicationEmojiInventory"
 >;
 
 const EMOJI_PAGE_SIZE = 20;
@@ -76,7 +78,7 @@ function buildEmojiListEmbed(params: {
     .setTitle("Bot Application Emojis")
     .setDescription(params.pages[params.page] ?? "")
     .setFooter({
-      text: `Page ${params.page + 1}/${params.pages.length} • Total ${params.emojis.length} emojis`,
+      text: `Page ${params.page + 1}/${params.pages.length} | Total ${params.emojis.length} emojis`,
     })
     .setColor(0x5865f2);
 }
@@ -125,6 +127,39 @@ function buildEmojiNameSuggestions(
     .map((emoji) => emoji.shortcode);
 }
 
+/** Purpose: map resolver failure code to the most accurate user-facing /emoji error response. */
+function buildEmojiFailureMessage(code: EmojiResolverFailureCode): string {
+  if (code === "application_missing" || code === "application_emoji_manager_unavailable") {
+    return "Could not load bot application emojis in this runtime. Please contact an admin.";
+  }
+  return "Could not fetch bot application emojis right now. Please try again later.";
+}
+
+/** Purpose: emit concise structured diagnostics for one /emoji resolver run. */
+function logEmojiFetchResult(input: {
+  interaction: ChatInputCommandInteraction;
+  result: EmojiInventoryFetchResult;
+}): void {
+  const { diagnostics } = input.result;
+  const fields = [
+    "command=emoji",
+    `guild_id=${input.interaction.guildId ?? "dm"}`,
+    `user_id=${input.interaction.user.id}`,
+    `application_present_pre_fetch=${diagnostics.applicationExistedBeforeFetch}`,
+    `application_fetch_attempted=${diagnostics.applicationFetchAttempted}`,
+    `application_emoji_fetch_available=${diagnostics.applicationEmojiFetchAvailable}`,
+    `emoji_fetch_succeeded=${diagnostics.emojiFetchSucceeded}`,
+    `fetched_emoji_count=${diagnostics.fetchedEmojiCount}`,
+    `failure_code=${input.result.ok ? "none" : input.result.code}`,
+  ];
+  const message = `[emoji] fetch ${fields.join(" ")}`;
+  if (input.result.ok) {
+    console.log(message);
+    return;
+  }
+  console.warn(message);
+}
+
 /** Purpose: allow tests to inject a resolver and assert command behavior deterministically. */
 export function setEmojiResolverForTest(resolver: EmojiResolverPort): void {
   activeEmojiResolver = resolver;
@@ -162,11 +197,27 @@ export const Emoji: Command = {
     const requestedName = normalizeEmojiLookupName(rawName ?? "");
 
     try {
+      const inventory = await activeEmojiResolver.fetchApplicationEmojiInventory(
+        interaction.client,
+        { forceRefresh: true },
+      );
+      logEmojiFetchResult({ interaction, result: inventory });
+      if (!inventory.ok) {
+        await interaction.editReply({
+          content: buildEmojiFailureMessage(inventory.code),
+          embeds: [],
+          components: [],
+        });
+        return;
+      }
+
+      const { snapshot } = inventory;
+      const emojis = snapshot.entries;
       if (requestedName) {
-        const resolved = await activeEmojiResolver.resolveByName(
-          interaction.client,
-          requestedName,
-        );
+        const resolved =
+          snapshot.exactByName.get(requestedName) ??
+          snapshot.lowercaseByName.get(requestedName.toLowerCase()) ??
+          null;
         if (resolved) {
           await interaction.editReply({
             embeds: [buildEmojiResolveEmbed(resolved)],
@@ -174,10 +225,7 @@ export const Emoji: Command = {
           return;
         }
 
-        const all = await activeEmojiResolver.listApplicationEmojis(
-          interaction.client,
-        );
-        const suggestions = buildEmojiNameSuggestions(requestedName, all);
+        const suggestions = buildEmojiNameSuggestions(requestedName, emojis);
         const suggestionText = suggestions.length
           ? `\nDid you mean: ${suggestions.join(", ")}`
           : "";
@@ -189,9 +237,6 @@ export const Emoji: Command = {
         return;
       }
 
-      const emojis = await activeEmojiResolver.listApplicationEmojis(
-        interaction.client,
-      );
       const pages = paginateEmojiLines(emojis);
       let page = 0;
       const paginatorPrefix = `emoji-list:${interaction.id}`;

--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -860,7 +860,17 @@ export const Help: Command = {
                 interaction.id,
                 allowPostToChannel,
               );
-              await interaction.channel?.send({
+              const postChannel = interaction.channel as
+                | { send?: (input: { embeds: EmbedBuilder[] }) => Promise<unknown> }
+                | null;
+              if (!postChannel || typeof postChannel.send !== "function") {
+                await component.reply({
+                  ephemeral: true,
+                  content: "Could not post help in this channel.",
+                });
+                return;
+              }
+              await postChannel.send({
                 embeds: payload.embeds,
               });
               await component.reply({

--- a/src/commands/Inactive.ts
+++ b/src/commands/Inactive.ts
@@ -2,8 +2,8 @@ import {
   ActionRowBuilder,
   ButtonBuilder,
   ButtonStyle,
+  ChatInputCommandInteraction,
   Client,
-  CommandInteraction,
   ComponentType,
   EmbedBuilder,
 } from "discord.js";
@@ -108,7 +108,7 @@ type InactiveWarRow = {
 };
 
 async function fetchInactiveDaysEntries(
-  interaction: CommandInteraction,
+  interaction: ChatInputCommandInteraction,
   cocService: CoCService,
   days: number
 ): Promise<{
@@ -231,7 +231,7 @@ async function fetchInactiveDaysEntries(
 }
 
 async function fetchInactiveWarEntries(
-  interaction: CommandInteraction,
+  interaction: ChatInputCommandInteraction,
   wars: number
 ): Promise<{
   results: InactiveWarRow[];
@@ -344,7 +344,7 @@ async function fetchInactiveWarEntries(
 }
 
 async function renderEmbedsWithPager(
-  interaction: CommandInteraction,
+  interaction: ChatInputCommandInteraction,
   title: string,
   pages: string[],
   footerSuffix = ""
@@ -457,7 +457,7 @@ function buildGroupedPages<T>(
 }
 
 async function runDaysMode(
-  interaction: CommandInteraction,
+  interaction: ChatInputCommandInteraction,
   cocService: CoCService,
   days: number
 ): Promise<void> {
@@ -588,7 +588,7 @@ async function runDaysMode(
 }
 
 async function runWarsMode(
-  interaction: CommandInteraction,
+  interaction: ChatInputCommandInteraction,
   wars: number
 ): Promise<void> {
   const { results, trackedTags, trackedNameByTag, warnings } = await fetchInactiveWarEntries(
@@ -638,7 +638,7 @@ async function runWarsMode(
 }
 
 async function runCombinedMode(
-  interaction: CommandInteraction,
+  interaction: ChatInputCommandInteraction,
   cocService: CoCService,
   days: number,
   wars: number
@@ -777,13 +777,13 @@ export const Inactive: Command = {
 
   run: async (
     _client: Client,
-    interaction: CommandInteraction,
+    interaction: ChatInputCommandInteraction,
     cocService: CoCService
   ) => {
     await interaction.deferReply({ ephemeral: true });
 
-    const daysValue = interaction.options.get("days")?.value as number | undefined;
-    const warsValue = interaction.options.get("wars")?.value as number | undefined;
+    const daysValue = interaction.options.getInteger("days", false) ?? undefined;
+    const warsValue = interaction.options.getInteger("wars", false) ?? undefined;
 
     if (!daysValue && !warsValue) {
       await interaction.editReply("Provide at least one filter: `days` and/or `wars`.");

--- a/src/commands/RoleUsers.ts
+++ b/src/commands/RoleUsers.ts
@@ -148,7 +148,10 @@ export const RoleUsers: Command = {
           ) {
             page += 1;
           } else if (button.customId === "role-users-print") {
-            if (!interaction.channel) {
+            const printChannel = interaction.channel as
+              | { send?: (input: { embeds: EmbedBuilder[] }) => Promise<unknown> }
+              | null;
+            if (!printChannel || typeof printChannel.send !== "function") {
               await button.reply({
                 content: "Could not print pages in this channel.",
                 ephemeral: true,
@@ -158,7 +161,7 @@ export const RoleUsers: Command = {
 
             await button.update({ components: [] });
             for (let i = 0; i < pages.length; i += 1) {
-              await interaction.channel.send({
+              await printChannel.send({
                 embeds: [getEmbed(interaction, role, pages[i], i, pages.length)],
               });
             }

--- a/src/listeners/ready.ts
+++ b/src/listeners/ready.ts
@@ -2,6 +2,7 @@ import {
   ApplicationCommandOptionType,
   Client,
   PermissionFlagsBits,
+  version as discordJsVersion,
 } from "discord.js";
 import { Commands } from "../Commands";
 import { CoCService } from "../services/CoCService";
@@ -162,6 +163,25 @@ export default (client: Client, cocService: CoCService): void => {
     if (!client.application) return;
 
     console.log("ClashCookies is starting...");
+    let applicationFetchAttempted = false;
+    let applicationFetchSucceeded = false;
+    if (client.application) {
+      applicationFetchAttempted = true;
+      try {
+        await client.application.fetch();
+        applicationFetchSucceeded = true;
+      } catch {
+        applicationFetchSucceeded = false;
+      }
+    }
+    const hasApplicationEmojiFetch = Boolean(
+      client.application &&
+        client.application.emojis &&
+        typeof client.application.emojis.fetch === "function"
+    );
+    console.log(
+      `[startup:discord] discord_js_version=${discordJsVersion} application_present=${Boolean(client.application)} application_fetch_attempted=${applicationFetchAttempted} application_fetch_succeeded=${applicationFetchSucceeded} application_emoji_fetch_available=${hasApplicationEmojiFetch}`
+    );
 
     const bootstrapConfig = getStartupBootstrapRetryConfigFromEnv(process.env);
     const summaryEvery = getStartupRetryLogSummaryEveryFromEnv(process.env);

--- a/src/services/emoji/EmojiResolverService.ts
+++ b/src/services/emoji/EmojiResolverService.ts
@@ -15,11 +15,43 @@ type EmojiSnapshot = {
   lowercaseByName: Map<string, ResolvedApplicationEmoji>;
 };
 
-type ApplicationEmojiFetchOwner = {
-  emojis?: {
-    fetch?: () => Promise<Map<string, any> | { values: () => Iterable<any> }>;
-  };
+export type EmojiResolverFailureCode =
+  | "application_missing"
+  | "application_fetch_failed"
+  | "application_emoji_manager_unavailable"
+  | "application_emoji_fetch_failed";
+
+export type EmojiResolverDiagnostics = {
+  applicationExistedBeforeFetch: boolean;
+  applicationFetchAttempted: boolean;
+  applicationEmojiFetchAvailable: boolean;
+  emojiFetchSucceeded: boolean;
+  fetchedEmojiCount: number;
 };
+
+export type EmojiInventoryFetchSuccess = {
+  ok: true;
+  snapshot: EmojiSnapshot;
+  diagnostics: EmojiResolverDiagnostics;
+};
+
+export type EmojiInventoryFetchFailure = {
+  ok: false;
+  code: EmojiResolverFailureCode;
+  diagnostics: EmojiResolverDiagnostics;
+  cause?: unknown;
+};
+
+export type EmojiInventoryFetchResult =
+  | EmojiInventoryFetchSuccess
+  | EmojiInventoryFetchFailure;
+
+type EnsureApplicationResult =
+  | {
+      ok: true;
+      application: NonNullable<Client["application"]>;
+    }
+  | EmojiInventoryFetchFailure;
 
 const SHORTCODE_REPLACE_PATTERN =
   /(^|[\s([{"']):([a-zA-Z0-9_]{2,32}):(?=$|[\s)\]}".,!?:;'"-])/g;
@@ -45,6 +77,38 @@ function sortResolvedEmojis(
   });
 }
 
+/** Purpose: represent resolver fetch failures with explicit reason codes and diagnostics. */
+export class EmojiResolverRuntimeError extends Error {
+  readonly code: EmojiResolverFailureCode;
+  readonly diagnostics: EmojiResolverDiagnostics;
+  readonly cause?: unknown;
+
+  constructor(params: {
+    code: EmojiResolverFailureCode;
+    diagnostics: EmojiResolverDiagnostics;
+    cause?: unknown;
+  }) {
+    super(`Emoji resolver failed: ${params.code}`);
+    this.name = "EmojiResolverRuntimeError";
+    this.code = params.code;
+    this.diagnostics = params.diagnostics;
+    this.cause = params.cause;
+  }
+}
+
+/** Purpose: create default diagnostics for one snapshot fetch attempt. */
+function createEmptyDiagnostics(
+  applicationExistedBeforeFetch: boolean,
+): EmojiResolverDiagnostics {
+  return {
+    applicationExistedBeforeFetch,
+    applicationFetchAttempted: false,
+    applicationEmojiFetchAvailable: false,
+    emojiFetchSucceeded: false,
+    fetchedEmojiCount: 0,
+  };
+}
+
 /** Purpose: resolve bot-owned application emojis by name and replace shortcode text safely. */
 export class EmojiResolverService {
   private snapshot: EmojiSnapshot | null = null;
@@ -52,9 +116,23 @@ export class EmojiResolverService {
   /** Purpose: configure refreshable in-memory cache TTL for resolver lookups. */
   constructor(private readonly cacheTtlMs: number = 30_000) {}
 
+  /** Purpose: fetch application-emoji inventory with explicit success/failure typing for command-level handling. */
+  async fetchApplicationEmojiInventory(
+    client: Client,
+    options?: { forceRefresh?: boolean },
+  ): Promise<EmojiInventoryFetchResult> {
+    return this.getSnapshotResult(client, options?.forceRefresh ?? false);
+  }
+
   /** Purpose: force-refresh the application emoji snapshot from Discord. */
   async refresh(client: Client): Promise<void> {
-    this.snapshot = await this.fetchSnapshot(client);
+    const result = await this.fetchApplicationEmojiInventory(client, {
+      forceRefresh: true,
+    });
+    if (!result.ok) {
+      throw this.toRuntimeError(result);
+    }
+    this.snapshot = result.snapshot;
   }
 
   /** Purpose: resolve one emoji by name (case-insensitive) from bot application emojis. */
@@ -109,52 +187,110 @@ export class EmojiResolverService {
     client: Client,
     forceRefresh: boolean,
   ): Promise<EmojiSnapshot> {
+    const result = await this.getSnapshotResult(client, forceRefresh);
+    if (!result.ok) {
+      throw this.toRuntimeError(result);
+    }
+    return result.snapshot;
+  }
+
+  /** Purpose: return a typed snapshot result while honoring cache freshness for repeat lookups. */
+  private async getSnapshotResult(
+    client: Client,
+    forceRefresh: boolean,
+  ): Promise<EmojiInventoryFetchResult> {
     const nowMs = Date.now();
     if (
       !forceRefresh &&
       this.snapshot &&
       nowMs - this.snapshot.fetchedAtMs <= this.cacheTtlMs
     ) {
-      return this.snapshot;
+      return {
+        ok: true,
+        snapshot: this.snapshot,
+        diagnostics: {
+          applicationExistedBeforeFetch: Boolean(client.application),
+          applicationFetchAttempted: false,
+          applicationEmojiFetchAvailable: true,
+          emojiFetchSucceeded: true,
+          fetchedEmojiCount: this.snapshot.entries.length,
+        },
+      };
     }
     const next = await this.fetchSnapshot(client);
-    this.snapshot = next;
+    if (next.ok) {
+      this.snapshot = next.snapshot;
+    }
     return next;
   }
 
   /** Purpose: safely ensure client application hydration before reading application emoji inventory. */
-  private async ensureApplication(client: Client) {
-    if (client.application) {
-      await client.application.fetch().catch(() => undefined);
-      return client.application;
+  private async ensureApplication(
+    client: Client,
+    diagnostics: EmojiResolverDiagnostics,
+  ): Promise<EnsureApplicationResult> {
+    if (!client.application) {
+      return {
+        ok: false,
+        code: "application_missing",
+        diagnostics,
+      };
     }
-    return null;
+    diagnostics.applicationFetchAttempted = true;
+    try {
+      await client.application.fetch();
+    } catch (error) {
+      return {
+        ok: false,
+        code: "application_fetch_failed",
+        diagnostics,
+        cause: error,
+      };
+    }
+    if (!client.application) {
+      return {
+        ok: false,
+        code: "application_missing",
+        diagnostics,
+      };
+    }
+    return {
+      ok: true,
+      application: client.application,
+    };
   }
 
   /** Purpose: build a fresh application-emoji snapshot keyed for exact and case-insensitive lookups. */
-  private async fetchSnapshot(client: Client): Promise<EmojiSnapshot> {
-    const application = await this.ensureApplication(client);
-    if (!application) {
+  private async fetchSnapshot(client: Client): Promise<EmojiInventoryFetchResult> {
+    const diagnostics = createEmptyDiagnostics(Boolean(client.application));
+    const applicationResult = await this.ensureApplication(client, diagnostics);
+    if (!applicationResult.ok) {
+      return applicationResult;
+    }
+    const application = applicationResult.application;
+
+    if (!application?.emojis || typeof application.emojis.fetch !== "function") {
       return {
-        fetchedAtMs: Date.now(),
-        entries: [],
-        exactByName: new Map<string, ResolvedApplicationEmoji>(),
-        lowercaseByName: new Map<string, ResolvedApplicationEmoji>(),
+        ok: false,
+        code: "application_emoji_manager_unavailable",
+        diagnostics,
       };
     }
+    diagnostics.applicationEmojiFetchAvailable = true;
 
-    const applicationWithEmojis = application as unknown as ApplicationEmojiFetchOwner;
-    const emojiFetch = applicationWithEmojis.emojis?.fetch;
-    if (typeof emojiFetch !== "function") {
+    let fetched;
+    try {
+      fetched = await application.emojis.fetch();
+    } catch (error) {
       return {
-        fetchedAtMs: Date.now(),
-        entries: [],
-        exactByName: new Map<string, ResolvedApplicationEmoji>(),
-        lowercaseByName: new Map<string, ResolvedApplicationEmoji>(),
+        ok: false,
+        code: "application_emoji_fetch_failed",
+        diagnostics,
+        cause: error,
       };
     }
+    diagnostics.emojiFetchSucceeded = true;
 
-    const fetched = await emojiFetch();
     const collected: ResolvedApplicationEmoji[] = [];
     for (const emoji of fetched.values()) {
       const name = String(emoji.name ?? "").trim();
@@ -168,6 +304,7 @@ export class EmojiResolverService {
         animated: Boolean(emoji.animated),
       });
     }
+    diagnostics.fetchedEmojiCount = collected.length;
 
     const entries = sortResolvedEmojis(collected);
     const exactByName = new Map<string, ResolvedApplicationEmoji>();
@@ -183,11 +320,24 @@ export class EmojiResolverService {
     }
 
     return {
-      fetchedAtMs: Date.now(),
-      entries,
-      exactByName,
-      lowercaseByName,
+      ok: true,
+      diagnostics,
+      snapshot: {
+        fetchedAtMs: Date.now(),
+        entries,
+        exactByName,
+        lowercaseByName,
+      },
     };
+  }
+
+  /** Purpose: normalize typed failure results into thrown errors for legacy call sites. */
+  private toRuntimeError(failure: EmojiInventoryFetchFailure): EmojiResolverRuntimeError {
+    return new EmojiResolverRuntimeError({
+      code: failure.code,
+      diagnostics: failure.diagnostics,
+      cause: failure.cause,
+    });
   }
 }
 

--- a/tests/emoji.command.test.ts
+++ b/tests/emoji.command.test.ts
@@ -6,12 +6,16 @@ import {
   resetEmojiResolverForTest,
   setEmojiResolverForTest,
 } from "../src/commands/Emoji";
+import type {
+  EmojiInventoryFetchResult,
+  ResolvedApplicationEmoji,
+} from "../src/services/emoji/EmojiResolverService";
 
 type EmojiResolverStub = {
-  resolveByName: ReturnType<typeof vi.fn>;
-  listApplicationEmojis: ReturnType<typeof vi.fn>;
+  fetchApplicationEmojiInventory: ReturnType<typeof vi.fn>;
 };
 
+/** Purpose: build minimal fake chat-input interaction for command unit tests. */
 function buildInteraction(input?: {
   name?: string | null;
 }): {
@@ -27,10 +31,13 @@ function buildInteraction(input?: {
   });
   const interaction = {
     id: "interaction-1",
+    guildId: "guild-1",
     user: { id: "user-1" },
     client: {} as Client,
     options: {
-      getString: vi.fn((name: string) => (name === "name" ? (input?.name ?? null) : null)),
+      getString: vi.fn((name: string) =>
+        name === "name" ? (input?.name ?? null) : null,
+      ),
     },
     deferReply,
     editReply,
@@ -39,10 +46,60 @@ function buildInteraction(input?: {
   return { interaction, deferReply, editReply, fetchReply };
 }
 
+/** Purpose: build resolver stub for deterministic command behavior assertions. */
 function buildResolverStub(): EmojiResolverStub {
   return {
-    resolveByName: vi.fn(),
-    listApplicationEmojis: vi.fn(),
+    fetchApplicationEmojiInventory: vi.fn(),
+  };
+}
+
+/** Purpose: create a successful inventory result from emoji entries for tests. */
+function buildSuccessResult(
+  emojis: ResolvedApplicationEmoji[],
+): EmojiInventoryFetchResult {
+  const exactByName = new Map<string, ResolvedApplicationEmoji>();
+  const lowercaseByName = new Map<string, ResolvedApplicationEmoji>();
+  for (const emoji of emojis) {
+    if (!exactByName.has(emoji.name)) {
+      exactByName.set(emoji.name, emoji);
+    }
+    const lower = emoji.name.toLowerCase();
+    if (!lowercaseByName.has(lower)) {
+      lowercaseByName.set(lower, emoji);
+    }
+  }
+  return {
+    ok: true,
+    diagnostics: {
+      applicationExistedBeforeFetch: true,
+      applicationFetchAttempted: true,
+      applicationEmojiFetchAvailable: true,
+      emojiFetchSucceeded: true,
+      fetchedEmojiCount: emojis.length,
+    },
+    snapshot: {
+      fetchedAtMs: Date.now(),
+      entries: emojis,
+      exactByName,
+      lowercaseByName,
+    },
+  };
+}
+
+/** Purpose: create a failed inventory result with resolver diagnostics for tests. */
+function buildFailureResult(
+  code: "application_emoji_manager_unavailable" | "application_emoji_fetch_failed",
+): EmojiInventoryFetchResult {
+  return {
+    ok: false,
+    code,
+    diagnostics: {
+      applicationExistedBeforeFetch: true,
+      applicationFetchAttempted: true,
+      applicationEmojiFetchAvailable: code !== "application_emoji_manager_unavailable",
+      emojiFetchSucceeded: false,
+      fetchedEmojiCount: 0,
+    },
   };
 }
 
@@ -54,19 +111,23 @@ describe("/emoji command", () => {
 
   it("supports name mode success", async () => {
     const resolver = buildResolverStub();
-    resolver.resolveByName.mockResolvedValue({
-      id: "1",
-      name: "arrow_arrow",
-      shortcode: ":arrow_arrow:",
-      rendered: "<:arrow_arrow:1>",
-      animated: false,
-    });
+    resolver.fetchApplicationEmojiInventory.mockResolvedValue(
+      buildSuccessResult([
+        {
+          id: "1",
+          name: "arrow_arrow",
+          shortcode: ":arrow_arrow:",
+          rendered: "<:arrow_arrow:1>",
+          animated: false,
+        },
+      ]),
+    );
     setEmojiResolverForTest(resolver as any);
     const { interaction, editReply } = buildInteraction({ name: "arrow_arrow" });
 
     await Emoji.run({} as Client, interaction, {} as any);
 
-    expect(resolver.resolveByName).toHaveBeenCalledTimes(1);
+    expect(resolver.fetchApplicationEmojiInventory).toHaveBeenCalledTimes(1);
     const payload = editReply.mock.calls[0]?.[0] ?? {};
     const embed = payload.embeds?.[0];
     const json = typeof embed?.toJSON === "function" ? embed.toJSON() : embed?.data ?? {};
@@ -75,16 +136,17 @@ describe("/emoji command", () => {
 
   it("supports name mode not found", async () => {
     const resolver = buildResolverStub();
-    resolver.resolveByName.mockResolvedValue(null);
-    resolver.listApplicationEmojis.mockResolvedValue([
-      {
-        id: "1",
-        name: "arrow_arrow",
-        shortcode: ":arrow_arrow:",
-        rendered: "<:arrow_arrow:1>",
-        animated: false,
-      },
-    ]);
+    resolver.fetchApplicationEmojiInventory.mockResolvedValue(
+      buildSuccessResult([
+        {
+          id: "1",
+          name: "arrow_arrow",
+          shortcode: ":arrow_arrow:",
+          rendered: "<:arrow_arrow:1>",
+          animated: false,
+        },
+      ]),
+    );
     setEmojiResolverForTest(resolver as any);
     const { interaction, editReply } = buildInteraction({ name: "not_real" });
 
@@ -96,22 +158,24 @@ describe("/emoji command", () => {
 
   it("renders list mode first page", async () => {
     const resolver = buildResolverStub();
-    resolver.listApplicationEmojis.mockResolvedValue([
-      {
-        id: "1",
-        name: "alpha",
-        shortcode: ":alpha:",
-        rendered: "<:alpha:1>",
-        animated: false,
-      },
-      {
-        id: "2",
-        name: "bravo",
-        shortcode: ":bravo:",
-        rendered: "<:bravo:2>",
-        animated: false,
-      },
-    ]);
+    resolver.fetchApplicationEmojiInventory.mockResolvedValue(
+      buildSuccessResult([
+        {
+          id: "1",
+          name: "alpha",
+          shortcode: ":alpha:",
+          rendered: "<:alpha:1>",
+          animated: false,
+        },
+        {
+          id: "2",
+          name: "bravo",
+          shortcode: ":bravo:",
+          rendered: "<:bravo:2>",
+          animated: false,
+        },
+      ]),
+    );
     setEmojiResolverForTest(resolver as any);
     const { interaction, editReply, fetchReply } = buildInteraction();
 
@@ -151,7 +215,7 @@ describe("/emoji command", () => {
 
   it("renders list mode empty state when no emojis are available", async () => {
     const resolver = buildResolverStub();
-    resolver.listApplicationEmojis.mockResolvedValue([]);
+    resolver.fetchApplicationEmojiInventory.mockResolvedValue(buildSuccessResult([]));
     setEmojiResolverForTest(resolver as any);
     const { interaction, editReply } = buildInteraction();
 
@@ -164,5 +228,37 @@ describe("/emoji command", () => {
       "No application emojis are currently available",
     );
     expect(payload.components ?? []).toEqual([]);
+  });
+
+  it("shows runtime-unavailable message when resolver reports manager unavailable", async () => {
+    const resolver = buildResolverStub();
+    resolver.fetchApplicationEmojiInventory.mockResolvedValue(
+      buildFailureResult("application_emoji_manager_unavailable"),
+    );
+    setEmojiResolverForTest(resolver as any);
+    const { interaction, editReply } = buildInteraction();
+
+    await Emoji.run({} as Client, interaction, {} as any);
+
+    const payload = editReply.mock.calls[0]?.[0] ?? {};
+    expect(String(payload.content ?? "")).toContain(
+      "Could not load bot application emojis in this runtime",
+    );
+  });
+
+  it("shows retry message when resolver reports fetch failure", async () => {
+    const resolver = buildResolverStub();
+    resolver.fetchApplicationEmojiInventory.mockResolvedValue(
+      buildFailureResult("application_emoji_fetch_failed"),
+    );
+    setEmojiResolverForTest(resolver as any);
+    const { interaction, editReply } = buildInteraction();
+
+    await Emoji.run({} as Client, interaction, {} as any);
+
+    const payload = editReply.mock.calls[0]?.[0] ?? {};
+    expect(String(payload.content ?? "")).toContain(
+      "Could not fetch bot application emojis right now",
+    );
   });
 });

--- a/tests/emojiResolver.service.test.ts
+++ b/tests/emojiResolver.service.test.ts
@@ -9,6 +9,14 @@ type FakeAppEmoji = {
   toString: () => string;
 };
 
+type FakeApplication = {
+  fetch: ReturnType<typeof vi.fn>;
+  emojis?: {
+    fetch?: ReturnType<typeof vi.fn>;
+  };
+};
+
+/** Purpose: build deterministic fake app emoji objects with Discord-like string rendering. */
 function buildFakeEmoji(input: {
   id: string;
   name: string;
@@ -19,11 +27,18 @@ function buildFakeEmoji(input: {
     id: input.id,
     name: input.name,
     animated,
-    toString: () =>
-      `<${animated ? "a" : ""}:${input.name}:${input.id}>`,
+    toString: () => `<${animated ? "a" : ""}:${input.name}:${input.id}>`,
   };
 }
 
+/** Purpose: create a minimal fake client with configurable application + emoji fetch behavior. */
+function buildClient(input: { application: FakeApplication | null }): Client {
+  return {
+    application: input.application,
+  } as unknown as Client;
+}
+
+/** Purpose: build fake client/application that returns an emoji collection successfully. */
 function buildClientWithApplicationEmojis(
   emojis: FakeAppEmoji[],
 ): {
@@ -31,22 +46,102 @@ function buildClientWithApplicationEmojis(
   fetchApplication: ReturnType<typeof vi.fn>;
   fetchEmojis: ReturnType<typeof vi.fn>;
 } {
-  const fetchEmojis = vi.fn().mockResolvedValue(
-    new Map(emojis.map((emoji) => [emoji.id, emoji])),
-  );
+  const fetchEmojis = vi
+    .fn()
+    .mockResolvedValue(new Map(emojis.map((emoji) => [emoji.id, emoji])));
   const fetchApplication = vi.fn().mockResolvedValue(undefined);
-  const client = {
-    application: {
-      fetch: fetchApplication,
-      emojis: {
-        fetch: fetchEmojis,
-      },
+  const application: FakeApplication = {
+    fetch: fetchApplication,
+    emojis: {
+      fetch: fetchEmojis,
     },
-  } as unknown as Client;
-  return { client, fetchApplication, fetchEmojis };
+  };
+  return {
+    client: buildClient({ application }),
+    fetchApplication,
+    fetchEmojis,
+  };
 }
 
 describe("EmojiResolverService", () => {
+  it("fetchApplicationEmojiInventory returns success with emojis", async () => {
+    const resolver = new EmojiResolverService(0);
+    const { client } = buildClientWithApplicationEmojis([
+      buildFakeEmoji({ id: "2", name: "bravo" }),
+      buildFakeEmoji({ id: "1", name: "alpha" }),
+    ]);
+
+    const result = await resolver.fetchApplicationEmojiInventory(client, {
+      forceRefresh: true,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.snapshot.entries.map((entry) => entry.name)).toEqual([
+      "alpha",
+      "bravo",
+    ]);
+    expect(result.snapshot.exactByName.get("alpha")?.rendered).toBe("<:alpha:1>");
+    expect(result.snapshot.lowercaseByName.get("bravo")?.rendered).toBe(
+      "<:bravo:2>",
+    );
+  });
+
+  it("fetchApplicationEmojiInventory returns success with zero emojis", async () => {
+    const resolver = new EmojiResolverService(0);
+    const { client } = buildClientWithApplicationEmojis([]);
+
+    const result = await resolver.fetchApplicationEmojiInventory(client, {
+      forceRefresh: true,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.snapshot.entries).toEqual([]);
+    expect(result.diagnostics.emojiFetchSucceeded).toBe(true);
+  });
+
+  it("fetchApplicationEmojiInventory returns manager-unavailable failure", async () => {
+    const resolver = new EmojiResolverService(0);
+    const fetchApplication = vi.fn().mockResolvedValue(undefined);
+    const client = buildClient({
+      application: {
+        fetch: fetchApplication,
+        emojis: {},
+      },
+    });
+
+    const result = await resolver.fetchApplicationEmojiInventory(client, {
+      forceRefresh: true,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.code).toBe("application_emoji_manager_unavailable");
+  });
+
+  it("fetchApplicationEmojiInventory returns fetch-failed failure", async () => {
+    const resolver = new EmojiResolverService(0);
+    const fetchApplication = vi.fn().mockResolvedValue(undefined);
+    const fetchEmojis = vi.fn().mockRejectedValue(new Error("boom"));
+    const client = buildClient({
+      application: {
+        fetch: fetchApplication,
+        emojis: {
+          fetch: fetchEmojis,
+        },
+      },
+    });
+
+    const result = await resolver.fetchApplicationEmojiInventory(client, {
+      forceRefresh: true,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.code).toBe("application_emoji_fetch_failed");
+  });
+
   it("resolves exact-name match", async () => {
     const resolver = new EmojiResolverService(0);
     const { client } = buildClientWithApplicationEmojis([
@@ -97,19 +192,6 @@ describe("EmojiResolverService", () => {
     );
 
     expect(out).toBe("Known <:arrow_arrow:1> unknown :not_real:");
-  });
-
-  it("handles empty emoji collections", async () => {
-    const resolver = new EmojiResolverService(0);
-    const { client } = buildClientWithApplicationEmojis([]);
-
-    const list = await resolver.listApplicationEmojis(client);
-    const resolved = await resolver.resolveByName(client, "arrow_arrow");
-    const replaced = await resolver.replaceShortcodes(client, "Plan :arrow_arrow:");
-
-    expect(list).toEqual([]);
-    expect(resolved).toBeNull();
-    expect(replaced).toBe("Plan :arrow_arrow:");
   });
 
   it("keeps static and animated emoji render tokens as returned by Discord", async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,64 +22,77 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@discordjs/builders@^1.6.3":
-  version "1.6.3"
-  resolved "https://registry.npmjs.org/@discordjs/builders/-/builders-1.6.3.tgz"
-  integrity sha512-CTCh8NqED3iecTNuiz49mwSsrc2iQb4d0MjMdmS/8pb69Y4IlzJ/DIy/p5GFlgOrFbNO2WzMHkWKQSiJ3VNXaw==
+"@discordjs/builders@^1.13.0":
+  version "1.13.1"
+  resolved "https://registry.npmjs.org/@discordjs/builders/-/builders-1.13.1.tgz"
+  integrity sha512-cOU0UDHc3lp/5nKByDxkmRiNZBpdp0kx55aarbiAfakfKJHlxv/yFW1zmIqCAmwH5CRlrH9iMFKJMpvW4DPB+w==
   dependencies:
-    "@discordjs/formatters" "^0.3.1"
-    "@discordjs/util" "^0.3.1"
-    "@sapphire/shapeshift" "^3.8.2"
-    discord-api-types "^0.37.41"
+    "@discordjs/formatters" "^0.6.2"
+    "@discordjs/util" "^1.2.0"
+    "@sapphire/shapeshift" "^4.0.0"
+    discord-api-types "^0.38.33"
     fast-deep-equal "^3.1.3"
-    ts-mixer "^6.0.3"
-    tslib "^2.5.0"
+    ts-mixer "^6.0.4"
+    tslib "^2.6.3"
 
-"@discordjs/collection@^1.5.1":
-  version "1.5.1"
-  resolved "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.1.tgz"
-  integrity sha512-aWEc9DCf3TMDe9iaJoOnO2+JVAjeRNuRxPZQA6GVvBf+Z3gqUuWYBy2NWh4+5CLYq5uoc3MOvUQ5H5m8CJBqOA==
+"@discordjs/collection@^2.1.0":
+  version "2.1.1"
+  resolved "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz"
+  integrity sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==
 
-"@discordjs/formatters@^0.3.1":
-  version "0.3.1"
-  resolved "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.3.1.tgz"
-  integrity sha512-M7X4IGiSeh4znwcRGcs+49B5tBkNDn4k5bmhxJDAUhRxRHTiFAOTVUNQ6yAKySu5jZTnCbSvTYHW3w0rAzV1MA==
+"@discordjs/collection@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz"
+  integrity sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==
+
+"@discordjs/collection@1.5.3":
+  version "1.5.3"
+  resolved "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.3.tgz"
+  integrity sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==
+
+"@discordjs/formatters@^0.6.2":
+  version "0.6.2"
+  resolved "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.6.2.tgz"
+  integrity sha512-y4UPwWhH6vChKRkGdMB4odasUbHOUwy7KL+OVwF86PvT6QVOwElx+TiI1/6kcmcEe+g5YRXJFiXSXUdabqZOvQ==
   dependencies:
-    discord-api-types "^0.37.41"
+    discord-api-types "^0.38.33"
 
-"@discordjs/rest@^1.7.1":
-  version "1.7.1"
-  resolved "https://registry.npmjs.org/@discordjs/rest/-/rest-1.7.1.tgz"
-  integrity sha512-Ofa9UqT0U45G/eX86cURQnX7gzOJLG2oC28VhIk/G6IliYgQF7jFByBJEykPSHE4MxPhqCleYvmsrtfKh1nYmQ==
+"@discordjs/rest@^2.5.1", "@discordjs/rest@^2.6.0":
+  version "2.6.0"
+  resolved "https://registry.npmjs.org/@discordjs/rest/-/rest-2.6.0.tgz"
+  integrity sha512-RDYrhmpB7mTvmCKcpj+pc5k7POKszS4E2O9TYc+U+Y4iaCP+r910QdO43qmpOja8LRr1RJ0b3U+CqVsnPqzf4w==
   dependencies:
-    "@discordjs/collection" "^1.5.1"
-    "@discordjs/util" "^0.3.0"
-    "@sapphire/async-queue" "^1.5.0"
-    "@sapphire/snowflake" "^3.4.2"
-    discord-api-types "^0.37.41"
-    file-type "^18.3.0"
-    tslib "^2.5.0"
-    undici "^5.22.0"
+    "@discordjs/collection" "^2.1.1"
+    "@discordjs/util" "^1.1.1"
+    "@sapphire/async-queue" "^1.5.3"
+    "@sapphire/snowflake" "^3.5.3"
+    "@vladfrangu/async_event_emitter" "^2.4.6"
+    discord-api-types "^0.38.16"
+    magic-bytes.js "^1.10.0"
+    tslib "^2.6.3"
+    undici "6.21.3"
 
-"@discordjs/util@^0.3.0", "@discordjs/util@^0.3.1":
-  version "0.3.1"
-  resolved "https://registry.npmjs.org/@discordjs/util/-/util-0.3.1.tgz"
-  integrity sha512-HxXKYKg7vohx2/OupUN/4Sd02Ev3PBJ5q0gtjdcvXb0ErCva8jNHWfe/v5sU3UKjIB/uxOhc+TDOnhqffj9pRA==
-
-"@discordjs/ws@^0.8.3":
-  version "0.8.3"
-  resolved "https://registry.npmjs.org/@discordjs/ws/-/ws-0.8.3.tgz"
-  integrity sha512-hcYtppanjHecbdNyCKQNH2I4RP9UrphDgmRgLYrATEQF1oo4sYSve7ZmGsBEXSzH72MO2tBPdWSThunbxUVk0g==
+"@discordjs/util@^1.1.0", "@discordjs/util@^1.1.1", "@discordjs/util@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/@discordjs/util/-/util-1.2.0.tgz"
+  integrity sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg==
   dependencies:
-    "@discordjs/collection" "^1.5.1"
-    "@discordjs/rest" "^1.7.1"
-    "@discordjs/util" "^0.3.1"
-    "@sapphire/async-queue" "^1.5.0"
-    "@types/ws" "^8.5.4"
-    "@vladfrangu/async_event_emitter" "^2.2.1"
-    discord-api-types "^0.37.41"
-    tslib "^2.5.0"
-    ws "^8.13.0"
+    discord-api-types "^0.38.33"
+
+"@discordjs/ws@^1.2.3":
+  version "1.2.3"
+  resolved "https://registry.npmjs.org/@discordjs/ws/-/ws-1.2.3.tgz"
+  integrity sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==
+  dependencies:
+    "@discordjs/collection" "^2.1.0"
+    "@discordjs/rest" "^2.5.1"
+    "@discordjs/util" "^1.1.0"
+    "@sapphire/async-queue" "^1.5.2"
+    "@types/ws" "^8.5.10"
+    "@vladfrangu/async_event_emitter" "^2.2.4"
+    discord-api-types "^0.38.1"
+    tslib "^2.6.2"
+    ws "^8.17.0"
 
 "@esbuild/win32-x64@0.21.5":
   version "0.21.5"
@@ -263,33 +276,28 @@
   resolved "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz"
   integrity sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==
 
-"@sapphire/async-queue@^1.5.0":
-  version "1.5.0"
-  resolved "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.0.tgz"
-  integrity sha512-JkLdIsP8fPAdh9ZZjrbHWR/+mZj0wvKS5ICibcLrRI1j84UmLMshx5n9QmL8b95d4onJ2xxiyugTgSAX7AalmA==
+"@sapphire/async-queue@^1.5.2", "@sapphire/async-queue@^1.5.3":
+  version "1.5.5"
+  resolved "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.5.tgz"
+  integrity sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==
 
-"@sapphire/shapeshift@^3.8.2":
-  version "3.9.2"
-  resolved "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.9.2.tgz"
-  integrity sha512-YRbCXWy969oGIdqR/wha62eX8GNHsvyYi0Rfd4rNW6tSVVa8p0ELiMEuOH/k8rgtvRoM+EMV7Csqz77YdwiDpA==
+"@sapphire/shapeshift@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-4.0.0.tgz"
+  integrity sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==
   dependencies:
     fast-deep-equal "^3.1.3"
     lodash "^4.17.21"
 
-"@sapphire/snowflake@^3.4.2":
-  version "3.5.1"
-  resolved "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.1.tgz"
-  integrity sha512-BxcYGzgEsdlG0dKAyOm0ehLGm2CafIrfQTZGWgkfKYbj+pNNsorZ7EotuZukc2MT70E0UbppVbtpBrqpzVzjNA==
+"@sapphire/snowflake@^3.5.3", "@sapphire/snowflake@3.5.3":
+  version "3.5.3"
+  resolved "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.3.tgz"
+  integrity sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==
 
 "@sinclair/typebox@^0.27.8":
   version "0.27.10"
   resolved "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz"
   integrity sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==
-
-"@tokenizer/token@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz"
-  integrity sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==
 
 "@tsconfig/node10@^1.0.7":
   version "1.0.9"
@@ -346,10 +354,10 @@
   resolved "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz"
   integrity sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==
 
-"@types/ws@^8.5.4":
-  version "8.5.5"
-  resolved "https://registry.npmjs.org/@types/ws/-/ws-8.5.5.tgz"
-  integrity sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==
+"@types/ws@^8.5.10":
+  version "8.18.1"
+  resolved "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz"
+  integrity sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==
   dependencies:
     "@types/node" "*"
 
@@ -504,10 +512,10 @@
     loupe "^2.3.6"
     pretty-format "^29.5.0"
 
-"@vladfrangu/async_event_emitter@^2.2.1":
-  version "2.2.2"
-  resolved "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.2.2.tgz"
-  integrity sha512-HIzRG7sy88UZjBJamssEczH5q7t5+axva19UbZLO6u0ySbYPrwzWiXBcC0WuHyhKKoeCyneH+FvYzKQq/zTtkQ==
+"@vladfrangu/async_event_emitter@^2.2.4", "@vladfrangu/async_event_emitter@^2.4.6":
+  version "2.4.7"
+  resolved "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.7.tgz"
+  integrity sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==
 
 acorn-jsx@^5.3.2:
   version "5.3.2"
@@ -624,13 +632,6 @@ braces@^3.0.3, braces@~3.0.2:
   integrity sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==
   dependencies:
     fill-range "^7.1.1"
-
-busboy@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz"
-  integrity sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==
-  dependencies:
-    streamsearch "^1.1.0"
 
 cac@^6.7.14:
   version "6.7.14"
@@ -789,30 +790,29 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
-discord-api-types@^0.37.41:
-  version "0.37.49"
-  resolved "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.49.tgz"
-  integrity sha512-a2vvjgmE/1cPtXOuOh5zHlLe+qheu0uO625K+FyZVFomoCmpV1xNpadC48S98K30CnQ4/XJyFGnOZLXxAyBbCQ==
+discord-api-types@^0.38.1, discord-api-types@^0.38.16, discord-api-types@^0.38.33:
+  version "0.38.42"
+  resolved "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.42.tgz"
+  integrity sha512-qs1kya7S84r5RR8m9kgttywGrmmoHaRifU1askAoi+wkoSefLpZP6aGXusjNw5b0jD3zOg3LTwUa3Tf2iHIceQ==
 
-discord.js@^14.11.0:
-  version "14.11.0"
-  resolved "https://registry.npmjs.org/discord.js/-/discord.js-14.11.0.tgz"
-  integrity sha512-CkueWYFQ28U38YPR8HgsBR/QT35oPpMbEsTNM30Fs8loBIhnA4s70AwQEoy6JvLcpWWJO7GY0y2BUzZmuBMepQ==
+discord.js@^14.25.1:
+  version "14.25.1"
+  resolved "https://registry.npmjs.org/discord.js/-/discord.js-14.25.1.tgz"
+  integrity sha512-2l0gsPOLPs5t6GFZfQZKnL1OJNYFcuC/ETWsW4VtKVD/tg4ICa9x+jb9bkPffkMdRpRpuUaO/fKkHCBeiCKh8g==
   dependencies:
-    "@discordjs/builders" "^1.6.3"
-    "@discordjs/collection" "^1.5.1"
-    "@discordjs/formatters" "^0.3.1"
-    "@discordjs/rest" "^1.7.1"
-    "@discordjs/util" "^0.3.1"
-    "@discordjs/ws" "^0.8.3"
-    "@sapphire/snowflake" "^3.4.2"
-    "@types/ws" "^8.5.4"
-    discord-api-types "^0.37.41"
-    fast-deep-equal "^3.1.3"
-    lodash.snakecase "^4.1.1"
-    tslib "^2.5.0"
-    undici "^5.22.0"
-    ws "^8.13.0"
+    "@discordjs/builders" "^1.13.0"
+    "@discordjs/collection" "1.5.3"
+    "@discordjs/formatters" "^0.6.2"
+    "@discordjs/rest" "^2.6.0"
+    "@discordjs/util" "^1.2.0"
+    "@discordjs/ws" "^1.2.3"
+    "@sapphire/snowflake" "3.5.3"
+    discord-api-types "^0.38.33"
+    fast-deep-equal "3.1.3"
+    lodash.snakecase "4.1.1"
+    magic-bytes.js "^1.10.0"
+    tslib "^2.6.3"
+    undici "6.21.3"
 
 doctrine@^3.0.0:
   version "3.0.0"
@@ -986,7 +986,7 @@ esutils@^2.0.2:
   resolved "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
-fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
+fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3, fast-deep-equal@3.1.3:
   version "3.1.3"
   resolved "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
@@ -1025,15 +1025,6 @@ file-entry-cache@^6.0.1:
   integrity sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==
   dependencies:
     flat-cache "^3.0.4"
-
-file-type@^18.3.0:
-  version "18.5.0"
-  resolved "https://registry.npmjs.org/file-type/-/file-type-18.5.0.tgz"
-  integrity sha512-yvpl5U868+V6PqXHMmsESpg6unQ5GfnPssl4dxdJudBrr9qy7Fddt7EVX1VLlddFfe8Gj9N7goCZH22FXuSQXQ==
-  dependencies:
-    readable-web-to-node-stream "^3.0.2"
-    strtok3 "^7.0.0"
-    token-types "^5.0.1"
 
 fill-range@^7.1.1:
   version "7.1.1"
@@ -1208,11 +1199,6 @@ html-escaper@^2.0.0:
   resolved "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz"
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
 
-ieee754@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz"
-  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
-
 ignore-by-default@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz"
@@ -1244,7 +1230,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@^2.0.3, inherits@2:
+inherits@2:
   version "2.0.4"
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -1373,15 +1359,15 @@ lodash.merge@^4.6.2:
   resolved "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash.snakecase@^4.1.1:
+lodash.snakecase@4.1.1:
   version "4.1.1"
   resolved "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz"
   integrity sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==
 
 lodash@^4.17.21:
-  version "4.17.21"
-  resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+  version "4.17.23"
+  resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz"
+  integrity sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==
 
 loupe@^2.3.6:
   version "2.3.7"
@@ -1389,6 +1375,11 @@ loupe@^2.3.6:
   integrity sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==
   dependencies:
     get-func-name "^2.0.1"
+
+magic-bytes.js@^1.10.0:
+  version "1.13.0"
+  resolved "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.13.0.tgz"
+  integrity sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg==
 
 magic-string@^0.30.1:
   version "0.30.21"
@@ -1593,11 +1584,6 @@ pathval@^1.1.1:
   resolved "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz"
   integrity sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==
 
-peek-readable@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.npmjs.org/peek-readable/-/peek-readable-5.0.0.tgz"
-  integrity sha512-YtCKvLUOvwtMGmrniQPdO7MwPjgkFBtFIrmfSbYmYuq3tKDV/mcfAhBth1+C3ru7uXIZasc/pHnb+YDYNkkj4A==
-
 picocolors@^1.0.0, picocolors@^1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz"
@@ -1684,22 +1670,6 @@ react-is@^18.0.0:
   resolved "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz"
   integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
 
-readable-stream@^3.6.0:
-  version "3.6.2"
-  resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz"
-  integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
-  dependencies:
-    inherits "^2.0.3"
-    string_decoder "^1.1.1"
-    util-deprecate "^1.0.1"
-
-readable-web-to-node-stream@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz"
-  integrity sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==
-  dependencies:
-    readable-stream "^3.6.0"
-
 readdirp@~3.6.0:
   version "3.6.0"
   resolved "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz"
@@ -1765,11 +1735,6 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
-safe-buffer@~5.2.0:
-  version "5.2.1"
-  resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz"
-  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
-
 semver@^7.5.3, semver@^7.5.4:
   version "7.7.3"
   resolved "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz"
@@ -1824,18 +1789,6 @@ std-env@^3.3.3:
   resolved "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz"
   integrity sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==
 
-streamsearch@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz"
-  integrity sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
-
-string_decoder@^1.1.1:
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz"
-  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
-  dependencies:
-    safe-buffer "~5.2.0"
-
 strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
@@ -1854,14 +1807,6 @@ strip-literal@^1.0.1:
   integrity sha512-PugKzOsyXpArk0yWmUwqOZecSO0GH0bPoctLcqNDH9J04pVW3lflYE0ujElBGTloevcxF5MofAOZ7C5l2b+wLg==
   dependencies:
     acorn "^8.10.0"
-
-strtok3@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.npmjs.org/strtok3/-/strtok3-7.0.0.tgz"
-  integrity sha512-pQ+V+nYQdC5H3Q7qBZAz/MO6lwGhoC2gOAjuouGf/VO0m7vQRh8QNMl2Uf6SwAtzZ9bOw3UIeBukEGNJl5dtXQ==
-  dependencies:
-    "@tokenizer/token" "^0.3.0"
-    peek-readable "^5.0.0"
 
 supports-color@^5.5.0:
   version "5.5.0"
@@ -1913,14 +1858,6 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
-token-types@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.npmjs.org/token-types/-/token-types-5.0.1.tgz"
-  integrity sha512-Y2fmSnZjQdDb9W4w4r1tswlMHylzWIeOKpx0aZH9BgGtACHhrk3OkT52AzwcuqTRBZtvvnTjDBh8eynMulu8Vg==
-  dependencies:
-    "@tokenizer/token" "^0.3.0"
-    ieee754 "^1.2.1"
-
 touch@^3.1.0:
   version "3.1.1"
   resolved "https://registry.npmjs.org/touch/-/touch-3.1.1.tgz"
@@ -1936,10 +1873,10 @@ ts-api-utils@^1.0.1:
   resolved "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz"
   integrity sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==
 
-ts-mixer@^6.0.3:
-  version "6.0.3"
-  resolved "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.3.tgz"
-  integrity sha512-k43M7uCG1AkTyxgnmI5MPwKoUvS/bRvLvUb7+Pgpdlmok8AoqmUaZxUUw8zKM5B1lqZrt41GjYgnvAi0fppqgQ==
+ts-mixer@^6.0.4:
+  version "6.0.4"
+  resolved "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz"
+  integrity sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==
 
 ts-node@^10.9.2:
   version "10.9.2"
@@ -1960,10 +1897,10 @@ ts-node@^10.9.2:
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
 
-tslib@^2.5.0:
-  version "2.6.0"
-  resolved "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz"
-  integrity sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==
+tslib@^2.6.2, tslib@^2.6.3:
+  version "2.8.1"
+  resolved "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
@@ -1997,12 +1934,10 @@ undefsafe@^2.0.5:
   resolved "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz"
   integrity sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==
 
-undici@^5.22.0:
-  version "5.22.1"
-  resolved "https://registry.npmjs.org/undici/-/undici-5.22.1.tgz"
-  integrity sha512-Ji2IJhFXZY0x/0tVBXeQwgPlLWw13GVzpsWPQ3rV50IFMMof2I55PZZxtm4P6iNq+L5znYN9nSTAq0ZyE6lSJw==
-  dependencies:
-    busboy "^1.6.0"
+undici@6.21.3:
+  version "6.21.3"
+  resolved "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz"
+  integrity sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==
 
 uri-js@^4.2.2:
   version "4.4.1"
@@ -2010,11 +1945,6 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
-
-util-deprecate@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-  integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"
@@ -2121,10 +2051,10 @@ wrappy@1:
   resolved "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
-ws@^8.13.0:
-  version "8.13.0"
-  resolved "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz"
-  integrity sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==
+ws@^8.17.0:
+  version "8.19.0"
+  resolved "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz"
+  integrity sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==
 
 yn@3.1.1:
   version "3.1.1"


### PR DESCRIPTION
- upgrade discord.js to ^14.25.1 and refresh lockfiles
- return typed emoji inventory success/failure results with explicit failure codes
- add /emoji diagnostics logging and honest empty-vs-failure user responses
- keep list pagination/formatting intact for successful fetches
- add resolver + command tests for populated, empty, manager-unavailable, and fetch-failed cases
- add startup discord.js emoji capability sanity logging
- apply discord.js 14.25 type-compatibility fixes in touched command files