### PR TITLE
Merge dev into main

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,7 +1,7 @@
 # Commands Reference
 
 - `/help [command:<name>] [visibility:private|public]` - List command docs/examples. Default visibility is private.
-- `/emoji [name:<emoji_name>]` - Resolve one bot application emoji by name, or browse a paginated list of all bot application emojis when `name` is omitted.
+- `/emoji [name:<emoji_name>] [react:<message-id>]` - Resolve one bot application emoji by name, react to a message in the current channel when `react` is provided, or browse a paginated list of all bot application emojis when `name` is omitted.
 - `/telemetry report [period:24h|7d|30d] [timezone:<ianaTz>]` - Show aggregate telemetry report (usage, latency, failures, API health) for the selected window.
 - `/telemetry schedule set target-channel:<channel> cadence-hours:<n> [timezone:<ianaTz>] [enabled:true|false]` - Configure scheduled telemetry report posting.
 - `/telemetry schedule show` - Show current telemetry schedule config and last posted window.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,7 +1,7 @@
 # Commands Reference
 
 - `/help [command:<name>] [visibility:private|public]` - List command docs/examples. Default visibility is private.
-- `/emoji [name:<emoji_name>] [react:<message-id>]` - Resolve one bot application emoji by name, react to a message in the current channel when `react` is provided, or browse a paginated list of all bot application emojis when `name` is omitted. For name-only resolves, `visibility:public` returns only the rendered emoji token while private keeps the detailed shortcode/raw-token output.
+- `/emoji [name:<emoji_name>] [react:<message-id>] [emoji:<emoji-token-or-url>] [short-code:<name>]` - Resolve one bot application emoji by name, react to a message in the current channel when `react` is provided, add a new bot application emoji when `emoji` + `short-code` are provided (admin-only by default), or browse a paginated list of all bot application emojis when `name` is omitted. For name-only resolves, `visibility:public` returns only the rendered emoji token while private keeps the detailed shortcode/raw-token output.
 - `/telemetry report [period:24h|7d|30d] [timezone:<ianaTz>]` - Show aggregate telemetry report (usage, latency, failures, API health) for the selected window.
 - `/telemetry schedule set target-channel:<channel> cadence-hours:<n> [timezone:<ianaTz>] [enabled:true|false]` - Configure scheduled telemetry report posting.
 - `/telemetry schedule show` - Show current telemetry schedule config and last posted window.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,6 +1,7 @@
 # Commands Reference
 
 - `/help [command:<name>] [visibility:private|public]` - List command docs/examples. Default visibility is private.
+- `/emoji [name:<emoji_name>]` - Resolve one bot application emoji by name, or browse a paginated list of all bot application emojis when `name` is omitted.
 - `/telemetry report [period:24h|7d|30d] [timezone:<ianaTz>]` - Show aggregate telemetry report (usage, latency, failures, API health) for the selected window.
 - `/telemetry schedule set target-channel:<channel> cadence-hours:<n> [timezone:<ianaTz>] [enabled:true|false]` - Configure scheduled telemetry report posting.
 - `/telemetry schedule show` - Show current telemetry schedule config and last posted window.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,7 +1,7 @@
 # Commands Reference
 
 - `/help [command:<name>] [visibility:private|public]` - List command docs/examples. Default visibility is private.
-- `/emoji [name:<emoji_name>] [react:<message-id>]` - Resolve one bot application emoji by name, react to a message in the current channel when `react` is provided, or browse a paginated list of all bot application emojis when `name` is omitted.
+- `/emoji [name:<emoji_name>] [react:<message-id>]` - Resolve one bot application emoji by name, react to a message in the current channel when `react` is provided, or browse a paginated list of all bot application emojis when `name` is omitted. For name-only resolves, `visibility:public` returns only the rendered emoji token while private keeps the detailed shortcode/raw-token output.
 - `/telemetry report [period:24h|7d|30d] [timezone:<ianaTz>]` - Show aggregate telemetry report (usage, latency, failures, API health) for the selected window.
 - `/telemetry schedule set target-channel:<channel> cadence-hours:<n> [timezone:<ianaTz>] [enabled:true|false]` - Configure scheduled telemetry report posting.
 - `/telemetry schedule show` - Show current telemetry schedule config and last posted window.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
         "@prisma/client": "^5.22.0",
         "axios": "^1.13.5",
         "clashofclans.js": "^3.1.0",
-        "discord.js": "^14.11.0",
+        "discord.js": "^14.25.1",
         "dotenv": "^16.3.1",
         "knockout": "^3.5.1",
         "pngjs": "^7.0.0",
@@ -71,90 +71,125 @@
       }
     },
     "node_modules/@discordjs/builders": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.6.3.tgz",
-      "integrity": "sha512-CTCh8NqED3iecTNuiz49mwSsrc2iQb4d0MjMdmS/8pb69Y4IlzJ/DIy/p5GFlgOrFbNO2WzMHkWKQSiJ3VNXaw==",
-      "license": "Apache-2.0",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.13.1.tgz",
+      "integrity": "sha512-cOU0UDHc3lp/5nKByDxkmRiNZBpdp0kx55aarbiAfakfKJHlxv/yFW1zmIqCAmwH5CRlrH9iMFKJMpvW4DPB+w==",
       "dependencies": {
-        "@discordjs/formatters": "^0.3.1",
-        "@discordjs/util": "^0.3.1",
-        "@sapphire/shapeshift": "^3.8.2",
-        "discord-api-types": "^0.37.41",
+        "@discordjs/formatters": "^0.6.2",
+        "@discordjs/util": "^1.2.0",
+        "@sapphire/shapeshift": "^4.0.0",
+        "discord-api-types": "^0.38.33",
         "fast-deep-equal": "^3.1.3",
-        "ts-mixer": "^6.0.3",
-        "tslib": "^2.5.0"
+        "ts-mixer": "^6.0.4",
+        "tslib": "^2.6.3"
       },
       "engines": {
-        "node": ">=16.9.0"
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
     "node_modules/@discordjs/collection": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.1.tgz",
-      "integrity": "sha512-aWEc9DCf3TMDe9iaJoOnO2+JVAjeRNuRxPZQA6GVvBf+Z3gqUuWYBy2NWh4+5CLYq5uoc3MOvUQ5H5m8CJBqOA==",
-      "license": "Apache-2.0",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.3.tgz",
+      "integrity": "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==",
       "engines": {
-        "node": ">=16.9.0"
+        "node": ">=16.11.0"
       }
     },
     "node_modules/@discordjs/formatters": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.3.1.tgz",
-      "integrity": "sha512-M7X4IGiSeh4znwcRGcs+49B5tBkNDn4k5bmhxJDAUhRxRHTiFAOTVUNQ6yAKySu5jZTnCbSvTYHW3w0rAzV1MA==",
-      "license": "Apache-2.0",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.6.2.tgz",
+      "integrity": "sha512-y4UPwWhH6vChKRkGdMB4odasUbHOUwy7KL+OVwF86PvT6QVOwElx+TiI1/6kcmcEe+g5YRXJFiXSXUdabqZOvQ==",
       "dependencies": {
-        "discord-api-types": "^0.37.41"
+        "discord-api-types": "^0.38.33"
       },
       "engines": {
-        "node": ">=16.9.0"
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
     "node_modules/@discordjs/rest": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-1.7.1.tgz",
-      "integrity": "sha512-Ofa9UqT0U45G/eX86cURQnX7gzOJLG2oC28VhIk/G6IliYgQF7jFByBJEykPSHE4MxPhqCleYvmsrtfKh1nYmQ==",
-      "license": "Apache-2.0",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.6.0.tgz",
+      "integrity": "sha512-RDYrhmpB7mTvmCKcpj+pc5k7POKszS4E2O9TYc+U+Y4iaCP+r910QdO43qmpOja8LRr1RJ0b3U+CqVsnPqzf4w==",
       "dependencies": {
-        "@discordjs/collection": "^1.5.1",
-        "@discordjs/util": "^0.3.0",
-        "@sapphire/async-queue": "^1.5.0",
-        "@sapphire/snowflake": "^3.4.2",
-        "discord-api-types": "^0.37.41",
-        "file-type": "^18.3.0",
-        "tslib": "^2.5.0",
-        "undici": "^5.22.0"
+        "@discordjs/collection": "^2.1.1",
+        "@discordjs/util": "^1.1.1",
+        "@sapphire/async-queue": "^1.5.3",
+        "@sapphire/snowflake": "^3.5.3",
+        "@vladfrangu/async_event_emitter": "^2.4.6",
+        "discord-api-types": "^0.38.16",
+        "magic-bytes.js": "^1.10.0",
+        "tslib": "^2.6.3",
+        "undici": "6.21.3"
       },
       "engines": {
-        "node": ">=16.9.0"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest/node_modules/@discordjs/collection": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
     "node_modules/@discordjs/util": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-0.3.1.tgz",
-      "integrity": "sha512-HxXKYKg7vohx2/OupUN/4Sd02Ev3PBJ5q0gtjdcvXb0ErCva8jNHWfe/v5sU3UKjIB/uxOhc+TDOnhqffj9pRA==",
-      "license": "Apache-2.0",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.2.0.tgz",
+      "integrity": "sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg==",
+      "dependencies": {
+        "discord-api-types": "^0.38.33"
+      },
       "engines": {
-        "node": ">=16.9.0"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
     "node_modules/@discordjs/ws": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-0.8.3.tgz",
-      "integrity": "sha512-hcYtppanjHecbdNyCKQNH2I4RP9UrphDgmRgLYrATEQF1oo4sYSve7ZmGsBEXSzH72MO2tBPdWSThunbxUVk0g==",
-      "license": "Apache-2.0",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.2.3.tgz",
+      "integrity": "sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==",
       "dependencies": {
-        "@discordjs/collection": "^1.5.1",
-        "@discordjs/rest": "^1.7.1",
-        "@discordjs/util": "^0.3.1",
-        "@sapphire/async-queue": "^1.5.0",
-        "@types/ws": "^8.5.4",
-        "@vladfrangu/async_event_emitter": "^2.2.1",
-        "discord-api-types": "^0.37.41",
-        "tslib": "^2.5.0",
-        "ws": "^8.13.0"
+        "@discordjs/collection": "^2.1.0",
+        "@discordjs/rest": "^2.5.1",
+        "@discordjs/util": "^1.1.0",
+        "@sapphire/async-queue": "^1.5.2",
+        "@types/ws": "^8.5.10",
+        "@vladfrangu/async_event_emitter": "^2.2.4",
+        "discord-api-types": "^0.38.1",
+        "tslib": "^2.6.2",
+        "ws": "^8.17.0"
       },
       "engines": {
-        "node": ">=16.9.0"
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/ws/node_modules/@discordjs/collection": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1110,34 +1145,30 @@
       ]
     },
     "node_modules/@sapphire/async-queue": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.0.tgz",
-      "integrity": "sha512-JkLdIsP8fPAdh9ZZjrbHWR/+mZj0wvKS5ICibcLrRI1j84UmLMshx5n9QmL8b95d4onJ2xxiyugTgSAX7AalmA==",
-      "license": "MIT",
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.5.tgz",
+      "integrity": "sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==",
       "engines": {
         "node": ">=v14.0.0",
         "npm": ">=7.0.0"
       }
     },
     "node_modules/@sapphire/shapeshift": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.9.2.tgz",
-      "integrity": "sha512-YRbCXWy969oGIdqR/wha62eX8GNHsvyYi0Rfd4rNW6tSVVa8p0ELiMEuOH/k8rgtvRoM+EMV7Csqz77YdwiDpA==",
-      "license": "MIT",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-4.0.0.tgz",
+      "integrity": "sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "lodash": "^4.17.21"
       },
       "engines": {
-        "node": ">=v14.0.0",
-        "npm": ">=7.0.0"
+        "node": ">=v16"
       }
     },
     "node_modules/@sapphire/snowflake": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.1.tgz",
-      "integrity": "sha512-BxcYGzgEsdlG0dKAyOm0ehLGm2CafIrfQTZGWgkfKYbj+pNNsorZ7EotuZukc2MT70E0UbppVbtpBrqpzVzjNA==",
-      "license": "MIT",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.3.tgz",
+      "integrity": "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==",
       "engines": {
         "node": ">=v14.0.0",
         "npm": ">=7.0.0"
@@ -1148,12 +1179,6 @@
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
       "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
       "dev": true
-    },
-    "node_modules/@tokenizer/token": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
-      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
-      "license": "MIT"
     },
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
@@ -1229,10 +1254,9 @@
       "dev": true
     },
     "node_modules/@types/ws": {
-      "version": "8.5.5",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.5.tgz",
-      "integrity": "sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==",
-      "license": "MIT",
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
       "dependencies": {
         "@types/node": "*"
       }
@@ -1837,10 +1861,9 @@
       }
     },
     "node_modules/@vladfrangu/async_event_emitter": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.2.2.tgz",
-      "integrity": "sha512-HIzRG7sy88UZjBJamssEczH5q7t5+axva19UbZLO6u0ySbYPrwzWiXBcC0WuHyhKKoeCyneH+FvYzKQq/zTtkQ==",
-      "license": "MIT",
+      "version": "2.4.7",
+      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.7.tgz",
+      "integrity": "sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==",
       "engines": {
         "node": ">=v14.0.0",
         "npm": ">=7.0.0"
@@ -2014,17 +2037,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/busboy": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
-      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
-      "dependencies": {
-        "streamsearch": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=10.16.0"
       }
     },
     "node_modules/cac": {
@@ -2302,34 +2314,34 @@
       }
     },
     "node_modules/discord-api-types": {
-      "version": "0.37.49",
-      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.49.tgz",
-      "integrity": "sha512-a2vvjgmE/1cPtXOuOh5zHlLe+qheu0uO625K+FyZVFomoCmpV1xNpadC48S98K30CnQ4/XJyFGnOZLXxAyBbCQ==",
-      "license": "MIT"
+      "version": "0.38.42",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.42.tgz",
+      "integrity": "sha512-qs1kya7S84r5RR8m9kgttywGrmmoHaRifU1askAoi+wkoSefLpZP6aGXusjNw5b0jD3zOg3LTwUa3Tf2iHIceQ=="
     },
     "node_modules/discord.js": {
-      "version": "14.11.0",
-      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.11.0.tgz",
-      "integrity": "sha512-CkueWYFQ28U38YPR8HgsBR/QT35oPpMbEsTNM30Fs8loBIhnA4s70AwQEoy6JvLcpWWJO7GY0y2BUzZmuBMepQ==",
-      "license": "Apache-2.0",
+      "version": "14.25.1",
+      "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-14.25.1.tgz",
+      "integrity": "sha512-2l0gsPOLPs5t6GFZfQZKnL1OJNYFcuC/ETWsW4VtKVD/tg4ICa9x+jb9bkPffkMdRpRpuUaO/fKkHCBeiCKh8g==",
       "dependencies": {
-        "@discordjs/builders": "^1.6.3",
-        "@discordjs/collection": "^1.5.1",
-        "@discordjs/formatters": "^0.3.1",
-        "@discordjs/rest": "^1.7.1",
-        "@discordjs/util": "^0.3.1",
-        "@discordjs/ws": "^0.8.3",
-        "@sapphire/snowflake": "^3.4.2",
-        "@types/ws": "^8.5.4",
-        "discord-api-types": "^0.37.41",
-        "fast-deep-equal": "^3.1.3",
-        "lodash.snakecase": "^4.1.1",
-        "tslib": "^2.5.0",
-        "undici": "^5.22.0",
-        "ws": "^8.13.0"
+        "@discordjs/builders": "^1.13.0",
+        "@discordjs/collection": "1.5.3",
+        "@discordjs/formatters": "^0.6.2",
+        "@discordjs/rest": "^2.6.0",
+        "@discordjs/util": "^1.2.0",
+        "@discordjs/ws": "^1.2.3",
+        "@sapphire/snowflake": "3.5.3",
+        "discord-api-types": "^0.38.33",
+        "fast-deep-equal": "3.1.3",
+        "lodash.snakecase": "4.1.1",
+        "magic-bytes.js": "^1.10.0",
+        "tslib": "^2.6.3",
+        "undici": "6.21.3"
       },
       "engines": {
-        "node": ">=16.9.0"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
       }
     },
     "node_modules/doctrine": {
@@ -2669,23 +2681,6 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
-    "node_modules/file-type": {
-      "version": "18.5.0",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-18.5.0.tgz",
-      "integrity": "sha512-yvpl5U868+V6PqXHMmsESpg6unQ5GfnPssl4dxdJudBrr9qy7Fddt7EVX1VLlddFfe8Gj9N7goCZH22FXuSQXQ==",
-      "license": "MIT",
-      "dependencies": {
-        "readable-web-to-node-stream": "^3.0.2",
-        "strtok3": "^7.0.0",
-        "token-types": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
-      }
-    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -2976,26 +2971,6 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true
     },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3051,6 +3026,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/is-binary-path": {
@@ -3266,10 +3242,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "license": "MIT"
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -3291,6 +3266,11 @@
       "dependencies": {
         "get-func-name": "^2.0.1"
       }
+    },
+    "node_modules/magic-bytes.js": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.13.0.tgz",
+      "integrity": "sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg=="
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -3607,19 +3587,6 @@
         "node": "*"
       }
     },
-    "node_modules/peek-readable": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-5.0.0.tgz",
-      "integrity": "sha512-YtCKvLUOvwtMGmrniQPdO7MwPjgkFBtFIrmfSbYmYuq3tKDV/mcfAhBth1+C3ru7uXIZasc/pHnb+YDYNkkj4A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
-      }
-    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -3801,36 +3768,6 @@
       "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
       "dev": true
     },
-    "node_modules/readable-stream": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
-      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
-    "node_modules/readable-web-to-node-stream": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz",
-      "integrity": "sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==",
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
-      }
-    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -3945,26 +3882,6 @@
         "queue-microtask": "^1.2.2"
       }
     },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT"
-    },
     "node_modules/semver": {
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
@@ -4055,23 +3972,6 @@
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true
     },
-    "node_modules/streamsearch": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
-      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
     "node_modules/strip-ansi": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -4106,23 +4006,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
-      }
-    },
-    "node_modules/strtok3": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-7.0.0.tgz",
-      "integrity": "sha512-pQ+V+nYQdC5H3Q7qBZAz/MO6lwGhoC2gOAjuouGf/VO0m7vQRh8QNMl2Uf6SwAtzZ9bOw3UIeBukEGNJl5dtXQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@tokenizer/token": "^0.3.0",
-        "peek-readable": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/supports-color": {
@@ -4193,23 +4076,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/token-types": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/token-types/-/token-types-5.0.1.tgz",
-      "integrity": "sha512-Y2fmSnZjQdDb9W4w4r1tswlMHylzWIeOKpx0aZH9BgGtACHhrk3OkT52AzwcuqTRBZtvvnTjDBh8eynMulu8Vg==",
-      "license": "MIT",
-      "dependencies": {
-        "@tokenizer/token": "^0.3.0",
-        "ieee754": "^1.2.1"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
-      }
-    },
     "node_modules/touch": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.1.tgz",
@@ -4225,10 +4091,9 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
     },
     "node_modules/ts-mixer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.3.tgz",
-      "integrity": "sha512-k43M7uCG1AkTyxgnmI5MPwKoUvS/bRvLvUb7+Pgpdlmok8AoqmUaZxUUw8zKM5B1lqZrt41GjYgnvAi0fppqgQ==",
-      "license": "MIT"
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
+      "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA=="
     },
     "node_modules/ts-node": {
       "version": "10.9.2",
@@ -4274,10 +4139,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz",
-      "integrity": "sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==",
-      "license": "0BSD"
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/type-check": {
       "version": "0.4.0",
@@ -4337,15 +4201,11 @@
       "dev": true
     },
     "node_modules/undici": {
-      "version": "5.22.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.22.1.tgz",
-      "integrity": "sha512-Ji2IJhFXZY0x/0tVBXeQwgPlLWw13GVzpsWPQ3rV50IFMMof2I55PZZxtm4P6iNq+L5znYN9nSTAq0ZyE6lSJw==",
-      "license": "MIT",
-      "dependencies": {
-        "busboy": "^1.6.0"
-      },
+      "version": "6.21.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
+      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
       "engines": {
-        "node": ">=14.0"
+        "node": ">=18.17"
       }
     },
     "node_modules/uri-js": {
@@ -4356,12 +4216,6 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "license": "MIT"
     },
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
@@ -4614,10 +4468,9 @@
       "dev": true
     },
     "node_modules/ws": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
-      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
-      "license": "MIT",
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "@prisma/client": "^5.22.0",
     "axios": "^1.13.5",
     "clashofclans.js": "^3.1.0",
-    "discord.js": "^14.11.0",
+    "discord.js": "^14.25.1",
     "dotenv": "^16.3.1",
     "knockout": "^3.5.1",
     "pngjs": "^7.0.0",

--- a/src/Commands.ts
+++ b/src/Commands.ts
@@ -1,4 +1,5 @@
 import { Help } from "./commands/Help";
+import { Emoji } from "./commands/Emoji";
 import { LastSeen } from "./commands/LastSeen";
 import { Inactive } from "./commands/Inactive";
 import { RoleUsers } from "./commands/RoleUsers";
@@ -26,6 +27,7 @@ import { Layout } from "./commands/Layout";
 // ...existing code...
 export const Commands = [
   Help,
+  Emoji,
   LastSeen,
   Inactive,
   RoleUsers,

--- a/src/commands/Compo.ts
+++ b/src/commands/Compo.ts
@@ -1,7 +1,7 @@
 import {
   ActionRowBuilder,
   APIActionRowComponent,
-  APIMessageActionRowComponent,
+  APIComponentInMessageActionRow,
   ApplicationCommandOptionType,
   AutocompleteInteraction,
   ButtonBuilder,
@@ -164,9 +164,9 @@ function buildCompoRefreshActionRow(
 
 function extractSupplementalRowsFromMessage(
   interaction: ButtonInteraction
-): Array<APIActionRowComponent<APIMessageActionRowComponent>> {
+): Array<APIActionRowComponent<APIComponentInMessageActionRow>> {
   return interaction.message.components
-    .map((row) => row.toJSON() as APIActionRowComponent<APIMessageActionRowComponent>)
+    .map((row) => row.toJSON() as APIActionRowComponent<APIComponentInMessageActionRow>)
     .filter(
       (row) =>
         !row.components.some(
@@ -865,9 +865,9 @@ function renderStatePng(mode: GoogleSheetMode, rows: string[][]): Buffer {
 function buildCompoRefreshComponents(input: {
   customId: string;
   loading: boolean;
-  supplementalRows?: Array<APIActionRowComponent<APIMessageActionRowComponent>>;
-}): Array<ActionRowBuilder<ButtonBuilder> | APIActionRowComponent<APIMessageActionRowComponent>> {
-  const components: Array<ActionRowBuilder<ButtonBuilder> | APIActionRowComponent<APIMessageActionRowComponent>> = [
+  supplementalRows?: Array<APIActionRowComponent<APIComponentInMessageActionRow>>;
+}): Array<ActionRowBuilder<ButtonBuilder> | APIActionRowComponent<APIComponentInMessageActionRow>> {
+  const components: Array<ActionRowBuilder<ButtonBuilder> | APIActionRowComponent<APIComponentInMessageActionRow>> = [
     buildCompoRefreshActionRow(input.customId, { loading: input.loading }),
   ];
   if (input.supplementalRows && input.supplementalRows.length > 0) {

--- a/src/commands/Emoji.ts
+++ b/src/commands/Emoji.ts
@@ -1,6 +1,7 @@
 import {
   ActionRowBuilder,
   ApplicationCommandOptionType,
+  AutocompleteInteraction,
   ButtonBuilder,
   ButtonInteraction,
   ButtonStyle,
@@ -8,6 +9,7 @@ import {
   Client,
   ComponentType,
   EmbedBuilder,
+  PermissionFlagsBits,
 } from "discord.js";
 import { Command } from "../Command";
 import { formatError } from "../helper/formatError";
@@ -28,6 +30,8 @@ type EmojiResolverPort = Pick<
 
 const EMOJI_PAGE_SIZE = 20;
 const EMOJI_PAGINATOR_TIMEOUT_MS = 10 * 60 * 1000;
+const MAX_AUTOCOMPLETE_CHOICES = 25;
+const MESSAGE_ID_PATTERN = /^\d{17,22}$/;
 
 let activeEmojiResolver: EmojiResolverPort = emojiResolverService;
 
@@ -127,37 +131,124 @@ function buildEmojiNameSuggestions(
     .map((emoji) => emoji.shortcode);
 }
 
+/** Purpose: cap text safely for Discord autocomplete option labels. */
+function truncateAutocompleteLabel(value: string): string {
+  const text = String(value ?? "");
+  if (text.length <= 100) return text;
+  return `${text.slice(0, 97)}...`;
+}
+
+/** Purpose: build deterministic emoji autocomplete options with exact/prefix/contains ranking. */
+function buildEmojiAutocompleteChoices(
+  emojis: ResolvedApplicationEmoji[],
+  focusedValue: string,
+): Array<{ name: string; value: string }> {
+  const queryRaw = normalizeEmojiLookupName(focusedValue);
+  const queryLower = queryRaw.toLowerCase();
+  const deduped = new Map<string, ResolvedApplicationEmoji>();
+  for (const emoji of emojis) {
+    const key = emoji.name.toLowerCase();
+    if (!deduped.has(key)) {
+      deduped.set(key, emoji);
+    }
+  }
+
+  const ranked = [...deduped.values()]
+    .map((emoji) => {
+      const nameLower = emoji.name.toLowerCase();
+      let rank = 3;
+      if (!queryLower) {
+        rank = 3;
+      } else if (nameLower === queryLower) {
+        rank = 0;
+      } else if (nameLower.startsWith(queryLower)) {
+        rank = 1;
+      } else if (nameLower.includes(queryLower)) {
+        rank = 2;
+      } else {
+        return null;
+      }
+      return { emoji, rank, nameLower };
+    })
+    .filter((entry): entry is { emoji: ResolvedApplicationEmoji; rank: number; nameLower: string } =>
+      entry !== null,
+    )
+    .sort((a, b) => {
+      if (a.rank !== b.rank) return a.rank - b.rank;
+      const byLower = a.nameLower.localeCompare(b.nameLower);
+      if (byLower !== 0) return byLower;
+      return a.emoji.name.localeCompare(b.emoji.name);
+    })
+    .slice(0, MAX_AUTOCOMPLETE_CHOICES);
+
+  return ranked.map(({ emoji }) => ({
+    name: truncateAutocompleteLabel(`${emoji.rendered} ${emoji.shortcode}`),
+    value: emoji.name,
+  }));
+}
+
+/** Purpose: classify whether a string is a plausible Discord message snowflake id. */
+function isValidMessageId(value: string): boolean {
+  return MESSAGE_ID_PATTERN.test(String(value ?? "").trim());
+}
+
 /** Purpose: map resolver failure code to the most accurate user-facing /emoji error response. */
 function buildEmojiFailureMessage(code: EmojiResolverFailureCode): string {
   if (code === "application_missing" || code === "application_emoji_manager_unavailable") {
-    return "Could not load bot application emojis in this runtime. Please contact an admin.";
+    return "Could not load application emojis right now.";
   }
-  return "Could not fetch bot application emojis right now. Please try again later.";
+  return "Could not fetch application emojis right now. Please try again later.";
 }
 
-/** Purpose: emit concise structured diagnostics for one /emoji resolver run. */
-function logEmojiFetchResult(input: {
-  interaction: ChatInputCommandInteraction;
-  result: EmojiInventoryFetchResult;
-}): void {
-  const { diagnostics } = input.result;
-  const fields = [
-    "command=emoji",
-    `guild_id=${input.interaction.guildId ?? "dm"}`,
-    `user_id=${input.interaction.user.id}`,
-    `application_present_pre_fetch=${diagnostics.applicationExistedBeforeFetch}`,
-    `application_fetch_attempted=${diagnostics.applicationFetchAttempted}`,
-    `application_emoji_fetch_available=${diagnostics.applicationEmojiFetchAvailable}`,
-    `emoji_fetch_succeeded=${diagnostics.emojiFetchSucceeded}`,
-    `fetched_emoji_count=${diagnostics.fetchedEmojiCount}`,
-    `failure_code=${input.result.ok ? "none" : input.result.code}`,
-  ];
-  const message = `[emoji] fetch ${fields.join(" ")}`;
-  if (input.result.ok) {
-    console.log(message);
+/** Purpose: emit concise structured diagnostics for /emoji execution and autocomplete paths. */
+function logEmojiEvent(fields: Record<string, string | number | boolean | null | undefined>): void {
+  const serialized = Object.entries(fields)
+    .map(([key, value]) => `${key}=${String(value ?? "")}`)
+    .join(" ");
+  const failureCode = String(fields.failure_code ?? "").trim();
+  if (failureCode && failureCode !== "none") {
+    console.warn(`[emoji] ${serialized}`);
     return;
   }
-  console.warn(message);
+  console.log(`[emoji] ${serialized}`);
+}
+
+/** Purpose: emit structured resolver diagnostics tied to command mode and caller identity. */
+function logEmojiInventoryResult(input: {
+  mode: "list" | "resolve" | "react" | "autocomplete";
+  guildId: string | null;
+  channelId: string | null;
+  userId: string;
+  requestedName?: string;
+  normalizedName?: string;
+  focusedText?: string;
+  targetMessageId?: string;
+  result: EmojiInventoryFetchResult;
+}): void {
+  const diagnostics = input.result.diagnostics;
+  logEmojiEvent({
+    command: "emoji",
+    mode: input.mode,
+    guild_id: input.guildId ?? "dm",
+    channel_id: input.channelId ?? "none",
+    user_id: input.userId,
+    requested_emoji_name: input.requestedName ?? "",
+    normalized_emoji_name: input.normalizedName ?? "",
+    focused_text: input.focusedText ?? "",
+    target_message_id: input.targetMessageId ?? "",
+    application_present_pre_fetch: diagnostics.applicationExistedBeforeFetch,
+    application_fetch_attempted: diagnostics.applicationFetchAttempted,
+    application_emoji_fetch_available: diagnostics.applicationEmojiFetchAvailable,
+    emoji_fetch_succeeded: diagnostics.emojiFetchSucceeded,
+    fetched_emoji_count: diagnostics.fetchedEmojiCount,
+    failure_code: input.result.ok ? "none" : input.result.code,
+  });
+}
+
+/** Purpose: provide a tiny guard for Discord API-style numeric error code extraction. */
+function getDiscordErrorCode(error: unknown): number | null {
+  const code = (error as { code?: number } | null | undefined)?.code;
+  return typeof code === "number" ? code : null;
 }
 
 /** Purpose: allow tests to inject a resolver and assert command behavior deterministically. */
@@ -175,6 +266,8 @@ export const paginateEmojiLinesForTest = paginateEmojiLines;
 export const buildEmojiListEmbedForTest = buildEmojiListEmbed;
 export const buildEmojiListRowForTest = buildEmojiListRow;
 export const normalizeEmojiLookupNameInputForTest = normalizeEmojiLookupName;
+export const buildEmojiAutocompleteChoicesForTest = buildEmojiAutocompleteChoices;
+export const isValidMessageIdForTest = isValidMessageId;
 
 export const Emoji: Command = {
   name: "emoji",
@@ -182,7 +275,14 @@ export const Emoji: Command = {
   options: [
     {
       name: "name",
-      description: "Emoji name or shortcode (for example: arrow_arrow or :arrow_arrow:)",
+      description: "Application emoji name or shortcode",
+      type: ApplicationCommandOptionType.String,
+      required: false,
+      autocomplete: true,
+    },
+    {
+      name: "react",
+      description: "Message ID to react to with the named emoji",
       type: ApplicationCommandOptionType.String,
       required: false,
     },
@@ -193,16 +293,70 @@ export const Emoji: Command = {
     _cocService: CoCService,
   ) => {
     await interaction.deferReply({ ephemeral: true });
+
     const rawName = interaction.options.getString("name", false);
-    const requestedName = normalizeEmojiLookupName(rawName ?? "");
+    const rawReact = interaction.options.getString("react", false);
+    const hasNameInput = rawName !== null;
+    const requestedName = String(rawName ?? "");
+    const normalizedName = normalizeEmojiLookupName(requestedName);
+    const targetMessageId = String(rawReact ?? "").trim();
+
+    const mode: "list" | "resolve" | "react" = !hasNameInput
+      ? "list"
+      : targetMessageId
+        ? "react"
+        : "resolve";
+
+    if (hasNameInput && !normalizedName) {
+      logEmojiEvent({
+        command: "emoji",
+        mode,
+        guild_id: interaction.guildId ?? "dm",
+        channel_id: interaction.channelId ?? "none",
+        user_id: interaction.user.id,
+        requested_emoji_name: requestedName,
+        normalized_emoji_name: normalizedName,
+        target_message_id: targetMessageId,
+        resolve_result: "invalid_name",
+        failure_code: "invalid_emoji_name",
+      });
+      await interaction.editReply({
+        content: "Please provide a valid emoji name.",
+        embeds: [],
+        components: [],
+      });
+      return;
+    }
 
     try {
       const inventory = await activeEmojiResolver.fetchApplicationEmojiInventory(
         interaction.client,
         { forceRefresh: true },
       );
-      logEmojiFetchResult({ interaction, result: inventory });
+      logEmojiInventoryResult({
+        mode,
+        guildId: interaction.guildId,
+        channelId: interaction.channelId,
+        userId: interaction.user.id,
+        requestedName,
+        normalizedName,
+        targetMessageId,
+        result: inventory,
+      });
+
       if (!inventory.ok) {
+        logEmojiEvent({
+          command: "emoji",
+          mode,
+          guild_id: interaction.guildId ?? "dm",
+          channel_id: interaction.channelId ?? "none",
+          user_id: interaction.user.id,
+          requested_emoji_name: requestedName,
+          normalized_emoji_name: normalizedName,
+          target_message_id: targetMessageId,
+          resolve_result: "inventory_unavailable",
+          failure_code: "emoji_inventory_unavailable",
+        });
         await interaction.editReply({
           content: buildEmojiFailureMessage(inventory.code),
           embeds: [],
@@ -211,84 +365,13 @@ export const Emoji: Command = {
         return;
       }
 
-      const { snapshot } = inventory;
-      const emojis = snapshot.entries;
-      if (requestedName) {
-        const resolved =
-          snapshot.exactByName.get(requestedName) ??
-          snapshot.lowercaseByName.get(requestedName.toLowerCase()) ??
-          null;
-        if (resolved) {
-          await interaction.editReply({
-            embeds: [buildEmojiResolveEmbed(resolved)],
-          });
-          return;
-        }
+      const emojis = inventory.snapshot.entries;
+      if (mode === "list") {
+        const pages = paginateEmojiLines(emojis);
+        let page = 0;
+        const paginatorPrefix = `emoji-list:${interaction.id}`;
 
-        const suggestions = buildEmojiNameSuggestions(requestedName, emojis);
-        const suggestionText = suggestions.length
-          ? `\nDid you mean: ${suggestions.join(", ")}`
-          : "";
         await interaction.editReply({
-          content: `No application emoji found for \`:${requestedName}:\`.${suggestionText}`,
-          embeds: [],
-          components: [],
-        });
-        return;
-      }
-
-      const pages = paginateEmojiLines(emojis);
-      let page = 0;
-      const paginatorPrefix = `emoji-list:${interaction.id}`;
-
-      await interaction.editReply({
-        embeds: [
-          buildEmojiListEmbed({
-            emojis,
-            pages,
-            page,
-          }),
-        ],
-        components:
-          pages.length > 1
-            ? [
-                buildEmojiListRow({
-                  prefix: paginatorPrefix,
-                  page,
-                  totalPages: pages.length,
-                }),
-              ]
-            : [],
-      });
-
-      if (pages.length <= 1) return;
-
-      const message = await interaction.fetchReply();
-      const collector = message.createMessageComponentCollector({
-        componentType: ComponentType.Button,
-        time: EMOJI_PAGINATOR_TIMEOUT_MS,
-      });
-
-      collector.on("collect", async (button: ButtonInteraction) => {
-        if (button.user.id !== interaction.user.id) {
-          await button.reply({
-            ephemeral: true,
-            content: "Only the command user can control this paginator.",
-          });
-          return;
-        }
-        if (
-          button.customId !== `${paginatorPrefix}:prev` &&
-          button.customId !== `${paginatorPrefix}:next`
-        ) {
-          return;
-        }
-        page = applyEmojiPageAction({
-          action: button.customId.endsWith(":prev") ? "prev" : "next",
-          page,
-          totalPages: pages.length,
-        });
-        await button.update({
           embeds: [
             buildEmojiListEmbed({
               emojis,
@@ -296,19 +379,46 @@ export const Emoji: Command = {
               page,
             }),
           ],
-          components: [
-            buildEmojiListRow({
-              prefix: paginatorPrefix,
-              page,
-              totalPages: pages.length,
-            }),
-          ],
+          components:
+            pages.length > 1
+              ? [
+                  buildEmojiListRow({
+                    prefix: paginatorPrefix,
+                    page,
+                    totalPages: pages.length,
+                  }),
+                ]
+              : [],
         });
-      });
 
-      collector.on("end", async () => {
-        await interaction
-          .editReply({
+        if (pages.length <= 1) return;
+
+        const message = await interaction.fetchReply();
+        const collector = message.createMessageComponentCollector({
+          componentType: ComponentType.Button,
+          time: EMOJI_PAGINATOR_TIMEOUT_MS,
+        });
+
+        collector.on("collect", async (button: ButtonInteraction) => {
+          if (button.user.id !== interaction.user.id) {
+            await button.reply({
+              ephemeral: true,
+              content: "Only the command user can control this paginator.",
+            });
+            return;
+          }
+          if (
+            button.customId !== `${paginatorPrefix}:prev` &&
+            button.customId !== `${paginatorPrefix}:next`
+          ) {
+            return;
+          }
+          page = applyEmojiPageAction({
+            action: button.customId.endsWith(":prev") ? "prev" : "next",
+            page,
+            totalPages: pages.length,
+          });
+          await button.update({
             embeds: [
               buildEmojiListEmbed({
                 emojis,
@@ -321,20 +431,306 @@ export const Emoji: Command = {
                 prefix: paginatorPrefix,
                 page,
                 totalPages: pages.length,
-                forceDisabled: true,
               }),
             ],
-          })
-          .catch(() => undefined);
+          });
+        });
+
+        collector.on("end", async () => {
+          await interaction
+            .editReply({
+              embeds: [
+                buildEmojiListEmbed({
+                  emojis,
+                  pages,
+                  page,
+                }),
+              ],
+              components: [
+                buildEmojiListRow({
+                  prefix: paginatorPrefix,
+                  page,
+                  totalPages: pages.length,
+                  forceDisabled: true,
+                }),
+              ],
+            })
+            .catch(() => undefined);
+        });
+
+        return;
+      }
+
+      const resolved =
+        inventory.snapshot.exactByName.get(normalizedName) ??
+        inventory.snapshot.lowercaseByName.get(normalizedName.toLowerCase()) ??
+        null;
+
+      if (!resolved) {
+        const suggestions = buildEmojiNameSuggestions(normalizedName, emojis);
+        const suggestionText = suggestions.length
+          ? `\nDid you mean: ${suggestions.join(", ")}`
+          : "";
+        logEmojiEvent({
+          command: "emoji",
+          mode,
+          guild_id: interaction.guildId ?? "dm",
+          channel_id: interaction.channelId ?? "none",
+          user_id: interaction.user.id,
+          requested_emoji_name: requestedName,
+          normalized_emoji_name: normalizedName,
+          target_message_id: targetMessageId,
+          resolve_result: "not_found",
+          failure_code: "emoji_not_found",
+        });
+        await interaction.editReply({
+          content: `Could not find an application emoji named \`${normalizedName}\`.${suggestionText}`,
+          embeds: [],
+          components: [],
+        });
+        return;
+      }
+
+      if (mode === "resolve") {
+        logEmojiEvent({
+          command: "emoji",
+          mode,
+          guild_id: interaction.guildId ?? "dm",
+          channel_id: interaction.channelId ?? "none",
+          user_id: interaction.user.id,
+          requested_emoji_name: requestedName,
+          normalized_emoji_name: normalizedName,
+          resolve_result: "found",
+          failure_code: "none",
+        });
+        await interaction.editReply({
+          embeds: [buildEmojiResolveEmbed(resolved)],
+          components: [],
+        });
+        return;
+      }
+
+      if (!isValidMessageId(targetMessageId)) {
+        logEmojiEvent({
+          command: "emoji",
+          mode,
+          guild_id: interaction.guildId ?? "dm",
+          channel_id: interaction.channelId ?? "none",
+          user_id: interaction.user.id,
+          requested_emoji_name: requestedName,
+          normalized_emoji_name: normalizedName,
+          target_message_id: targetMessageId,
+          resolve_result: "found",
+          reaction_result: "validation_failed",
+          failure_code: "invalid_message_id",
+        });
+        await interaction.editReply({
+          content: "Please provide a valid message ID.",
+          embeds: [],
+          components: [],
+        });
+        return;
+      }
+
+      const channel = interaction.channel;
+      if (
+        !channel ||
+        !channel.isTextBased() ||
+        !("messages" in channel) ||
+        !channel.messages ||
+        typeof channel.messages.fetch !== "function"
+      ) {
+        logEmojiEvent({
+          command: "emoji",
+          mode,
+          guild_id: interaction.guildId ?? "dm",
+          channel_id: interaction.channelId ?? "none",
+          user_id: interaction.user.id,
+          requested_emoji_name: requestedName,
+          normalized_emoji_name: normalizedName,
+          target_message_id: targetMessageId,
+          resolve_result: "found",
+          reaction_result: "channel_unavailable",
+          failure_code: "message_fetch_failed",
+        });
+        await interaction.editReply({
+          content: "Could not find that message in this channel.",
+          embeds: [],
+          components: [],
+        });
+        return;
+      }
+
+      const appPermissions = interaction.appPermissions;
+      if (
+        appPermissions &&
+        (!appPermissions.has(PermissionFlagsBits.ViewChannel) ||
+          !appPermissions.has(PermissionFlagsBits.ReadMessageHistory) ||
+          !appPermissions.has(PermissionFlagsBits.AddReactions))
+      ) {
+        logEmojiEvent({
+          command: "emoji",
+          mode,
+          guild_id: interaction.guildId ?? "dm",
+          channel_id: interaction.channelId ?? "none",
+          user_id: interaction.user.id,
+          requested_emoji_name: requestedName,
+          normalized_emoji_name: normalizedName,
+          target_message_id: targetMessageId,
+          resolve_result: "found",
+          reaction_result: "permission_denied",
+          failure_code: "react_permission_denied",
+        });
+        await interaction.editReply({
+          content: "I do not have permission to add that reaction.",
+          embeds: [],
+          components: [],
+        });
+        return;
+      }
+
+      let targetMessage;
+      try {
+        targetMessage = await channel.messages.fetch(targetMessageId);
+      } catch (error) {
+        logEmojiEvent({
+          command: "emoji",
+          mode,
+          guild_id: interaction.guildId ?? "dm",
+          channel_id: interaction.channelId ?? "none",
+          user_id: interaction.user.id,
+          requested_emoji_name: requestedName,
+          normalized_emoji_name: normalizedName,
+          target_message_id: targetMessageId,
+          resolve_result: "found",
+          reaction_result: "message_fetch_failed",
+          failure_code: "message_fetch_failed",
+        });
+        await interaction.editReply({
+          content: `Could not find message \`${targetMessageId}\` in this channel.`,
+          embeds: [],
+          components: [],
+        });
+        return;
+      }
+
+      try {
+        await targetMessage.react(resolved.rendered);
+      } catch (error) {
+        const code = getDiscordErrorCode(error);
+        const failureCode = code === 50013 || code === 50001
+          ? "react_permission_denied"
+          : "reaction_api_failed";
+        logEmojiEvent({
+          command: "emoji",
+          mode,
+          guild_id: interaction.guildId ?? "dm",
+          channel_id: interaction.channelId ?? "none",
+          user_id: interaction.user.id,
+          requested_emoji_name: requestedName,
+          normalized_emoji_name: normalizedName,
+          target_message_id: targetMessageId,
+          resolve_result: "found",
+          reaction_result: "failed",
+          failure_code: failureCode,
+        });
+        await interaction.editReply({
+          content:
+            failureCode === "react_permission_denied"
+              ? "I do not have permission to add that reaction."
+              : "Discord rejected that reaction. Please try again.",
+          embeds: [],
+          components: [],
+        });
+        return;
+      }
+
+      logEmojiEvent({
+        command: "emoji",
+        mode,
+        guild_id: interaction.guildId ?? "dm",
+        channel_id: interaction.channelId ?? "none",
+        user_id: interaction.user.id,
+        requested_emoji_name: requestedName,
+        normalized_emoji_name: normalizedName,
+        target_message_id: targetMessageId,
+        resolve_result: "found",
+        reaction_result: "success",
+        failure_code: "none",
+      });
+      await interaction.editReply({
+        content: `Reacted to message \`${targetMessageId}\` with ${resolved.rendered}.`,
+        embeds: [],
+        components: [],
       });
     } catch (error) {
       console.error(`[emoji] command failed: ${formatError(error)}`);
       await interaction.editReply({
         content:
-          "Could not load bot application emojis right now. Please try again later.",
+          "Could not load application emojis right now. Please try again later.",
         embeds: [],
         components: [],
       });
+    }
+  },
+  autocomplete: async (interaction: AutocompleteInteraction) => {
+    const focused = interaction.options.getFocused(true);
+    if (focused.name !== "name") {
+      await interaction.respond([]);
+      return;
+    }
+
+    const focusedText = String(focused.value ?? "");
+    const normalizedName = normalizeEmojiLookupName(focusedText);
+
+    try {
+      const inventory = await activeEmojiResolver.fetchApplicationEmojiInventory(
+        interaction.client,
+      );
+      logEmojiInventoryResult({
+        mode: "autocomplete",
+        guildId: interaction.guildId,
+        channelId: interaction.channelId,
+        userId: interaction.user.id,
+        focusedText,
+        normalizedName,
+        result: inventory,
+      });
+      if (!inventory.ok) {
+        logEmojiEvent({
+          command: "emoji",
+          mode: "autocomplete",
+          guild_id: interaction.guildId ?? "dm",
+          channel_id: interaction.channelId ?? "none",
+          user_id: interaction.user.id,
+          focused_text: focusedText,
+          normalized_emoji_name: normalizedName,
+          autocomplete_suggestion_count: 0,
+          failure_code: "autocomplete_inventory_unavailable",
+        });
+        await interaction.respond([]);
+        return;
+      }
+
+      const choices = buildEmojiAutocompleteChoices(
+        inventory.snapshot.entries,
+        focusedText,
+      );
+      logEmojiEvent({
+        command: "emoji",
+        mode: "autocomplete",
+        guild_id: interaction.guildId ?? "dm",
+        channel_id: interaction.channelId ?? "none",
+        user_id: interaction.user.id,
+        focused_text: focusedText,
+        normalized_emoji_name: normalizedName,
+        autocomplete_suggestion_count: choices.length,
+        failure_code: "none",
+      });
+      await interaction.respond(choices);
+    } catch (error) {
+      console.error(`[emoji] autocomplete failed: ${formatError(error)}`);
+      await interaction.respond([]).catch(() => undefined);
     }
   },
 };

--- a/src/commands/Emoji.ts
+++ b/src/commands/Emoji.ts
@@ -11,29 +11,48 @@ import {
   EmbedBuilder,
   PermissionFlagsBits,
 } from "discord.js";
+import axios from "axios";
 import { Command } from "../Command";
 import { formatError } from "../helper/formatError";
 import {
   emojiResolverService,
+  isValidEmojiShortcodeName,
   normalizeEmojiLookupName,
+  normalizeEmojiShortcodeName,
+  parseEmojiImageSource,
+  type EmojiInputSourceType,
   type EmojiInventoryFetchResult,
   type EmojiResolverFailureCode,
   type EmojiResolverService,
   type ResolvedApplicationEmoji,
 } from "../services/emoji/EmojiResolverService";
 import { CoCService } from "../services/CoCService";
+import { CommandPermissionService } from "../services/CommandPermissionService";
 
 type EmojiResolverPort = Pick<
   EmojiResolverService,
-  "fetchApplicationEmojiInventory"
+  "fetchApplicationEmojiInventory" | "refresh" | "invalidateCache"
 >;
+
+type CommandPermissionPort = Pick<CommandPermissionService, "canUseAnyTarget">;
+
+type EmojiAttachmentDownloadResult =
+  | { ok: true; attachment: Buffer }
+  | {
+      ok: false;
+      code: "invalid_emoji_input" | "image_download_failed";
+      statusCode?: number;
+    };
 
 const EMOJI_PAGE_SIZE = 20;
 const EMOJI_PAGINATOR_TIMEOUT_MS = 10 * 60 * 1000;
 const MAX_AUTOCOMPLETE_CHOICES = 25;
 const MESSAGE_ID_PATTERN = /^\d{17,22}$/;
+const INVENTORY_FULL_ERROR_CODES = new Set<number>([30008, 30018, 30056]);
 
 let activeEmojiResolver: EmojiResolverPort = emojiResolverService;
+let activeCommandPermissionService: CommandPermissionPort =
+  new CommandPermissionService();
 
 /** Purpose: convert one resolved emoji into compact list-display text. */
 function formatEmojiListLine(emoji: ResolvedApplicationEmoji): string {
@@ -192,6 +211,70 @@ function isValidMessageId(value: string): boolean {
   return MESSAGE_ID_PATTERN.test(String(value ?? "").trim());
 }
 
+/** Purpose: classify a Discord/HTTP error payload as application emoji inventory-full for clear user feedback. */
+function isApplicationEmojiInventoryFullError(error: unknown): boolean {
+  const code = getDiscordErrorCode(error);
+  if (code !== null && INVENTORY_FULL_ERROR_CODES.has(code)) return true;
+  const message = String((error as { message?: string } | null)?.message ?? "").toLowerCase();
+  return (
+    message.includes("maximum number of emojis") ||
+    message.includes("maximum number of application emojis") ||
+    message.includes("emoji slots")
+  );
+}
+
+/** Purpose: fetch one image attachment buffer from a parsed input source before emoji create calls. */
+async function downloadEmojiAttachment(
+  sourceUrl: string,
+): Promise<EmojiAttachmentDownloadResult> {
+  let response;
+  try {
+    response = await axios.get(sourceUrl, {
+      responseType: "arraybuffer",
+      timeout: 15_000,
+      validateStatus: () => true,
+    });
+  } catch {
+    return {
+      ok: false,
+      code: "image_download_failed",
+    };
+  }
+
+  if (response.status < 200 || response.status >= 300) {
+    return {
+      ok: false,
+      code: "image_download_failed",
+      statusCode: response.status,
+    };
+  }
+
+  const contentType = String(response.headers?.["content-type"] ?? "").toLowerCase();
+  if (!contentType.startsWith("image/")) {
+    return {
+      ok: false,
+      code: "invalid_emoji_input",
+      statusCode: response.status,
+    };
+  }
+
+  const bytes = Buffer.isBuffer(response.data)
+    ? response.data
+    : Buffer.from(response.data ?? "");
+  if (bytes.length === 0) {
+    return {
+      ok: false,
+      code: "invalid_emoji_input",
+      statusCode: response.status,
+    };
+  }
+
+  return {
+    ok: true,
+    attachment: bytes,
+  };
+}
+
 /** Purpose: read the shared command visibility value injected by framework registration plumbing. */
 function resolveInteractionVisibility(
   interaction: ChatInputCommandInteraction,
@@ -223,7 +306,7 @@ function logEmojiEvent(fields: Record<string, string | number | boolean | null |
 
 /** Purpose: emit structured resolver diagnostics tied to command mode and caller identity. */
 function logEmojiInventoryResult(input: {
-  mode: "list" | "resolve" | "react" | "autocomplete";
+  mode: "list" | "resolve" | "react" | "autocomplete" | "add";
   guildId: string | null;
   channelId: string | null;
   userId: string;
@@ -271,6 +354,18 @@ export function resetEmojiResolverForTest(): void {
   activeEmojiResolver = emojiResolverService;
 }
 
+/** Purpose: allow tests to inject command-permission behavior for add-path authorization checks. */
+export function setEmojiCommandPermissionServiceForTest(
+  service: CommandPermissionPort,
+): void {
+  activeCommandPermissionService = service;
+}
+
+/** Purpose: restore production command-permission service after test injection. */
+export function resetEmojiCommandPermissionServiceForTest(): void {
+  activeCommandPermissionService = new CommandPermissionService();
+}
+
 export const applyEmojiPageActionForTest = applyEmojiPageAction;
 export const paginateEmojiLinesForTest = paginateEmojiLines;
 export const buildEmojiListEmbedForTest = buildEmojiListEmbed;
@@ -278,10 +373,12 @@ export const buildEmojiListRowForTest = buildEmojiListRow;
 export const normalizeEmojiLookupNameInputForTest = normalizeEmojiLookupName;
 export const buildEmojiAutocompleteChoicesForTest = buildEmojiAutocompleteChoices;
 export const isValidMessageIdForTest = isValidMessageId;
+export const normalizeEmojiShortcodeNameForTest = normalizeEmojiShortcodeName;
+export const downloadEmojiAttachmentForTest = downloadEmojiAttachment;
 
 export const Emoji: Command = {
   name: "emoji",
-  description: "Resolve and browse bot application emojis",
+  description: "Resolve, browse, react with, and add bot application emojis",
   options: [
     {
       name: "name",
@@ -296,6 +393,18 @@ export const Emoji: Command = {
       type: ApplicationCommandOptionType.String,
       required: false,
     },
+    {
+      name: "emoji",
+      description: "Custom emoji token or direct image URL for add flow",
+      type: ApplicationCommandOptionType.String,
+      required: false,
+    },
+    {
+      name: "short-code",
+      description: "Shortcode name for a new bot application emoji",
+      type: ApplicationCommandOptionType.String,
+      required: false,
+    },
   ],
   run: async (
     _client: Client,
@@ -306,19 +415,77 @@ export const Emoji: Command = {
 
     const rawName = interaction.options.getString("name", false);
     const rawReact = interaction.options.getString("react", false);
+    const rawEmojiInput = interaction.options.getString("emoji", false);
+    const rawShortCode = interaction.options.getString("short-code", false);
     const hasNameInput = rawName !== null;
+    const hasEmojiInput = rawEmojiInput !== null;
+    const hasShortCodeInput = rawShortCode !== null;
+    const hasAddInputs = hasEmojiInput || hasShortCodeInput;
     const requestedName = String(rawName ?? "");
     const normalizedName = normalizeEmojiLookupName(requestedName);
     const targetMessageId = String(rawReact ?? "").trim();
+    const requestedEmojiInput = String(rawEmojiInput ?? "").trim();
+    const requestedShortCode = String(rawShortCode ?? "");
+    const normalizedShortCode = normalizeEmojiShortcodeName(requestedShortCode);
     const visibilityState = resolveInteractionVisibility(interaction);
 
-    const mode: "list" | "resolve" | "react" = !hasNameInput
-      ? "list"
-      : targetMessageId
-        ? "react"
-        : "resolve";
+    const mode: "list" | "resolve" | "react" | "add" = hasAddInputs
+      ? "add"
+      : !hasNameInput
+        ? "list"
+        : targetMessageId
+          ? "react"
+          : "resolve";
 
-    if (hasNameInput && !normalizedName) {
+    if (hasAddInputs && (!hasEmojiInput || !hasShortCodeInput)) {
+      logEmojiEvent({
+        command: "emoji",
+        mode,
+        guild_id: interaction.guildId ?? "dm",
+        channel_id: interaction.channelId ?? "none",
+        user_id: interaction.user.id,
+        requested_emoji_input: requestedEmojiInput,
+        requested_shortcode: requestedShortCode,
+        normalized_shortcode: normalizedShortCode,
+        create_attempted: false,
+        create_result: "validation_failed",
+        failure_code: "invalid_emoji_input",
+      });
+      await interaction.editReply({
+        content:
+          "To add an application emoji, provide both `emoji` and `short-code`.",
+        embeds: [],
+        components: [],
+      });
+      return;
+    }
+
+    if (hasAddInputs && (hasNameInput || targetMessageId)) {
+      logEmojiEvent({
+        command: "emoji",
+        mode,
+        guild_id: interaction.guildId ?? "dm",
+        channel_id: interaction.channelId ?? "none",
+        user_id: interaction.user.id,
+        requested_emoji_name: requestedName,
+        target_message_id: targetMessageId,
+        requested_emoji_input: requestedEmojiInput,
+        requested_shortcode: requestedShortCode,
+        normalized_shortcode: normalizedShortCode,
+        create_attempted: false,
+        create_result: "validation_failed",
+        failure_code: "invalid_emoji_input",
+      });
+      await interaction.editReply({
+        content:
+          "Use either add options (`emoji` + `short-code`) or resolve/react options (`name`/`react`), not both.",
+        embeds: [],
+        components: [],
+      });
+      return;
+    }
+
+    if (mode !== "add" && hasNameInput && !normalizedName) {
       logEmojiEvent({
         command: "emoji",
         mode,
@@ -341,6 +508,294 @@ export const Emoji: Command = {
     }
 
     try {
+      if (mode === "add") {
+        const allowed = await activeCommandPermissionService.canUseAnyTarget(
+          ["emoji:add", "emoji"],
+          interaction,
+        );
+        if (!allowed) {
+          logEmojiEvent({
+            command: "emoji",
+            mode,
+            guild_id: interaction.guildId ?? "dm",
+            channel_id: interaction.channelId ?? "none",
+            user_id: interaction.user.id,
+            requested_emoji_input: requestedEmojiInput,
+            requested_shortcode: requestedShortCode,
+            normalized_shortcode: normalizedShortCode,
+            create_attempted: false,
+            create_result: "permission_denied",
+            failure_code: "permission_denied",
+          });
+          await interaction.editReply({
+            content: "You do not have permission to use /emoji add.",
+            embeds: [],
+            components: [],
+          });
+          return;
+        }
+
+        if (!normalizedShortCode || !isValidEmojiShortcodeName(normalizedShortCode)) {
+          logEmojiEvent({
+            command: "emoji",
+            mode,
+            guild_id: interaction.guildId ?? "dm",
+            channel_id: interaction.channelId ?? "none",
+            user_id: interaction.user.id,
+            requested_emoji_input: requestedEmojiInput,
+            requested_shortcode: requestedShortCode,
+            normalized_shortcode: normalizedShortCode,
+            create_attempted: false,
+            create_result: "validation_failed",
+            failure_code: "invalid_shortcode",
+          });
+          await interaction.editReply({
+            content:
+              "Please provide a valid shortcode using letters, numbers, or underscores (2-32 chars).",
+            embeds: [],
+            components: [],
+          });
+          return;
+        }
+
+        const parsedSource = parseEmojiImageSource(requestedEmojiInput);
+        if (!parsedSource.ok) {
+          const failureCode = parsedSource.code;
+          const sourceType: EmojiInputSourceType = parsedSource.sourceType;
+          logEmojiEvent({
+            command: "emoji",
+            mode,
+            guild_id: interaction.guildId ?? "dm",
+            channel_id: interaction.channelId ?? "none",
+            user_id: interaction.user.id,
+            requested_emoji_input: requestedEmojiInput,
+            parsed_source_type: sourceType,
+            requested_shortcode: requestedShortCode,
+            normalized_shortcode: normalizedShortCode,
+            create_attempted: false,
+            create_result: "validation_failed",
+            failure_code: failureCode,
+          });
+          await interaction.editReply({
+            content:
+              failureCode === "unsupported_unicode_emoji"
+                ? "Unicode emoji input is not supported for `/emoji add` yet. Use a custom emoji token like `<:name:id>` or a direct image URL."
+                : "Invalid emoji input. Use a custom emoji token like `<:name:id>` or a direct image URL.",
+            embeds: [],
+            components: [],
+          });
+          return;
+        }
+
+        const inventory = await activeEmojiResolver.fetchApplicationEmojiInventory(
+          interaction.client,
+          { forceRefresh: true },
+        );
+        logEmojiInventoryResult({
+          mode,
+          guildId: interaction.guildId,
+          channelId: interaction.channelId,
+          userId: interaction.user.id,
+          requestedName: requestedShortCode,
+          normalizedName: normalizedShortCode,
+          result: inventory,
+        });
+        if (!inventory.ok) {
+          logEmojiEvent({
+            command: "emoji",
+            mode,
+            guild_id: interaction.guildId ?? "dm",
+            channel_id: interaction.channelId ?? "none",
+            user_id: interaction.user.id,
+            requested_emoji_input: requestedEmojiInput,
+            parsed_source_type: parsedSource.sourceType,
+            requested_shortcode: requestedShortCode,
+            normalized_shortcode: normalizedShortCode,
+            create_attempted: false,
+            create_result: "inventory_unavailable",
+            failure_code: "emoji_inventory_unavailable",
+          });
+          await interaction.editReply({
+            content: buildEmojiFailureMessage(inventory.code),
+            embeds: [],
+            components: [],
+          });
+          return;
+        }
+
+        const existingByName =
+          inventory.snapshot.exactByName.get(normalizedShortCode) ??
+          inventory.snapshot.lowercaseByName.get(normalizedShortCode.toLowerCase()) ??
+          null;
+        if (existingByName) {
+          logEmojiEvent({
+            command: "emoji",
+            mode,
+            guild_id: interaction.guildId ?? "dm",
+            channel_id: interaction.channelId ?? "none",
+            user_id: interaction.user.id,
+            requested_emoji_input: requestedEmojiInput,
+            parsed_source_type: parsedSource.sourceType,
+            requested_shortcode: requestedShortCode,
+            normalized_shortcode: normalizedShortCode,
+            create_attempted: false,
+            create_result: "duplicate_shortcode",
+            failure_code: "duplicate_shortcode",
+          });
+          await interaction.editReply({
+            content: `Shortcode \`${normalizedShortCode}\` already exists as ${existingByName.rendered}.`,
+            embeds: [],
+            components: [],
+          });
+          return;
+        }
+
+        const download = await downloadEmojiAttachment(parsedSource.imageUrl);
+        if (!download.ok) {
+          logEmojiEvent({
+            command: "emoji",
+            mode,
+            guild_id: interaction.guildId ?? "dm",
+            channel_id: interaction.channelId ?? "none",
+            user_id: interaction.user.id,
+            requested_emoji_input: requestedEmojiInput,
+            parsed_source_type: parsedSource.sourceType,
+            requested_shortcode: requestedShortCode,
+            normalized_shortcode: normalizedShortCode,
+            create_attempted: false,
+            create_result: "image_source_failed",
+            failure_code: download.code,
+          });
+          await interaction.editReply({
+            content:
+              download.code === "image_download_failed"
+                ? "Could not download the emoji image from that source."
+                : "That source did not resolve to a valid image.",
+            embeds: [],
+            components: [],
+          });
+          return;
+        }
+
+        const application = interaction.client.application;
+        if (!application) {
+          logEmojiEvent({
+            command: "emoji",
+            mode,
+            guild_id: interaction.guildId ?? "dm",
+            channel_id: interaction.channelId ?? "none",
+            user_id: interaction.user.id,
+            requested_emoji_input: requestedEmojiInput,
+            parsed_source_type: parsedSource.sourceType,
+            requested_shortcode: requestedShortCode,
+            normalized_shortcode: normalizedShortCode,
+            create_attempted: false,
+            create_result: "application_unavailable",
+            failure_code: "application_unavailable",
+          });
+          await interaction.editReply({
+            content: "Could not load bot application state right now.",
+            embeds: [],
+            components: [],
+          });
+          return;
+        }
+
+        if (!application.emojis || typeof application.emojis.create !== "function") {
+          logEmojiEvent({
+            command: "emoji",
+            mode,
+            guild_id: interaction.guildId ?? "dm",
+            channel_id: interaction.channelId ?? "none",
+            user_id: interaction.user.id,
+            requested_emoji_input: requestedEmojiInput,
+            parsed_source_type: parsedSource.sourceType,
+            requested_shortcode: requestedShortCode,
+            normalized_shortcode: normalizedShortCode,
+            create_attempted: false,
+            create_result: "application_emoji_manager_unavailable",
+            failure_code: "application_emoji_manager_unavailable",
+          });
+          await interaction.editReply({
+            content: "Application emoji manager is unavailable in this runtime.",
+            embeds: [],
+            components: [],
+          });
+          return;
+        }
+
+        let createdEmoji;
+        try {
+          createdEmoji = await application.emojis.create({
+            attachment: download.attachment,
+            name: normalizedShortCode,
+          });
+        } catch (error) {
+          const failureCode = isApplicationEmojiInventoryFullError(error)
+            ? "application_emoji_inventory_full"
+            : "application_emoji_create_failed";
+          logEmojiEvent({
+            command: "emoji",
+            mode,
+            guild_id: interaction.guildId ?? "dm",
+            channel_id: interaction.channelId ?? "none",
+            user_id: interaction.user.id,
+            requested_emoji_input: requestedEmojiInput,
+            parsed_source_type: parsedSource.sourceType,
+            requested_shortcode: requestedShortCode,
+            normalized_shortcode: normalizedShortCode,
+            create_attempted: true,
+            create_result: "failed",
+            failure_code: failureCode,
+          });
+          await interaction.editReply({
+            content:
+              failureCode === "application_emoji_inventory_full"
+                ? "Could not add emoji because this application emoji inventory is full."
+                : "Discord rejected the emoji create request. Verify the image and try again.",
+            embeds: [],
+            components: [],
+          });
+          return;
+        }
+
+        activeEmojiResolver.invalidateCache();
+        try {
+          await activeEmojiResolver.refresh(interaction.client);
+        } catch (error) {
+          console.warn(
+            `[emoji] cache refresh failed after add: ${formatError(error)}`,
+          );
+        }
+
+        const createdRendered = String(createdEmoji.toString?.() ?? "").trim();
+        const createdName = String(createdEmoji.name ?? normalizedShortCode).trim();
+
+        logEmojiEvent({
+          command: "emoji",
+          mode,
+          guild_id: interaction.guildId ?? "dm",
+          channel_id: interaction.channelId ?? "none",
+          user_id: interaction.user.id,
+          requested_emoji_input: requestedEmojiInput,
+          parsed_source_type: parsedSource.sourceType,
+          requested_shortcode: requestedShortCode,
+          normalized_shortcode: normalizedShortCode,
+          create_attempted: true,
+          create_result: "success",
+          created_emoji_id: createdEmoji.id,
+          created_emoji_name: createdName,
+          failure_code: "none",
+        });
+
+        await interaction.editReply({
+          content: `Added application emoji ${createdRendered} with shortcode \`${createdName}\`.`,
+          embeds: [],
+          components: [],
+        });
+        return;
+      }
+
       const inventory = await activeEmojiResolver.fetchApplicationEmojiInventory(
         interaction.client,
         { forceRefresh: true },

--- a/src/commands/Emoji.ts
+++ b/src/commands/Emoji.ts
@@ -14,6 +14,8 @@ import { formatError } from "../helper/formatError";
 import {
   emojiResolverService,
   normalizeEmojiLookupName,
+  type EmojiInventoryFetchResult,
+  type EmojiResolverFailureCode,
   type EmojiResolverService,
   type ResolvedApplicationEmoji,
 } from "../services/emoji/EmojiResolverService";
@@ -21,7 +23,7 @@ import { CoCService } from "../services/CoCService";
 
 type EmojiResolverPort = Pick<
   EmojiResolverService,
-  "listApplicationEmojis" | "resolveByName"
+  "fetchApplicationEmojiInventory"
 >;
 
 const EMOJI_PAGE_SIZE = 20;
@@ -76,7 +78,7 @@ function buildEmojiListEmbed(params: {
     .setTitle("Bot Application Emojis")
     .setDescription(params.pages[params.page] ?? "")
     .setFooter({
-      text: `Page ${params.page + 1}/${params.pages.length} • Total ${params.emojis.length} emojis`,
+      text: `Page ${params.page + 1}/${params.pages.length} | Total ${params.emojis.length} emojis`,
     })
     .setColor(0x5865f2);
 }
@@ -125,6 +127,39 @@ function buildEmojiNameSuggestions(
     .map((emoji) => emoji.shortcode);
 }
 
+/** Purpose: map resolver failure code to the most accurate user-facing /emoji error response. */
+function buildEmojiFailureMessage(code: EmojiResolverFailureCode): string {
+  if (code === "application_missing" || code === "application_emoji_manager_unavailable") {
+    return "Could not load bot application emojis in this runtime. Please contact an admin.";
+  }
+  return "Could not fetch bot application emojis right now. Please try again later.";
+}
+
+/** Purpose: emit concise structured diagnostics for one /emoji resolver run. */
+function logEmojiFetchResult(input: {
+  interaction: ChatInputCommandInteraction;
+  result: EmojiInventoryFetchResult;
+}): void {
+  const { diagnostics } = input.result;
+  const fields = [
+    "command=emoji",
+    `guild_id=${input.interaction.guildId ?? "dm"}`,
+    `user_id=${input.interaction.user.id}`,
+    `application_present_pre_fetch=${diagnostics.applicationExistedBeforeFetch}`,
+    `application_fetch_attempted=${diagnostics.applicationFetchAttempted}`,
+    `application_emoji_fetch_available=${diagnostics.applicationEmojiFetchAvailable}`,
+    `emoji_fetch_succeeded=${diagnostics.emojiFetchSucceeded}`,
+    `fetched_emoji_count=${diagnostics.fetchedEmojiCount}`,
+    `failure_code=${input.result.ok ? "none" : input.result.code}`,
+  ];
+  const message = `[emoji] fetch ${fields.join(" ")}`;
+  if (input.result.ok) {
+    console.log(message);
+    return;
+  }
+  console.warn(message);
+}
+
 /** Purpose: allow tests to inject a resolver and assert command behavior deterministically. */
 export function setEmojiResolverForTest(resolver: EmojiResolverPort): void {
   activeEmojiResolver = resolver;
@@ -162,11 +197,27 @@ export const Emoji: Command = {
     const requestedName = normalizeEmojiLookupName(rawName ?? "");
 
     try {
+      const inventory = await activeEmojiResolver.fetchApplicationEmojiInventory(
+        interaction.client,
+        { forceRefresh: true },
+      );
+      logEmojiFetchResult({ interaction, result: inventory });
+      if (!inventory.ok) {
+        await interaction.editReply({
+          content: buildEmojiFailureMessage(inventory.code),
+          embeds: [],
+          components: [],
+        });
+        return;
+      }
+
+      const { snapshot } = inventory;
+      const emojis = snapshot.entries;
       if (requestedName) {
-        const resolved = await activeEmojiResolver.resolveByName(
-          interaction.client,
-          requestedName,
-        );
+        const resolved =
+          snapshot.exactByName.get(requestedName) ??
+          snapshot.lowercaseByName.get(requestedName.toLowerCase()) ??
+          null;
         if (resolved) {
           await interaction.editReply({
             embeds: [buildEmojiResolveEmbed(resolved)],
@@ -174,10 +225,7 @@ export const Emoji: Command = {
           return;
         }
 
-        const all = await activeEmojiResolver.listApplicationEmojis(
-          interaction.client,
-        );
-        const suggestions = buildEmojiNameSuggestions(requestedName, all);
+        const suggestions = buildEmojiNameSuggestions(requestedName, emojis);
         const suggestionText = suggestions.length
           ? `\nDid you mean: ${suggestions.join(", ")}`
           : "";
@@ -189,9 +237,6 @@ export const Emoji: Command = {
         return;
       }
 
-      const emojis = await activeEmojiResolver.listApplicationEmojis(
-        interaction.client,
-      );
       const pages = paginateEmojiLines(emojis);
       let page = 0;
       const paginatorPrefix = `emoji-list:${interaction.id}`;

--- a/src/commands/Emoji.ts
+++ b/src/commands/Emoji.ts
@@ -1,0 +1,295 @@
+import {
+  ActionRowBuilder,
+  ApplicationCommandOptionType,
+  ButtonBuilder,
+  ButtonInteraction,
+  ButtonStyle,
+  ChatInputCommandInteraction,
+  Client,
+  ComponentType,
+  EmbedBuilder,
+} from "discord.js";
+import { Command } from "../Command";
+import { formatError } from "../helper/formatError";
+import {
+  emojiResolverService,
+  normalizeEmojiLookupName,
+  type EmojiResolverService,
+  type ResolvedApplicationEmoji,
+} from "../services/emoji/EmojiResolverService";
+import { CoCService } from "../services/CoCService";
+
+type EmojiResolverPort = Pick<
+  EmojiResolverService,
+  "listApplicationEmojis" | "resolveByName"
+>;
+
+const EMOJI_PAGE_SIZE = 20;
+const EMOJI_PAGINATOR_TIMEOUT_MS = 10 * 60 * 1000;
+
+let activeEmojiResolver: EmojiResolverPort = emojiResolverService;
+
+/** Purpose: convert one resolved emoji into compact list-display text. */
+function formatEmojiListLine(emoji: ResolvedApplicationEmoji): string {
+  return `${emoji.rendered} \`${emoji.shortcode}\``;
+}
+
+/** Purpose: split emoji list output into deterministic page chunks for embed display. */
+function paginateEmojiLines(
+  emojis: ResolvedApplicationEmoji[],
+  pageSize: number = EMOJI_PAGE_SIZE,
+): string[] {
+  if (emojis.length === 0) return [];
+  const pages: string[] = [];
+  for (let i = 0; i < emojis.length; i += pageSize) {
+    const slice = emojis.slice(i, i + pageSize);
+    pages.push(slice.map(formatEmojiListLine).join("\n"));
+  }
+  return pages;
+}
+
+/** Purpose: apply previous/next pagination input while keeping page index bounded. */
+function applyEmojiPageAction(params: {
+  action: "prev" | "next";
+  page: number;
+  totalPages: number;
+}): number {
+  if (params.totalPages <= 0) return 0;
+  if (params.action === "prev") return Math.max(0, params.page - 1);
+  return Math.min(params.totalPages - 1, params.page + 1);
+}
+
+/** Purpose: build paginated list embed for current bot application emoji inventory. */
+function buildEmojiListEmbed(params: {
+  emojis: ResolvedApplicationEmoji[];
+  pages: string[];
+  page: number;
+}): EmbedBuilder {
+  if (params.emojis.length === 0) {
+    return new EmbedBuilder()
+      .setTitle("Bot Application Emojis")
+      .setDescription("No application emojis are currently available for this bot.")
+      .setFooter({ text: "Total 0 emojis" })
+      .setColor(0x5865f2);
+  }
+  return new EmbedBuilder()
+    .setTitle("Bot Application Emojis")
+    .setDescription(params.pages[params.page] ?? "")
+    .setFooter({
+      text: `Page ${params.page + 1}/${params.pages.length} • Total ${params.emojis.length} emojis`,
+    })
+    .setColor(0x5865f2);
+}
+
+/** Purpose: build prev/next paginator buttons with proper boundary and timeout disabled states. */
+function buildEmojiListRow(params: {
+  prefix: string;
+  page: number;
+  totalPages: number;
+  forceDisabled?: boolean;
+}): ActionRowBuilder<ButtonBuilder> {
+  const disabled = Boolean(params.forceDisabled);
+  return new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder()
+      .setCustomId(`${params.prefix}:prev`)
+      .setLabel("Previous")
+      .setStyle(ButtonStyle.Secondary)
+      .setDisabled(disabled || params.page <= 0),
+    new ButtonBuilder()
+      .setCustomId(`${params.prefix}:next`)
+      .setLabel("Next")
+      .setStyle(ButtonStyle.Secondary)
+      .setDisabled(disabled || params.page >= params.totalPages - 1),
+  );
+}
+
+/** Purpose: build resolve-mode embed for one shortcode-to-rendered-emoji mapping. */
+function buildEmojiResolveEmbed(emoji: ResolvedApplicationEmoji): EmbedBuilder {
+  return new EmbedBuilder()
+    .setTitle("Emoji Resolved")
+    .setDescription(`${emoji.rendered}  ${emoji.shortcode}`)
+    .addFields({ name: "Raw token", value: `\`${emoji.rendered}\`` })
+    .setColor(0x57f287);
+}
+
+/** Purpose: derive lightweight same-command suggestions for close emoji-name misses. */
+function buildEmojiNameSuggestions(
+  input: string,
+  emojis: ResolvedApplicationEmoji[],
+): string[] {
+  const query = input.toLowerCase();
+  if (!query) return [];
+  return emojis
+    .filter((emoji) => emoji.name.toLowerCase().includes(query))
+    .slice(0, 5)
+    .map((emoji) => emoji.shortcode);
+}
+
+/** Purpose: allow tests to inject a resolver and assert command behavior deterministically. */
+export function setEmojiResolverForTest(resolver: EmojiResolverPort): void {
+  activeEmojiResolver = resolver;
+}
+
+/** Purpose: restore production resolver after test injection. */
+export function resetEmojiResolverForTest(): void {
+  activeEmojiResolver = emojiResolverService;
+}
+
+export const applyEmojiPageActionForTest = applyEmojiPageAction;
+export const paginateEmojiLinesForTest = paginateEmojiLines;
+export const buildEmojiListEmbedForTest = buildEmojiListEmbed;
+export const buildEmojiListRowForTest = buildEmojiListRow;
+export const normalizeEmojiLookupNameInputForTest = normalizeEmojiLookupName;
+
+export const Emoji: Command = {
+  name: "emoji",
+  description: "Resolve and browse bot application emojis",
+  options: [
+    {
+      name: "name",
+      description: "Emoji name or shortcode (for example: arrow_arrow or :arrow_arrow:)",
+      type: ApplicationCommandOptionType.String,
+      required: false,
+    },
+  ],
+  run: async (
+    _client: Client,
+    interaction: ChatInputCommandInteraction,
+    _cocService: CoCService,
+  ) => {
+    await interaction.deferReply({ ephemeral: true });
+    const rawName = interaction.options.getString("name", false);
+    const requestedName = normalizeEmojiLookupName(rawName ?? "");
+
+    try {
+      if (requestedName) {
+        const resolved = await activeEmojiResolver.resolveByName(
+          interaction.client,
+          requestedName,
+        );
+        if (resolved) {
+          await interaction.editReply({
+            embeds: [buildEmojiResolveEmbed(resolved)],
+          });
+          return;
+        }
+
+        const all = await activeEmojiResolver.listApplicationEmojis(
+          interaction.client,
+        );
+        const suggestions = buildEmojiNameSuggestions(requestedName, all);
+        const suggestionText = suggestions.length
+          ? `\nDid you mean: ${suggestions.join(", ")}`
+          : "";
+        await interaction.editReply({
+          content: `No application emoji found for \`:${requestedName}:\`.${suggestionText}`,
+          embeds: [],
+          components: [],
+        });
+        return;
+      }
+
+      const emojis = await activeEmojiResolver.listApplicationEmojis(
+        interaction.client,
+      );
+      const pages = paginateEmojiLines(emojis);
+      let page = 0;
+      const paginatorPrefix = `emoji-list:${interaction.id}`;
+
+      await interaction.editReply({
+        embeds: [
+          buildEmojiListEmbed({
+            emojis,
+            pages,
+            page,
+          }),
+        ],
+        components:
+          pages.length > 1
+            ? [
+                buildEmojiListRow({
+                  prefix: paginatorPrefix,
+                  page,
+                  totalPages: pages.length,
+                }),
+              ]
+            : [],
+      });
+
+      if (pages.length <= 1) return;
+
+      const message = await interaction.fetchReply();
+      const collector = message.createMessageComponentCollector({
+        componentType: ComponentType.Button,
+        time: EMOJI_PAGINATOR_TIMEOUT_MS,
+      });
+
+      collector.on("collect", async (button: ButtonInteraction) => {
+        if (button.user.id !== interaction.user.id) {
+          await button.reply({
+            ephemeral: true,
+            content: "Only the command user can control this paginator.",
+          });
+          return;
+        }
+        if (
+          button.customId !== `${paginatorPrefix}:prev` &&
+          button.customId !== `${paginatorPrefix}:next`
+        ) {
+          return;
+        }
+        page = applyEmojiPageAction({
+          action: button.customId.endsWith(":prev") ? "prev" : "next",
+          page,
+          totalPages: pages.length,
+        });
+        await button.update({
+          embeds: [
+            buildEmojiListEmbed({
+              emojis,
+              pages,
+              page,
+            }),
+          ],
+          components: [
+            buildEmojiListRow({
+              prefix: paginatorPrefix,
+              page,
+              totalPages: pages.length,
+            }),
+          ],
+        });
+      });
+
+      collector.on("end", async () => {
+        await interaction
+          .editReply({
+            embeds: [
+              buildEmojiListEmbed({
+                emojis,
+                pages,
+                page,
+              }),
+            ],
+            components: [
+              buildEmojiListRow({
+                prefix: paginatorPrefix,
+                page,
+                totalPages: pages.length,
+                forceDisabled: true,
+              }),
+            ],
+          })
+          .catch(() => undefined);
+      });
+    } catch (error) {
+      console.error(`[emoji] command failed: ${formatError(error)}`);
+      await interaction.editReply({
+        content:
+          "Could not load bot application emojis right now. Please try again later.",
+        embeds: [],
+        components: [],
+      });
+    }
+  },
+};

--- a/src/commands/Emoji.ts
+++ b/src/commands/Emoji.ts
@@ -192,6 +192,14 @@ function isValidMessageId(value: string): boolean {
   return MESSAGE_ID_PATTERN.test(String(value ?? "").trim());
 }
 
+/** Purpose: read the shared command visibility value injected by framework registration plumbing. */
+function resolveInteractionVisibility(
+  interaction: ChatInputCommandInteraction,
+): "private" | "public" {
+  const visibility = interaction.options.getString("visibility", false);
+  return visibility === "public" ? "public" : "private";
+}
+
 /** Purpose: map resolver failure code to the most accurate user-facing /emoji error response. */
 function buildEmojiFailureMessage(code: EmojiResolverFailureCode): string {
   if (code === "application_missing" || code === "application_emoji_manager_unavailable") {
@@ -219,6 +227,7 @@ function logEmojiInventoryResult(input: {
   guildId: string | null;
   channelId: string | null;
   userId: string;
+  visibilityState?: "private" | "public";
   requestedName?: string;
   normalizedName?: string;
   focusedText?: string;
@@ -232,6 +241,7 @@ function logEmojiInventoryResult(input: {
     guild_id: input.guildId ?? "dm",
     channel_id: input.channelId ?? "none",
     user_id: input.userId,
+    visibility_state: input.visibilityState ?? "",
     requested_emoji_name: input.requestedName ?? "",
     normalized_emoji_name: input.normalizedName ?? "",
     focused_text: input.focusedText ?? "",
@@ -300,6 +310,7 @@ export const Emoji: Command = {
     const requestedName = String(rawName ?? "");
     const normalizedName = normalizeEmojiLookupName(requestedName);
     const targetMessageId = String(rawReact ?? "").trim();
+    const visibilityState = resolveInteractionVisibility(interaction);
 
     const mode: "list" | "resolve" | "react" = !hasNameInput
       ? "list"
@@ -314,6 +325,7 @@ export const Emoji: Command = {
         guild_id: interaction.guildId ?? "dm",
         channel_id: interaction.channelId ?? "none",
         user_id: interaction.user.id,
+        visibility_state: visibilityState,
         requested_emoji_name: requestedName,
         normalized_emoji_name: normalizedName,
         target_message_id: targetMessageId,
@@ -338,6 +350,7 @@ export const Emoji: Command = {
         guildId: interaction.guildId,
         channelId: interaction.channelId,
         userId: interaction.user.id,
+        visibilityState,
         requestedName,
         normalizedName,
         targetMessageId,
@@ -351,10 +364,12 @@ export const Emoji: Command = {
           guild_id: interaction.guildId ?? "dm",
           channel_id: interaction.channelId ?? "none",
           user_id: interaction.user.id,
+          visibility_state: visibilityState,
           requested_emoji_name: requestedName,
           normalized_emoji_name: normalizedName,
           target_message_id: targetMessageId,
           resolve_result: "inventory_unavailable",
+          result_type: mode === "resolve" ? "emoji_inventory_unavailable" : "",
           failure_code: "emoji_inventory_unavailable",
         });
         await interaction.editReply({
@@ -477,10 +492,12 @@ export const Emoji: Command = {
           guild_id: interaction.guildId ?? "dm",
           channel_id: interaction.channelId ?? "none",
           user_id: interaction.user.id,
+          visibility_state: visibilityState,
           requested_emoji_name: requestedName,
           normalized_emoji_name: normalizedName,
           target_message_id: targetMessageId,
           resolve_result: "not_found",
+          result_type: mode === "resolve" ? "emoji_not_found" : "",
           failure_code: "emoji_not_found",
         });
         await interaction.editReply({
@@ -492,21 +509,32 @@ export const Emoji: Command = {
       }
 
       if (mode === "resolve") {
+        const isVisibleOnly = visibilityState === "public";
         logEmojiEvent({
           command: "emoji",
           mode,
           guild_id: interaction.guildId ?? "dm",
           channel_id: interaction.channelId ?? "none",
           user_id: interaction.user.id,
+          visibility_state: visibilityState,
           requested_emoji_name: requestedName,
           normalized_emoji_name: normalizedName,
           resolve_result: "found",
+          result_type: isVisibleOnly ? "success_visible_only" : "success_detailed",
           failure_code: "none",
         });
-        await interaction.editReply({
-          embeds: [buildEmojiResolveEmbed(resolved)],
-          components: [],
-        });
+        if (isVisibleOnly) {
+          await interaction.editReply({
+            content: resolved.rendered,
+            embeds: [],
+            components: [],
+          });
+        } else {
+          await interaction.editReply({
+            embeds: [buildEmojiResolveEmbed(resolved)],
+            components: [],
+          });
+        }
         return;
       }
 

--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -18,6 +18,10 @@ import { Command } from "../Command";
 import { truncateDiscordContent } from "../helper/discordContent";
 import { recordFetchEvent } from "../helper/fetchTelemetry";
 import { formatError } from "../helper/formatError";
+import {
+  resolveSteadyStateLogLevel,
+  SteadyStateLogGate,
+} from "../helper/steadyStateLogGate";
 import { prisma } from "../prisma";
 import { CoCService } from "../services/CoCService";
 import { listPlayerLinksForClanMembers } from "../services/PlayerLinkService";
@@ -83,6 +87,7 @@ import {
 } from "../services/MatchTypeResolutionService";
 import {
   PointsDirectFetchGateService,
+  type PollerPointsFetchDecision,
   type PointsDirectFetchCaller,
   PointsDirectFetchBlockedError,
   isPointsDirectFetchBlockedError,
@@ -700,9 +705,107 @@ function logFwaMatchTelemetry(event: string, detail: string): void {
   console.log(`[telemetry-fwa-match] event=${event} ${detail}`);
 }
 
+type MatchTypeResolutionLogStage = "mail_embed" | "alliance_view" | "single_view";
+
+/** Purpose: build stable match-type log identity for one clan+war+stage. */
+function buildMatchTypeResolutionLogIdentity(params: {
+  stage: MatchTypeResolutionLogStage;
+  clanTag: string;
+  warId: number | null | undefined;
+}): string {
+  const warIdText =
+    params.warId !== null &&
+    params.warId !== undefined &&
+    Number.isFinite(params.warId)
+      ? String(Math.trunc(params.warId))
+      : "unknown";
+  return `matchtype|stage=${params.stage}|clan=${normalizeTag(params.clanTag)}|war=${warIdText}`;
+}
+
+/** Purpose: build match-type state signature used for steady-state info suppression. */
+function buildMatchTypeResolutionLogSignature(params: {
+  source: MatchTypeResolutionSource;
+  matchType: "FWA" | "BL" | "MM" | "SKIP";
+  inferred: boolean;
+  confirmed: boolean;
+}): string {
+  return `source=${params.source}|match_type=${params.matchType}|inferred=${params.inferred ? "1" : "0"}|confirmed=${params.confirmed ? "1" : "0"}`;
+}
+
+/** Purpose: emit info only when match-type state changes for the same clan+war+stage identity. */
+function resolveMatchTypeResolutionLogLevel(params: {
+  stage: MatchTypeResolutionLogStage;
+  clanTag: string;
+  warId: number | null | undefined;
+  source: MatchTypeResolutionSource;
+  matchType: "FWA" | "BL" | "MM" | "SKIP";
+  inferred: boolean;
+  confirmed: boolean;
+}): "info" | "debug" {
+  return resolveSteadyStateLogLevel({
+    gate: fwaMatchTypeResolutionLogGate,
+    identity: buildMatchTypeResolutionLogIdentity({
+      stage: params.stage,
+      clanTag: params.clanTag,
+      warId: params.warId,
+    }),
+    signature: buildMatchTypeResolutionLogSignature({
+      source: params.source,
+      matchType: params.matchType,
+      inferred: params.inferred,
+      confirmed: params.confirmed,
+    }),
+  });
+}
+
+/** Purpose: build stable routine blocked-fetch identity for one guild+clan+fetch reason. */
+function buildRoutineBlockedPointsFetchLogIdentity(params: {
+  guildId: string;
+  clanTag: string;
+  fetchReason: PointsApiFetchReason;
+}): string {
+  return `points_skip|guild=${params.guildId}|clan=${normalizeTag(params.clanTag)}|fetch_reason=${params.fetchReason}`;
+}
+
+/** Purpose: build routine blocked-fetch state signature for steady-state suppression. */
+function buildRoutineBlockedPointsFetchLogSignature(params: {
+  outcome: PollerPointsFetchDecision["outcome"];
+  decisionCode: PollerPointsFetchDecision["decisionCode"];
+}): string {
+  return `outcome=${params.outcome}|code=${params.decisionCode}`;
+}
+
+/** Purpose: emit info only when routine blocked-fetch state changes for one guild+clan reason. */
+function resolveRoutineBlockedPointsFetchSkipLogLevel(params: {
+  guildId: string;
+  clanTag: string;
+  fetchReason: PointsApiFetchReason;
+  outcome: PollerPointsFetchDecision["outcome"];
+  decisionCode: PollerPointsFetchDecision["decisionCode"];
+}): "info" | "debug" {
+  return resolveSteadyStateLogLevel({
+    gate: fwaRoutinePointsSkipLogGate,
+    identity: buildRoutineBlockedPointsFetchLogIdentity({
+      guildId: params.guildId,
+      clanTag: params.clanTag,
+      fetchReason: params.fetchReason,
+    }),
+    signature: buildRoutineBlockedPointsFetchLogSignature({
+      outcome: params.outcome,
+      decisionCode: params.decisionCode,
+    }),
+  });
+}
+
+/** Purpose: clear in-memory steady-state log trackers for deterministic tests. */
+function resetFwaSteadyStateLogTrackers(): void {
+  fwaMatchTypeResolutionLogGate.clear();
+  fwaRoutinePointsSkipLogGate.clear();
+}
+
 /** Purpose: emit structured logs for match-type source/inference/confirmation decisions. */
 function logMatchTypeResolution(params: {
-  stage: "mail_embed" | "alliance_view" | "single_view";
+  stage: MatchTypeResolutionLogStage;
   clanTag: string;
   opponentTag: string | null;
   warId: number | null | undefined;
@@ -718,9 +821,21 @@ function logMatchTypeResolution(params: {
       ? String(Math.trunc(params.warId))
       : "unknown";
   const opponent = normalizeTag(String(params.opponentTag ?? ""));
-  console.info(
-    `[fwa-matchtype] stage=${params.stage} clan=#${normalizeTag(params.clanTag)} opponent=${opponent ? `#${opponent}` : "unknown"} war_id=${warIdText} source=${params.source} match_type=${params.matchType} inferred=${params.inferred ? "1" : "0"} confirmed=${params.confirmed ? "1" : "0"}`,
-  );
+  const line = `[fwa-matchtype] stage=${params.stage} clan=#${normalizeTag(params.clanTag)} opponent=${opponent ? `#${opponent}` : "unknown"} war_id=${warIdText} source=${params.source} match_type=${params.matchType} inferred=${params.inferred ? "1" : "0"} confirmed=${params.confirmed ? "1" : "0"}`;
+  const logLevel = resolveMatchTypeResolutionLogLevel({
+    stage: params.stage,
+    clanTag: params.clanTag,
+    warId: params.warId,
+    source: params.source,
+    matchType: params.matchType,
+    inferred: params.inferred,
+    confirmed: params.confirmed,
+  });
+  if (logLevel === "info") {
+    console.info(line);
+    return;
+  }
+  console.debug(line);
 }
 
 type MatchView = {
@@ -814,6 +929,8 @@ const fwaComplianceViewPayloads = new Map<string, FwaComplianceViewPayload>();
 const fwaMailPollers = new Map<string, ReturnType<typeof setInterval>>();
 const pointsSnapshotCache = new Map<string, PointsSnapshotCacheEntry>();
 const pointsSnapshotInFlight = new Map<string, Promise<PointsSnapshot>>();
+const fwaMatchTypeResolutionLogGate = new SteadyStateLogGate();
+const fwaRoutinePointsSkipLogGate = new SteadyStateLogGate();
 
 /** Purpose: normalize any war id input to a comparable string key. */
 function normalizeWarIdText(
@@ -1943,9 +2060,19 @@ async function buildWarMailEmbedForTag(
     routineDecision.fetchReason ??
     (options?.routine ? "mail_refresh" : "mail_preview");
   if (options?.routine && !routineDecision.allowed) {
-    console.info(
-      `[fwa-mail] points fetch skipped guild=${guildId} clan=#${normalizedTag} outcome=${routineDecision.outcome} code=${routineDecision.decisionCode} reason=${routineDecision.reason}`,
-    );
+    const line = `[fwa-mail] points fetch skipped guild=${guildId} clan=#${normalizedTag} outcome=${routineDecision.outcome} code=${routineDecision.decisionCode} reason=${routineDecision.reason}`;
+    const logLevel = resolveRoutineBlockedPointsFetchSkipLogLevel({
+      guildId,
+      clanTag: normalizedTag,
+      fetchReason,
+      outcome: routineDecision.outcome,
+      decisionCode: routineDecision.decisionCode,
+    });
+    if (logLevel === "info") {
+      console.info(line);
+    } else {
+      console.debug(line);
+    }
   }
 
   let primaryBalance: number | null = null;
@@ -6426,6 +6553,12 @@ export const hasSameWarExplicitFwaConfirmationForTest =
   hasSameWarExplicitFwaConfirmation;
 export const applyExplicitOpponentNotFoundFallbackGuardForTest =
   applyExplicitOpponentNotFoundFallbackGuard;
+export const resolveMatchTypeResolutionLogLevelForTest =
+  resolveMatchTypeResolutionLogLevel;
+export const resolveRoutineBlockedPointsFetchSkipLogLevelForTest =
+  resolveRoutineBlockedPointsFetchSkipLogLevel;
+export const resetFwaSteadyStateLogTrackersForTest =
+  resetFwaSteadyStateLogTrackers;
 
 /** Purpose: infer match type strictly from opponent points-site signals. */
 function inferMatchTypeFromPointsSnapshots(

--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -860,7 +860,17 @@ export const Help: Command = {
                 interaction.id,
                 allowPostToChannel,
               );
-              await interaction.channel?.send({
+              const postChannel = interaction.channel as
+                | { send?: (input: { embeds: EmbedBuilder[] }) => Promise<unknown> }
+                | null;
+              if (!postChannel || typeof postChannel.send !== "function") {
+                await component.reply({
+                  ephemeral: true,
+                  content: "Could not post help in this channel.",
+                });
+                return;
+              }
+              await postChannel.send({
                 embeds: payload.embeds,
               });
               await component.reply({

--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -70,6 +70,7 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
       "Use `/emoji name:<emoji_name>` to resolve one emoji and show rendered + raw token output.",
       "Use `/emoji name:<emoji_name> react:<message-id>` to react to a message in the current channel with that resolved emoji.",
       "Use `/emoji` with no args to browse a paginated list of all available bot application emojis.",
+      "For name-only resolves, `visibility:public` returns only the rendered emoji message content.",
       "`name` supports dynamic autocomplete backed by application emojis for this bot instance.",
       "Emoji resolution is environment-safe by name (application emoji IDs may differ per bot instance).",
     ],

--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -68,10 +68,17 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
     summary: "Resolve or browse bot-owned application emojis by shortcode name.",
     details: [
       "Use `/emoji name:<emoji_name>` to resolve one emoji and show rendered + raw token output.",
+      "Use `/emoji name:<emoji_name> react:<message-id>` to react to a message in the current channel with that resolved emoji.",
       "Use `/emoji` with no args to browse a paginated list of all available bot application emojis.",
+      "`name` supports dynamic autocomplete backed by application emojis for this bot instance.",
       "Emoji resolution is environment-safe by name (application emoji IDs may differ per bot instance).",
     ],
-    examples: ["/emoji", "/emoji name:arrow_arrow", "/emoji name::arrow_arrow:"],
+    examples: [
+      "/emoji",
+      "/emoji name:arrow_arrow",
+      "/emoji name::arrow_arrow:",
+      "/emoji name:arrow_arrow react:123456789012345678",
+    ],
   },
   lastseen: {
     summary: "Estimate when a player was last active.",

--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -64,6 +64,15 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
     ],
     examples: ["/help", "/help command:sheet", "/help visibility:public"],
   },
+  emoji: {
+    summary: "Resolve or browse bot-owned application emojis by shortcode name.",
+    details: [
+      "Use `/emoji name:<emoji_name>` to resolve one emoji and show rendered + raw token output.",
+      "Use `/emoji` with no args to browse a paginated list of all available bot application emojis.",
+      "Emoji resolution is environment-safe by name (application emoji IDs may differ per bot instance).",
+    ],
+    examples: ["/emoji", "/emoji name:arrow_arrow", "/emoji name::arrow_arrow:"],
+  },
   lastseen: {
     summary: "Estimate when a player was last active.",
     details: [

--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -69,6 +69,7 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
     details: [
       "Use `/emoji name:<emoji_name>` to resolve one emoji and show rendered + raw token output.",
       "Use `/emoji name:<emoji_name> react:<message-id>` to react to a message in the current channel with that resolved emoji.",
+      "Use `/emoji emoji:<emoji-token-or-url> short-code:<name>` to add one new bot application emoji (admin-only by default).",
       "Use `/emoji` with no args to browse a paginated list of all available bot application emojis.",
       "For name-only resolves, `visibility:public` returns only the rendered emoji message content.",
       "`name` supports dynamic autocomplete backed by application emojis for this bot instance.",
@@ -79,6 +80,7 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
       "/emoji name:arrow_arrow",
       "/emoji name::arrow_arrow:",
       "/emoji name:arrow_arrow react:123456789012345678",
+      "/emoji emoji:<:arrow_arrow:123456789012345678> short-code:arrow_arrow",
     ],
   },
   lastseen: {

--- a/src/commands/Inactive.ts
+++ b/src/commands/Inactive.ts
@@ -2,8 +2,8 @@ import {
   ActionRowBuilder,
   ButtonBuilder,
   ButtonStyle,
+  ChatInputCommandInteraction,
   Client,
-  CommandInteraction,
   ComponentType,
   EmbedBuilder,
 } from "discord.js";
@@ -108,7 +108,7 @@ type InactiveWarRow = {
 };
 
 async function fetchInactiveDaysEntries(
-  interaction: CommandInteraction,
+  interaction: ChatInputCommandInteraction,
   cocService: CoCService,
   days: number
 ): Promise<{
@@ -231,7 +231,7 @@ async function fetchInactiveDaysEntries(
 }
 
 async function fetchInactiveWarEntries(
-  interaction: CommandInteraction,
+  interaction: ChatInputCommandInteraction,
   wars: number
 ): Promise<{
   results: InactiveWarRow[];
@@ -344,7 +344,7 @@ async function fetchInactiveWarEntries(
 }
 
 async function renderEmbedsWithPager(
-  interaction: CommandInteraction,
+  interaction: ChatInputCommandInteraction,
   title: string,
   pages: string[],
   footerSuffix = ""
@@ -457,7 +457,7 @@ function buildGroupedPages<T>(
 }
 
 async function runDaysMode(
-  interaction: CommandInteraction,
+  interaction: ChatInputCommandInteraction,
   cocService: CoCService,
   days: number
 ): Promise<void> {
@@ -588,7 +588,7 @@ async function runDaysMode(
 }
 
 async function runWarsMode(
-  interaction: CommandInteraction,
+  interaction: ChatInputCommandInteraction,
   wars: number
 ): Promise<void> {
   const { results, trackedTags, trackedNameByTag, warnings } = await fetchInactiveWarEntries(
@@ -638,7 +638,7 @@ async function runWarsMode(
 }
 
 async function runCombinedMode(
-  interaction: CommandInteraction,
+  interaction: ChatInputCommandInteraction,
   cocService: CoCService,
   days: number,
   wars: number
@@ -777,13 +777,13 @@ export const Inactive: Command = {
 
   run: async (
     _client: Client,
-    interaction: CommandInteraction,
+    interaction: ChatInputCommandInteraction,
     cocService: CoCService
   ) => {
     await interaction.deferReply({ ephemeral: true });
 
-    const daysValue = interaction.options.get("days")?.value as number | undefined;
-    const warsValue = interaction.options.get("wars")?.value as number | undefined;
+    const daysValue = interaction.options.getInteger("days", false) ?? undefined;
+    const warsValue = interaction.options.getInteger("wars", false) ?? undefined;
 
     if (!daysValue && !warsValue) {
       await interaction.editReply("Provide at least one filter: `days` and/or `wars`.");

--- a/src/commands/RoleUsers.ts
+++ b/src/commands/RoleUsers.ts
@@ -148,7 +148,10 @@ export const RoleUsers: Command = {
           ) {
             page += 1;
           } else if (button.customId === "role-users-print") {
-            if (!interaction.channel) {
+            const printChannel = interaction.channel as
+              | { send?: (input: { embeds: EmbedBuilder[] }) => Promise<unknown> }
+              | null;
+            if (!printChannel || typeof printChannel.send !== "function") {
               await button.reply({
                 content: "Could not print pages in this channel.",
                 ephemeral: true,
@@ -158,7 +161,7 @@ export const RoleUsers: Command = {
 
             await button.update({ components: [] });
             for (let i = 0; i < pages.length; i += 1) {
-              await interaction.channel.send({
+              await printChannel.send({
                 embeds: [getEmbed(interaction, role, pages[i], i, pages.length)],
               });
             }

--- a/src/commands/WarPlan.ts
+++ b/src/commands/WarPlan.ts
@@ -19,6 +19,10 @@ import {
   type WarPlanComplianceConfig,
 } from "../services/warPlanComplianceConfig";
 import { WarEventHistoryService } from "../services/war-events/history";
+import {
+  emojiResolverService,
+  type EmojiResolverService,
+} from "../services/emoji/EmojiResolverService";
 
 type PlanMatchType = "FWA" | "BL" | "MM";
 type PlanOutcome = "WIN" | "LOSE" | "ANY";
@@ -105,54 +109,18 @@ function buildComplianceConfigLine(input: {
   return `Compliance gate: nonMirrorTripleMinClanStars=${input.nonMirrorTripleMinClanStars}, allBasesOpenHoursLeft=${input.allBasesOpenHoursLeft}h${applicability}`;
 }
 
-async function resolveCustomEmojiShortcodes(
-  text: string,
-  interaction: ChatInputCommandInteraction,
-): Promise<string> {
-  const exact = new Map<string, string>();
-  const lowercase = new Map<string, string>();
-  const pushEmoji = (name: string | null | undefined, token: string): void => {
-    if (!name) return;
-    if (!exact.has(name)) {
-      exact.set(name, token);
-    }
-    const lowered = name.toLowerCase();
-    if (!lowercase.has(lowered)) {
-      lowercase.set(lowered, token);
-    }
-  };
+type EmojiShortcodeResolver = Pick<EmojiResolverService, "replaceShortcodes">;
 
-  const guild = interaction.guild;
-  if (guild) {
-    try {
-      await guild.emojis.fetch();
-    } catch {
-      // Keep going; we can still use cached/global emojis.
-    }
-    for (const emoji of guild.emojis.cache.values()) {
-      pushEmoji(
-        emoji.name,
-        `<${emoji.animated ? "a" : ""}:${emoji.name}:${emoji.id}>`,
-      );
-    }
-  }
-
-  for (const emoji of interaction.client.emojis.cache.values()) {
-    pushEmoji(
-      emoji.name,
-      `<${emoji.animated ? "a" : ""}:${emoji.name}:${emoji.id}>`,
-    );
-  }
-
-  return text.replace(
-    /(^|[\s([{"']):([a-zA-Z0-9_]{2,32}):(?=$|[\s)\]}".,!?:;'"-])/g,
-    (full, prefix: string, emojiName: string) => {
-      const token =
-        exact.get(emojiName) ?? lowercase.get(emojiName.toLowerCase());
-      if (!token) return full;
-      return `${prefix}${token}`;
-    },
-  );
+/** Purpose: normalize warplan shortcode text via shared application-emoji resolver. */
+async function resolveWarPlanEmojiShortcodes(params: {
+  text: string;
+  client: Client;
+  resolver?: EmojiShortcodeResolver;
+}): Promise<string> {
+  const resolver = params.resolver ?? emojiResolverService;
+  return resolver
+    .replaceShortcodes(params.client, params.text)
+    .catch(() => params.text);
 }
 
 function formatKeyLabel(
@@ -387,6 +355,9 @@ async function getCurrentOrDefaultPlanData(params: {
     allBasesOpenHoursLeft: modalDefaults.allBasesOpenHoursLeft,
   };
 }
+
+export const resolveWarPlanEmojiShortcodesForTest =
+  resolveWarPlanEmojiShortcodes;
 
 export const WarPlan: Command = {
   name: "warplan",
@@ -644,10 +615,10 @@ export const WarPlan: Command = {
           return;
         }
 
-        const planText = await resolveCustomEmojiShortcodes(
-          normalizedPlanText,
-          interaction,
-        );
+        const planText = await resolveWarPlanEmojiShortcodes({
+          text: normalizedPlanText,
+          client: interaction.client,
+        });
         if (!planText.length) {
           await submitted.reply({
             ephemeral: true,

--- a/src/helper/steadyStateLogGate.ts
+++ b/src/helper/steadyStateLogGate.ts
@@ -1,0 +1,45 @@
+export type SteadyStateLogLevel = "info" | "debug";
+
+/** Purpose: track last-emitted signatures and suppress repeated steady-state info logs. */
+export class SteadyStateLogGate {
+  private readonly lastSignatureByIdentity = new Map<string, string>();
+
+  /** Purpose: initialize bounded in-memory signature storage for logging-only dedupe. */
+  constructor(private readonly maxIdentities: number = 2000) {}
+
+  /** Purpose: return true when the identity's signature is new or changed since last emit. */
+  shouldEmitInfo(identity: string, signature: string): boolean {
+    const normalizedIdentity = identity.trim();
+    const normalizedSignature = signature.trim();
+    const previous = this.lastSignatureByIdentity.get(normalizedIdentity);
+    if (previous === normalizedSignature) return false;
+    this.lastSignatureByIdentity.set(normalizedIdentity, normalizedSignature);
+    this.pruneOverflow();
+    return true;
+  }
+
+  /** Purpose: clear tracked signatures for deterministic tests or lifecycle resets. */
+  clear(): void {
+    this.lastSignatureByIdentity.clear();
+  }
+
+  /** Purpose: evict oldest identities to keep log-only dedupe memory bounded. */
+  private pruneOverflow(): void {
+    while (this.lastSignatureByIdentity.size > this.maxIdentities) {
+      const oldestKey = this.lastSignatureByIdentity.keys().next().value;
+      if (typeof oldestKey !== "string") break;
+      this.lastSignatureByIdentity.delete(oldestKey);
+    }
+  }
+}
+
+/** Purpose: classify steady-state logs into info for changes and debug for repeats. */
+export function resolveSteadyStateLogLevel(params: {
+  gate: SteadyStateLogGate;
+  identity: string;
+  signature: string;
+}): SteadyStateLogLevel {
+  return params.gate.shouldEmitInfo(params.identity, params.signature)
+    ? "info"
+    : "debug";
+}

--- a/src/listeners/ready.ts
+++ b/src/listeners/ready.ts
@@ -2,6 +2,7 @@ import {
   ApplicationCommandOptionType,
   Client,
   PermissionFlagsBits,
+  version as discordJsVersion,
 } from "discord.js";
 import { Commands } from "../Commands";
 import { CoCService } from "../services/CoCService";
@@ -162,6 +163,25 @@ export default (client: Client, cocService: CoCService): void => {
     if (!client.application) return;
 
     console.log("ClashCookies is starting...");
+    let applicationFetchAttempted = false;
+    let applicationFetchSucceeded = false;
+    if (client.application) {
+      applicationFetchAttempted = true;
+      try {
+        await client.application.fetch();
+        applicationFetchSucceeded = true;
+      } catch {
+        applicationFetchSucceeded = false;
+      }
+    }
+    const hasApplicationEmojiFetch = Boolean(
+      client.application &&
+        client.application.emojis &&
+        typeof client.application.emojis.fetch === "function"
+    );
+    console.log(
+      `[startup:discord] discord_js_version=${discordJsVersion} application_present=${Boolean(client.application)} application_fetch_attempted=${applicationFetchAttempted} application_fetch_succeeded=${applicationFetchSucceeded} application_emoji_fetch_available=${hasApplicationEmojiFetch}`
+    );
 
     const bootstrapConfig = getStartupBootstrapRetryConfigFromEnv(process.env);
     const summaryEvery = getStartupRetryLogSummaryEveryFromEnv(process.env);

--- a/src/services/CommandPermissionService.ts
+++ b/src/services/CommandPermissionService.ts
@@ -10,6 +10,7 @@ export const FWA_LEADER_ROLE_SETTING_KEY = "fwa_leader_role";
 
 export const COMMAND_PERMISSION_TARGETS = [
   "help",
+  "emoji",
   "lastseen",
   "inactive",
   "role-users",

--- a/src/services/CommandPermissionService.ts
+++ b/src/services/CommandPermissionService.ts
@@ -11,6 +11,7 @@ export const FWA_LEADER_ROLE_SETTING_KEY = "fwa_leader_role";
 export const COMMAND_PERMISSION_TARGETS = [
   "help",
   "emoji",
+  "emoji:add",
   "lastseen",
   "inactive",
   "role-users",
@@ -99,6 +100,7 @@ const ADMIN_DEFAULT_TARGETS = new Set<string>([
   "sheet:link",
   "sheet:unlink",
   "sheet:show",
+  "emoji:add",
   "telemetry",
   "kick-list:clear",
   "notify:war",

--- a/src/services/WarMailLifecycleService.ts
+++ b/src/services/WarMailLifecycleService.ts
@@ -165,19 +165,29 @@ export class WarMailLifecycleService {
   /** Purpose: persist lifecycle status=POSTED for one clan and one war. */
   async markPosted(input: UpsertPostedLifecycleInput): Promise<void> {
     const clanTag = normalizeTag(input.clanTag);
+    const warId = Math.trunc(input.warId);
     const postedAt = input.postedAt ?? new Date();
+    const existing = await prisma.warMailLifecycle.findUnique({
+      where: {
+        guildId_clanTag_warId: {
+          guildId: input.guildId,
+          clanTag,
+          warId,
+        },
+      },
+    });
     await prisma.warMailLifecycle.upsert({
       where: {
         guildId_clanTag_warId: {
           guildId: input.guildId,
           clanTag,
-          warId: Math.trunc(input.warId),
+          warId,
         },
       },
       create: {
         guildId: input.guildId,
         clanTag,
-        warId: Math.trunc(input.warId),
+        warId,
         status: WarMailLifecycleStatus.POSTED,
         channelId: input.channelId,
         messageId: input.messageId,
@@ -192,9 +202,17 @@ export class WarMailLifecycleService {
         deletedAt: null,
       },
     });
-    console.info(
-      `[mail-lifecycle] guild=${input.guildId} clan=${clanTag} war=${Math.trunc(input.warId)} status=POSTED`
-    );
+    const isTransitionToPosted =
+      !existing || existing.status !== WarMailLifecycleStatus.POSTED;
+    const postedIdentityChanged =
+      existing?.channelId !== input.channelId ||
+      existing?.messageId !== input.messageId;
+    const logLine = `[mail-lifecycle] guild=${input.guildId} clan=${clanTag} war=${warId} status=POSTED`;
+    if (isTransitionToPosted || postedIdentityChanged) {
+      console.info(logLine);
+      return;
+    }
+    console.debug(`${logLine} outcome=noop_reasserted`);
   }
 
   /** Purpose: persist lifecycle status=DELETED for one clan and one war. */

--- a/src/services/emoji/EmojiResolverService.ts
+++ b/src/services/emoji/EmojiResolverService.ts
@@ -15,11 +15,43 @@ type EmojiSnapshot = {
   lowercaseByName: Map<string, ResolvedApplicationEmoji>;
 };
 
-type ApplicationEmojiFetchOwner = {
-  emojis?: {
-    fetch?: () => Promise<Map<string, any> | { values: () => Iterable<any> }>;
-  };
+export type EmojiResolverFailureCode =
+  | "application_missing"
+  | "application_fetch_failed"
+  | "application_emoji_manager_unavailable"
+  | "application_emoji_fetch_failed";
+
+export type EmojiResolverDiagnostics = {
+  applicationExistedBeforeFetch: boolean;
+  applicationFetchAttempted: boolean;
+  applicationEmojiFetchAvailable: boolean;
+  emojiFetchSucceeded: boolean;
+  fetchedEmojiCount: number;
 };
+
+export type EmojiInventoryFetchSuccess = {
+  ok: true;
+  snapshot: EmojiSnapshot;
+  diagnostics: EmojiResolverDiagnostics;
+};
+
+export type EmojiInventoryFetchFailure = {
+  ok: false;
+  code: EmojiResolverFailureCode;
+  diagnostics: EmojiResolverDiagnostics;
+  cause?: unknown;
+};
+
+export type EmojiInventoryFetchResult =
+  | EmojiInventoryFetchSuccess
+  | EmojiInventoryFetchFailure;
+
+type EnsureApplicationResult =
+  | {
+      ok: true;
+      application: NonNullable<Client["application"]>;
+    }
+  | EmojiInventoryFetchFailure;
 
 const SHORTCODE_REPLACE_PATTERN =
   /(^|[\s([{"']):([a-zA-Z0-9_]{2,32}):(?=$|[\s)\]}".,!?:;'"-])/g;
@@ -45,6 +77,38 @@ function sortResolvedEmojis(
   });
 }
 
+/** Purpose: represent resolver fetch failures with explicit reason codes and diagnostics. */
+export class EmojiResolverRuntimeError extends Error {
+  readonly code: EmojiResolverFailureCode;
+  readonly diagnostics: EmojiResolverDiagnostics;
+  readonly cause?: unknown;
+
+  constructor(params: {
+    code: EmojiResolverFailureCode;
+    diagnostics: EmojiResolverDiagnostics;
+    cause?: unknown;
+  }) {
+    super(`Emoji resolver failed: ${params.code}`);
+    this.name = "EmojiResolverRuntimeError";
+    this.code = params.code;
+    this.diagnostics = params.diagnostics;
+    this.cause = params.cause;
+  }
+}
+
+/** Purpose: create default diagnostics for one snapshot fetch attempt. */
+function createEmptyDiagnostics(
+  applicationExistedBeforeFetch: boolean,
+): EmojiResolverDiagnostics {
+  return {
+    applicationExistedBeforeFetch,
+    applicationFetchAttempted: false,
+    applicationEmojiFetchAvailable: false,
+    emojiFetchSucceeded: false,
+    fetchedEmojiCount: 0,
+  };
+}
+
 /** Purpose: resolve bot-owned application emojis by name and replace shortcode text safely. */
 export class EmojiResolverService {
   private snapshot: EmojiSnapshot | null = null;
@@ -52,9 +116,23 @@ export class EmojiResolverService {
   /** Purpose: configure refreshable in-memory cache TTL for resolver lookups. */
   constructor(private readonly cacheTtlMs: number = 30_000) {}
 
+  /** Purpose: fetch application-emoji inventory with explicit success/failure typing for command-level handling. */
+  async fetchApplicationEmojiInventory(
+    client: Client,
+    options?: { forceRefresh?: boolean },
+  ): Promise<EmojiInventoryFetchResult> {
+    return this.getSnapshotResult(client, options?.forceRefresh ?? false);
+  }
+
   /** Purpose: force-refresh the application emoji snapshot from Discord. */
   async refresh(client: Client): Promise<void> {
-    this.snapshot = await this.fetchSnapshot(client);
+    const result = await this.fetchApplicationEmojiInventory(client, {
+      forceRefresh: true,
+    });
+    if (!result.ok) {
+      throw this.toRuntimeError(result);
+    }
+    this.snapshot = result.snapshot;
   }
 
   /** Purpose: resolve one emoji by name (case-insensitive) from bot application emojis. */
@@ -109,52 +187,110 @@ export class EmojiResolverService {
     client: Client,
     forceRefresh: boolean,
   ): Promise<EmojiSnapshot> {
+    const result = await this.getSnapshotResult(client, forceRefresh);
+    if (!result.ok) {
+      throw this.toRuntimeError(result);
+    }
+    return result.snapshot;
+  }
+
+  /** Purpose: return a typed snapshot result while honoring cache freshness for repeat lookups. */
+  private async getSnapshotResult(
+    client: Client,
+    forceRefresh: boolean,
+  ): Promise<EmojiInventoryFetchResult> {
     const nowMs = Date.now();
     if (
       !forceRefresh &&
       this.snapshot &&
       nowMs - this.snapshot.fetchedAtMs <= this.cacheTtlMs
     ) {
-      return this.snapshot;
+      return {
+        ok: true,
+        snapshot: this.snapshot,
+        diagnostics: {
+          applicationExistedBeforeFetch: Boolean(client.application),
+          applicationFetchAttempted: false,
+          applicationEmojiFetchAvailable: true,
+          emojiFetchSucceeded: true,
+          fetchedEmojiCount: this.snapshot.entries.length,
+        },
+      };
     }
     const next = await this.fetchSnapshot(client);
-    this.snapshot = next;
+    if (next.ok) {
+      this.snapshot = next.snapshot;
+    }
     return next;
   }
 
   /** Purpose: safely ensure client application hydration before reading application emoji inventory. */
-  private async ensureApplication(client: Client) {
-    if (client.application) {
-      await client.application.fetch().catch(() => undefined);
-      return client.application;
+  private async ensureApplication(
+    client: Client,
+    diagnostics: EmojiResolverDiagnostics,
+  ): Promise<EnsureApplicationResult> {
+    if (!client.application) {
+      return {
+        ok: false,
+        code: "application_missing",
+        diagnostics,
+      };
     }
-    return null;
+    diagnostics.applicationFetchAttempted = true;
+    try {
+      await client.application.fetch();
+    } catch (error) {
+      return {
+        ok: false,
+        code: "application_fetch_failed",
+        diagnostics,
+        cause: error,
+      };
+    }
+    if (!client.application) {
+      return {
+        ok: false,
+        code: "application_missing",
+        diagnostics,
+      };
+    }
+    return {
+      ok: true,
+      application: client.application,
+    };
   }
 
   /** Purpose: build a fresh application-emoji snapshot keyed for exact and case-insensitive lookups. */
-  private async fetchSnapshot(client: Client): Promise<EmojiSnapshot> {
-    const application = await this.ensureApplication(client);
-    if (!application) {
+  private async fetchSnapshot(client: Client): Promise<EmojiInventoryFetchResult> {
+    const diagnostics = createEmptyDiagnostics(Boolean(client.application));
+    const applicationResult = await this.ensureApplication(client, diagnostics);
+    if (!applicationResult.ok) {
+      return applicationResult;
+    }
+    const application = applicationResult.application;
+
+    if (!application?.emojis || typeof application.emojis.fetch !== "function") {
       return {
-        fetchedAtMs: Date.now(),
-        entries: [],
-        exactByName: new Map<string, ResolvedApplicationEmoji>(),
-        lowercaseByName: new Map<string, ResolvedApplicationEmoji>(),
+        ok: false,
+        code: "application_emoji_manager_unavailable",
+        diagnostics,
       };
     }
+    diagnostics.applicationEmojiFetchAvailable = true;
 
-    const applicationWithEmojis = application as unknown as ApplicationEmojiFetchOwner;
-    const emojiFetch = applicationWithEmojis.emojis?.fetch;
-    if (typeof emojiFetch !== "function") {
+    let fetched;
+    try {
+      fetched = await application.emojis.fetch();
+    } catch (error) {
       return {
-        fetchedAtMs: Date.now(),
-        entries: [],
-        exactByName: new Map<string, ResolvedApplicationEmoji>(),
-        lowercaseByName: new Map<string, ResolvedApplicationEmoji>(),
+        ok: false,
+        code: "application_emoji_fetch_failed",
+        diagnostics,
+        cause: error,
       };
     }
+    diagnostics.emojiFetchSucceeded = true;
 
-    const fetched = await emojiFetch();
     const collected: ResolvedApplicationEmoji[] = [];
     for (const emoji of fetched.values()) {
       const name = String(emoji.name ?? "").trim();
@@ -168,6 +304,7 @@ export class EmojiResolverService {
         animated: Boolean(emoji.animated),
       });
     }
+    diagnostics.fetchedEmojiCount = collected.length;
 
     const entries = sortResolvedEmojis(collected);
     const exactByName = new Map<string, ResolvedApplicationEmoji>();
@@ -183,11 +320,24 @@ export class EmojiResolverService {
     }
 
     return {
-      fetchedAtMs: Date.now(),
-      entries,
-      exactByName,
-      lowercaseByName,
+      ok: true,
+      diagnostics,
+      snapshot: {
+        fetchedAtMs: Date.now(),
+        entries,
+        exactByName,
+        lowercaseByName,
+      },
     };
+  }
+
+  /** Purpose: normalize typed failure results into thrown errors for legacy call sites. */
+  private toRuntimeError(failure: EmojiInventoryFetchFailure): EmojiResolverRuntimeError {
+    return new EmojiResolverRuntimeError({
+      code: failure.code,
+      diagnostics: failure.diagnostics,
+      cause: failure.cause,
+    });
   }
 }
 

--- a/src/services/emoji/EmojiResolverService.ts
+++ b/src/services/emoji/EmojiResolverService.ts
@@ -15,6 +15,36 @@ type EmojiSnapshot = {
   lowercaseByName: Map<string, ResolvedApplicationEmoji>;
 };
 
+type ParsedCustomEmojiToken = {
+  animated: boolean;
+  name: string;
+  id: string;
+};
+
+export type EmojiInputSourceType =
+  | "custom_emoji_token"
+  | "direct_image_url"
+  | "unicode_emoji_unsupported"
+  | "invalid_input";
+
+export type ParsedEmojiImageSourceSuccess = {
+  ok: true;
+  sourceType: "custom_emoji_token" | "direct_image_url";
+  imageUrl: string;
+  customEmojiId: string | null;
+  animated: boolean;
+};
+
+export type ParsedEmojiImageSourceFailure = {
+  ok: false;
+  sourceType: "unicode_emoji_unsupported" | "invalid_input";
+  code: "unsupported_unicode_emoji" | "invalid_emoji_input";
+};
+
+export type ParsedEmojiImageSourceResult =
+  | ParsedEmojiImageSourceSuccess
+  | ParsedEmojiImageSourceFailure;
+
 export type EmojiResolverFailureCode =
   | "application_missing"
   | "application_fetch_failed"
@@ -55,6 +85,93 @@ type EnsureApplicationResult =
 
 const SHORTCODE_REPLACE_PATTERN =
   /(^|[\s([{"']):([a-zA-Z0-9_]{2,32}):(?=$|[\s)\]}".,!?:;'"-])/g;
+const CUSTOM_EMOJI_TOKEN_PATTERN = /^<(a?):([a-zA-Z0-9_]{2,32}):(\d{17,22})>$/;
+const SHORTCODE_NAME_PATTERN = /^[a-zA-Z0-9_]{2,32}$/;
+const UNICODE_EMOJI_PATTERN = /[\p{Extended_Pictographic}\uFE0F]/u;
+
+/** Purpose: trim and de-colon one shortcode name for canonical application emoji creation lookup. */
+export function normalizeEmojiShortcodeName(input: string): string {
+  const trimmed = String(input ?? "").trim();
+  if (!trimmed) return "";
+  const withoutColons = trimmed.replace(/^:+/, "").replace(/:+$/, "");
+  return withoutColons.trim();
+}
+
+/** Purpose: validate one normalized application emoji shortcode name against Discord naming constraints. */
+export function isValidEmojiShortcodeName(input: string): boolean {
+  return SHORTCODE_NAME_PATTERN.test(String(input ?? ""));
+}
+
+/** Purpose: parse one custom Discord emoji token into id/name/animated fields for CDN source resolution. */
+function parseCustomEmojiToken(input: string): ParsedCustomEmojiToken | null {
+  const match = input.match(CUSTOM_EMOJI_TOKEN_PATTERN);
+  if (!match) return null;
+  return {
+    animated: match[1] === "a",
+    name: match[2],
+    id: match[3],
+  };
+}
+
+/** Purpose: test whether one arbitrary input likely contains a unicode emoji that this patch does not rasterize. */
+function looksLikeUnicodeEmoji(input: string): boolean {
+  return UNICODE_EMOJI_PATTERN.test(input);
+}
+
+/** Purpose: parse user-provided emoji image input into a canonical application-emoji upload source. */
+export function parseEmojiImageSource(
+  input: string,
+): ParsedEmojiImageSourceResult {
+  const trimmed = String(input ?? "").trim();
+  if (!trimmed) {
+    return {
+      ok: false,
+      sourceType: "invalid_input",
+      code: "invalid_emoji_input",
+    };
+  }
+
+  const parsedToken = parseCustomEmojiToken(trimmed);
+  if (parsedToken) {
+    const ext = parsedToken.animated ? "gif" : "png";
+    return {
+      ok: true,
+      sourceType: "custom_emoji_token",
+      imageUrl: `https://cdn.discordapp.com/emojis/${parsedToken.id}.${ext}?quality=lossless`,
+      customEmojiId: parsedToken.id,
+      animated: parsedToken.animated,
+    };
+  }
+
+  try {
+    const url = new URL(trimmed);
+    if (url.protocol === "http:" || url.protocol === "https:") {
+      return {
+        ok: true,
+        sourceType: "direct_image_url",
+        imageUrl: url.toString(),
+        customEmojiId: null,
+        animated: false,
+      };
+    }
+  } catch {
+    // Ignore URL parse errors and fall through to deterministic input classification.
+  }
+
+  if (looksLikeUnicodeEmoji(trimmed)) {
+    return {
+      ok: false,
+      sourceType: "unicode_emoji_unsupported",
+      code: "unsupported_unicode_emoji",
+    };
+  }
+
+  return {
+    ok: false,
+    sourceType: "invalid_input",
+    code: "invalid_emoji_input",
+  };
+}
 
 /** Purpose: normalize user-provided emoji-name input while preserving name-based environment stability. */
 export function normalizeEmojiLookupName(input: string): string {
@@ -133,6 +250,11 @@ export class EmojiResolverService {
       throw this.toRuntimeError(result);
     }
     this.snapshot = result.snapshot;
+  }
+
+  /** Purpose: invalidate in-memory emoji snapshot cache so subsequent reads refetch current application state. */
+  invalidateCache(): void {
+    this.snapshot = null;
   }
 
   /** Purpose: resolve one emoji by name (case-insensitive) from bot application emojis. */

--- a/src/services/emoji/EmojiResolverService.ts
+++ b/src/services/emoji/EmojiResolverService.ts
@@ -1,0 +1,194 @@
+import { Client } from "discord.js";
+
+export type ResolvedApplicationEmoji = {
+  id: string;
+  name: string;
+  shortcode: string;
+  rendered: string;
+  animated: boolean;
+};
+
+type EmojiSnapshot = {
+  fetchedAtMs: number;
+  entries: ResolvedApplicationEmoji[];
+  exactByName: Map<string, ResolvedApplicationEmoji>;
+  lowercaseByName: Map<string, ResolvedApplicationEmoji>;
+};
+
+type ApplicationEmojiFetchOwner = {
+  emojis?: {
+    fetch?: () => Promise<Map<string, any> | { values: () => Iterable<any> }>;
+  };
+};
+
+const SHORTCODE_REPLACE_PATTERN =
+  /(^|[\s([{"']):([a-zA-Z0-9_]{2,32}):(?=$|[\s)\]}".,!?:;'"-])/g;
+
+/** Purpose: normalize user-provided emoji-name input while preserving name-based environment stability. */
+export function normalizeEmojiLookupName(input: string): string {
+  const trimmed = String(input ?? "").trim();
+  if (!trimmed) return "";
+  const inner = trimmed.replace(/^:/, "").replace(/:$/, "");
+  return inner.trim();
+}
+
+/** Purpose: sort emoji entries deterministically for stable command output across runs. */
+function sortResolvedEmojis(
+  values: ResolvedApplicationEmoji[],
+): ResolvedApplicationEmoji[] {
+  return [...values].sort((a, b) => {
+    const byLower = a.name.toLowerCase().localeCompare(b.name.toLowerCase());
+    if (byLower !== 0) return byLower;
+    const byExact = a.name.localeCompare(b.name);
+    if (byExact !== 0) return byExact;
+    return a.id.localeCompare(b.id);
+  });
+}
+
+/** Purpose: resolve bot-owned application emojis by name and replace shortcode text safely. */
+export class EmojiResolverService {
+  private snapshot: EmojiSnapshot | null = null;
+
+  /** Purpose: configure refreshable in-memory cache TTL for resolver lookups. */
+  constructor(private readonly cacheTtlMs: number = 30_000) {}
+
+  /** Purpose: force-refresh the application emoji snapshot from Discord. */
+  async refresh(client: Client): Promise<void> {
+    this.snapshot = await this.fetchSnapshot(client);
+  }
+
+  /** Purpose: resolve one emoji by name (case-insensitive) from bot application emojis. */
+  async resolveByName(
+    client: Client,
+    name: string,
+    options?: { forceRefresh?: boolean },
+  ): Promise<ResolvedApplicationEmoji | null> {
+    const normalizedName = normalizeEmojiLookupName(name);
+    if (!normalizedName) return null;
+    const snapshot = await this.getSnapshot(client, options?.forceRefresh ?? false);
+    return (
+      snapshot.exactByName.get(normalizedName) ??
+      snapshot.lowercaseByName.get(normalizedName.toLowerCase()) ??
+      null
+    );
+  }
+
+  /** Purpose: replace valid `:emoji_name:` shortcodes with application emoji render tokens. */
+  async replaceShortcodes(
+    client: Client,
+    text: string,
+    options?: { forceRefresh?: boolean },
+  ): Promise<string> {
+    const source = String(text ?? "");
+    if (!source.includes(":")) return source;
+    const snapshot = await this.getSnapshot(client, options?.forceRefresh ?? false);
+    if (snapshot.entries.length === 0) return source;
+    return source.replace(
+      SHORTCODE_REPLACE_PATTERN,
+      (full, prefix: string, emojiName: string) => {
+        const resolved =
+          snapshot.exactByName.get(emojiName) ??
+          snapshot.lowercaseByName.get(emojiName.toLowerCase());
+        if (!resolved) return full;
+        return `${prefix}${resolved.rendered}`;
+      },
+    );
+  }
+
+  /** Purpose: list all available bot application emojis in deterministic order. */
+  async listApplicationEmojis(
+    client: Client,
+    options?: { forceRefresh?: boolean },
+  ): Promise<ResolvedApplicationEmoji[]> {
+    const snapshot = await this.getSnapshot(client, options?.forceRefresh ?? false);
+    return [...snapshot.entries];
+  }
+
+  /** Purpose: fetch cached snapshot when fresh, otherwise rebuild from current bot application emojis. */
+  private async getSnapshot(
+    client: Client,
+    forceRefresh: boolean,
+  ): Promise<EmojiSnapshot> {
+    const nowMs = Date.now();
+    if (
+      !forceRefresh &&
+      this.snapshot &&
+      nowMs - this.snapshot.fetchedAtMs <= this.cacheTtlMs
+    ) {
+      return this.snapshot;
+    }
+    const next = await this.fetchSnapshot(client);
+    this.snapshot = next;
+    return next;
+  }
+
+  /** Purpose: safely ensure client application hydration before reading application emoji inventory. */
+  private async ensureApplication(client: Client) {
+    if (client.application) {
+      await client.application.fetch().catch(() => undefined);
+      return client.application;
+    }
+    return null;
+  }
+
+  /** Purpose: build a fresh application-emoji snapshot keyed for exact and case-insensitive lookups. */
+  private async fetchSnapshot(client: Client): Promise<EmojiSnapshot> {
+    const application = await this.ensureApplication(client);
+    if (!application) {
+      return {
+        fetchedAtMs: Date.now(),
+        entries: [],
+        exactByName: new Map<string, ResolvedApplicationEmoji>(),
+        lowercaseByName: new Map<string, ResolvedApplicationEmoji>(),
+      };
+    }
+
+    const applicationWithEmojis = application as unknown as ApplicationEmojiFetchOwner;
+    const emojiFetch = applicationWithEmojis.emojis?.fetch;
+    if (typeof emojiFetch !== "function") {
+      return {
+        fetchedAtMs: Date.now(),
+        entries: [],
+        exactByName: new Map<string, ResolvedApplicationEmoji>(),
+        lowercaseByName: new Map<string, ResolvedApplicationEmoji>(),
+      };
+    }
+
+    const fetched = await emojiFetch();
+    const collected: ResolvedApplicationEmoji[] = [];
+    for (const emoji of fetched.values()) {
+      const name = String(emoji.name ?? "").trim();
+      const rendered = String(emoji.toString?.() ?? "").trim();
+      if (!name || !rendered) continue;
+      collected.push({
+        id: String(emoji.id),
+        name,
+        shortcode: `:${name}:`,
+        rendered,
+        animated: Boolean(emoji.animated),
+      });
+    }
+
+    const entries = sortResolvedEmojis(collected);
+    const exactByName = new Map<string, ResolvedApplicationEmoji>();
+    const lowercaseByName = new Map<string, ResolvedApplicationEmoji>();
+    for (const entry of entries) {
+      if (!exactByName.has(entry.name)) {
+        exactByName.set(entry.name, entry);
+      }
+      const lowered = entry.name.toLowerCase();
+      if (!lowercaseByName.has(lowered)) {
+        lowercaseByName.set(lowered, entry);
+      }
+    }
+
+    return {
+      fetchedAtMs: Date.now(),
+      entries,
+      exactByName,
+      lowercaseByName,
+    };
+  }
+}
+
+export const emojiResolverService = new EmojiResolverService();

--- a/src/services/fwa-feeds/FwaFeedSchedulerService.ts
+++ b/src/services/fwa-feeds/FwaFeedSchedulerService.ts
@@ -1,5 +1,6 @@
 import { recordFetchEvent, runFetchTelemetryBatch } from "../../helper/fetchTelemetry";
 import { formatError } from "../../helper/formatError";
+import { SteadyStateLogGate } from "../../helper/steadyStateLogGate";
 import { FwaClansCatalogSyncService } from "./FwaClansCatalogSyncService";
 import { FwaClanMembersSyncService } from "./FwaClanMembersSyncService";
 import { FwaWarMembersSyncService } from "./FwaWarMembersSyncService";
@@ -23,6 +24,13 @@ type SchedulerConfig = {
   jitterMs: number;
 };
 
+type TrackedClanWarsWatchSummary = {
+  trackedClanCount: number;
+  activeClanCount: number;
+  polledClanCount: number;
+  updateAcquiredCount: number;
+};
+
 function toBool(input: string | undefined, fallback: boolean): boolean {
   if (input === undefined) return fallback;
   const normalized = input.trim().toLowerCase();
@@ -40,6 +48,36 @@ function minutesToMsWithMin(valueMinutes: number, minMinutes: number): number {
   return Math.max(minMinutes, valueMinutes) * 60 * 1000;
 }
 
+/** Purpose: serialize tracked-clan watch summary into a deterministic comparison key. */
+function buildTrackedClanWarsWatchSummaryKey(summary: TrackedClanWarsWatchSummary): string {
+  return `tracked=${summary.trackedClanCount}|active=${summary.activeClanCount}|polled=${summary.polledClanCount}|acquired=${summary.updateAcquiredCount}`;
+}
+
+/** Purpose: flag whether a tracked-clan watch summary represents actual polling work. */
+function hasTrackedClanWarsWatchActivity(summary: TrackedClanWarsWatchSummary): boolean {
+  return (
+    summary.activeClanCount > 0 ||
+    summary.polledClanCount > 0 ||
+    summary.updateAcquiredCount > 0
+  );
+}
+
+/** Purpose: keep watch summaries at info for work/changes, and demote repeated no-op states to debug. */
+function resolveTrackedClanWarsWatchSummaryLogLevel(params: {
+  summary: TrackedClanWarsWatchSummary;
+  summaryChanged: boolean;
+}): "info" | "debug" {
+  if (hasTrackedClanWarsWatchActivity(params.summary) || params.summaryChanged) {
+    return "info";
+  }
+  return "debug";
+}
+
+export const buildTrackedClanWarsWatchSummaryKeyForTest =
+  buildTrackedClanWarsWatchSummaryKey;
+export const resolveTrackedClanWarsWatchSummaryLogLevelForTest =
+  resolveTrackedClanWarsWatchSummaryLogLevel;
+
 /** Purpose: orchestrate bounded fwastats feed scheduler jobs with explicit cadence and cost controls. */
 export class FwaFeedSchedulerService {
   private readonly config: SchedulerConfig;
@@ -55,6 +93,7 @@ export class FwaFeedSchedulerService {
   private warMembersInProgress = false;
   private watchInProgress = false;
   private globalWarsInProgress = false;
+  private readonly trackedClanWarsWatchSummaryLogGate = new SteadyStateLogGate();
 
   /** Purpose: initialize scheduler config from env with safe minimum intervals and bounded defaults. */
   constructor() {
@@ -324,9 +363,20 @@ export class FwaFeedSchedulerService {
           },
           now,
         );
-        console.info(
-          `[fwa-feed] job=tracked_clan_wars_watch tracked=${summary.trackedClanCount} active=${summary.activeClanCount} polled=${summary.polledClanCount} acquired=${summary.updateAcquiredCount} duration_ms=${Date.now() - startedAt}`,
+        const summaryChanged = this.trackedClanWarsWatchSummaryLogGate.shouldEmitInfo(
+          "tracked_clan_wars_watch",
+          buildTrackedClanWarsWatchSummaryKey(summary),
         );
+        const logLevel = resolveTrackedClanWarsWatchSummaryLogLevel({
+          summary,
+          summaryChanged,
+        });
+        const line = `[fwa-feed] job=tracked_clan_wars_watch tracked=${summary.trackedClanCount} active=${summary.activeClanCount} polled=${summary.polledClanCount} acquired=${summary.updateAcquiredCount} duration_ms=${Date.now() - startedAt}`;
+        if (logLevel === "info") {
+          console.info(line);
+        } else {
+          console.debug(line);
+        }
       });
     } catch (error) {
       await this.syncState.recordFailure(

--- a/tests/emoji.command.test.ts
+++ b/tests/emoji.command.test.ts
@@ -1,5 +1,10 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import type { ChatInputCommandInteraction, Client } from "discord.js";
+import type {
+  AutocompleteInteraction,
+  ChatInputCommandInteraction,
+  Client,
+  PermissionResolvable,
+} from "discord.js";
 import {
   Emoji,
   applyEmojiPageActionForTest,
@@ -14,37 +19,6 @@ import type {
 type EmojiResolverStub = {
   fetchApplicationEmojiInventory: ReturnType<typeof vi.fn>;
 };
-
-/** Purpose: build minimal fake chat-input interaction for command unit tests. */
-function buildInteraction(input?: {
-  name?: string | null;
-}): {
-  interaction: ChatInputCommandInteraction;
-  deferReply: ReturnType<typeof vi.fn>;
-  editReply: ReturnType<typeof vi.fn>;
-  fetchReply: ReturnType<typeof vi.fn>;
-} {
-  const deferReply = vi.fn().mockResolvedValue(undefined);
-  const editReply = vi.fn().mockResolvedValue(undefined);
-  const fetchReply = vi.fn().mockResolvedValue({
-    createMessageComponentCollector: vi.fn(),
-  });
-  const interaction = {
-    id: "interaction-1",
-    guildId: "guild-1",
-    user: { id: "user-1" },
-    client: {} as Client,
-    options: {
-      getString: vi.fn((name: string) =>
-        name === "name" ? (input?.name ?? null) : null,
-      ),
-    },
-    deferReply,
-    editReply,
-    fetchReply,
-  } as unknown as ChatInputCommandInteraction;
-  return { interaction, deferReply, editReply, fetchReply };
-}
 
 /** Purpose: build resolver stub for deterministic command behavior assertions. */
 function buildResolverStub(): EmojiResolverStub {
@@ -103,6 +77,105 @@ function buildFailureResult(
   };
 }
 
+/** Purpose: build minimal fake chat-input interaction for command unit tests. */
+function buildInteraction(input?: {
+  name?: string | null;
+  react?: string | null;
+  messageFetchError?: unknown;
+  reactionError?: unknown;
+  appPermissionHas?: (permission: PermissionResolvable) => boolean;
+}): {
+  interaction: ChatInputCommandInteraction;
+  deferReply: ReturnType<typeof vi.fn>;
+  editReply: ReturnType<typeof vi.fn>;
+  fetchReply: ReturnType<typeof vi.fn>;
+  messageFetch: ReturnType<typeof vi.fn>;
+  messageReact: ReturnType<typeof vi.fn>;
+} {
+  const deferReply = vi.fn().mockResolvedValue(undefined);
+  const editReply = vi.fn().mockResolvedValue(undefined);
+  const fetchReply = vi.fn().mockResolvedValue({
+    createMessageComponentCollector: vi.fn(),
+  });
+
+  const messageReact = vi.fn();
+  if (input?.reactionError) {
+    messageReact.mockRejectedValue(input.reactionError);
+  } else {
+    messageReact.mockResolvedValue(undefined);
+  }
+
+  const messageFetch = vi.fn();
+  if (input?.messageFetchError) {
+    messageFetch.mockRejectedValue(input.messageFetchError);
+  } else {
+    messageFetch.mockResolvedValue({ react: messageReact });
+  }
+
+  const interaction = {
+    id: "interaction-1",
+    guildId: "guild-1",
+    channelId: "channel-1",
+    user: { id: "user-1" },
+    client: {} as Client,
+    appPermissions: {
+      has: vi.fn((permission: PermissionResolvable) =>
+        input?.appPermissionHas ? input.appPermissionHas(permission) : true,
+      ),
+    },
+    channel: {
+      isTextBased: () => true,
+      messages: {
+        fetch: messageFetch,
+      },
+    },
+    options: {
+      getString: vi.fn((name: string) => {
+        if (name === "name") return input?.name ?? null;
+        if (name === "react") return input?.react ?? null;
+        return null;
+      }),
+    },
+    deferReply,
+    editReply,
+    fetchReply,
+  } as unknown as ChatInputCommandInteraction;
+
+  return {
+    interaction,
+    deferReply,
+    editReply,
+    fetchReply,
+    messageFetch,
+    messageReact,
+  };
+}
+
+/** Purpose: build minimal autocomplete interaction for command autocomplete tests. */
+function buildAutocompleteInteraction(input?: {
+  focusedName?: string;
+  focusedValue?: string;
+}): {
+  interaction: AutocompleteInteraction;
+  respond: ReturnType<typeof vi.fn>;
+} {
+  const respond = vi.fn().mockResolvedValue(undefined);
+  const interaction = {
+    guildId: "guild-1",
+    channelId: "channel-1",
+    user: { id: "user-1" },
+    client: {} as Client,
+    options: {
+      getFocused: vi.fn(() => ({
+        name: input?.focusedName ?? "name",
+        value: input?.focusedValue ?? "",
+      })),
+    },
+    respond,
+  } as unknown as AutocompleteInteraction;
+  return { interaction, respond };
+}
+
 describe("/emoji command", () => {
   afterEach(() => {
     resetEmojiResolverForTest();
@@ -127,7 +200,30 @@ describe("/emoji command", () => {
 
     await Emoji.run({} as Client, interaction, {} as any);
 
-    expect(resolver.fetchApplicationEmojiInventory).toHaveBeenCalledTimes(1);
+    const payload = editReply.mock.calls[0]?.[0] ?? {};
+    const embed = payload.embeds?.[0];
+    const json = typeof embed?.toJSON === "function" ? embed.toJSON() : embed?.data ?? {};
+    expect(String(json.description ?? "")).toContain(":arrow_arrow:");
+  });
+
+  it("supports name mode with colon-wrapped input", async () => {
+    const resolver = buildResolverStub();
+    resolver.fetchApplicationEmojiInventory.mockResolvedValue(
+      buildSuccessResult([
+        {
+          id: "1",
+          name: "arrow_arrow",
+          shortcode: ":arrow_arrow:",
+          rendered: "<:arrow_arrow:1>",
+          animated: false,
+        },
+      ]),
+    );
+    setEmojiResolverForTest(resolver as any);
+    const { interaction, editReply } = buildInteraction({ name: ":arrow_arrow:" });
+
+    await Emoji.run({} as Client, interaction, {} as any);
+
     const payload = editReply.mock.calls[0]?.[0] ?? {};
     const embed = payload.embeds?.[0];
     const json = typeof embed?.toJSON === "function" ? embed.toJSON() : embed?.data ?? {};
@@ -153,7 +249,21 @@ describe("/emoji command", () => {
     await Emoji.run({} as Client, interaction, {} as any);
 
     const payload = editReply.mock.calls[0]?.[0] ?? {};
-    expect(String(payload.content ?? "")).toContain("No application emoji found");
+    expect(String(payload.content ?? "")).toContain(
+      "Could not find an application emoji named",
+    );
+  });
+
+  it("rejects invalid empty name input", async () => {
+    const resolver = buildResolverStub();
+    setEmojiResolverForTest(resolver as any);
+    const { interaction, editReply } = buildInteraction({ name: "   " });
+
+    await Emoji.run({} as Client, interaction, {} as any);
+
+    expect(resolver.fetchApplicationEmojiInventory).not.toHaveBeenCalled();
+    const payload = editReply.mock.calls[0]?.[0] ?? {};
+    expect(String(payload.content ?? "")).toContain("Please provide a valid emoji name");
   });
 
   it("renders list mode first page", async () => {
@@ -189,6 +299,172 @@ describe("/emoji command", () => {
     expect(fetchReply).not.toHaveBeenCalled();
   });
 
+  it("ignores react when name is omitted and keeps list mode", async () => {
+    const resolver = buildResolverStub();
+    resolver.fetchApplicationEmojiInventory.mockResolvedValue(
+      buildSuccessResult([
+        {
+          id: "1",
+          name: "alpha",
+          shortcode: ":alpha:",
+          rendered: "<:alpha:1>",
+          animated: false,
+        },
+      ]),
+    );
+    setEmojiResolverForTest(resolver as any);
+    const { interaction, editReply, messageFetch } = buildInteraction({
+      react: "123456789012345678",
+    });
+
+    await Emoji.run({} as Client, interaction, {} as any);
+
+    const payload = editReply.mock.calls[0]?.[0] ?? {};
+    const embed = payload.embeds?.[0];
+    const json = typeof embed?.toJSON === "function" ? embed.toJSON() : embed?.data ?? {};
+    expect(json.title).toBe("Bot Application Emojis");
+    expect(messageFetch).not.toHaveBeenCalled();
+  });
+
+  it("supports react mode success", async () => {
+    const resolver = buildResolverStub();
+    resolver.fetchApplicationEmojiInventory.mockResolvedValue(
+      buildSuccessResult([
+        {
+          id: "1",
+          name: "arrow_arrow",
+          shortcode: ":arrow_arrow:",
+          rendered: "<:arrow_arrow:1>",
+          animated: false,
+        },
+      ]),
+    );
+    setEmojiResolverForTest(resolver as any);
+    const { interaction, editReply, messageFetch, messageReact } = buildInteraction({
+      name: "arrow_arrow",
+      react: "123456789012345678",
+    });
+
+    await Emoji.run({} as Client, interaction, {} as any);
+
+    expect(messageFetch).toHaveBeenCalledWith("123456789012345678");
+    expect(messageReact).toHaveBeenCalledWith("<:arrow_arrow:1>");
+    const payload = editReply.mock.calls[0]?.[0] ?? {};
+    expect(String(payload.content ?? "")).toContain("Reacted to message");
+  });
+
+  it("rejects invalid message id before fetch", async () => {
+    const resolver = buildResolverStub();
+    resolver.fetchApplicationEmojiInventory.mockResolvedValue(
+      buildSuccessResult([
+        {
+          id: "1",
+          name: "arrow_arrow",
+          shortcode: ":arrow_arrow:",
+          rendered: "<:arrow_arrow:1>",
+          animated: false,
+        },
+      ]),
+    );
+    setEmojiResolverForTest(resolver as any);
+    const { interaction, editReply, messageFetch } = buildInteraction({
+      name: "arrow_arrow",
+      react: "abc",
+    });
+
+    await Emoji.run({} as Client, interaction, {} as any);
+
+    expect(messageFetch).not.toHaveBeenCalled();
+    const payload = editReply.mock.calls[0]?.[0] ?? {};
+    expect(String(payload.content ?? "")).toContain("Please provide a valid message ID");
+  });
+
+  it("shows message-not-found error when current-channel fetch fails", async () => {
+    const resolver = buildResolverStub();
+    resolver.fetchApplicationEmojiInventory.mockResolvedValue(
+      buildSuccessResult([
+        {
+          id: "1",
+          name: "arrow_arrow",
+          shortcode: ":arrow_arrow:",
+          rendered: "<:arrow_arrow:1>",
+          animated: false,
+        },
+      ]),
+    );
+    setEmojiResolverForTest(resolver as any);
+    const { interaction, editReply } = buildInteraction({
+      name: "arrow_arrow",
+      react: "123456789012345678",
+      messageFetchError: new Error("missing"),
+    });
+
+    await Emoji.run({} as Client, interaction, {} as any);
+
+    const payload = editReply.mock.calls[0]?.[0] ?? {};
+    expect(String(payload.content ?? "")).toContain("Could not find message");
+  });
+
+  it("shows permission error when reaction is denied", async () => {
+    const resolver = buildResolverStub();
+    resolver.fetchApplicationEmojiInventory.mockResolvedValue(
+      buildSuccessResult([
+        {
+          id: "1",
+          name: "arrow_arrow",
+          shortcode: ":arrow_arrow:",
+          rendered: "<:arrow_arrow:1>",
+          animated: false,
+        },
+      ]),
+    );
+    setEmojiResolverForTest(resolver as any);
+    const { interaction, editReply } = buildInteraction({
+      name: "arrow_arrow",
+      react: "123456789012345678",
+      reactionError: { code: 50013 },
+    });
+
+    await Emoji.run({} as Client, interaction, {} as any);
+
+    const payload = editReply.mock.calls[0]?.[0] ?? {};
+    expect(String(payload.content ?? "")).toContain(
+      "I do not have permission to add that reaction",
+    );
+  });
+
+  it("shows runtime-unavailable message when resolver reports manager unavailable", async () => {
+    const resolver = buildResolverStub();
+    resolver.fetchApplicationEmojiInventory.mockResolvedValue(
+      buildFailureResult("application_emoji_manager_unavailable"),
+    );
+    setEmojiResolverForTest(resolver as any);
+    const { interaction, editReply } = buildInteraction();
+
+    await Emoji.run({} as Client, interaction, {} as any);
+
+    const payload = editReply.mock.calls[0]?.[0] ?? {};
+    expect(String(payload.content ?? "")).toContain(
+      "Could not load application emojis right now",
+    );
+  });
+
+  it("shows retry message when resolver reports fetch failure", async () => {
+    const resolver = buildResolverStub();
+    resolver.fetchApplicationEmojiInventory.mockResolvedValue(
+      buildFailureResult("application_emoji_fetch_failed"),
+    );
+    setEmojiResolverForTest(resolver as any);
+    const { interaction, editReply } = buildInteraction();
+
+    await Emoji.run({} as Client, interaction, {} as any);
+
+    const payload = editReply.mock.calls[0]?.[0] ?? {};
+    expect(String(payload.content ?? "")).toContain(
+      "Could not fetch application emojis right now",
+    );
+  });
+
   it("supports pagination next/previous behavior", () => {
     expect(
       applyEmojiPageActionForTest({
@@ -212,53 +488,166 @@ describe("/emoji command", () => {
       }),
     ).toBe(2);
   });
+});
 
-  it("renders list mode empty state when no emojis are available", async () => {
-    const resolver = buildResolverStub();
-    resolver.fetchApplicationEmojiInventory.mockResolvedValue(buildSuccessResult([]));
-    setEmojiResolverForTest(resolver as any);
-    const { interaction, editReply } = buildInteraction();
-
-    await Emoji.run({} as Client, interaction, {} as any);
-
-    const payload = editReply.mock.calls[0]?.[0] ?? {};
-    const embed = payload.embeds?.[0];
-    const json = typeof embed?.toJSON === "function" ? embed.toJSON() : embed?.data ?? {};
-    expect(String(json.description ?? "")).toContain(
-      "No application emojis are currently available",
-    );
-    expect(payload.components ?? []).toEqual([]);
+describe("/emoji autocomplete", () => {
+  afterEach(() => {
+    resetEmojiResolverForTest();
+    vi.restoreAllMocks();
   });
 
-  it("shows runtime-unavailable message when resolver reports manager unavailable", async () => {
+  it("returns prefix matches from application emoji inventory", async () => {
+    const resolver = buildResolverStub();
+    resolver.fetchApplicationEmojiInventory.mockResolvedValue(
+      buildSuccessResult([
+        {
+          id: "1",
+          name: "arrow_arrow",
+          shortcode: ":arrow_arrow:",
+          rendered: "<:arrow_arrow:1>",
+          animated: false,
+        },
+        {
+          id: "2",
+          name: "shield",
+          shortcode: ":shield:",
+          rendered: "<:shield:2>",
+          animated: false,
+        },
+      ]),
+    );
+    setEmojiResolverForTest(resolver as any);
+    const { interaction, respond } = buildAutocompleteInteraction({
+      focusedValue: "arr",
+    });
+
+    await Emoji.autocomplete?.(interaction);
+
+    const payload = respond.mock.calls[0]?.[0] ?? [];
+    expect(payload).toEqual([
+      { name: "<:arrow_arrow:1> :arrow_arrow:", value: "arrow_arrow" },
+    ]);
+  });
+
+  it("supports colon-prefixed autocomplete input", async () => {
+    const resolver = buildResolverStub();
+    resolver.fetchApplicationEmojiInventory.mockResolvedValue(
+      buildSuccessResult([
+        {
+          id: "1",
+          name: "arrow_arrow",
+          shortcode: ":arrow_arrow:",
+          rendered: "<:arrow_arrow:1>",
+          animated: false,
+        },
+      ]),
+    );
+    setEmojiResolverForTest(resolver as any);
+    const { interaction, respond } = buildAutocompleteInteraction({
+      focusedValue: ":arr",
+    });
+
+    await Emoji.autocomplete?.(interaction);
+
+    const payload = respond.mock.calls[0]?.[0] ?? [];
+    expect(payload[0]).toEqual({
+      name: "<:arrow_arrow:1> :arrow_arrow:",
+      value: "arrow_arrow",
+    });
+  });
+
+  it("orders autocomplete by exact, then prefix, then contains", async () => {
+    const resolver = buildResolverStub();
+    resolver.fetchApplicationEmojiInventory.mockResolvedValue(
+      buildSuccessResult([
+        {
+          id: "1",
+          name: "xarrz",
+          shortcode: ":xarrz:",
+          rendered: "<:xarrz:1>",
+          animated: false,
+        },
+        {
+          id: "2",
+          name: "arr",
+          shortcode: ":arr:",
+          rendered: "<:arr:2>",
+          animated: false,
+        },
+        {
+          id: "3",
+          name: "arrow_arrow",
+          shortcode: ":arrow_arrow:",
+          rendered: "<:arrow_arrow:3>",
+          animated: false,
+        },
+      ]),
+    );
+    setEmojiResolverForTest(resolver as any);
+    const { interaction, respond } = buildAutocompleteInteraction({
+      focusedValue: "arr",
+    });
+
+    await Emoji.autocomplete?.(interaction);
+
+    const payload = respond.mock.calls[0]?.[0] ?? [];
+    expect(payload.map((entry: { value: string }) => entry.value)).toEqual([
+      "arr",
+      "arrow_arrow",
+      "xarrz",
+    ]);
+  });
+
+  it("caps autocomplete results to Discord max choices", async () => {
+    const resolver = buildResolverStub();
+    const emojis: ResolvedApplicationEmoji[] = [];
+    for (let i = 0; i < 40; i += 1) {
+      emojis.push({
+        id: String(i + 1),
+        name: `arrow_${String(i + 1).padStart(2, "0")}`,
+        shortcode: `:arrow_${String(i + 1).padStart(2, "0")}:`,
+        rendered: `<:arrow_${String(i + 1).padStart(2, "0")}:${i + 1}>`,
+        animated: false,
+      });
+    }
+    resolver.fetchApplicationEmojiInventory.mockResolvedValue(buildSuccessResult(emojis));
+    setEmojiResolverForTest(resolver as any);
+    const { interaction, respond } = buildAutocompleteInteraction({
+      focusedValue: "arrow_",
+    });
+
+    await Emoji.autocomplete?.(interaction);
+
+    const payload = respond.mock.calls[0]?.[0] ?? [];
+    expect(payload).toHaveLength(25);
+  });
+
+  it("returns empty suggestions when inventory is unavailable", async () => {
     const resolver = buildResolverStub();
     resolver.fetchApplicationEmojiInventory.mockResolvedValue(
       buildFailureResult("application_emoji_manager_unavailable"),
     );
     setEmojiResolverForTest(resolver as any);
-    const { interaction, editReply } = buildInteraction();
+    const { interaction, respond } = buildAutocompleteInteraction({
+      focusedValue: "arr",
+    });
 
-    await Emoji.run({} as Client, interaction, {} as any);
+    await Emoji.autocomplete?.(interaction);
 
-    const payload = editReply.mock.calls[0]?.[0] ?? {};
-    expect(String(payload.content ?? "")).toContain(
-      "Could not load bot application emojis in this runtime",
-    );
+    expect(respond).toHaveBeenCalledWith([]);
   });
 
-  it("shows retry message when resolver reports fetch failure", async () => {
+  it("returns empty suggestions for non-name focused option", async () => {
     const resolver = buildResolverStub();
-    resolver.fetchApplicationEmojiInventory.mockResolvedValue(
-      buildFailureResult("application_emoji_fetch_failed"),
-    );
     setEmojiResolverForTest(resolver as any);
-    const { interaction, editReply } = buildInteraction();
+    const { interaction, respond } = buildAutocompleteInteraction({
+      focusedName: "react",
+      focusedValue: "123",
+    });
 
-    await Emoji.run({} as Client, interaction, {} as any);
+    await Emoji.autocomplete?.(interaction);
 
-    const payload = editReply.mock.calls[0]?.[0] ?? {};
-    expect(String(payload.content ?? "")).toContain(
-      "Could not fetch bot application emojis right now",
-    );
+    expect(resolver.fetchApplicationEmojiInventory).not.toHaveBeenCalled();
+    expect(respond).toHaveBeenCalledWith([]);
   });
 });

--- a/tests/emoji.command.test.ts
+++ b/tests/emoji.command.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import axios from "axios";
 import type {
   AutocompleteInteraction,
   ChatInputCommandInteraction,
@@ -8,7 +9,9 @@ import type {
 import {
   Emoji,
   applyEmojiPageActionForTest,
+  resetEmojiCommandPermissionServiceForTest,
   resetEmojiResolverForTest,
+  setEmojiCommandPermissionServiceForTest,
   setEmojiResolverForTest,
 } from "../src/commands/Emoji";
 import type {
@@ -18,13 +21,39 @@ import type {
 
 type EmojiResolverStub = {
   fetchApplicationEmojiInventory: ReturnType<typeof vi.fn>;
+  refresh: ReturnType<typeof vi.fn>;
+  invalidateCache: ReturnType<typeof vi.fn>;
+};
+
+type CommandPermissionStub = {
+  canUseAnyTarget: ReturnType<typeof vi.fn>;
 };
 
 /** Purpose: build resolver stub for deterministic command behavior assertions. */
 function buildResolverStub(): EmojiResolverStub {
   return {
     fetchApplicationEmojiInventory: vi.fn(),
+    refresh: vi.fn().mockResolvedValue(undefined),
+    invalidateCache: vi.fn(),
   };
+}
+
+/** Purpose: build permission stub for deterministic add-path authorization behavior. */
+function buildPermissionStub(): CommandPermissionStub {
+  return {
+    canUseAnyTarget: vi.fn().mockResolvedValue(true),
+  };
+}
+
+/** Purpose: mock one successful image download response for emoji-add attachment ingestion. */
+function mockEmojiImageDownloadSuccess(): void {
+  vi.spyOn(axios, "get").mockResolvedValue({
+    status: 200,
+    headers: {
+      "content-type": "image/png",
+    },
+    data: Buffer.from([1, 2, 3]),
+  } as any);
 }
 
 /** Purpose: create a successful inventory result from emoji entries for tests. */
@@ -81,7 +110,14 @@ function buildFailureResult(
 function buildInteraction(input?: {
   name?: string | null;
   react?: string | null;
+  emoji?: string | null;
+  shortCode?: string | null;
   visibility?: "private" | "public";
+  application?: {
+    emojis?: {
+      create?: ReturnType<typeof vi.fn>;
+    };
+  } | null;
   messageFetchError?: unknown;
   reactionError?: unknown;
   appPermissionHas?: (permission: PermissionResolvable) => boolean;
@@ -118,7 +154,9 @@ function buildInteraction(input?: {
     guildId: "guild-1",
     channelId: "channel-1",
     user: { id: "user-1" },
-    client: {} as Client,
+    client: {
+      application: input?.application ?? null,
+    } as Client,
     appPermissions: {
       has: vi.fn((permission: PermissionResolvable) =>
         input?.appPermissionHas ? input.appPermissionHas(permission) : true,
@@ -134,6 +172,8 @@ function buildInteraction(input?: {
       getString: vi.fn((name: string) => {
         if (name === "name") return input?.name ?? null;
         if (name === "react") return input?.react ?? null;
+        if (name === "emoji") return input?.emoji ?? null;
+        if (name === "short-code") return input?.shortCode ?? null;
         if (name === "visibility") return input?.visibility ?? "private";
         return null;
       }),
@@ -181,6 +221,8 @@ function buildAutocompleteInteraction(input?: {
 describe("/emoji command", () => {
   afterEach(() => {
     resetEmojiResolverForTest();
+    resetEmojiCommandPermissionServiceForTest();
+    vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
 
@@ -311,6 +353,215 @@ describe("/emoji command", () => {
     expect(resolver.fetchApplicationEmojiInventory).not.toHaveBeenCalled();
     const payload = editReply.mock.calls[0]?.[0] ?? {};
     expect(String(payload.content ?? "")).toContain("Please provide a valid emoji name");
+  });
+
+  it("adds a new application emoji from custom token input", async () => {
+    const resolver = buildResolverStub();
+    resolver.fetchApplicationEmojiInventory.mockResolvedValue(buildSuccessResult([]));
+    setEmojiResolverForTest(resolver as any);
+    const permission = buildPermissionStub();
+    setEmojiCommandPermissionServiceForTest(permission as any);
+
+    mockEmojiImageDownloadSuccess();
+
+    const create = vi.fn().mockResolvedValue({
+      id: "999",
+      name: "arrow_arrow",
+      toString: () => "<:arrow_arrow:999>",
+    });
+    const { interaction, editReply } = buildInteraction({
+      emoji: "<:source_icon:123456789012345678>",
+      shortCode: ":arrow_arrow:",
+      application: {
+        emojis: {
+          create,
+        },
+      },
+    });
+
+    await Emoji.run({} as Client, interaction, {} as any);
+
+    expect(permission.canUseAnyTarget).toHaveBeenCalledWith(
+      ["emoji:add", "emoji"],
+      interaction,
+    );
+    expect(create).toHaveBeenCalledTimes(1);
+    const createInput = create.mock.calls[0]?.[0] ?? {};
+    expect(createInput.name).toBe("arrow_arrow");
+    expect(Buffer.isBuffer(createInput.attachment)).toBe(true);
+    expect(resolver.invalidateCache).toHaveBeenCalledTimes(1);
+    expect(resolver.refresh).toHaveBeenCalledTimes(1);
+
+    const payload = editReply.mock.calls[0]?.[0] ?? {};
+    expect(String(payload.content ?? "")).toContain(
+      "Added application emoji <:arrow_arrow:999> with shortcode `arrow_arrow`.",
+    );
+  });
+
+  it("blocks duplicate shortcode names before create", async () => {
+    const resolver = buildResolverStub();
+    resolver.fetchApplicationEmojiInventory.mockResolvedValue(
+      buildSuccessResult([
+        {
+          id: "4",
+          name: "arrow_arrow",
+          shortcode: ":arrow_arrow:",
+          rendered: "<:arrow_arrow:4>",
+          animated: false,
+        },
+      ]),
+    );
+    setEmojiResolverForTest(resolver as any);
+    const permission = buildPermissionStub();
+    setEmojiCommandPermissionServiceForTest(permission as any);
+    const create = vi.fn();
+
+    const { interaction, editReply } = buildInteraction({
+      emoji: "<:source_icon:123456789012345678>",
+      shortCode: "arrow_arrow",
+      application: {
+        emojis: {
+          create,
+        },
+      },
+    });
+
+    await Emoji.run({} as Client, interaction, {} as any);
+
+    expect(create).not.toHaveBeenCalled();
+    const payload = editReply.mock.calls[0]?.[0] ?? {};
+    expect(String(payload.content ?? "")).toContain("already exists");
+  });
+
+  it("rejects unsupported unicode emoji input on add path", async () => {
+    const resolver = buildResolverStub();
+    setEmojiResolverForTest(resolver as any);
+    const permission = buildPermissionStub();
+    setEmojiCommandPermissionServiceForTest(permission as any);
+    const { interaction, editReply } = buildInteraction({
+      emoji: "🔥",
+      shortCode: "arrow_arrow",
+    });
+
+    await Emoji.run({} as Client, interaction, {} as any);
+
+    expect(resolver.fetchApplicationEmojiInventory).not.toHaveBeenCalled();
+    const payload = editReply.mock.calls[0]?.[0] ?? {};
+    expect(String(payload.content ?? "")).toContain("Unicode emoji input is not supported");
+  });
+
+  it("rejects malformed shortcode on add path", async () => {
+    const resolver = buildResolverStub();
+    setEmojiResolverForTest(resolver as any);
+    const permission = buildPermissionStub();
+    setEmojiCommandPermissionServiceForTest(permission as any);
+    const { interaction, editReply } = buildInteraction({
+      emoji: "<:source_icon:123456789012345678>",
+      shortCode: "bad-name",
+    });
+
+    await Emoji.run({} as Client, interaction, {} as any);
+
+    expect(resolver.fetchApplicationEmojiInventory).not.toHaveBeenCalled();
+    const payload = editReply.mock.calls[0]?.[0] ?? {};
+    expect(String(payload.content ?? "")).toContain("Please provide a valid shortcode");
+  });
+
+  it("returns permission denied for unauthorized add-path users", async () => {
+    const resolver = buildResolverStub();
+    setEmojiResolverForTest(resolver as any);
+    const permission = buildPermissionStub();
+    permission.canUseAnyTarget.mockResolvedValue(false);
+    setEmojiCommandPermissionServiceForTest(permission as any);
+    const { interaction, editReply } = buildInteraction({
+      emoji: "<:source_icon:123456789012345678>",
+      shortCode: "arrow_arrow",
+    });
+
+    await Emoji.run({} as Client, interaction, {} as any);
+
+    expect(resolver.fetchApplicationEmojiInventory).not.toHaveBeenCalled();
+    const payload = editReply.mock.calls[0]?.[0] ?? {};
+    expect(String(payload.content ?? "")).toContain(
+      "You do not have permission to use /emoji add",
+    );
+  });
+
+  it("returns clear failure when application state is unavailable during add", async () => {
+    const resolver = buildResolverStub();
+    resolver.fetchApplicationEmojiInventory.mockResolvedValue(buildSuccessResult([]));
+    setEmojiResolverForTest(resolver as any);
+    const permission = buildPermissionStub();
+    setEmojiCommandPermissionServiceForTest(permission as any);
+
+    mockEmojiImageDownloadSuccess();
+
+    const { interaction, editReply } = buildInteraction({
+      emoji: "<:source_icon:123456789012345678>",
+      shortCode: "arrow_arrow",
+      application: null,
+    });
+
+    await Emoji.run({} as Client, interaction, {} as any);
+
+    const payload = editReply.mock.calls[0]?.[0] ?? {};
+    expect(String(payload.content ?? "")).toContain(
+      "Could not load bot application state right now",
+    );
+  });
+
+  it("returns inventory-full failure when add create API reports capacity reached", async () => {
+    const resolver = buildResolverStub();
+    resolver.fetchApplicationEmojiInventory.mockResolvedValue(buildSuccessResult([]));
+    setEmojiResolverForTest(resolver as any);
+    const permission = buildPermissionStub();
+    setEmojiCommandPermissionServiceForTest(permission as any);
+
+    mockEmojiImageDownloadSuccess();
+
+    const create = vi.fn().mockRejectedValue({ code: 30056 });
+    const { interaction, editReply } = buildInteraction({
+      emoji: "https://example.com/icon.png",
+      shortCode: "arrow_arrow",
+      application: {
+        emojis: {
+          create,
+        },
+      },
+    });
+
+    await Emoji.run({} as Client, interaction, {} as any);
+
+    const payload = editReply.mock.calls[0]?.[0] ?? {};
+    expect(String(payload.content ?? "")).toContain("inventory is full");
+  });
+
+  it("returns generic create failure when Discord rejects add request", async () => {
+    const resolver = buildResolverStub();
+    resolver.fetchApplicationEmojiInventory.mockResolvedValue(buildSuccessResult([]));
+    setEmojiResolverForTest(resolver as any);
+    const permission = buildPermissionStub();
+    setEmojiCommandPermissionServiceForTest(permission as any);
+
+    mockEmojiImageDownloadSuccess();
+
+    const create = vi.fn().mockRejectedValue(new Error("bad upload"));
+    const { interaction, editReply } = buildInteraction({
+      emoji: "https://example.com/icon.png",
+      shortCode: "arrow_arrow",
+      application: {
+        emojis: {
+          create,
+        },
+      },
+    });
+
+    await Emoji.run({} as Client, interaction, {} as any);
+
+    const payload = editReply.mock.calls[0]?.[0] ?? {};
+    expect(String(payload.content ?? "")).toContain(
+      "Discord rejected the emoji create request",
+    );
   });
 
   it("renders list mode first page", async () => {
@@ -559,6 +810,8 @@ describe("/emoji command", () => {
 describe("/emoji autocomplete", () => {
   afterEach(() => {
     resetEmojiResolverForTest();
+    resetEmojiCommandPermissionServiceForTest();
+    vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
 

--- a/tests/emoji.command.test.ts
+++ b/tests/emoji.command.test.ts
@@ -81,6 +81,7 @@ function buildFailureResult(
 function buildInteraction(input?: {
   name?: string | null;
   react?: string | null;
+  visibility?: "private" | "public";
   messageFetchError?: unknown;
   reactionError?: unknown;
   appPermissionHas?: (permission: PermissionResolvable) => boolean;
@@ -133,6 +134,7 @@ function buildInteraction(input?: {
       getString: vi.fn((name: string) => {
         if (name === "name") return input?.name ?? null;
         if (name === "react") return input?.react ?? null;
+        if (name === "visibility") return input?.visibility ?? "private";
         return null;
       }),
     },
@@ -204,6 +206,7 @@ describe("/emoji command", () => {
     const embed = payload.embeds?.[0];
     const json = typeof embed?.toJSON === "function" ? embed.toJSON() : embed?.data ?? {};
     expect(String(json.description ?? "")).toContain(":arrow_arrow:");
+    expect(String(payload.content ?? "")).not.toBe("<:arrow_arrow:1>");
   });
 
   it("supports name mode with colon-wrapped input", async () => {
@@ -230,6 +233,33 @@ describe("/emoji command", () => {
     expect(String(json.description ?? "")).toContain(":arrow_arrow:");
   });
 
+  it("returns only visible emoji content for name mode when visibility is public", async () => {
+    const resolver = buildResolverStub();
+    resolver.fetchApplicationEmojiInventory.mockResolvedValue(
+      buildSuccessResult([
+        {
+          id: "1",
+          name: "arrow_arrow",
+          shortcode: ":arrow_arrow:",
+          rendered: "<:arrow_arrow:1>",
+          animated: false,
+        },
+      ]),
+    );
+    setEmojiResolverForTest(resolver as any);
+    const { interaction, editReply } = buildInteraction({
+      name: "arrow_arrow",
+      visibility: "public",
+    });
+
+    await Emoji.run({} as Client, interaction, {} as any);
+
+    const payload = editReply.mock.calls[0]?.[0] ?? {};
+    expect(payload.content).toBe("<:arrow_arrow:1>");
+    expect(payload.embeds ?? []).toEqual([]);
+    expect(payload.components ?? []).toEqual([]);
+  });
+
   it("supports name mode not found", async () => {
     const resolver = buildResolverStub();
     resolver.fetchApplicationEmojiInventory.mockResolvedValue(
@@ -245,6 +275,23 @@ describe("/emoji command", () => {
     );
     setEmojiResolverForTest(resolver as any);
     const { interaction, editReply } = buildInteraction({ name: "not_real" });
+
+    await Emoji.run({} as Client, interaction, {} as any);
+
+    const payload = editReply.mock.calls[0]?.[0] ?? {};
+    expect(String(payload.content ?? "")).toContain(
+      "Could not find an application emoji named",
+    );
+  });
+
+  it("returns not-found message for name mode when visibility is public", async () => {
+    const resolver = buildResolverStub();
+    resolver.fetchApplicationEmojiInventory.mockResolvedValue(buildSuccessResult([]));
+    setEmojiResolverForTest(resolver as any);
+    const { interaction, editReply } = buildInteraction({
+      name: "not_real",
+      visibility: "public",
+    });
 
     await Emoji.run({} as Client, interaction, {} as any);
 
@@ -440,6 +487,25 @@ describe("/emoji command", () => {
     );
     setEmojiResolverForTest(resolver as any);
     const { interaction, editReply } = buildInteraction();
+
+    await Emoji.run({} as Client, interaction, {} as any);
+
+    const payload = editReply.mock.calls[0]?.[0] ?? {};
+    expect(String(payload.content ?? "")).toContain(
+      "Could not load application emojis right now",
+    );
+  });
+
+  it("shows runtime-unavailable message for name mode in public visibility", async () => {
+    const resolver = buildResolverStub();
+    resolver.fetchApplicationEmojiInventory.mockResolvedValue(
+      buildFailureResult("application_emoji_manager_unavailable"),
+    );
+    setEmojiResolverForTest(resolver as any);
+    const { interaction, editReply } = buildInteraction({
+      name: "arrow_arrow",
+      visibility: "public",
+    });
 
     await Emoji.run({} as Client, interaction, {} as any);
 

--- a/tests/emoji.command.test.ts
+++ b/tests/emoji.command.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { ChatInputCommandInteraction, Client } from "discord.js";
+import {
+  Emoji,
+  applyEmojiPageActionForTest,
+  resetEmojiResolverForTest,
+  setEmojiResolverForTest,
+} from "../src/commands/Emoji";
+
+type EmojiResolverStub = {
+  resolveByName: ReturnType<typeof vi.fn>;
+  listApplicationEmojis: ReturnType<typeof vi.fn>;
+};
+
+function buildInteraction(input?: {
+  name?: string | null;
+}): {
+  interaction: ChatInputCommandInteraction;
+  deferReply: ReturnType<typeof vi.fn>;
+  editReply: ReturnType<typeof vi.fn>;
+  fetchReply: ReturnType<typeof vi.fn>;
+} {
+  const deferReply = vi.fn().mockResolvedValue(undefined);
+  const editReply = vi.fn().mockResolvedValue(undefined);
+  const fetchReply = vi.fn().mockResolvedValue({
+    createMessageComponentCollector: vi.fn(),
+  });
+  const interaction = {
+    id: "interaction-1",
+    user: { id: "user-1" },
+    client: {} as Client,
+    options: {
+      getString: vi.fn((name: string) => (name === "name" ? (input?.name ?? null) : null)),
+    },
+    deferReply,
+    editReply,
+    fetchReply,
+  } as unknown as ChatInputCommandInteraction;
+  return { interaction, deferReply, editReply, fetchReply };
+}
+
+function buildResolverStub(): EmojiResolverStub {
+  return {
+    resolveByName: vi.fn(),
+    listApplicationEmojis: vi.fn(),
+  };
+}
+
+describe("/emoji command", () => {
+  afterEach(() => {
+    resetEmojiResolverForTest();
+    vi.restoreAllMocks();
+  });
+
+  it("supports name mode success", async () => {
+    const resolver = buildResolverStub();
+    resolver.resolveByName.mockResolvedValue({
+      id: "1",
+      name: "arrow_arrow",
+      shortcode: ":arrow_arrow:",
+      rendered: "<:arrow_arrow:1>",
+      animated: false,
+    });
+    setEmojiResolverForTest(resolver as any);
+    const { interaction, editReply } = buildInteraction({ name: "arrow_arrow" });
+
+    await Emoji.run({} as Client, interaction, {} as any);
+
+    expect(resolver.resolveByName).toHaveBeenCalledTimes(1);
+    const payload = editReply.mock.calls[0]?.[0] ?? {};
+    const embed = payload.embeds?.[0];
+    const json = typeof embed?.toJSON === "function" ? embed.toJSON() : embed?.data ?? {};
+    expect(String(json.description ?? "")).toContain(":arrow_arrow:");
+  });
+
+  it("supports name mode not found", async () => {
+    const resolver = buildResolverStub();
+    resolver.resolveByName.mockResolvedValue(null);
+    resolver.listApplicationEmojis.mockResolvedValue([
+      {
+        id: "1",
+        name: "arrow_arrow",
+        shortcode: ":arrow_arrow:",
+        rendered: "<:arrow_arrow:1>",
+        animated: false,
+      },
+    ]);
+    setEmojiResolverForTest(resolver as any);
+    const { interaction, editReply } = buildInteraction({ name: "not_real" });
+
+    await Emoji.run({} as Client, interaction, {} as any);
+
+    const payload = editReply.mock.calls[0]?.[0] ?? {};
+    expect(String(payload.content ?? "")).toContain("No application emoji found");
+  });
+
+  it("renders list mode first page", async () => {
+    const resolver = buildResolverStub();
+    resolver.listApplicationEmojis.mockResolvedValue([
+      {
+        id: "1",
+        name: "alpha",
+        shortcode: ":alpha:",
+        rendered: "<:alpha:1>",
+        animated: false,
+      },
+      {
+        id: "2",
+        name: "bravo",
+        shortcode: ":bravo:",
+        rendered: "<:bravo:2>",
+        animated: false,
+      },
+    ]);
+    setEmojiResolverForTest(resolver as any);
+    const { interaction, editReply, fetchReply } = buildInteraction();
+
+    await Emoji.run({} as Client, interaction, {} as any);
+
+    const payload = editReply.mock.calls[0]?.[0] ?? {};
+    const embed = payload.embeds?.[0];
+    const json = typeof embed?.toJSON === "function" ? embed.toJSON() : embed?.data ?? {};
+    expect(json.title).toBe("Bot Application Emojis");
+    expect(String(json.description ?? "")).toContain(":alpha:");
+    expect(fetchReply).not.toHaveBeenCalled();
+  });
+
+  it("supports pagination next/previous behavior", () => {
+    expect(
+      applyEmojiPageActionForTest({
+        action: "next",
+        page: 0,
+        totalPages: 3,
+      }),
+    ).toBe(1);
+    expect(
+      applyEmojiPageActionForTest({
+        action: "prev",
+        page: 1,
+        totalPages: 3,
+      }),
+    ).toBe(0);
+    expect(
+      applyEmojiPageActionForTest({
+        action: "next",
+        page: 2,
+        totalPages: 3,
+      }),
+    ).toBe(2);
+  });
+
+  it("renders list mode empty state when no emojis are available", async () => {
+    const resolver = buildResolverStub();
+    resolver.listApplicationEmojis.mockResolvedValue([]);
+    setEmojiResolverForTest(resolver as any);
+    const { interaction, editReply } = buildInteraction();
+
+    await Emoji.run({} as Client, interaction, {} as any);
+
+    const payload = editReply.mock.calls[0]?.[0] ?? {};
+    const embed = payload.embeds?.[0];
+    const json = typeof embed?.toJSON === "function" ? embed.toJSON() : embed?.data ?? {};
+    expect(String(json.description ?? "")).toContain(
+      "No application emojis are currently available",
+    );
+    expect(payload.components ?? []).toEqual([]);
+  });
+});

--- a/tests/emoji.command.test.ts
+++ b/tests/emoji.command.test.ts
@@ -6,12 +6,16 @@ import {
   resetEmojiResolverForTest,
   setEmojiResolverForTest,
 } from "../src/commands/Emoji";
+import type {
+  EmojiInventoryFetchResult,
+  ResolvedApplicationEmoji,
+} from "../src/services/emoji/EmojiResolverService";
 
 type EmojiResolverStub = {
-  resolveByName: ReturnType<typeof vi.fn>;
-  listApplicationEmojis: ReturnType<typeof vi.fn>;
+  fetchApplicationEmojiInventory: ReturnType<typeof vi.fn>;
 };
 
+/** Purpose: build minimal fake chat-input interaction for command unit tests. */
 function buildInteraction(input?: {
   name?: string | null;
 }): {
@@ -27,10 +31,13 @@ function buildInteraction(input?: {
   });
   const interaction = {
     id: "interaction-1",
+    guildId: "guild-1",
     user: { id: "user-1" },
     client: {} as Client,
     options: {
-      getString: vi.fn((name: string) => (name === "name" ? (input?.name ?? null) : null)),
+      getString: vi.fn((name: string) =>
+        name === "name" ? (input?.name ?? null) : null,
+      ),
     },
     deferReply,
     editReply,
@@ -39,10 +46,60 @@ function buildInteraction(input?: {
   return { interaction, deferReply, editReply, fetchReply };
 }
 
+/** Purpose: build resolver stub for deterministic command behavior assertions. */
 function buildResolverStub(): EmojiResolverStub {
   return {
-    resolveByName: vi.fn(),
-    listApplicationEmojis: vi.fn(),
+    fetchApplicationEmojiInventory: vi.fn(),
+  };
+}
+
+/** Purpose: create a successful inventory result from emoji entries for tests. */
+function buildSuccessResult(
+  emojis: ResolvedApplicationEmoji[],
+): EmojiInventoryFetchResult {
+  const exactByName = new Map<string, ResolvedApplicationEmoji>();
+  const lowercaseByName = new Map<string, ResolvedApplicationEmoji>();
+  for (const emoji of emojis) {
+    if (!exactByName.has(emoji.name)) {
+      exactByName.set(emoji.name, emoji);
+    }
+    const lower = emoji.name.toLowerCase();
+    if (!lowercaseByName.has(lower)) {
+      lowercaseByName.set(lower, emoji);
+    }
+  }
+  return {
+    ok: true,
+    diagnostics: {
+      applicationExistedBeforeFetch: true,
+      applicationFetchAttempted: true,
+      applicationEmojiFetchAvailable: true,
+      emojiFetchSucceeded: true,
+      fetchedEmojiCount: emojis.length,
+    },
+    snapshot: {
+      fetchedAtMs: Date.now(),
+      entries: emojis,
+      exactByName,
+      lowercaseByName,
+    },
+  };
+}
+
+/** Purpose: create a failed inventory result with resolver diagnostics for tests. */
+function buildFailureResult(
+  code: "application_emoji_manager_unavailable" | "application_emoji_fetch_failed",
+): EmojiInventoryFetchResult {
+  return {
+    ok: false,
+    code,
+    diagnostics: {
+      applicationExistedBeforeFetch: true,
+      applicationFetchAttempted: true,
+      applicationEmojiFetchAvailable: code !== "application_emoji_manager_unavailable",
+      emojiFetchSucceeded: false,
+      fetchedEmojiCount: 0,
+    },
   };
 }
 
@@ -54,19 +111,23 @@ describe("/emoji command", () => {
 
   it("supports name mode success", async () => {
     const resolver = buildResolverStub();
-    resolver.resolveByName.mockResolvedValue({
-      id: "1",
-      name: "arrow_arrow",
-      shortcode: ":arrow_arrow:",
-      rendered: "<:arrow_arrow:1>",
-      animated: false,
-    });
+    resolver.fetchApplicationEmojiInventory.mockResolvedValue(
+      buildSuccessResult([
+        {
+          id: "1",
+          name: "arrow_arrow",
+          shortcode: ":arrow_arrow:",
+          rendered: "<:arrow_arrow:1>",
+          animated: false,
+        },
+      ]),
+    );
     setEmojiResolverForTest(resolver as any);
     const { interaction, editReply } = buildInteraction({ name: "arrow_arrow" });
 
     await Emoji.run({} as Client, interaction, {} as any);
 
-    expect(resolver.resolveByName).toHaveBeenCalledTimes(1);
+    expect(resolver.fetchApplicationEmojiInventory).toHaveBeenCalledTimes(1);
     const payload = editReply.mock.calls[0]?.[0] ?? {};
     const embed = payload.embeds?.[0];
     const json = typeof embed?.toJSON === "function" ? embed.toJSON() : embed?.data ?? {};
@@ -75,16 +136,17 @@ describe("/emoji command", () => {
 
   it("supports name mode not found", async () => {
     const resolver = buildResolverStub();
-    resolver.resolveByName.mockResolvedValue(null);
-    resolver.listApplicationEmojis.mockResolvedValue([
-      {
-        id: "1",
-        name: "arrow_arrow",
-        shortcode: ":arrow_arrow:",
-        rendered: "<:arrow_arrow:1>",
-        animated: false,
-      },
-    ]);
+    resolver.fetchApplicationEmojiInventory.mockResolvedValue(
+      buildSuccessResult([
+        {
+          id: "1",
+          name: "arrow_arrow",
+          shortcode: ":arrow_arrow:",
+          rendered: "<:arrow_arrow:1>",
+          animated: false,
+        },
+      ]),
+    );
     setEmojiResolverForTest(resolver as any);
     const { interaction, editReply } = buildInteraction({ name: "not_real" });
 
@@ -96,22 +158,24 @@ describe("/emoji command", () => {
 
   it("renders list mode first page", async () => {
     const resolver = buildResolverStub();
-    resolver.listApplicationEmojis.mockResolvedValue([
-      {
-        id: "1",
-        name: "alpha",
-        shortcode: ":alpha:",
-        rendered: "<:alpha:1>",
-        animated: false,
-      },
-      {
-        id: "2",
-        name: "bravo",
-        shortcode: ":bravo:",
-        rendered: "<:bravo:2>",
-        animated: false,
-      },
-    ]);
+    resolver.fetchApplicationEmojiInventory.mockResolvedValue(
+      buildSuccessResult([
+        {
+          id: "1",
+          name: "alpha",
+          shortcode: ":alpha:",
+          rendered: "<:alpha:1>",
+          animated: false,
+        },
+        {
+          id: "2",
+          name: "bravo",
+          shortcode: ":bravo:",
+          rendered: "<:bravo:2>",
+          animated: false,
+        },
+      ]),
+    );
     setEmojiResolverForTest(resolver as any);
     const { interaction, editReply, fetchReply } = buildInteraction();
 
@@ -151,7 +215,7 @@ describe("/emoji command", () => {
 
   it("renders list mode empty state when no emojis are available", async () => {
     const resolver = buildResolverStub();
-    resolver.listApplicationEmojis.mockResolvedValue([]);
+    resolver.fetchApplicationEmojiInventory.mockResolvedValue(buildSuccessResult([]));
     setEmojiResolverForTest(resolver as any);
     const { interaction, editReply } = buildInteraction();
 
@@ -164,5 +228,37 @@ describe("/emoji command", () => {
       "No application emojis are currently available",
     );
     expect(payload.components ?? []).toEqual([]);
+  });
+
+  it("shows runtime-unavailable message when resolver reports manager unavailable", async () => {
+    const resolver = buildResolverStub();
+    resolver.fetchApplicationEmojiInventory.mockResolvedValue(
+      buildFailureResult("application_emoji_manager_unavailable"),
+    );
+    setEmojiResolverForTest(resolver as any);
+    const { interaction, editReply } = buildInteraction();
+
+    await Emoji.run({} as Client, interaction, {} as any);
+
+    const payload = editReply.mock.calls[0]?.[0] ?? {};
+    expect(String(payload.content ?? "")).toContain(
+      "Could not load bot application emojis in this runtime",
+    );
+  });
+
+  it("shows retry message when resolver reports fetch failure", async () => {
+    const resolver = buildResolverStub();
+    resolver.fetchApplicationEmojiInventory.mockResolvedValue(
+      buildFailureResult("application_emoji_fetch_failed"),
+    );
+    setEmojiResolverForTest(resolver as any);
+    const { interaction, editReply } = buildInteraction();
+
+    await Emoji.run({} as Client, interaction, {} as any);
+
+    const payload = editReply.mock.calls[0]?.[0] ?? {};
+    expect(String(payload.content ?? "")).toContain(
+      "Could not fetch bot application emojis right now",
+    );
   });
 });

--- a/tests/emoji.commandShape.test.ts
+++ b/tests/emoji.commandShape.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { ApplicationCommandOptionType } from "discord.js";
+import { Emoji } from "../src/commands/Emoji";
+
+describe("/emoji command shape", () => {
+  it("registers optional name autocomplete and optional react message-id options", () => {
+    const nameOption = Emoji.options?.find((option) => option.name === "name");
+    const reactOption = Emoji.options?.find((option) => option.name === "react");
+
+    expect(nameOption?.type).toBe(ApplicationCommandOptionType.String);
+    expect(nameOption?.required).toBe(false);
+    expect(nameOption?.autocomplete).toBe(true);
+
+    expect(reactOption?.type).toBe(ApplicationCommandOptionType.String);
+    expect(reactOption?.required).toBe(false);
+  });
+});

--- a/tests/emoji.commandShape.test.ts
+++ b/tests/emoji.commandShape.test.ts
@@ -3,9 +3,11 @@ import { ApplicationCommandOptionType } from "discord.js";
 import { Emoji } from "../src/commands/Emoji";
 
 describe("/emoji command shape", () => {
-  it("registers optional name autocomplete and optional react message-id options", () => {
+  it("registers optional resolve/react options plus add-flow emoji source + shortcode options", () => {
     const nameOption = Emoji.options?.find((option) => option.name === "name");
     const reactOption = Emoji.options?.find((option) => option.name === "react");
+    const emojiOption = Emoji.options?.find((option) => option.name === "emoji");
+    const shortCodeOption = Emoji.options?.find((option) => option.name === "short-code");
 
     expect(nameOption?.type).toBe(ApplicationCommandOptionType.String);
     expect(nameOption?.required).toBe(false);
@@ -13,5 +15,11 @@ describe("/emoji command shape", () => {
 
     expect(reactOption?.type).toBe(ApplicationCommandOptionType.String);
     expect(reactOption?.required).toBe(false);
+
+    expect(emojiOption?.type).toBe(ApplicationCommandOptionType.String);
+    expect(emojiOption?.required).toBe(false);
+
+    expect(shortCodeOption?.type).toBe(ApplicationCommandOptionType.String);
+    expect(shortCodeOption?.required).toBe(false);
   });
 });

--- a/tests/emojiResolver.service.test.ts
+++ b/tests/emojiResolver.service.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from "vitest";
 import type { Client } from "discord.js";
-import { EmojiResolverService } from "../src/services/emoji/EmojiResolverService";
+import {
+  EmojiResolverService,
+  isValidEmojiShortcodeName,
+  normalizeEmojiShortcodeName,
+  parseEmojiImageSource,
+} from "../src/services/emoji/EmojiResolverService";
 
 type FakeAppEmoji = {
   id: string;
@@ -64,6 +69,76 @@ function buildClientWithApplicationEmojis(
 }
 
 describe("EmojiResolverService", () => {
+  it("normalizes shortcode names by trimming and stripping surrounding colons", () => {
+    expect(normalizeEmojiShortcodeName("arrow_arrow")).toBe("arrow_arrow");
+    expect(normalizeEmojiShortcodeName(":arrow_arrow:")).toBe("arrow_arrow");
+    expect(normalizeEmojiShortcodeName("::arrow_arrow::")).toBe("arrow_arrow");
+  });
+
+  it("validates shortcode names using Discord-safe constraints", () => {
+    expect(isValidEmojiShortcodeName("arrow_arrow")).toBe(true);
+    expect(isValidEmojiShortcodeName("a")).toBe(false);
+    expect(isValidEmojiShortcodeName("bad-name")).toBe(false);
+  });
+
+  it("parses static custom emoji tokens into discord CDN image urls", () => {
+    const parsed = parseEmojiImageSource("<:arrow_arrow:123456789012345678>");
+
+    expect(parsed).toEqual({
+      ok: true,
+      sourceType: "custom_emoji_token",
+      imageUrl:
+        "https://cdn.discordapp.com/emojis/123456789012345678.png?quality=lossless",
+      customEmojiId: "123456789012345678",
+      animated: false,
+    });
+  });
+
+  it("parses animated custom emoji tokens into gif CDN image urls", () => {
+    const parsed = parseEmojiImageSource("<a:arrow_arrow:123456789012345678>");
+
+    expect(parsed).toEqual({
+      ok: true,
+      sourceType: "custom_emoji_token",
+      imageUrl:
+        "https://cdn.discordapp.com/emojis/123456789012345678.gif?quality=lossless",
+      customEmojiId: "123456789012345678",
+      animated: true,
+    });
+  });
+
+  it("parses direct image urls", () => {
+    const parsed = parseEmojiImageSource("https://example.com/icon.webp");
+
+    expect(parsed).toEqual({
+      ok: true,
+      sourceType: "direct_image_url",
+      imageUrl: "https://example.com/icon.webp",
+      customEmojiId: null,
+      animated: false,
+    });
+  });
+
+  it("rejects unsupported unicode emoji input for add-flow source parsing", () => {
+    const parsed = parseEmojiImageSource("🔥");
+
+    expect(parsed).toEqual({
+      ok: false,
+      sourceType: "unicode_emoji_unsupported",
+      code: "unsupported_unicode_emoji",
+    });
+  });
+
+  it("rejects random invalid image-source input", () => {
+    const parsed = parseEmojiImageSource("definitely-not-an-image-source");
+
+    expect(parsed).toEqual({
+      ok: false,
+      sourceType: "invalid_input",
+      code: "invalid_emoji_input",
+    });
+  });
+
   it("fetchApplicationEmojiInventory returns success with emojis", async () => {
     const resolver = new EmojiResolverService(0);
     const { client } = buildClientWithApplicationEmojis([

--- a/tests/emojiResolver.service.test.ts
+++ b/tests/emojiResolver.service.test.ts
@@ -165,6 +165,42 @@ describe("EmojiResolverService", () => {
     expect(resolved?.rendered).toBe("<:arrow_arrow:1>");
   });
 
+  it("normalizes colon-wrapped lookup names", async () => {
+    const resolver = new EmojiResolverService(0);
+    const { client } = buildClientWithApplicationEmojis([
+      buildFakeEmoji({ id: "1", name: "arrow_arrow" }),
+    ]);
+
+    const resolved = await resolver.resolveByName(client, ":arrow_arrow:");
+
+    expect(resolved?.rendered).toBe("<:arrow_arrow:1>");
+  });
+
+  it("returns null for not-found names while keeping failures distinct", async () => {
+    const resolver = new EmojiResolverService(0);
+    const { client } = buildClientWithApplicationEmojis([
+      buildFakeEmoji({ id: "1", name: "arrow_arrow" }),
+    ]);
+
+    await expect(resolver.resolveByName(client, "missing_name")).resolves.toBeNull();
+  });
+
+  it("throws a typed runtime error when emoji inventory is unavailable", async () => {
+    const resolver = new EmojiResolverService(0);
+    const fetchApplication = vi.fn().mockResolvedValue(undefined);
+    const client = buildClient({
+      application: {
+        fetch: fetchApplication,
+        emojis: {},
+      },
+    });
+
+    await expect(resolver.resolveByName(client, "arrow_arrow")).rejects.toMatchObject({
+      name: "EmojiResolverRuntimeError",
+      code: "application_emoji_manager_unavailable",
+    });
+  });
+
   it("replaces multiple shortcodes in one text body", async () => {
     const resolver = new EmojiResolverService(0);
     const { client } = buildClientWithApplicationEmojis([

--- a/tests/emojiResolver.service.test.ts
+++ b/tests/emojiResolver.service.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Client } from "discord.js";
+import { EmojiResolverService } from "../src/services/emoji/EmojiResolverService";
+
+type FakeAppEmoji = {
+  id: string;
+  name: string;
+  animated: boolean;
+  toString: () => string;
+};
+
+function buildFakeEmoji(input: {
+  id: string;
+  name: string;
+  animated?: boolean;
+}): FakeAppEmoji {
+  const animated = Boolean(input.animated);
+  return {
+    id: input.id,
+    name: input.name,
+    animated,
+    toString: () =>
+      `<${animated ? "a" : ""}:${input.name}:${input.id}>`,
+  };
+}
+
+function buildClientWithApplicationEmojis(
+  emojis: FakeAppEmoji[],
+): {
+  client: Client;
+  fetchApplication: ReturnType<typeof vi.fn>;
+  fetchEmojis: ReturnType<typeof vi.fn>;
+} {
+  const fetchEmojis = vi.fn().mockResolvedValue(
+    new Map(emojis.map((emoji) => [emoji.id, emoji])),
+  );
+  const fetchApplication = vi.fn().mockResolvedValue(undefined);
+  const client = {
+    application: {
+      fetch: fetchApplication,
+      emojis: {
+        fetch: fetchEmojis,
+      },
+    },
+  } as unknown as Client;
+  return { client, fetchApplication, fetchEmojis };
+}
+
+describe("EmojiResolverService", () => {
+  it("resolves exact-name match", async () => {
+    const resolver = new EmojiResolverService(0);
+    const { client } = buildClientWithApplicationEmojis([
+      buildFakeEmoji({ id: "1", name: "arrow_arrow" }),
+    ]);
+
+    const resolved = await resolver.resolveByName(client, "arrow_arrow");
+
+    expect(resolved?.shortcode).toBe(":arrow_arrow:");
+    expect(resolved?.rendered).toBe("<:arrow_arrow:1>");
+  });
+
+  it("resolves case-insensitive match", async () => {
+    const resolver = new EmojiResolverService(0);
+    const { client } = buildClientWithApplicationEmojis([
+      buildFakeEmoji({ id: "1", name: "arrow_arrow" }),
+    ]);
+
+    const resolved = await resolver.resolveByName(client, "ArRoW_ArRoW");
+
+    expect(resolved?.rendered).toBe("<:arrow_arrow:1>");
+  });
+
+  it("replaces multiple shortcodes in one text body", async () => {
+    const resolver = new EmojiResolverService(0);
+    const { client } = buildClientWithApplicationEmojis([
+      buildFakeEmoji({ id: "1", name: "arrow_arrow" }),
+      buildFakeEmoji({ id: "2", name: "check_mark" }),
+    ]);
+
+    const out = await resolver.replaceShortcodes(
+      client,
+      "Top :arrow_arrow: and :check_mark: done",
+    );
+
+    expect(out).toBe("Top <:arrow_arrow:1> and <:check_mark:2> done");
+  });
+
+  it("leaves unknown shortcodes unchanged", async () => {
+    const resolver = new EmojiResolverService(0);
+    const { client } = buildClientWithApplicationEmojis([
+      buildFakeEmoji({ id: "1", name: "arrow_arrow" }),
+    ]);
+
+    const out = await resolver.replaceShortcodes(
+      client,
+      "Known :arrow_arrow: unknown :not_real:",
+    );
+
+    expect(out).toBe("Known <:arrow_arrow:1> unknown :not_real:");
+  });
+
+  it("handles empty emoji collections", async () => {
+    const resolver = new EmojiResolverService(0);
+    const { client } = buildClientWithApplicationEmojis([]);
+
+    const list = await resolver.listApplicationEmojis(client);
+    const resolved = await resolver.resolveByName(client, "arrow_arrow");
+    const replaced = await resolver.replaceShortcodes(client, "Plan :arrow_arrow:");
+
+    expect(list).toEqual([]);
+    expect(resolved).toBeNull();
+    expect(replaced).toBe("Plan :arrow_arrow:");
+  });
+
+  it("keeps static and animated emoji render tokens as returned by Discord", async () => {
+    const resolver = new EmojiResolverService(0);
+    const { client } = buildClientWithApplicationEmojis([
+      buildFakeEmoji({ id: "1", name: "static_icon", animated: false }),
+      buildFakeEmoji({ id: "2", name: "animated_icon", animated: true }),
+    ]);
+
+    const staticResolved = await resolver.resolveByName(client, "static_icon");
+    const animatedResolved = await resolver.resolveByName(client, "animated_icon");
+
+    expect(staticResolved?.rendered).toBe("<:static_icon:1>");
+    expect(animatedResolved?.rendered).toBe("<a:animated_icon:2>");
+  });
+});

--- a/tests/emojiResolver.service.test.ts
+++ b/tests/emojiResolver.service.test.ts
@@ -9,6 +9,14 @@ type FakeAppEmoji = {
   toString: () => string;
 };
 
+type FakeApplication = {
+  fetch: ReturnType<typeof vi.fn>;
+  emojis?: {
+    fetch?: ReturnType<typeof vi.fn>;
+  };
+};
+
+/** Purpose: build deterministic fake app emoji objects with Discord-like string rendering. */
 function buildFakeEmoji(input: {
   id: string;
   name: string;
@@ -19,11 +27,18 @@ function buildFakeEmoji(input: {
     id: input.id,
     name: input.name,
     animated,
-    toString: () =>
-      `<${animated ? "a" : ""}:${input.name}:${input.id}>`,
+    toString: () => `<${animated ? "a" : ""}:${input.name}:${input.id}>`,
   };
 }
 
+/** Purpose: create a minimal fake client with configurable application + emoji fetch behavior. */
+function buildClient(input: { application: FakeApplication | null }): Client {
+  return {
+    application: input.application,
+  } as unknown as Client;
+}
+
+/** Purpose: build fake client/application that returns an emoji collection successfully. */
 function buildClientWithApplicationEmojis(
   emojis: FakeAppEmoji[],
 ): {
@@ -31,22 +46,102 @@ function buildClientWithApplicationEmojis(
   fetchApplication: ReturnType<typeof vi.fn>;
   fetchEmojis: ReturnType<typeof vi.fn>;
 } {
-  const fetchEmojis = vi.fn().mockResolvedValue(
-    new Map(emojis.map((emoji) => [emoji.id, emoji])),
-  );
+  const fetchEmojis = vi
+    .fn()
+    .mockResolvedValue(new Map(emojis.map((emoji) => [emoji.id, emoji])));
   const fetchApplication = vi.fn().mockResolvedValue(undefined);
-  const client = {
-    application: {
-      fetch: fetchApplication,
-      emojis: {
-        fetch: fetchEmojis,
-      },
+  const application: FakeApplication = {
+    fetch: fetchApplication,
+    emojis: {
+      fetch: fetchEmojis,
     },
-  } as unknown as Client;
-  return { client, fetchApplication, fetchEmojis };
+  };
+  return {
+    client: buildClient({ application }),
+    fetchApplication,
+    fetchEmojis,
+  };
 }
 
 describe("EmojiResolverService", () => {
+  it("fetchApplicationEmojiInventory returns success with emojis", async () => {
+    const resolver = new EmojiResolverService(0);
+    const { client } = buildClientWithApplicationEmojis([
+      buildFakeEmoji({ id: "2", name: "bravo" }),
+      buildFakeEmoji({ id: "1", name: "alpha" }),
+    ]);
+
+    const result = await resolver.fetchApplicationEmojiInventory(client, {
+      forceRefresh: true,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.snapshot.entries.map((entry) => entry.name)).toEqual([
+      "alpha",
+      "bravo",
+    ]);
+    expect(result.snapshot.exactByName.get("alpha")?.rendered).toBe("<:alpha:1>");
+    expect(result.snapshot.lowercaseByName.get("bravo")?.rendered).toBe(
+      "<:bravo:2>",
+    );
+  });
+
+  it("fetchApplicationEmojiInventory returns success with zero emojis", async () => {
+    const resolver = new EmojiResolverService(0);
+    const { client } = buildClientWithApplicationEmojis([]);
+
+    const result = await resolver.fetchApplicationEmojiInventory(client, {
+      forceRefresh: true,
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.snapshot.entries).toEqual([]);
+    expect(result.diagnostics.emojiFetchSucceeded).toBe(true);
+  });
+
+  it("fetchApplicationEmojiInventory returns manager-unavailable failure", async () => {
+    const resolver = new EmojiResolverService(0);
+    const fetchApplication = vi.fn().mockResolvedValue(undefined);
+    const client = buildClient({
+      application: {
+        fetch: fetchApplication,
+        emojis: {},
+      },
+    });
+
+    const result = await resolver.fetchApplicationEmojiInventory(client, {
+      forceRefresh: true,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.code).toBe("application_emoji_manager_unavailable");
+  });
+
+  it("fetchApplicationEmojiInventory returns fetch-failed failure", async () => {
+    const resolver = new EmojiResolverService(0);
+    const fetchApplication = vi.fn().mockResolvedValue(undefined);
+    const fetchEmojis = vi.fn().mockRejectedValue(new Error("boom"));
+    const client = buildClient({
+      application: {
+        fetch: fetchApplication,
+        emojis: {
+          fetch: fetchEmojis,
+        },
+      },
+    });
+
+    const result = await resolver.fetchApplicationEmojiInventory(client, {
+      forceRefresh: true,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.code).toBe("application_emoji_fetch_failed");
+  });
+
   it("resolves exact-name match", async () => {
     const resolver = new EmojiResolverService(0);
     const { client } = buildClientWithApplicationEmojis([
@@ -97,19 +192,6 @@ describe("EmojiResolverService", () => {
     );
 
     expect(out).toBe("Known <:arrow_arrow:1> unknown :not_real:");
-  });
-
-  it("handles empty emoji collections", async () => {
-    const resolver = new EmojiResolverService(0);
-    const { client } = buildClientWithApplicationEmojis([]);
-
-    const list = await resolver.listApplicationEmojis(client);
-    const resolved = await resolver.resolveByName(client, "arrow_arrow");
-    const replaced = await resolver.replaceShortcodes(client, "Plan :arrow_arrow:");
-
-    expect(list).toEqual([]);
-    expect(resolved).toBeNull();
-    expect(replaced).toBe("Plan :arrow_arrow:");
   });
 
   it("keeps static and animated emoji render tokens as returned by Discord", async () => {

--- a/tests/fwaSteadyStateLogs.logic.test.ts
+++ b/tests/fwaSteadyStateLogs.logic.test.ts
@@ -1,0 +1,186 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  resetFwaSteadyStateLogTrackersForTest,
+  resolveMatchTypeResolutionLogLevelForTest,
+  resolveRoutineBlockedPointsFetchSkipLogLevelForTest,
+} from "../src/commands/Fwa";
+import { SteadyStateLogGate } from "../src/helper/steadyStateLogGate";
+import {
+  buildTrackedClanWarsWatchSummaryKeyForTest,
+  resolveTrackedClanWarsWatchSummaryLogLevelForTest,
+} from "../src/services/fwa-feeds/FwaFeedSchedulerService";
+
+describe("fwa routine points-skip logging policy", () => {
+  beforeEach(() => {
+    resetFwaSteadyStateLogTrackersForTest();
+  });
+
+  it("demotes repeated validated_active_war_locked routine skips to debug", () => {
+    const first = resolveRoutineBlockedPointsFetchSkipLogLevelForTest({
+      guildId: "guild-1",
+      clanTag: "AAA111",
+      fetchReason: "mail_refresh",
+      outcome: "blocked",
+      decisionCode: "validated_active_war_locked",
+    });
+    const second = resolveRoutineBlockedPointsFetchSkipLogLevelForTest({
+      guildId: "guild-1",
+      clanTag: "AAA111",
+      fetchReason: "mail_refresh",
+      outcome: "blocked",
+      decisionCode: "validated_active_war_locked",
+    });
+
+    expect(first).toBe("info");
+    expect(second).toBe("debug");
+  });
+
+  it("keeps changed blocked-state events at info", () => {
+    const first = resolveRoutineBlockedPointsFetchSkipLogLevelForTest({
+      guildId: "guild-1",
+      clanTag: "AAA111",
+      fetchReason: "mail_refresh",
+      outcome: "blocked",
+      decisionCode: "validated_active_war_locked",
+    });
+    const changed = resolveRoutineBlockedPointsFetchSkipLogLevelForTest({
+      guildId: "guild-1",
+      clanTag: "AAA111",
+      fetchReason: "mail_refresh",
+      outcome: "blocked",
+      decisionCode: "policy_blocked",
+    });
+
+    expect(first).toBe("info");
+    expect(changed).toBe("info");
+  });
+});
+
+describe("fwa match-type logging policy", () => {
+  beforeEach(() => {
+    resetFwaSteadyStateLogTrackersForTest();
+  });
+
+  it("demotes repeated identical match-type confirmations to debug", () => {
+    const first = resolveMatchTypeResolutionLogLevelForTest({
+      stage: "mail_embed",
+      clanTag: "AAA111",
+      warId: 1001,
+      source: "confirmed_current_war",
+      matchType: "FWA",
+      inferred: false,
+      confirmed: true,
+    });
+    const second = resolveMatchTypeResolutionLogLevelForTest({
+      stage: "mail_embed",
+      clanTag: "AAA111",
+      warId: 1001,
+      source: "confirmed_current_war",
+      matchType: "FWA",
+      inferred: false,
+      confirmed: true,
+    });
+
+    expect(first).toBe("info");
+    expect(second).toBe("debug");
+  });
+
+  it("logs source/type/flag changes at info", () => {
+    resolveMatchTypeResolutionLogLevelForTest({
+      stage: "mail_embed",
+      clanTag: "AAA111",
+      warId: 1001,
+      source: "confirmed_current_war",
+      matchType: "FWA",
+      inferred: false,
+      confirmed: true,
+    });
+    const changedSource = resolveMatchTypeResolutionLogLevelForTest({
+      stage: "mail_embed",
+      clanTag: "AAA111",
+      warId: 1001,
+      source: "stored_sync",
+      matchType: "FWA",
+      inferred: true,
+      confirmed: false,
+    });
+    const changedType = resolveMatchTypeResolutionLogLevelForTest({
+      stage: "mail_embed",
+      clanTag: "AAA111",
+      warId: 1001,
+      source: "live_points_active_fwa_no",
+      matchType: "BL",
+      inferred: true,
+      confirmed: false,
+    });
+
+    expect(changedSource).toBe("info");
+    expect(changedType).toBe("info");
+  });
+});
+
+describe("tracked clan wars watch summary logging policy", () => {
+  it("keeps repeated empty/no-op watch summaries out of info", () => {
+    const summary = {
+      trackedClanCount: 9,
+      activeClanCount: 0,
+      polledClanCount: 0,
+      updateAcquiredCount: 0,
+    };
+
+    const gate = new SteadyStateLogGate();
+    const firstChanged = gate.shouldEmitInfo(
+      "tracked_clan_wars_watch",
+      buildTrackedClanWarsWatchSummaryKeyForTest(summary),
+    );
+    const secondChanged = gate.shouldEmitInfo(
+      "tracked_clan_wars_watch",
+      buildTrackedClanWarsWatchSummaryKeyForTest(summary),
+    );
+    const secondLevel = resolveTrackedClanWarsWatchSummaryLogLevelForTest({
+      summary,
+      summaryChanged: secondChanged,
+    });
+
+    expect(firstChanged).toBe(true);
+    expect(secondChanged).toBe(false);
+    expect(secondLevel).toBe("debug");
+  });
+
+  it("logs changed or non-empty watch summaries at info", () => {
+    const noOpSummary = {
+      trackedClanCount: 9,
+      activeClanCount: 0,
+      polledClanCount: 0,
+      updateAcquiredCount: 0,
+    };
+    const changedSummary = {
+      trackedClanCount: 9,
+      activeClanCount: 1,
+      polledClanCount: 1,
+      updateAcquiredCount: 0,
+    };
+    const gate = new SteadyStateLogGate();
+    gate.shouldEmitInfo(
+      "tracked_clan_wars_watch",
+      buildTrackedClanWarsWatchSummaryKeyForTest(noOpSummary),
+    );
+    const changed = gate.shouldEmitInfo(
+      "tracked_clan_wars_watch",
+      buildTrackedClanWarsWatchSummaryKeyForTest(changedSummary),
+    );
+
+    const changedLevel = resolveTrackedClanWarsWatchSummaryLogLevelForTest({
+      summary: noOpSummary,
+      summaryChanged: changed,
+    });
+    const nonEmptyLevel = resolveTrackedClanWarsWatchSummaryLogLevelForTest({
+      summary: changedSummary,
+      summaryChanged: false,
+    });
+
+    expect(changed).toBe(true);
+    expect(changedLevel).toBe("info");
+    expect(nonEmptyLevel).toBe("info");
+  });
+});

--- a/tests/interactionCreate.autocomplete.test.ts
+++ b/tests/interactionCreate.autocomplete.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Client } from "discord.js";
+import type { Command } from "../src/Command";
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+  vi.resetModules();
+});
+
+/** Purpose: register interactionCreate listener and return the bound interaction handler for tests. */
+async function loadInteractionHandler() {
+  const { default: registerInteractionCreate } = await import(
+    "../src/listeners/interactionCreate"
+  );
+  const handlers = new Map<string, (interaction: unknown) => Promise<void>>();
+  const client = {
+    on: vi.fn((event: string, callback: (interaction: unknown) => Promise<void>) => {
+      handlers.set(event, callback);
+    }),
+  } as unknown as Client;
+
+  registerInteractionCreate(client, {} as any);
+  const handler = handlers.get("interactionCreate");
+  if (!handler) {
+    throw new Error("interactionCreate listener was not registered");
+  }
+  return handler;
+}
+
+describe("interactionCreate autocomplete dispatch", () => {
+  it("dispatches autocomplete to the matching command handler", async () => {
+    const { Commands } = await import("../src/Commands");
+    const emojiCommand = Commands.find((cmd): cmd is Command => cmd.name === "emoji");
+    if (!emojiCommand) throw new Error("Could not find /emoji command");
+
+    const originalAutocomplete = emojiCommand.autocomplete;
+    const autocompleteMock = vi.fn().mockResolvedValue(undefined);
+    emojiCommand.autocomplete = autocompleteMock;
+
+    const handler = await loadInteractionHandler();
+    const interaction = {
+      commandName: "emoji",
+      isAutocomplete: () => true,
+      respond: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await handler(interaction as any);
+
+    expect(autocompleteMock).toHaveBeenCalledWith(interaction);
+    emojiCommand.autocomplete = originalAutocomplete;
+  });
+
+  it("responds with empty suggestions when command has no autocomplete handler", async () => {
+    const handler = await loadInteractionHandler();
+    const interaction = {
+      commandName: "post",
+      isAutocomplete: () => true,
+      respond: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await handler(interaction as any);
+
+    expect(interaction.respond).toHaveBeenCalledWith([]);
+  });
+});

--- a/tests/warMailLifecycle.service.test.ts
+++ b/tests/warMailLifecycle.service.test.ts
@@ -171,5 +171,88 @@ describe("WarMailLifecycleService", () => {
     expect(result.status).toBe("posted");
     expect(result.debug.reconciliationOutcome).toBe("channel_inaccessible");
   });
+
+  it("logs POSTED at info for first lifecycle transition", async () => {
+    const findSpy = vi.spyOn(prisma.warMailLifecycle, "findUnique").mockResolvedValueOnce(null as never);
+    const upsertSpy = vi.spyOn(prisma.warMailLifecycle, "upsert").mockResolvedValueOnce({} as never);
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
+    const service = new WarMailLifecycleService();
+
+    await service.markPosted({
+      guildId: "guild-1",
+      clanTag: "AAA111",
+      warId: 1001,
+      channelId: "123",
+      messageId: "456",
+    });
+
+    expect(findSpy).toHaveBeenCalledTimes(1);
+    expect(upsertSpy).toHaveBeenCalledTimes(1);
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    expect(String(infoSpy.mock.calls[0]?.[0] ?? "")).toContain("status=POSTED");
+    expect(debugSpy).not.toHaveBeenCalled();
+  });
+
+  it("does not repeat POSTED info for no-op upserts with same message identity", async () => {
+    vi.spyOn(prisma.warMailLifecycle, "findUnique").mockResolvedValueOnce({
+      guildId: "guild-1",
+      clanTag: "#AAA111",
+      warId: 1001,
+      status: "POSTED",
+      channelId: "123",
+      messageId: "456",
+      postedAt: new Date(),
+      deletedAt: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as never);
+    vi.spyOn(prisma.warMailLifecycle, "upsert").mockResolvedValueOnce({} as never);
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
+    const service = new WarMailLifecycleService();
+
+    await service.markPosted({
+      guildId: "guild-1",
+      clanTag: "AAA111",
+      warId: 1001,
+      channelId: "123",
+      messageId: "456",
+    });
+
+    expect(infoSpy).not.toHaveBeenCalled();
+    expect(debugSpy).toHaveBeenCalledTimes(1);
+    expect(String(debugSpy.mock.calls[0]?.[0] ?? "")).toContain("status=POSTED");
+  });
+
+  it("logs POSTED info when posted message identity changes", async () => {
+    vi.spyOn(prisma.warMailLifecycle, "findUnique").mockResolvedValueOnce({
+      guildId: "guild-1",
+      clanTag: "#AAA111",
+      warId: 1001,
+      status: "POSTED",
+      channelId: "123",
+      messageId: "old-message",
+      postedAt: new Date(),
+      deletedAt: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as never);
+    vi.spyOn(prisma.warMailLifecycle, "upsert").mockResolvedValueOnce({} as never);
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
+    const service = new WarMailLifecycleService();
+
+    await service.markPosted({
+      guildId: "guild-1",
+      clanTag: "AAA111",
+      warId: 1001,
+      channelId: "123",
+      messageId: "new-message",
+    });
+
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    expect(debugSpy).not.toHaveBeenCalled();
+  });
 });
 

--- a/tests/warPlanEmojiNormalization.logic.test.ts
+++ b/tests/warPlanEmojiNormalization.logic.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Client } from "discord.js";
+import { resolveWarPlanEmojiShortcodesForTest } from "../src/commands/WarPlan";
+import { EmojiResolverService } from "../src/services/emoji/EmojiResolverService";
+
+describe("warplan emoji shortcode normalization", () => {
+  it("uses shared emoji resolver service for shortcode replacement", async () => {
+    const replaceShortcodes = vi
+      .fn()
+      .mockResolvedValue("Plan <:arrow_arrow:123>");
+    const client = {} as Client;
+    const out = await resolveWarPlanEmojiShortcodesForTest({
+      text: "Plan :arrow_arrow:",
+      client,
+      resolver: { replaceShortcodes } as any,
+    });
+
+    expect(replaceShortcodes).toHaveBeenCalledWith(
+      client,
+      "Plan :arrow_arrow:",
+    );
+    expect(out).toBe("Plan <:arrow_arrow:123>");
+  });
+
+  it("preserves unknown shortcodes", async () => {
+    const resolver = new EmojiResolverService(0);
+    const client = {
+      application: {
+        fetch: vi.fn().mockResolvedValue(undefined),
+        emojis: {
+          fetch: vi.fn().mockResolvedValue(new Map()),
+        },
+      },
+    } as unknown as Client;
+
+    const out = await resolveWarPlanEmojiShortcodesForTest({
+      text: "Unknown stays :not_real:",
+      client,
+      resolver,
+    });
+
+    expect(out).toBe("Unknown stays :not_real:");
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -22,64 +22,77 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@discordjs/builders@^1.6.3":
-  version "1.6.3"
-  resolved "https://registry.npmjs.org/@discordjs/builders/-/builders-1.6.3.tgz"
-  integrity sha512-CTCh8NqED3iecTNuiz49mwSsrc2iQb4d0MjMdmS/8pb69Y4IlzJ/DIy/p5GFlgOrFbNO2WzMHkWKQSiJ3VNXaw==
+"@discordjs/builders@^1.13.0":
+  version "1.13.1"
+  resolved "https://registry.npmjs.org/@discordjs/builders/-/builders-1.13.1.tgz"
+  integrity sha512-cOU0UDHc3lp/5nKByDxkmRiNZBpdp0kx55aarbiAfakfKJHlxv/yFW1zmIqCAmwH5CRlrH9iMFKJMpvW4DPB+w==
   dependencies:
-    "@discordjs/formatters" "^0.3.1"
-    "@discordjs/util" "^0.3.1"
-    "@sapphire/shapeshift" "^3.8.2"
-    discord-api-types "^0.37.41"
+    "@discordjs/formatters" "^0.6.2"
+    "@discordjs/util" "^1.2.0"
+    "@sapphire/shapeshift" "^4.0.0"
+    discord-api-types "^0.38.33"
     fast-deep-equal "^3.1.3"
-    ts-mixer "^6.0.3"
-    tslib "^2.5.0"
+    ts-mixer "^6.0.4"
+    tslib "^2.6.3"
 
-"@discordjs/collection@^1.5.1":
-  version "1.5.1"
-  resolved "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.1.tgz"
-  integrity sha512-aWEc9DCf3TMDe9iaJoOnO2+JVAjeRNuRxPZQA6GVvBf+Z3gqUuWYBy2NWh4+5CLYq5uoc3MOvUQ5H5m8CJBqOA==
+"@discordjs/collection@^2.1.0":
+  version "2.1.1"
+  resolved "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz"
+  integrity sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==
 
-"@discordjs/formatters@^0.3.1":
-  version "0.3.1"
-  resolved "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.3.1.tgz"
-  integrity sha512-M7X4IGiSeh4znwcRGcs+49B5tBkNDn4k5bmhxJDAUhRxRHTiFAOTVUNQ6yAKySu5jZTnCbSvTYHW3w0rAzV1MA==
+"@discordjs/collection@^2.1.1":
+  version "2.1.1"
+  resolved "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz"
+  integrity sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==
+
+"@discordjs/collection@1.5.3":
+  version "1.5.3"
+  resolved "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.3.tgz"
+  integrity sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==
+
+"@discordjs/formatters@^0.6.2":
+  version "0.6.2"
+  resolved "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.6.2.tgz"
+  integrity sha512-y4UPwWhH6vChKRkGdMB4odasUbHOUwy7KL+OVwF86PvT6QVOwElx+TiI1/6kcmcEe+g5YRXJFiXSXUdabqZOvQ==
   dependencies:
-    discord-api-types "^0.37.41"
+    discord-api-types "^0.38.33"
 
-"@discordjs/rest@^1.7.1":
-  version "1.7.1"
-  resolved "https://registry.npmjs.org/@discordjs/rest/-/rest-1.7.1.tgz"
-  integrity sha512-Ofa9UqT0U45G/eX86cURQnX7gzOJLG2oC28VhIk/G6IliYgQF7jFByBJEykPSHE4MxPhqCleYvmsrtfKh1nYmQ==
+"@discordjs/rest@^2.5.1", "@discordjs/rest@^2.6.0":
+  version "2.6.0"
+  resolved "https://registry.npmjs.org/@discordjs/rest/-/rest-2.6.0.tgz"
+  integrity sha512-RDYrhmpB7mTvmCKcpj+pc5k7POKszS4E2O9TYc+U+Y4iaCP+r910QdO43qmpOja8LRr1RJ0b3U+CqVsnPqzf4w==
   dependencies:
-    "@discordjs/collection" "^1.5.1"
-    "@discordjs/util" "^0.3.0"
-    "@sapphire/async-queue" "^1.5.0"
-    "@sapphire/snowflake" "^3.4.2"
-    discord-api-types "^0.37.41"
-    file-type "^18.3.0"
-    tslib "^2.5.0"
-    undici "^5.22.0"
+    "@discordjs/collection" "^2.1.1"
+    "@discordjs/util" "^1.1.1"
+    "@sapphire/async-queue" "^1.5.3"
+    "@sapphire/snowflake" "^3.5.3"
+    "@vladfrangu/async_event_emitter" "^2.4.6"
+    discord-api-types "^0.38.16"
+    magic-bytes.js "^1.10.0"
+    tslib "^2.6.3"
+    undici "6.21.3"
 
-"@discordjs/util@^0.3.0", "@discordjs/util@^0.3.1":
-  version "0.3.1"
-  resolved "https://registry.npmjs.org/@discordjs/util/-/util-0.3.1.tgz"
-  integrity sha512-HxXKYKg7vohx2/OupUN/4Sd02Ev3PBJ5q0gtjdcvXb0ErCva8jNHWfe/v5sU3UKjIB/uxOhc+TDOnhqffj9pRA==
-
-"@discordjs/ws@^0.8.3":
-  version "0.8.3"
-  resolved "https://registry.npmjs.org/@discordjs/ws/-/ws-0.8.3.tgz"
-  integrity sha512-hcYtppanjHecbdNyCKQNH2I4RP9UrphDgmRgLYrATEQF1oo4sYSve7ZmGsBEXSzH72MO2tBPdWSThunbxUVk0g==
+"@discordjs/util@^1.1.0", "@discordjs/util@^1.1.1", "@discordjs/util@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.npmjs.org/@discordjs/util/-/util-1.2.0.tgz"
+  integrity sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg==
   dependencies:
-    "@discordjs/collection" "^1.5.1"
-    "@discordjs/rest" "^1.7.1"
-    "@discordjs/util" "^0.3.1"
-    "@sapphire/async-queue" "^1.5.0"
-    "@types/ws" "^8.5.4"
-    "@vladfrangu/async_event_emitter" "^2.2.1"
-    discord-api-types "^0.37.41"
-    tslib "^2.5.0"
-    ws "^8.13.0"
+    discord-api-types "^0.38.33"
+
+"@discordjs/ws@^1.2.3":
+  version "1.2.3"
+  resolved "https://registry.npmjs.org/@discordjs/ws/-/ws-1.2.3.tgz"
+  integrity sha512-wPlQDxEmlDg5IxhJPuxXr3Vy9AjYq5xCvFWGJyD7w7Np8ZGu+Mc+97LCoEc/+AYCo2IDpKioiH0/c/mj5ZR9Uw==
+  dependencies:
+    "@discordjs/collection" "^2.1.0"
+    "@discordjs/rest" "^2.5.1"
+    "@discordjs/util" "^1.1.0"
+    "@sapphire/async-queue" "^1.5.2"
+    "@types/ws" "^8.5.10"
+    "@vladfrangu/async_event_emitter" "^2.2.4"
+    discord-api-types "^0.38.1"
+    tslib "^2.6.2"
+    ws "^8.17.0"
 
 "@esbuild/win32-x64@0.21.5":
   version "0.21.5"
@@ -263,33 +276,28 @@
   resolved "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz"
   integrity sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==
 
-"@sapphire/async-queue@^1.5.0":
-  version "1.5.0"
-  resolved "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.0.tgz"
-  integrity sha512-JkLdIsP8fPAdh9ZZjrbHWR/+mZj0wvKS5ICibcLrRI1j84UmLMshx5n9QmL8b95d4onJ2xxiyugTgSAX7AalmA==
+"@sapphire/async-queue@^1.5.2", "@sapphire/async-queue@^1.5.3":
+  version "1.5.5"
+  resolved "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.5.tgz"
+  integrity sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==
 
-"@sapphire/shapeshift@^3.8.2":
-  version "3.9.2"
-  resolved "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-3.9.2.tgz"
-  integrity sha512-YRbCXWy969oGIdqR/wha62eX8GNHsvyYi0Rfd4rNW6tSVVa8p0ELiMEuOH/k8rgtvRoM+EMV7Csqz77YdwiDpA==
+"@sapphire/shapeshift@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-4.0.0.tgz"
+  integrity sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==
   dependencies:
     fast-deep-equal "^3.1.3"
     lodash "^4.17.21"
 
-"@sapphire/snowflake@^3.4.2":
-  version "3.5.1"
-  resolved "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.1.tgz"
-  integrity sha512-BxcYGzgEsdlG0dKAyOm0ehLGm2CafIrfQTZGWgkfKYbj+pNNsorZ7EotuZukc2MT70E0UbppVbtpBrqpzVzjNA==
+"@sapphire/snowflake@^3.5.3", "@sapphire/snowflake@3.5.3":
+  version "3.5.3"
+  resolved "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.3.tgz"
+  integrity sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==
 
 "@sinclair/typebox@^0.27.8":
   version "0.27.10"
   resolved "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz"
   integrity sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==
-
-"@tokenizer/token@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz"
-  integrity sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==
 
 "@tsconfig/node10@^1.0.7":
   version "1.0.9"
@@ -346,10 +354,10 @@
   resolved "https://registry.npmjs.org/@types/semver/-/semver-7.7.1.tgz"
   integrity sha512-FmgJfu+MOcQ370SD0ev7EI8TlCAfKYU+B4m5T3yXc1CiRN94g/SZPtsCkk506aUDtlMnFZvasDwHHUcZUEaYuA==
 
-"@types/ws@^8.5.4":
-  version "8.5.5"
-  resolved "https://registry.npmjs.org/@types/ws/-/ws-8.5.5.tgz"
-  integrity sha512-lwhs8hktwxSjf9UaZ9tG5M03PGogvFaH8gUgLNbN9HKIg0dvv6q+gkSuJ8HN4/VbyxkuLzCjlN7GquQ0gUJfIg==
+"@types/ws@^8.5.10":
+  version "8.18.1"
+  resolved "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz"
+  integrity sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==
   dependencies:
     "@types/node" "*"
 
@@ -504,10 +512,10 @@
     loupe "^2.3.6"
     pretty-format "^29.5.0"
 
-"@vladfrangu/async_event_emitter@^2.2.1":
-  version "2.2.2"
-  resolved "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.2.2.tgz"
-  integrity sha512-HIzRG7sy88UZjBJamssEczH5q7t5+axva19UbZLO6u0ySbYPrwzWiXBcC0WuHyhKKoeCyneH+FvYzKQq/zTtkQ==
+"@vladfrangu/async_event_emitter@^2.2.4", "@vladfrangu/async_event_emitter@^2.4.6":
+  version "2.4.7"
+  resolved "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.7.tgz"
+  integrity sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==
 
 acorn-jsx@^5.3.2:
   version "5.3.2"
@@ -624,13 +632,6 @@ braces@^3.0.3, braces@~3.0.2:
   integrity sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==
   dependencies:
     fill-range "^7.1.1"
-
-busboy@^1.6.0:
-  version "1.6.0"
-  resolved "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz"
-  integrity sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==
-  dependencies:
-    streamsearch "^1.1.0"
 
 cac@^6.7.14:
   version "6.7.14"
@@ -789,30 +790,29 @@ dir-glob@^3.0.1:
   dependencies:
     path-type "^4.0.0"
 
-discord-api-types@^0.37.41:
-  version "0.37.49"
-  resolved "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.49.tgz"
-  integrity sha512-a2vvjgmE/1cPtXOuOh5zHlLe+qheu0uO625K+FyZVFomoCmpV1xNpadC48S98K30CnQ4/XJyFGnOZLXxAyBbCQ==
+discord-api-types@^0.38.1, discord-api-types@^0.38.16, discord-api-types@^0.38.33:
+  version "0.38.42"
+  resolved "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.42.tgz"
+  integrity sha512-qs1kya7S84r5RR8m9kgttywGrmmoHaRifU1askAoi+wkoSefLpZP6aGXusjNw5b0jD3zOg3LTwUa3Tf2iHIceQ==
 
-discord.js@^14.11.0:
-  version "14.11.0"
-  resolved "https://registry.npmjs.org/discord.js/-/discord.js-14.11.0.tgz"
-  integrity sha512-CkueWYFQ28U38YPR8HgsBR/QT35oPpMbEsTNM30Fs8loBIhnA4s70AwQEoy6JvLcpWWJO7GY0y2BUzZmuBMepQ==
+discord.js@^14.25.1:
+  version "14.25.1"
+  resolved "https://registry.npmjs.org/discord.js/-/discord.js-14.25.1.tgz"
+  integrity sha512-2l0gsPOLPs5t6GFZfQZKnL1OJNYFcuC/ETWsW4VtKVD/tg4ICa9x+jb9bkPffkMdRpRpuUaO/fKkHCBeiCKh8g==
   dependencies:
-    "@discordjs/builders" "^1.6.3"
-    "@discordjs/collection" "^1.5.1"
-    "@discordjs/formatters" "^0.3.1"
-    "@discordjs/rest" "^1.7.1"
-    "@discordjs/util" "^0.3.1"
-    "@discordjs/ws" "^0.8.3"
-    "@sapphire/snowflake" "^3.4.2"
-    "@types/ws" "^8.5.4"
-    discord-api-types "^0.37.41"
-    fast-deep-equal "^3.1.3"
-    lodash.snakecase "^4.1.1"
-    tslib "^2.5.0"
-    undici "^5.22.0"
-    ws "^8.13.0"
+    "@discordjs/builders" "^1.13.0"
+    "@discordjs/collection" "1.5.3"
+    "@discordjs/formatters" "^0.6.2"
+    "@discordjs/rest" "^2.6.0"
+    "@discordjs/util" "^1.2.0"
+    "@discordjs/ws" "^1.2.3"
+    "@sapphire/snowflake" "3.5.3"
+    discord-api-types "^0.38.33"
+    fast-deep-equal "3.1.3"
+    lodash.snakecase "4.1.1"
+    magic-bytes.js "^1.10.0"
+    tslib "^2.6.3"
+    undici "6.21.3"
 
 doctrine@^3.0.0:
   version "3.0.0"
@@ -986,7 +986,7 @@ esutils@^2.0.2:
   resolved "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
-fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
+fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3, fast-deep-equal@3.1.3:
   version "3.1.3"
   resolved "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
@@ -1025,15 +1025,6 @@ file-entry-cache@^6.0.1:
   integrity sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==
   dependencies:
     flat-cache "^3.0.4"
-
-file-type@^18.3.0:
-  version "18.5.0"
-  resolved "https://registry.npmjs.org/file-type/-/file-type-18.5.0.tgz"
-  integrity sha512-yvpl5U868+V6PqXHMmsESpg6unQ5GfnPssl4dxdJudBrr9qy7Fddt7EVX1VLlddFfe8Gj9N7goCZH22FXuSQXQ==
-  dependencies:
-    readable-web-to-node-stream "^3.0.2"
-    strtok3 "^7.0.0"
-    token-types "^5.0.1"
 
 fill-range@^7.1.1:
   version "7.1.1"
@@ -1208,11 +1199,6 @@ html-escaper@^2.0.0:
   resolved "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz"
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
 
-ieee754@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz"
-  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
-
 ignore-by-default@^1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz"
@@ -1244,7 +1230,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@^2.0.3, inherits@2:
+inherits@2:
   version "2.0.4"
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -1373,15 +1359,15 @@ lodash.merge@^4.6.2:
   resolved "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash.snakecase@^4.1.1:
+lodash.snakecase@4.1.1:
   version "4.1.1"
   resolved "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz"
   integrity sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==
 
 lodash@^4.17.21:
-  version "4.17.21"
-  resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+  version "4.17.23"
+  resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz"
+  integrity sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==
 
 loupe@^2.3.6:
   version "2.3.7"
@@ -1389,6 +1375,11 @@ loupe@^2.3.6:
   integrity sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==
   dependencies:
     get-func-name "^2.0.1"
+
+magic-bytes.js@^1.10.0:
+  version "1.13.0"
+  resolved "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.13.0.tgz"
+  integrity sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg==
 
 magic-string@^0.30.1:
   version "0.30.21"
@@ -1593,11 +1584,6 @@ pathval@^1.1.1:
   resolved "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz"
   integrity sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==
 
-peek-readable@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.npmjs.org/peek-readable/-/peek-readable-5.0.0.tgz"
-  integrity sha512-YtCKvLUOvwtMGmrniQPdO7MwPjgkFBtFIrmfSbYmYuq3tKDV/mcfAhBth1+C3ru7uXIZasc/pHnb+YDYNkkj4A==
-
 picocolors@^1.0.0, picocolors@^1.1.1:
   version "1.1.1"
   resolved "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz"
@@ -1684,22 +1670,6 @@ react-is@^18.0.0:
   resolved "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz"
   integrity sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==
 
-readable-stream@^3.6.0:
-  version "3.6.2"
-  resolved "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz"
-  integrity sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==
-  dependencies:
-    inherits "^2.0.3"
-    string_decoder "^1.1.1"
-    util-deprecate "^1.0.1"
-
-readable-web-to-node-stream@^3.0.2:
-  version "3.0.2"
-  resolved "https://registry.npmjs.org/readable-web-to-node-stream/-/readable-web-to-node-stream-3.0.2.tgz"
-  integrity sha512-ePeK6cc1EcKLEhJFt/AebMCLL+GgSKhuygrZ/GLaKZYEecIgIECf4UaUuaByiGtzckwR4ain9VzUh95T1exYGw==
-  dependencies:
-    readable-stream "^3.6.0"
-
 readdirp@~3.6.0:
   version "3.6.0"
   resolved "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz"
@@ -1765,11 +1735,6 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
-safe-buffer@~5.2.0:
-  version "5.2.1"
-  resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz"
-  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
-
 semver@^7.5.3, semver@^7.5.4:
   version "7.7.3"
   resolved "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz"
@@ -1824,18 +1789,6 @@ std-env@^3.3.3:
   resolved "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz"
   integrity sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==
 
-streamsearch@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz"
-  integrity sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
-
-string_decoder@^1.1.1:
-  version "1.3.0"
-  resolved "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz"
-  integrity sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
-  dependencies:
-    safe-buffer "~5.2.0"
-
 strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz"
@@ -1854,14 +1807,6 @@ strip-literal@^1.0.1:
   integrity sha512-PugKzOsyXpArk0yWmUwqOZecSO0GH0bPoctLcqNDH9J04pVW3lflYE0ujElBGTloevcxF5MofAOZ7C5l2b+wLg==
   dependencies:
     acorn "^8.10.0"
-
-strtok3@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.npmjs.org/strtok3/-/strtok3-7.0.0.tgz"
-  integrity sha512-pQ+V+nYQdC5H3Q7qBZAz/MO6lwGhoC2gOAjuouGf/VO0m7vQRh8QNMl2Uf6SwAtzZ9bOw3UIeBukEGNJl5dtXQ==
-  dependencies:
-    "@tokenizer/token" "^0.3.0"
-    peek-readable "^5.0.0"
 
 supports-color@^5.5.0:
   version "5.5.0"
@@ -1913,14 +1858,6 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
-token-types@^5.0.1:
-  version "5.0.1"
-  resolved "https://registry.npmjs.org/token-types/-/token-types-5.0.1.tgz"
-  integrity sha512-Y2fmSnZjQdDb9W4w4r1tswlMHylzWIeOKpx0aZH9BgGtACHhrk3OkT52AzwcuqTRBZtvvnTjDBh8eynMulu8Vg==
-  dependencies:
-    "@tokenizer/token" "^0.3.0"
-    ieee754 "^1.2.1"
-
 touch@^3.1.0:
   version "3.1.1"
   resolved "https://registry.npmjs.org/touch/-/touch-3.1.1.tgz"
@@ -1936,10 +1873,10 @@ ts-api-utils@^1.0.1:
   resolved "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz"
   integrity sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==
 
-ts-mixer@^6.0.3:
-  version "6.0.3"
-  resolved "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.3.tgz"
-  integrity sha512-k43M7uCG1AkTyxgnmI5MPwKoUvS/bRvLvUb7+Pgpdlmok8AoqmUaZxUUw8zKM5B1lqZrt41GjYgnvAi0fppqgQ==
+ts-mixer@^6.0.4:
+  version "6.0.4"
+  resolved "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz"
+  integrity sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA==
 
 ts-node@^10.9.2:
   version "10.9.2"
@@ -1960,10 +1897,10 @@ ts-node@^10.9.2:
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
 
-tslib@^2.5.0:
-  version "2.6.0"
-  resolved "https://registry.npmjs.org/tslib/-/tslib-2.6.0.tgz"
-  integrity sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==
+tslib@^2.6.2, tslib@^2.6.3:
+  version "2.8.1"
+  resolved "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
@@ -1997,12 +1934,10 @@ undefsafe@^2.0.5:
   resolved "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz"
   integrity sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==
 
-undici@^5.22.0:
-  version "5.22.1"
-  resolved "https://registry.npmjs.org/undici/-/undici-5.22.1.tgz"
-  integrity sha512-Ji2IJhFXZY0x/0tVBXeQwgPlLWw13GVzpsWPQ3rV50IFMMof2I55PZZxtm4P6iNq+L5znYN9nSTAq0ZyE6lSJw==
-  dependencies:
-    busboy "^1.6.0"
+undici@6.21.3:
+  version "6.21.3"
+  resolved "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz"
+  integrity sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==
 
 uri-js@^4.2.2:
   version "4.4.1"
@@ -2010,11 +1945,6 @@ uri-js@^4.2.2:
   integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
-
-util-deprecate@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
-  integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
 
 v8-compile-cache-lib@^3.0.1:
   version "3.0.1"
@@ -2121,10 +2051,10 @@ wrappy@1:
   resolved "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
   integrity sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==
 
-ws@^8.13.0:
-  version "8.13.0"
-  resolved "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz"
-  integrity sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==
+ws@^8.17.0:
+  version "8.19.0"
+  resolved "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz"
+  integrity sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==
 
 yn@3.1.1:
   version "3.1.1"


### PR DESCRIPTION
## Summary
This PR adds a new `/emoji` command with shared application-emoji resolution, improves warplan emoji shortcode handling, reduces steady-state log noise in FWA/mail flows, and includes a few Discord.js compatibility/type-safety updates.

## Highlights

### New `/emoji` command
Adds a new top-level `/emoji` command with four main behaviors:

- Browse all bot application emojis in a paginated view
- Resolve one emoji by shortcode/name
- React to a message in the current channel using a resolved bot emoji
- Add a new bot application emoji from either:
  - a custom emoji token
  - or a direct image URL

Key details:
- Name-based resolution is environment-safe, so staging/prod can use the same shortcode even if emoji IDs differ
- Supports autocomplete for emoji names
- Public/private visibility behavior is respected
- Add mode is admin-only by default via command permissions

Files:
- `src/commands/Emoji.ts`
- `src/services/emoji/EmojiResolverService.ts`
- `src/Commands.ts`
- `src/services/CommandPermissionService.ts`
- `docs/commands.md`

---

### Shared emoji resolver for warplan shortcode normalization
Warplan modal text now uses a shared application-emoji resolver instead of local guild/client emoji lookup logic.

What changed:
- Replaced inline custom shortcode replacement logic in `WarPlan.ts`
- Added shared resolver service usage for `:emoji_name:` normalization
- Makes warplan emoji resolution consistent with the new `/emoji` system
- Better supports cross-environment stability by resolving bot application emojis by name

Files:
- `src/commands/WarPlan.ts`
- `src/services/emoji/EmojiResolverService.ts`

---

### Reduced steady-state log noise
Introduces a reusable steady-state log gate to suppress repeated info logs and demote unchanged/repeated state to debug.

Applied in:
- FWA match-type resolution logging
- Routine blocked points-fetch skip logging
- FWA tracked clan wars watch summaries
- War mail lifecycle POSTED reassertions

Net effect:
- First transition/state change still logs at info
- Repeated unchanged states become debug
- Cleaner deploy/runtime logs without losing signal on real changes

Files:
- `src/helper/steadyStateLogGate.ts`
- `src/commands/Fwa.ts`
- `src/services/WarMailLifecycleService.ts`
- `src/services/fwa-feeds/FwaFeedSchedulerService.ts`

---

### Startup/runtime diagnostics for Discord application emoji support
Adds startup diagnostics to confirm whether the runtime supports application emoji fetches and whether the bot application fetch succeeded.

Useful for:
- Validating `/emoji` readiness
- Debugging staging/prod differences
- Confirming Discord.js/application emoji availability at startup

Files:
- `src/listeners/ready.ts`

---

### Discord.js upgrade and related compatibility updates
Upgrades `discord.js` and adjusts a few types/usages for compatibility and safer command handling.

Changes include:
- `discord.js` bump from `^14.11.0` to `^14.25.1`
- Type updates in `Compo.ts`
- Safer interaction option reads in `Inactive.ts`
- Safer channel send handling in `RoleUsers.ts`

Files:
- `package.json`
- `package-lock.json`
- `yarn.lock`
- `src/commands/Compo.ts`
- `src/commands/Inactive.ts`
- `src/commands/RoleUsers.ts`

## Testing
Added/updated tests for:
- `/emoji` command behavior
- `/emoji` command shape
- Emoji resolver service
- Warplan emoji normalization
- FWA steady-state log behavior
- Interaction autocomplete coverage
- War mail lifecycle logging behavior

Files:
- `tests/emoji.command.test.ts`
- `tests/emoji.commandShape.test.ts`
- `tests/emojiResolver.service.test.ts`
- `tests/warPlanEmojiNormalization.logic.test.ts`
- `tests/fwaSteadyStateLogs.logic.test.ts`
- `tests/interactionCreate.autocomplete.test.ts`
- `tests/warMailLifecycle.service.test.ts`

## Notes
- No Prisma/schema changes detected in this diff
- No migration files included
- Main functional additions are command/service/runtime behavior changes

## Changed files overview
- `docs/commands.md`
- `package.json`
- `package-lock.json`
- `yarn.lock`
- `src/Commands.ts`
- `src/commands/Emoji.ts`
- `src/commands/Fwa.ts`
- `src/commands/Help.ts`
- `src/commands/WarPlan.ts`
- `src/commands/Compo.ts`
- `src/commands/Inactive.ts`
- `src/commands/RoleUsers.ts`
- `src/helper/steadyStateLogGate.ts`
- `src/listeners/ready.ts`
- `src/services/CommandPermissionService.ts`
- `src/services/WarMailLifecycleService.ts`
- `src/services/emoji/EmojiResolverService.ts`
- `src/services/fwa-feeds/FwaFeedSchedulerService.ts`

## Risk / review focus
Suggested review focus:
- `/emoji` add flow and permission gating
- Application emoji fetch/create behavior in staging/prod
- Warplan shortcode replacement behavior in modal submit flow
- Logging changes to ensure important operational signals are still visible
- Discord.js version bump compatibility