### PR TITLE
fix(war-events): fix participation guild scoping for inactive wars

### DIFF
--- a/src/scripts/repairClanWarParticipationGuildScope.ts
+++ b/src/scripts/repairClanWarParticipationGuildScope.ts
@@ -1,0 +1,182 @@
+import { randomUUID } from "crypto";
+import { Prisma } from "@prisma/client";
+import { prisma } from "../prisma";
+import { normalizeTag } from "../services/war-events/core";
+
+type ScriptArgs = {
+  sourceGuildId: string;
+  targetGuildId: string;
+  apply: boolean;
+};
+
+function parseArgs(argv: string[]): ScriptArgs {
+  const values = new Map<string, string | boolean>();
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (token === "--apply") {
+      values.set("apply", true);
+      continue;
+    }
+    if (token.startsWith("--") && i + 1 < argv.length) {
+      values.set(token.replace(/^--/, ""), argv[i + 1]);
+      i += 1;
+    }
+  }
+
+  const sourceGuildId = String(values.get("source-guild") ?? "").trim();
+  const targetGuildId = String(values.get("target-guild") ?? "").trim();
+  if (!sourceGuildId || !targetGuildId) {
+    throw new Error(
+      "Usage: ts-node src/scripts/repairClanWarParticipationGuildScope.ts --source-guild <guild-id> --target-guild <guild-id> [--apply]",
+    );
+  }
+  if (sourceGuildId === targetGuildId) {
+    throw new Error("source and target guild IDs must be different.");
+  }
+  return {
+    sourceGuildId,
+    targetGuildId,
+    apply: Boolean(values.get("apply")),
+  };
+}
+
+async function readParticipationSummary(guildId: string): Promise<{
+  totalRows: number;
+  fwaRows: number;
+  endedFwaWars: number;
+}> {
+  const rows = await prisma.$queryRaw<
+    Array<{ totalRows: number; fwaRows: number; endedFwaWars: number }>
+  >(Prisma.sql`
+    SELECT
+      COUNT(*)::int AS "totalRows",
+      COUNT(*) FILTER (WHERE "matchType" = 'FWA')::int AS "fwaRows",
+      COUNT(DISTINCT "warId") FILTER (
+        WHERE "matchType" = 'FWA'
+          AND "warEndTime" IS NOT NULL
+      )::int AS "endedFwaWars"
+    FROM "ClanWarParticipation"
+    WHERE "guildId" = ${guildId}
+  `);
+  return (
+    rows[0] ?? {
+      totalRows: 0,
+      fwaRows: 0,
+      endedFwaWars: 0,
+    }
+  );
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const targetCurrentWarRows = await prisma.currentWar.findMany({
+    where: { guildId: args.targetGuildId },
+    select: { clanTag: true },
+  });
+  const targetClanTags = Array.from(
+    new Set(
+      targetCurrentWarRows
+        .map((row) => normalizeTag(row.clanTag))
+        .filter((value) => Boolean(value)),
+    ),
+  );
+  if (targetClanTags.length === 0) {
+    throw new Error(
+      `No CurrentWar clans found for target guild ${args.targetGuildId}; aborting repair.`,
+    );
+  }
+
+  const sourceRows = await prisma.clanWarParticipation.findMany({
+    where: {
+      guildId: args.sourceGuildId,
+      matchType: "FWA",
+      warEndTime: { not: null },
+    },
+    orderBy: [{ warStartTime: "desc" }, { createdAt: "desc" }],
+  });
+  const targetTagSet = new Set(targetClanTags);
+  const candidateRows = sourceRows.filter((row) =>
+    targetTagSet.has(normalizeTag(row.clanTag)),
+  );
+  const candidateClanTags = Array.from(
+    new Set(candidateRows.map((row) => normalizeTag(row.clanTag))),
+  );
+  const nonCandidateRows = sourceRows.filter(
+    (row) => !targetTagSet.has(normalizeTag(row.clanTag)),
+  );
+
+  const sourceSummary = await readParticipationSummary(args.sourceGuildId);
+  const targetSummaryBefore = await readParticipationSummary(args.targetGuildId);
+  const proof = {
+    sourceGuildId: args.sourceGuildId,
+    targetGuildId: args.targetGuildId,
+    sourceSummary,
+    targetSummaryBefore,
+    targetCurrentWarClanCount: targetClanTags.length,
+    sourceEndedFwaRows: sourceRows.length,
+    candidateEndedFwaRows: candidateRows.length,
+    candidateClanCount: candidateClanTags.length,
+    candidateClanTags,
+    excludedSourceRows: nonCandidateRows.length,
+    excludedClanTags: Array.from(
+      new Set(nonCandidateRows.map((row) => normalizeTag(row.clanTag))),
+    ),
+    canRepair: candidateRows.length > 0,
+    mode: args.apply ? "apply" : "dry-run",
+  };
+  console.log(JSON.stringify(proof, null, 2));
+
+  if (candidateRows.length === 0) {
+    throw new Error(
+      "Safety guard: no provable candidate rows overlap target CurrentWar clans; no mutation performed.",
+    );
+  }
+  if (!args.apply) {
+    console.log("Dry run complete. Re-run with --apply to insert repaired rows.");
+    return;
+  }
+
+  const insertPayload = candidateRows.map((row) => ({
+    id: randomUUID(),
+    guildId: args.targetGuildId,
+    warId: row.warId,
+    clanTag: row.clanTag,
+    opponentTag: row.opponentTag,
+    playerTag: row.playerTag,
+    playerName: row.playerName,
+    townHall: row.townHall,
+    attacksUsed: row.attacksUsed,
+    attacksMissed: row.attacksMissed,
+    starsEarned: row.starsEarned,
+    trueStars: row.trueStars,
+    missedBoth: row.missedBoth,
+    firstAttackAt: row.firstAttackAt,
+    attackDelayMinutes: row.attackDelayMinutes,
+    attackWindowMissed: row.attackWindowMissed,
+    matchType: row.matchType,
+    warStartTime: row.warStartTime,
+    warEndTime: row.warEndTime,
+    createdAt: row.createdAt,
+  }));
+
+  const inserted = await prisma.clanWarParticipation.createMany({
+    data: insertPayload,
+    skipDuplicates: true,
+  });
+  const targetSummaryAfter = await readParticipationSummary(args.targetGuildId);
+  const verification = {
+    insertedRows: inserted.count,
+    targetSummaryAfter,
+  };
+  console.log(JSON.stringify(verification, null, 2));
+}
+
+main()
+  .catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });
+

--- a/src/services/WarEventLogService.ts
+++ b/src/services/WarEventLogService.ts
@@ -2866,7 +2866,12 @@ export class WarEventLogService {
     let payloadForDelivery = params.payload;
     let resolvedWarIdForDelivery = params.resolvedWarId;
     if (params.payload.eventType === "war_ended") {
-      await this.history.persistWarEndHistory(params.payload).catch((err) => {
+      await this.history
+        .persistWarEndHistory({
+          ...params.payload,
+          guildId: params.sub.guildId,
+        })
+        .catch((err) => {
         console.error(
           `[war-events] persist war history failed guild=${params.sub.guildId} clan=${params.sub.clanTag} error=${formatError(err)}`
         );
@@ -2897,11 +2902,16 @@ export class WarEventLogService {
         testFinalResultOverride: canonicalFinalResult,
       };
       if (payloadForDelivery.warEndFwaPoints !== params.payload.warEndFwaPoints) {
-        await this.history.persistWarEndHistory(payloadForDelivery).catch((err) => {
-          console.error(
-            `[war-events] persist canonical war history failed guild=${params.sub.guildId} clan=${params.sub.clanTag} error=${formatError(err)}`
-          );
-        });
+        await this.history
+          .persistWarEndHistory({
+            ...payloadForDelivery,
+            guildId: params.sub.guildId,
+          })
+          .catch((err) => {
+            console.error(
+              `[war-events] persist canonical war history failed guild=${params.sub.guildId} clan=${params.sub.clanTag} error=${formatError(err)}`
+            );
+          });
       }
     }
     if (!params.sub.notify || !params.sub.channelId) return;

--- a/src/services/war-events/history.ts
+++ b/src/services/war-events/history.ts
@@ -15,6 +15,18 @@ import {
   parseCocTime,
 } from "./core";
 
+/** Purpose: select the authoritative guild scope for participation persistence with explicit precedence. */
+export function resolveParticipationGuildId(input: {
+  payloadGuildId: string | null | undefined;
+  snapshotGuildId: string | null | undefined;
+}): string | null {
+  const payloadGuildId = String(input.payloadGuildId ?? "").trim();
+  if (payloadGuildId) return payloadGuildId;
+  const snapshotGuildId = String(input.snapshotGuildId ?? "").trim();
+  if (snapshotGuildId) return snapshotGuildId;
+  return null;
+}
+
 /** Purpose: encapsulate war-end history, compliance, and war-plan related logic. */
 export class WarEventHistoryService {
   /** Purpose: initialize war history service dependencies. */
@@ -340,6 +352,7 @@ export class WarEventHistoryService {
   /** Purpose: persist clan-level war-end summary and full attack payload into history/lookup tables. */
   async persistWarEndHistory(payload: {
     eventType: EventType;
+    guildId?: string | null;
     clanTag: string;
     clanName: string;
     opponentTag: string;
@@ -419,8 +432,13 @@ export class WarEventHistoryService {
         ? payload.outcome
         : finalResult.resultLabel;
     
+    const scopedGuildId = String(payload.guildId ?? "").trim() || null;
     const currentSnapshot = await prisma.currentWar.findFirst({
-      where: { clanTag, startTime: warStartTime },
+      where: {
+        clanTag,
+        startTime: warStartTime,
+        ...(scopedGuildId ? { guildId: scopedGuildId } : {}),
+      },
       select: {
         guildId: true,
         inferredMatchType: true,
@@ -489,9 +507,13 @@ export class WarEventHistoryService {
     });
 
     
-    const syncRow = currentSnapshot?.guildId
+    const participationGuildId = resolveParticipationGuildId({
+      payloadGuildId: scopedGuildId,
+      snapshotGuildId: currentSnapshot?.guildId ?? null,
+    });
+    const syncRow = participationGuildId
       ? await this.pointsSync.getCurrentSyncForClan({
-          guildId: currentSnapshot.guildId,
+          guildId: participationGuildId,
           clanTag,
           warId: String(warId),
           warStartTime,
@@ -636,7 +658,7 @@ export class WarEventHistoryService {
       `,
     );
     await this.persistWarParticipationSnapshot({
-      guildId: currentSnapshot?.guildId ?? null,
+      guildId: participationGuildId,
       warId: String(warId),
       clanTag,
       opponentTag:

--- a/tests/warEventLog.logic.test.ts
+++ b/tests/warEventLog.logic.test.ts
@@ -15,7 +15,10 @@ import {
   resolveActiveWarTimingForTest,
   sanitizeWarPlanForEmbedForTest,
 } from "../src/services/WarEventLogService";
-import { WarEventHistoryService } from "../src/services/war-events/history";
+import {
+  resolveParticipationGuildId,
+  WarEventHistoryService,
+} from "../src/services/war-events/history";
 
 function dateAt(hour: number): Date {
   return new Date(Date.UTC(2026, 0, 1, hour, 0, 0));
@@ -59,6 +62,35 @@ describe("War-end metadata value", () => {
         timestampUnix: 1773407400,
       })
     ).toBe("War ID: 1000055 - Sync: 476 - <t:1773407400:F>");
+  });
+});
+
+describe("WarEventHistoryService participation guild resolution", () => {
+  it("prefers payload guild over snapshot guild to avoid cross-guild writes", () => {
+    expect(
+      resolveParticipationGuildId({
+        payloadGuildId: "prod-guild",
+        snapshotGuildId: "staging-guild",
+      }),
+    ).toBe("prod-guild");
+  });
+
+  it("falls back to snapshot guild when payload guild is unavailable", () => {
+    expect(
+      resolveParticipationGuildId({
+        payloadGuildId: "",
+        snapshotGuildId: "snapshot-guild",
+      }),
+    ).toBe("snapshot-guild");
+  });
+
+  it("returns null when neither guild source is available", () => {
+    expect(
+      resolveParticipationGuildId({
+        payloadGuildId: null,
+        snapshotGuildId: undefined,
+      }),
+    ).toBeNull();
   });
 });
 

--- a/tests/warEventLog.warEndPointsReconcile.test.ts
+++ b/tests/warEventLog.warEndPointsReconcile.test.ts
@@ -912,8 +912,9 @@ describe("War-ended sync and metadata canonicalization", () => {
       .mockResolvedValue({ allowed: true, existingMessage: null, warId: "1001303" });
     const emitSpy = vi.spyOn(service as any, "emitEvent").mockResolvedValue(undefined);
 
+    const persistSpy = vi.fn().mockResolvedValue(undefined);
     (service as any).history = {
-      persistWarEndHistory: vi.fn().mockResolvedValue(undefined),
+      persistWarEndHistory: persistSpy,
       resolveCanonicalWarEndedContext: vi.fn().mockResolvedValue({
         warId: 1001303,
         syncNumber: 477,
@@ -948,6 +949,8 @@ describe("War-ended sync and metadata canonicalization", () => {
     expect(emitSpy).toHaveBeenCalledTimes(1);
     expect(emitSpy.mock.calls[0]?.[2]).toBe(1001303);
     expect(emitSpy.mock.calls[0]?.[1]?.syncNumber).toBe(477);
+    expect(persistSpy).toHaveBeenCalledTimes(1);
+    expect(persistSpy.mock.calls[0]?.[0]?.guildId).toBe("guild-1");
   });
 
   it("recomputes canonical war-ended expected points before live emit", async () => {
@@ -1010,6 +1013,8 @@ describe("War-ended sync and metadata canonicalization", () => {
     expect(emitSpy.mock.calls[0]?.[1]?.warEndFwaPoints).toBe(8);
     expect(emitSpy.mock.calls[0]?.[1]?.testFinalResultOverride?.resultLabel).toBe("WIN");
     expect(persistSpy).toHaveBeenCalledTimes(2);
+    expect(persistSpy.mock.calls[0]?.[0]?.guildId).toBe("guild-1");
+    expect(persistSpy.mock.calls[1]?.[0]?.guildId).toBe("guild-1");
     expect(persistSpy.mock.calls[1]?.[0]?.warEndFwaPoints).toBe(8);
   });
 


### PR DESCRIPTION
- scope war-end participation persistence to the subscription guild id
- add guarded repair script to copy mis-scoped ended FWA rows into prod guild