### PR TITLE
feat(emoji): render /emoji list in 3-column embed layout

### DIFF
--- a/src/commands/Emoji.ts
+++ b/src/commands/Emoji.ts
@@ -97,13 +97,26 @@ function buildEmojiListEmbed(params: {
       .setFooter({ text: "Total 0 emojis" })
       .setColor(0x5865f2);
   }
-  return new EmbedBuilder()
+  const embed = new EmbedBuilder()
     .setTitle("Bot Application Emojis")
-    .setDescription(params.pages[params.page] ?? "")
     .setFooter({
       text: `Page ${params.page + 1}/${params.pages.length} | Total ${params.emojis.length} emojis`,
     })
     .setColor(0x5865f2);
+  const pageLines = String(params.pages[params.page] ?? "")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  if (pageLines.length > 0) {
+    embed.addFields(
+      pageLines.map((line) => ({
+        name: "\u200b",
+        value: line,
+        inline: true,
+      })),
+    );
+  }
+  return embed;
 }
 
 /** Purpose: build prev/next paginator buttons with proper boundary and timeout disabled states. */

--- a/tests/emoji.command.test.ts
+++ b/tests/emoji.command.test.ts
@@ -9,6 +9,7 @@ import type {
 import {
   Emoji,
   applyEmojiPageActionForTest,
+  buildEmojiListEmbedForTest,
   resetEmojiCommandPermissionServiceForTest,
   resetEmojiResolverForTest,
   setEmojiCommandPermissionServiceForTest,
@@ -654,8 +655,64 @@ describe("/emoji command", () => {
         ? embed.toJSON()
         : (embed?.data ?? {});
     expect(json.title).toBe("Bot Application Emojis");
-    expect(String(json.description ?? "")).toContain(":alpha:");
+    expect(Array.isArray(json.fields)).toBe(true);
+    expect(json.fields).toHaveLength(2);
+    expect(json.fields?.[0]?.inline).toBe(true);
+    expect(String(json.fields?.[0]?.value ?? "")).toContain(":alpha:");
+    expect(String(json.fields?.[1]?.value ?? "")).toContain(":bravo:");
     expect(fetchReply).not.toHaveBeenCalled();
+  });
+
+  it("builds list embeds with inline fields for 3-column layout and uneven rows", () => {
+    const emojis: ResolvedApplicationEmoji[] = [
+      {
+        id: "1",
+        name: "alpha",
+        shortcode: ":alpha:",
+        rendered: "<:alpha:1>",
+        animated: false,
+      },
+      {
+        id: "2",
+        name: "bravo",
+        shortcode: ":bravo:",
+        rendered: "<:bravo:2>",
+        animated: false,
+      },
+      {
+        id: "3",
+        name: "charlie",
+        shortcode: ":charlie:",
+        rendered: "<:charlie:3>",
+        animated: false,
+      },
+      {
+        id: "4",
+        name: "delta",
+        shortcode: ":delta:",
+        rendered: "<:delta:4>",
+        animated: false,
+      },
+      {
+        id: "5",
+        name: "echo",
+        shortcode: ":echo:",
+        rendered: "<:echo:5>",
+        animated: false,
+      },
+    ];
+    const pageText = emojis
+      .map((emoji) => `${emoji.rendered} \`${emoji.shortcode}\``)
+      .join("\n");
+    const embed = buildEmojiListEmbedForTest({
+      emojis,
+      pages: [pageText],
+      page: 0,
+    });
+    const json = embed.toJSON();
+    expect(json.fields).toHaveLength(5);
+    expect(json.fields?.every((field) => field.inline === true)).toBe(true);
+    expect(String(json.fields?.[4]?.value ?? "")).toContain(":echo:");
   });
 
   it("ignores react when name is omitted and keeps list mode", async () => {


### PR DESCRIPTION
- switch paginated list entries to inline embed fields for compact 3-column scanning
- add tests for inline field rendering and uneven final-row behavior