### PR TITLE
feat(emoji): add application emoji creation flow to /emoji

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,7 +1,7 @@
 # Commands Reference
 
 - `/help [command:<name>] [visibility:private|public]` - List command docs/examples. Default visibility is private.
-- `/emoji [name:<emoji_name>] [react:<message-id>]` - Resolve one bot application emoji by name, react to a message in the current channel when `react` is provided, or browse a paginated list of all bot application emojis when `name` is omitted. For name-only resolves, `visibility:public` returns only the rendered emoji token while private keeps the detailed shortcode/raw-token output.
+- `/emoji [name:<emoji_name>] [react:<message-id>] [emoji:<emoji-token-or-url>] [short-code:<name>]` - Resolve one bot application emoji by name, react to a message in the current channel when `react` is provided, add a new bot application emoji when `emoji` + `short-code` are provided (admin-only by default), or browse a paginated list of all bot application emojis when `name` is omitted. For name-only resolves, `visibility:public` returns only the rendered emoji token while private keeps the detailed shortcode/raw-token output.
 - `/telemetry report [period:24h|7d|30d] [timezone:<ianaTz>]` - Show aggregate telemetry report (usage, latency, failures, API health) for the selected window.
 - `/telemetry schedule set target-channel:<channel> cadence-hours:<n> [timezone:<ianaTz>] [enabled:true|false]` - Configure scheduled telemetry report posting.
 - `/telemetry schedule show` - Show current telemetry schedule config and last posted window.

--- a/src/commands/Emoji.ts
+++ b/src/commands/Emoji.ts
@@ -11,29 +11,48 @@ import {
   EmbedBuilder,
   PermissionFlagsBits,
 } from "discord.js";
+import axios from "axios";
 import { Command } from "../Command";
 import { formatError } from "../helper/formatError";
 import {
   emojiResolverService,
+  isValidEmojiShortcodeName,
   normalizeEmojiLookupName,
+  normalizeEmojiShortcodeName,
+  parseEmojiImageSource,
+  type EmojiInputSourceType,
   type EmojiInventoryFetchResult,
   type EmojiResolverFailureCode,
   type EmojiResolverService,
   type ResolvedApplicationEmoji,
 } from "../services/emoji/EmojiResolverService";
 import { CoCService } from "../services/CoCService";
+import { CommandPermissionService } from "../services/CommandPermissionService";
 
 type EmojiResolverPort = Pick<
   EmojiResolverService,
-  "fetchApplicationEmojiInventory"
+  "fetchApplicationEmojiInventory" | "refresh" | "invalidateCache"
 >;
+
+type CommandPermissionPort = Pick<CommandPermissionService, "canUseAnyTarget">;
+
+type EmojiAttachmentDownloadResult =
+  | { ok: true; attachment: Buffer }
+  | {
+      ok: false;
+      code: "invalid_emoji_input" | "image_download_failed";
+      statusCode?: number;
+    };
 
 const EMOJI_PAGE_SIZE = 20;
 const EMOJI_PAGINATOR_TIMEOUT_MS = 10 * 60 * 1000;
 const MAX_AUTOCOMPLETE_CHOICES = 25;
 const MESSAGE_ID_PATTERN = /^\d{17,22}$/;
+const INVENTORY_FULL_ERROR_CODES = new Set<number>([30008, 30018, 30056]);
 
 let activeEmojiResolver: EmojiResolverPort = emojiResolverService;
+let activeCommandPermissionService: CommandPermissionPort =
+  new CommandPermissionService();
 
 /** Purpose: convert one resolved emoji into compact list-display text. */
 function formatEmojiListLine(emoji: ResolvedApplicationEmoji): string {
@@ -192,6 +211,70 @@ function isValidMessageId(value: string): boolean {
   return MESSAGE_ID_PATTERN.test(String(value ?? "").trim());
 }
 
+/** Purpose: classify a Discord/HTTP error payload as application emoji inventory-full for clear user feedback. */
+function isApplicationEmojiInventoryFullError(error: unknown): boolean {
+  const code = getDiscordErrorCode(error);
+  if (code !== null && INVENTORY_FULL_ERROR_CODES.has(code)) return true;
+  const message = String((error as { message?: string } | null)?.message ?? "").toLowerCase();
+  return (
+    message.includes("maximum number of emojis") ||
+    message.includes("maximum number of application emojis") ||
+    message.includes("emoji slots")
+  );
+}
+
+/** Purpose: fetch one image attachment buffer from a parsed input source before emoji create calls. */
+async function downloadEmojiAttachment(
+  sourceUrl: string,
+): Promise<EmojiAttachmentDownloadResult> {
+  let response;
+  try {
+    response = await axios.get(sourceUrl, {
+      responseType: "arraybuffer",
+      timeout: 15_000,
+      validateStatus: () => true,
+    });
+  } catch {
+    return {
+      ok: false,
+      code: "image_download_failed",
+    };
+  }
+
+  if (response.status < 200 || response.status >= 300) {
+    return {
+      ok: false,
+      code: "image_download_failed",
+      statusCode: response.status,
+    };
+  }
+
+  const contentType = String(response.headers?.["content-type"] ?? "").toLowerCase();
+  if (!contentType.startsWith("image/")) {
+    return {
+      ok: false,
+      code: "invalid_emoji_input",
+      statusCode: response.status,
+    };
+  }
+
+  const bytes = Buffer.isBuffer(response.data)
+    ? response.data
+    : Buffer.from(response.data ?? "");
+  if (bytes.length === 0) {
+    return {
+      ok: false,
+      code: "invalid_emoji_input",
+      statusCode: response.status,
+    };
+  }
+
+  return {
+    ok: true,
+    attachment: bytes,
+  };
+}
+
 /** Purpose: read the shared command visibility value injected by framework registration plumbing. */
 function resolveInteractionVisibility(
   interaction: ChatInputCommandInteraction,
@@ -223,7 +306,7 @@ function logEmojiEvent(fields: Record<string, string | number | boolean | null |
 
 /** Purpose: emit structured resolver diagnostics tied to command mode and caller identity. */
 function logEmojiInventoryResult(input: {
-  mode: "list" | "resolve" | "react" | "autocomplete";
+  mode: "list" | "resolve" | "react" | "autocomplete" | "add";
   guildId: string | null;
   channelId: string | null;
   userId: string;
@@ -271,6 +354,18 @@ export function resetEmojiResolverForTest(): void {
   activeEmojiResolver = emojiResolverService;
 }
 
+/** Purpose: allow tests to inject command-permission behavior for add-path authorization checks. */
+export function setEmojiCommandPermissionServiceForTest(
+  service: CommandPermissionPort,
+): void {
+  activeCommandPermissionService = service;
+}
+
+/** Purpose: restore production command-permission service after test injection. */
+export function resetEmojiCommandPermissionServiceForTest(): void {
+  activeCommandPermissionService = new CommandPermissionService();
+}
+
 export const applyEmojiPageActionForTest = applyEmojiPageAction;
 export const paginateEmojiLinesForTest = paginateEmojiLines;
 export const buildEmojiListEmbedForTest = buildEmojiListEmbed;
@@ -278,10 +373,12 @@ export const buildEmojiListRowForTest = buildEmojiListRow;
 export const normalizeEmojiLookupNameInputForTest = normalizeEmojiLookupName;
 export const buildEmojiAutocompleteChoicesForTest = buildEmojiAutocompleteChoices;
 export const isValidMessageIdForTest = isValidMessageId;
+export const normalizeEmojiShortcodeNameForTest = normalizeEmojiShortcodeName;
+export const downloadEmojiAttachmentForTest = downloadEmojiAttachment;
 
 export const Emoji: Command = {
   name: "emoji",
-  description: "Resolve and browse bot application emojis",
+  description: "Resolve, browse, react with, and add bot application emojis",
   options: [
     {
       name: "name",
@@ -296,6 +393,18 @@ export const Emoji: Command = {
       type: ApplicationCommandOptionType.String,
       required: false,
     },
+    {
+      name: "emoji",
+      description: "Custom emoji token or direct image URL for add flow",
+      type: ApplicationCommandOptionType.String,
+      required: false,
+    },
+    {
+      name: "short-code",
+      description: "Shortcode name for a new bot application emoji",
+      type: ApplicationCommandOptionType.String,
+      required: false,
+    },
   ],
   run: async (
     _client: Client,
@@ -306,19 +415,77 @@ export const Emoji: Command = {
 
     const rawName = interaction.options.getString("name", false);
     const rawReact = interaction.options.getString("react", false);
+    const rawEmojiInput = interaction.options.getString("emoji", false);
+    const rawShortCode = interaction.options.getString("short-code", false);
     const hasNameInput = rawName !== null;
+    const hasEmojiInput = rawEmojiInput !== null;
+    const hasShortCodeInput = rawShortCode !== null;
+    const hasAddInputs = hasEmojiInput || hasShortCodeInput;
     const requestedName = String(rawName ?? "");
     const normalizedName = normalizeEmojiLookupName(requestedName);
     const targetMessageId = String(rawReact ?? "").trim();
+    const requestedEmojiInput = String(rawEmojiInput ?? "").trim();
+    const requestedShortCode = String(rawShortCode ?? "");
+    const normalizedShortCode = normalizeEmojiShortcodeName(requestedShortCode);
     const visibilityState = resolveInteractionVisibility(interaction);
 
-    const mode: "list" | "resolve" | "react" = !hasNameInput
-      ? "list"
-      : targetMessageId
-        ? "react"
-        : "resolve";
+    const mode: "list" | "resolve" | "react" | "add" = hasAddInputs
+      ? "add"
+      : !hasNameInput
+        ? "list"
+        : targetMessageId
+          ? "react"
+          : "resolve";
 
-    if (hasNameInput && !normalizedName) {
+    if (hasAddInputs && (!hasEmojiInput || !hasShortCodeInput)) {
+      logEmojiEvent({
+        command: "emoji",
+        mode,
+        guild_id: interaction.guildId ?? "dm",
+        channel_id: interaction.channelId ?? "none",
+        user_id: interaction.user.id,
+        requested_emoji_input: requestedEmojiInput,
+        requested_shortcode: requestedShortCode,
+        normalized_shortcode: normalizedShortCode,
+        create_attempted: false,
+        create_result: "validation_failed",
+        failure_code: "invalid_emoji_input",
+      });
+      await interaction.editReply({
+        content:
+          "To add an application emoji, provide both `emoji` and `short-code`.",
+        embeds: [],
+        components: [],
+      });
+      return;
+    }
+
+    if (hasAddInputs && (hasNameInput || targetMessageId)) {
+      logEmojiEvent({
+        command: "emoji",
+        mode,
+        guild_id: interaction.guildId ?? "dm",
+        channel_id: interaction.channelId ?? "none",
+        user_id: interaction.user.id,
+        requested_emoji_name: requestedName,
+        target_message_id: targetMessageId,
+        requested_emoji_input: requestedEmojiInput,
+        requested_shortcode: requestedShortCode,
+        normalized_shortcode: normalizedShortCode,
+        create_attempted: false,
+        create_result: "validation_failed",
+        failure_code: "invalid_emoji_input",
+      });
+      await interaction.editReply({
+        content:
+          "Use either add options (`emoji` + `short-code`) or resolve/react options (`name`/`react`), not both.",
+        embeds: [],
+        components: [],
+      });
+      return;
+    }
+
+    if (mode !== "add" && hasNameInput && !normalizedName) {
       logEmojiEvent({
         command: "emoji",
         mode,
@@ -341,6 +508,294 @@ export const Emoji: Command = {
     }
 
     try {
+      if (mode === "add") {
+        const allowed = await activeCommandPermissionService.canUseAnyTarget(
+          ["emoji:add", "emoji"],
+          interaction,
+        );
+        if (!allowed) {
+          logEmojiEvent({
+            command: "emoji",
+            mode,
+            guild_id: interaction.guildId ?? "dm",
+            channel_id: interaction.channelId ?? "none",
+            user_id: interaction.user.id,
+            requested_emoji_input: requestedEmojiInput,
+            requested_shortcode: requestedShortCode,
+            normalized_shortcode: normalizedShortCode,
+            create_attempted: false,
+            create_result: "permission_denied",
+            failure_code: "permission_denied",
+          });
+          await interaction.editReply({
+            content: "You do not have permission to use /emoji add.",
+            embeds: [],
+            components: [],
+          });
+          return;
+        }
+
+        if (!normalizedShortCode || !isValidEmojiShortcodeName(normalizedShortCode)) {
+          logEmojiEvent({
+            command: "emoji",
+            mode,
+            guild_id: interaction.guildId ?? "dm",
+            channel_id: interaction.channelId ?? "none",
+            user_id: interaction.user.id,
+            requested_emoji_input: requestedEmojiInput,
+            requested_shortcode: requestedShortCode,
+            normalized_shortcode: normalizedShortCode,
+            create_attempted: false,
+            create_result: "validation_failed",
+            failure_code: "invalid_shortcode",
+          });
+          await interaction.editReply({
+            content:
+              "Please provide a valid shortcode using letters, numbers, or underscores (2-32 chars).",
+            embeds: [],
+            components: [],
+          });
+          return;
+        }
+
+        const parsedSource = parseEmojiImageSource(requestedEmojiInput);
+        if (!parsedSource.ok) {
+          const failureCode = parsedSource.code;
+          const sourceType: EmojiInputSourceType = parsedSource.sourceType;
+          logEmojiEvent({
+            command: "emoji",
+            mode,
+            guild_id: interaction.guildId ?? "dm",
+            channel_id: interaction.channelId ?? "none",
+            user_id: interaction.user.id,
+            requested_emoji_input: requestedEmojiInput,
+            parsed_source_type: sourceType,
+            requested_shortcode: requestedShortCode,
+            normalized_shortcode: normalizedShortCode,
+            create_attempted: false,
+            create_result: "validation_failed",
+            failure_code: failureCode,
+          });
+          await interaction.editReply({
+            content:
+              failureCode === "unsupported_unicode_emoji"
+                ? "Unicode emoji input is not supported for `/emoji add` yet. Use a custom emoji token like `<:name:id>` or a direct image URL."
+                : "Invalid emoji input. Use a custom emoji token like `<:name:id>` or a direct image URL.",
+            embeds: [],
+            components: [],
+          });
+          return;
+        }
+
+        const inventory = await activeEmojiResolver.fetchApplicationEmojiInventory(
+          interaction.client,
+          { forceRefresh: true },
+        );
+        logEmojiInventoryResult({
+          mode,
+          guildId: interaction.guildId,
+          channelId: interaction.channelId,
+          userId: interaction.user.id,
+          requestedName: requestedShortCode,
+          normalizedName: normalizedShortCode,
+          result: inventory,
+        });
+        if (!inventory.ok) {
+          logEmojiEvent({
+            command: "emoji",
+            mode,
+            guild_id: interaction.guildId ?? "dm",
+            channel_id: interaction.channelId ?? "none",
+            user_id: interaction.user.id,
+            requested_emoji_input: requestedEmojiInput,
+            parsed_source_type: parsedSource.sourceType,
+            requested_shortcode: requestedShortCode,
+            normalized_shortcode: normalizedShortCode,
+            create_attempted: false,
+            create_result: "inventory_unavailable",
+            failure_code: "emoji_inventory_unavailable",
+          });
+          await interaction.editReply({
+            content: buildEmojiFailureMessage(inventory.code),
+            embeds: [],
+            components: [],
+          });
+          return;
+        }
+
+        const existingByName =
+          inventory.snapshot.exactByName.get(normalizedShortCode) ??
+          inventory.snapshot.lowercaseByName.get(normalizedShortCode.toLowerCase()) ??
+          null;
+        if (existingByName) {
+          logEmojiEvent({
+            command: "emoji",
+            mode,
+            guild_id: interaction.guildId ?? "dm",
+            channel_id: interaction.channelId ?? "none",
+            user_id: interaction.user.id,
+            requested_emoji_input: requestedEmojiInput,
+            parsed_source_type: parsedSource.sourceType,
+            requested_shortcode: requestedShortCode,
+            normalized_shortcode: normalizedShortCode,
+            create_attempted: false,
+            create_result: "duplicate_shortcode",
+            failure_code: "duplicate_shortcode",
+          });
+          await interaction.editReply({
+            content: `Shortcode \`${normalizedShortCode}\` already exists as ${existingByName.rendered}.`,
+            embeds: [],
+            components: [],
+          });
+          return;
+        }
+
+        const download = await downloadEmojiAttachment(parsedSource.imageUrl);
+        if (!download.ok) {
+          logEmojiEvent({
+            command: "emoji",
+            mode,
+            guild_id: interaction.guildId ?? "dm",
+            channel_id: interaction.channelId ?? "none",
+            user_id: interaction.user.id,
+            requested_emoji_input: requestedEmojiInput,
+            parsed_source_type: parsedSource.sourceType,
+            requested_shortcode: requestedShortCode,
+            normalized_shortcode: normalizedShortCode,
+            create_attempted: false,
+            create_result: "image_source_failed",
+            failure_code: download.code,
+          });
+          await interaction.editReply({
+            content:
+              download.code === "image_download_failed"
+                ? "Could not download the emoji image from that source."
+                : "That source did not resolve to a valid image.",
+            embeds: [],
+            components: [],
+          });
+          return;
+        }
+
+        const application = interaction.client.application;
+        if (!application) {
+          logEmojiEvent({
+            command: "emoji",
+            mode,
+            guild_id: interaction.guildId ?? "dm",
+            channel_id: interaction.channelId ?? "none",
+            user_id: interaction.user.id,
+            requested_emoji_input: requestedEmojiInput,
+            parsed_source_type: parsedSource.sourceType,
+            requested_shortcode: requestedShortCode,
+            normalized_shortcode: normalizedShortCode,
+            create_attempted: false,
+            create_result: "application_unavailable",
+            failure_code: "application_unavailable",
+          });
+          await interaction.editReply({
+            content: "Could not load bot application state right now.",
+            embeds: [],
+            components: [],
+          });
+          return;
+        }
+
+        if (!application.emojis || typeof application.emojis.create !== "function") {
+          logEmojiEvent({
+            command: "emoji",
+            mode,
+            guild_id: interaction.guildId ?? "dm",
+            channel_id: interaction.channelId ?? "none",
+            user_id: interaction.user.id,
+            requested_emoji_input: requestedEmojiInput,
+            parsed_source_type: parsedSource.sourceType,
+            requested_shortcode: requestedShortCode,
+            normalized_shortcode: normalizedShortCode,
+            create_attempted: false,
+            create_result: "application_emoji_manager_unavailable",
+            failure_code: "application_emoji_manager_unavailable",
+          });
+          await interaction.editReply({
+            content: "Application emoji manager is unavailable in this runtime.",
+            embeds: [],
+            components: [],
+          });
+          return;
+        }
+
+        let createdEmoji;
+        try {
+          createdEmoji = await application.emojis.create({
+            attachment: download.attachment,
+            name: normalizedShortCode,
+          });
+        } catch (error) {
+          const failureCode = isApplicationEmojiInventoryFullError(error)
+            ? "application_emoji_inventory_full"
+            : "application_emoji_create_failed";
+          logEmojiEvent({
+            command: "emoji",
+            mode,
+            guild_id: interaction.guildId ?? "dm",
+            channel_id: interaction.channelId ?? "none",
+            user_id: interaction.user.id,
+            requested_emoji_input: requestedEmojiInput,
+            parsed_source_type: parsedSource.sourceType,
+            requested_shortcode: requestedShortCode,
+            normalized_shortcode: normalizedShortCode,
+            create_attempted: true,
+            create_result: "failed",
+            failure_code: failureCode,
+          });
+          await interaction.editReply({
+            content:
+              failureCode === "application_emoji_inventory_full"
+                ? "Could not add emoji because this application emoji inventory is full."
+                : "Discord rejected the emoji create request. Verify the image and try again.",
+            embeds: [],
+            components: [],
+          });
+          return;
+        }
+
+        activeEmojiResolver.invalidateCache();
+        try {
+          await activeEmojiResolver.refresh(interaction.client);
+        } catch (error) {
+          console.warn(
+            `[emoji] cache refresh failed after add: ${formatError(error)}`,
+          );
+        }
+
+        const createdRendered = String(createdEmoji.toString?.() ?? "").trim();
+        const createdName = String(createdEmoji.name ?? normalizedShortCode).trim();
+
+        logEmojiEvent({
+          command: "emoji",
+          mode,
+          guild_id: interaction.guildId ?? "dm",
+          channel_id: interaction.channelId ?? "none",
+          user_id: interaction.user.id,
+          requested_emoji_input: requestedEmojiInput,
+          parsed_source_type: parsedSource.sourceType,
+          requested_shortcode: requestedShortCode,
+          normalized_shortcode: normalizedShortCode,
+          create_attempted: true,
+          create_result: "success",
+          created_emoji_id: createdEmoji.id,
+          created_emoji_name: createdName,
+          failure_code: "none",
+        });
+
+        await interaction.editReply({
+          content: `Added application emoji ${createdRendered} with shortcode \`${createdName}\`.`,
+          embeds: [],
+          components: [],
+        });
+        return;
+      }
+
       const inventory = await activeEmojiResolver.fetchApplicationEmojiInventory(
         interaction.client,
         { forceRefresh: true },

--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -69,6 +69,7 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
     details: [
       "Use `/emoji name:<emoji_name>` to resolve one emoji and show rendered + raw token output.",
       "Use `/emoji name:<emoji_name> react:<message-id>` to react to a message in the current channel with that resolved emoji.",
+      "Use `/emoji emoji:<emoji-token-or-url> short-code:<name>` to add one new bot application emoji (admin-only by default).",
       "Use `/emoji` with no args to browse a paginated list of all available bot application emojis.",
       "For name-only resolves, `visibility:public` returns only the rendered emoji message content.",
       "`name` supports dynamic autocomplete backed by application emojis for this bot instance.",
@@ -79,6 +80,7 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
       "/emoji name:arrow_arrow",
       "/emoji name::arrow_arrow:",
       "/emoji name:arrow_arrow react:123456789012345678",
+      "/emoji emoji:<:arrow_arrow:123456789012345678> short-code:arrow_arrow",
     ],
   },
   lastseen: {

--- a/src/services/CommandPermissionService.ts
+++ b/src/services/CommandPermissionService.ts
@@ -11,6 +11,7 @@ export const FWA_LEADER_ROLE_SETTING_KEY = "fwa_leader_role";
 export const COMMAND_PERMISSION_TARGETS = [
   "help",
   "emoji",
+  "emoji:add",
   "lastseen",
   "inactive",
   "role-users",
@@ -99,6 +100,7 @@ const ADMIN_DEFAULT_TARGETS = new Set<string>([
   "sheet:link",
   "sheet:unlink",
   "sheet:show",
+  "emoji:add",
   "telemetry",
   "kick-list:clear",
   "notify:war",

--- a/src/services/emoji/EmojiResolverService.ts
+++ b/src/services/emoji/EmojiResolverService.ts
@@ -15,6 +15,36 @@ type EmojiSnapshot = {
   lowercaseByName: Map<string, ResolvedApplicationEmoji>;
 };
 
+type ParsedCustomEmojiToken = {
+  animated: boolean;
+  name: string;
+  id: string;
+};
+
+export type EmojiInputSourceType =
+  | "custom_emoji_token"
+  | "direct_image_url"
+  | "unicode_emoji_unsupported"
+  | "invalid_input";
+
+export type ParsedEmojiImageSourceSuccess = {
+  ok: true;
+  sourceType: "custom_emoji_token" | "direct_image_url";
+  imageUrl: string;
+  customEmojiId: string | null;
+  animated: boolean;
+};
+
+export type ParsedEmojiImageSourceFailure = {
+  ok: false;
+  sourceType: "unicode_emoji_unsupported" | "invalid_input";
+  code: "unsupported_unicode_emoji" | "invalid_emoji_input";
+};
+
+export type ParsedEmojiImageSourceResult =
+  | ParsedEmojiImageSourceSuccess
+  | ParsedEmojiImageSourceFailure;
+
 export type EmojiResolverFailureCode =
   | "application_missing"
   | "application_fetch_failed"
@@ -55,6 +85,93 @@ type EnsureApplicationResult =
 
 const SHORTCODE_REPLACE_PATTERN =
   /(^|[\s([{"']):([a-zA-Z0-9_]{2,32}):(?=$|[\s)\]}".,!?:;'"-])/g;
+const CUSTOM_EMOJI_TOKEN_PATTERN = /^<(a?):([a-zA-Z0-9_]{2,32}):(\d{17,22})>$/;
+const SHORTCODE_NAME_PATTERN = /^[a-zA-Z0-9_]{2,32}$/;
+const UNICODE_EMOJI_PATTERN = /[\p{Extended_Pictographic}\uFE0F]/u;
+
+/** Purpose: trim and de-colon one shortcode name for canonical application emoji creation lookup. */
+export function normalizeEmojiShortcodeName(input: string): string {
+  const trimmed = String(input ?? "").trim();
+  if (!trimmed) return "";
+  const withoutColons = trimmed.replace(/^:+/, "").replace(/:+$/, "");
+  return withoutColons.trim();
+}
+
+/** Purpose: validate one normalized application emoji shortcode name against Discord naming constraints. */
+export function isValidEmojiShortcodeName(input: string): boolean {
+  return SHORTCODE_NAME_PATTERN.test(String(input ?? ""));
+}
+
+/** Purpose: parse one custom Discord emoji token into id/name/animated fields for CDN source resolution. */
+function parseCustomEmojiToken(input: string): ParsedCustomEmojiToken | null {
+  const match = input.match(CUSTOM_EMOJI_TOKEN_PATTERN);
+  if (!match) return null;
+  return {
+    animated: match[1] === "a",
+    name: match[2],
+    id: match[3],
+  };
+}
+
+/** Purpose: test whether one arbitrary input likely contains a unicode emoji that this patch does not rasterize. */
+function looksLikeUnicodeEmoji(input: string): boolean {
+  return UNICODE_EMOJI_PATTERN.test(input);
+}
+
+/** Purpose: parse user-provided emoji image input into a canonical application-emoji upload source. */
+export function parseEmojiImageSource(
+  input: string,
+): ParsedEmojiImageSourceResult {
+  const trimmed = String(input ?? "").trim();
+  if (!trimmed) {
+    return {
+      ok: false,
+      sourceType: "invalid_input",
+      code: "invalid_emoji_input",
+    };
+  }
+
+  const parsedToken = parseCustomEmojiToken(trimmed);
+  if (parsedToken) {
+    const ext = parsedToken.animated ? "gif" : "png";
+    return {
+      ok: true,
+      sourceType: "custom_emoji_token",
+      imageUrl: `https://cdn.discordapp.com/emojis/${parsedToken.id}.${ext}?quality=lossless`,
+      customEmojiId: parsedToken.id,
+      animated: parsedToken.animated,
+    };
+  }
+
+  try {
+    const url = new URL(trimmed);
+    if (url.protocol === "http:" || url.protocol === "https:") {
+      return {
+        ok: true,
+        sourceType: "direct_image_url",
+        imageUrl: url.toString(),
+        customEmojiId: null,
+        animated: false,
+      };
+    }
+  } catch {
+    // Ignore URL parse errors and fall through to deterministic input classification.
+  }
+
+  if (looksLikeUnicodeEmoji(trimmed)) {
+    return {
+      ok: false,
+      sourceType: "unicode_emoji_unsupported",
+      code: "unsupported_unicode_emoji",
+    };
+  }
+
+  return {
+    ok: false,
+    sourceType: "invalid_input",
+    code: "invalid_emoji_input",
+  };
+}
 
 /** Purpose: normalize user-provided emoji-name input while preserving name-based environment stability. */
 export function normalizeEmojiLookupName(input: string): string {
@@ -133,6 +250,11 @@ export class EmojiResolverService {
       throw this.toRuntimeError(result);
     }
     this.snapshot = result.snapshot;
+  }
+
+  /** Purpose: invalidate in-memory emoji snapshot cache so subsequent reads refetch current application state. */
+  invalidateCache(): void {
+    this.snapshot = null;
   }
 
   /** Purpose: resolve one emoji by name (case-insensitive) from bot application emojis. */

--- a/tests/emoji.command.test.ts
+++ b/tests/emoji.command.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import axios from "axios";
 import type {
   AutocompleteInteraction,
   ChatInputCommandInteraction,
@@ -8,7 +9,9 @@ import type {
 import {
   Emoji,
   applyEmojiPageActionForTest,
+  resetEmojiCommandPermissionServiceForTest,
   resetEmojiResolverForTest,
+  setEmojiCommandPermissionServiceForTest,
   setEmojiResolverForTest,
 } from "../src/commands/Emoji";
 import type {
@@ -18,13 +21,39 @@ import type {
 
 type EmojiResolverStub = {
   fetchApplicationEmojiInventory: ReturnType<typeof vi.fn>;
+  refresh: ReturnType<typeof vi.fn>;
+  invalidateCache: ReturnType<typeof vi.fn>;
+};
+
+type CommandPermissionStub = {
+  canUseAnyTarget: ReturnType<typeof vi.fn>;
 };
 
 /** Purpose: build resolver stub for deterministic command behavior assertions. */
 function buildResolverStub(): EmojiResolverStub {
   return {
     fetchApplicationEmojiInventory: vi.fn(),
+    refresh: vi.fn().mockResolvedValue(undefined),
+    invalidateCache: vi.fn(),
   };
+}
+
+/** Purpose: build permission stub for deterministic add-path authorization behavior. */
+function buildPermissionStub(): CommandPermissionStub {
+  return {
+    canUseAnyTarget: vi.fn().mockResolvedValue(true),
+  };
+}
+
+/** Purpose: mock one successful image download response for emoji-add attachment ingestion. */
+function mockEmojiImageDownloadSuccess(): void {
+  vi.spyOn(axios, "get").mockResolvedValue({
+    status: 200,
+    headers: {
+      "content-type": "image/png",
+    },
+    data: Buffer.from([1, 2, 3]),
+  } as any);
 }
 
 /** Purpose: create a successful inventory result from emoji entries for tests. */
@@ -81,7 +110,14 @@ function buildFailureResult(
 function buildInteraction(input?: {
   name?: string | null;
   react?: string | null;
+  emoji?: string | null;
+  shortCode?: string | null;
   visibility?: "private" | "public";
+  application?: {
+    emojis?: {
+      create?: ReturnType<typeof vi.fn>;
+    };
+  } | null;
   messageFetchError?: unknown;
   reactionError?: unknown;
   appPermissionHas?: (permission: PermissionResolvable) => boolean;
@@ -118,7 +154,9 @@ function buildInteraction(input?: {
     guildId: "guild-1",
     channelId: "channel-1",
     user: { id: "user-1" },
-    client: {} as Client,
+    client: {
+      application: input?.application ?? null,
+    } as Client,
     appPermissions: {
       has: vi.fn((permission: PermissionResolvable) =>
         input?.appPermissionHas ? input.appPermissionHas(permission) : true,
@@ -134,6 +172,8 @@ function buildInteraction(input?: {
       getString: vi.fn((name: string) => {
         if (name === "name") return input?.name ?? null;
         if (name === "react") return input?.react ?? null;
+        if (name === "emoji") return input?.emoji ?? null;
+        if (name === "short-code") return input?.shortCode ?? null;
         if (name === "visibility") return input?.visibility ?? "private";
         return null;
       }),
@@ -181,6 +221,8 @@ function buildAutocompleteInteraction(input?: {
 describe("/emoji command", () => {
   afterEach(() => {
     resetEmojiResolverForTest();
+    resetEmojiCommandPermissionServiceForTest();
+    vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
 
@@ -311,6 +353,215 @@ describe("/emoji command", () => {
     expect(resolver.fetchApplicationEmojiInventory).not.toHaveBeenCalled();
     const payload = editReply.mock.calls[0]?.[0] ?? {};
     expect(String(payload.content ?? "")).toContain("Please provide a valid emoji name");
+  });
+
+  it("adds a new application emoji from custom token input", async () => {
+    const resolver = buildResolverStub();
+    resolver.fetchApplicationEmojiInventory.mockResolvedValue(buildSuccessResult([]));
+    setEmojiResolverForTest(resolver as any);
+    const permission = buildPermissionStub();
+    setEmojiCommandPermissionServiceForTest(permission as any);
+
+    mockEmojiImageDownloadSuccess();
+
+    const create = vi.fn().mockResolvedValue({
+      id: "999",
+      name: "arrow_arrow",
+      toString: () => "<:arrow_arrow:999>",
+    });
+    const { interaction, editReply } = buildInteraction({
+      emoji: "<:source_icon:123456789012345678>",
+      shortCode: ":arrow_arrow:",
+      application: {
+        emojis: {
+          create,
+        },
+      },
+    });
+
+    await Emoji.run({} as Client, interaction, {} as any);
+
+    expect(permission.canUseAnyTarget).toHaveBeenCalledWith(
+      ["emoji:add", "emoji"],
+      interaction,
+    );
+    expect(create).toHaveBeenCalledTimes(1);
+    const createInput = create.mock.calls[0]?.[0] ?? {};
+    expect(createInput.name).toBe("arrow_arrow");
+    expect(Buffer.isBuffer(createInput.attachment)).toBe(true);
+    expect(resolver.invalidateCache).toHaveBeenCalledTimes(1);
+    expect(resolver.refresh).toHaveBeenCalledTimes(1);
+
+    const payload = editReply.mock.calls[0]?.[0] ?? {};
+    expect(String(payload.content ?? "")).toContain(
+      "Added application emoji <:arrow_arrow:999> with shortcode `arrow_arrow`.",
+    );
+  });
+
+  it("blocks duplicate shortcode names before create", async () => {
+    const resolver = buildResolverStub();
+    resolver.fetchApplicationEmojiInventory.mockResolvedValue(
+      buildSuccessResult([
+        {
+          id: "4",
+          name: "arrow_arrow",
+          shortcode: ":arrow_arrow:",
+          rendered: "<:arrow_arrow:4>",
+          animated: false,
+        },
+      ]),
+    );
+    setEmojiResolverForTest(resolver as any);
+    const permission = buildPermissionStub();
+    setEmojiCommandPermissionServiceForTest(permission as any);
+    const create = vi.fn();
+
+    const { interaction, editReply } = buildInteraction({
+      emoji: "<:source_icon:123456789012345678>",
+      shortCode: "arrow_arrow",
+      application: {
+        emojis: {
+          create,
+        },
+      },
+    });
+
+    await Emoji.run({} as Client, interaction, {} as any);
+
+    expect(create).not.toHaveBeenCalled();
+    const payload = editReply.mock.calls[0]?.[0] ?? {};
+    expect(String(payload.content ?? "")).toContain("already exists");
+  });
+
+  it("rejects unsupported unicode emoji input on add path", async () => {
+    const resolver = buildResolverStub();
+    setEmojiResolverForTest(resolver as any);
+    const permission = buildPermissionStub();
+    setEmojiCommandPermissionServiceForTest(permission as any);
+    const { interaction, editReply } = buildInteraction({
+      emoji: "🔥",
+      shortCode: "arrow_arrow",
+    });
+
+    await Emoji.run({} as Client, interaction, {} as any);
+
+    expect(resolver.fetchApplicationEmojiInventory).not.toHaveBeenCalled();
+    const payload = editReply.mock.calls[0]?.[0] ?? {};
+    expect(String(payload.content ?? "")).toContain("Unicode emoji input is not supported");
+  });
+
+  it("rejects malformed shortcode on add path", async () => {
+    const resolver = buildResolverStub();
+    setEmojiResolverForTest(resolver as any);
+    const permission = buildPermissionStub();
+    setEmojiCommandPermissionServiceForTest(permission as any);
+    const { interaction, editReply } = buildInteraction({
+      emoji: "<:source_icon:123456789012345678>",
+      shortCode: "bad-name",
+    });
+
+    await Emoji.run({} as Client, interaction, {} as any);
+
+    expect(resolver.fetchApplicationEmojiInventory).not.toHaveBeenCalled();
+    const payload = editReply.mock.calls[0]?.[0] ?? {};
+    expect(String(payload.content ?? "")).toContain("Please provide a valid shortcode");
+  });
+
+  it("returns permission denied for unauthorized add-path users", async () => {
+    const resolver = buildResolverStub();
+    setEmojiResolverForTest(resolver as any);
+    const permission = buildPermissionStub();
+    permission.canUseAnyTarget.mockResolvedValue(false);
+    setEmojiCommandPermissionServiceForTest(permission as any);
+    const { interaction, editReply } = buildInteraction({
+      emoji: "<:source_icon:123456789012345678>",
+      shortCode: "arrow_arrow",
+    });
+
+    await Emoji.run({} as Client, interaction, {} as any);
+
+    expect(resolver.fetchApplicationEmojiInventory).not.toHaveBeenCalled();
+    const payload = editReply.mock.calls[0]?.[0] ?? {};
+    expect(String(payload.content ?? "")).toContain(
+      "You do not have permission to use /emoji add",
+    );
+  });
+
+  it("returns clear failure when application state is unavailable during add", async () => {
+    const resolver = buildResolverStub();
+    resolver.fetchApplicationEmojiInventory.mockResolvedValue(buildSuccessResult([]));
+    setEmojiResolverForTest(resolver as any);
+    const permission = buildPermissionStub();
+    setEmojiCommandPermissionServiceForTest(permission as any);
+
+    mockEmojiImageDownloadSuccess();
+
+    const { interaction, editReply } = buildInteraction({
+      emoji: "<:source_icon:123456789012345678>",
+      shortCode: "arrow_arrow",
+      application: null,
+    });
+
+    await Emoji.run({} as Client, interaction, {} as any);
+
+    const payload = editReply.mock.calls[0]?.[0] ?? {};
+    expect(String(payload.content ?? "")).toContain(
+      "Could not load bot application state right now",
+    );
+  });
+
+  it("returns inventory-full failure when add create API reports capacity reached", async () => {
+    const resolver = buildResolverStub();
+    resolver.fetchApplicationEmojiInventory.mockResolvedValue(buildSuccessResult([]));
+    setEmojiResolverForTest(resolver as any);
+    const permission = buildPermissionStub();
+    setEmojiCommandPermissionServiceForTest(permission as any);
+
+    mockEmojiImageDownloadSuccess();
+
+    const create = vi.fn().mockRejectedValue({ code: 30056 });
+    const { interaction, editReply } = buildInteraction({
+      emoji: "https://example.com/icon.png",
+      shortCode: "arrow_arrow",
+      application: {
+        emojis: {
+          create,
+        },
+      },
+    });
+
+    await Emoji.run({} as Client, interaction, {} as any);
+
+    const payload = editReply.mock.calls[0]?.[0] ?? {};
+    expect(String(payload.content ?? "")).toContain("inventory is full");
+  });
+
+  it("returns generic create failure when Discord rejects add request", async () => {
+    const resolver = buildResolverStub();
+    resolver.fetchApplicationEmojiInventory.mockResolvedValue(buildSuccessResult([]));
+    setEmojiResolverForTest(resolver as any);
+    const permission = buildPermissionStub();
+    setEmojiCommandPermissionServiceForTest(permission as any);
+
+    mockEmojiImageDownloadSuccess();
+
+    const create = vi.fn().mockRejectedValue(new Error("bad upload"));
+    const { interaction, editReply } = buildInteraction({
+      emoji: "https://example.com/icon.png",
+      shortCode: "arrow_arrow",
+      application: {
+        emojis: {
+          create,
+        },
+      },
+    });
+
+    await Emoji.run({} as Client, interaction, {} as any);
+
+    const payload = editReply.mock.calls[0]?.[0] ?? {};
+    expect(String(payload.content ?? "")).toContain(
+      "Discord rejected the emoji create request",
+    );
   });
 
   it("renders list mode first page", async () => {
@@ -559,6 +810,8 @@ describe("/emoji command", () => {
 describe("/emoji autocomplete", () => {
   afterEach(() => {
     resetEmojiResolverForTest();
+    resetEmojiCommandPermissionServiceForTest();
+    vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
 

--- a/tests/emoji.commandShape.test.ts
+++ b/tests/emoji.commandShape.test.ts
@@ -3,9 +3,11 @@ import { ApplicationCommandOptionType } from "discord.js";
 import { Emoji } from "../src/commands/Emoji";
 
 describe("/emoji command shape", () => {
-  it("registers optional name autocomplete and optional react message-id options", () => {
+  it("registers optional resolve/react options plus add-flow emoji source + shortcode options", () => {
     const nameOption = Emoji.options?.find((option) => option.name === "name");
     const reactOption = Emoji.options?.find((option) => option.name === "react");
+    const emojiOption = Emoji.options?.find((option) => option.name === "emoji");
+    const shortCodeOption = Emoji.options?.find((option) => option.name === "short-code");
 
     expect(nameOption?.type).toBe(ApplicationCommandOptionType.String);
     expect(nameOption?.required).toBe(false);
@@ -13,5 +15,11 @@ describe("/emoji command shape", () => {
 
     expect(reactOption?.type).toBe(ApplicationCommandOptionType.String);
     expect(reactOption?.required).toBe(false);
+
+    expect(emojiOption?.type).toBe(ApplicationCommandOptionType.String);
+    expect(emojiOption?.required).toBe(false);
+
+    expect(shortCodeOption?.type).toBe(ApplicationCommandOptionType.String);
+    expect(shortCodeOption?.required).toBe(false);
   });
 });

--- a/tests/emojiResolver.service.test.ts
+++ b/tests/emojiResolver.service.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 import type { Client } from "discord.js";
-import { EmojiResolverService } from "../src/services/emoji/EmojiResolverService";
+import {
+  EmojiResolverService,
+  isValidEmojiShortcodeName,
+  normalizeEmojiShortcodeName,
+  parseEmojiImageSource,
+} from "../src/services/emoji/EmojiResolverService";
 
 type FakeAppEmoji = {
   id: string;
@@ -64,6 +69,76 @@ function buildClientWithApplicationEmojis(
 }
 
 describe("EmojiResolverService", () => {
+  it("normalizes shortcode names by trimming and stripping surrounding colons", () => {
+    expect(normalizeEmojiShortcodeName("arrow_arrow")).toBe("arrow_arrow");
+    expect(normalizeEmojiShortcodeName(":arrow_arrow:")).toBe("arrow_arrow");
+    expect(normalizeEmojiShortcodeName("::arrow_arrow::")).toBe("arrow_arrow");
+  });
+
+  it("validates shortcode names using Discord-safe constraints", () => {
+    expect(isValidEmojiShortcodeName("arrow_arrow")).toBe(true);
+    expect(isValidEmojiShortcodeName("a")).toBe(false);
+    expect(isValidEmojiShortcodeName("bad-name")).toBe(false);
+  });
+
+  it("parses static custom emoji tokens into discord CDN image urls", () => {
+    const parsed = parseEmojiImageSource("<:arrow_arrow:123456789012345678>");
+
+    expect(parsed).toEqual({
+      ok: true,
+      sourceType: "custom_emoji_token",
+      imageUrl:
+        "https://cdn.discordapp.com/emojis/123456789012345678.png?quality=lossless",
+      customEmojiId: "123456789012345678",
+      animated: false,
+    });
+  });
+
+  it("parses animated custom emoji tokens into gif CDN image urls", () => {
+    const parsed = parseEmojiImageSource("<a:arrow_arrow:123456789012345678>");
+
+    expect(parsed).toEqual({
+      ok: true,
+      sourceType: "custom_emoji_token",
+      imageUrl:
+        "https://cdn.discordapp.com/emojis/123456789012345678.gif?quality=lossless",
+      customEmojiId: "123456789012345678",
+      animated: true,
+    });
+  });
+
+  it("parses direct image urls", () => {
+    const parsed = parseEmojiImageSource("https://example.com/icon.webp");
+
+    expect(parsed).toEqual({
+      ok: true,
+      sourceType: "direct_image_url",
+      imageUrl: "https://example.com/icon.webp",
+      customEmojiId: null,
+      animated: false,
+    });
+  });
+
+  it("rejects unsupported unicode emoji input for add-flow source parsing", () => {
+    const parsed = parseEmojiImageSource("🔥");
+
+    expect(parsed).toEqual({
+      ok: false,
+      sourceType: "unicode_emoji_unsupported",
+      code: "unsupported_unicode_emoji",
+    });
+  });
+
+  it("rejects random invalid image-source input", () => {
+    const parsed = parseEmojiImageSource("definitely-not-an-image-source");
+
+    expect(parsed).toEqual({
+      ok: false,
+      sourceType: "invalid_input",
+      code: "invalid_emoji_input",
+    });
+  });
+
   it("fetchApplicationEmojiInventory returns success with emojis", async () => {
     const resolver = new EmojiResolverService(0);
     const { client } = buildClientWithApplicationEmojis([


### PR DESCRIPTION
- add `/emoji` options for `emoji` image input and `short-code` create path
- gate add path with runtime `emoji:add` permission target (admin by default)
- parse custom emoji tokens/direct image URLs, validate shortcode, and create app emojis
- invalidate/refresh emoji resolver cache after successful create for immediate visibility
- add structured add-path diagnostics and update docs/help command references
- extend resolver/command tests for add flow, parsing, normalization, and regressions