### PR TITLE
fix(emoji): keep 3-column list layout compact

### DIFF
--- a/src/commands/Emoji.ts
+++ b/src/commands/Emoji.ts
@@ -45,6 +45,7 @@ type EmojiAttachmentDownloadResult =
     };
 
 const EMOJI_PAGE_SIZE = 20;
+const EMOJI_LIST_COLUMNS = 3;
 const EMOJI_PAGINATOR_TIMEOUT_MS = 10 * 60 * 1000;
 const MAX_AUTOCOMPLETE_CHOICES = 25;
 const MESSAGE_ID_PATTERN = /^\d{17,22}$/;
@@ -71,6 +72,22 @@ function paginateEmojiLines(
     pages.push(slice.map(formatEmojiListLine).join("\n"));
   }
   return pages;
+}
+
+/** Purpose: distribute one compact emoji line list into balanced columns while preserving row-wise order. */
+function buildEmojiListColumns(
+  lines: string[],
+  columnCount: number = EMOJI_LIST_COLUMNS,
+): string[] {
+  if (lines.length === 0) return [];
+  const effectiveColumns = Math.max(1, Math.min(columnCount, lines.length));
+  const columns = Array.from({ length: effectiveColumns }, () => [] as string[]);
+  lines.forEach((line, index) => {
+    columns[index % effectiveColumns].push(line);
+  });
+  return columns
+    .map((columnLines) => columnLines.join("\n").trim())
+    .filter((value) => value.length > 0);
 }
 
 /** Purpose: apply previous/next pagination input while keeping page index bounded. */
@@ -107,11 +124,12 @@ function buildEmojiListEmbed(params: {
     .split("\n")
     .map((line) => line.trim())
     .filter((line) => line.length > 0);
-  if (pageLines.length > 0) {
+  const columns = buildEmojiListColumns(pageLines);
+  if (columns.length > 0) {
     embed.addFields(
-      pageLines.map((line) => ({
+      columns.map((value) => ({
         name: "\u200b",
-        value: line,
+        value,
         inline: true,
       })),
     );

--- a/tests/emoji.command.test.ts
+++ b/tests/emoji.command.test.ts
@@ -710,9 +710,13 @@ describe("/emoji command", () => {
       page: 0,
     });
     const json = embed.toJSON();
-    expect(json.fields).toHaveLength(5);
+    expect(json.fields).toHaveLength(3);
     expect(json.fields?.every((field) => field.inline === true)).toBe(true);
-    expect(String(json.fields?.[4]?.value ?? "")).toContain(":echo:");
+    expect(String(json.fields?.[0]?.value ?? "")).toContain(":alpha:");
+    expect(String(json.fields?.[0]?.value ?? "")).toContain(":delta:");
+    expect(String(json.fields?.[1]?.value ?? "")).toContain(":bravo:");
+    expect(String(json.fields?.[1]?.value ?? "")).toContain(":echo:");
+    expect(String(json.fields?.[2]?.value ?? "")).toContain(":charlie:");
   });
 
   it("ignores react when name is omitted and keeps list mode", async () => {


### PR DESCRIPTION
- group page entries into three inline compact columns instead of one field per emoji
- update emoji list tests to assert dense uneven-column rendering