### PR TITLE
feat(fwa-match): append match-state emoji to alliance clan selector

### DIFF
--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -4312,6 +4312,19 @@ function startWarMailPolling(client: Client, key: string): void {
   fwaMailPollers.set(key, timer);
 }
 
+/** Purpose: append a compact alliance dropdown state indicator aligned to the effective displayed match state. */
+function resolveAllianceDropdownMatchStateEmoji(
+  view: MatchView | null | undefined,
+): "⚪" | "⚫" | "🟢" | "🔴" | "💤" {
+  if (view?.matchTypeCurrent === "MM") return "⚪";
+  if (view?.matchTypeCurrent === "BL") return "⚫";
+  if (view?.matchTypeCurrent === "FWA") {
+    if (view.outcomeAction?.currentOutcome === "WIN") return "🟢";
+    if (view.outcomeAction?.currentOutcome === "LOSE") return "🔴";
+  }
+  return "💤";
+}
+
 function buildFwaMatchCopyComponents(
   payload: FwaMatchCopyPayload,
   userId: string,
@@ -4504,8 +4517,10 @@ function buildFwaMatchCopyComponents(
             const warningSuffix = viewForTag?.inferredMatchType ? " ⚠️" : "";
             const mailStatusEmoji =
               viewForTag?.mailStatusEmoji ?? MAILBOX_NOT_SENT_EMOJI;
+            const matchStateEmoji =
+              resolveAllianceDropdownMatchStateEmoji(viewForTag);
             return {
-              label: `${mailStatusEmoji} ${clanName}${warningSuffix}`.slice(
+              label: `${mailStatusEmoji} ${clanName} ${matchStateEmoji}${warningSuffix}`.slice(
                 0,
                 100,
               ),
@@ -7435,6 +7450,8 @@ export const isLowConfidenceAllianceMismatchScenarioForTest =
 export const resolveSingleClanMatchEmbedColorForTest =
   resolveSingleClanMatchEmbedColor;
 export const buildSingleClanMatchLinksForTest = buildSingleClanMatchLinks;
+export const resolveAllianceDropdownMatchStateEmojiForTest =
+  resolveAllianceDropdownMatchStateEmoji;
 export const buildOpponentSnapshotFromTrackedClanFallbackForTest =
   buildOpponentSnapshotFromTrackedClanFallback;
 export const resolveForceSyncMatchupEvidenceForTest =

--- a/tests/fwaMatchRevisionDraft.logic.test.ts
+++ b/tests/fwaMatchRevisionDraft.logic.test.ts
@@ -17,6 +17,7 @@ import {
   resolveForceSyncMatchupEvidenceForTest,
   resolveSingleClanMatchEmbedColorForTest,
   buildSingleClanMatchLinksForTest,
+  resolveAllianceDropdownMatchStateEmojiForTest,
   shouldDisplayInferredMatchTypeForTest,
   shouldHydrateAlliancePayloadForTest,
   resolveEffectiveFwaOutcomeForTest,
@@ -1289,5 +1290,43 @@ describe("fwa single-clan links presentation", () => {
       "https://points.fwafarm.com/clan?tag=ENEMY111"
     );
     expect(rendered.copyLines.join("\n")).not.toContain("lvoJgZB.png");
+  });
+});
+
+describe("fwa alliance dropdown state emoji", () => {
+  it("maps effective displayed match state to the expected dropdown emoji", () => {
+    const cases: Array<{
+      view: {
+        matchTypeCurrent?: "FWA" | "BL" | "MM" | "SKIP" | null;
+        outcomeAction?: { tag: string; currentOutcome: "WIN" | "LOSE" } | null;
+      } | null;
+      expected: "⚪" | "⚫" | "🟢" | "🔴" | "💤";
+    }> = [
+      { view: { matchTypeCurrent: "MM" }, expected: "⚪" },
+      { view: { matchTypeCurrent: "BL" }, expected: "⚫" },
+      {
+        view: {
+          matchTypeCurrent: "FWA",
+          outcomeAction: { tag: "TAG1", currentOutcome: "WIN" },
+        },
+        expected: "🟢",
+      },
+      {
+        view: {
+          matchTypeCurrent: "FWA",
+          outcomeAction: { tag: "TAG1", currentOutcome: "LOSE" },
+        },
+        expected: "🔴",
+      },
+      { view: { matchTypeCurrent: "FWA", outcomeAction: null }, expected: "💤" },
+      { view: { matchTypeCurrent: "SKIP" }, expected: "💤" },
+      { view: null, expected: "💤" },
+    ];
+
+    for (const testCase of cases) {
+      expect(
+        resolveAllianceDropdownMatchStateEmojiForTest(testCase.view as any),
+      ).toBe(testCase.expected);
+    }
   });
 });


### PR DESCRIPTION
- append MM/BL/FWA outcome state emoji to alliance dropdown labels
- reuse current effective single-view state fields and add mapping tests