### PR TITLE
fix(war-events): resolve notify refresh sync fallback chain

### DIFF
--- a/src/services/WarEventLogService.ts
+++ b/src/services/WarEventLogService.ts
@@ -777,6 +777,36 @@ function makeBattleDayPostKey(guildId: string, clanTag: string): string {
   return `${guildId}:${normalizeTag(clanTag)}`;
 }
 
+function toValidSyncNumber(input: unknown): number | null {
+  const value = Number(input);
+  if (!Number.isFinite(value)) return null;
+  const normalized = Math.trunc(value);
+  return normalized > 0 ? normalized : null;
+}
+
+function resolveEventRenderSyncNumber(input: {
+  sameWarSyncNumber: number | null;
+  postedSyncNumber: number | null;
+  previousSyncNumber: number | null;
+  currentState: WarState;
+}): number | null {
+  const sameWarSyncNumber = toValidSyncNumber(input.sameWarSyncNumber);
+  if (sameWarSyncNumber !== null) return sameWarSyncNumber;
+
+  const postedSyncNumber = toValidSyncNumber(input.postedSyncNumber);
+  if (postedSyncNumber !== null) return postedSyncNumber;
+
+  const previousSyncNumber = toValidSyncNumber(input.previousSyncNumber);
+  if (previousSyncNumber === null) return null;
+
+  if (input.currentState === "preparation" || input.currentState === "inWar") {
+    return previousSyncNumber + 1;
+  }
+  return previousSyncNumber;
+}
+
+export const resolveEventRenderSyncNumberForTest = resolveEventRenderSyncNumber;
+
 function formatWarStatCellLeft(value: string): string {
   return value.padStart(10, " ");
 }
@@ -3658,20 +3688,21 @@ export class WarEventLogService {
     const message = await (channel as any).messages.fetch(existingMessage.messageId).catch(() => null);
     if (!message) return false;
 
+    const syncNumber = await this.resolveNotifyEventSyncNumber({
+      guildId,
+      clanTag,
+      warId: warIdText,
+      warStartTime,
+      currentState: state,
+      postedSyncNumber: toValidSyncNumber(existingMessage.syncNum),
+    });
+
     const basePayload = {
       clanTag: refreshedSub.clanTag,
       clanName: nextClanName,
       opponentTag: nextOpponentTag,
       opponentName: nextOpponentName,
-      syncNumber:
-        (
-          await this.currentSyncs.getCurrentSyncForClan({
-            guildId,
-            clanTag,
-            warId: warIdText,
-            warStartTime,
-          })
-        )?.syncNum ?? null,
+      syncNumber,
       notifyRole: refreshedSub.notifyRole,
       pingRole: refreshedSub.pingRole,
       fwaPoints: refreshedSub.fwaPoints,
@@ -3824,6 +3855,34 @@ export class WarEventLogService {
       return "missing";
     }
 
+    const resolvedWarIdText =
+      resolvedWarId !== null && resolvedWarId !== undefined
+        ? String(Math.trunc(Number(resolvedWarId)))
+        : refreshedSub.warId !== null && refreshedSub.warId !== undefined
+          ? String(Math.trunc(Number(refreshedSub.warId)))
+          : null;
+    const existingMessage = await this.postedMessages.findExistingMessage({
+      guildId,
+      clanTag,
+      warId: resolvedWarIdText,
+      type: "notify",
+      event: "battle_day",
+    });
+    const postedSyncNumber =
+      existingMessage &&
+      existingMessage.channelId === tracked.channelId &&
+      existingMessage.messageId === tracked.messageId
+        ? toValidSyncNumber(existingMessage.syncNum)
+        : null;
+    const syncNumber = await this.resolveNotifyEventSyncNumber({
+      guildId,
+      clanTag,
+      warId: resolvedWarIdText,
+      warStartTime,
+      currentState: "inWar",
+      postedSyncNumber,
+    });
+
     const payload = {
       eventType: "battle_day" as const,
       clanTag: refreshedSub.clanTag,
@@ -3831,20 +3890,7 @@ export class WarEventLogService {
       opponentTag: normalizeTag(war.opponent?.tag ?? refreshedSub.opponentTag ?? ""),
       opponentName:
         String(war.opponent?.name ?? refreshedSub.opponentName ?? "Unknown").trim() || "Unknown",
-      syncNumber:
-        (
-          await this.currentSyncs.getCurrentSyncForClan({
-            guildId,
-            clanTag,
-            warId:
-              resolvedWarId !== null && resolvedWarId !== undefined
-                ? String(Math.trunc(Number(resolvedWarId)))
-                : refreshedSub.warId !== null && refreshedSub.warId !== undefined
-                  ? String(Math.trunc(Number(refreshedSub.warId)))
-                  : null,
-            warStartTime,
-          })
-        )?.syncNum ?? null,
+      syncNumber,
       notifyRole: refreshedSub.notifyRole,
       pingRole: refreshedSub.pingRole,
       fwaPoints: refreshedSub.fwaPoints,
@@ -3898,6 +3944,41 @@ export class WarEventLogService {
       ],
     });
     return "refreshed";
+  }
+
+  private async resolveNotifyEventSyncNumber(input: {
+    guildId: string;
+    clanTag: string;
+    warId: string | null;
+    warStartTime: Date | null;
+    currentState: WarState;
+    postedSyncNumber: number | null;
+  }): Promise<number | null> {
+    const sameWarSync = await this.currentSyncs
+      .getCurrentSyncForClan({
+        guildId: input.guildId,
+        clanTag: input.clanTag,
+        warId: input.warId,
+        warStartTime: input.warStartTime,
+      })
+      .catch(() => null);
+    const sameWarSyncNumber = toValidSyncNumber(sameWarSync?.syncNum ?? null);
+    if (sameWarSyncNumber !== null) {
+      return sameWarSyncNumber;
+    }
+
+    const postedSyncNumber = toValidSyncNumber(input.postedSyncNumber);
+    if (postedSyncNumber !== null) {
+      return postedSyncNumber;
+    }
+
+    const previousSyncNumber = toValidSyncNumber(await this.pointsSync.getPreviousSyncNum());
+    return resolveEventRenderSyncNumber({
+      sameWarSyncNumber: null,
+      postedSyncNumber: null,
+      previousSyncNumber,
+      currentState: input.currentState,
+    });
   }
 
   private async buildBattleDayRefreshEmbed(

--- a/tests/warEventLog.logic.test.ts
+++ b/tests/warEventLog.logic.test.ts
@@ -11,6 +11,7 @@ import {
   computeWarPointsDeltaForTest,
   isNotifyWarEndedViewButtonCustomId,
   parseNotifyWarEndedViewCustomId,
+  resolveEventRenderSyncNumberForTest,
   resolveActiveWarTimingForTest,
   sanitizeWarPlanForEmbedForTest,
 } from "../src/services/WarEventLogService";
@@ -58,6 +59,60 @@ describe("War-end metadata value", () => {
         timestampUnix: 1773407400,
       })
     ).toBe("War ID: 1000055 - Sync: 476 - <t:1773407400:F>");
+  });
+});
+
+describe("WarEventLogService resolved notify sync fallback", () => {
+  it("prefers same-war sync over posted and derived values", () => {
+    expect(
+      resolveEventRenderSyncNumberForTest({
+        sameWarSyncNumber: 482,
+        postedSyncNumber: 481,
+        previousSyncNumber: 480,
+        currentState: "inWar",
+      })
+    ).toBe(482);
+  });
+
+  it("falls back to posted sync when same-war sync is unavailable", () => {
+    expect(
+      resolveEventRenderSyncNumberForTest({
+        sameWarSyncNumber: null,
+        postedSyncNumber: 482,
+        previousSyncNumber: 480,
+        currentState: "inWar",
+      })
+    ).toBe(482);
+  });
+
+  it("derives active-war sync as previous + 1 for preparation/inWar", () => {
+    expect(
+      resolveEventRenderSyncNumberForTest({
+        sameWarSyncNumber: null,
+        postedSyncNumber: null,
+        previousSyncNumber: 481,
+        currentState: "preparation",
+      })
+    ).toBe(482);
+    expect(
+      resolveEventRenderSyncNumberForTest({
+        sameWarSyncNumber: null,
+        postedSyncNumber: null,
+        previousSyncNumber: 481,
+        currentState: "inWar",
+      })
+    ).toBe(482);
+  });
+
+  it("falls back to previous sync when war is not active", () => {
+    expect(
+      resolveEventRenderSyncNumberForTest({
+        sameWarSyncNumber: null,
+        postedSyncNumber: null,
+        previousSyncNumber: 481,
+        currentState: "notInWar",
+      })
+    ).toBe(481);
   });
 });
 

--- a/tests/warEventLog.warEndPointsReconcile.test.ts
+++ b/tests/warEventLog.warEndPointsReconcile.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Client } from "discord.js";
-import { ChannelType } from "discord.js";
+import { ChannelType, EmbedBuilder } from "discord.js";
 import { prisma } from "../src/prisma";
 import {
   WarEventLogService,
@@ -1061,5 +1061,118 @@ describe("War-ended sync and metadata canonicalization", () => {
     const metadataField = fields.find((field) => field.name === "War Metadata");
     expect(metadataField?.value).toContain("War ID: 1001303");
     expect(metadataField?.value).toContain("Sync: 477");
+  });
+});
+
+describe("War-start notify refresh sync fallback", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  async function runWarStartedRefreshCase(input: {
+    sameWarSync: number | null;
+    postedSync: number | null;
+    previousSync: number | null;
+  }): Promise<{
+    ok: boolean;
+    payloadSyncNumber: number | null;
+    getPreviousSyncNumSpy: ReturnType<typeof vi.fn>;
+  }> {
+    const messageEdit = vi.fn().mockResolvedValue(undefined);
+    const messageFetch = vi.fn().mockResolvedValue({
+      content: "War declared against Enemy",
+      embeds: [],
+      edit: messageEdit,
+    });
+    const channelFetch = vi.fn().mockResolvedValue({
+      isTextBased: () => true,
+      messages: { fetch: messageFetch },
+    });
+    const coc = {
+      getCurrentWar: vi.fn().mockResolvedValue({
+        state: "preparation",
+        clan: { name: "Alpha", stars: 0 },
+        opponent: { tag: "#OPP123", name: "Enemy", stars: 0 },
+      }),
+    };
+    const service = new WarEventLogService(
+      { channels: { fetch: channelFetch } } as unknown as Client,
+      coc as any
+    );
+    const sub = makeSubscription({
+      guildId: "guild-1",
+      clanTag: "#AAA111",
+      startTime: new Date("2026-03-12T00:00:00.000Z"),
+      prepStartTime: new Date("2026-03-11T00:00:00.000Z"),
+      endTime: new Date("2026-03-13T00:00:00.000Z"),
+    });
+
+    vi.spyOn(prisma.currentWar, "update").mockResolvedValue({} as any);
+    (service as any).findSubscriptionByGuildAndTag = vi.fn().mockResolvedValue(sub);
+    (service as any).ensureCurrentWarId = vi.fn().mockResolvedValue(1000105);
+    (service as any).postedMessages = {
+      findExistingMessage: vi.fn().mockResolvedValue({
+        channelId: "chan-1",
+        messageId: "msg-1",
+        syncNum: input.postedSync,
+      }),
+    };
+    (service as any).currentSyncs = {
+      getCurrentSyncForClan: vi
+        .fn()
+        .mockResolvedValue(input.sameWarSync === null ? null : { syncNum: input.sameWarSync }),
+    };
+    const getPreviousSyncNumSpy = vi.fn().mockResolvedValue(input.previousSync);
+    (service as any).pointsSync = {
+      getPreviousSyncNum: getPreviousSyncNumSpy,
+    };
+
+    const buildSpy = vi
+      .spyOn(service as any, "buildWarStartedRefreshEmbed")
+      .mockResolvedValue(new EmbedBuilder());
+
+    const ok = await service.refreshCurrentNotifyPost("guild-1", "#AAA111");
+    const payloadSyncNumber = (buildSpy.mock.calls[0]?.[0]?.syncNumber as number | null) ?? null;
+    return {
+      ok,
+      payloadSyncNumber,
+      getPreviousSyncNumSpy,
+    };
+  }
+
+  it("prefers same-war sync over posted and derived values", async () => {
+    const result = await runWarStartedRefreshCase({
+      sameWarSync: 482,
+      postedSync: 481,
+      previousSync: 480,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.payloadSyncNumber).toBe(482);
+    expect(result.getPreviousSyncNumSpy).not.toHaveBeenCalled();
+  });
+
+  it("falls back to posted sync when same-war sync is unavailable", async () => {
+    const result = await runWarStartedRefreshCase({
+      sameWarSync: null,
+      postedSync: 482,
+      previousSync: 481,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.payloadSyncNumber).toBe(482);
+    expect(result.getPreviousSyncNumSpy).not.toHaveBeenCalled();
+  });
+
+  it("derives active-war sync as previous+1 when same-war and posted sync are unavailable", async () => {
+    const result = await runWarStartedRefreshCase({
+      sameWarSync: null,
+      postedSync: null,
+      previousSync: 481,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.payloadSyncNumber).toBe(482);
+    expect(result.getPreviousSyncNumSpy).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
- add shared WarEventLogService sync resolver for notify refresh embeds with same-war > posted > derived precedence
- wire refresh war-start and battle-day edit paths to the shared resolver to avoid unknown sync rendering
- add focused tests for precedence logic and war-start refresh payload sync selection