### PR TITLE
feat(fwa): restore single-view links and add tie-breaker image button

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -59,6 +59,7 @@
 - `/fwa match-type [visibility:private|public] [tag:<trackedClanTag>] [type:FWA|BL|MM]` - Manually set or view per-clan match type override used by matchup output. If no args, lists overrides for all tracked clans.
 - `/fwa mail send tag:<trackedClanTag>` - Show ephemeral war mail preview with confirm-and-send to the tracked clan mail channel. Confirm-and-send pings `TrackedClan.clanRoleId` when enabled. Uses the same active-war mail freshness gating as `/fwa match` (up-to-date send is disabled; out-of-date resend is enabled when matchType/outcome differ). War-mail embed sidebar colors are mapped by effective match state only: BL=black, MM=white, FWA WIN=green, FWA LOSE=red, unresolved=gray.
 - `/fwa match` single-clan view includes a `Send Mail` button that follows the same access policy as `/fwa mail send` and uses the same role-ping behavior.
+- `/fwa match` single-clan embed view includes a `Tie-breaker rules` button that opens an ephemeral image (`https://i.imgur.com/lvoJgZB.png`) for the requesting user.
 - `/recruitment show platform:discord|reddit|band clan:<tag>` - Render platform-specific recruitment template output for a tracked clan.
 - `/recruitment edit platform:discord|reddit|band clan:<tag>` - Open platform-specific modal:
   - Discord: clan tag, body (max 1024), optional image URL(s)

--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -107,6 +107,7 @@ import {
   buildFwaMatchCopyCustomId,
   buildFwaMatchSelectCustomId,
   buildFwaMatchSendMailCustomId,
+  buildFwaMatchTieBreakerCustomId,
   buildMatchSkipSyncActionCustomId,
   buildMatchSkipSyncConfirmCustomId,
   buildMatchSkipSyncUndoCustomId,
@@ -125,6 +126,7 @@ import {
   parseFwaMatchCopyCustomId,
   parseFwaMatchSelectCustomId,
   parseFwaMatchSendMailCustomId,
+  parseFwaMatchTieBreakerCustomId,
   parseMatchSkipSyncActionCustomId,
   parseMatchSkipSyncConfirmCustomId,
   parseMatchSkipSyncUndoCustomId,
@@ -198,6 +200,7 @@ export {
   isFwaMatchCopyButtonCustomId,
   isFwaMatchSelectCustomId,
   isFwaMatchSendMailButtonCustomId,
+  isFwaMatchTieBreakerButtonCustomId,
   isFwaMatchSkipSyncActionButtonCustomId,
   isFwaMatchSkipSyncConfirmButtonCustomId,
   isFwaMatchSkipSyncUndoButtonCustomId,
@@ -1281,13 +1284,12 @@ function buildSingleClanMatchLinks(input: {
   const opponentCcUrl = buildCcVerifyUrl(input.opponentTag);
   const trackedPointsUrl = buildOfficialPointsUrl(input.trackedClanTag);
   return {
-    pointsFieldName: `[Points](${trackedPointsUrl})`,
+    pointsFieldName: "Points",
     linksFieldName: "Links",
-    linksFieldValue: `[cc.fwafarm](<${opponentCcUrl}>)\n[Tie-breaker rules](<${FWA_MATCH_TIEBREAKER_RULES_URL}>)`,
+    linksFieldValue: `[cc.fwafarm](<${opponentCcUrl}>)\n[points.fwafarm](<${trackedPointsUrl}>)`,
     copyLines: [
       `CC (opponent): [cc.fwafarm](<${opponentCcUrl}>)`,
       `Points (tracked clan): [points.fwafarm](<${trackedPointsUrl}>)`,
-      `Tie-breaker rules: [Tie-breaker rules](<${FWA_MATCH_TIEBREAKER_RULES_URL}>)`,
     ],
   };
 }
@@ -4352,6 +4354,20 @@ function buildFwaMatchCopyComponents(
         .setStyle(ButtonStyle.Secondary),
     );
   }
+  if (payload.currentScope === "single" && payload.currentTag && showMode === "embed") {
+    baseRow.addComponents(
+      new ButtonBuilder()
+        .setCustomId(
+          buildFwaMatchTieBreakerCustomId({
+            userId,
+            key,
+            tag: payload.currentTag,
+          }),
+        )
+        .setLabel("Tie-breaker rules")
+        .setStyle(ButtonStyle.Secondary),
+    );
+  }
   const rows: Array<
     ActionRowBuilder<ButtonBuilder> | ActionRowBuilder<StringSelectMenuBuilder>
   > = [baseRow];
@@ -4736,6 +4752,30 @@ export async function handleFwaMatchAllianceButton(
       parsed.key,
       "embed",
     ),
+  });
+}
+
+export async function handleFwaMatchTieBreakerButton(
+  interaction: ButtonInteraction,
+): Promise<void> {
+  const parsed = parseFwaMatchTieBreakerCustomId(interaction.customId);
+  if (!parsed) return;
+
+  if (interaction.user.id !== parsed.userId) {
+    await interaction.reply({
+      ephemeral: true,
+      content: "Only the command requester can use this button.",
+    });
+    return;
+  }
+
+  await interaction.reply({
+    ephemeral: true,
+    embeds: [
+      new EmbedBuilder()
+        .setTitle("Tie-breaker rules")
+        .setImage(FWA_MATCH_TIEBREAKER_RULES_URL),
+    ],
   });
 }
 

--- a/src/commands/fwa/customIds.ts
+++ b/src/commands/fwa/customIds.ts
@@ -14,6 +14,7 @@ const FWA_MAIL_CONFIRM_NO_PING_PREFIX = "fwa-mail-confirm-no-ping";
 const FWA_MAIL_BACK_PREFIX = "fwa-mail-back";
 const FWA_MAIL_REFRESH_PREFIX = "fwa-mail-refresh";
 const FWA_MATCH_SEND_MAIL_PREFIX = "fwa-match-send-mail";
+const FWA_MATCH_TIEBREAKER_PREFIX = "fwa-match-tiebreaker";
 const FWA_COMPLIANCE_VIEW_PREFIX = "fwa-compliance-view";
 const FWA_BASE_SWAP_SPLIT_POST_PREFIX = "fwa-base-swap-split-post";
 
@@ -41,6 +42,12 @@ export type MatchSyncActionParams = {
 };
 
 export type MatchSkipSyncActionParams = {
+  userId: string;
+  key: string;
+  tag: string;
+};
+
+export type FwaMatchTieBreakerParams = {
   userId: string;
   key: string;
   tag: string;
@@ -374,6 +381,27 @@ export function parseFwaMatchSendMailCustomId(
 /** Purpose: detect send-mail-from-match button prefix. */
 export function isFwaMatchSendMailButtonCustomId(customId: string): boolean {
   return customId.startsWith(`${FWA_MATCH_SEND_MAIL_PREFIX}:`);
+}
+
+/** Purpose: build custom-id for single-clan tie-breaker rules button. */
+export function buildFwaMatchTieBreakerCustomId(
+  params: FwaMatchTieBreakerParams,
+): string {
+  return `${FWA_MATCH_TIEBREAKER_PREFIX}:${params.userId}:${params.key}:${normalizeTag(params.tag)}`;
+}
+
+/** Purpose: parse single-clan tie-breaker rules button custom-id payload. */
+export function parseFwaMatchTieBreakerCustomId(
+  customId: string,
+): FwaMatchTieBreakerParams | null {
+  const values = parseCustomIdParts(customId, FWA_MATCH_TIEBREAKER_PREFIX, 4);
+  if (!values) return null;
+  return { userId: values[0], key: values[1], tag: normalizeTag(values[2]) };
+}
+
+/** Purpose: detect single-clan tie-breaker rules button prefix. */
+export function isFwaMatchTieBreakerButtonCustomId(customId: string): boolean {
+  return customId.startsWith(`${FWA_MATCH_TIEBREAKER_PREFIX}:`);
 }
 
 /** Purpose: build custom-id for /fwa compliance embed view buttons. */

--- a/src/listeners/interactionCreate.ts
+++ b/src/listeners/interactionCreate.ts
@@ -35,6 +35,7 @@ import {
   handleFwaMailBackButton,
   handleFwaMailRefreshButton,
   handleFwaMatchSendMailButton,
+  handleFwaMatchTieBreakerButton,
   handleFwaBaseSwapSplitPostButton,
   isFwaMatchAllianceButtonCustomId,
   isFwaMatchSyncActionButtonCustomId,
@@ -46,6 +47,7 @@ import {
   isFwaMailBackButtonCustomId,
   isFwaMailRefreshButtonCustomId,
   isFwaMatchSendMailButtonCustomId,
+  isFwaMatchTieBreakerButtonCustomId,
   isFwaMatchTypeEditButtonCustomId,
   isFwaOutcomeActionButtonCustomId,
   isFwaMatchSelectCustomId,
@@ -403,6 +405,20 @@ const handleButtonInteraction = async (
         await interaction.reply({
           ephemeral: true,
           content: "Failed to toggle match view.",
+        });
+      }
+    }
+  }
+
+  if (isFwaMatchTieBreakerButtonCustomId(interaction.customId)) {
+    try {
+      await handleFwaMatchTieBreakerButton(interaction);
+    } catch (err) {
+      console.error(`FWA match tie-breaker button failed: ${formatError(err)}`);
+      if (!interaction.replied && !interaction.deferred) {
+        await interaction.reply({
+          ephemeral: true,
+          content: "Failed to open tie-breaker rules.",
         });
       }
     }

--- a/tests/fwaCustomIds.logic.test.ts
+++ b/tests/fwaCustomIds.logic.test.ts
@@ -3,16 +3,19 @@ import {
   buildFwaBaseSwapSplitPostCustomId,
   buildFwaComplianceViewCustomId,
   buildFwaMatchSendMailCustomId,
+  buildFwaMatchTieBreakerCustomId,
   buildMatchTypeActionCustomId,
   buildPointsPostButtonCustomId,
   createTransientFwaKey,
   isFwaBaseSwapSplitPostButtonCustomId,
   isFwaComplianceViewButtonCustomId,
   isFwaMatchSendMailButtonCustomId,
+  isFwaMatchTieBreakerButtonCustomId,
   isPointsPostButtonCustomId,
   parseFwaBaseSwapSplitPostCustomId,
   parseFwaComplianceViewCustomId,
   parseFwaMatchSendMailCustomId,
+  parseFwaMatchTieBreakerCustomId,
   parseMatchTypeActionCustomId,
   parsePointsPostButtonCustomId,
 } from "../src/commands/fwa/customIds";
@@ -42,6 +45,21 @@ describe("fwa custom-id helpers", () => {
 
     expect(isFwaMatchSendMailButtonCustomId(customId)).toBe(true);
     expect(parseFwaMatchSendMailCustomId(customId)).toEqual({
+      userId: "321",
+      key: "payload",
+      tag: "QWERTY",
+    });
+  });
+
+  it("round-trips tie-breaker ids and supports selector checks", () => {
+    const customId = buildFwaMatchTieBreakerCustomId({
+      userId: "321",
+      key: "payload",
+      tag: "#qwerty",
+    });
+
+    expect(isFwaMatchTieBreakerButtonCustomId(customId)).toBe(true);
+    expect(parseFwaMatchTieBreakerCustomId(customId)).toEqual({
       userId: "321",
       key: "payload",
       tag: "QWERTY",

--- a/tests/fwaMatchRevisionDraft.logic.test.ts
+++ b/tests/fwaMatchRevisionDraft.logic.test.ts
@@ -1258,7 +1258,7 @@ describe("fwa single-clan match embed color", () => {
 });
 
 describe("fwa single-clan links presentation", () => {
-  it("builds the new shared links field contract and removes opponent points link clutter", () => {
+  it("keeps plain points header and includes tracked points in links", () => {
     const rendered = buildSingleClanMatchLinksForTest({
       trackedClanTag: "#CLAN123",
       opponentTag: "#OPPO456",
@@ -1269,15 +1269,13 @@ describe("fwa single-clan links presentation", () => {
       "[cc.fwafarm](<https://cc.fwafarm.com/cc_n/clan.php?tag=OPPO456>)"
     );
     expect(rendered.linksFieldValue).toContain(
-      "[Tie-breaker rules](<https://i.imgur.com/lvoJgZB.png>)"
+      "[points.fwafarm](<https://points.fwafarm.com/clan?tag=CLAN123>)"
     );
-    expect(rendered.linksFieldValue).not.toContain("points.fwafarm");
-    expect(rendered.pointsFieldName).toBe(
-      "[Points](https://points.fwafarm.com/clan?tag=CLAN123)"
-    );
+    expect(rendered.linksFieldValue).not.toContain("lvoJgZB.png");
+    expect(rendered.pointsFieldName).toBe("Points");
   });
 
-  it("labels copy output links by ownership using tracked-clan points and tie-breaker docs", () => {
+  it("labels copy output links by ownership without advertising tie-breaker as web link", () => {
     const rendered = buildSingleClanMatchLinksForTest({
       trackedClanTag: "#TEAM999",
       opponentTag: "#ENEMY111",
@@ -1286,10 +1284,10 @@ describe("fwa single-clan links presentation", () => {
     expect(rendered.copyLines).toEqual([
       "CC (opponent): [cc.fwafarm](<https://cc.fwafarm.com/cc_n/clan.php?tag=ENEMY111>)",
       "Points (tracked clan): [points.fwafarm](<https://points.fwafarm.com/clan?tag=TEAM999>)",
-      "Tie-breaker rules: [Tie-breaker rules](<https://i.imgur.com/lvoJgZB.png>)",
     ]);
     expect(rendered.copyLines.join("\n")).not.toContain(
       "https://points.fwafarm.com/clan?tag=ENEMY111"
     );
+    expect(rendered.copyLines.join("\n")).not.toContain("lvoJgZB.png");
   });
 });

--- a/tests/fwaMatchTieBreakerButton.logic.test.ts
+++ b/tests/fwaMatchTieBreakerButton.logic.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest";
+import { handleFwaMatchTieBreakerButton } from "../src/commands/Fwa";
+import { buildFwaMatchTieBreakerCustomId } from "../src/commands/fwa/customIds";
+
+describe("fwa match tie-breaker button", () => {
+  it("rejects non-requesters", async () => {
+    const reply = vi.fn().mockResolvedValue(undefined);
+    const interaction = {
+      customId: buildFwaMatchTieBreakerCustomId({
+        userId: "owner-1",
+        key: "payload-1",
+        tag: "#ABC123",
+      }),
+      user: { id: "other-user" },
+      reply,
+    };
+
+    await handleFwaMatchTieBreakerButton(interaction as any);
+
+    expect(reply).toHaveBeenCalledWith({
+      ephemeral: true,
+      content: "Only the command requester can use this button.",
+    });
+  });
+
+  it("replies ephemerally with the tie-breaker image for the requester", async () => {
+    const reply = vi.fn().mockResolvedValue(undefined);
+    const interaction = {
+      customId: buildFwaMatchTieBreakerCustomId({
+        userId: "owner-1",
+        key: "payload-1",
+        tag: "#ABC123",
+      }),
+      user: { id: "owner-1" },
+      reply,
+    };
+
+    await handleFwaMatchTieBreakerButton(interaction as any);
+
+    const payload = reply.mock.calls[0]?.[0] as
+      | { ephemeral?: boolean; embeds?: Array<{ toJSON?: () => any }> }
+      | undefined;
+    const firstEmbed = payload?.embeds?.[0];
+    const imageUrl =
+      typeof firstEmbed?.toJSON === "function"
+        ? firstEmbed.toJSON()?.image?.url
+        : null;
+
+    expect(payload?.ephemeral).toBe(true);
+    expect(imageUrl).toBe("https://i.imgur.com/lvoJgZB.png");
+  });
+});


### PR DESCRIPTION
- revert single-clan links layout to plain Points header plus tracked points link in Links
- add requester-scoped tie-breaker button with ephemeral image response in /fwa match single view
- wire new custom-id helpers, interaction routing, and focused tests for link builder and button behavior