### PR TITLE
fix(force): reconcile force mail update against active-war lifecycle

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -84,5 +84,5 @@
 - `/force sync data tag:<trackedClanTag> [datapoint:points|syncNum]` - Manually force-sync tracked clan points and/or sync number from points.fwafarm (explicitly bypasses points lock and war-scoped reuse).
 - `/force sync mail tag:<trackedClanTag> message-type:<mail|notify:war start|notify:battle start|notify:war end> message-id:<id>` - Upsert `CurrentWar.mailConfig` with current match configuration plus a posted message reference.
 - `/force sync warid [tag:<trackedClanTag>]` - Backfill missing war IDs in `ClanWarHistory`, `WarAttacks`, and `CurrentWar` (database-only flow; no external scrape/API calls).
-- `/force mail update tag:<trackedClanTag>` - Refresh an existing sent war-mail embed in place (no re-ping) and resume 20-minute refresh tracking.
+- `/force mail update tag:<trackedClanTag>` - Reconcile active-war lifecycle tracking first (marking definitively missing tracked references as `DELETED`), then refresh an existing sent war-mail embed in place (no re-ping) and resume 20-minute refresh tracking when the tracked message is still valid.
 - `/remaining war [tag:<trackedClanTag>]` - With `tag`, show one tracked clan's phase-end and remaining duration. Without `tag`, summarize alliance-wide active-war timing using a 10-minute dominant cluster (mean + spread) and list outlier clans.

--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -2267,6 +2267,16 @@ function formatMailBlockedReason(
   return `:warning: ${reason}`;
 }
 
+/** Purpose: identify lifecycle reconciliation outcomes that definitively prove the tracked target is gone. */
+function isDefinitiveMissingLifecycleOutcome(
+  outcome: WarMailLifecycleReconciliationOutcome,
+): boolean {
+  return (
+    outcome === "message_missing_confirmed" ||
+    outcome === "channel_missing_confirmed"
+  );
+}
+
 async function getCurrentWarMailConfig(
   guildId: string,
   tag: string,
@@ -6850,17 +6860,39 @@ export async function runForceMailUpdateCommand(
     ? currentWar.startTime.getTime()
     : null;
   const lifecycle = await warMailLifecycleService
-    .getLifecycleForWar({
+    .resolveStatusForCurrentWar({
+      client: interaction.client,
       guildId: interaction.guildId,
       clanTag: tag,
       warId: currentWarIdNumber,
+      sentEmoji: MAILBOX_SENT_EMOJI,
+      unsentEmoji: MAILBOX_NOT_SENT_EMOJI,
     })
     .catch(() => null);
+  const trackedChannelId = lifecycle?.debug.trackedChannelId ?? null;
+  const trackedMessageId = lifecycle?.debug.trackedMessageId ?? null;
+  const hasTrackedTarget = Boolean(trackedChannelId && trackedMessageId);
+  if (
+    lifecycle &&
+    lifecycle.status === "deleted" &&
+    hasTrackedTarget &&
+    isDefinitiveMissingLifecycleOutcome(
+      lifecycle.debug.reconciliationOutcome,
+    )
+  ) {
+    await interaction.editReply(
+      [
+        `Tracked mail reference for #${tag} is missing or deleted.`,
+        "Lifecycle state was corrected for the active war: **WarMailLifecycle -> DELETED**.",
+        "Send mail again or repair the reference with `/force sync mail`.",
+      ].join("\n"),
+    );
+    return;
+  }
   if (
     !lifecycle ||
-    lifecycle.status !== "POSTED" ||
-    !lifecycle.channelId ||
-    !lifecycle.messageId
+    lifecycle.status !== "posted" ||
+    !hasTrackedTarget
   ) {
     await interaction.editReply(
       `No active sent mail reference found for #${tag}. Send mail first or sync it via \`/force sync mail\`.`,
@@ -6868,8 +6900,8 @@ export async function runForceMailUpdateCommand(
     return;
   }
   const stored = {
-    channelId: lifecycle.channelId,
-    messageId: lifecycle.messageId,
+    channelId: trackedChannelId as string,
+    messageId: trackedMessageId as string,
   };
   const pollKey = buildWarMailPollKey(
     interaction.guildId,

--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -452,7 +452,7 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
       "`/force sync data` refreshes live points.fwafarm data into `ClanPointsSync` for the current war when possible.",
       "`/force sync mail` repairs tracked Discord message references in `ClanPostedMessage` and keeps legacy mail settings aligned for compatibility.",
       "`/force sync warid` is a DB repair tool for `CurrentWar` and `ClanWarHistory` only.",
-      "`/force mail update` refreshes an existing sent war-mail message in place and re-attaches it to the 20-minute refresh loop.",
+      "`/force mail update` first reconciles active-war lifecycle tracking (marking definitively missing references as DELETED), then refreshes existing sent war-mail in place and re-attaches it to the 20-minute refresh loop when valid.",
       "`/force poll war-events` runs the real war-event poll + refresh pipeline immediately.",
       "`force` commands are admin-only by default.",
     ],

--- a/tests/fwaForceMailUpdate.command.test.ts
+++ b/tests/fwaForceMailUpdate.command.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { runForceMailUpdateCommand } from "../src/commands/Fwa";
+import { prisma } from "../src/prisma";
+import {
+  WarMailLifecycleService,
+  type ResolveWarMailLifecycleStatusResult,
+} from "../src/services/WarMailLifecycleService";
+
+function buildLifecycleResult(
+  input: Partial<ResolveWarMailLifecycleStatusResult> = {},
+): ResolveWarMailLifecycleStatusResult {
+  const debug =
+    input.debug ??
+    ({
+      currentWarId: "1000110",
+      trackedMailWarId: "1000110",
+      trackedChannelId: "mail-channel-1",
+      trackedMessageId: "mail-message-1",
+      trackedMessageExists: "no",
+      currentWarConfigMatchesTrackedMessage: true,
+      winningSource: "WarMailLifecycle",
+      finalNormalizedStatus: "deleted",
+      reconciliationOutcome: "message_missing_confirmed",
+      reconciliationCertainty: "definitive",
+      debugReasonCode: "tracked_post_missing_message",
+      debugReason: "Tracked lifecycle message is definitively missing/deleted; lifecycle was marked DELETED.",
+      environmentMismatchSignal: false,
+      trackingCleared: true,
+    } as const);
+  return {
+    status: input.status ?? "deleted",
+    mailStatusEmoji: input.mailStatusEmoji ?? "U",
+    debug,
+  };
+}
+
+function createInteraction(input?: { tag?: string; guildId?: string }) {
+  const editReply = vi.fn().mockResolvedValue(undefined);
+  return {
+    guildId: input?.guildId ?? "guild-1",
+    channelId: "command-channel-1",
+    client: {},
+    deferReply: vi.fn().mockResolvedValue(undefined),
+    editReply,
+    options: {
+      getString: vi.fn((name: string) => {
+        if (name === "visibility") return null;
+        if (name === "tag") return input?.tag ?? "R80L8VYG";
+        return null;
+      }),
+    },
+  } as any;
+}
+
+describe("runForceMailUpdateCommand", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns lifecycle-corrected response when tracked active-war reference is definitively missing", async () => {
+    vi.spyOn(prisma.trackedClan, "findFirst").mockResolvedValueOnce({
+      tag: "#R80L8VYG",
+      name: "DARK EMPIRE",
+    } as never);
+    vi.spyOn(prisma.currentWar, "findUnique").mockResolvedValueOnce({
+      warId: 1000110,
+      startTime: new Date("2026-03-25T04:22:17.000Z"),
+    } as never);
+    vi.spyOn(WarMailLifecycleService.prototype, "resolveStatusForCurrentWar").mockResolvedValueOnce(
+      buildLifecycleResult(),
+    );
+    const interaction = createInteraction();
+
+    await runForceMailUpdateCommand(interaction);
+
+    const reply = String(interaction.editReply.mock.calls[0]?.[0] ?? "");
+    expect(reply).toContain("Tracked mail reference for #R80L8VYG is missing or deleted.");
+    expect(reply).toContain("WarMailLifecycle -> DELETED");
+    expect(reply).toContain("`/force sync mail`");
+  });
+
+  it("keeps existing no-reference behavior when lifecycle is not posted", async () => {
+    vi.spyOn(prisma.trackedClan, "findFirst").mockResolvedValueOnce({
+      tag: "#R80L8VYG",
+      name: "DARK EMPIRE",
+    } as never);
+    vi.spyOn(prisma.currentWar, "findUnique").mockResolvedValueOnce({
+      warId: 1000110,
+      startTime: new Date("2026-03-25T04:22:17.000Z"),
+    } as never);
+    vi.spyOn(WarMailLifecycleService.prototype, "resolveStatusForCurrentWar").mockResolvedValueOnce(
+      buildLifecycleResult({
+        status: "not_posted",
+        debug: {
+          ...buildLifecycleResult().debug,
+          trackedChannelId: null,
+          trackedMessageId: null,
+          trackedMessageExists: "unknown",
+          finalNormalizedStatus: "not_posted",
+          reconciliationOutcome: "not_checked",
+          reconciliationCertainty: "not_checked",
+          debugReasonCode: "no_post_tracked",
+          debugReason: "No POSTED lifecycle row exists for the active war.",
+          trackingCleared: false,
+        },
+      }),
+    );
+    const interaction = createInteraction();
+
+    await runForceMailUpdateCommand(interaction);
+
+    expect(interaction.editReply).toHaveBeenCalledWith(
+      "No active sent mail reference found for #R80L8VYG. Send mail first or sync it via `/force sync mail`.",
+    );
+  });
+});
+


### PR DESCRIPTION
- route /force mail update through WarMailLifecycleService status reconciliation for the active war
- mark definitively missing tracked references as DELETED and return a correction response instead of attempting refresh
- add focused command tests and update force command docs/help text