### PR TITLE
feat(fwa): add current-war phase timing to base-swap post

### DIFF
--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -240,6 +240,7 @@ type FwaBaseSwapAnnouncementState = {
   createdByUserId: string;
   entries: FwaBaseSwapAnnouncementEntry[];
   layoutLinks?: FwaBaseSwapLayoutLink[];
+  phaseTimingLine?: string | null;
   createdAtIso: string;
 };
 
@@ -377,10 +378,25 @@ function renderBaseSwapLayoutLinkLine(link: FwaBaseSwapLayoutLink): string {
   return `## ${FWA_BASE_SWAP_LAYOUT_BULLET} TH${link.townhall} Link: ${wrapDiscordLink(link.layoutLink)}`;
 }
 
+function buildFwaBaseSwapPhaseTimingLine(input: {
+  warState: WarStateForSync;
+  prepEndMs: number | null;
+  warEndMs: number | null;
+}): string | null {
+  if (input.warState !== "preparation" && input.warState !== "inWar") {
+    return null;
+  }
+  const targetMs =
+    input.warState === "preparation" ? input.prepEndMs : input.warEndMs;
+  if (targetMs === null || !Number.isFinite(targetMs)) return null;
+  return `## ${mailStatusLabelForState(input.warState)} ends ${formatDiscordFullAndRelativeMs(targetMs)}`;
+}
+
 function renderFwaBaseSwapAnnouncement(
   state: {
     entries: FwaBaseSwapAnnouncementEntry[];
     layoutLinks?: FwaBaseSwapLayoutLink[];
+    phaseTimingLine?: string | null;
   },
 ): string {
   const warBaseLines = state.entries
@@ -419,6 +435,9 @@ function renderFwaBaseSwapAnnouncement(
     parts.push("", "──────────────────────────────────");
     if (layoutLinkLines.length > 0) {
       parts.push("", ...layoutLinkLines);
+    }
+    if (state.phaseTimingLine) {
+      parts.push("", state.phaseTimingLine);
     }
     parts.push("", `👇 React with ${FWA_BASE_SWAP_ACK_EMOJI} once your base is fixed.`);
   }
@@ -6503,6 +6522,8 @@ export const getMailBlockedReasonFromStatusForTest =
 export const collectBaseSwapTownhallLevelsForTest =
   collectBaseSwapTownhallLevels;
 export const buildBaseSwapLayoutLinksForTest = buildBaseSwapLayoutLinks;
+export const buildFwaBaseSwapPhaseTimingLineForTest =
+  buildFwaBaseSwapPhaseTimingLine;
 export const renderFwaBaseSwapAnnouncementForTest =
   renderFwaBaseSwapAnnouncement;
 export const getMailBlockedReasonFromRevisionStateForTest =
@@ -10351,6 +10372,26 @@ export const Fwa: Command = {
         return;
       }
 
+      const currentWarRow = await prisma.currentWar.findFirst({
+        where: {
+          guildId: interaction.guildId,
+          OR: [{ clanTag: `#${clanTag}` }, { clanTag: clanTag }],
+        },
+        orderBy: [{ updatedAt: "desc" }],
+        select: {
+          state: true,
+          startTime: true,
+          endTime: true,
+        },
+      });
+      const baseSwapPhaseTimingLine = buildFwaBaseSwapPhaseTimingLine({
+        warState: deriveWarState(currentWarRow?.state ?? null),
+        prepEndMs: currentWarRow?.startTime
+          ? currentWarRow.startTime.getTime()
+          : null,
+        warEndMs: currentWarRow?.endTime ? currentWarRow.endTime.getTime() : null,
+      });
+
       const war = await getCurrentWarCached(
         cocService,
         clanTag,
@@ -10472,6 +10513,7 @@ export const Fwa: Command = {
         renderFwaBaseSwapAnnouncement({
           entries,
           layoutLinks,
+          phaseTimingLine: baseSwapPhaseTimingLine,
         }),
       );
 
@@ -10496,6 +10538,7 @@ export const Fwa: Command = {
         createdByUserId: interaction.user.id,
         entries,
         layoutLinks,
+        phaseTimingLine: baseSwapPhaseTimingLine,
         createdAtIso: new Date().toISOString(),
       };
       const expiresAt = new Date(Date.now() + FWA_BASE_SWAP_TTL_MS);
@@ -10511,6 +10554,7 @@ export const Fwa: Command = {
           createdAtIso: state.createdAtIso,
           entries: state.entries,
           layoutLinks: state.layoutLinks,
+          phaseTimingLine: state.phaseTimingLine,
         },
       });
 

--- a/src/services/TrackedMessageService.ts
+++ b/src/services/TrackedMessageService.ts
@@ -24,6 +24,7 @@ export type FwaBaseSwapTrackedMetadata = {
   clanName: string;
   createdByUserId: string;
   createdAtIso: string;
+  phaseTimingLine?: string | null;
   entries: Array<{
     position: number;
     playerTag: string;
@@ -114,7 +115,15 @@ export function parseFwaBaseSwapMetadata(value: unknown): FwaBaseSwapTrackedMeta
             Boolean(layoutLink)
         )
     : undefined;
-  return { clanName, createdByUserId, createdAtIso, entries, layoutLinks };
+  const phaseTimingLineRaw = String(value.phaseTimingLine ?? "").trim();
+  return {
+    clanName,
+    createdByUserId,
+    createdAtIso,
+    phaseTimingLine: phaseTimingLineRaw || null,
+    entries,
+    layoutLinks,
+  };
 }
 
 export function parseSyncTimeMetadata(value: unknown): SyncTimeTrackedMetadata | null {

--- a/tests/fwaBaseSwap.layoutLinks.test.ts
+++ b/tests/fwaBaseSwap.layoutLinks.test.ts
@@ -13,6 +13,7 @@ vi.mock("../src/prisma", () => ({
 
 import {
   FWA_BASE_SWAP_ACK_EMOJI,
+  buildFwaBaseSwapPhaseTimingLineForTest,
   renderFwaBaseSwapAnnouncementForTest,
 } from "../src/commands/Fwa";
 import {
@@ -105,6 +106,90 @@ describe("FWA base-swap layout links", () => {
     expect(playerLineIndex).toBeGreaterThan(-1);
     expect(th18Index).toBeGreaterThan(playerLineIndex);
     expect(reactIndex).toBeGreaterThan(th17Index);
+  });
+
+  it("builds preparation-day phase timing lines from prep-end timestamps", () => {
+    const line = buildFwaBaseSwapPhaseTimingLineForTest({
+      warState: "preparation",
+      prepEndMs: 1740000000000,
+      warEndMs: 1740003600000,
+    });
+
+    expect(line).toBe(
+      "## Preparation Day ends <t:1740000000:F> (<t:1740000000:R>)",
+    );
+  });
+
+  it("builds battle-day phase timing lines from war-end timestamps", () => {
+    const line = buildFwaBaseSwapPhaseTimingLineForTest({
+      warState: "inWar",
+      prepEndMs: 1740000000000,
+      warEndMs: 1740003600000,
+    });
+
+    expect(line).toBe("## Battle Day ends <t:1740003600:F> (<t:1740003600:R>)");
+  });
+
+  it("renders the phase timing line immediately above the acknowledge react line", () => {
+    const phaseLine = buildFwaBaseSwapPhaseTimingLineForTest({
+      warState: "inWar",
+      prepEndMs: 1740000000000,
+      warEndMs: 1740003600000,
+    });
+    const content = renderFwaBaseSwapAnnouncementForTest({
+      entries: [
+        buildEntry({
+          position: 1,
+          playerTag: "#AAA111",
+          playerName: "Alpha",
+          section: "war_bases",
+          discordUserId: "100",
+          townhallLevel: 18,
+        }),
+      ],
+      layoutLinks: [
+        buildLayoutLink({
+          townhall: 18,
+          layoutLink:
+            "https://link.clashofclans.com/en?action=OpenLayout&id=TH18%3AWB%3AAAAABQAAAAL-snjB9XgCUUcMqq1dHYjg",
+        }),
+      ],
+      phaseTimingLine: phaseLine,
+    });
+
+    const reactPrompt = `React with ${FWA_BASE_SWAP_ACK_EMOJI} once your base is fixed.`;
+    expect(phaseLine).not.toBeNull();
+    expect(content).toContain(`${phaseLine}\n\n`);
+    expect(content.indexOf(String(phaseLine))).toBeLessThan(
+      content.indexOf(reactPrompt),
+    );
+  });
+
+  it("omits phase timing lines when current-war timing data is unavailable", () => {
+    const missingPrep = buildFwaBaseSwapPhaseTimingLineForTest({
+      warState: "preparation",
+      prepEndMs: null,
+      warEndMs: 1740003600000,
+    });
+    expect(missingPrep).toBeNull();
+
+    const content = renderFwaBaseSwapAnnouncementForTest({
+      entries: [
+        buildEntry({
+          position: 1,
+          playerTag: "#AAA111",
+          playerName: "Alpha",
+          section: "war_bases",
+          discordUserId: "100",
+          townhallLevel: 18,
+        }),
+      ],
+      layoutLinks: [],
+      phaseTimingLine: missingPrep,
+    });
+
+    expect(content).not.toContain("Preparation Day ends");
+    expect(content).not.toContain("Battle Day ends");
   });
 
   it("renders one TH line per townhall even when multiple entries share the TH", () => {


### PR DESCRIPTION
- add a phase timing line above base-swap acknowledgement using CurrentWar state/timestamps
- persist phase timing in tracked metadata so reaction re-renders keep the same output
- add tests for preparation/battle timing, placement, and omission when timing is unavailable