### PR TITLE
feat(tracked-clan): add seasonal CWL registry and type-aware management

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The project is designed as a maintainable application, not a one-off bot script:
 - `/force mail update` reconciles tracked references before in-place refresh and resumes/stops refresh tracking based on validity.
 - Match state rendering supports deterministic active-war inference and explicit confirmation persistence for BL/MM/FWA decisions.
 - Sync validation uses war-scoped persisted snapshots (`ClanPointsSync`) with explicit force-sync paths for refresh-scrape operations.
-- `/todo` renders from precomputed per-player snapshots (`TodoPlayerSnapshot`) so high-traffic reads stay fast and avoid live per-player multi-source aggregation on command execution, with grouped WAR/CWL sections, shared top timers for RAIDS/GAMES, and explicit inactive-state messaging.
+- `/todo` renders from precomputed per-player snapshots (`TodoPlayerSnapshot`) so high-traffic reads stay fast and avoid live per-player multi-source aggregation on command execution, with grouped WAR/CWL sections, shared top timers for RAIDS/GAMES, explicit inactive-state messaging, and CWL context resolved from a seasonal CWL clan registry/player mapping layer instead of assuming home FWA clan.
 - War-mail and match embeds use consistent effective-state color mapping for BL/MM/FWA/unresolved states.
 - Notification and posting flows include operational logging controls (`/bot-logs`, `/say`, telemetry report + schedule commands).
 - FWA stats and operations commands include weight-age/health tooling, compliance checks, and layout management.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -17,8 +17,9 @@
 - `/role-users role:<discordRole>` - List users in a role with pagination.
 - `/layout [th:<number>] [type:RISINGDAWN|BASIC|ICE] [edit:<layout-link>] [img-url:<url>]` - Fetch or list stored FWA layouts; `edit` upserts are admin-only at runtime, and `img-url` is only valid when `edit` is provided.
 - `/tracked-clan configure tag:<tag> [lose-style:triple-top-30|traditional] [mail-channel:<discordChannel>] [log-channel:<discordChannel>] [clan-role:<discordRole>] [clan-badge:<emoji>] [short-name:<abbr>]` - Add/update tracked clan settings.
-- `/tracked-clan remove tag:<tag>` - Remove tracked clan.
-- `/tracked-clan list` - List tracked clans and settings.
+- `/tracked-clan cwl-tags cwl-tags:[<tag-array-or-comma-list>]` - Add one batch of seasonal CWL tracked clans (supports tags with or without `#`), with partial-success summary buckets for added/already-existing/invalid/duplicates.
+- `/tracked-clan remove tag:<tag> [type:FWA|CWL]` - Remove tracked clan from FWA or current-season CWL registry. When `type` is omitted and a tag exists in both registries, command returns an explicit ambiguity prompt instead of deleting.
+- `/tracked-clan list [type:FWA|CWL]` - List tracked clans and settings. Default is `type:FWA`; `type:CWL` lists current-season CWL throwaway registry.
 - `/sheet link sheet_id_or_url:<id-or-url> [tab:<tab-name>] [mode:actual|war]` - Link or relink sheet; mode is optional.
 - `/sheet show [mode:actual|war]` - Show linked sheet settings (single mode or all).
 - `/sheet unlink [mode:actual|war]` - Remove one mode link or all links.

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -10,7 +10,7 @@
 - `/layout` is public by default; runtime `edit` (and optional `img-url` edit flow) still requires Administrator.
 
 ## Default Administrator-Only Targets
-- `/tracked-clan configure`, `/tracked-clan remove`
+- `/tracked-clan configure`, `/tracked-clan cwl-tags`, `/tracked-clan remove`
 - `/permission add`, `/permission remove`
 - `/sheet link`, `/sheet unlink`, `/sheet show`, `/sheet refresh`
 - `/kick-list build`, `/kick-list add`, `/kick-list remove`, `/kick-list show`, `/kick-list clear`

--- a/prisma/migrations/20260326001000_add_cwl_registry_and_snapshot_context/migration.sql
+++ b/prisma/migrations/20260326001000_add_cwl_registry_and_snapshot_context/migration.sql
@@ -1,0 +1,34 @@
+ALTER TABLE "TodoPlayerSnapshot"
+ADD COLUMN "cwlClanTag" TEXT,
+ADD COLUMN "cwlClanName" TEXT;
+
+CREATE INDEX "TodoPlayerSnapshot_cwlClanTag_idx" ON "TodoPlayerSnapshot"("cwlClanTag");
+
+CREATE TABLE "CwlTrackedClan" (
+    "id" SERIAL NOT NULL,
+    "season" TEXT NOT NULL,
+    "tag" TEXT NOT NULL,
+    "name" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "CwlTrackedClan_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "CwlTrackedClan_season_tag_key" ON "CwlTrackedClan"("season", "tag");
+CREATE INDEX "CwlTrackedClan_season_createdAt_idx" ON "CwlTrackedClan"("season", "createdAt");
+
+CREATE TABLE "CwlPlayerClanSeason" (
+    "id" SERIAL NOT NULL,
+    "season" TEXT NOT NULL,
+    "playerTag" TEXT NOT NULL,
+    "cwlClanTag" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "CwlPlayerClanSeason_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "CwlPlayerClanSeason_season_playerTag_key" ON "CwlPlayerClanSeason"("season", "playerTag");
+CREATE INDEX "CwlPlayerClanSeason_season_cwlClanTag_idx" ON "CwlPlayerClanSeason"("season", "cwlClanTag");
+CREATE INDEX "CwlPlayerClanSeason_season_playerTag_idx" ON "CwlPlayerClanSeason"("season", "playerTag");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -69,6 +69,8 @@ model TodoPlayerSnapshot {
   playerName      String
   clanTag         String?
   clanName        String?
+  cwlClanTag      String?
+  cwlClanName     String?
   warActive       Boolean  @default(false)
   warAttacksUsed  Int      @default(0)
   warAttacksMax   Int      @default(2)
@@ -92,7 +94,33 @@ model TodoPlayerSnapshot {
   updatedAt       DateTime @updatedAt
 
   @@index([clanTag])
+  @@index([cwlClanTag])
   @@index([updatedAt])
+}
+
+model CwlTrackedClan {
+  id        Int      @id @default(autoincrement())
+  season    String
+  tag       String
+  name      String?
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([season, tag])
+  @@index([season, createdAt])
+}
+
+model CwlPlayerClanSeason {
+  id         Int      @id @default(autoincrement())
+  season     String
+  playerTag  String
+  cwlClanTag String
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @updatedAt
+
+  @@unique([season, playerTag])
+  @@index([season, cwlClanTag])
+  @@index([season, playerTag])
 }
 
 enum KickListSource {

--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -20,6 +20,7 @@ const HELP_TIMEOUT_MS = 10 * 60 * 1000;
 const HELP_POST_BUTTON_PREFIX = "help-post-channel";
 const ADMIN_DEFAULT_TARGETS = new Set<string>([
   "tracked-clan:configure",
+  "tracked-clan:cwl-tags",
   "tracked-clan:remove",
   "sheet:link",
   "sheet:unlink",
@@ -147,14 +148,19 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
     details: [
       "Configure/remove tracked clans or list current tracked set.",
       "`configure` upserts tracked clan settings (lose-style, mail channel, log channel, clan role, clan badge emoji, short name).",
-      "`configure` and `remove` are admin-only by default.",
+      "`cwl-tags` adds one seasonal CWL throwaway clan batch (array-style or comma-separated tags) without polluting the FWA tracked list.",
+      "`list type:FWA|CWL` switches between permanent FWA tracked clans (default) and seasonal CWL registry.",
+      "`remove` supports deterministic FWA/CWL deletion; when a tag exists in both registries, pass `type` explicitly.",
+      "`configure`, `cwl-tags`, and `remove` are admin-only by default.",
     ],
     examples: [
       "/tracked-clan configure tag:#2QG2C08UP",
       "/tracked-clan configure tag:#2QG2C08UP lose-style:Traditional mail-channel:#war-mail",
       "/tracked-clan configure tag:#2QG2C08UP clan-badge::Logo_Gabbar:",
       "/tracked-clan configure tag:#2QG2C08UP short-name:GB",
-      "/tracked-clan remove tag:#2QG2C08UP",
+      "/tracked-clan cwl-tags cwl-tags:[#PYLQ0289,#QGRJ2222]",
+      "/tracked-clan list type:CWL",
+      "/tracked-clan remove tag:#2QG2C08UP type:FWA",
       "/tracked-clan list",
     ],
   },

--- a/src/commands/TrackedClan.ts
+++ b/src/commands/TrackedClan.ts
@@ -16,11 +16,14 @@ import { safeReply } from "../helper/safeReply";
 import { prisma } from "../prisma";
 import { ActivityService } from "../services/ActivityService";
 import { CoCService } from "../services/CoCService";
-
-function normalizeClanTag(input: string): string {
-  const cleaned = input.trim().toUpperCase().replace(/^#/, "");
-  return `#${cleaned}`;
-}
+import { normalizeClanTag } from "../services/PlayerLinkService";
+import {
+  addCwlClanTagsForSeason,
+  listCwlTrackedClansForSeason,
+  removeTrackedClanTagFromRegistries,
+  resolveCurrentCwlSeasonKey,
+  type TrackedClanRegistryType,
+} from "../services/CwlRegistryService";
 
 const CUSTOM_EMOJI_PATTERN = /^<(a?):([A-Za-z0-9_]+):(\d+)>$/;
 const SHORTCODE_EMOJI_PATTERN = /^:([A-Za-z0-9_]+):$/;
@@ -57,6 +60,14 @@ function buildTrackedClanBlock(clan: {
   ].join("\n");
 }
 
+function buildCwlTrackedClanBlock(clan: {
+  name: string | null;
+  tag: string;
+}): string {
+  const label = clan.name ? `${clan.tag} (${clan.name})` : clan.tag;
+  return [`**${label}**`, "registry: CWL seasonal"].join("\n");
+}
+
 function paginateTrackedClanBlocks(blocks: string[]): string[] {
   const pages: string[] = [];
   let i = 0;
@@ -91,6 +102,20 @@ function buildTrackedClanListEmbed(total: number, pageContent: string, page: num
     .setFooter({ text: `Page ${page + 1}/${pages}` });
 }
 
+function buildCwlTrackedClanListEmbed(
+  total: number,
+  season: string,
+  pageContent: string,
+  page: number,
+  pages: number
+) {
+  return new EmbedBuilder()
+    .setTitle(`Tracked Clans (CWL ${season}) (${total})`)
+    .setDescription(pageContent)
+    .setColor(0xfee75c)
+    .setFooter({ text: `Page ${page + 1}/${pages}` });
+}
+
 function buildTrackedClanListRow(prefix: string, page: number, totalPages: number) {
   return new ActionRowBuilder<ButtonBuilder>().addComponents(
     new ButtonBuilder()
@@ -104,6 +129,11 @@ function buildTrackedClanListRow(prefix: string, page: number, totalPages: numbe
       .setStyle(ButtonStyle.Secondary)
       .setDisabled(page >= totalPages - 1)
   );
+}
+
+function formatTagListForSummary(tags: string[]): string {
+  if (tags.length <= 0) return "none";
+  return tags.join(", ");
 }
 
 async function normalizeClanBadgeInput(
@@ -214,12 +244,47 @@ export const TrackedClan: Command = {
           required: true,
           autocomplete: true,
         },
+        {
+          name: "type",
+          description: "Registry type to remove from (omit for auto/safe lookup)",
+          type: ApplicationCommandOptionType.String,
+          required: false,
+          choices: [
+            { name: "FWA", value: "FWA" },
+            { name: "CWL", value: "CWL" },
+          ],
+        },
       ],
     },
     {
       name: "list",
       description: "List tracked clans",
       type: ApplicationCommandOptionType.Subcommand,
+      options: [
+        {
+          name: "type",
+          description: "Registry type to list",
+          type: ApplicationCommandOptionType.String,
+          required: false,
+          choices: [
+            { name: "FWA", value: "FWA" },
+            { name: "CWL", value: "CWL" },
+          ],
+        },
+      ],
+    },
+    {
+      name: "cwl-tags",
+      description: "Add one or more CWL tracked clan tags for the current season",
+      type: ApplicationCommandOptionType.Subcommand,
+      options: [
+        {
+          name: "cwl-tags",
+          description: "Array-style or comma-separated clan tags (with or without #)",
+          type: ApplicationCommandOptionType.String,
+          required: true,
+        },
+      ],
     },
   ],
   run: async (
@@ -232,6 +297,87 @@ export const TrackedClan: Command = {
       const subcommand = interaction.options.getSubcommand(true);
 
       if (subcommand === "list") {
+        const listType =
+          (interaction.options.getString("type", false) as TrackedClanRegistryType | null) ??
+          "FWA";
+        if (listType === "CWL") {
+          const season = resolveCurrentCwlSeasonKey();
+          const tracked = await listCwlTrackedClansForSeason({ season });
+          if (tracked.length === 0) {
+            await safeReply(interaction, {
+              ephemeral: true,
+              content: `No CWL tracked clans for season ${season}.`,
+            });
+            return;
+          }
+
+          const blocks = tracked.map((clan) => buildCwlTrackedClanBlock(clan));
+          const pages = paginateTrackedClanBlocks(blocks);
+          let page = 0;
+          const paginatorPrefix = `tracked-clan-list:cwl:${interaction.id}`;
+          await interaction.editReply({
+            embeds: [buildCwlTrackedClanListEmbed(tracked.length, season, pages[page], page, pages.length)],
+            components:
+              pages.length > 1 ? [buildTrackedClanListRow(paginatorPrefix, page, pages.length)] : [],
+          });
+
+          if (pages.length <= 1) {
+            return;
+          }
+
+          const message = await interaction.fetchReply();
+          const collector = message.createMessageComponentCollector({
+            componentType: ComponentType.Button,
+            time: 10 * 60 * 1000,
+          });
+
+          collector.on("collect", async (button: ButtonInteraction) => {
+            try {
+              if (button.user.id !== interaction.user.id) {
+                await button.reply({
+                  content: "Only the command user can control this paginator.",
+                  ephemeral: true,
+                });
+                return;
+              }
+              if (
+                button.customId !== `${paginatorPrefix}:prev` &&
+                button.customId !== `${paginatorPrefix}:next`
+              ) {
+                return;
+              }
+
+              if (button.customId.endsWith(":prev")) page = Math.max(0, page - 1);
+              if (button.customId.endsWith(":next")) page = Math.min(pages.length - 1, page + 1);
+
+              await button.update({
+                embeds: [buildCwlTrackedClanListEmbed(tracked.length, season, pages[page], page, pages.length)],
+                components: [buildTrackedClanListRow(paginatorPrefix, page, pages.length)],
+              });
+            } catch (err) {
+              console.error(`tracked-clan CWL list paginator failed: ${formatError(err)}`);
+              if (!button.replied && !button.deferred) {
+                await button.reply({
+                  ephemeral: true,
+                  content: "Failed to update tracked-clan CWL list page.",
+                });
+              }
+            }
+          });
+
+          collector.on("end", async () => {
+            try {
+              await interaction.editReply({
+                embeds: [buildCwlTrackedClanListEmbed(tracked.length, season, pages[page], page, pages.length)],
+                components: [],
+              });
+            } catch {
+              // no-op
+            }
+          });
+          return;
+        }
+
         const tracked = await prisma.trackedClan.findMany({
           orderBy: { createdAt: "asc" },
         });
@@ -309,10 +455,37 @@ export const TrackedClan: Command = {
         return;
       }
 
-      const tagInput = interaction.options.getString("tag", true);
-      const tag = normalizeClanTag(tagInput);
+      if (subcommand === "cwl-tags") {
+        const rawCwlTags = interaction.options.getString("cwl-tags", true);
+        const result = await addCwlClanTagsForSeason({
+          rawTags: rawCwlTags,
+          cocService,
+        });
+
+        await safeReply(interaction, {
+          ephemeral: true,
+          content: [
+            `Updated CWL tracked clans for season ${result.season}.`,
+            `added: ${formatTagListForSummary(result.added)}`,
+            `already existed: ${formatTagListForSummary(result.alreadyExisting)}`,
+            `invalid: ${formatTagListForSummary(result.invalid)}`,
+            `duplicates in request: ${formatTagListForSummary(result.duplicateInRequest)}`,
+          ].join("\n"),
+        });
+        return;
+      }
 
       if (subcommand === "configure") {
+        const tagInput = interaction.options.getString("tag", true);
+        const tag = normalizeClanTag(tagInput);
+        if (!tag) {
+          await safeReply(interaction, {
+            ephemeral: true,
+            content: "Invalid clan tag format. Use a valid clan tag with or without `#`.",
+          });
+          return;
+        }
+
         const loseStyle = interaction.options.getString("lose-style", false) as
           | "TRIPLE_TOP_30"
           | "TRADITIONAL"
@@ -507,19 +680,39 @@ export const TrackedClan: Command = {
       }
 
       if (subcommand === "remove") {
-        const deleted = await prisma.trackedClan.deleteMany({
-          where: { tag },
-        });
-
-        if (deleted.count === 0) {
+        const tagInput = interaction.options.getString("tag", true);
+        const tag = normalizeClanTag(tagInput);
+        if (!tag) {
           await safeReply(interaction, {
             ephemeral: true,
-            content: `${tag} is not currently tracked.`,
+            content: "Invalid clan tag format. Use a valid clan tag with or without `#`.",
+          });
+          return;
+        }
+        const requestedType =
+          (interaction.options.getString("type", false) as TrackedClanRegistryType | null) ?? null;
+        const result = await removeTrackedClanTagFromRegistries({
+          tag,
+          type: requestedType,
+        });
+        if (result.outcome === "not_found") {
+          await safeReply(interaction, {
+            ephemeral: true,
+            content: `${tag} was not found in ${requestedType ? `${requestedType} tracked clans` : "FWA tracked clans or current-season CWL tracked clans"}.`,
+          });
+          return;
+        }
+        if (result.outcome === "ambiguous") {
+          await safeReply(interaction, {
+            ephemeral: true,
+            content:
+              `Ambiguous remove for ${tag}: it exists in both FWA and CWL (${result.season}) registries.\n` +
+              "Re-run `/tracked-clan remove` with `type:FWA` or `type:CWL`.",
           });
           return;
         }
 
-        if (interaction.guildId) {
+        if (result.removedFrom === "FWA" && interaction.guildId) {
           await prisma.currentWar.deleteMany({
             where: {
               guildId: interaction.guildId,
@@ -530,7 +723,10 @@ export const TrackedClan: Command = {
 
         await safeReply(interaction, {
           ephemeral: true,
-          content: `Removed tracked clan ${tag}.`,
+          content:
+            result.removedFrom === "FWA"
+              ? `Removed tracked clan ${tag} from FWA registry.`
+              : `Removed tracked clan ${tag} from CWL registry for season ${result.season}.`,
         });
       }
     } catch (err) {
@@ -548,7 +744,60 @@ export const TrackedClan: Command = {
       return;
     }
 
+    const subcommand = interaction.options.getSubcommand(false);
     const query = String(focused.value ?? "").trim().toLowerCase();
+    if (subcommand === "remove") {
+      const season = resolveCurrentCwlSeasonKey();
+      const [trackedFwa, trackedCwl] = await Promise.all([
+        prisma.trackedClan.findMany({
+          orderBy: { createdAt: "asc" },
+          select: { name: true, tag: true },
+        }),
+        prisma.cwlTrackedClan.findMany({
+          where: { season },
+          orderBy: { createdAt: "asc" },
+          select: { name: true, tag: true },
+        }),
+      ]);
+
+      const choiceByTag = new Map<string, { name: string; value: string }>();
+      for (const clan of trackedFwa) {
+        const tag = normalizeClanTag(clan.tag);
+        if (!tag) continue;
+        const label = clan.name?.trim() ? `${clan.name.trim()} (${tag}) [FWA]` : `${tag} [FWA]`;
+        choiceByTag.set(tag, { name: label.slice(0, 100), value: tag });
+      }
+      for (const clan of trackedCwl) {
+        const tag = normalizeClanTag(clan.tag);
+        if (!tag) continue;
+        const existing = choiceByTag.get(tag);
+        if (existing) {
+          const merged = existing.name.includes(`[CWL ${season}]`)
+            ? existing.name
+            : `${existing.name} [CWL ${season}]`;
+          choiceByTag.set(tag, {
+            name: merged.slice(0, 100),
+            value: tag,
+          });
+          continue;
+        }
+        const label = clan.name?.trim()
+          ? `${clan.name.trim()} (${tag}) [CWL ${season}]`
+          : `${tag} [CWL ${season}]`;
+        choiceByTag.set(tag, { name: label.slice(0, 100), value: tag });
+      }
+
+      const choices = [...choiceByTag.values()]
+        .filter(
+          (choice) =>
+            choice.name.toLowerCase().includes(query) || choice.value.toLowerCase().includes(query)
+        )
+        .slice(0, 25);
+
+      await interaction.respond(choices);
+      return;
+    }
+
     const tracked = await prisma.trackedClan.findMany({
       orderBy: { createdAt: "asc" },
       select: { name: true, tag: true },

--- a/src/services/CommandPermissionService.ts
+++ b/src/services/CommandPermissionService.ts
@@ -30,6 +30,7 @@ export const COMMAND_PERMISSION_TARGETS = [
   "notify",
   "warplan",
   "tracked-clan:configure",
+  "tracked-clan:cwl-tags",
   "tracked-clan:remove",
   "tracked-clan:list",
   "sheet:link",
@@ -99,6 +100,7 @@ type GuildInteraction = ChatInputCommandInteraction | ModalSubmitInteraction;
 
 const ADMIN_DEFAULT_TARGETS = new Set<string>([
   "tracked-clan:configure",
+  "tracked-clan:cwl-tags",
   "tracked-clan:remove",
   "sheet:link",
   "sheet:unlink",

--- a/src/services/CwlRegistryService.ts
+++ b/src/services/CwlRegistryService.ts
@@ -1,0 +1,307 @@
+import { prisma } from "../prisma";
+import { normalizeClanTag } from "./PlayerLinkService";
+import { CoCService } from "./CoCService";
+
+export type TrackedClanRegistryType = "FWA" | "CWL";
+
+export type ParsedCwlTagInput = {
+  validTags: string[];
+  invalidTags: string[];
+  duplicateTagsInRequest: string[];
+};
+
+export type AddCwlClanTagsResult = {
+  season: string;
+  added: string[];
+  alreadyExisting: string[];
+  invalid: string[];
+  duplicateInRequest: string[];
+};
+
+export type RemoveTrackedClanResult =
+  | {
+      outcome: "removed";
+      tag: string;
+      removedFrom: TrackedClanRegistryType;
+      season: string;
+      removedCount: number;
+    }
+  | {
+      outcome: "not_found";
+      tag: string;
+      season: string;
+    }
+  | {
+      outcome: "ambiguous";
+      tag: string;
+      season: string;
+    };
+
+/** Purpose: resolve current CWL month key in stable UTC `YYYY-MM` format. */
+export function resolveCurrentCwlSeasonKey(nowMs?: number): string {
+  const now = Number.isFinite(nowMs) ? new Date(Number(nowMs)) : new Date();
+  const year = now.getUTCFullYear();
+  const month = String(now.getUTCMonth() + 1).padStart(2, "0");
+  return `${year}-${month}`;
+}
+
+/** Purpose: parse one free-form CWL tags input string into normalized valid/invalid/duplicate buckets. */
+export function parseCwlClanTagsInput(rawInput: string): ParsedCwlTagInput {
+  const trimmed = String(rawInput ?? "").trim();
+  if (!trimmed) {
+    return {
+      validTags: [],
+      invalidTags: [],
+      duplicateTagsInRequest: [],
+    };
+  }
+
+  const withoutBrackets =
+    trimmed.startsWith("[") && trimmed.endsWith("]")
+      ? trimmed.slice(1, -1)
+      : trimmed;
+  const parts = withoutBrackets
+    .split(/[\s,;]+/g)
+    .map((part) => part.trim().replace(/^['"`]+|['"`]+$/g, ""))
+    .filter(Boolean);
+
+  const seen = new Set<string>();
+  const validTags: string[] = [];
+  const invalidTags: string[] = [];
+  const duplicateTagsInRequest: string[] = [];
+  for (const part of parts) {
+    const normalized = normalizeClanTag(part);
+    if (!normalized) {
+      invalidTags.push(part);
+      continue;
+    }
+    if (seen.has(normalized)) {
+      duplicateTagsInRequest.push(normalized);
+      continue;
+    }
+    seen.add(normalized);
+    validTags.push(normalized);
+  }
+
+  return {
+    validTags,
+    invalidTags,
+    duplicateTagsInRequest: [...new Set(duplicateTagsInRequest)],
+  };
+}
+
+/** Purpose: add one CWL clan-tag batch for a target season with partial-success semantics. */
+export async function addCwlClanTagsForSeason(input: {
+  rawTags: string;
+  season?: string;
+  cocService?: CoCService;
+}): Promise<AddCwlClanTagsResult> {
+  const season = input.season ?? resolveCurrentCwlSeasonKey();
+  const parsed = parseCwlClanTagsInput(input.rawTags);
+  if (parsed.validTags.length <= 0) {
+    return {
+      season,
+      added: [],
+      alreadyExisting: [],
+      invalid: parsed.invalidTags,
+      duplicateInRequest: parsed.duplicateTagsInRequest,
+    };
+  }
+
+  const existing = await prisma.cwlTrackedClan.findMany({
+    where: {
+      season,
+      tag: { in: parsed.validTags },
+    },
+    select: { tag: true },
+  });
+  const existingSet = new Set(existing.map((row) => normalizeClanTag(row.tag)).filter(Boolean));
+  const toCreate = parsed.validTags.filter((tag) => !existingSet.has(tag));
+
+  const namesByTag = new Map<string, string | null>();
+  if (input.cocService && toCreate.length > 0) {
+    const lookups = await Promise.allSettled(
+      toCreate.map(async (tag) => {
+        const clan = await input.cocService!.getClan(tag);
+        return [tag, String(clan.name ?? "").trim() || null] as const;
+      }),
+    );
+    for (const lookup of lookups) {
+      if (lookup.status !== "fulfilled") continue;
+      namesByTag.set(lookup.value[0], lookup.value[1]);
+    }
+  }
+
+  if (toCreate.length > 0) {
+    await prisma.cwlTrackedClan.createMany({
+      data: toCreate.map((tag) => ({
+        season,
+        tag,
+        name: namesByTag.get(tag) ?? null,
+      })),
+      skipDuplicates: true,
+    });
+  }
+
+  const finalRows = await prisma.cwlTrackedClan.findMany({
+    where: {
+      season,
+      tag: { in: parsed.validTags },
+    },
+    select: { tag: true },
+  });
+  const finalSet = new Set(finalRows.map((row) => normalizeClanTag(row.tag)).filter(Boolean));
+
+  const added: string[] = [];
+  const alreadyExisting: string[] = [];
+  for (const tag of parsed.validTags) {
+    if (!finalSet.has(tag)) continue;
+    if (existingSet.has(tag)) {
+      alreadyExisting.push(tag);
+      continue;
+    }
+    added.push(tag);
+  }
+
+  return {
+    season,
+    added,
+    alreadyExisting,
+    invalid: parsed.invalidTags,
+    duplicateInRequest: parsed.duplicateTagsInRequest,
+  };
+}
+
+/** Purpose: list one season-scoped CWL tracked-clan registry in deterministic order. */
+export async function listCwlTrackedClansForSeason(input?: {
+  season?: string;
+}): Promise<Array<{ season: string; tag: string; name: string | null; createdAt: Date }>> {
+  const season = input?.season ?? resolveCurrentCwlSeasonKey();
+  const rows = await prisma.cwlTrackedClan.findMany({
+    where: { season },
+    orderBy: [{ createdAt: "asc" }, { tag: "asc" }],
+    select: {
+      season: true,
+      tag: true,
+      name: true,
+      createdAt: true,
+    },
+  });
+
+  return rows.map((row) => ({
+    season: row.season,
+    tag: normalizeClanTag(row.tag) || row.tag,
+    name: row.name,
+    createdAt: row.createdAt,
+  }));
+}
+
+/** Purpose: remove one tag from FWA/CWL registries with deterministic ambiguity handling. */
+export async function removeTrackedClanTagFromRegistries(input: {
+  tag: string;
+  type?: TrackedClanRegistryType | null;
+  season?: string;
+}): Promise<RemoveTrackedClanResult> {
+  const normalizedTag = normalizeClanTag(input.tag);
+  const season = input.season ?? resolveCurrentCwlSeasonKey();
+  if (!normalizedTag) {
+    return {
+      outcome: "not_found",
+      tag: "",
+      season,
+    };
+  }
+
+  if (input.type === "FWA") {
+    const deleted = await prisma.trackedClan.deleteMany({
+      where: { tag: normalizedTag },
+    });
+    if (deleted.count <= 0) {
+      return { outcome: "not_found", tag: normalizedTag, season };
+    }
+    return {
+      outcome: "removed",
+      tag: normalizedTag,
+      removedFrom: "FWA",
+      season,
+      removedCount: deleted.count,
+    };
+  }
+
+  if (input.type === "CWL") {
+    const [deletedClans, deletedMappings] = await prisma.$transaction([
+      prisma.cwlTrackedClan.deleteMany({
+        where: { season, tag: normalizedTag },
+      }),
+      prisma.cwlPlayerClanSeason.deleteMany({
+        where: { season, cwlClanTag: normalizedTag },
+      }),
+    ]);
+    if (deletedClans.count <= 0) {
+      return { outcome: "not_found", tag: normalizedTag, season };
+    }
+    return {
+      outcome: "removed",
+      tag: normalizedTag,
+      removedFrom: "CWL",
+      season,
+      removedCount: deletedClans.count + deletedMappings.count,
+    };
+  }
+
+  const [fwaRow, cwlRow] = await Promise.all([
+    prisma.trackedClan.findUnique({
+      where: { tag: normalizedTag },
+      select: { tag: true },
+    }),
+    prisma.cwlTrackedClan.findFirst({
+      where: { season, tag: normalizedTag },
+      select: { id: true },
+    }),
+  ]);
+
+  if (fwaRow && cwlRow) {
+    return {
+      outcome: "ambiguous",
+      tag: normalizedTag,
+      season,
+    };
+  }
+
+  if (fwaRow) {
+    const deleted = await prisma.trackedClan.deleteMany({
+      where: { tag: normalizedTag },
+    });
+    return {
+      outcome: "removed",
+      tag: normalizedTag,
+      removedFrom: "FWA",
+      season,
+      removedCount: deleted.count,
+    };
+  }
+
+  if (cwlRow) {
+    const [deletedClans, deletedMappings] = await prisma.$transaction([
+      prisma.cwlTrackedClan.deleteMany({
+        where: { season, tag: normalizedTag },
+      }),
+      prisma.cwlPlayerClanSeason.deleteMany({
+        where: { season, cwlClanTag: normalizedTag },
+      }),
+    ]);
+    return {
+      outcome: "removed",
+      tag: normalizedTag,
+      removedFrom: "CWL",
+      season,
+      removedCount: deletedClans.count + deletedMappings.count,
+    };
+  }
+
+  return {
+    outcome: "not_found",
+    tag: normalizedTag,
+    season,
+  };
+}

--- a/src/services/TodoService.ts
+++ b/src/services/TodoService.ts
@@ -21,6 +21,8 @@ type TodoRenderRow = {
   playerName: string;
   clanTag: string | null;
   clanName: string | null;
+  cwlClanTag: string | null;
+  cwlClanName: string | null;
   snapshot: TodoSnapshotRecord | null;
   missingSnapshot: boolean;
   staleSnapshot: boolean;
@@ -122,6 +124,8 @@ export async function buildTodoPagesForUser(input: {
       playerName: snapshot?.playerName ?? normalizedTag,
       clanTag: snapshot?.clanTag ?? null,
       clanName: snapshot?.clanName ?? null,
+      cwlClanTag: snapshot?.cwlClanTag ?? null,
+      cwlClanName: snapshot?.cwlClanName ?? null,
       snapshot,
       missingSnapshot,
       staleSnapshot,
@@ -349,9 +353,11 @@ function buildEventGroups(
         : sanitizeStatusText(row.snapshot.cwlPhase) || "active phase";
     const phaseEndsAt =
       mode === "war" ? row.snapshot.warEndsAt : row.snapshot.cwlEndsAt;
+    const groupedClanTag = mode === "war" ? row.clanTag : row.cwlClanTag;
+    const groupedClanName = mode === "war" ? row.clanName : row.cwlClanName;
     const key = [
-      row.clanTag ?? "",
-      row.clanName ?? "",
+      groupedClanTag ?? "",
+      groupedClanName ?? "",
       phase,
       phaseEndsAt ? String(phaseEndsAt.getTime()) : "0",
     ].join("|");
@@ -362,8 +368,8 @@ function buildEventGroups(
       continue;
     }
     grouped.set(key, {
-      clanTag: row.clanTag ?? null,
-      clanName: row.clanName ?? null,
+      clanTag: groupedClanTag ?? null,
+      clanName: groupedClanName ?? null,
       phase,
       phaseEndsAt: phaseEndsAt ?? null,
       rows: [row],

--- a/src/services/TodoSnapshotService.ts
+++ b/src/services/TodoSnapshotService.ts
@@ -1,5 +1,6 @@
 import { ClanWar } from "../generated/coc-api";
 import { prisma } from "../prisma";
+import { resolveCurrentCwlSeasonKey } from "./CwlRegistryService";
 import { CoCService } from "./CoCService";
 import { normalizeClanTag, normalizePlayerTag } from "./PlayerLinkService";
 import { parseCocTime } from "./war-events/core";
@@ -9,6 +10,8 @@ const TODO_SNAPSHOT_SELECT = {
   playerName: true,
   clanTag: true,
   clanName: true,
+  cwlClanTag: true,
+  cwlClanName: true,
   warActive: true,
   warAttacksUsed: true,
   warAttacksMax: true,
@@ -91,6 +94,7 @@ export class TodoSnapshotService {
         ...row,
         playerTag: normalizePlayerTag(row.playerTag),
         clanTag: row.clanTag ? normalizeClanTag(row.clanTag) : null,
+        cwlClanTag: row.cwlClanTag ? normalizeClanTag(row.cwlClanTag) : null,
       }))
       .filter((row) => row.playerTag.length > 0)
       .sort((a, b) => {
@@ -247,6 +251,7 @@ export class TodoSnapshotService {
     );
     const latestClanMemberByTag = pickLatestClanMemberByPlayerTag(clanMemberRows);
     const latestWarMemberByClanAndTag = pickLatestWarMemberByClanAndPlayer(warMemberRows);
+    const currentCwlSeason = resolveCurrentCwlSeasonKey(now.getTime());
 
     const clanTags = [
       ...new Set(
@@ -260,7 +265,8 @@ export class TodoSnapshotService {
       ),
     ];
 
-    const [trackedClanRows, currentWarRows, cwlWarByClan] = await Promise.all([
+    const [trackedClanRows, currentWarRows, cwlTrackedClanRows, cwlSeasonMappingRows] =
+      await Promise.all([
       clanTags.length > 0
         ? prisma.trackedClan.findMany({
             where: { tag: { in: clanTags } },
@@ -279,9 +285,20 @@ export class TodoSnapshotService {
             },
           })
         : Promise.resolve([]),
-      input.cocService
-        ? loadActiveCwlWarsByClan(input.cocService, clanTags)
-        : Promise.resolve(new Map<string, ClanWar | null>()),
+      prisma.cwlTrackedClan.findMany({
+        where: { season: currentCwlSeason },
+        select: { tag: true, name: true },
+      }),
+      prisma.cwlPlayerClanSeason.findMany({
+        where: {
+          season: currentCwlSeason,
+          playerTag: { in: normalizedTags },
+        },
+        select: {
+          playerTag: true,
+          cwlClanTag: true,
+        },
+      }),
     ]);
 
     const trackedClanNameByTag = new Map(
@@ -293,6 +310,35 @@ export class TodoSnapshotService {
         .filter((entry): entry is [string, string] => Boolean(entry[0] && entry[1])),
     );
     const currentWarByClanTag = pickLatestCurrentWarByClanTag(currentWarRows);
+    const cwlTrackedTagSet = new Set(
+      cwlTrackedClanRows
+        .map((row) => normalizeClanTag(row.tag))
+        .filter(Boolean),
+    );
+    const cwlTrackedClanNameByTag = new Map(
+      cwlTrackedClanRows
+        .map((row) => [
+          normalizeClanTag(row.tag),
+          sanitizeDisplayText(String(row.name ?? "")),
+        ] as const)
+        .filter((entry): entry is [string, string] => Boolean(entry[0] && entry[1])),
+    );
+    const mappedCwlClanByPlayerTag = new Map(
+      cwlSeasonMappingRows
+        .map((row) => [
+          normalizePlayerTag(row.playerTag),
+          normalizeClanTag(row.cwlClanTag),
+        ] as const)
+        .filter((entry): entry is [string, string] => Boolean(entry[0] && entry[1])),
+    );
+    const cwlWarByClan =
+      input.cocService && cwlTrackedTagSet.size > 0
+        ? await loadActiveCwlWarsByClan(input.cocService, [...cwlTrackedTagSet])
+        : new Map<string, ClanWar | null>();
+    const activeCwlClanByPlayerTag = buildActiveCwlClanByPlayerTag({
+      cwlWarByClan,
+      trackedCwlTags: cwlTrackedTagSet,
+    });
 
     const raidWindow = resolveRaidWeekendWindow(now.getTime());
     const gamesWindow = resolveClanGamesWindow(now.getTime());
@@ -309,6 +355,23 @@ export class TodoSnapshotService {
         const resolvedClanName =
           (resolvedClanTag ? trackedClanNameByTag.get(resolvedClanTag) : null) ||
           sanitizeDisplayText(existing?.clanName ?? "") ||
+          null;
+        const activeMappedCwlClanTag = activeCwlClanByPlayerTag.get(playerTag) ?? "";
+        const persistedMappedCwlClanTag = mappedCwlClanByPlayerTag.get(playerTag) ?? "";
+        const fallbackCwlClanTag =
+          resolvedClanTag && cwlTrackedTagSet.has(resolvedClanTag)
+            ? resolvedClanTag
+            : "";
+        const resolvedCwlClanTag =
+          normalizeClanTag(
+            activeMappedCwlClanTag || persistedMappedCwlClanTag || fallbackCwlClanTag,
+          ) || null;
+        const resolvedCwlClanName =
+          (resolvedCwlClanTag
+            ? cwlTrackedClanNameByTag.get(resolvedCwlClanTag) ||
+              trackedClanNameByTag.get(resolvedCwlClanTag)
+            : null) ||
+          sanitizeDisplayText(existing?.cwlClanName ?? "") ||
           null;
         const resolvedPlayerName =
           sanitizeDisplayText(latestClanMember?.playerName ?? "") ||
@@ -333,8 +396,8 @@ export class TodoSnapshotService {
           ? clampInt(warMember?.attacks, 0, 2)
           : 0;
 
-        const cwlWar = resolvedClanTag
-          ? cwlWarByClan.get(resolvedClanTag) ?? null
+        const cwlWar = resolvedCwlClanTag
+          ? cwlWarByClan.get(resolvedCwlClanTag) ?? null
           : null;
         const cwlActive = isWarStateActive(cwlWar?.state ?? "");
         const cwlPhase = cwlActive ? normalizeWarPhaseLabel(cwlWar?.state ?? "") : null;
@@ -349,6 +412,8 @@ export class TodoSnapshotService {
           playerName: resolvedPlayerName,
           clanTag: resolvedClanTag,
           clanName: resolvedClanName,
+          cwlClanTag: resolvedCwlClanTag,
+          cwlClanName: resolvedCwlClanName,
           warActive,
           warAttacksUsed,
           warAttacksMax: 2,
@@ -378,6 +443,25 @@ export class TodoSnapshotService {
             ...data,
           },
         });
+
+        if (resolvedCwlClanTag) {
+          await tx.cwlPlayerClanSeason.upsert({
+            where: {
+              season_playerTag: {
+                season: currentCwlSeason,
+                playerTag,
+              },
+            },
+            update: {
+              cwlClanTag: resolvedCwlClanTag,
+            },
+            create: {
+              season: currentCwlSeason,
+              playerTag,
+              cwlClanTag: resolvedCwlClanTag,
+            },
+          });
+        }
         updatedCount += 1;
       }
     });
@@ -588,6 +672,38 @@ function findWarAttacksUsed(war: ClanWar | null, playerTag: string): number {
     (member) => normalizePlayerTag(String(member?.tag ?? "")) === normalizedTarget,
   );
   return Array.isArray(match?.attacks) ? match.attacks.length : 0;
+}
+
+/** Purpose: derive a season-scoped player->CWL-clan map from active CWL wars for tracked CWL clans. */
+function buildActiveCwlClanByPlayerTag(input: {
+  cwlWarByClan: Map<string, ClanWar | null>;
+  trackedCwlTags: Set<string>;
+}): Map<string, string> {
+  const mapped = new Map<string, string>();
+  for (const [trackedCwlTag, war] of input.cwlWarByClan.entries()) {
+    const normalizedTracked = normalizeClanTag(trackedCwlTag);
+    if (!normalizedTracked || !input.trackedCwlTags.has(normalizedTracked)) continue;
+    if (!war || !isWarStateActive(war.state)) continue;
+
+    const clanTag = normalizeClanTag(String(war.clan?.tag ?? ""));
+    const opponentTag = normalizeClanTag(String(war.opponent?.tag ?? ""));
+    const trackedSideMembers =
+      clanTag === normalizedTracked
+        ? Array.isArray(war.clan?.members)
+          ? war.clan.members
+          : []
+        : opponentTag === normalizedTracked
+          ? Array.isArray(war.opponent?.members)
+            ? war.opponent.members
+            : []
+          : [];
+    for (const member of trackedSideMembers) {
+      const playerTag = normalizePlayerTag(String(member?.tag ?? ""));
+      if (!playerTag) continue;
+      mapped.set(playerTag, normalizedTracked);
+    }
+  }
+  return mapped;
 }
 
 /** Purpose: load one active CWL war per clan tag with grouped war-tag reuse to avoid duplicate fetches. */

--- a/tests/todo.command.test.ts
+++ b/tests/todo.command.test.ts
@@ -24,10 +24,19 @@ const prismaMock = vi.hoisted(() => ({
   trackedClan: {
     findMany: vi.fn(),
   },
+  cwlTrackedClan: {
+    findMany: vi.fn(),
+  },
+  cwlPlayerClanSeason: {
+    findMany: vi.fn(),
+  },
   $transaction: vi.fn(async (arg: any) => {
     if (typeof arg === "function") {
       return arg({
         todoPlayerSnapshot: {
+          upsert: vi.fn().mockResolvedValue(undefined),
+        },
+        cwlPlayerClanSeason: {
           upsert: vi.fn().mockResolvedValue(undefined),
         },
       });
@@ -80,6 +89,8 @@ function makeSnapshotRow(input: {
   playerName: string;
   clanTag?: string | null;
   clanName?: string | null;
+  cwlClanTag?: string | null;
+  cwlClanName?: string | null;
   warActive?: boolean;
   warAttacksUsed?: number;
   warAttacksMax?: number;
@@ -107,6 +118,8 @@ function makeSnapshotRow(input: {
     playerName: input.playerName,
     clanTag: input.clanTag ?? "#PQL0289",
     clanName: input.clanName ?? "Clan One",
+    cwlClanTag: input.cwlClanTag ?? input.clanTag ?? "#PQL0289",
+    cwlClanName: input.cwlClanName ?? input.clanName ?? "Clan One",
     warActive: input.warActive ?? true,
     warAttacksUsed: input.warAttacksUsed ?? 0,
     warAttacksMax: input.warAttacksMax ?? 2,
@@ -178,6 +191,8 @@ describe("/todo command", () => {
     prismaMock.fwaWarMemberCurrent.findMany.mockReset();
     prismaMock.currentWar.findMany.mockReset();
     prismaMock.trackedClan.findMany.mockReset();
+    prismaMock.cwlTrackedClan.findMany.mockReset();
+    prismaMock.cwlPlayerClanSeason.findMany.mockReset();
     prismaMock.$transaction.mockClear();
 
     prismaMock.todoPlayerSnapshot.aggregate.mockResolvedValue({
@@ -190,6 +205,8 @@ describe("/todo command", () => {
     prismaMock.fwaWarMemberCurrent.findMany.mockResolvedValue([]);
     prismaMock.currentWar.findMany.mockResolvedValue([]);
     prismaMock.trackedClan.findMany.mockResolvedValue([]);
+    prismaMock.cwlTrackedClan.findMany.mockResolvedValue([]);
+    prismaMock.cwlPlayerClanSeason.findMany.mockResolvedValue([]);
   });
 
   afterEach(() => {
@@ -371,6 +388,45 @@ describe("/todo command", () => {
     expect(description).toContain(
       "- Delta #LQ9P8R2 - CWL attacks: 0/1 - not in active CWL war",
     );
+  });
+
+  it("groups CWL rows by cwlClanTag/cwlClanName when different from home clan", async () => {
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      { playerTag: "#PYLQ0289", createdAt: new Date("2026-03-01T00:00:00.000Z") },
+      { playerTag: "#QGRJ2222", createdAt: new Date("2026-03-02T00:00:00.000Z") },
+    ]);
+    prismaMock.todoPlayerSnapshot.aggregate.mockResolvedValue({
+      _count: { _all: 2 },
+      _max: { updatedAt: new Date("2026-03-26T00:00:00.000Z") },
+    });
+    prismaMock.todoPlayerSnapshot.findMany.mockResolvedValue([
+      makeSnapshotRow({
+        playerTag: "#PYLQ0289",
+        playerName: "Alpha",
+        clanTag: "#PQL0289",
+        clanName: "Home Clan",
+        cwlClanTag: "#2QG2C08UP",
+        cwlClanName: "CWL One",
+        cwlAttacksUsed: 1,
+      }),
+      makeSnapshotRow({
+        playerTag: "#QGRJ2222",
+        playerName: "Bravo",
+        clanTag: "#PQL0289",
+        clanName: "Home Clan",
+        cwlClanTag: "#2QG2C08UP",
+        cwlClanName: "CWL One",
+        cwlAttacksUsed: 0,
+      }),
+    ]);
+
+    const interaction = makeTodoInteraction({ type: "CWL" });
+    await Todo.run({} as any, interaction as any, makeCocServiceSpy() as any);
+
+    const description = getReplyDescription(interaction);
+    expect(description).toContain("**CWL One (#2QG2C08UP) - preparation ends <t:");
+    expect(description).not.toContain("**Home Clan (#PQL0289) - preparation ends <t:");
+    expect(description).toContain("- Alpha #PYLQ0289 - CWL attacks: 1/1");
   });
 
   it("shows explicit inactive WAR page message when no active war contexts exist", async () => {

--- a/tests/todoSnapshot.service.test.ts
+++ b/tests/todoSnapshot.service.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const upsertMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
+const cwlSeasonUpsertMock = vi.hoisted(() => vi.fn().mockResolvedValue(undefined));
 
 const prismaMock = vi.hoisted(() => ({
   playerLink: {
@@ -25,11 +26,20 @@ const prismaMock = vi.hoisted(() => ({
   trackedClan: {
     findMany: vi.fn(),
   },
+  cwlTrackedClan: {
+    findMany: vi.fn(),
+  },
+  cwlPlayerClanSeason: {
+    findMany: vi.fn(),
+  },
   $transaction: vi.fn(async (arg: any) => {
     if (typeof arg === "function") {
       return arg({
         todoPlayerSnapshot: {
           upsert: upsertMock,
+        },
+        cwlPlayerClanSeason: {
+          upsert: cwlSeasonUpsertMock,
         },
       });
     }
@@ -48,6 +58,7 @@ describe("TodoSnapshotService", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     upsertMock.mockClear();
+    cwlSeasonUpsertMock.mockClear();
 
     prismaMock.todoPlayerSnapshot.findMany.mockResolvedValue([]);
     prismaMock.fwaPlayerCatalog.findMany.mockResolvedValue([]);
@@ -91,6 +102,10 @@ describe("TodoSnapshotService", () => {
     prismaMock.trackedClan.findMany.mockResolvedValue([
       { tag: "#PQL0289", name: "Clan One" },
     ]);
+    prismaMock.cwlTrackedClan.findMany.mockResolvedValue([
+      { tag: "#PQL0289", name: "Clan One" },
+    ]);
+    prismaMock.cwlPlayerClanSeason.findMany.mockResolvedValue([]);
   });
 
   it("fans out grouped CWL source fetches once per clan when refreshing multiple player tags", async () => {
@@ -127,5 +142,71 @@ describe("TodoSnapshotService", () => {
     expect(cocService.getClanWarLeagueGroup).toHaveBeenCalledTimes(1);
     expect(cocService.getClanWarLeagueWar).toHaveBeenCalledTimes(1);
     expect(upsertMock).toHaveBeenCalledTimes(2);
+    expect(cwlSeasonUpsertMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("resolves CWL context from seasonal CWL registry mapping instead of home clan tag", async () => {
+    prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue([
+      {
+        playerTag: "#PYLQ0289",
+        clanTag: "#PQL0289",
+        playerName: "Alpha",
+        sourceSyncedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.fwaWarMemberCurrent.findMany.mockResolvedValue([
+      {
+        playerTag: "#PYLQ0289",
+        clanTag: "#PQL0289",
+        attacks: 2,
+        sourceSyncedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.trackedClan.findMany.mockResolvedValue([
+      { tag: "#PQL0289", name: "Home Clan" },
+    ]);
+    prismaMock.cwlTrackedClan.findMany.mockResolvedValue([
+      { tag: "#2QG2C08UP", name: "CWL Clan" },
+    ]);
+    prismaMock.cwlPlayerClanSeason.findMany.mockResolvedValue([
+      { playerTag: "#PYLQ0289", cwlClanTag: "#2QG2C08UP" },
+    ]);
+    const cocService = {
+      getClanWarLeagueGroup: vi.fn().mockResolvedValue({
+        state: "inWar",
+        rounds: [{ warTags: ["#WAR1"] }],
+      }),
+      getClanWarLeagueWar: vi.fn().mockResolvedValue({
+        state: "inWar",
+        endTime: "20260330T120000.000Z",
+        clan: {
+          tag: "#2QG2C08UP",
+          members: [{ tag: "#PYLQ0289", attacks: [{ order: 1 }] }],
+        },
+        opponent: {
+          tag: "#PQL0289",
+          members: [],
+        },
+      }),
+    };
+
+    await todoSnapshotService.refreshSnapshotsForPlayerTags({
+      playerTags: ["#PYLQ0289"],
+      cocService: cocService as any,
+      nowMs: Date.UTC(2026, 2, 26, 0, 0, 0, 0),
+    });
+
+    expect(cocService.getClanWarLeagueGroup).toHaveBeenCalledWith("#2QG2C08UP");
+    expect(upsertMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({
+          clanTag: "#PQL0289",
+          clanName: "Home Clan",
+          cwlClanTag: "#2QG2C08UP",
+          cwlClanName: "CWL Clan",
+          cwlAttacksUsed: 1,
+        }),
+      }),
+    );
   });
 });

--- a/tests/trackedClan.command.test.ts
+++ b/tests/trackedClan.command.test.ts
@@ -1,0 +1,218 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const prismaMock = vi.hoisted(() => ({
+  trackedClan: {
+    findMany: vi.fn(),
+    findUnique: vi.fn(),
+    deleteMany: vi.fn(),
+    upsert: vi.fn(),
+  },
+  cwlTrackedClan: {
+    findMany: vi.fn(),
+    createMany: vi.fn(),
+    findFirst: vi.fn(),
+    deleteMany: vi.fn(),
+  },
+  cwlPlayerClanSeason: {
+    findMany: vi.fn(),
+    deleteMany: vi.fn(),
+  },
+  currentWar: {
+    deleteMany: vi.fn(),
+    upsert: vi.fn(),
+  },
+  $transaction: vi.fn(async (arg: any) => {
+    if (Array.isArray(arg)) return Promise.all(arg);
+    if (typeof arg === "function") return arg({});
+    return arg;
+  }),
+}));
+
+vi.mock("../src/prisma", () => ({
+  prisma: prismaMock,
+}));
+
+import { TrackedClan } from "../src/commands/TrackedClan";
+
+type InteractionInput = {
+  subcommand: string;
+  strings?: Record<string, string | null | undefined>;
+  guildId?: string | null;
+};
+
+/** Purpose: build a focused tracked-clan chat interaction mock for subcommand tests. */
+function createInteraction(input: InteractionInput) {
+  const strings = input.strings ?? {};
+  return {
+    id: "tracked-clan-itx-1",
+    commandName: "tracked-clan",
+    deferred: true,
+    replied: false,
+    guildId: input.guildId ?? "guild-1",
+    channelId: "channel-1",
+    user: { id: "user-1" },
+    options: {
+      getSubcommand: vi.fn().mockReturnValue(input.subcommand),
+      getString: vi.fn((name: string) => strings[name] ?? null),
+      getChannel: vi.fn().mockReturnValue(null),
+      getRole: vi.fn().mockReturnValue(null),
+    },
+    deferReply: vi.fn().mockResolvedValue(undefined),
+    editReply: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+/** Purpose: extract command reply content from one tracked-clan interaction mock. */
+function getReplyContent(interaction: any): string {
+  const payload = interaction.editReply.mock.calls[0]?.[0] as any;
+  return String(payload?.content ?? "");
+}
+
+describe("/tracked-clan command behavior", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-26T00:00:00.000Z"));
+
+    prismaMock.trackedClan.findMany.mockResolvedValue([]);
+    prismaMock.trackedClan.findUnique.mockResolvedValue(null);
+    prismaMock.trackedClan.deleteMany.mockResolvedValue({ count: 0 });
+    prismaMock.cwlTrackedClan.findMany.mockResolvedValue([]);
+    prismaMock.cwlTrackedClan.createMany.mockResolvedValue({ count: 0 });
+    prismaMock.cwlTrackedClan.findFirst.mockResolvedValue(null);
+    prismaMock.cwlTrackedClan.deleteMany.mockResolvedValue({ count: 0 });
+    prismaMock.cwlPlayerClanSeason.findMany.mockResolvedValue([]);
+    prismaMock.cwlPlayerClanSeason.deleteMany.mockResolvedValue({ count: 0 });
+    prismaMock.currentWar.deleteMany.mockResolvedValue({ count: 0 });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("adds CWL tags with partial success and reports added/existing/invalid/duplicates", async () => {
+    prismaMock.cwlTrackedClan.findMany
+      .mockResolvedValueOnce([{ tag: "#QGRJ2222" }])
+      .mockResolvedValueOnce([{ tag: "#PYLQ0289" }, { tag: "#QGRJ2222" }]);
+    const interaction = createInteraction({
+      subcommand: "cwl-tags",
+      strings: {
+        "cwl-tags": "[#PYLQ0289,QGRJ2222,BADTAG,#PYLQ0289]",
+      },
+    });
+    const cocService = {
+      getClan: vi.fn().mockResolvedValue({ name: "CWL Alpha" }),
+    };
+
+    await TrackedClan.run({} as any, interaction as any, cocService as any);
+
+    expect(prismaMock.cwlTrackedClan.createMany).toHaveBeenCalledWith({
+      data: [
+        {
+          season: "2026-03",
+          tag: "#PYLQ0289",
+          name: "CWL Alpha",
+        },
+      ],
+      skipDuplicates: true,
+    });
+    const content = getReplyContent(interaction);
+    expect(content).toContain("Updated CWL tracked clans for season 2026-03.");
+    expect(content).toContain("added: #PYLQ0289");
+    expect(content).toContain("already existed: #QGRJ2222");
+    expect(content).toContain("invalid: BADTAG");
+    expect(content).toContain("duplicates in request: #PYLQ0289");
+  });
+
+  it("keeps default /tracked-clan list behavior on FWA registry when type is omitted", async () => {
+    const interaction = createInteraction({
+      subcommand: "list",
+      strings: {},
+    });
+
+    await TrackedClan.run({} as any, interaction as any, {} as any);
+
+    expect(prismaMock.trackedClan.findMany).toHaveBeenCalledTimes(1);
+    expect(prismaMock.cwlTrackedClan.findMany).not.toHaveBeenCalled();
+    expect(getReplyContent(interaction)).toContain("No tracked clans in the database.");
+  });
+
+  it("returns clear empty state for /tracked-clan list type:CWL", async () => {
+    const interaction = createInteraction({
+      subcommand: "list",
+      strings: { type: "CWL" },
+    });
+
+    await TrackedClan.run({} as any, interaction as any, {} as any);
+
+    expect(prismaMock.cwlTrackedClan.findMany).toHaveBeenCalledWith({
+      where: { season: "2026-03" },
+      orderBy: [{ createdAt: "asc" }, { tag: "asc" }],
+      select: {
+        season: true,
+        tag: true,
+        name: true,
+        createdAt: true,
+      },
+    });
+    expect(getReplyContent(interaction)).toContain("No CWL tracked clans for season 2026-03.");
+  });
+
+  it("blocks ambiguous remove when tag exists in both FWA and CWL registries", async () => {
+    prismaMock.trackedClan.findUnique.mockResolvedValue({ tag: "#PYLQ0289" });
+    prismaMock.cwlTrackedClan.findFirst.mockResolvedValue({ id: 99 });
+    const interaction = createInteraction({
+      subcommand: "remove",
+      strings: { tag: "PYLQ0289" },
+    });
+
+    await TrackedClan.run({} as any, interaction as any, {} as any);
+
+    expect(getReplyContent(interaction)).toContain("Ambiguous remove for #PYLQ0289");
+    expect(prismaMock.trackedClan.deleteMany).not.toHaveBeenCalled();
+    expect(prismaMock.cwlTrackedClan.deleteMany).not.toHaveBeenCalled();
+  });
+
+  it("removes from CWL registry when explicit type:CWL is provided", async () => {
+    prismaMock.cwlTrackedClan.deleteMany.mockResolvedValue({ count: 1 });
+    prismaMock.cwlPlayerClanSeason.deleteMany.mockResolvedValue({ count: 2 });
+    const interaction = createInteraction({
+      subcommand: "remove",
+      strings: { tag: "#PYLQ0289", type: "CWL" },
+    });
+
+    await TrackedClan.run({} as any, interaction as any, {} as any);
+
+    expect(prismaMock.cwlTrackedClan.deleteMany).toHaveBeenCalledWith({
+      where: { season: "2026-03", tag: "#PYLQ0289" },
+    });
+    expect(prismaMock.currentWar.deleteMany).not.toHaveBeenCalled();
+    expect(getReplyContent(interaction)).toContain(
+      "Removed tracked clan #PYLQ0289 from CWL registry for season 2026-03.",
+    );
+  });
+
+  it("removes from FWA registry and clears current-war rows when type:FWA is provided", async () => {
+    prismaMock.trackedClan.deleteMany.mockResolvedValue({ count: 1 });
+    const interaction = createInteraction({
+      subcommand: "remove",
+      strings: { tag: "PYLQ0289", type: "FWA" },
+      guildId: "guild-99",
+    });
+
+    await TrackedClan.run({} as any, interaction as any, {} as any);
+
+    expect(prismaMock.trackedClan.deleteMany).toHaveBeenCalledWith({
+      where: { tag: "#PYLQ0289" },
+    });
+    expect(prismaMock.currentWar.deleteMany).toHaveBeenCalledWith({
+      where: {
+        guildId: "guild-99",
+        clanTag: "#PYLQ0289",
+      },
+    });
+    expect(getReplyContent(interaction)).toContain(
+      "Removed tracked clan #PYLQ0289 from FWA registry.",
+    );
+  });
+});

--- a/tests/trackedClan.commandShape.test.ts
+++ b/tests/trackedClan.commandShape.test.ts
@@ -1,0 +1,46 @@
+import { ApplicationCommandOptionType } from "discord.js";
+import { describe, expect, it } from "vitest";
+import { TrackedClan } from "../src/commands/TrackedClan";
+
+describe("/tracked-clan command shape", () => {
+  it("registers CWL and type-aware tracked-clan options without changing existing subcommands", () => {
+    const configure = TrackedClan.options?.find(
+      (option) =>
+        option.type === ApplicationCommandOptionType.Subcommand &&
+        option.name === "configure",
+    );
+    const remove = TrackedClan.options?.find(
+      (option) =>
+        option.type === ApplicationCommandOptionType.Subcommand &&
+        option.name === "remove",
+    );
+    const list = TrackedClan.options?.find(
+      (option) =>
+        option.type === ApplicationCommandOptionType.Subcommand &&
+        option.name === "list",
+    );
+    const cwlTags = TrackedClan.options?.find(
+      (option) =>
+        option.type === ApplicationCommandOptionType.Subcommand &&
+        option.name === "cwl-tags",
+    );
+
+    expect(configure).toBeTruthy();
+    expect(remove).toBeTruthy();
+    expect(list).toBeTruthy();
+    expect(cwlTags).toBeTruthy();
+
+    expect(remove?.options?.find((o: any) => o.name === "type")?.type).toBe(
+      ApplicationCommandOptionType.String,
+    );
+    expect(remove?.options?.find((o: any) => o.name === "type")?.required).toBe(false);
+    expect(list?.options?.find((o: any) => o.name === "type")?.type).toBe(
+      ApplicationCommandOptionType.String,
+    );
+    expect(list?.options?.find((o: any) => o.name === "type")?.required).toBe(false);
+    expect(cwlTags?.options?.find((o: any) => o.name === "cwl-tags")?.type).toBe(
+      ApplicationCommandOptionType.String,
+    );
+    expect(cwlTags?.options?.find((o: any) => o.name === "cwl-tags")?.required).toBe(true);
+  });
+});


### PR DESCRIPTION
- add seasonal CWL tracked clan and player mapping persistence plus /tracked-clan cwl-tags and type-aware list/remove flows
- resolve /todo CWL context from seasonal CWL registry mapping and update docs/permissions/tests