### PR TITLE
fix(fwa-mail): guard lifecycle delete against stale refresh targets

### DIFF
--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -4176,6 +4176,29 @@ async function refreshWarMailPostByResolvedTarget(params: {
       `[fwa-mail-refresh-identity] guild=${params.guildId} clan=#${normalizedTag} message_id=${params.messageId} expected_war_id=${expectedWarIdText} expected_war_start_ms=${expectedWarStartText} posted_war_id=${postedWarIdText} posted_opponent=${postedOpponentTag ? `#${postedOpponentTag}` : "unknown"} rendered_war_id=${renderedWarIdText} rendered_war_start_ms=${renderedWarStartText} rendered_opponent=${renderedOpponentTag ? `#${renderedOpponentTag}` : "unknown"} identity_shifted=${input.identityShifted ? "1" : "0"} action=${input.action}`,
     );
   };
+  const reconcileMissingExplicitTarget = async (): Promise<void> => {
+    const expectedWarIdNumber =
+      typeof params.expectedWarId === "string" &&
+      params.expectedWarId.trim() &&
+      Number.isFinite(Number(params.expectedWarId))
+        ? Number(params.expectedWarId)
+        : null;
+    if (expectedWarIdNumber === null) return;
+    const deletionResult = await warMailLifecycleService
+      .markDeletedIfTrackedMessageMatches({
+        guildId: params.guildId,
+        clanTag: normalizedTag,
+        warId: expectedWarIdNumber,
+        channelId: params.channelId,
+        messageId: params.messageId,
+      })
+      .catch(() => "missing_row" as const);
+    if (deletionResult === "stale_target") {
+      console.info(
+        `[fwa-mail-refresh-reconcile] guild=${params.guildId} clan=#${normalizedTag} war_id=${expectedWarIdNumber} action=skip_stale_target channel_id=${params.channelId} message_id=${params.messageId}`
+      );
+    }
+  };
   let channel: any = null;
   try {
     channel = await params.client.channels.fetch(params.channelId);
@@ -4190,13 +4213,7 @@ async function refreshWarMailPostByResolvedTarget(params: {
         code === 50013) &&
       params.expectedWarId
     ) {
-      await warMailLifecycleService
-        .markDeleted({
-          guildId: params.guildId,
-          clanTag: normalizedTag,
-          warId: Number(params.expectedWarId),
-        })
-        .catch(() => undefined);
+      await reconcileMissingExplicitTarget().catch(() => undefined);
     }
     logIdentityDecision({
       action: "missing",
@@ -4231,13 +4248,7 @@ async function refreshWarMailPostByResolvedTarget(params: {
         code === 50013) &&
       params.expectedWarId
     ) {
-      await warMailLifecycleService
-        .markDeleted({
-          guildId: params.guildId,
-          clanTag: normalizedTag,
-          warId: Number(params.expectedWarId),
-        })
-        .catch(() => undefined);
+      await reconcileMissingExplicitTarget().catch(() => undefined);
     }
     logIdentityDecision({
       action: "missing",
@@ -4247,13 +4258,7 @@ async function refreshWarMailPostByResolvedTarget(params: {
   }
   if (!message) {
     if (params.expectedWarId) {
-      await warMailLifecycleService
-        .markDeleted({
-          guildId: params.guildId,
-          clanTag: normalizedTag,
-          warId: Number(params.expectedWarId),
-        })
-        .catch(() => undefined);
+      await reconcileMissingExplicitTarget().catch(() => undefined);
     }
     logIdentityDecision({
       action: "missing",

--- a/src/services/WarMailLifecycleService.ts
+++ b/src/services/WarMailLifecycleService.ts
@@ -69,7 +69,25 @@ type MarkDeletedLifecycleInput = {
   clanTag: string;
   warId: number;
   deletedAt?: Date;
+  requirePosted?: boolean;
+  matchChannelId?: string;
+  matchMessageId?: string;
 };
+
+type MarkDeletedIfTrackedMessageMatchesInput = {
+  guildId: string;
+  clanTag: string;
+  warId: number;
+  channelId: string;
+  messageId: string;
+  deletedAt?: Date;
+};
+
+export type MarkDeletedIfTrackedMessageMatchesResult =
+  | "deleted"
+  | "stale_target"
+  | "not_posted"
+  | "missing_row";
 
 type GetLifecycleInput = {
   guildId: string;
@@ -231,11 +249,19 @@ export class WarMailLifecycleService {
   async markDeleted(input: MarkDeletedLifecycleInput): Promise<boolean> {
     const clanTag = normalizeTag(input.clanTag);
     const deletedAt = input.deletedAt ?? new Date();
+    const warId = Math.trunc(input.warId);
     const updated = await prisma.warMailLifecycle.updateMany({
       where: {
         guildId: input.guildId,
         clanTag,
-        warId: Math.trunc(input.warId),
+        warId,
+        ...(input.requirePosted ? { status: WarMailLifecycleStatus.POSTED } : {}),
+        ...(typeof input.matchChannelId === "string" && input.matchChannelId.trim()
+          ? { channelId: input.matchChannelId }
+          : {}),
+        ...(typeof input.matchMessageId === "string" && input.matchMessageId.trim()
+          ? { messageId: input.matchMessageId }
+          : {}),
       },
       data: {
         status: WarMailLifecycleStatus.DELETED,
@@ -244,11 +270,50 @@ export class WarMailLifecycleService {
     });
     if (updated.count > 0) {
       console.info(
-        `[mail-lifecycle] guild=${input.guildId} clan=${clanTag} war=${Math.trunc(input.warId)} status=DELETED`
+        `[mail-lifecycle] guild=${input.guildId} clan=${clanTag} war=${warId} status=DELETED`
       );
       return true;
     }
     return false;
+  }
+
+  /** Purpose: mark lifecycle DELETED only when the currently tracked active-war message still matches the failing message identity. */
+  async markDeletedIfTrackedMessageMatches(
+    input: MarkDeletedIfTrackedMessageMatchesInput
+  ): Promise<MarkDeletedIfTrackedMessageMatchesResult> {
+    const clanTag = normalizeTag(input.clanTag);
+    const warId = Math.trunc(input.warId);
+    const row = await this.getLifecycleForWar({
+      guildId: input.guildId,
+      clanTag,
+      warId,
+    });
+    if (!row) {
+      return "missing_row";
+    }
+    if (
+      row.status !== WarMailLifecycleStatus.POSTED ||
+      !row.channelId ||
+      !row.messageId
+    ) {
+      return "not_posted";
+    }
+    if (row.channelId !== input.channelId || row.messageId !== input.messageId) {
+      console.info(
+        `[mail-lifecycle] guild=${input.guildId} clan=${clanTag} war=${warId} status=NOOP_STALE_TARGET tracked_channel=${row.channelId} tracked_message=${row.messageId} failing_channel=${input.channelId} failing_message=${input.messageId}`
+      );
+      return "stale_target";
+    }
+    const deleted = await this.markDeleted({
+      guildId: input.guildId,
+      clanTag,
+      warId,
+      deletedAt: input.deletedAt,
+      requirePosted: true,
+      matchChannelId: input.channelId,
+      matchMessageId: input.messageId,
+    });
+    return deleted ? "deleted" : "stale_target";
   }
 
   /** Purpose: fetch one lifecycle row by guild/clan/war identity. */

--- a/tests/fwaForceMailUpdate.command.test.ts
+++ b/tests/fwaForceMailUpdate.command.test.ts
@@ -34,12 +34,12 @@ function buildLifecycleResult(
   };
 }
 
-function createInteraction(input?: { tag?: string; guildId?: string }) {
+function createInteraction(input?: { tag?: string; guildId?: string; client?: any }) {
   const editReply = vi.fn().mockResolvedValue(undefined);
   return {
     guildId: input?.guildId ?? "guild-1",
     channelId: "command-channel-1",
-    client: {},
+    client: input?.client ?? {},
     deferReply: vi.fn().mockResolvedValue(undefined),
     editReply,
     options: {
@@ -142,6 +142,60 @@ describe("runForceMailUpdateCommand", () => {
     const reply = String(interaction.editReply.mock.calls[0]?.[0] ?? "");
     expect(reply).toContain("Tracked mail reference for #R80L8VYG is missing, inaccessible, or otherwise unusable.");
     expect(reply).toContain("WarMailLifecycle -> DELETED");
+  });
+
+  it("guards lifecycle deletion by tracked message identity when refresh target is missing", async () => {
+    vi.spyOn(prisma.trackedClan, "findFirst").mockResolvedValueOnce({
+      tag: "#R80L8VYG",
+      name: "DARK EMPIRE",
+    } as never);
+    vi.spyOn(prisma.currentWar, "findUnique").mockResolvedValueOnce({
+      warId: 1000110,
+      startTime: new Date("2026-03-25T04:22:17.000Z"),
+    } as never);
+    vi.spyOn(WarMailLifecycleService.prototype, "resolveStatusForCurrentWar").mockResolvedValueOnce(
+      buildLifecycleResult({
+        status: "posted",
+        debug: {
+          ...buildLifecycleResult().debug,
+          trackedMessageExists: "yes",
+          finalNormalizedStatus: "posted",
+          reconciliationOutcome: "exists",
+          reconciliationCertainty: "definitive",
+          debugReasonCode: "live_matching_post_exists",
+          debugReason: "Tracked lifecycle message exists for the active war.",
+          trackingCleared: false,
+        },
+      }),
+    );
+    const guardedDeleteSpy = vi
+      .spyOn(WarMailLifecycleService.prototype, "markDeletedIfTrackedMessageMatches")
+      .mockResolvedValueOnce("stale_target");
+    const interaction = createInteraction({
+      client: {
+        channels: {
+          fetch: vi.fn().mockResolvedValue({
+            isTextBased: () => true,
+            messages: {
+              fetch: vi.fn().mockRejectedValue({ code: 10008, message: "Unknown Message" }),
+            },
+          }),
+        },
+      },
+    });
+
+    await runForceMailUpdateCommand(interaction);
+
+    expect(guardedDeleteSpy).toHaveBeenCalledWith({
+      guildId: "guild-1",
+      clanTag: "R80L8VYG",
+      warId: 1000110,
+      channelId: "mail-channel-1",
+      messageId: "mail-message-1",
+    });
+    expect(interaction.editReply).toHaveBeenCalledWith(
+      "Could not refresh #R80L8VYG mail in place. The stored message was missing or inaccessible.",
+    );
   });
 });
 

--- a/tests/warMailLifecycle.service.test.ts
+++ b/tests/warMailLifecycle.service.test.ts
@@ -139,6 +139,75 @@ describe("WarMailLifecycleService", () => {
     expect(fetchMessage).toHaveBeenCalledWith({ message: "456", force: true });
   });
 
+  it("skips deletion when a failing explicit target is stale versus current tracked lifecycle message", async () => {
+    vi.spyOn(prisma.warMailLifecycle, "findUnique").mockResolvedValueOnce({
+      guildId: "guild-1",
+      clanTag: "#AAA111",
+      warId: 1001,
+      status: "POSTED",
+      messageId: "new-message",
+      channelId: "new-channel",
+      postedAt: new Date(),
+      deletedAt: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as never);
+    const updateManySpy = vi.spyOn(prisma.warMailLifecycle, "updateMany");
+    const service = new WarMailLifecycleService();
+
+    const result = await service.markDeletedIfTrackedMessageMatches({
+      guildId: "guild-1",
+      clanTag: "AAA111",
+      warId: 1001,
+      channelId: "old-channel",
+      messageId: "old-message",
+    });
+
+    expect(result).toBe("stale_target");
+    expect(updateManySpy).not.toHaveBeenCalled();
+  });
+
+  it("deletes lifecycle when failing explicit target still matches current tracked lifecycle identity", async () => {
+    vi.spyOn(prisma.warMailLifecycle, "findUnique").mockResolvedValueOnce({
+      guildId: "guild-1",
+      clanTag: "#AAA111",
+      warId: 1001,
+      status: "POSTED",
+      messageId: "current-message",
+      channelId: "current-channel",
+      postedAt: new Date(),
+      deletedAt: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    } as never);
+    const updateManySpy = vi
+      .spyOn(prisma.warMailLifecycle, "updateMany")
+      .mockResolvedValueOnce({ count: 1 } as never);
+    const service = new WarMailLifecycleService();
+
+    const result = await service.markDeletedIfTrackedMessageMatches({
+      guildId: "guild-1",
+      clanTag: "AAA111",
+      warId: 1001,
+      channelId: "current-channel",
+      messageId: "current-message",
+    });
+
+    expect(result).toBe("deleted");
+    expect(updateManySpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          guildId: "guild-1",
+          clanTag: "#AAA111",
+          warId: 1001,
+          status: "POSTED",
+          channelId: "current-channel",
+          messageId: "current-message",
+        }),
+      }),
+    );
+  });
+
   it("marks lifecycle deleted when tracked channel is inaccessible for active-war mail", async () => {
     vi.spyOn(prisma.warMailLifecycle, "findUnique").mockResolvedValueOnce({
       guildId: "guild-1",


### PR DESCRIPTION
- delete active-war lifecycle rows only when failing channel/message still matches tracked identity
- keep stale superseded refresh targets from clobbering newer POSTED mail rows
- add regression coverage for guarded delete path in service and force mail update refresh flow