### PR TITLE
fix(fwa): harden post-war points lock reconciliation

### DIFF
--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -6725,18 +6725,26 @@ async function resolveMatchTypeWithFallback(params: {
     matchType: params.existingMatchType ?? null,
     inferredMatchType: params.existingInferredMatchType ?? true,
   });
-  if (params.warState === "notInWar") {
-    return {
-      confirmedCurrent: currentResolution.confirmed,
-      storedSync: null,
-      unconfirmedCurrent: currentResolution.unconfirmed,
-    };
-  }
   const hasWarIdentity =
     (params.warId !== null &&
       params.warId !== undefined &&
       Number.isFinite(params.warId)) ||
     params.warStartTime instanceof Date;
+  if (params.warState === "notInWar") {
+    return {
+      confirmedCurrent: currentResolution.confirmed,
+      storedSync: hasWarIdentity
+        ? await resolveMatchTypeFromStoredSync({
+            guildId: params.guildId,
+            clanTag: params.clanTag,
+            opponentTag: params.opponentTag,
+            warId: params.warId,
+            warStartTime: params.warStartTime,
+          })
+        : null,
+      unconfirmedCurrent: currentResolution.unconfirmed,
+    };
+  }
   return {
     confirmedCurrent: currentResolution.confirmed,
     storedSync: hasWarIdentity
@@ -6751,6 +6759,8 @@ async function resolveMatchTypeWithFallback(params: {
     unconfirmedCurrent: currentResolution.unconfirmed,
   };
 }
+
+export const resolveMatchTypeWithFallbackForTest = resolveMatchTypeWithFallback;
 
 /** Purpose: apply source-of-truth sync number over a scraped points snapshot. */
 function applySourceSync(

--- a/src/services/PointsDirectFetchGateService.ts
+++ b/src/services/PointsDirectFetchGateService.ts
@@ -130,6 +130,21 @@ type ApplyObservedPointValueInput = {
   nowMs: number;
 };
 
+type ObservedPointTransitionGuardCode =
+  | "not_waiting_for_point_change"
+  | "mm_wait_guard"
+  | "missing_points"
+  | "equal_points_blocked"
+  | "point_change_allowed";
+
+type ObservedPointTransitionEvaluation = {
+  next: PointsLockStateRecord;
+  observedPoints: number | null;
+  baselinePointsBefore: number | null;
+  guardCode: ObservedPointTransitionGuardCode;
+  equalityGuard: "allowed" | "blocked" | "not_applicable";
+};
+
 const PRESYNC_UNLOCK_OFFSET_MS = 10 * 60 * 1000;
 const MM_POSTWAR_UNLOCK_DELAY_MS = 60 * 60 * 1000;
 const ACTIVE_SYNC_POST_KEY_PREFIX = "active_sync_post:";
@@ -436,6 +451,56 @@ export function applyObservedPointValueTransitionForTest(
   };
 }
 
+/** Purpose: evaluate post-war observed-point transition decisions with explicit guard metadata. */
+function evaluateObservedPointTransition(input: ApplyObservedPointValueInput): ObservedPointTransitionEvaluation {
+  const state = input.state;
+  const observedPoints = toOptionalInt(input.observedPoints);
+  const baselinePointsBefore = toOptionalInt(state.baselinePoints);
+  if (state.lifecycleState !== "post_war_unlocked_waiting_for_point_change") {
+    return {
+      next: state,
+      observedPoints,
+      baselinePointsBefore,
+      guardCode: "not_waiting_for_point_change",
+      equalityGuard: "not_applicable",
+    };
+  }
+  if (state.matchType === "MM") {
+    return {
+      next: state,
+      observedPoints,
+      baselinePointsBefore,
+      guardCode: "mm_wait_guard",
+      equalityGuard: "not_applicable",
+    };
+  }
+  if (observedPoints === null || baselinePointsBefore === null) {
+    return {
+      next: state,
+      observedPoints,
+      baselinePointsBefore,
+      guardCode: "missing_points",
+      equalityGuard: "not_applicable",
+    };
+  }
+  if (observedPoints === baselinePointsBefore) {
+    return {
+      next: state,
+      observedPoints,
+      baselinePointsBefore,
+      guardCode: "equal_points_blocked",
+      equalityGuard: "blocked",
+    };
+  }
+  return {
+    next: applyObservedPointValueTransitionForTest(input),
+    observedPoints,
+    baselinePointsBefore,
+    guardCode: "point_change_allowed",
+    equalityGuard: "allowed",
+  };
+}
+
 /** Purpose: compare two lock-state records while ignoring harmless timestamp jitter. */
 function isSameLockState(a: PointsLockStateRecord | null, b: PointsLockStateRecord): boolean {
   if (!a) return false;
@@ -710,6 +775,7 @@ export function isPointsDirectFetchBlockedError(
 
 export class PointsDirectFetchGateService {
   private static readonly decisionRollups = new Map<string, number>();
+  private static readonly observedTransitionQueues = new Map<string, Promise<void>>();
 
   /** Purpose: initialize lock gate persistence dependencies. */
   constructor(private readonly settings: SettingsService = new SettingsService()) {}
@@ -850,22 +916,29 @@ export class PointsDirectFetchGateService {
   }): Promise<void> {
     const normalizedTag = normalizeTag(params.clanTag);
     if (!normalizedTag) return;
-    const nowMs = toOptionalInt(params.nowMs ?? Date.now()) ?? Date.now();
-    const persisted = await this.readPersistedState(normalizedTag);
-    if (!persisted) return;
+    await this.runObservedTransitionSerial(normalizedTag, async () => {
+      const nowMs = toOptionalInt(params.nowMs ?? Date.now()) ?? Date.now();
+      const persisted = await this.readPersistedState(normalizedTag);
+      if (!persisted) return;
 
-    const next = applyObservedPointValueTransitionForTest({
-      state: persisted,
-      observedPoints: params.observedPoints,
-      nowMs,
+      const evaluation = evaluateObservedPointTransition({
+        state: persisted,
+        observedPoints: params.observedPoints,
+        nowMs,
+      });
+      if (isSameLockState(persisted, evaluation.next)) {
+        if (evaluation.guardCode === "equal_points_blocked") {
+          console.debug(
+            `[points-lock] transition_noop clan=${normalizedTag} state=${persisted.lifecycleState} observed_points=${evaluation.observedPoints ?? "none"} baseline_before=${evaluation.baselinePointsBefore ?? "none"} equality_guard=${evaluation.equalityGuard} guard_code=${evaluation.guardCode} state_source=persisted_storage`
+          );
+        }
+        return;
+      }
+      await this.writePersistedState(evaluation.next);
+      console.info(
+        `[points-lock] transition clan=${normalizedTag} from=${persisted.lifecycleState} to=${evaluation.next.lifecycleState} observed_points=${evaluation.observedPoints ?? "none"} baseline_before=${evaluation.baselinePointsBefore ?? "none"} baseline_after=${evaluation.next.baselinePoints ?? "none"} equality_guard=${evaluation.equalityGuard} guard_code=${evaluation.guardCode} state_source=persisted_storage lock_until_ms=${evaluation.next.lockUntilMs ?? "none"} changed_at_ms=${evaluation.next.pointValueChangedAtMs ?? "none"}`
+      );
     });
-    if (isSameLockState(persisted, next)) return;
-    await this.writePersistedState(next);
-    console.info(
-      `[points-lock] transition clan=${normalizedTag} from=${persisted.lifecycleState} to=${next.lifecycleState} observed_points=${toOptionalInt(
-        params.observedPoints
-      ) ?? "none"} baseline=${next.baselinePoints ?? "none"} lock_until_ms=${next.lockUntilMs ?? "none"} changed_at_ms=${next.pointValueChangedAtMs ?? "none"}`
-    );
   }
 
   /** Purpose: load runtime policy inputs from authoritative tracked/current/sync state. */
@@ -1008,6 +1081,20 @@ export class PointsDirectFetchGateService {
   /** Purpose: persist lock-state JSON atomically for deterministic transitions. */
   private async writePersistedState(state: PointsLockStateRecord): Promise<void> {
     await this.settings.set(buildLockStateKey(state.clanTag), JSON.stringify(state));
+  }
+
+  /** Purpose: serialize observed-point transitions per clan to keep post-war updates idempotent. */
+  private async runObservedTransitionSerial(clanTag: string, task: () => Promise<void>): Promise<void> {
+    const previous = PointsDirectFetchGateService.observedTransitionQueues.get(clanTag) ?? Promise.resolve();
+    const nextTask = previous.catch(() => undefined).then(task);
+    let tracked: Promise<void>;
+    tracked = nextTask.finally(() => {
+      if (PointsDirectFetchGateService.observedTransitionQueues.get(clanTag) === tracked) {
+        PointsDirectFetchGateService.observedTransitionQueues.delete(clanTag);
+      }
+    });
+    PointsDirectFetchGateService.observedTransitionQueues.set(clanTag, tracked);
+    await nextTask;
   }
 
 

--- a/tests/fwaMatchInference.logic.test.ts
+++ b/tests/fwaMatchInference.logic.test.ts
@@ -1,15 +1,17 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   applyExplicitOpponentNotFoundFallbackGuardForTest,
   hasSameWarExplicitFwaConfirmationForTest,
   getMailBlockedReasonFromStatusForTest,
   inferMatchTypeFromPointsSnapshotsForTest,
+  resolveMatchTypeWithFallbackForTest,
   resolveMatchTypeFromStoredSyncRowForTest,
 } from "../src/commands/Fwa";
 import {
   chooseMatchTypeResolution,
   resolveCurrentWarMatchTypeSignal,
 } from "../src/services/MatchTypeResolutionService";
+import { PointsSyncService } from "../src/services/PointsSyncService";
 
 describe("fwa match inference from points snapshots", () => {
   it("returns null when opponent evidence is unavailable", () => {
@@ -226,6 +228,43 @@ describe("fwa match stored sync fallback", () => {
       inferred: true,
       confirmed: false,
       syncIsFwa: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("keeps post-war resolution stable by preferring stored sync over unconfirmed current-war state", async () => {
+    vi.spyOn(PointsSyncService.prototype, "getCurrentSyncForClan").mockResolvedValue({
+      opponentTag: "#20P292Q2V",
+      isFwa: false,
+      lastKnownMatchType: "BL",
+    } as any);
+
+    const fallback = await resolveMatchTypeWithFallbackForTest({
+      guildId: "guild-1",
+      clanTag: "9GLGQCCU",
+      opponentTag: "20P292Q2V",
+      warState: "notInWar",
+      warId: 1001383,
+      warStartTime: new Date("2026-03-18T22:12:43.000Z"),
+      existingMatchType: "MM",
+      existingInferredMatchType: true,
+    });
+    const resolved = chooseMatchTypeResolution({
+      confirmedCurrent: fallback.confirmedCurrent,
+      liveOpponent: null,
+      storedSync: fallback.storedSync,
+      unconfirmedCurrent: fallback.unconfirmedCurrent,
+    });
+
+    expect(resolved).toMatchObject({
+      matchType: "BL",
+      source: "stored_sync",
+      inferred: true,
+      confirmed: false,
+      syncIsFwa: false,
     });
   });
 });

--- a/tests/pointsDirectFetchGate.pollerGate.test.ts
+++ b/tests/pointsDirectFetchGate.pollerGate.test.ts
@@ -201,4 +201,62 @@ describe("PointsDirectFetchGateService.evaluatePollerFetch", () => {
     expect(decision.fetchReason).toBeNull();
     expect(decision.lockState).toBe("between_wars_locked_until_presync");
   });
+
+  it("skips mail-refresh fetches after war end but still allows post-war reconciliation", async () => {
+    const postedSyncAtMs = new Date("2026-03-09T09:00:00.000Z").getTime();
+    const { service } = buildService({
+      runtime: buildRuntime({
+        warState: "notInWar",
+        lifecycle: null,
+        postedSyncAtMs,
+        matchType: "BL",
+      }),
+      persisted: buildState({
+        lifecycleState: "post_war_unlocked_waiting_for_point_change",
+        postedSyncAtMs,
+        matchType: "BL",
+        baselinePoints: 6,
+      }),
+    });
+
+    const mailDecision = await service.evaluatePollerFetch({
+      guildId: "guild-1",
+      clanTag: "#AAA111",
+      pollerSource: "mail_refresh_loop",
+      requestedReason: "mail_refresh",
+      warState: "notInWar",
+      warStartTime: null,
+      warEndTime: new Date("2026-03-09T07:00:00.000Z"),
+      currentSyncNumber: null,
+      lifecycle: null,
+      activeOpponentTag: null,
+      activeWarId: null,
+      nowMs: new Date("2026-03-09T07:20:00.000Z").getTime(),
+    });
+    const reconciliationDecision = await service.evaluatePollerFetch({
+      guildId: "guild-1",
+      clanTag: "#AAA111",
+      pollerSource: "war_event_poll_cycle",
+      requestedReason: "post_war_reconciliation",
+      warState: "notInWar",
+      warStartTime: null,
+      warEndTime: new Date("2026-03-09T07:00:00.000Z"),
+      currentSyncNumber: null,
+      lifecycle: null,
+      activeOpponentTag: null,
+      activeWarId: null,
+      nowMs: new Date("2026-03-09T07:20:00.000Z").getTime(),
+    });
+
+    expect(mailDecision.allowed).toBe(false);
+    expect(mailDecision.decisionCode).toBe("inactive_war_for_mail_refresh");
+    expect(mailDecision.fetchReason).toBeNull();
+
+    expect(reconciliationDecision.allowed).toBe(true);
+    expect(reconciliationDecision.decisionCode).toBe("policy_allowed");
+    expect(reconciliationDecision.fetchReason).toBe("post_war_reconciliation");
+    expect(reconciliationDecision.lockState).toBe(
+      "post_war_unlocked_waiting_for_point_change",
+    );
+  });
 });

--- a/tests/pointsDirectFetchGate.recordObserved.test.ts
+++ b/tests/pointsDirectFetchGate.recordObserved.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  PointsDirectFetchGateService,
+  type PointsLockStateRecord,
+} from "../src/services/PointsDirectFetchGateService";
+
+function buildState(
+  overrides?: Partial<PointsLockStateRecord>,
+): PointsLockStateRecord {
+  return {
+    lifecycleState: "post_war_unlocked_waiting_for_point_change",
+    clanTag: "#9GLGQCCU",
+    guildId: "guild-1",
+    warId: "1001383",
+    warStartMs: new Date("2026-03-18T22:12:43.000Z").getTime(),
+    warEndMs: new Date("2026-03-19T22:39:26.000Z").getTime(),
+    matchType: "BL",
+    baselinePoints: 6,
+    pointValueChangedAtMs: null,
+    postedSyncAtMs: new Date("2026-03-18T07:05:00.000Z").getTime(),
+    lockUntilMs: null,
+    updatedAtMs: new Date("2026-03-19T22:43:00.000Z").getTime(),
+    ...overrides,
+  };
+}
+
+describe("PointsDirectFetchGateService.recordObservedPointValue", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("keeps non-MM post-war wait state unchanged when observed points equal baseline (#9GLGQCCU scenario)", async () => {
+    const service = new PointsDirectFetchGateService({} as never);
+    let persisted = buildState({ baselinePoints: 6, matchType: "BL" });
+    const readSpy = vi
+      .spyOn(service as any, "readPersistedState")
+      .mockImplementation(async () => persisted);
+    const writeSpy = vi
+      .spyOn(service as any, "writePersistedState")
+      .mockImplementation(async (next: PointsLockStateRecord) => {
+        persisted = next;
+      });
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => undefined);
+    const debugSpy = vi.spyOn(console, "debug").mockImplementation(() => undefined);
+
+    await service.recordObservedPointValue({
+      clanTag: "#9GLGQCCU",
+      observedPoints: 6,
+      nowMs: new Date("2026-03-19T22:48:43.000Z").getTime(),
+    });
+
+    expect(readSpy).toHaveBeenCalledTimes(1);
+    expect(writeSpy).not.toHaveBeenCalled();
+    expect(infoSpy).not.toHaveBeenCalled();
+    expect(debugSpy).toHaveBeenCalledTimes(1);
+    expect(debugSpy.mock.calls[0]?.[0]).toContain(
+      "guard_code=equal_points_blocked",
+    );
+    expect(persisted.lifecycleState).toBe(
+      "post_war_unlocked_waiting_for_point_change",
+    );
+    expect(persisted.baselinePoints).toBe(6);
+  });
+
+  it("transitions non-MM post-war state on changed points and logs pre/post baselines", async () => {
+    const service = new PointsDirectFetchGateService({} as never);
+    let persisted = buildState({ baselinePoints: 5, matchType: "BL" });
+    const writeSpy = vi
+      .spyOn(service as any, "writePersistedState")
+      .mockImplementation(async (next: PointsLockStateRecord) => {
+        persisted = next;
+      });
+    vi.spyOn(service as any, "readPersistedState").mockImplementation(
+      async () => persisted,
+    );
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => undefined);
+
+    await service.recordObservedPointValue({
+      clanTag: "#9GLGQCCU",
+      observedPoints: 6,
+      nowMs: new Date("2026-03-19T22:48:43.000Z").getTime(),
+    });
+
+    expect(writeSpy).toHaveBeenCalledTimes(1);
+    expect(persisted.lifecycleState).toBe("unlocked");
+    expect(persisted.baselinePoints).toBe(6);
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    const line = String(infoSpy.mock.calls[0]?.[0] ?? "");
+    expect(line).toContain("from=post_war_unlocked_waiting_for_point_change");
+    expect(line).toContain("to=unlocked");
+    expect(line).toContain("baseline_before=5");
+    expect(line).toContain("baseline_after=6");
+    expect(line).toContain("equality_guard=allowed");
+    expect(line).toContain("guard_code=point_change_allowed");
+  });
+
+  it("does not unlock MM post-war wait state when observed points change", async () => {
+    const service = new PointsDirectFetchGateService({} as never);
+    let persisted = buildState({ baselinePoints: 6, matchType: "MM" });
+    const writeSpy = vi
+      .spyOn(service as any, "writePersistedState")
+      .mockImplementation(async (next: PointsLockStateRecord) => {
+        persisted = next;
+      });
+    vi.spyOn(service as any, "readPersistedState").mockImplementation(
+      async () => persisted,
+    );
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => undefined);
+
+    await service.recordObservedPointValue({
+      clanTag: "#9GLGQCCU",
+      observedPoints: 7,
+      nowMs: new Date("2026-03-19T22:48:43.000Z").getTime(),
+    });
+
+    expect(writeSpy).not.toHaveBeenCalled();
+    expect(infoSpy).not.toHaveBeenCalled();
+    expect(persisted.lifecycleState).toBe(
+      "post_war_unlocked_waiting_for_point_change",
+    );
+    expect(persisted.baselinePoints).toBe(6);
+  });
+
+  it("serializes repeated reconciliation updates for the same clan and avoids duplicate transitions", async () => {
+    const service = new PointsDirectFetchGateService({} as never);
+    let persisted = buildState({ baselinePoints: 5, matchType: "BL" });
+    const writeSpy = vi
+      .spyOn(service as any, "writePersistedState")
+      .mockImplementation(async (next: PointsLockStateRecord) => {
+        persisted = next;
+      });
+    vi.spyOn(service as any, "readPersistedState").mockImplementation(
+      async () => persisted,
+    );
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => undefined);
+
+    await Promise.all([
+      service.recordObservedPointValue({
+        clanTag: "#9GLGQCCU",
+        observedPoints: 6,
+        nowMs: new Date("2026-03-19T22:48:43.100Z").getTime(),
+      }),
+      service.recordObservedPointValue({
+        clanTag: "#9GLGQCCU",
+        observedPoints: 6,
+        nowMs: new Date("2026-03-19T22:48:43.200Z").getTime(),
+      }),
+    ]);
+
+    expect(writeSpy).toHaveBeenCalledTimes(1);
+    expect(infoSpy).toHaveBeenCalledTimes(1);
+    expect(persisted.lifecycleState).toBe("unlocked");
+    expect(persisted.baselinePoints).toBe(6);
+  });
+});
+

--- a/tests/pointsDirectFetchGate.service.test.ts
+++ b/tests/pointsDirectFetchGate.service.test.ts
@@ -164,6 +164,76 @@ describe("PointsDirectFetchGate lifecycle", () => {
     expect(transitioned.lockUntilMs).toBeNull();
   });
 
+  it("keeps non-MM post-war wait state unchanged when observed points equal baseline", () => {
+    const state = buildState({
+      lifecycleState: "post_war_unlocked_waiting_for_point_change",
+      postedSyncAtMs: null,
+      lockUntilMs: null,
+      matchType: "BL",
+      baselinePoints: 6,
+      pointValueChangedAtMs: null,
+    });
+    const transitioned = applyObservedPointValueTransitionForTest({
+      state,
+      observedPoints: 6,
+      nowMs: new Date("2026-03-09T08:00:00.000Z").getTime(),
+    });
+
+    expect(transitioned).toEqual(state);
+    expect(transitioned.lifecycleState).toBe(
+      "post_war_unlocked_waiting_for_point_change",
+    );
+    expect(transitioned.baselinePoints).toBe(6);
+  });
+
+  it("does not unlock MM post-war state when observed points change", () => {
+    const state = buildState({
+      lifecycleState: "post_war_unlocked_waiting_for_point_change",
+      postedSyncAtMs: null,
+      lockUntilMs: null,
+      matchType: "MM",
+      baselinePoints: 6,
+      pointValueChangedAtMs: null,
+    });
+    const transitioned = applyObservedPointValueTransitionForTest({
+      state,
+      observedPoints: 7,
+      nowMs: new Date("2026-03-09T08:00:00.000Z").getTime(),
+    });
+
+    expect(transitioned).toEqual(state);
+    expect(transitioned.lifecycleState).toBe(
+      "post_war_unlocked_waiting_for_point_change",
+    );
+    expect(transitioned.baselinePoints).toBe(6);
+  });
+
+  it("keeps post-war waiting lifecycle when reusable sync snapshot blocks direct fetch", () => {
+    const runtime = buildRuntime({
+      warState: "notInWar",
+      matchType: "BL",
+      hasReusableWarSnapshot: true,
+    });
+    const state = buildState({
+      lifecycleState: "post_war_unlocked_waiting_for_point_change",
+      matchType: "BL",
+      baselinePoints: 6,
+    });
+    const decision = buildPointsDirectFetchDecisionForTest({
+      runtime,
+      state,
+      caller: "poller",
+      fetchReason: "post_war_reconciliation",
+      manualForceBypass: false,
+    });
+
+    expect(decision.allowed).toBe(false);
+    expect(decision.decisionCode).toBe("reused_war_snapshot");
+    expect(decision.lockState).toBe(
+      "post_war_unlocked_waiting_for_point_change",
+    );
+  });
+
   it("keeps MM locked until pre-sync window when posted sync exists", () => {
     const warEndMs = new Date("2026-03-09T07:00:00.000Z").getTime();
     const postedSyncAtMs = new Date("2026-03-09T09:00:00.000Z").getTime();


### PR DESCRIPTION
- serialize per-clan observed-point transitions and log true pre-transition baselines
- keep equal-point and MM post-war guards explicit to prevent accidental unlock drift
- prefer stored same-war sync fallback in notInWar match-type resolution to avoid unconfirmed downgrade in mail rendering
- add regression tests for equal-point no-op, changed-point transition, MM guard, reconciliation idempotence, and post-war mail-vs-reconciliation gate behavior