### PR TITLE
refactor(war-events): unify notify sync resolver for initial and refr…

### DIFF
--- a/src/services/WarEventLogService.ts
+++ b/src/services/WarEventLogService.ts
@@ -2602,23 +2602,21 @@ export class WarEventLogService {
       warStartTime: nextWarStartTime,
       currentState,
     });
-    const syncRow =
-      guildId && nextWarStartTime
-        ? await this.currentSyncs.getCurrentSyncForClan({
-            guildId,
-            clanTag: sub.clanTag,
-            warId:
-              resolvedWarId !== null && resolvedWarId !== undefined
-                ? String(Math.trunc(Number(resolvedWarId)))
-                : sub.warId !== null && sub.warId !== undefined
-                  ? String(Math.trunc(Number(sub.warId)))
-                  : null,
-            warStartTime: nextWarStartTime,
-          })
-        : null;
-    const syncNumberForEvent =
-      syncRow?.syncNum ??
-      fallbackSyncNumberForEvent;
+    const resolvedWarIdText =
+      resolvedWarId !== null && resolvedWarId !== undefined
+        ? String(Math.trunc(Number(resolvedWarId)))
+        : sub.warId !== null && sub.warId !== undefined
+          ? String(Math.trunc(Number(sub.warId)))
+          : null;
+    const syncNumberForEvent = await this.resolveNotifyEventSyncNumber({
+      guildId,
+      clanTag: sub.clanTag,
+      warId: resolvedWarIdText,
+      warStartTime: nextWarStartTime,
+      currentState,
+      postedSyncNumber: null,
+      previousSyncNumber: syncContext.previousSync,
+    });
     if (outcomeComputationInput) {
       nextOutcome = deriveExpectedOutcome(
         outcomeComputationInput.clanTag,
@@ -3953,6 +3951,7 @@ export class WarEventLogService {
     warStartTime: Date | null;
     currentState: WarState;
     postedSyncNumber: number | null;
+    previousSyncNumber?: number | null;
   }): Promise<number | null> {
     const sameWarSync = await this.currentSyncs
       .getCurrentSyncForClan({
@@ -3972,7 +3971,9 @@ export class WarEventLogService {
       return postedSyncNumber;
     }
 
-    const previousSyncNumber = toValidSyncNumber(await this.pointsSync.getPreviousSyncNum());
+    const previousSyncNumber = toValidSyncNumber(
+      input.previousSyncNumber ?? (await this.pointsSync.getPreviousSyncNum())
+    );
     return resolveEventRenderSyncNumber({
       sameWarSyncNumber: null,
       postedSyncNumber: null,

--- a/tests/warEventLog.warEndPointsReconcile.test.ts
+++ b/tests/warEventLog.warEndPointsReconcile.test.ts
@@ -1069,6 +1069,102 @@ describe("War-start notify refresh sync fallback", () => {
     vi.restoreAllMocks();
   });
 
+  async function runWarStartedInitialCase(input: {
+    sameWarSync: number | null;
+    previousSync: number | null;
+  }): Promise<{
+    payloadSyncNumber: number | null;
+  }> {
+    vi.restoreAllMocks();
+    const service = new WarEventLogService(
+      { channels: { fetch: vi.fn() } } as unknown as Client,
+      {} as any,
+    );
+    const sub = makeSubscription({
+      guildId: "guild-1",
+      clanTag: "#AAA111",
+      warId: null,
+      state: "notInWar",
+      prepStartTime: null,
+      startTime: null,
+      endTime: null,
+      opponentTag: null,
+      opponentName: null,
+    });
+
+    vi.spyOn(prisma, "$queryRaw").mockResolvedValue([sub] as any);
+    vi.spyOn(prisma.currentWar, "update").mockResolvedValue({} as any);
+    (service as any).getCurrentWarSnapshot = vi.fn().mockResolvedValue({
+      war: {
+        state: "preparation",
+        clan: {
+          name: "Alpha",
+          stars: 0,
+          attacks: 0,
+          destructionPercentage: 0,
+        },
+        opponent: {
+          tag: "#OPP123",
+          name: "Enemy",
+          stars: 0,
+          attacks: 0,
+          destructionPercentage: 0,
+        },
+        preparationStartTime: "20260311T000000.000Z",
+        startTime: "20260312T000000.000Z",
+        endTime: "20260313T000000.000Z",
+        teamSize: 50,
+        attacksPerMember: 2,
+      },
+      observation: { kind: "success" },
+    });
+    (service as any).recordCocWarObservation = vi
+      .fn()
+      .mockReturnValue({ suspected: false });
+    (service as any).hasWarEndRecorded = vi.fn().mockResolvedValue(false);
+    (service as any).ensureCurrentWarId = vi.fn().mockResolvedValue(1000105);
+    (service as any).syncWarAttacksFromWarSnapshot = vi
+      .fn()
+      .mockResolvedValue(undefined);
+    const dispatchDetectedEventSpy = vi.fn().mockResolvedValue(undefined);
+    (service as any).dispatchDetectedEvent = dispatchDetectedEventSpy;
+    (service as any).reconcileWarEndedPointsDiscrepancy = vi
+      .fn()
+      .mockResolvedValue(undefined);
+    (service as any).pointsGate = {
+      evaluatePollerFetch: vi.fn().mockResolvedValue({
+        allowed: false,
+        fetchReason: "post_war_reconciliation",
+      }),
+    };
+    (service as any).pointsSync = {
+      resetWarStartPointsJob: vi.fn().mockResolvedValue(undefined),
+      maybeRunWarStartPointsCheck: vi.fn().mockResolvedValue(undefined),
+      getPreviousSyncNum: vi.fn().mockResolvedValue(input.previousSync),
+    };
+    (service as any).currentSyncs = {
+      markNeedsValidation: vi.fn().mockResolvedValue(undefined),
+      getCurrentSyncForClan: vi
+        .fn()
+        .mockResolvedValue(input.sameWarSync === null ? null : { syncNum: input.sameWarSync }),
+    };
+
+    await (service as any).processSubscription("guild-1", "#AAA111", {
+      previousSync: input.previousSync,
+      activeSync:
+        input.previousSync !== null && Number.isFinite(input.previousSync)
+          ? Math.trunc(input.previousSync) + 1
+          : null,
+    });
+
+    const payloadSyncNumber =
+      (dispatchDetectedEventSpy.mock.calls[0]?.[0]?.payload?.syncNumber as
+        | number
+        | null
+        | undefined) ?? null;
+    return { payloadSyncNumber };
+  }
+
   async function runWarStartedRefreshCase(input: {
     sameWarSync: number | null;
     postedSync: number | null;
@@ -1078,6 +1174,7 @@ describe("War-start notify refresh sync fallback", () => {
     payloadSyncNumber: number | null;
     getPreviousSyncNumSpy: ReturnType<typeof vi.fn>;
   }> {
+    vi.restoreAllMocks();
     const messageEdit = vi.fn().mockResolvedValue(undefined);
     const messageFetch = vi.fn().mockResolvedValue({
       content: "War declared against Enemy",
@@ -1174,5 +1271,37 @@ describe("War-start notify refresh sync fallback", () => {
     expect(result.ok).toBe(true);
     expect(result.payloadSyncNumber).toBe(482);
     expect(result.getPreviousSyncNumSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps initial notify and refresh sync aligned when same-war sync exists", async () => {
+    const initial = await runWarStartedInitialCase({
+      sameWarSync: 482,
+      previousSync: 480,
+    });
+    const refresh = await runWarStartedRefreshCase({
+      sameWarSync: 482,
+      postedSync: null,
+      previousSync: 480,
+    });
+
+    expect(initial.payloadSyncNumber).toBe(482);
+    expect(refresh.payloadSyncNumber).toBe(482);
+    expect(initial.payloadSyncNumber).toBe(refresh.payloadSyncNumber);
+  });
+
+  it("keeps initial notify and refresh sync aligned for derived active fallback", async () => {
+    const initial = await runWarStartedInitialCase({
+      sameWarSync: null,
+      previousSync: 481,
+    });
+    const refresh = await runWarStartedRefreshCase({
+      sameWarSync: null,
+      postedSync: null,
+      previousSync: 481,
+    });
+
+    expect(initial.payloadSyncNumber).toBe(482);
+    expect(refresh.payloadSyncNumber).toBe(482);
+    expect(initial.payloadSyncNumber).toBe(refresh.payloadSyncNumber);
   });
 });


### PR DESCRIPTION
…esh paths

- route processSubscription sync resolution through resolveNotifyEventSyncNumber
- add tests proving initial and refresh war-start sync stay aligned for persisted and derived fallbacks