### PR TITLE
feat(defer): add routed clan weight-page link to reminders

### DIFF
--- a/src/services/WeightInputDefermentService.ts
+++ b/src/services/WeightInputDefermentService.ts
@@ -2,6 +2,7 @@ import { Client } from "discord.js";
 import { formatError } from "../helper/formatError";
 import { prisma } from "../prisma";
 import { CommandPermissionService } from "./CommandPermissionService";
+import { buildFwaWeightPageUrl } from "./FwaStatsWeightService";
 import { normalizeTag, normalizeTagBare } from "./war-events/core";
 
 export type DefermentStatus = "open" | "resolved" | "cleared";
@@ -438,6 +439,7 @@ function buildStageMessage(input: {
       ? `${input.clanName} (${input.clanTag})`
       : input.clanTag
     : "unscoped";
+  const weightPageUrl = input.clanTag ? buildFwaWeightPageUrl(input.clanTag) : null;
   return [
     `${mention}**${header}**`,
     `Player: ${input.playerTag}`,
@@ -445,6 +447,7 @@ function buildStageMessage(input: {
     `Current weight: ${input.currentWeight ?? "unknown"}`,
     `Pending age: ${input.pendingAge}`,
     `Current clan: ${clanLabel}`,
+    `FWA Stats weights: ${weightPageUrl ? `<${weightPageUrl}>` : "unknown"}`,
     "Resolve after FWAStats entry with `/defer remove <player-tag>`.",
   ].join("\n");
 }

--- a/tests/weightInputDeferment.service.test.ts
+++ b/tests/weightInputDeferment.service.test.ts
@@ -221,6 +221,9 @@ describe("WeightInputDefermentService lifecycle processing", () => {
       "<@&role-global-leader>",
     );
     expect(String(send.mock.calls[0]?.[0]?.content)).toContain("Current clan: Bravo (#BBB222)");
+    expect(String(send.mock.calls[0]?.[0]?.content)).toContain(
+      "<https://fwastats.com/Clan/BBB222/Weight>",
+    );
     expect(String(send.mock.calls[0]?.[0]?.content)).not.toContain("<@&role-1>");
     expect(String(send.mock.calls[0]?.[0]?.content)).not.toContain(
       "<@&role-lead-2>",


### PR DESCRIPTION
- include routed tracked-clan FWA Stats weights URL in deferment stage messages
- assert rerouted reminders point to the current destination clan weight page