### PR TITLE
Merge `dev` into `main` — harden `/fwa match`, war-event sync, and mail decision flow

### DIFF
--- a/src/commands/Emoji.ts
+++ b/src/commands/Emoji.ts
@@ -45,6 +45,7 @@ type EmojiAttachmentDownloadResult =
     };
 
 const EMOJI_PAGE_SIZE = 20;
+const EMOJI_LIST_COLUMNS = 3;
 const EMOJI_PAGINATOR_TIMEOUT_MS = 10 * 60 * 1000;
 const MAX_AUTOCOMPLETE_CHOICES = 25;
 const MESSAGE_ID_PATTERN = /^\d{17,22}$/;
@@ -71,6 +72,22 @@ function paginateEmojiLines(
     pages.push(slice.map(formatEmojiListLine).join("\n"));
   }
   return pages;
+}
+
+/** Purpose: distribute one compact emoji line list into balanced columns while preserving row-wise order. */
+function buildEmojiListColumns(
+  lines: string[],
+  columnCount: number = EMOJI_LIST_COLUMNS,
+): string[] {
+  if (lines.length === 0) return [];
+  const effectiveColumns = Math.max(1, Math.min(columnCount, lines.length));
+  const columns = Array.from({ length: effectiveColumns }, () => [] as string[]);
+  lines.forEach((line, index) => {
+    columns[index % effectiveColumns].push(line);
+  });
+  return columns
+    .map((columnLines) => columnLines.join("\n").trim())
+    .filter((value) => value.length > 0);
 }
 
 /** Purpose: apply previous/next pagination input while keeping page index bounded. */
@@ -107,11 +124,12 @@ function buildEmojiListEmbed(params: {
     .split("\n")
     .map((line) => line.trim())
     .filter((line) => line.length > 0);
-  if (pageLines.length > 0) {
+  const columns = buildEmojiListColumns(pageLines);
+  if (columns.length > 0) {
     embed.addFields(
-      pageLines.map((line) => ({
+      columns.map((value) => ({
         name: "\u200b",
-        value: line,
+        value,
         inline: true,
       })),
     );

--- a/src/commands/Emoji.ts
+++ b/src/commands/Emoji.ts
@@ -97,13 +97,26 @@ function buildEmojiListEmbed(params: {
       .setFooter({ text: "Total 0 emojis" })
       .setColor(0x5865f2);
   }
-  return new EmbedBuilder()
+  const embed = new EmbedBuilder()
     .setTitle("Bot Application Emojis")
-    .setDescription(params.pages[params.page] ?? "")
     .setFooter({
       text: `Page ${params.page + 1}/${params.pages.length} | Total ${params.emojis.length} emojis`,
     })
     .setColor(0x5865f2);
+  const pageLines = String(params.pages[params.page] ?? "")
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  if (pageLines.length > 0) {
+    embed.addFields(
+      pageLines.map((line) => ({
+        name: "\u200b",
+        value: line,
+        inline: true,
+      })),
+    );
+  }
+  return embed;
 }
 
 /** Purpose: build prev/next paginator buttons with proper boundary and timeout disabled states. */

--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -3347,6 +3347,66 @@ function formatMailLifecycleStatusLine(
   return "Mail status: **Send Mail Available**";
 }
 
+type NonActiveMailProjectionMode = "pre_war" | "no_opponent";
+
+type NonActiveMailProjection = {
+  mode: NonActiveMailProjectionMode;
+  mailStatusEmoji: string;
+  mailStatusLine: string;
+  mailDebugLines: string[];
+  mailAction: MatchView["mailAction"] | undefined;
+};
+
+/** Purpose: project non-active mail status/action semantics shared by overview + direct single-tag renders. */
+function buildNonActiveMailProjection(params: {
+  mode: NonActiveMailProjectionMode;
+  tag: string;
+  resolvedStatus: ResolvedLiveWarMailStatus;
+  mailStatusDebugEnabled?: boolean;
+}): NonActiveMailProjection {
+  return {
+    mode: params.mode,
+    mailStatusEmoji: params.resolvedStatus.mailStatusEmoji,
+    mailStatusLine: formatMailLifecycleStatusLine(params.resolvedStatus.status),
+    mailDebugLines: params.mailStatusDebugEnabled
+      ? buildMailStatusDebugLines(params.resolvedStatus.debug)
+      : [],
+    mailAction:
+      params.mode === "no_opponent"
+        ? {
+            tag: normalizeTag(params.tag),
+            enabled: false,
+            reason: "No active war opponent.",
+          }
+        : undefined,
+  };
+}
+
+/** Purpose: resolve lifecycle and project non-active mail status/action semantics for overview + direct single-tag renders. */
+async function resolveNonActiveMailProjection(params: {
+  mode: NonActiveMailProjectionMode;
+  client: Client | null | undefined;
+  guildId: string | null;
+  tag: string;
+  warId: number | null | undefined;
+  emitDebugLog?: boolean;
+  mailStatusDebugEnabled?: boolean;
+}): Promise<NonActiveMailProjection> {
+  const resolved = await resolveLiveWarMailStatus({
+    client: params.client,
+    guildId: params.guildId,
+    tag: params.tag,
+    warId: params.warId ?? null,
+    emitDebugLog: params.emitDebugLog,
+  });
+  return buildNonActiveMailProjection({
+    mode: params.mode,
+    tag: params.tag,
+    resolvedStatus: resolved,
+    mailStatusDebugEnabled: params.mailStatusDebugEnabled,
+  });
+}
+
 /** Purpose: compute shared mail-send gating from lifecycle status + persisted baseline for one rendered war state. */
 async function resolveMailSendGateForRenderedState(params: {
   client: Client | null | undefined;
@@ -7599,6 +7659,7 @@ export const resolveWarMailFreshnessStatusForTest =
   resolveWarMailFreshnessStatus;
 export const formatMailLifecycleStatusLineForTest =
   formatMailLifecycleStatusLine;
+export const buildNonActiveMailProjectionForTest = buildNonActiveMailProjection;
 export const buildMailSendGateDecisionForTest = buildMailSendGateDecision;
 export const buildOverviewMailDecisionProjectionForTest =
   buildOverviewMailDecisionProjection;
@@ -8985,17 +9046,17 @@ async function buildTrackedMatchOverview(
     const clanTimeRemainingLine = getWarStateRemaining(war, warState);
     const sub = subByTag.get(clanTag);
     if (warState === "notInWar") {
-      const preWarMailStatus = await resolveLiveWarMailStatus({
+      const nonActiveMailProjection = await resolveNonActiveMailProjection({
+        mode: "pre_war",
         client: client ?? null,
         guildId,
         tag: clanTag,
         warId: sub?.warId ?? null,
         emitDebugLog: mailStatusDebugEnabled,
+        mailStatusDebugEnabled,
       });
-      const mailStatusEmoji = preWarMailStatus.mailStatusEmoji;
-      const preWarMailDebugLines = mailStatusDebugEnabled
-        ? buildMailStatusDebugLines(preWarMailStatus.debug)
-        : [];
+      const mailStatusEmoji = nonActiveMailProjection.mailStatusEmoji;
+      const preWarMailDebugLines = nonActiveMailProjection.mailDebugLines;
       const clanProfile = await cocService
         .getClan(`#${clanTag}`)
         .catch(() => null);
@@ -9031,7 +9092,7 @@ async function buildTrackedMatchOverview(
         `War State: **${clanWarStateLine}**`,
         `Time Remaining: **${clanTimeRemainingLine}**`,
         `Sync: **${clanSyncLine}**`,
-        formatMailLifecycleStatusLine(preWarMailStatus.status),
+        nonActiveMailProjection.mailStatusLine,
         ...preWarMailDebugLines,
       ];
       if (includeInOverview) {
@@ -9109,24 +9170,24 @@ async function buildTrackedMatchOverview(
     });
 
     if (!opponentTag) {
-      const noOpponentMailStatus = await resolveLiveWarMailStatus({
+      const nonActiveMailProjection = await resolveNonActiveMailProjection({
+        mode: "no_opponent",
         client: client ?? null,
         guildId,
         tag: clanTag,
         warId: sub?.warId ?? null,
         emitDebugLog: mailStatusDebugEnabled,
+        mailStatusDebugEnabled,
       });
-      const mailStatusEmoji = noOpponentMailStatus.mailStatusEmoji;
-      const noOpponentMailDebugLines = mailStatusDebugEnabled
-        ? buildMailStatusDebugLines(noOpponentMailStatus.debug)
-        : [];
+      const mailStatusEmoji = nonActiveMailProjection.mailStatusEmoji;
+      const noOpponentMailDebugLines = nonActiveMailProjection.mailDebugLines;
       const noOpponentHeader = `${mailStatusEmoji} | ${clanName} (#${clanTag}) vs Unknown`;
       const noOpponentLines = [
         "No active war opponent",
         `War State: **${clanWarStateLine}**`,
         `Time Remaining: **${clanTimeRemainingLine}**`,
         `Sync: **${clanSyncLine}**`,
-        formatMailLifecycleStatusLine(noOpponentMailStatus.status),
+        nonActiveMailProjection.mailStatusLine,
         ...noOpponentMailDebugLines,
       ];
       if (includeInOverview) {
@@ -9171,11 +9232,7 @@ async function buildTrackedMatchOverview(
         clanName,
         clanTag,
         mailStatusEmoji,
-        mailAction: {
-          tag: clanTag,
-          enabled: false,
-          reason: "No active war opponent.",
-        },
+        mailAction: nonActiveMailProjection.mailAction,
         skipSyncAction: sub?.matchType === "SKIP" ? null : { tag: clanTag },
         undoSkipSyncAction: sub?.matchType === "SKIP" ? { tag: clanTag } : null,
       };
@@ -12605,105 +12662,171 @@ export const Fwa: Command = {
           !opponentTag ||
           subscription?.state === "notInWar"
         ) {
-          const clanProfile = await cocService
-            .getClan(`#${tag}`)
-            .catch(() => null);
-          const memberCount = Array.isArray(clanProfile?.members)
-            ? clanProfile.members.length
-            : Number.isFinite(Number(clanProfile?.members))
-              ? Number(clanProfile?.members)
-              : null;
-          const livePoints = await getClanPointsCached(
-            settings,
-            cocService,
-            tag,
-            sourceSync,
-            warLookupCache,
-          ).catch(() => null);
-          const clanPoints =
-            livePoints?.balance ?? subscription?.fwaPoints ?? null;
-          const outOfSync =
-            subscription?.fwaPoints !== null &&
-            subscription?.fwaPoints !== undefined &&
-            livePoints?.balance !== null &&
-            livePoints?.balance !== undefined &&
-            Number(subscription.fwaPoints) !== Number(livePoints.balance);
-          const actualByTag = await getActualSheetSnapshotCached(
-            settings,
-          ).catch(() => new Map<string, ActualSheetClanSnapshot>());
-          const actual = actualByTag.get(tag) ?? null;
-          const preWarMailStatus = await resolveLiveWarMailStatus({
+          const nonActiveMode: NonActiveMailProjectionMode =
+            warState === "notInWar" || subscription?.state === "notInWar"
+              ? "pre_war"
+              : "no_opponent";
+          const nonActiveMailProjection = await resolveNonActiveMailProjection({
+            mode: nonActiveMode,
             client: interaction.client,
             guildId: interaction.guildId ?? null,
             tag,
             warId: subscription?.warId ?? null,
             emitDebugLog: matchMailStatusDebugEnabled,
+            mailStatusDebugEnabled: matchMailStatusDebugEnabled,
           });
-          const mailStatusEmoji = preWarMailStatus.mailStatusEmoji;
-          const preWarMailDebugLines = matchMailStatusDebugEnabled
-            ? buildMailStatusDebugLines(preWarMailStatus.debug)
-            : [];
+          const mailStatusEmoji = nonActiveMailProjection.mailStatusEmoji;
+          const nonActiveMailDebugLines = nonActiveMailProjection.mailDebugLines;
           const clanName =
             sanitizeClanName(trackedClanMeta?.name ?? "") ?? `#${tag}`;
-          const preWarHeader = `${mailStatusEmoji} | ${clanName} (#${tag})`;
-          const preWarLines = [
-            outOfSync
-              ? ":warning: out of sync with points site"
-              : ":white_check_mark: data in sync with points site",
-            `Clan points: **${clanPoints !== null && clanPoints !== undefined ? clanPoints : "unknown"}**`,
-            `Members: **${memberCount ?? "?"}/50**`,
-            `Total weight (ACTUAL): **${actual?.totalWeight ?? "unknown"}**`,
-            `Weight compo (ACTUAL): ${actual?.weightCompo ?? "unknown"}`,
-            `Weight deltas (ACTUAL): ${actual?.weightDeltas ?? "unknown"}`,
-            `Compo advice (ACTUAL): ${actual?.compoAdvice ?? "none"}`,
-            `War State: **${formatWarStateLabel(warState)}**`,
-            `Time Remaining: **${warRemaining}**`,
-            `Sync: **${withSyncModeLabel(getSyncDisplay(sourceSync, warState), sourceSync)}**`,
-            formatMailLifecycleStatusLine(preWarMailStatus.status),
-            ...preWarMailDebugLines,
-          ];
-          const singleView: MatchView = {
-            embed: new EmbedBuilder()
-              .setTitle(preWarHeader)
-              .setDescription(preWarLines.join("\n"))
-              .setColor(
-                resolveSingleClanMatchEmbedColor({
-                  effectiveMatchType:
-                    (subscription?.matchType as
-                      | "FWA"
-                      | "BL"
-                      | "MM"
-                      | "SKIP"
-                      | "UNKNOWN"
-                      | null
-                      | undefined) ?? "UNKNOWN",
-                  effectiveExpectedOutcome: null,
-                }),
+
+          let singleView: MatchView;
+          if (nonActiveMode === "no_opponent") {
+            singleView = {
+              embed: new EmbedBuilder()
+                .setTitle(`${mailStatusEmoji} | ${clanName} (#${tag}) vs Unknown`)
+                .setDescription(
+                  [
+                    "No active war opponent",
+                    `War State: **${formatWarStateLabel(warState)}**`,
+                    `Time Remaining: **${warRemaining}**`,
+                    `Sync: **${withSyncModeLabel(getSyncDisplay(sourceSync, warState), sourceSync)}**`,
+                    nonActiveMailProjection.mailStatusLine,
+                    ...nonActiveMailDebugLines,
+                  ].join("\n"),
+                )
+                .setColor(
+                  resolveSingleClanMatchEmbedColor({
+                    effectiveMatchType:
+                      (subscription?.matchType as
+                        | "FWA"
+                        | "BL"
+                        | "MM"
+                        | "SKIP"
+                        | "UNKNOWN"
+                        | null
+                        | undefined) ?? "UNKNOWN",
+                    effectiveExpectedOutcome: null,
+                  }),
+                ),
+              copyText: limitDiscordContent(
+                [
+                  `# ${mailStatusEmoji} | ${clanName} (#${tag}) vs Unknown`,
+                  "No active war opponent",
+                  `War State: ${formatWarStateLabel(warState)}`,
+                  `Time Remaining: ${warRemaining}`,
+                  `Sync: ${withSyncModeLabel(getSyncDisplay(sourceSync, warState), sourceSync)}`,
+                  nonActiveMailProjection.mailStatusLine.replace(/\*\*/g, ""),
+                  ...nonActiveMailDebugLines,
+                ].join("\n"),
               ),
-            copyText: limitDiscordContent(
-              [`# ${preWarHeader}`, ...preWarLines].join("\n"),
-            ),
-            matchTypeAction: null,
-            matchTypeCurrent:
-              (subscription?.matchType as
-                | "FWA"
-                | "BL"
-                | "MM"
-                | "SKIP"
-                | null
-                | undefined) ?? null,
-            inferredMatchType: false,
-            outcomeAction: null,
-            syncAction: null,
-            clanName,
-            clanTag: tag,
-            mailStatusEmoji,
-            skipSyncAction: subscription?.matchType === "SKIP" ? null : { tag },
-            undoSkipSyncAction:
-              subscription?.matchType === "SKIP" ? { tag } : null,
-          };
+              matchTypeAction: null,
+              matchTypeCurrent:
+                (subscription?.matchType as
+                  | "FWA"
+                  | "BL"
+                  | "MM"
+                  | "SKIP"
+                  | null
+                  | undefined) ?? null,
+              inferredMatchType: false,
+              outcomeAction: null,
+              syncAction: null,
+              clanName,
+              clanTag: tag,
+              mailStatusEmoji,
+              mailAction: nonActiveMailProjection.mailAction,
+              skipSyncAction: subscription?.matchType === "SKIP" ? null : { tag },
+              undoSkipSyncAction:
+                subscription?.matchType === "SKIP" ? { tag } : null,
+            };
+          } else {
+            const clanProfile = await cocService
+              .getClan(`#${tag}`)
+              .catch(() => null);
+            const memberCount = Array.isArray(clanProfile?.members)
+              ? clanProfile.members.length
+              : Number.isFinite(Number(clanProfile?.members))
+                ? Number(clanProfile?.members)
+                : null;
+            const livePoints = await getClanPointsCached(
+              settings,
+              cocService,
+              tag,
+              sourceSync,
+              warLookupCache,
+            ).catch(() => null);
+            const clanPoints = livePoints?.balance ?? subscription?.fwaPoints ?? null;
+            const outOfSync =
+              subscription?.fwaPoints !== null &&
+              subscription?.fwaPoints !== undefined &&
+              livePoints?.balance !== null &&
+              livePoints?.balance !== undefined &&
+              Number(subscription.fwaPoints) !== Number(livePoints.balance);
+            const actualByTag = await getActualSheetSnapshotCached(
+              settings,
+            ).catch(() => new Map<string, ActualSheetClanSnapshot>());
+            const actual = actualByTag.get(tag) ?? null;
+            const preWarHeader = `${mailStatusEmoji} | ${clanName} (#${tag})`;
+            const preWarLines = [
+              outOfSync
+                ? ":warning: out of sync with points site"
+                : ":white_check_mark: data in sync with points site",
+              `Clan points: **${clanPoints !== null && clanPoints !== undefined ? clanPoints : "unknown"}**`,
+              `Members: **${memberCount ?? "?"}/50**`,
+              `Total weight (ACTUAL): **${actual?.totalWeight ?? "unknown"}**`,
+              `Weight compo (ACTUAL): ${actual?.weightCompo ?? "unknown"}`,
+              `Weight deltas (ACTUAL): ${actual?.weightDeltas ?? "unknown"}`,
+              `Compo advice (ACTUAL): ${actual?.compoAdvice ?? "none"}`,
+              `War State: **${formatWarStateLabel(warState)}**`,
+              `Time Remaining: **${warRemaining}**`,
+              `Sync: **${withSyncModeLabel(getSyncDisplay(sourceSync, warState), sourceSync)}**`,
+              nonActiveMailProjection.mailStatusLine,
+              ...nonActiveMailDebugLines,
+            ];
+            singleView = {
+              embed: new EmbedBuilder()
+                .setTitle(preWarHeader)
+                .setDescription(preWarLines.join("\n"))
+                .setColor(
+                  resolveSingleClanMatchEmbedColor({
+                    effectiveMatchType:
+                      (subscription?.matchType as
+                        | "FWA"
+                        | "BL"
+                        | "MM"
+                        | "SKIP"
+                        | "UNKNOWN"
+                        | null
+                        | undefined) ?? "UNKNOWN",
+                    effectiveExpectedOutcome: null,
+                  }),
+                ),
+              copyText: limitDiscordContent(
+                [`# ${preWarHeader}`, ...preWarLines].join("\n"),
+              ),
+              matchTypeAction: null,
+              matchTypeCurrent:
+                (subscription?.matchType as
+                  | "FWA"
+                  | "BL"
+                  | "MM"
+                  | "SKIP"
+                  | null
+                  | undefined) ?? null,
+              inferredMatchType: false,
+              outcomeAction: null,
+              syncAction: null,
+              clanName,
+              clanTag: tag,
+              mailStatusEmoji,
+              skipSyncAction: subscription?.matchType === "SKIP" ? null : { tag },
+              undoSkipSyncAction:
+                subscription?.matchType === "SKIP" ? { tag } : null,
+            };
+          }
           console.info(
-            `[fwa-match-payload] stage=command_build scope=scoped guild=${interaction.guildId ?? "none"} source=single_tag_prewar tag=#${tag}`,
+            `[fwa-match-payload] stage=command_build scope=scoped guild=${interaction.guildId ?? "none"} source=${nonActiveMode === "no_opponent" ? "single_tag_no_opponent" : "single_tag_prewar"} tag=#${tag}`,
           );
           fwaMatchCopyPayloads.set(key, {
             userId: interaction.user.id,

--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -2495,6 +2495,7 @@ async function buildWarMailEmbedForTag(
   unavailableReasons: string[];
   matchType: "FWA" | "BL" | "MM" | "UNKNOWN";
   expectedOutcome: "WIN" | "LOSE" | "UNKNOWN" | null;
+  mailRevisionDecision: MailRevisionDecisionContract;
 }> {
   const normalizedTag = normalizeTag(tag);
   const trackedConfig = await getTrackedClanMailConfig(normalizedTag);
@@ -2600,20 +2601,6 @@ async function buildWarMailEmbedForTag(
     warIdForSync !== null && Number.isFinite(Number(warIdForSync))
       ? Math.trunc(Number(warIdForSync))
       : null;
-  const mailConfig = await getCurrentWarMailConfig(guildId, normalizedTag);
-  const lifecycleStatus = warIdForSync
-    ? ((
-        await warMailLifecycleService
-          .getLifecycleForWar({
-            guildId,
-            clanTag: normalizedTag,
-            warId: Number(warIdForSync),
-          })
-          .catch(() => null)
-      )?.status === "POSTED"
-      ? "posted"
-        : "not_posted")
-    : "not_posted";
   const syncRow = await pointsSyncService
     .getCurrentSyncForClan({
       guildId,
@@ -2843,45 +2830,29 @@ async function buildWarMailEmbedForTag(
     });
   }
 
-  const liveRevisionFields = buildLiveRevisionFields({
-    warId: subscription?.warId ?? null,
-    opponentTag: effectiveOpponentTag,
-    matchType:
-      matchType === "FWA" || matchType === "BL" || matchType === "MM"
-        ? matchType
-        : "UNKNOWN",
-    expectedOutcome: matchType === "FWA" ? (outcome ?? "UNKNOWN") : null,
-  });
-  const confirmedRevisionBaseline = resolveConfirmedRevisionBaseline({
-    syncRow: syncRow
-      ? {
-          warId: syncRow.warId ?? null,
-          opponentTag: syncRow.opponentTag,
-          lastKnownMatchType: syncRow.lastKnownMatchType ?? null,
-          lastKnownOutcome: syncRow.lastKnownOutcome ?? null,
-          isFwa: syncRow.isFwa ?? null,
-          confirmedByClanMail: Boolean(syncRow.confirmedByClanMail),
-        }
-      : null,
-    mailConfig: {
-      lastWarId: mailConfig.lastWarId,
-      lastOpponentTag: mailConfig.lastOpponentTag,
-      lastMatchType: mailConfig.lastMatchType,
-      lastExpectedOutcome: mailConfig.lastExpectedOutcome,
+  const mailRevisionDecision = await resolveMailRevisionDecisionForRenderedState(
+    {
+      client: null,
+      guildId,
+      tag: normalizedTag,
+      hasMailChannel: Boolean(trackedConfig.mailChannelId),
+      inferredMatchType,
+      warId: warIdForSyncNumber,
+      warStartMs: warStartTimeForSync?.getTime?.() ?? null,
+      opponentTag: effectiveOpponentTag || null,
+      matchType:
+        matchType === "FWA" || matchType === "BL" || matchType === "MM"
+          ? matchType
+          : "UNKNOWN",
+      expectedOutcome: matchType === "FWA" ? (outcome ?? "UNKNOWN") : null,
+      draft: options?.revisionOverride ?? null,
     },
-    liveFields: liveRevisionFields,
-    lifecycleStatus,
-  });
-  const effectiveRevisionState = resolveEffectiveRevisionState({
-    liveFields: liveRevisionFields,
-    confirmedBaseline: confirmedRevisionBaseline,
-    draft: options?.revisionOverride ?? null,
-  });
-  const effectiveRevisionFields = effectiveRevisionState.effective;
+  );
+  const effectiveRevisionFields = mailRevisionDecision.effectiveRevisionFields;
   const mailMatchType = effectiveRevisionFields?.matchType ?? matchType;
-  const mailInferredMatchType = effectiveRevisionState.appliedDraft
+  const mailInferredMatchType = mailRevisionDecision.appliedDraftRevision
     ? false
-    : confirmedRevisionBaseline
+    : mailRevisionDecision.confirmedRevisionBaseline
       ? false
       : inferredMatchType;
   const mailExpectedOutcome =
@@ -3069,6 +3040,7 @@ async function buildWarMailEmbedForTag(
     unavailableReasons,
     matchType: mailMatchType,
     expectedOutcome: mailExpectedOutcome,
+    mailRevisionDecision,
   };
 }
 
@@ -3388,13 +3360,69 @@ async function resolveMailSendGateForRenderedState(params: {
   opponentTag: string | null | undefined;
   matchType: "FWA" | "BL" | "MM" | "UNKNOWN";
   expectedOutcome: "WIN" | "LOSE" | "UNKNOWN" | null;
-}): Promise<{
+}): Promise<MailSendGateDecision> {
+  const decision = await resolveMailRevisionDecisionForRenderedState({
+    client: params.client,
+    guildId: params.guildId,
+    tag: params.tag,
+    hasMailChannel: params.hasMailChannel,
+    inferredMatchType: params.inferredMatchType,
+    emitDebugLog: params.emitDebugLog,
+    warId: params.warId,
+    warStartMs: params.warStartMs,
+    opponentTag: params.opponentTag,
+    matchType: params.matchType,
+    expectedOutcome: params.expectedOutcome,
+    draft: null,
+  });
+  return buildMailSendGateDecision(decision);
+}
+
+type MailRevisionDecisionContract = {
+  mailStatus: ResolvedLiveWarMailStatus;
+  liveRevisionFields: MatchRevisionFields | null;
+  confirmedRevisionBaseline: MatchRevisionFields | null;
+  effectiveRevisionFields: MatchRevisionFields | null;
+  appliedDraftRevision: MatchRevisionFields | null;
+  draftDiffersFromBaseline: boolean;
+  mailBlockedReason: string | null;
+};
+
+type MailSendGateDecision = {
   mailStatus: ResolvedLiveWarMailStatus;
   liveRevisionFields: MatchRevisionFields | null;
   confirmedRevisionBaseline: MatchRevisionFields | null;
   draftDiffersFromBaseline: boolean;
   mailBlockedReason: string | null;
-}> {
+};
+
+/** Purpose: project the shared revision decision into gate fields consumed by `/fwa match` views. */
+function buildMailSendGateDecision(
+  decision: MailRevisionDecisionContract,
+): MailSendGateDecision {
+  return {
+    mailStatus: decision.mailStatus,
+    liveRevisionFields: decision.liveRevisionFields,
+    confirmedRevisionBaseline: decision.confirmedRevisionBaseline,
+    draftDiffersFromBaseline: decision.draftDiffersFromBaseline,
+    mailBlockedReason: decision.mailBlockedReason,
+  };
+}
+
+async function resolveMailRevisionDecisionForRenderedState(params: {
+  client: Client | null | undefined;
+  guildId: string;
+  tag: string;
+  hasMailChannel: boolean;
+  inferredMatchType: boolean;
+  emitDebugLog?: boolean;
+  warId: number | null | undefined;
+  warStartMs: number | null | undefined;
+  opponentTag: string | null | undefined;
+  matchType: "FWA" | "BL" | "MM" | "UNKNOWN";
+  expectedOutcome: "WIN" | "LOSE" | "UNKNOWN" | null;
+  draft: MatchRevisionFields | null;
+}): Promise<MailRevisionDecisionContract> {
   const mailStatus = await resolveLiveWarMailStatus({
     client: params.client,
     guildId: params.guildId,
@@ -3445,16 +3473,18 @@ async function resolveMailSendGateForRenderedState(params: {
     liveFields: liveRevisionFields,
     lifecycleStatus: mailStatus.status,
   });
-  const draftDiffersFromBaseline = Boolean(
-    confirmedRevisionBaseline &&
-    liveRevisionFields &&
-    !areRevisionFieldsEqual(confirmedRevisionBaseline, liveRevisionFields),
-  );
+  const effectiveRevisionState = resolveEffectiveRevisionState({
+    liveFields: liveRevisionFields,
+    confirmedBaseline: confirmedRevisionBaseline,
+    draft: params.draft ?? null,
+  });
+  const draftDiffersFromBaseline =
+    effectiveRevisionState.draftDiffersFromBaseline;
   const mailBlockedReason = getMailBlockedReasonFromRevisionState({
     inferredMatchType: params.inferredMatchType,
     hasMailChannel: params.hasMailChannel,
     mailStatus: mailStatus.status,
-    appliedDraft: draftDiffersFromBaseline ? liveRevisionFields : null,
+    appliedDraft: effectiveRevisionState.appliedDraft,
     draftDiffersFromBaseline,
     hasConfirmedBaseline: Boolean(confirmedRevisionBaseline),
   });
@@ -3462,6 +3492,8 @@ async function resolveMailSendGateForRenderedState(params: {
     mailStatus,
     liveRevisionFields,
     confirmedRevisionBaseline,
+    effectiveRevisionFields: effectiveRevisionState.effective,
+    appliedDraftRevision: effectiveRevisionState.appliedDraft,
     draftDiffersFromBaseline,
     mailBlockedReason,
   };
@@ -5761,18 +5793,7 @@ async function showWarMailPreview(
     revisionOverride: revisionOverride ?? null,
   });
 
-  const mailSendGate = await resolveMailSendGateForRenderedState({
-    client: interaction.client,
-    guildId,
-    tag,
-    hasMailChannel: Boolean(rendered.mailChannelId),
-    inferredMatchType: rendered.inferredMatchType,
-    warId: rendered.warId,
-    warStartMs: rendered.warStartMs,
-    opponentTag: rendered.opponentTag,
-    matchType: rendered.matchType,
-    expectedOutcome: rendered.expectedOutcome,
-  });
+  const mailSendGate = rendered.mailRevisionDecision;
   const channel = rendered.mailChannelId
     ? await interaction.client.channels
         .fetch(rendered.mailChannelId)
@@ -6157,18 +6178,7 @@ async function handleFwaMailConfirmAction(
     });
     return;
   }
-  const mailSendGate = await resolveMailSendGateForRenderedState({
-    client: interaction.client,
-    guildId: payload.guildId,
-    tag: payload.tag,
-    hasMailChannel: true,
-    inferredMatchType: rendered.inferredMatchType,
-    warId: rendered.warId,
-    warStartMs: rendered.warStartMs,
-    opponentTag: rendered.opponentTag,
-    matchType: rendered.matchType,
-    expectedOutcome: rendered.expectedOutcome,
-  });
+  const mailSendGate = rendered.mailRevisionDecision;
   if (mailSendGate.mailBlockedReason) {
     await interaction.editReply({
       content: `Cannot send mail: ${
@@ -7549,6 +7559,7 @@ export const resolveWarMailFreshnessStatusForTest =
   resolveWarMailFreshnessStatus;
 export const formatMailLifecycleStatusLineForTest =
   formatMailLifecycleStatusLine;
+export const buildMailSendGateDecisionForTest = buildMailSendGateDecision;
 export const buildWarMailStatusDebugSnapshotForTest =
   buildWarMailStatusDebugSnapshot;
 export const buildMailStatusDebugLinesForTest = buildMailStatusDebugLines;
@@ -13136,7 +13147,7 @@ export const Fwa: Command = {
           hasMailChannel: Boolean(trackedMailConfig?.mailChannelId),
           inferredMatchType,
           emitDebugLog: matchMailStatusDebugEnabled,
-          warId: subscription?.warId ?? null,
+          warId: warIdForReuseNumber,
           warStartMs: warStartTimeForSync?.getTime?.() ?? null,
           opponentTag,
           matchType: renderedMatchTypeForMailGate,

--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -1303,8 +1303,10 @@ function buildSingleClanMatchLinks(input: {
   };
 }
 
+const INFERRED_MATCHTYPE_MAIL_BLOCK_REASON =
+  "Match type is inferred. Confirm match type before sending mail.";
 const MATCHTYPE_WARNING_LEGEND =
-  ":warning: Match type is inferred. Confirm match type before sending mail.";
+  `:warning: ${INFERRED_MATCHTYPE_MAIL_BLOCK_REASON}`;
 const POINTS_CLAN_NOT_FOUND_STATUS_LINE =
   ":interrobang: Clan not found on points.fwafarm";
 
@@ -1816,7 +1818,7 @@ function getMailBlockedReasonFromRevisionState(params: {
     return "Mail channel is not configured. Use /tracked-clan configure with a mail channel.";
   }
   if (params.inferredMatchType) {
-    return "Match type is inferred. Confirm match type before sending mail.";
+    return INFERRED_MATCHTYPE_MAIL_BLOCK_REASON;
   }
   if (params.mailStatus === "posted") {
     if (!params.hasConfirmedBaseline) return null;
@@ -1824,6 +1826,22 @@ function getMailBlockedReasonFromRevisionState(params: {
     return "Current mail is already up to date. Change match config before sending again.";
   }
   return null;
+}
+
+/** Purpose: avoid duplicate inferred-warning rendering when shared mail gate already emits the same reason. */
+function buildInferredMatchWarningLines(params: {
+  inferredMatchType: boolean;
+  mailBlockedReason: string | null | undefined;
+  includeSpacer?: boolean;
+}): string[] {
+  if (!params.inferredMatchType) return [];
+  if (params.mailBlockedReason === INFERRED_MATCHTYPE_MAIL_BLOCK_REASON) {
+    return [];
+  }
+  if (params.includeSpacer) {
+    return [MATCHTYPE_WARNING_LEGEND, "\u200B"];
+  }
+  return [MATCHTYPE_WARNING_LEGEND];
 }
 
 /** Purpose: keep inferred-match warnings visible until the user explicitly applies a draft/confirmation. */
@@ -7673,6 +7691,8 @@ export const formatMailLifecycleStatusLineForTest =
   formatMailLifecycleStatusLine;
 export const buildNonActiveMailProjectionForTest = buildNonActiveMailProjection;
 export const buildMailSendGateDecisionForTest = buildMailSendGateDecision;
+export const buildInferredMatchWarningLinesForTest =
+  buildInferredMatchWarningLines;
 export const buildOverviewMailDecisionProjectionForTest =
   buildOverviewMailDecisionProjection;
 export const buildWarMailStatusDebugSnapshotForTest =
@@ -9678,6 +9698,11 @@ async function buildTrackedMatchOverview(
     const mailStatusEmoji = liveMailStatus.mailStatusEmoji;
     const mailBlockedReason = mailProjection.mailBlockedReason;
     const mailBlockedReasonLine = mailProjection.mailBlockedReasonLine;
+    const inferredWarningLines = buildInferredMatchWarningLines({
+      inferredMatchType: effectiveInferredMatchType,
+      mailBlockedReason,
+      includeSpacer: true,
+    });
     const mailLifecycleStatusLine = mailProjection.mailLifecycleStatusLine;
     const mailDebugLines = mailStatusDebugEnabled
       ? buildMailStatusDebugLines(liveMailStatus.debug)
@@ -9798,8 +9823,7 @@ async function buildTrackedMatchOverview(
     const singleDescription = [
       pointsSyncStatus,
       storedSyncSummary.stateLine,
-      effectiveInferredMatchType ? MATCHTYPE_WARNING_LEGEND : "",
-      effectiveInferredMatchType ? "\u200B" : "",
+      ...inferredWarningLines,
       mailBlockedReasonLine ?? "",
       mailLifecycleStatusLine,
       `Match Type: **${effectiveMatchType}${effectiveInferredMatchType ? " :warning:" : ""}**${
@@ -9885,7 +9909,10 @@ async function buildTrackedMatchOverview(
             outcome: effectiveExpectedOutcome ?? "UNKNOWN",
             mailStatusEmoji,
           })}`,
-          effectiveInferredMatchType ? MATCHTYPE_WARNING_LEGEND : "",
+          ...buildInferredMatchWarningLines({
+            inferredMatchType: effectiveInferredMatchType,
+            mailBlockedReason,
+          }),
           pointsSyncStatus,
           storedSyncSummary.stateLine,
           mailLifecycleStatusLine.replace(/\*\*/g, ""),
@@ -13297,6 +13324,15 @@ export const Fwa: Command = {
         );
         const mailBlockedReasonLine =
           formatMailBlockedReason(mailBlockedReason);
+        const inferredWarningLines = buildInferredMatchWarningLines({
+          inferredMatchType,
+          mailBlockedReason,
+          includeSpacer: true,
+        });
+        const inferredWarningCopyLines = buildInferredMatchWarningLines({
+          inferredMatchType,
+          mailBlockedReason,
+        });
         const mailDebugLines = matchMailStatusDebugEnabled
           ? buildMailStatusDebugLines(liveMailStatus.debug)
           : [];
@@ -13328,7 +13364,7 @@ export const Fwa: Command = {
           "opponent",
         );
         const singleDescription = [
-          inferredMatchType ? `${MATCHTYPE_WARNING_LEGEND}\n\u200B` : "",
+          ...inferredWarningLines,
           `Match Type: **${matchTypeText}**${verifyLink ? ` ${verifyLink}` : ""}`,
           outcomeLine ? `Expected outcome: **${outcomeLine}**` : "",
           siteStatusLine,
@@ -13377,7 +13413,7 @@ export const Fwa: Command = {
         const copyText = limitDiscordContent(
           [
             `# ${singleHeader}`,
-            inferredMatchType ? MATCHTYPE_WARNING_LEGEND : "",
+            ...inferredWarningCopyLines,
             siteStatusLine,
             storedSyncSummary.stateLine,
             mailStatusLine.replace(/\*\*/g, ""),

--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -3409,6 +3409,46 @@ function buildMailSendGateDecision(
   };
 }
 
+type OverviewMailDecisionProjection = {
+  effectiveInferredMatchType: boolean;
+  mailBlockedReason: string | null;
+  mailBlockedReasonLine: string | null;
+  mailLifecycleStatusLine: string;
+  lifecycleStatus: WarMailLifecycleNormalizedStatus;
+  hasConfirmedBaseline: boolean;
+  draftDiffersFromBaseline: boolean;
+  mailActionEnabled: boolean;
+};
+
+/** Purpose: project shared mail decision fields into the overview/scoped active-war presentation model. */
+function buildOverviewMailDecisionProjection(params: {
+  decision: MailRevisionDecisionContract;
+  inferredMatchType: boolean;
+}): OverviewMailDecisionProjection {
+  const mailSendGate = buildMailSendGateDecision(params.decision);
+  const effectiveInferredMatchType = shouldDisplayInferredMatchType({
+    inferredMatchType: params.inferredMatchType,
+    appliedDraft: params.decision.appliedDraftRevision,
+  });
+  const mailBlockedReason = mailSendGate.mailBlockedReason;
+  return {
+    effectiveInferredMatchType,
+    mailBlockedReason,
+    mailBlockedReasonLine: formatMailBlockedReason(mailBlockedReason),
+    mailLifecycleStatusLine: formatMailLifecycleStatusLine(
+      mailSendGate.mailStatus.status,
+      {
+        hasConfirmedBaseline: Boolean(mailSendGate.confirmedRevisionBaseline),
+        draftDiffersFromBaseline: mailSendGate.draftDiffersFromBaseline,
+      },
+    ),
+    lifecycleStatus: mailSendGate.mailStatus.status,
+    hasConfirmedBaseline: Boolean(mailSendGate.confirmedRevisionBaseline),
+    draftDiffersFromBaseline: mailSendGate.draftDiffersFromBaseline,
+    mailActionEnabled: mailBlockedReason === null,
+  };
+}
+
 async function resolveMailRevisionDecisionForRenderedState(params: {
   client: Client | null | undefined;
   guildId: string;
@@ -7560,6 +7600,8 @@ export const resolveWarMailFreshnessStatusForTest =
 export const formatMailLifecycleStatusLineForTest =
   formatMailLifecycleStatusLine;
 export const buildMailSendGateDecisionForTest = buildMailSendGateDecision;
+export const buildOverviewMailDecisionProjectionForTest =
+  buildOverviewMailDecisionProjection;
 export const buildWarMailStatusDebugSnapshotForTest =
   buildWarMailStatusDebugSnapshot;
 export const buildMailStatusDebugLinesForTest = buildMailStatusDebugLines;
@@ -8746,7 +8788,7 @@ async function buildTrackedMatchOverview(
     : new Map<string, ActualSheetClanSnapshot>();
   const tracked = await prisma.trackedClan.findMany({
     orderBy: { createdAt: "asc" },
-    select: { tag: true, name: true, mailChannelId: true, mailConfig: true },
+    select: { tag: true, name: true, mailChannelId: true },
   });
   const scopedTracked = scopedTagSet
     ? tracked.filter((clan) => scopedTagSet.has(normalizeTag(clan.tag)))
@@ -8755,14 +8797,6 @@ async function buildTrackedMatchOverview(
     scopedTracked.map((row) => [
       normalizeTag(row.tag),
       row.mailChannelId ?? null,
-    ]),
-  );
-  const mailConfigByTag = new Map(
-    scopedTracked.map((row) => [
-      normalizeTag(row.tag),
-      parseMatchMailConfig(
-        row.mailConfig as Prisma.JsonValue | null | undefined,
-      ),
     ]),
   );
   if (scopedTracked.length === 0) {
@@ -9455,75 +9489,49 @@ async function buildTrackedMatchOverview(
       opponentTag,
     });
     const mailChannelId = mailChannelByTag.get(clanTag) ?? null;
-    const liveMailStatus = await resolveLiveWarMailStatus({
-      client: client ?? null,
-      guildId,
-      tag: clanTag,
-      warId: sub?.warId ?? null,
-      emitDebugLog: mailStatusDebugEnabled,
-    });
-    const revisionWarId =
-      normalizeWarIdText(sub?.warId ?? null) ??
-      normalizeWarIdText(liveMailStatus.debug.currentWarId);
-    const liveRevisionFields = buildLiveRevisionFields({
-      warId: revisionWarId,
-      opponentTag,
-      matchType:
-        matchType === "FWA" || matchType === "BL" || matchType === "MM"
-          ? matchType
-          : "UNKNOWN",
-      expectedOutcome:
-        matchType === "FWA" ? (liveExpectedOutcome ?? "UNKNOWN") : null,
-    });
-    const confirmedRevisionBaseline = resolveConfirmedRevisionBaseline({
-      syncRow: syncRow
-        ? {
-            warId: syncRow.warId ?? null,
-            opponentTag: syncRow.opponentTag,
-            lastKnownMatchType: syncRow.lastKnownMatchType ?? null,
-            lastKnownOutcome: syncRow.lastKnownOutcome ?? null,
-            isFwa: syncRow.isFwa ?? null,
-            confirmedByClanMail: Boolean(syncRow.confirmedByClanMail),
-          }
-        : null,
-      mailConfig: {
-        lastWarId: mailConfigByTag.get(clanTag)?.lastWarId ?? null,
-        lastOpponentTag: mailConfigByTag.get(clanTag)?.lastOpponentTag ?? null,
-        lastMatchType: mailConfigByTag.get(clanTag)?.lastMatchType ?? null,
-        lastExpectedOutcome:
-          mailConfigByTag.get(clanTag)?.lastExpectedOutcome ?? null,
+    const matchTypeForMailDecision =
+      matchType === "FWA" || matchType === "BL" || matchType === "MM"
+        ? matchType
+        : "UNKNOWN";
+    const mailRevisionDecision = await resolveMailRevisionDecisionForRenderedState(
+      {
+        client: client ?? null,
+        guildId: guildId ?? "",
+        tag: clanTag,
+        hasMailChannel: Boolean(mailChannelId),
+        inferredMatchType,
+        emitDebugLog: mailStatusDebugEnabled,
+        warId: warIdForReuseNumber,
+        warStartMs: warStartTimeForSync?.getTime?.() ?? null,
+        opponentTag,
+        matchType: matchTypeForMailDecision,
+        expectedOutcome:
+          matchTypeForMailDecision === "FWA"
+            ? (liveExpectedOutcome ?? "UNKNOWN")
+            : null,
+        draft: revisionDraftByTag[clanTag] ?? null,
       },
-      liveFields: liveRevisionFields,
-      lifecycleStatus: liveMailStatus.status,
-    });
-    console.info(
-      `[fwa-mail-baseline] stage=alliance_view clan=#${clanTag} owner=${confirmedRevisionBaseline ? "ClanPointsSync" : "none"} lifecycle=${liveMailStatus.status} war_id=${revisionWarId ?? "unknown"} opponent=#${opponentTag}`,
     );
-    if (
-      confirmedRevisionBaseline &&
-      liveRevisionFields &&
-      !areRevisionFieldsEqual(confirmedRevisionBaseline, liveRevisionFields)
-    ) {
-      console.info(
-        `[fwa-mail-baseline] stage=alliance_view mismatch=1 clan=#${clanTag} baseline_match_type=${confirmedRevisionBaseline.matchType} live_match_type=${liveRevisionFields.matchType} baseline_outcome=${confirmedRevisionBaseline.expectedOutcome ?? "N/A"} live_outcome=${liveRevisionFields.expectedOutcome ?? "N/A"}`,
-      );
-    }
-    const revisionState = resolveEffectiveRevisionState({
-      liveFields: liveRevisionFields,
-      confirmedBaseline: confirmedRevisionBaseline,
-      draft: revisionDraftByTag[clanTag] ?? null,
+    const mailSendGate = buildMailSendGateDecision(mailRevisionDecision);
+    const mailProjection = buildOverviewMailDecisionProjection({
+      decision: mailRevisionDecision,
+      inferredMatchType,
     });
+    const liveMailStatus = mailSendGate.mailStatus;
+    const liveRevisionFields = mailSendGate.liveRevisionFields;
+    const confirmedRevisionBaseline = mailSendGate.confirmedRevisionBaseline;
     const effectiveMatchType =
-      revisionState.effective?.matchType === "FWA" ||
-      revisionState.effective?.matchType === "BL" ||
-      revisionState.effective?.matchType === "MM"
-        ? revisionState.effective.matchType
+      mailRevisionDecision.effectiveRevisionFields?.matchType === "FWA" ||
+      mailRevisionDecision.effectiveRevisionFields?.matchType === "BL" ||
+      mailRevisionDecision.effectiveRevisionFields?.matchType === "MM"
+        ? mailRevisionDecision.effectiveRevisionFields.matchType
         : matchType;
     const projectedFwaOutcome =
       toWinLoseOutcome(liveExpectedOutcome) ?? toWinLoseOutcome(derivedOutcome);
     const effectiveExpectedOutcome = resolveEffectiveFwaOutcome({
       matchType: effectiveMatchType,
-      explicitOutcome: revisionState.effective?.expectedOutcome ?? null,
+      explicitOutcome:
+        mailRevisionDecision.effectiveRevisionFields?.expectedOutcome ?? null,
       projectedOutcome: projectedFwaOutcome,
     });
     const validationState = buildSyncValidationState({
@@ -9595,28 +9603,13 @@ async function buildTrackedMatchOverview(
       effectiveMismatchWarnings.matchTypeVsFwaMismatch ||
       validationState.differences.length > 0,
     );
-    const effectiveInferredMatchType = shouldDisplayInferredMatchType({
-      inferredMatchType,
-      appliedDraft: revisionState.appliedDraft,
-    });
+    const effectiveInferredMatchType =
+      mailProjection.effectiveInferredMatchType;
     if (effectiveInferredMatchType) hasAnyInferredMatchType = true;
     const mailStatusEmoji = liveMailStatus.mailStatusEmoji;
-    const mailBlockedReason = getMailBlockedReasonFromRevisionState({
-      inferredMatchType: effectiveInferredMatchType,
-      hasMailChannel: Boolean(mailChannelId),
-      mailStatus: liveMailStatus.status,
-      appliedDraft: revisionState.appliedDraft,
-      draftDiffersFromBaseline: revisionState.draftDiffersFromBaseline,
-      hasConfirmedBaseline: Boolean(confirmedRevisionBaseline),
-    });
-    const mailBlockedReasonLine = formatMailBlockedReason(mailBlockedReason);
-    const mailLifecycleStatusLine = formatMailLifecycleStatusLine(
-      liveMailStatus.status,
-      {
-        hasConfirmedBaseline: Boolean(confirmedRevisionBaseline),
-        draftDiffersFromBaseline: revisionState.draftDiffersFromBaseline,
-      },
-    );
+    const mailBlockedReason = mailProjection.mailBlockedReason;
+    const mailBlockedReasonLine = mailProjection.mailBlockedReasonLine;
+    const mailLifecycleStatusLine = mailProjection.mailLifecycleStatusLine;
     const mailDebugLines = mailStatusDebugEnabled
       ? buildMailStatusDebugLines(liveMailStatus.debug)
       : [];
@@ -9879,17 +9872,17 @@ async function buildTrackedMatchOverview(
       clanName,
       clanTag,
       mailStatusEmoji,
-      lifecycleStatus: liveMailStatus.status,
+      lifecycleStatus: mailProjection.lifecycleStatus,
       hasMailChannel: Boolean(mailChannelId),
       liveRevisionFields,
       confirmedRevisionBaseline,
-      effectiveRevisionFields: revisionState.effective,
-      appliedDraftRevision: revisionState.appliedDraft,
-      draftDiffersFromBaseline: revisionState.draftDiffersFromBaseline,
+      effectiveRevisionFields: mailRevisionDecision.effectiveRevisionFields,
+      appliedDraftRevision: mailRevisionDecision.appliedDraftRevision,
+      draftDiffersFromBaseline: mailRevisionDecision.draftDiffersFromBaseline,
       projectedFwaOutcome,
       mailAction: {
         tag: clanTag,
-        enabled: !mailBlockedReason,
+        enabled: mailProjection.mailActionEnabled,
         reason: mailBlockedReason,
       },
     };

--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -1281,15 +1281,24 @@ function buildSingleClanMatchLinks(input: {
   linksFieldValue: string;
   copyLines: string[];
 } {
+  const trackedCcUrl = buildCcVerifyUrl(input.trackedClanTag);
   const opponentCcUrl = buildCcVerifyUrl(input.opponentTag);
+  const opponentPointsUrl = buildOfficialPointsUrl(input.opponentTag);
   const trackedPointsUrl = buildOfficialPointsUrl(input.trackedClanTag);
   return {
     pointsFieldName: "Points",
     linksFieldName: "Links",
-    linksFieldValue: `[cc.fwafarm](<${opponentCcUrl}>)\n[points.fwafarm](<${trackedPointsUrl}>)`,
+    linksFieldValue: [
+      `[cc.fwafarm (them)](<${opponentCcUrl}>)`,
+      `[cc.fwafarm (us)](<${trackedCcUrl}>)`,
+      `[points.fwafarm (them)](<${opponentPointsUrl}>)`,
+      `[points.fwafarm (us)](<${trackedPointsUrl}>)`,
+    ].join("\n"),
     copyLines: [
-      `CC (opponent): [cc.fwafarm](<${opponentCcUrl}>)`,
-      `Points (tracked clan): [points.fwafarm](<${trackedPointsUrl}>)`,
+      `CC (them): [cc.fwafarm](<${opponentCcUrl}>)`,
+      `CC (us): [cc.fwafarm](<${trackedCcUrl}>)`,
+      `Points (them): [points.fwafarm](<${opponentPointsUrl}>)`,
+      `Points (us): [points.fwafarm](<${trackedPointsUrl}>)`,
     ],
   };
 }

--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -1304,7 +1304,7 @@ function buildSingleClanMatchLinks(input: {
 }
 
 const MATCHTYPE_WARNING_LEGEND =
-  ":warning: Match type is inferred. Sending is still allowed, but confirm before posting if this looks wrong.";
+  ":warning: Match type is inferred. Confirm match type before sending mail.";
 const POINTS_CLAN_NOT_FOUND_STATUS_LINE =
   ":interrobang: Clan not found on points.fwafarm";
 
@@ -1814,6 +1814,9 @@ function getMailBlockedReasonFromRevisionState(params: {
 }): string | null {
   if (!params.hasMailChannel) {
     return "Mail channel is not configured. Use /tracked-clan configure with a mail channel.";
+  }
+  if (params.inferredMatchType) {
+    return "Match type is inferred. Confirm match type before sending mail.";
   }
   if (params.mailStatus === "posted") {
     if (!params.hasConfirmedBaseline) return null;

--- a/src/scripts/repairClanWarParticipationGuildScope.ts
+++ b/src/scripts/repairClanWarParticipationGuildScope.ts
@@ -1,0 +1,182 @@
+import { randomUUID } from "crypto";
+import { Prisma } from "@prisma/client";
+import { prisma } from "../prisma";
+import { normalizeTag } from "../services/war-events/core";
+
+type ScriptArgs = {
+  sourceGuildId: string;
+  targetGuildId: string;
+  apply: boolean;
+};
+
+function parseArgs(argv: string[]): ScriptArgs {
+  const values = new Map<string, string | boolean>();
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (token === "--apply") {
+      values.set("apply", true);
+      continue;
+    }
+    if (token.startsWith("--") && i + 1 < argv.length) {
+      values.set(token.replace(/^--/, ""), argv[i + 1]);
+      i += 1;
+    }
+  }
+
+  const sourceGuildId = String(values.get("source-guild") ?? "").trim();
+  const targetGuildId = String(values.get("target-guild") ?? "").trim();
+  if (!sourceGuildId || !targetGuildId) {
+    throw new Error(
+      "Usage: ts-node src/scripts/repairClanWarParticipationGuildScope.ts --source-guild <guild-id> --target-guild <guild-id> [--apply]",
+    );
+  }
+  if (sourceGuildId === targetGuildId) {
+    throw new Error("source and target guild IDs must be different.");
+  }
+  return {
+    sourceGuildId,
+    targetGuildId,
+    apply: Boolean(values.get("apply")),
+  };
+}
+
+async function readParticipationSummary(guildId: string): Promise<{
+  totalRows: number;
+  fwaRows: number;
+  endedFwaWars: number;
+}> {
+  const rows = await prisma.$queryRaw<
+    Array<{ totalRows: number; fwaRows: number; endedFwaWars: number }>
+  >(Prisma.sql`
+    SELECT
+      COUNT(*)::int AS "totalRows",
+      COUNT(*) FILTER (WHERE "matchType" = 'FWA')::int AS "fwaRows",
+      COUNT(DISTINCT "warId") FILTER (
+        WHERE "matchType" = 'FWA'
+          AND "warEndTime" IS NOT NULL
+      )::int AS "endedFwaWars"
+    FROM "ClanWarParticipation"
+    WHERE "guildId" = ${guildId}
+  `);
+  return (
+    rows[0] ?? {
+      totalRows: 0,
+      fwaRows: 0,
+      endedFwaWars: 0,
+    }
+  );
+}
+
+async function main(): Promise<void> {
+  const args = parseArgs(process.argv.slice(2));
+  const targetCurrentWarRows = await prisma.currentWar.findMany({
+    where: { guildId: args.targetGuildId },
+    select: { clanTag: true },
+  });
+  const targetClanTags = Array.from(
+    new Set(
+      targetCurrentWarRows
+        .map((row) => normalizeTag(row.clanTag))
+        .filter((value) => Boolean(value)),
+    ),
+  );
+  if (targetClanTags.length === 0) {
+    throw new Error(
+      `No CurrentWar clans found for target guild ${args.targetGuildId}; aborting repair.`,
+    );
+  }
+
+  const sourceRows = await prisma.clanWarParticipation.findMany({
+    where: {
+      guildId: args.sourceGuildId,
+      matchType: "FWA",
+      warEndTime: { not: null },
+    },
+    orderBy: [{ warStartTime: "desc" }, { createdAt: "desc" }],
+  });
+  const targetTagSet = new Set(targetClanTags);
+  const candidateRows = sourceRows.filter((row) =>
+    targetTagSet.has(normalizeTag(row.clanTag)),
+  );
+  const candidateClanTags = Array.from(
+    new Set(candidateRows.map((row) => normalizeTag(row.clanTag))),
+  );
+  const nonCandidateRows = sourceRows.filter(
+    (row) => !targetTagSet.has(normalizeTag(row.clanTag)),
+  );
+
+  const sourceSummary = await readParticipationSummary(args.sourceGuildId);
+  const targetSummaryBefore = await readParticipationSummary(args.targetGuildId);
+  const proof = {
+    sourceGuildId: args.sourceGuildId,
+    targetGuildId: args.targetGuildId,
+    sourceSummary,
+    targetSummaryBefore,
+    targetCurrentWarClanCount: targetClanTags.length,
+    sourceEndedFwaRows: sourceRows.length,
+    candidateEndedFwaRows: candidateRows.length,
+    candidateClanCount: candidateClanTags.length,
+    candidateClanTags,
+    excludedSourceRows: nonCandidateRows.length,
+    excludedClanTags: Array.from(
+      new Set(nonCandidateRows.map((row) => normalizeTag(row.clanTag))),
+    ),
+    canRepair: candidateRows.length > 0,
+    mode: args.apply ? "apply" : "dry-run",
+  };
+  console.log(JSON.stringify(proof, null, 2));
+
+  if (candidateRows.length === 0) {
+    throw new Error(
+      "Safety guard: no provable candidate rows overlap target CurrentWar clans; no mutation performed.",
+    );
+  }
+  if (!args.apply) {
+    console.log("Dry run complete. Re-run with --apply to insert repaired rows.");
+    return;
+  }
+
+  const insertPayload = candidateRows.map((row) => ({
+    id: randomUUID(),
+    guildId: args.targetGuildId,
+    warId: row.warId,
+    clanTag: row.clanTag,
+    opponentTag: row.opponentTag,
+    playerTag: row.playerTag,
+    playerName: row.playerName,
+    townHall: row.townHall,
+    attacksUsed: row.attacksUsed,
+    attacksMissed: row.attacksMissed,
+    starsEarned: row.starsEarned,
+    trueStars: row.trueStars,
+    missedBoth: row.missedBoth,
+    firstAttackAt: row.firstAttackAt,
+    attackDelayMinutes: row.attackDelayMinutes,
+    attackWindowMissed: row.attackWindowMissed,
+    matchType: row.matchType,
+    warStartTime: row.warStartTime,
+    warEndTime: row.warEndTime,
+    createdAt: row.createdAt,
+  }));
+
+  const inserted = await prisma.clanWarParticipation.createMany({
+    data: insertPayload,
+    skipDuplicates: true,
+  });
+  const targetSummaryAfter = await readParticipationSummary(args.targetGuildId);
+  const verification = {
+    insertedRows: inserted.count,
+    targetSummaryAfter,
+  };
+  console.log(JSON.stringify(verification, null, 2));
+}
+
+main()
+  .catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });
+

--- a/src/services/WarEventLogService.ts
+++ b/src/services/WarEventLogService.ts
@@ -2866,7 +2866,12 @@ export class WarEventLogService {
     let payloadForDelivery = params.payload;
     let resolvedWarIdForDelivery = params.resolvedWarId;
     if (params.payload.eventType === "war_ended") {
-      await this.history.persistWarEndHistory(params.payload).catch((err) => {
+      await this.history
+        .persistWarEndHistory({
+          ...params.payload,
+          guildId: params.sub.guildId,
+        })
+        .catch((err) => {
         console.error(
           `[war-events] persist war history failed guild=${params.sub.guildId} clan=${params.sub.clanTag} error=${formatError(err)}`
         );
@@ -2897,11 +2902,16 @@ export class WarEventLogService {
         testFinalResultOverride: canonicalFinalResult,
       };
       if (payloadForDelivery.warEndFwaPoints !== params.payload.warEndFwaPoints) {
-        await this.history.persistWarEndHistory(payloadForDelivery).catch((err) => {
-          console.error(
-            `[war-events] persist canonical war history failed guild=${params.sub.guildId} clan=${params.sub.clanTag} error=${formatError(err)}`
-          );
-        });
+        await this.history
+          .persistWarEndHistory({
+            ...payloadForDelivery,
+            guildId: params.sub.guildId,
+          })
+          .catch((err) => {
+            console.error(
+              `[war-events] persist canonical war history failed guild=${params.sub.guildId} clan=${params.sub.clanTag} error=${formatError(err)}`
+            );
+          });
       }
     }
     if (!params.sub.notify || !params.sub.channelId) return;

--- a/src/services/WarEventLogService.ts
+++ b/src/services/WarEventLogService.ts
@@ -777,6 +777,36 @@ function makeBattleDayPostKey(guildId: string, clanTag: string): string {
   return `${guildId}:${normalizeTag(clanTag)}`;
 }
 
+function toValidSyncNumber(input: unknown): number | null {
+  const value = Number(input);
+  if (!Number.isFinite(value)) return null;
+  const normalized = Math.trunc(value);
+  return normalized > 0 ? normalized : null;
+}
+
+function resolveEventRenderSyncNumber(input: {
+  sameWarSyncNumber: number | null;
+  postedSyncNumber: number | null;
+  previousSyncNumber: number | null;
+  currentState: WarState;
+}): number | null {
+  const sameWarSyncNumber = toValidSyncNumber(input.sameWarSyncNumber);
+  if (sameWarSyncNumber !== null) return sameWarSyncNumber;
+
+  const postedSyncNumber = toValidSyncNumber(input.postedSyncNumber);
+  if (postedSyncNumber !== null) return postedSyncNumber;
+
+  const previousSyncNumber = toValidSyncNumber(input.previousSyncNumber);
+  if (previousSyncNumber === null) return null;
+
+  if (input.currentState === "preparation" || input.currentState === "inWar") {
+    return previousSyncNumber + 1;
+  }
+  return previousSyncNumber;
+}
+
+export const resolveEventRenderSyncNumberForTest = resolveEventRenderSyncNumber;
+
 function formatWarStatCellLeft(value: string): string {
   return value.padStart(10, " ");
 }
@@ -3658,20 +3688,21 @@ export class WarEventLogService {
     const message = await (channel as any).messages.fetch(existingMessage.messageId).catch(() => null);
     if (!message) return false;
 
+    const syncNumber = await this.resolveNotifyEventSyncNumber({
+      guildId,
+      clanTag,
+      warId: warIdText,
+      warStartTime,
+      currentState: state,
+      postedSyncNumber: toValidSyncNumber(existingMessage.syncNum),
+    });
+
     const basePayload = {
       clanTag: refreshedSub.clanTag,
       clanName: nextClanName,
       opponentTag: nextOpponentTag,
       opponentName: nextOpponentName,
-      syncNumber:
-        (
-          await this.currentSyncs.getCurrentSyncForClan({
-            guildId,
-            clanTag,
-            warId: warIdText,
-            warStartTime,
-          })
-        )?.syncNum ?? null,
+      syncNumber,
       notifyRole: refreshedSub.notifyRole,
       pingRole: refreshedSub.pingRole,
       fwaPoints: refreshedSub.fwaPoints,
@@ -3824,6 +3855,34 @@ export class WarEventLogService {
       return "missing";
     }
 
+    const resolvedWarIdText =
+      resolvedWarId !== null && resolvedWarId !== undefined
+        ? String(Math.trunc(Number(resolvedWarId)))
+        : refreshedSub.warId !== null && refreshedSub.warId !== undefined
+          ? String(Math.trunc(Number(refreshedSub.warId)))
+          : null;
+    const existingMessage = await this.postedMessages.findExistingMessage({
+      guildId,
+      clanTag,
+      warId: resolvedWarIdText,
+      type: "notify",
+      event: "battle_day",
+    });
+    const postedSyncNumber =
+      existingMessage &&
+      existingMessage.channelId === tracked.channelId &&
+      existingMessage.messageId === tracked.messageId
+        ? toValidSyncNumber(existingMessage.syncNum)
+        : null;
+    const syncNumber = await this.resolveNotifyEventSyncNumber({
+      guildId,
+      clanTag,
+      warId: resolvedWarIdText,
+      warStartTime,
+      currentState: "inWar",
+      postedSyncNumber,
+    });
+
     const payload = {
       eventType: "battle_day" as const,
       clanTag: refreshedSub.clanTag,
@@ -3831,20 +3890,7 @@ export class WarEventLogService {
       opponentTag: normalizeTag(war.opponent?.tag ?? refreshedSub.opponentTag ?? ""),
       opponentName:
         String(war.opponent?.name ?? refreshedSub.opponentName ?? "Unknown").trim() || "Unknown",
-      syncNumber:
-        (
-          await this.currentSyncs.getCurrentSyncForClan({
-            guildId,
-            clanTag,
-            warId:
-              resolvedWarId !== null && resolvedWarId !== undefined
-                ? String(Math.trunc(Number(resolvedWarId)))
-                : refreshedSub.warId !== null && refreshedSub.warId !== undefined
-                  ? String(Math.trunc(Number(refreshedSub.warId)))
-                  : null,
-            warStartTime,
-          })
-        )?.syncNum ?? null,
+      syncNumber,
       notifyRole: refreshedSub.notifyRole,
       pingRole: refreshedSub.pingRole,
       fwaPoints: refreshedSub.fwaPoints,
@@ -3898,6 +3944,41 @@ export class WarEventLogService {
       ],
     });
     return "refreshed";
+  }
+
+  private async resolveNotifyEventSyncNumber(input: {
+    guildId: string;
+    clanTag: string;
+    warId: string | null;
+    warStartTime: Date | null;
+    currentState: WarState;
+    postedSyncNumber: number | null;
+  }): Promise<number | null> {
+    const sameWarSync = await this.currentSyncs
+      .getCurrentSyncForClan({
+        guildId: input.guildId,
+        clanTag: input.clanTag,
+        warId: input.warId,
+        warStartTime: input.warStartTime,
+      })
+      .catch(() => null);
+    const sameWarSyncNumber = toValidSyncNumber(sameWarSync?.syncNum ?? null);
+    if (sameWarSyncNumber !== null) {
+      return sameWarSyncNumber;
+    }
+
+    const postedSyncNumber = toValidSyncNumber(input.postedSyncNumber);
+    if (postedSyncNumber !== null) {
+      return postedSyncNumber;
+    }
+
+    const previousSyncNumber = toValidSyncNumber(await this.pointsSync.getPreviousSyncNum());
+    return resolveEventRenderSyncNumber({
+      sameWarSyncNumber: null,
+      postedSyncNumber: null,
+      previousSyncNumber,
+      currentState: input.currentState,
+    });
   }
 
   private async buildBattleDayRefreshEmbed(

--- a/src/services/WarEventLogService.ts
+++ b/src/services/WarEventLogService.ts
@@ -2602,23 +2602,21 @@ export class WarEventLogService {
       warStartTime: nextWarStartTime,
       currentState,
     });
-    const syncRow =
-      guildId && nextWarStartTime
-        ? await this.currentSyncs.getCurrentSyncForClan({
-            guildId,
-            clanTag: sub.clanTag,
-            warId:
-              resolvedWarId !== null && resolvedWarId !== undefined
-                ? String(Math.trunc(Number(resolvedWarId)))
-                : sub.warId !== null && sub.warId !== undefined
-                  ? String(Math.trunc(Number(sub.warId)))
-                  : null,
-            warStartTime: nextWarStartTime,
-          })
-        : null;
-    const syncNumberForEvent =
-      syncRow?.syncNum ??
-      fallbackSyncNumberForEvent;
+    const resolvedWarIdText =
+      resolvedWarId !== null && resolvedWarId !== undefined
+        ? String(Math.trunc(Number(resolvedWarId)))
+        : sub.warId !== null && sub.warId !== undefined
+          ? String(Math.trunc(Number(sub.warId)))
+          : null;
+    const syncNumberForEvent = await this.resolveNotifyEventSyncNumber({
+      guildId,
+      clanTag: sub.clanTag,
+      warId: resolvedWarIdText,
+      warStartTime: nextWarStartTime,
+      currentState,
+      postedSyncNumber: null,
+      previousSyncNumber: syncContext.previousSync,
+    });
     if (outcomeComputationInput) {
       nextOutcome = deriveExpectedOutcome(
         outcomeComputationInput.clanTag,
@@ -3953,6 +3951,7 @@ export class WarEventLogService {
     warStartTime: Date | null;
     currentState: WarState;
     postedSyncNumber: number | null;
+    previousSyncNumber?: number | null;
   }): Promise<number | null> {
     const sameWarSync = await this.currentSyncs
       .getCurrentSyncForClan({
@@ -3972,7 +3971,9 @@ export class WarEventLogService {
       return postedSyncNumber;
     }
 
-    const previousSyncNumber = toValidSyncNumber(await this.pointsSync.getPreviousSyncNum());
+    const previousSyncNumber = toValidSyncNumber(
+      input.previousSyncNumber ?? (await this.pointsSync.getPreviousSyncNum())
+    );
     return resolveEventRenderSyncNumber({
       sameWarSyncNumber: null,
       postedSyncNumber: null,

--- a/src/services/WeightInputDefermentService.ts
+++ b/src/services/WeightInputDefermentService.ts
@@ -2,6 +2,7 @@ import { Client } from "discord.js";
 import { formatError } from "../helper/formatError";
 import { prisma } from "../prisma";
 import { CommandPermissionService } from "./CommandPermissionService";
+import { buildFwaWeightPageUrl } from "./FwaStatsWeightService";
 import { normalizeTag, normalizeTagBare } from "./war-events/core";
 
 export type DefermentStatus = "open" | "resolved" | "cleared";
@@ -438,6 +439,7 @@ function buildStageMessage(input: {
       ? `${input.clanName} (${input.clanTag})`
       : input.clanTag
     : "unscoped";
+  const weightPageUrl = input.clanTag ? buildFwaWeightPageUrl(input.clanTag) : null;
   return [
     `${mention}**${header}**`,
     `Player: ${input.playerTag}`,
@@ -445,6 +447,7 @@ function buildStageMessage(input: {
     `Current weight: ${input.currentWeight ?? "unknown"}`,
     `Pending age: ${input.pendingAge}`,
     `Current clan: ${clanLabel}`,
+    `FWA Stats weights: ${weightPageUrl ? `<${weightPageUrl}>` : "unknown"}`,
     "Resolve after FWAStats entry with `/defer remove <player-tag>`.",
   ].join("\n");
 }

--- a/src/services/war-events/history.ts
+++ b/src/services/war-events/history.ts
@@ -15,6 +15,18 @@ import {
   parseCocTime,
 } from "./core";
 
+/** Purpose: select the authoritative guild scope for participation persistence with explicit precedence. */
+export function resolveParticipationGuildId(input: {
+  payloadGuildId: string | null | undefined;
+  snapshotGuildId: string | null | undefined;
+}): string | null {
+  const payloadGuildId = String(input.payloadGuildId ?? "").trim();
+  if (payloadGuildId) return payloadGuildId;
+  const snapshotGuildId = String(input.snapshotGuildId ?? "").trim();
+  if (snapshotGuildId) return snapshotGuildId;
+  return null;
+}
+
 /** Purpose: encapsulate war-end history, compliance, and war-plan related logic. */
 export class WarEventHistoryService {
   /** Purpose: initialize war history service dependencies. */
@@ -340,6 +352,7 @@ export class WarEventHistoryService {
   /** Purpose: persist clan-level war-end summary and full attack payload into history/lookup tables. */
   async persistWarEndHistory(payload: {
     eventType: EventType;
+    guildId?: string | null;
     clanTag: string;
     clanName: string;
     opponentTag: string;
@@ -419,8 +432,13 @@ export class WarEventHistoryService {
         ? payload.outcome
         : finalResult.resultLabel;
     
+    const scopedGuildId = String(payload.guildId ?? "").trim() || null;
     const currentSnapshot = await prisma.currentWar.findFirst({
-      where: { clanTag, startTime: warStartTime },
+      where: {
+        clanTag,
+        startTime: warStartTime,
+        ...(scopedGuildId ? { guildId: scopedGuildId } : {}),
+      },
       select: {
         guildId: true,
         inferredMatchType: true,
@@ -489,9 +507,13 @@ export class WarEventHistoryService {
     });
 
     
-    const syncRow = currentSnapshot?.guildId
+    const participationGuildId = resolveParticipationGuildId({
+      payloadGuildId: scopedGuildId,
+      snapshotGuildId: currentSnapshot?.guildId ?? null,
+    });
+    const syncRow = participationGuildId
       ? await this.pointsSync.getCurrentSyncForClan({
-          guildId: currentSnapshot.guildId,
+          guildId: participationGuildId,
           clanTag,
           warId: String(warId),
           warStartTime,
@@ -636,7 +658,7 @@ export class WarEventHistoryService {
       `,
     );
     await this.persistWarParticipationSnapshot({
-      guildId: currentSnapshot?.guildId ?? null,
+      guildId: participationGuildId,
       warId: String(warId),
       clanTag,
       opponentTag:

--- a/tests/emoji.command.test.ts
+++ b/tests/emoji.command.test.ts
@@ -9,6 +9,7 @@ import type {
 import {
   Emoji,
   applyEmojiPageActionForTest,
+  buildEmojiListEmbedForTest,
   resetEmojiCommandPermissionServiceForTest,
   resetEmojiResolverForTest,
   setEmojiCommandPermissionServiceForTest,
@@ -654,8 +655,64 @@ describe("/emoji command", () => {
         ? embed.toJSON()
         : (embed?.data ?? {});
     expect(json.title).toBe("Bot Application Emojis");
-    expect(String(json.description ?? "")).toContain(":alpha:");
+    expect(Array.isArray(json.fields)).toBe(true);
+    expect(json.fields).toHaveLength(2);
+    expect(json.fields?.[0]?.inline).toBe(true);
+    expect(String(json.fields?.[0]?.value ?? "")).toContain(":alpha:");
+    expect(String(json.fields?.[1]?.value ?? "")).toContain(":bravo:");
     expect(fetchReply).not.toHaveBeenCalled();
+  });
+
+  it("builds list embeds with inline fields for 3-column layout and uneven rows", () => {
+    const emojis: ResolvedApplicationEmoji[] = [
+      {
+        id: "1",
+        name: "alpha",
+        shortcode: ":alpha:",
+        rendered: "<:alpha:1>",
+        animated: false,
+      },
+      {
+        id: "2",
+        name: "bravo",
+        shortcode: ":bravo:",
+        rendered: "<:bravo:2>",
+        animated: false,
+      },
+      {
+        id: "3",
+        name: "charlie",
+        shortcode: ":charlie:",
+        rendered: "<:charlie:3>",
+        animated: false,
+      },
+      {
+        id: "4",
+        name: "delta",
+        shortcode: ":delta:",
+        rendered: "<:delta:4>",
+        animated: false,
+      },
+      {
+        id: "5",
+        name: "echo",
+        shortcode: ":echo:",
+        rendered: "<:echo:5>",
+        animated: false,
+      },
+    ];
+    const pageText = emojis
+      .map((emoji) => `${emoji.rendered} \`${emoji.shortcode}\``)
+      .join("\n");
+    const embed = buildEmojiListEmbedForTest({
+      emojis,
+      pages: [pageText],
+      page: 0,
+    });
+    const json = embed.toJSON();
+    expect(json.fields).toHaveLength(5);
+    expect(json.fields?.every((field) => field.inline === true)).toBe(true);
+    expect(String(json.fields?.[4]?.value ?? "")).toContain(":echo:");
   });
 
   it("ignores react when name is omitted and keeps list mode", async () => {

--- a/tests/emoji.command.test.ts
+++ b/tests/emoji.command.test.ts
@@ -710,9 +710,13 @@ describe("/emoji command", () => {
       page: 0,
     });
     const json = embed.toJSON();
-    expect(json.fields).toHaveLength(5);
+    expect(json.fields).toHaveLength(3);
     expect(json.fields?.every((field) => field.inline === true)).toBe(true);
-    expect(String(json.fields?.[4]?.value ?? "")).toContain(":echo:");
+    expect(String(json.fields?.[0]?.value ?? "")).toContain(":alpha:");
+    expect(String(json.fields?.[0]?.value ?? "")).toContain(":delta:");
+    expect(String(json.fields?.[1]?.value ?? "")).toContain(":bravo:");
+    expect(String(json.fields?.[1]?.value ?? "")).toContain(":echo:");
+    expect(String(json.fields?.[2]?.value ?? "")).toContain(":charlie:");
   });
 
   it("ignores react when name is omitted and keeps list mode", async () => {

--- a/tests/fwaMatchInference.logic.test.ts
+++ b/tests/fwaMatchInference.logic.test.ts
@@ -270,14 +270,16 @@ describe("fwa match stored sync fallback", () => {
 });
 
 describe("fwa mail send gating", () => {
-  it("does not block send mail solely because match type is inferred", () => {
+  it("blocks send mail while match type is inferred", () => {
     const reason = getMailBlockedReasonFromStatusForTest({
       inferredMatchType: true,
       hasMailChannel: true,
       mailStatus: "not_posted",
     });
 
-    expect(reason).toBeNull();
+    expect(reason).toBe(
+      "Match type is inferred. Confirm match type before sending mail."
+    );
   });
 });
 

--- a/tests/fwaMatchResolvedSync.logic.test.ts
+++ b/tests/fwaMatchResolvedSync.logic.test.ts
@@ -93,4 +93,93 @@ describe("fwa match resolved current sync", () => {
 
     expect(renderedSync).toBe(476);
   });
+
+  it("uses the same derived sync value for display and tie-break parity when same-war sync is missing", () => {
+    const resolved = resolveCurrentSyncNumberForMatchForTest({
+      warState: "preparation",
+      previousSyncNum: 481,
+      currentWarSyncNum: null,
+    });
+    const renderedSync = resolveRenderedSyncNumberForStoredSummaryForTest({
+      syncRow: null,
+      fallbackSyncNum: resolved.resolvedCurrentSyncNum,
+      warId: "3001",
+      warStartTime: new Date("2026-03-25T04:20:57.000Z"),
+      opponentNotFound: false,
+      validationState: {
+        siteCurrent: false,
+        syncRowMissing: true,
+        differences: [],
+        statusLine: "",
+      },
+    });
+
+    expect(renderedSync).toBe(482);
+    expect(renderedSync).toBe(resolved.resolvedCurrentSyncNum);
+
+    const outcomeFromResolved = deriveProjectedOutcomeForTest(
+      "B000",
+      "A000",
+      1000,
+      1000,
+      resolved.resolvedCurrentSyncNum,
+    );
+    const outcomeFromRendered = deriveProjectedOutcomeForTest(
+      "B000",
+      "A000",
+      1000,
+      1000,
+      renderedSync,
+    );
+
+    expect(outcomeFromResolved).toBe("WIN");
+    expect(outcomeFromRendered).toBe(outcomeFromResolved);
+  });
+
+  it("uses the same confirmed same-war sync value for display and tie-break parity", () => {
+    const resolved = resolveCurrentSyncNumberForMatchForTest({
+      warState: "inWar",
+      previousSyncNum: 481,
+      currentWarSyncNum: 482,
+    });
+    const renderedSync = resolveRenderedSyncNumberForStoredSummaryForTest({
+      syncRow: {
+        syncNum: 482,
+        lastKnownSyncNumber: 482,
+        warId: "3002",
+        warStartTime: new Date("2026-03-25T04:21:07.000Z"),
+      },
+      fallbackSyncNum: resolved.resolvedCurrentSyncNum,
+      warId: "3002",
+      warStartTime: new Date("2026-03-25T04:21:07.000Z"),
+      opponentNotFound: false,
+      validationState: {
+        siteCurrent: false,
+        syncRowMissing: false,
+        differences: [],
+        statusLine: "",
+      },
+    });
+
+    expect(renderedSync).toBe(482);
+    expect(renderedSync).toBe(resolved.resolvedCurrentSyncNum);
+
+    const outcomeFromResolved = deriveProjectedOutcomeForTest(
+      "B000",
+      "A000",
+      1000,
+      1000,
+      resolved.resolvedCurrentSyncNum,
+    );
+    const outcomeFromRendered = deriveProjectedOutcomeForTest(
+      "B000",
+      "A000",
+      1000,
+      1000,
+      renderedSync,
+    );
+
+    expect(outcomeFromResolved).toBe("WIN");
+    expect(outcomeFromRendered).toBe(outcomeFromResolved);
+  });
 });

--- a/tests/fwaMatchRevisionDraft.logic.test.ts
+++ b/tests/fwaMatchRevisionDraft.logic.test.ts
@@ -6,6 +6,7 @@ import {
   buildDraftFromOutcomeToggleForTest,
   buildDraftFromMatchTypeSelectionForTest,
   buildEffectiveMatchMismatchWarningsForTest,
+  buildMailSendGateDecisionForTest,
   formatMailLifecycleStatusLineForTest,
   getMailBlockedReasonFromRevisionStateForTest,
   isPointsValidationCurrentForMatchupForTest,
@@ -408,6 +409,90 @@ describe("fwa mail freshness status mapping", () => {
 
     expect(freshness).toBe("unsent");
     expect(line).toBe("Mail status: **Send Mail Available**");
+  });
+});
+
+describe("fwa mail revision decision contract projection", () => {
+  it("keeps gate and status line aligned for posted up-to-date state", () => {
+    const decision = {
+      mailStatus: {
+        status: "posted" as const,
+        mailStatusEmoji: ":mailbox_with_mail:",
+        debug: {},
+      },
+      liveRevisionFields: {
+        warId: "1001",
+        opponentTag: "2TAG",
+        matchType: "FWA" as const,
+        expectedOutcome: "WIN" as const,
+      },
+      confirmedRevisionBaseline: {
+        warId: "1001",
+        opponentTag: "2TAG",
+        matchType: "FWA" as const,
+        expectedOutcome: "WIN" as const,
+      },
+      effectiveRevisionFields: {
+        warId: "1001",
+        opponentTag: "2TAG",
+        matchType: "FWA" as const,
+        expectedOutcome: "WIN" as const,
+      },
+      appliedDraftRevision: null,
+      draftDiffersFromBaseline: false,
+      mailBlockedReason:
+        "Current mail is already up to date. Change match config before sending again.",
+    } as Parameters<typeof buildMailSendGateDecisionForTest>[0];
+
+    const gate = buildMailSendGateDecisionForTest(decision);
+    const statusLine = formatMailLifecycleStatusLineForTest(gate.mailStatus.status, {
+      hasConfirmedBaseline: Boolean(gate.confirmedRevisionBaseline),
+      draftDiffersFromBaseline: gate.draftDiffersFromBaseline,
+    });
+
+    expect(gate.mailStatus).toBe(decision.mailStatus);
+    expect(gate.mailBlockedReason).toBe(decision.mailBlockedReason);
+    expect(statusLine).toBe("Mail status: **Mail Sent (Up to Date)**");
+  });
+
+  it("keeps deleted lifecycle semantics aligned with resend availability", () => {
+    const decision = {
+      mailStatus: {
+        status: "deleted" as const,
+        mailStatusEmoji: ":mailbox_with_no_mail:",
+        debug: {},
+      },
+      liveRevisionFields: {
+        warId: "1001",
+        opponentTag: "2TAG",
+        matchType: "BL" as const,
+        expectedOutcome: null,
+      },
+      confirmedRevisionBaseline: {
+        warId: "1001",
+        opponentTag: "2TAG",
+        matchType: "BL" as const,
+        expectedOutcome: null,
+      },
+      effectiveRevisionFields: {
+        warId: "1001",
+        opponentTag: "2TAG",
+        matchType: "BL" as const,
+        expectedOutcome: null,
+      },
+      appliedDraftRevision: null,
+      draftDiffersFromBaseline: false,
+      mailBlockedReason: null,
+    } as Parameters<typeof buildMailSendGateDecisionForTest>[0];
+
+    const gate = buildMailSendGateDecisionForTest(decision);
+    const statusLine = formatMailLifecycleStatusLineForTest(gate.mailStatus.status, {
+      hasConfirmedBaseline: Boolean(gate.confirmedRevisionBaseline),
+      draftDiffersFromBaseline: gate.draftDiffersFromBaseline,
+    });
+
+    expect(gate.mailBlockedReason).toBeNull();
+    expect(statusLine).toBe("Mail status: **Mail Deleted / Resend Available**");
   });
 });
 

--- a/tests/fwaMatchRevisionDraft.logic.test.ts
+++ b/tests/fwaMatchRevisionDraft.logic.test.ts
@@ -348,7 +348,7 @@ describe("fwa match posted mail gating with revisions", () => {
     expect(reason).toBeNull();
   });
 
-  it("allows draft-confirmed send for inferred not-posted state", () => {
+  it("blocks send for inferred not-posted state even when a draft is present", () => {
     const reason = getMailBlockedReasonFromRevisionStateForTest({
       inferredMatchType: true,
       hasMailChannel: true,
@@ -360,6 +360,21 @@ describe("fwa match posted mail gating with revisions", () => {
         expectedOutcome: "LOSE",
       },
       draftDiffersFromBaseline: true,
+      hasConfirmedBaseline: false,
+    });
+
+    expect(reason).toBe(
+      "Match type is inferred. Confirm match type before sending mail."
+    );
+  });
+
+  it("allows normal not-posted send gating once match type is confirmed", () => {
+    const reason = getMailBlockedReasonFromRevisionStateForTest({
+      inferredMatchType: false,
+      hasMailChannel: true,
+      mailStatus: "not_posted",
+      appliedDraft: null,
+      draftDiffersFromBaseline: false,
       hasConfirmedBaseline: false,
     });
 

--- a/tests/fwaMatchRevisionDraft.logic.test.ts
+++ b/tests/fwaMatchRevisionDraft.logic.test.ts
@@ -7,6 +7,7 @@ import {
   buildDraftFromMatchTypeSelectionForTest,
   buildEffectiveMatchMismatchWarningsForTest,
   buildMailSendGateDecisionForTest,
+  buildOverviewMailDecisionProjectionForTest,
   formatMailLifecycleStatusLineForTest,
   getMailBlockedReasonFromRevisionStateForTest,
   isPointsValidationCurrentForMatchupForTest,
@@ -493,6 +494,126 @@ describe("fwa mail revision decision contract projection", () => {
 
     expect(gate.mailBlockedReason).toBeNull();
     expect(statusLine).toBe("Mail status: **Mail Deleted / Resend Available**");
+  });
+
+  it("keeps overview active-war status/action aligned with posted up-to-date decisions", () => {
+    const projection = buildOverviewMailDecisionProjectionForTest({
+      inferredMatchType: true,
+      decision: {
+        mailStatus: {
+          status: "posted",
+          mailStatusEmoji: ":mailbox_with_mail:",
+          debug: {},
+        },
+        liveRevisionFields: {
+          warId: "1001",
+          opponentTag: "2TAG",
+          matchType: "FWA",
+          expectedOutcome: "WIN",
+        },
+        confirmedRevisionBaseline: {
+          warId: "1001",
+          opponentTag: "2TAG",
+          matchType: "FWA",
+          expectedOutcome: "WIN",
+        },
+        effectiveRevisionFields: {
+          warId: "1001",
+          opponentTag: "2TAG",
+          matchType: "FWA",
+          expectedOutcome: "WIN",
+        },
+        appliedDraftRevision: null,
+        draftDiffersFromBaseline: false,
+        mailBlockedReason:
+          "Current mail is already up to date. Change match config before sending again.",
+      },
+    } as Parameters<typeof buildOverviewMailDecisionProjectionForTest>[0]);
+
+    expect(projection.mailLifecycleStatusLine).toBe(
+      "Mail status: **Mail Sent (Up to Date)**"
+    );
+    expect(projection.mailActionEnabled).toBe(false);
+    expect(projection.effectiveInferredMatchType).toBe(true);
+  });
+
+  it("enables action when a same-war draft differs from the posted baseline", () => {
+    const projection = buildOverviewMailDecisionProjectionForTest({
+      inferredMatchType: true,
+      decision: {
+        mailStatus: {
+          status: "posted",
+          mailStatusEmoji: ":mailbox_with_mail:",
+          debug: {},
+        },
+        liveRevisionFields: {
+          warId: "1001",
+          opponentTag: "2TAG",
+          matchType: "FWA",
+          expectedOutcome: "LOSE",
+        },
+        confirmedRevisionBaseline: {
+          warId: "1001",
+          opponentTag: "2TAG",
+          matchType: "FWA",
+          expectedOutcome: "WIN",
+        },
+        effectiveRevisionFields: {
+          warId: "1001",
+          opponentTag: "2TAG",
+          matchType: "BL",
+          expectedOutcome: null,
+        },
+        appliedDraftRevision: {
+          warId: "1001",
+          opponentTag: "2TAG",
+          matchType: "BL",
+          expectedOutcome: null,
+        },
+        draftDiffersFromBaseline: true,
+        mailBlockedReason: null,
+      },
+    } as Parameters<typeof buildOverviewMailDecisionProjectionForTest>[0]);
+
+    expect(projection.mailLifecycleStatusLine).toBe(
+      "Mail status: **Mail Sent (Out of Date)**"
+    );
+    expect(projection.mailActionEnabled).toBe(true);
+    expect(projection.effectiveInferredMatchType).toBe(false);
+  });
+
+  it("keeps not-posted status semantics unchanged for pre-war/no-opponent paths", () => {
+    const projection = buildOverviewMailDecisionProjectionForTest({
+      inferredMatchType: false,
+      decision: {
+        mailStatus: {
+          status: "not_posted",
+          mailStatusEmoji: ":mailbox_with_no_mail:",
+          debug: {},
+        },
+        liveRevisionFields: {
+          warId: "1001",
+          opponentTag: "2TAG",
+          matchType: "BL",
+          expectedOutcome: null,
+        },
+        confirmedRevisionBaseline: null,
+        effectiveRevisionFields: {
+          warId: "1001",
+          opponentTag: "2TAG",
+          matchType: "BL",
+          expectedOutcome: null,
+        },
+        appliedDraftRevision: null,
+        draftDiffersFromBaseline: false,
+        mailBlockedReason: null,
+      },
+    } as Parameters<typeof buildOverviewMailDecisionProjectionForTest>[0]);
+
+    expect(projection.mailLifecycleStatusLine).toBe(
+      "Mail status: **Send Mail Available**"
+    );
+    expect(projection.mailActionEnabled).toBe(true);
   });
 });
 

--- a/tests/fwaMatchRevisionDraft.logic.test.ts
+++ b/tests/fwaMatchRevisionDraft.logic.test.ts
@@ -7,6 +7,7 @@ import {
   buildDraftFromMatchTypeSelectionForTest,
   buildEffectiveMatchMismatchWarningsForTest,
   buildMailSendGateDecisionForTest,
+  buildNonActiveMailProjectionForTest,
   buildOverviewMailDecisionProjectionForTest,
   formatMailLifecycleStatusLineForTest,
   getMailBlockedReasonFromRevisionStateForTest,
@@ -614,6 +615,57 @@ describe("fwa mail revision decision contract projection", () => {
       "Mail status: **Send Mail Available**"
     );
     expect(projection.mailActionEnabled).toBe(true);
+  });
+
+  it("aligns pre-war status/action semantics across overview and direct projections", () => {
+    const projection = buildNonActiveMailProjectionForTest({
+      mode: "pre_war",
+      tag: "2RYGLU2UY",
+      resolvedStatus: {
+        status: "not_posted",
+        mailStatusEmoji: ":mailbox_with_no_mail:",
+        debug: {},
+      },
+      mailStatusDebugEnabled: false,
+    } as Parameters<typeof buildNonActiveMailProjectionForTest>[0]);
+
+    expect(projection.mailStatusLine).toBe("Mail status: **Send Mail Available**");
+    expect(projection.mailAction).toBeUndefined();
+  });
+
+  it("aligns no-opponent status/action semantics across overview and direct projections", () => {
+    const projection = buildNonActiveMailProjectionForTest({
+      mode: "no_opponent",
+      tag: "2RYGLU2UY",
+      resolvedStatus: {
+        status: "posted",
+        mailStatusEmoji: ":mailbox_with_mail:",
+        debug: {},
+      },
+      mailStatusDebugEnabled: false,
+    } as Parameters<typeof buildNonActiveMailProjectionForTest>[0]);
+
+    expect(projection.mailStatusLine).toBe("Mail status: **Mail Sent**");
+    expect(projection.mailAction).toEqual({
+      tag: "2RYGLU2UY",
+      enabled: false,
+      reason: "No active war opponent.",
+    });
+  });
+
+  it("keeps non-active projection intentionally separate from active-war freshness semantics", () => {
+    const projection = buildNonActiveMailProjectionForTest({
+      mode: "pre_war",
+      tag: "2RYGLU2UY",
+      resolvedStatus: {
+        status: "posted",
+        mailStatusEmoji: ":mailbox_with_mail:",
+        debug: {},
+      },
+      mailStatusDebugEnabled: false,
+    } as Parameters<typeof buildNonActiveMailProjectionForTest>[0]);
+
+    expect(projection.mailStatusLine).toBe("Mail status: **Mail Sent**");
   });
 });
 

--- a/tests/fwaMatchRevisionDraft.logic.test.ts
+++ b/tests/fwaMatchRevisionDraft.logic.test.ts
@@ -7,6 +7,7 @@ import {
   buildDraftFromMatchTypeSelectionForTest,
   buildEffectiveMatchMismatchWarningsForTest,
   buildMailSendGateDecisionForTest,
+  buildInferredMatchWarningLinesForTest,
   buildNonActiveMailProjectionForTest,
   buildOverviewMailDecisionProjectionForTest,
   formatMailLifecycleStatusLineForTest,
@@ -261,6 +262,41 @@ describe("fwa inferred warning visibility", () => {
         },
       })
     ).toBe(false);
+  });
+});
+
+describe("fwa inferred warning rendering", () => {
+  it("suppresses standalone inferred warning when inferred block reason is already present", () => {
+    const lines = buildInferredMatchWarningLinesForTest({
+      inferredMatchType: true,
+      mailBlockedReason: "Match type is inferred. Confirm match type before sending mail.",
+      includeSpacer: true,
+    });
+
+    expect(lines).toEqual([]);
+  });
+
+  it("renders standalone inferred warning when inferred and no inferred-block reason is present", () => {
+    const lines = buildInferredMatchWarningLinesForTest({
+      inferredMatchType: true,
+      mailBlockedReason: null,
+      includeSpacer: true,
+    });
+
+    expect(lines).toEqual([
+      ":warning: Match type is inferred. Confirm match type before sending mail.",
+      "\u200B",
+    ]);
+  });
+
+  it("does not render inferred warning lines for confirmed match type", () => {
+    const lines = buildInferredMatchWarningLinesForTest({
+      inferredMatchType: false,
+      mailBlockedReason: "Match type is inferred. Confirm match type before sending mail.",
+      includeSpacer: true,
+    });
+
+    expect(lines).toEqual([]);
   });
 });
 

--- a/tests/fwaMatchRevisionDraft.logic.test.ts
+++ b/tests/fwaMatchRevisionDraft.logic.test.ts
@@ -1517,7 +1517,7 @@ describe("fwa single-clan match embed color", () => {
 });
 
 describe("fwa single-clan links presentation", () => {
-  it("keeps plain points header and includes tracked points in links", () => {
+  it("keeps plain points header and includes labeled us/them links for cc and points", () => {
     const rendered = buildSingleClanMatchLinksForTest({
       trackedClanTag: "#CLAN123",
       opponentTag: "#OPPO456",
@@ -1525,28 +1525,33 @@ describe("fwa single-clan links presentation", () => {
 
     expect(rendered.linksFieldName).toBe("Links");
     expect(rendered.linksFieldValue).toContain(
-      "[cc.fwafarm](<https://cc.fwafarm.com/cc_n/clan.php?tag=OPPO456>)"
+      "[cc.fwafarm (them)](<https://cc.fwafarm.com/cc_n/clan.php?tag=OPPO456>)"
     );
     expect(rendered.linksFieldValue).toContain(
-      "[points.fwafarm](<https://points.fwafarm.com/clan?tag=CLAN123>)"
+      "[cc.fwafarm (us)](<https://cc.fwafarm.com/cc_n/clan.php?tag=CLAN123>)"
+    );
+    expect(rendered.linksFieldValue).toContain(
+      "[points.fwafarm (them)](<https://points.fwafarm.com/clan?tag=OPPO456>)"
+    );
+    expect(rendered.linksFieldValue).toContain(
+      "[points.fwafarm (us)](<https://points.fwafarm.com/clan?tag=CLAN123>)"
     );
     expect(rendered.linksFieldValue).not.toContain("lvoJgZB.png");
     expect(rendered.pointsFieldName).toBe("Points");
   });
 
-  it("labels copy output links by ownership without advertising tie-breaker as web link", () => {
+  it("labels copy output links with deterministic us/them ownership", () => {
     const rendered = buildSingleClanMatchLinksForTest({
       trackedClanTag: "#TEAM999",
       opponentTag: "#ENEMY111",
     });
 
     expect(rendered.copyLines).toEqual([
-      "CC (opponent): [cc.fwafarm](<https://cc.fwafarm.com/cc_n/clan.php?tag=ENEMY111>)",
-      "Points (tracked clan): [points.fwafarm](<https://points.fwafarm.com/clan?tag=TEAM999>)",
+      "CC (them): [cc.fwafarm](<https://cc.fwafarm.com/cc_n/clan.php?tag=ENEMY111>)",
+      "CC (us): [cc.fwafarm](<https://cc.fwafarm.com/cc_n/clan.php?tag=TEAM999>)",
+      "Points (them): [points.fwafarm](<https://points.fwafarm.com/clan?tag=ENEMY111>)",
+      "Points (us): [points.fwafarm](<https://points.fwafarm.com/clan?tag=TEAM999>)",
     ]);
-    expect(rendered.copyLines.join("\n")).not.toContain(
-      "https://points.fwafarm.com/clan?tag=ENEMY111"
-    );
     expect(rendered.copyLines.join("\n")).not.toContain("lvoJgZB.png");
   });
 });

--- a/tests/warEventLog.logic.test.ts
+++ b/tests/warEventLog.logic.test.ts
@@ -11,6 +11,7 @@ import {
   computeWarPointsDeltaForTest,
   isNotifyWarEndedViewButtonCustomId,
   parseNotifyWarEndedViewCustomId,
+  resolveEventRenderSyncNumberForTest,
   resolveActiveWarTimingForTest,
   sanitizeWarPlanForEmbedForTest,
 } from "../src/services/WarEventLogService";
@@ -58,6 +59,60 @@ describe("War-end metadata value", () => {
         timestampUnix: 1773407400,
       })
     ).toBe("War ID: 1000055 - Sync: 476 - <t:1773407400:F>");
+  });
+});
+
+describe("WarEventLogService resolved notify sync fallback", () => {
+  it("prefers same-war sync over posted and derived values", () => {
+    expect(
+      resolveEventRenderSyncNumberForTest({
+        sameWarSyncNumber: 482,
+        postedSyncNumber: 481,
+        previousSyncNumber: 480,
+        currentState: "inWar",
+      })
+    ).toBe(482);
+  });
+
+  it("falls back to posted sync when same-war sync is unavailable", () => {
+    expect(
+      resolveEventRenderSyncNumberForTest({
+        sameWarSyncNumber: null,
+        postedSyncNumber: 482,
+        previousSyncNumber: 480,
+        currentState: "inWar",
+      })
+    ).toBe(482);
+  });
+
+  it("derives active-war sync as previous + 1 for preparation/inWar", () => {
+    expect(
+      resolveEventRenderSyncNumberForTest({
+        sameWarSyncNumber: null,
+        postedSyncNumber: null,
+        previousSyncNumber: 481,
+        currentState: "preparation",
+      })
+    ).toBe(482);
+    expect(
+      resolveEventRenderSyncNumberForTest({
+        sameWarSyncNumber: null,
+        postedSyncNumber: null,
+        previousSyncNumber: 481,
+        currentState: "inWar",
+      })
+    ).toBe(482);
+  });
+
+  it("falls back to previous sync when war is not active", () => {
+    expect(
+      resolveEventRenderSyncNumberForTest({
+        sameWarSyncNumber: null,
+        postedSyncNumber: null,
+        previousSyncNumber: 481,
+        currentState: "notInWar",
+      })
+    ).toBe(481);
   });
 });
 

--- a/tests/warEventLog.logic.test.ts
+++ b/tests/warEventLog.logic.test.ts
@@ -15,7 +15,10 @@ import {
   resolveActiveWarTimingForTest,
   sanitizeWarPlanForEmbedForTest,
 } from "../src/services/WarEventLogService";
-import { WarEventHistoryService } from "../src/services/war-events/history";
+import {
+  resolveParticipationGuildId,
+  WarEventHistoryService,
+} from "../src/services/war-events/history";
 
 function dateAt(hour: number): Date {
   return new Date(Date.UTC(2026, 0, 1, hour, 0, 0));
@@ -59,6 +62,35 @@ describe("War-end metadata value", () => {
         timestampUnix: 1773407400,
       })
     ).toBe("War ID: 1000055 - Sync: 476 - <t:1773407400:F>");
+  });
+});
+
+describe("WarEventHistoryService participation guild resolution", () => {
+  it("prefers payload guild over snapshot guild to avoid cross-guild writes", () => {
+    expect(
+      resolveParticipationGuildId({
+        payloadGuildId: "prod-guild",
+        snapshotGuildId: "staging-guild",
+      }),
+    ).toBe("prod-guild");
+  });
+
+  it("falls back to snapshot guild when payload guild is unavailable", () => {
+    expect(
+      resolveParticipationGuildId({
+        payloadGuildId: "",
+        snapshotGuildId: "snapshot-guild",
+      }),
+    ).toBe("snapshot-guild");
+  });
+
+  it("returns null when neither guild source is available", () => {
+    expect(
+      resolveParticipationGuildId({
+        payloadGuildId: null,
+        snapshotGuildId: undefined,
+      }),
+    ).toBeNull();
   });
 });
 

--- a/tests/warEventLog.warEndPointsReconcile.test.ts
+++ b/tests/warEventLog.warEndPointsReconcile.test.ts
@@ -912,8 +912,9 @@ describe("War-ended sync and metadata canonicalization", () => {
       .mockResolvedValue({ allowed: true, existingMessage: null, warId: "1001303" });
     const emitSpy = vi.spyOn(service as any, "emitEvent").mockResolvedValue(undefined);
 
+    const persistSpy = vi.fn().mockResolvedValue(undefined);
     (service as any).history = {
-      persistWarEndHistory: vi.fn().mockResolvedValue(undefined),
+      persistWarEndHistory: persistSpy,
       resolveCanonicalWarEndedContext: vi.fn().mockResolvedValue({
         warId: 1001303,
         syncNumber: 477,
@@ -948,6 +949,8 @@ describe("War-ended sync and metadata canonicalization", () => {
     expect(emitSpy).toHaveBeenCalledTimes(1);
     expect(emitSpy.mock.calls[0]?.[2]).toBe(1001303);
     expect(emitSpy.mock.calls[0]?.[1]?.syncNumber).toBe(477);
+    expect(persistSpy).toHaveBeenCalledTimes(1);
+    expect(persistSpy.mock.calls[0]?.[0]?.guildId).toBe("guild-1");
   });
 
   it("recomputes canonical war-ended expected points before live emit", async () => {
@@ -1010,6 +1013,8 @@ describe("War-ended sync and metadata canonicalization", () => {
     expect(emitSpy.mock.calls[0]?.[1]?.warEndFwaPoints).toBe(8);
     expect(emitSpy.mock.calls[0]?.[1]?.testFinalResultOverride?.resultLabel).toBe("WIN");
     expect(persistSpy).toHaveBeenCalledTimes(2);
+    expect(persistSpy.mock.calls[0]?.[0]?.guildId).toBe("guild-1");
+    expect(persistSpy.mock.calls[1]?.[0]?.guildId).toBe("guild-1");
     expect(persistSpy.mock.calls[1]?.[0]?.warEndFwaPoints).toBe(8);
   });
 

--- a/tests/warEventLog.warEndPointsReconcile.test.ts
+++ b/tests/warEventLog.warEndPointsReconcile.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { Client } from "discord.js";
-import { ChannelType } from "discord.js";
+import { ChannelType, EmbedBuilder } from "discord.js";
 import { prisma } from "../src/prisma";
 import {
   WarEventLogService,
@@ -1061,5 +1061,118 @@ describe("War-ended sync and metadata canonicalization", () => {
     const metadataField = fields.find((field) => field.name === "War Metadata");
     expect(metadataField?.value).toContain("War ID: 1001303");
     expect(metadataField?.value).toContain("Sync: 477");
+  });
+});
+
+describe("War-start notify refresh sync fallback", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  async function runWarStartedRefreshCase(input: {
+    sameWarSync: number | null;
+    postedSync: number | null;
+    previousSync: number | null;
+  }): Promise<{
+    ok: boolean;
+    payloadSyncNumber: number | null;
+    getPreviousSyncNumSpy: ReturnType<typeof vi.fn>;
+  }> {
+    const messageEdit = vi.fn().mockResolvedValue(undefined);
+    const messageFetch = vi.fn().mockResolvedValue({
+      content: "War declared against Enemy",
+      embeds: [],
+      edit: messageEdit,
+    });
+    const channelFetch = vi.fn().mockResolvedValue({
+      isTextBased: () => true,
+      messages: { fetch: messageFetch },
+    });
+    const coc = {
+      getCurrentWar: vi.fn().mockResolvedValue({
+        state: "preparation",
+        clan: { name: "Alpha", stars: 0 },
+        opponent: { tag: "#OPP123", name: "Enemy", stars: 0 },
+      }),
+    };
+    const service = new WarEventLogService(
+      { channels: { fetch: channelFetch } } as unknown as Client,
+      coc as any
+    );
+    const sub = makeSubscription({
+      guildId: "guild-1",
+      clanTag: "#AAA111",
+      startTime: new Date("2026-03-12T00:00:00.000Z"),
+      prepStartTime: new Date("2026-03-11T00:00:00.000Z"),
+      endTime: new Date("2026-03-13T00:00:00.000Z"),
+    });
+
+    vi.spyOn(prisma.currentWar, "update").mockResolvedValue({} as any);
+    (service as any).findSubscriptionByGuildAndTag = vi.fn().mockResolvedValue(sub);
+    (service as any).ensureCurrentWarId = vi.fn().mockResolvedValue(1000105);
+    (service as any).postedMessages = {
+      findExistingMessage: vi.fn().mockResolvedValue({
+        channelId: "chan-1",
+        messageId: "msg-1",
+        syncNum: input.postedSync,
+      }),
+    };
+    (service as any).currentSyncs = {
+      getCurrentSyncForClan: vi
+        .fn()
+        .mockResolvedValue(input.sameWarSync === null ? null : { syncNum: input.sameWarSync }),
+    };
+    const getPreviousSyncNumSpy = vi.fn().mockResolvedValue(input.previousSync);
+    (service as any).pointsSync = {
+      getPreviousSyncNum: getPreviousSyncNumSpy,
+    };
+
+    const buildSpy = vi
+      .spyOn(service as any, "buildWarStartedRefreshEmbed")
+      .mockResolvedValue(new EmbedBuilder());
+
+    const ok = await service.refreshCurrentNotifyPost("guild-1", "#AAA111");
+    const payloadSyncNumber = (buildSpy.mock.calls[0]?.[0]?.syncNumber as number | null) ?? null;
+    return {
+      ok,
+      payloadSyncNumber,
+      getPreviousSyncNumSpy,
+    };
+  }
+
+  it("prefers same-war sync over posted and derived values", async () => {
+    const result = await runWarStartedRefreshCase({
+      sameWarSync: 482,
+      postedSync: 481,
+      previousSync: 480,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.payloadSyncNumber).toBe(482);
+    expect(result.getPreviousSyncNumSpy).not.toHaveBeenCalled();
+  });
+
+  it("falls back to posted sync when same-war sync is unavailable", async () => {
+    const result = await runWarStartedRefreshCase({
+      sameWarSync: null,
+      postedSync: 482,
+      previousSync: 481,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.payloadSyncNumber).toBe(482);
+    expect(result.getPreviousSyncNumSpy).not.toHaveBeenCalled();
+  });
+
+  it("derives active-war sync as previous+1 when same-war and posted sync are unavailable", async () => {
+    const result = await runWarStartedRefreshCase({
+      sameWarSync: null,
+      postedSync: null,
+      previousSync: 481,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.payloadSyncNumber).toBe(482);
+    expect(result.getPreviousSyncNumSpy).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/warEventLog.warEndPointsReconcile.test.ts
+++ b/tests/warEventLog.warEndPointsReconcile.test.ts
@@ -1069,6 +1069,102 @@ describe("War-start notify refresh sync fallback", () => {
     vi.restoreAllMocks();
   });
 
+  async function runWarStartedInitialCase(input: {
+    sameWarSync: number | null;
+    previousSync: number | null;
+  }): Promise<{
+    payloadSyncNumber: number | null;
+  }> {
+    vi.restoreAllMocks();
+    const service = new WarEventLogService(
+      { channels: { fetch: vi.fn() } } as unknown as Client,
+      {} as any,
+    );
+    const sub = makeSubscription({
+      guildId: "guild-1",
+      clanTag: "#AAA111",
+      warId: null,
+      state: "notInWar",
+      prepStartTime: null,
+      startTime: null,
+      endTime: null,
+      opponentTag: null,
+      opponentName: null,
+    });
+
+    vi.spyOn(prisma, "$queryRaw").mockResolvedValue([sub] as any);
+    vi.spyOn(prisma.currentWar, "update").mockResolvedValue({} as any);
+    (service as any).getCurrentWarSnapshot = vi.fn().mockResolvedValue({
+      war: {
+        state: "preparation",
+        clan: {
+          name: "Alpha",
+          stars: 0,
+          attacks: 0,
+          destructionPercentage: 0,
+        },
+        opponent: {
+          tag: "#OPP123",
+          name: "Enemy",
+          stars: 0,
+          attacks: 0,
+          destructionPercentage: 0,
+        },
+        preparationStartTime: "20260311T000000.000Z",
+        startTime: "20260312T000000.000Z",
+        endTime: "20260313T000000.000Z",
+        teamSize: 50,
+        attacksPerMember: 2,
+      },
+      observation: { kind: "success" },
+    });
+    (service as any).recordCocWarObservation = vi
+      .fn()
+      .mockReturnValue({ suspected: false });
+    (service as any).hasWarEndRecorded = vi.fn().mockResolvedValue(false);
+    (service as any).ensureCurrentWarId = vi.fn().mockResolvedValue(1000105);
+    (service as any).syncWarAttacksFromWarSnapshot = vi
+      .fn()
+      .mockResolvedValue(undefined);
+    const dispatchDetectedEventSpy = vi.fn().mockResolvedValue(undefined);
+    (service as any).dispatchDetectedEvent = dispatchDetectedEventSpy;
+    (service as any).reconcileWarEndedPointsDiscrepancy = vi
+      .fn()
+      .mockResolvedValue(undefined);
+    (service as any).pointsGate = {
+      evaluatePollerFetch: vi.fn().mockResolvedValue({
+        allowed: false,
+        fetchReason: "post_war_reconciliation",
+      }),
+    };
+    (service as any).pointsSync = {
+      resetWarStartPointsJob: vi.fn().mockResolvedValue(undefined),
+      maybeRunWarStartPointsCheck: vi.fn().mockResolvedValue(undefined),
+      getPreviousSyncNum: vi.fn().mockResolvedValue(input.previousSync),
+    };
+    (service as any).currentSyncs = {
+      markNeedsValidation: vi.fn().mockResolvedValue(undefined),
+      getCurrentSyncForClan: vi
+        .fn()
+        .mockResolvedValue(input.sameWarSync === null ? null : { syncNum: input.sameWarSync }),
+    };
+
+    await (service as any).processSubscription("guild-1", "#AAA111", {
+      previousSync: input.previousSync,
+      activeSync:
+        input.previousSync !== null && Number.isFinite(input.previousSync)
+          ? Math.trunc(input.previousSync) + 1
+          : null,
+    });
+
+    const payloadSyncNumber =
+      (dispatchDetectedEventSpy.mock.calls[0]?.[0]?.payload?.syncNumber as
+        | number
+        | null
+        | undefined) ?? null;
+    return { payloadSyncNumber };
+  }
+
   async function runWarStartedRefreshCase(input: {
     sameWarSync: number | null;
     postedSync: number | null;
@@ -1078,6 +1174,7 @@ describe("War-start notify refresh sync fallback", () => {
     payloadSyncNumber: number | null;
     getPreviousSyncNumSpy: ReturnType<typeof vi.fn>;
   }> {
+    vi.restoreAllMocks();
     const messageEdit = vi.fn().mockResolvedValue(undefined);
     const messageFetch = vi.fn().mockResolvedValue({
       content: "War declared against Enemy",
@@ -1174,5 +1271,37 @@ describe("War-start notify refresh sync fallback", () => {
     expect(result.ok).toBe(true);
     expect(result.payloadSyncNumber).toBe(482);
     expect(result.getPreviousSyncNumSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps initial notify and refresh sync aligned when same-war sync exists", async () => {
+    const initial = await runWarStartedInitialCase({
+      sameWarSync: 482,
+      previousSync: 480,
+    });
+    const refresh = await runWarStartedRefreshCase({
+      sameWarSync: 482,
+      postedSync: null,
+      previousSync: 480,
+    });
+
+    expect(initial.payloadSyncNumber).toBe(482);
+    expect(refresh.payloadSyncNumber).toBe(482);
+    expect(initial.payloadSyncNumber).toBe(refresh.payloadSyncNumber);
+  });
+
+  it("keeps initial notify and refresh sync aligned for derived active fallback", async () => {
+    const initial = await runWarStartedInitialCase({
+      sameWarSync: null,
+      previousSync: 481,
+    });
+    const refresh = await runWarStartedRefreshCase({
+      sameWarSync: null,
+      postedSync: null,
+      previousSync: 481,
+    });
+
+    expect(initial.payloadSyncNumber).toBe(482);
+    expect(refresh.payloadSyncNumber).toBe(482);
+    expect(initial.payloadSyncNumber).toBe(refresh.payloadSyncNumber);
   });
 });

--- a/tests/weightInputDeferment.service.test.ts
+++ b/tests/weightInputDeferment.service.test.ts
@@ -221,6 +221,9 @@ describe("WeightInputDefermentService lifecycle processing", () => {
       "<@&role-global-leader>",
     );
     expect(String(send.mock.calls[0]?.[0]?.content)).toContain("Current clan: Bravo (#BBB222)");
+    expect(String(send.mock.calls[0]?.[0]?.content)).toContain(
+      "<https://fwastats.com/Clan/BBB222/Weight>",
+    );
     expect(String(send.mock.calls[0]?.[0]?.content)).not.toContain("<@&role-1>");
     expect(String(send.mock.calls[0]?.[0]?.content)).not.toContain(
       "<@&role-lead-2>",


### PR DESCRIPTION
## Summary

This merge hardens `/fwa match`, war-event sync rendering, and war mail decision flow by removing several legacy/compatibility reader paths that were allowing different parts of the system to resolve the same state differently.

The work focused on:

* unifying current-war sync resolution
* fixing war-event `Sync #` fallback behavior
* consolidating mail revision / send-gating decisions
* aligning overview and non-active mail projections
* restoring confirmed-match-type requirement before direct `/fwa match tag:` mail send
* deduping inferred-match warning rendering

---

## Included changes

### `/fwa match` sync resolution hardening

* locked in the resolved current-war sync path with focused regression tests
* ensured displayed `Sync #` and tie-breaker parity both use the same resolved sync source
* covered:

  * derived active-war fallback (`previous + 1`)
  * same-war persisted sync precedence

### War event `Sync #` fallback fix

* added shared notify refresh sync resolver in `WarEventLogService`
* war-start / battle-day refresh paths now resolve sync with this precedence:

  1. same-war `ClanPointsSync.syncNum`
  2. existing posted notify sync
  3. derived active sync (`previous + 1` during `preparation|inWar`, else previous)
* prevents war event embeds from falling back to `Unknown` when sync is resolvable or derivable

### War event initial vs refresh resolver unification

* removed separate inline initial-notify sync fallback logic
* initial notify and refresh/edit now use the same shared event sync resolver
* eliminates initial-vs-refresh `Sync #` drift

### Mail revision decision unification

* unified direct single-tag `/fwa match`, preview, confirm/send, and builder inputs around one shared mail revision decision contract
* consolidated gate projection into a shared helper
* removed duplicate preview/confirm gate recomputation
* aligned builder inputs with reconciled lifecycle truth

### Overview active-war mail decision unification

* refactored `buildTrackedMatchOverview` active-war mail block to consume the shared mail revision decision + gate projection contract
* removed local lifecycle/baseline/gate recomputation in overview/scoped active-war mail logic
* aligns overview/scoped active-war behavior with direct single-tag behavior

### Non-active mail projection unification

* extracted shared non-active mail projection logic for:

  * pre-war
  * no-opponent
* reused it across overview and direct single-tag `/fwa match` non-active branches
* keeps non-active semantics intentionally separate from the active-war revision contract while removing duplicated rendering/action logic

### Confirmed match-type gate restored for direct mail send

* restored the rule that direct `/fwa match tag:` mail cannot be sent while match type is inferred
* inferred state can still be displayed
* preview/send/confirm are blocked until match type is confirmed

### Inferred warning dedupe

* removed duplicate `Match type is inferred. Confirm match type before sending mail.` rendering in direct `/fwa match tag:`
* preserved shared gate ownership for the actual send block
* warning now renders once

---

## Behavior impact

### Fixed / improved

* `/fwa match` no longer risks stale sync driving display vs tie-break parity
* war-start / refresh event embeds are less likely to show `Sync # = Unknown` when sync is available or derivable
* initial event posts and refreshes now stay aligned
* direct single-tag mail status, preview, confirm, and send decisions now share the same decision basis
* overview/scoped active-war mail presentation now aligns with direct single-tag behavior
* non-active pre-war/no-opponent branches now align across overview/direct render paths
* direct `/fwa match tag:` mail send is blocked until match type is confirmed
* inferred warning duplication removed

### Intentionally unchanged

* no schema/state-owner changes
* no broad redesign of mail/event architecture
* pre-war/no-opponent branches remain separate from the active-war revision decision contract by design

---

## Testing / validation

Focused logic coverage was added or updated around:

* resolved sync consistency
* war-event sync fallback precedence
* initial vs refresh event sync alignment
* mail revision decision contract alignment
* overview active-war mail projection alignment
* non-active mail projection alignment
* inferred-match send blocking
* inferred warning dedupe

Build/test/eslint were reported passing for the touched slices, aside from pre-existing unrelated warnings in `Fwa.ts`.

---

## Risk assessment

**Low to medium**, but localized.

Main risk areas:

* `/fwa match` mail action/status presentation
* overview active-war mail projection behavior
* direct inferred-state mail blocking flow
* war event sync rendering in real war-cycle conditions

No persistence ownership changes were introduced, which keeps risk lower.
