### PR TITLE
fix(fwa): require confirmed match type for direct mail send gating

### DIFF
--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -1304,7 +1304,7 @@ function buildSingleClanMatchLinks(input: {
 }
 
 const MATCHTYPE_WARNING_LEGEND =
-  ":warning: Match type is inferred. Sending is still allowed, but confirm before posting if this looks wrong.";
+  ":warning: Match type is inferred. Confirm match type before sending mail.";
 const POINTS_CLAN_NOT_FOUND_STATUS_LINE =
   ":interrobang: Clan not found on points.fwafarm";
 
@@ -1814,6 +1814,9 @@ function getMailBlockedReasonFromRevisionState(params: {
 }): string | null {
   if (!params.hasMailChannel) {
     return "Mail channel is not configured. Use /tracked-clan configure with a mail channel.";
+  }
+  if (params.inferredMatchType) {
+    return "Match type is inferred. Confirm match type before sending mail.";
   }
   if (params.mailStatus === "posted") {
     if (!params.hasConfirmedBaseline) return null;

--- a/tests/fwaMatchInference.logic.test.ts
+++ b/tests/fwaMatchInference.logic.test.ts
@@ -270,14 +270,16 @@ describe("fwa match stored sync fallback", () => {
 });
 
 describe("fwa mail send gating", () => {
-  it("does not block send mail solely because match type is inferred", () => {
+  it("blocks send mail while match type is inferred", () => {
     const reason = getMailBlockedReasonFromStatusForTest({
       inferredMatchType: true,
       hasMailChannel: true,
       mailStatus: "not_posted",
     });
 
-    expect(reason).toBeNull();
+    expect(reason).toBe(
+      "Match type is inferred. Confirm match type before sending mail."
+    );
   });
 });
 

--- a/tests/fwaMatchRevisionDraft.logic.test.ts
+++ b/tests/fwaMatchRevisionDraft.logic.test.ts
@@ -348,7 +348,7 @@ describe("fwa match posted mail gating with revisions", () => {
     expect(reason).toBeNull();
   });
 
-  it("allows draft-confirmed send for inferred not-posted state", () => {
+  it("blocks send for inferred not-posted state even when a draft is present", () => {
     const reason = getMailBlockedReasonFromRevisionStateForTest({
       inferredMatchType: true,
       hasMailChannel: true,
@@ -360,6 +360,21 @@ describe("fwa match posted mail gating with revisions", () => {
         expectedOutcome: "LOSE",
       },
       draftDiffersFromBaseline: true,
+      hasConfirmedBaseline: false,
+    });
+
+    expect(reason).toBe(
+      "Match type is inferred. Confirm match type before sending mail."
+    );
+  });
+
+  it("allows normal not-posted send gating once match type is confirmed", () => {
+    const reason = getMailBlockedReasonFromRevisionStateForTest({
+      inferredMatchType: false,
+      hasMailChannel: true,
+      mailStatus: "not_posted",
+      appliedDraft: null,
+      draftDiffersFromBaseline: false,
       hasConfirmedBaseline: false,
     });
 


### PR DESCRIPTION
- block shared mail gate when match type is inferred to align preview/send/confirm
- update fwa mail gating tests to enforce inferred-blocked and confirmed-allowed flows