### PR TITLE
fix(war-events): link war-end mismatch warning to tracked points page

### DIFF
--- a/src/services/WarEventLogService.ts
+++ b/src/services/WarEventLogService.ts
@@ -63,6 +63,17 @@ const battleDayPostByGuildTag = new Map<string, { channelId: string; messageId: 
 const warEndedViewStateByMessage = new Map<string, NotifyWarEndedViewState>();
 const NOTIFY_UNKNOWN_OPPONENT = "Unknown Opponent";
 const WAR_END_DISCREPANCY_MARKER = "war_end_discrepancy";
+const POINTS_FWA_CLAN_URL_BASE = "https://points.fwafarm.com/clan?tag=";
+
+/** Purpose: build canonical tracked-clan points URL for war-end mismatch follow-up. */
+function buildTrackedClanPointsUrl(clanTag: string): string {
+  return `${POINTS_FWA_CLAN_URL_BASE}${normalizeTagBare(clanTag)}`;
+}
+
+/** Purpose: keep mismatch warning headline concise while linking to tracked-clan points page. */
+function buildWarEndMismatchWarningHeadline(clanTag: string): string {
+  return `⚠️ War-end points mismatch detected. [points.fwafarm](<${buildTrackedClanPointsUrl(clanTag)}>)`;
+}
 
 function buildNextRefreshRelativeLabel(
   intervalMs: number,
@@ -189,6 +200,7 @@ function buildWarEndDiscrepancyFingerprint(
 /** Purpose: build visible warning content for war-end points reconciliation mismatches. */
 function buildWarEndDiscrepancyContent(params: {
   existingPostedContent: string | null | undefined;
+  clanTag: string;
   opponentName: string | null | undefined;
   expectedPoints: number;
   actualPoints: number;
@@ -205,7 +217,7 @@ function buildWarEndDiscrepancyContent(params: {
     includeRoleMention: Boolean(existingMentionRoleId),
   });
   const warningLines = [
-    "⚠️ War-end points mismatch detected.",
+    buildWarEndMismatchWarningHeadline(params.clanTag),
     `Expected points: ${Math.trunc(params.expectedPoints)}`,
     `Actual points: ${Math.trunc(params.actualPoints)}`,
   ];
@@ -2968,7 +2980,8 @@ export class WarEventLogService {
       ? ({ parse: [], roles: [fwaLeaderRoleId] } as const)
       : ({ parse: [] } as const);
     const warningContent =
-      `⚠️ War-end points mismatch detected for ${historyRow?.clanName ?? clanTag} (War ID: ${Math.trunc(warId)}).\n` +
+      `${buildWarEndMismatchWarningHeadline(clanTag)}\n` +
+      `${historyRow?.clanName ?? clanTag} (War ID: ${Math.trunc(warId)}).\n` +
       `Expected points: ${expectedPoints}\n` +
       `Actual points: ${actualPoints}` +
       (fwaLeaderRoleId ? `\n<@&${fwaLeaderRoleId}>` : "");
@@ -2980,6 +2993,7 @@ export class WarEventLogService {
       if (message) {
         const edited = buildWarEndDiscrepancyContent({
           existingPostedContent: String(message.content ?? ""),
+          clanTag,
           opponentName: historyRow?.opponentName ?? params.fallbackOpponentName,
           expectedPoints,
           actualPoints,

--- a/tests/warEventLog.warEndPointsReconcile.test.ts
+++ b/tests/warEventLog.warEndPointsReconcile.test.ts
@@ -689,10 +689,13 @@ describe("War-end points reconciliation", () => {
 
     expect(edit).toHaveBeenCalledTimes(1);
     const editPayload = edit.mock.calls[0]?.[0];
-    expect(editPayload.content).toContain("⚠️ War-end points mismatch detected.");
+    expect(editPayload.content).toContain(
+      "⚠️ War-end points mismatch detected. [points.fwafarm](<https://points.fwafarm.com/clan?tag=AAA111>)"
+    );
     expect(editPayload.content).toContain("Expected points: 100");
     expect(editPayload.content).toContain("Actual points: 99");
     expect(editPayload.content).toContain("<@&777>");
+    expect(editPayload.content).not.toContain("clan?tag=OPP123");
     expect(updateSpy).toHaveBeenCalledTimes(1);
   });
 
@@ -791,8 +794,12 @@ describe("War-end points reconciliation", () => {
     });
 
     expect(send).toHaveBeenCalledTimes(1);
+    expect(send.mock.calls[0]?.[0]?.content).toContain(
+      "[points.fwafarm](<https://points.fwafarm.com/clan?tag=AAA111>)"
+    );
     expect(send.mock.calls[0]?.[0]?.content).toContain("Expected points: 100");
     expect(send.mock.calls[0]?.[0]?.content).toContain("Actual points: 99");
+    expect(send.mock.calls[0]?.[0]?.content).not.toContain("clan?tag=OPP123");
     expect(updateSpy).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
- add tracked-clan points.fwafarm link to war-end mismatch warning content
- keep mismatch detection/trigger behavior unchanged and update reconcile tests