### PR TITLE
feat(emoji): improve no-arg list pagination and 3-column ordering

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,7 +1,7 @@
 # Commands Reference
 
 - `/help [command:<name>] [visibility:private|public]` - List command docs/examples. Default visibility is private.
-- `/emoji [name:<emoji_name>] [react:<message-id>] [emoji:<emoji-token-or-url>] [short-code:<name>]` - Resolve one bot application emoji by name, react to a message in the current channel when `react` is provided, add a new bot application emoji when `emoji` + `short-code` are provided (admin-only by default), or browse a paginated list of all bot application emojis when `name` is omitted. For name-only resolves, `visibility:public` returns only the rendered emoji token while private keeps the detailed shortcode/raw-token output.
+- `/emoji [name:<emoji_name>] [react:<message-id>] [emoji:<emoji-token-or-url>] [short-code:<name>]` - Resolve one bot application emoji by name, react to a message in the current channel when `react` is provided, add a new bot application emoji when `emoji` + `short-code` are provided (admin-only by default), or browse a paginated list of all bot application emojis when `name` is omitted. No-arg list pages are capped to ~2500 characters of emoji-entry content and rendered in compact row-wise 3 columns sorted by shortcode length. For name-only resolves, `visibility:public` returns only the rendered emoji token while private keeps the detailed shortcode/raw-token output.
 - `/telemetry report [period:24h|7d|30d] [timezone:<ianaTz>]` - Show aggregate telemetry report (usage, latency, failures, API health) for the selected window.
 - `/telemetry schedule set target-channel:<channel> cadence-hours:<n> [timezone:<ianaTz>] [enabled:true|false]` - Configure scheduled telemetry report posting.
 - `/telemetry schedule show` - Show current telemetry schedule config and last posted window.

--- a/src/commands/Emoji.ts
+++ b/src/commands/Emoji.ts
@@ -44,7 +44,7 @@ type EmojiAttachmentDownloadResult =
       statusCode?: number;
     };
 
-const EMOJI_PAGE_SIZE = 20;
+const EMOJI_PAGE_CONTENT_BUDGET = 2500;
 const EMOJI_LIST_COLUMNS = 3;
 const EMOJI_PAGINATOR_TIMEOUT_MS = 10 * 60 * 1000;
 const MAX_AUTOCOMPLETE_CHOICES = 25;
@@ -60,17 +60,65 @@ function formatEmojiListLine(emoji: ResolvedApplicationEmoji): string {
   return `${emoji.rendered} \`${emoji.shortcode}\``;
 }
 
-/** Purpose: split emoji list output into deterministic page chunks for embed display. */
+/** Purpose: sort one list page by shortcode length with deterministic tie-breakers for stable output. */
+function sortEmojiPageEntries(
+  emojis: ResolvedApplicationEmoji[],
+): ResolvedApplicationEmoji[] {
+  return emojis
+    .map((emoji, index) => ({ emoji, index }))
+    .sort((a, b) => {
+      const byLength = a.emoji.shortcode.length - b.emoji.shortcode.length;
+      if (byLength !== 0) return byLength;
+      const byShortcode = a.emoji.shortcode.localeCompare(b.emoji.shortcode, undefined, {
+        sensitivity: "base",
+      });
+      if (byShortcode !== 0) return byShortcode;
+      const byName = a.emoji.name.localeCompare(b.emoji.name, undefined, {
+        sensitivity: "base",
+      });
+      if (byName !== 0) return byName;
+      return a.index - b.index;
+    })
+    .map((entry) => entry.emoji);
+}
+
+/** Purpose: split emoji list output into deterministic page chunks using rendered-list character budget per page. */
 function paginateEmojiLines(
   emojis: ResolvedApplicationEmoji[],
-  pageSize: number = EMOJI_PAGE_SIZE,
+  pageContentBudget: number = EMOJI_PAGE_CONTENT_BUDGET,
 ): string[] {
   if (emojis.length === 0) return [];
+  const effectiveBudget = Math.max(1, Math.floor(pageContentBudget));
   const pages: string[] = [];
-  for (let i = 0; i < emojis.length; i += pageSize) {
-    const slice = emojis.slice(i, i + pageSize);
-    pages.push(slice.map(formatEmojiListLine).join("\n"));
+
+  let cursor = 0;
+  while (cursor < emojis.length) {
+    const pageSlice: ResolvedApplicationEmoji[] = [];
+    let usedChars = 0;
+
+    while (cursor < emojis.length) {
+      const entry = emojis[cursor];
+      const line = formatEmojiListLine(entry);
+      const nextUsedChars = usedChars + line.length + (pageSlice.length > 0 ? 1 : 0);
+
+      if (pageSlice.length > 0 && nextUsedChars > effectiveBudget) {
+        break;
+      }
+
+      pageSlice.push(entry);
+      usedChars = nextUsedChars <= effectiveBudget ? nextUsedChars : line.length;
+      cursor += 1;
+
+      // Ensure progress even if one entry alone is longer than the page budget.
+      if (pageSlice.length === 1 && usedChars > effectiveBudget) {
+        break;
+      }
+    }
+
+    const sortedPage = sortEmojiPageEntries(pageSlice);
+    pages.push(sortedPage.map(formatEmojiListLine).join("\n"));
   }
+
   return pages;
 }
 

--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -72,6 +72,7 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
       "Use `/emoji name:<emoji_name> react:<message-id>` to react to a message in the current channel with that resolved emoji.",
       "Use `/emoji emoji:<emoji-token-or-url> short-code:<name>` to add one new bot application emoji (admin-only by default).",
       "Use `/emoji` with no args to browse a paginated list of all available bot application emojis.",
+      "No-arg list pages are capped to ~2500 characters of emoji-entry content and shown in compact row-wise 3 columns sorted by shortcode length.",
       "For name-only resolves, `visibility:public` returns only the rendered emoji message content.",
       "`name` supports dynamic autocomplete backed by application emojis for this bot instance.",
       "Emoji resolution is environment-safe by name (application emoji IDs may differ per bot instance).",

--- a/tests/emoji.command.test.ts
+++ b/tests/emoji.command.test.ts
@@ -10,6 +10,7 @@ import {
   Emoji,
   applyEmojiPageActionForTest,
   buildEmojiListEmbedForTest,
+  paginateEmojiLinesForTest,
   resetEmojiCommandPermissionServiceForTest,
   resetEmojiResolverForTest,
   setEmojiCommandPermissionServiceForTest,
@@ -691,56 +692,94 @@ describe("/emoji command", () => {
     const emojis: ResolvedApplicationEmoji[] = [
       {
         id: "1",
-        name: "alpha",
-        shortcode: ":alpha:",
-        rendered: "<:alpha:1>",
+        name: "foxno",
+        shortcode: ":foxno:",
+        rendered: "<:foxno:1>",
         animated: false,
       },
       {
         id: "2",
-        name: "bravo",
-        shortcode: ":bravo:",
-        rendered: "<:bravo:2>",
+        name: "yes",
+        shortcode: ":yes:",
+        rendered: "<:yes:2>",
         animated: false,
       },
       {
         id: "3",
-        name: "charlie",
-        shortcode: ":charlie:",
-        rendered: "<:charlie:3>",
+        name: "lvlup",
+        shortcode: ":lvlup:",
+        rendered: "<:lvlup:3>",
         animated: false,
       },
       {
         id: "4",
-        name: "delta",
-        shortcode: ":delta:",
-        rendered: "<:delta:4>",
+        name: "no",
+        shortcode: ":no:",
+        rendered: "<:no:4>",
         animated: false,
       },
       {
         id: "5",
-        name: "echo",
-        shortcode: ":echo:",
-        rendered: "<:echo:5>",
+        name: "happy",
+        shortcode: ":happy:",
+        rendered: "<:happy:5>",
+        animated: false,
+      },
+      {
+        id: "6",
+        name: "foxhi",
+        shortcode: ":foxhi:",
+        rendered: "<:foxhi:6>",
         animated: false,
       },
     ];
-    const pageText = emojis
-      .map((emoji) => `${emoji.rendered} \`${emoji.shortcode}\``)
-      .join("\n");
+    const pages = paginateEmojiLinesForTest(emojis, 2500);
+    expect(pages).toHaveLength(1);
+    const sortedShortcodes = String(pages[0] ?? "")
+      .split("\n")
+      .map((line) => (line.match(/`(:[^`]+:)`/)?.[1] ?? ""))
+      .filter((line) => line.length > 0);
+    expect(sortedShortcodes).toEqual([
+      ":no:",
+      ":yes:",
+      ":foxhi:",
+      ":foxno:",
+      ":happy:",
+      ":lvlup:",
+    ]);
+
     const embed = buildEmojiListEmbedForTest({
       emojis,
-      pages: [pageText],
+      pages,
       page: 0,
     });
     const json = embed.toJSON();
     expect(json.fields).toHaveLength(3);
     expect(json.fields?.every((field) => field.inline === true)).toBe(true);
-    expect(String(json.fields?.[0]?.value ?? "")).toContain(":alpha:");
-    expect(String(json.fields?.[0]?.value ?? "")).toContain(":delta:");
-    expect(String(json.fields?.[1]?.value ?? "")).toContain(":bravo:");
-    expect(String(json.fields?.[1]?.value ?? "")).toContain(":echo:");
-    expect(String(json.fields?.[2]?.value ?? "")).toContain(":charlie:");
+    expect(String(json.fields?.[0]?.value ?? "")).toContain(":no:");
+    expect(String(json.fields?.[0]?.value ?? "")).toContain(":foxno:");
+    expect(String(json.fields?.[1]?.value ?? "")).toContain(":yes:");
+    expect(String(json.fields?.[1]?.value ?? "")).toContain(":happy:");
+    expect(String(json.fields?.[2]?.value ?? "")).toContain(":foxhi:");
+    expect(String(json.fields?.[2]?.value ?? "")).toContain(":lvlup:");
+  });
+
+  it("caps list page content by rendered-line character budget", () => {
+    const emojis: ResolvedApplicationEmoji[] = Array.from({ length: 120 }, (_, index) => {
+      const id = String(index + 1);
+      const name = `emoji_${String(index + 1).padStart(3, "0")}`;
+      return {
+        id,
+        name,
+        shortcode: `:${name}:`,
+        rendered: `<:${name}:${id}>`,
+        animated: false,
+      };
+    });
+
+    const pages = paginateEmojiLinesForTest(emojis, 250);
+    expect(pages.length).toBeGreaterThan(1);
+    expect(pages.every((page) => page.length <= 250)).toBe(true);
   });
 
   it("ignores react when name is omitted and keeps list mode", async () => {


### PR DESCRIPTION
- page no-arg /emoji list entries by 2500-character rendered content budget
- sort each page by shortcode length with stable ties before row-wise 3-column layout
- add tests for per-page ordering and character-budget pagination