### PR TITLE
docs(readme): improve top-level project overview and structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,60 @@
 # ClashCookies
-Discord bot for Clash of Clans activity tooling.
+ClashCookies is a TypeScript-based Discord bot and operations tooling platform for Clash of Clans clan management. It combines command-driven workflows, persistent data models, and automation loops to support day-to-day war operations, player activity tracking, and alliance reporting.
+
+The project is designed as a maintainable application, not a one-off bot script: it has clear service boundaries, Prisma-backed persistence, operational scripts, and a broad automated test suite. The intent is reliable ongoing iteration for real clan operations.
+
+## Highlights
+- TypeScript + Node.js application with a command-first Discord UX
+- Workflow automation for war lifecycle, mail refresh, and sync flows
+- Reporting and operational visibility for leaders and staff
+- Prisma-backed data ownership with explicit lifecycle/state modeling
+- Test coverage, scripts, docs, and deployment/configuration support
+- Built for maintainability, determinism, and operational reliability
+
+## Tech Stack
+- TypeScript, Node.js
+- Discord API via slash commands and interactive message components
+- Prisma ORM with PostgreSQL-backed persistence
+- Vitest test suite + TypeScript type-checking
+- Scripted local/dev workflows and Docker-compatible deployment paths
 
 ## What It Does
-- Tracks configured clans and updates player activity records.
-- Supports last seen and inactivity queries.
-- Manages tracked clans and roster/sheet integrations.
-- Provides FWA points and matchup tooling.
-- Uses cached `/fwa match` rendering with processing indicators for faster button interactions.
-- Supports tracked-clan mail channel config via `/tracked-clan configure` and send-preview flow via `/fwa mail send`.
-- War mail send paths now mention the tracked clan role (`TrackedClan.clanRoleId`) when pinging is enabled.
-- `/fwa match` and `/fwa mail send` now share active-war mail freshness gating: sent state is scoped to current war identity, shows explicit up-to-date/out-of-date status, disables resend when matchType/outcome are unchanged, and re-enables resend when those fields change.
-- Active-war mail lifecycle reconciliation now treats inaccessible tracked references as unusable (moves out of healthy posted state), and `/force sync mail` now validates supplied `message_id` against current-channel active-war identity before writing `WarMailLifecycle`.
-- Supports configurable war plans by match type/outcome via `/warplan set|show|reset`; these templates are used in posted war mail content (including line breaks, emoji, and media links).
-- Optimized points polling now tracks lifecycle state in `ClanPointsSync` (`confirmedByClanMail`, `needsValidation`, last-known values) and reduces routine `points.fwafarm` calls after clan-mail confirmation.
-- Poller-side points fetches now use a shared gate that enforces an active-war mail-confirmed lock (`confirmedByClanMail=true`, `needsValidation=false`, matching war identity), blocking routine `post_war_reconciliation`/`mail_refresh` calls until an explicit unlock trigger.
-- `/fwa match` now shows actionable sync status only when validation is needed, keeps single-clan sync/fetch timing details, and hides non-actionable lifecycle/debug lines from user-facing output.
-- `/fwa match` now reuses war-scoped verified points snapshots from persisted sync data for the active war, and `/force sync data` remains the explicit refresh-scrape path.
-- `/fwa match` now applies deterministic active-war opponent inference (`Active FWA: No` -> BL, `Active FWA: Yes` -> inferred FWA, opponent-missing non-FWA wars resolve BL/MM only from owned active-war evidence or explicit confirmation), keeps active-war sync lookup war-scoped, keeps inferred states visibly flagged until confirmed, and still allows war-mail preview/send while that warning is present.
-- Final `Send Mail` confirmation now persists explicit match confirmation for the same active war identity, so rerender/refresh does not regress confirmed BL/MM/FWA back to inference fallback.
-- In `/fwa match` war-changing state, mismatch output now shows field-specific differences (opponent, sync #, outcome, match type) against persisted validation, uses `:interrobang: Clan not found on points.fwafarm` for opponent-page-missing validation, and supports MM/BL no-opponent-page sync advancement via tracked-clan page fallback in the shared points snapshot path.
-- Direct `/fwa match tag:<clan>` cards now return to the full alliance overview when `Alliance View` is pressed, while keeping fast initial single-clan render behavior.
-- Prisma client bootstrap is now lazy and test-safe: importing persistence-backed modules no longer initializes the Prisma engine until first real DB use, which keeps CI/unit tests independent from live DB runtime.
-- War-mail embeds now use state-coded sidebars (BL=black, MM=white, FWA WIN=green, FWA LOSE=red, unresolved=gray) and refresh/update paths keep color aligned with current match type/outcome.
-- Single-clan `/fwa match` embeds now use the same state-coded sidebar mapping from the currently displayed effective state (including draft revisions), without changing confirmation/persistence semantics.
-- `/remaining war` now supports alliance-wide aggregate mode (no tag) with dominant-cluster mean remaining time, spread, and outlier clan reporting.
-- Telemetry now records command lifecycle/API/stage aggregates and supports `/telemetry report` plus scheduled Discord report posting.
-- `/bot-logs` now lets admins set or inspect the guild-scoped destination channel for important bot log posts, with stale channel handling.
-- `/say` now allows anyone to use `show-from:false`, keeps the normal channel-send path for shortcode rendering, and logs hidden-source sends to `/bot-logs` when configured.
-- `/clan-health` now provides a DB-only leadership snapshot per tracked clan (last-30 match/win rates, inactivity counts, and missing Discord links).
-- `/fwa weight-age`, `/fwa weight-link`, `/fwa weight-health`, and `/fwa weight-cookie` now provide FWA Stats weight monitoring with cached scraping, stale-weight flags, auth-expiry recovery guidance, and secure cookie status/update flows.
-- `/fwa compliance` now runs the shared war-end compliance engine on demand for a tracked clan (latest ended war by default, optional `war-id` override).
-- `/layout` now supports FWA base layout listing/fetch by Town Hall and admin-only link upserts (with optional `img-url` preview updates), backed by the new `FwaLayouts` table.
-- FWAStats JSON feed ingestion foundation is now DB-backed with dedicated current-state tables, feed-sync metadata ownership (`FwaFeedSyncState`), tracked-clan wars watch state (`FwaClanWarsWatchState`), and bounded scheduler loops.
+### Command-driven workflows
+- Runs a large slash-command surface for war operations, roster tasks, compliance checks, and admin tooling.
+- Supports interactive command flows (buttons/modals/selects) for in-channel operational actions.
+- Keeps command behavior deterministic with DB-first command rendering where possible.
+
+### Reporting and visibility
+- Produces matchup, sync, activity, and compliance views for tracked clans.
+- Supports leadership-focused summaries such as inactivity and clan-health snapshots.
+- Includes telemetry reporting and scheduled report delivery in Discord.
+
+### Operational automation
+- Polls and reconciles war-related state with explicit lifecycle ownership.
+- Refreshes tracked war-mail posts and applies guarded reconciliation rules for missing/stale targets.
+- Uses bounded feed-sync/watch loops for external data ingestion and update timing.
+
+### Clan management tooling
+- Manages tracked clan configuration, mail channels/roles, and war plans.
+- Supports player-linking, roster-related utilities, and operational helper commands.
+- Provides FWA-focused tooling for points, match handling, layouts, and related workflows.
+
+### Reliability and maintainability support
+- Uses explicit data ownership boundaries across lifecycle/persistence tables.
+- Includes force/repair commands for operational recovery without bypassing core state rules.
+- Maintains contributor documentation, setup guides, and script-based workflows.
+
+## Detailed Capability Notes
+- `/fwa match` and `/fwa mail send` share active-war mail freshness gating and only treat same-war, same-outcome references as up to date.
+- Active-war mail lifecycle reconciliation handles missing/inaccessible tracked references and keeps lifecycle state aligned with usable message targets.
+- `/force sync mail` validates supplied mail `message_id` against current-channel active-war identity before writing `WarMailLifecycle`.
+- `/force mail update` reconciles tracked references before in-place refresh and resumes/stops refresh tracking based on validity.
+- Match state rendering supports deterministic active-war inference and explicit confirmation persistence for BL/MM/FWA decisions.
+- Sync validation uses war-scoped persisted snapshots (`ClanPointsSync`) with explicit force-sync paths for refresh-scrape operations.
+- War-mail and match embeds use consistent effective-state color mapping for BL/MM/FWA/unresolved states.
+- Notification and posting flows include operational logging controls (`/bot-logs`, `/say`, telemetry report + schedule commands).
+- FWA stats and operations commands include weight-age/health tooling, compliance checks, and layout management.
+- FWAStats feed ingestion is DB-backed (`FwaFeedSyncState`, `FwaClanWarsWatchState`, related current-state tables) with bounded scheduler cadence.
 
 ## Quick Start
 ```bash


### PR DESCRIPTION
- rewrite opening sections with overview, highlights, and tech stack for first-time readers
- reorganize what-it-does into capability buckets and preserve deeper contributor/ops documentation