### PR TITLE
fix(recruitment): harden edit setup and repair guild-scoped indexes

### DIFF
--- a/prisma/migrations/20260326130000_repair_recruitment_scoped_indexes/migration.sql
+++ b/prisma/migrations/20260326130000_repair_recruitment_scoped_indexes/migration.sql
@@ -1,0 +1,8 @@
+DROP INDEX IF EXISTS "RecruitmentTemplate_clanTag_platform_key";
+DROP INDEX IF EXISTS "RecruitmentCooldown_userId_clanTag_platform_key";
+
+CREATE UNIQUE INDEX IF NOT EXISTS "RecruitmentTemplate_guildId_clanTag_platform_key"
+ON "RecruitmentTemplate" ("guildId", "clanTag", "platform");
+
+CREATE UNIQUE INDEX IF NOT EXISTS "RecruitmentCooldown_guildId_userId_clanTag_platform_key"
+ON "RecruitmentCooldown" ("guildId", "userId", "clanTag", "platform");

--- a/src/commands/Recruitment.ts
+++ b/src/commands/Recruitment.ts
@@ -313,79 +313,92 @@ async function handleEditSubcommand(
     return;
   }
 
-  const tracked = await findTrackedClan(clanTag);
-  if (!tracked) {
-    await interaction.reply({
-      ephemeral: true,
-      content: "Clan is not tracked. Add it first with `/tracked-clan configure`.",
-    });
-    return;
-  }
+  try {
+    const tracked = await findTrackedClan(clanTag);
+    if (!tracked) {
+      await interaction.reply({
+        ephemeral: true,
+        content: "Clan is not tracked. Add it first with `/tracked-clan configure`.",
+      });
+      return;
+    }
 
-  const existing = await getRecruitmentTemplate(interaction.guildId, clanTag, platform);
-  const modal = new ModalBuilder()
-    .setCustomId(buildModalCustomId(interaction.user.id, clanTag, platform))
-    .setTitle(`Edit ${formatPlatform(platform)} ${formatClanTag(clanTag)}`);
+    const existing = await getRecruitmentTemplate(interaction.guildId, clanTag, platform);
+    const modal = new ModalBuilder()
+      .setCustomId(buildModalCustomId(interaction.user.id, clanTag, platform))
+      .setTitle(`Edit ${formatPlatform(platform)} ${formatClanTag(clanTag)}`);
 
-  const bodyInput = new TextInputBuilder()
-    .setCustomId(BODY_INPUT_ID)
-    .setLabel(platform === "reddit" ? "Message body (markdown supported)" : "Recruitment body")
-    .setStyle(TextInputStyle.Paragraph)
-    .setRequired(true)
-    .setMaxLength(1024)
-    .setValue(existing?.body ?? "");
-
-  const imageUrlsInput = new TextInputBuilder()
-    .setCustomId(IMAGE_URLS_INPUT_ID)
-    .setLabel("Default image URLs (comma separated)")
-    .setStyle(TextInputStyle.Paragraph)
-    .setRequired(false)
-    .setMaxLength(1024)
-    .setValue(existing ? toImageUrlsCsv(existing.imageUrls) : "");
-
-  const rows: Array<ActionRowBuilder<TextInputBuilder>> = [];
-  if (platform === "discord") {
-    const clanTagInput = new TextInputBuilder()
-      .setCustomId(DISCORD_CLAN_TAG_INPUT_ID)
-      .setLabel("Clan tag")
-      .setStyle(TextInputStyle.Short)
+    const bodyInput = new TextInputBuilder()
+      .setCustomId(BODY_INPUT_ID)
+      .setLabel(platform === "reddit" ? "Message body (markdown supported)" : "Recruitment body")
+      .setStyle(TextInputStyle.Paragraph)
       .setRequired(true)
-      .setMaxLength(32)
-      .setValue(formatClanTag(clanTag));
-    rows.push(new ActionRowBuilder<TextInputBuilder>().addComponents(clanTagInput));
+      .setMaxLength(1024)
+      .setValue(existing?.body ?? "");
+
+    const imageUrlsInput = new TextInputBuilder()
+      .setCustomId(IMAGE_URLS_INPUT_ID)
+      .setLabel("Default image URLs (comma separated)")
+      .setStyle(TextInputStyle.Paragraph)
+      .setRequired(false)
+      .setMaxLength(1024)
+      .setValue(existing ? toImageUrlsCsv(existing.imageUrls) : "");
+
+    const rows: Array<ActionRowBuilder<TextInputBuilder>> = [];
+    if (platform === "discord") {
+      const clanTagInput = new TextInputBuilder()
+        .setCustomId(DISCORD_CLAN_TAG_INPUT_ID)
+        .setLabel("Clan tag")
+        .setStyle(TextInputStyle.Short)
+        .setRequired(true)
+        .setMaxLength(32)
+        .setValue(formatClanTag(clanTag));
+      rows.push(new ActionRowBuilder<TextInputBuilder>().addComponents(clanTagInput));
+    }
+
+    if (platform === "reddit") {
+      const clan = await cocService.getClan(clanTag).catch(() => null);
+      const requiredTh = Number(clan?.requiredTownhallLevel);
+      const clanLevel = Number(clan?.clanLevel);
+      const requiredThText =
+        Number.isFinite(requiredTh) && requiredTh > 0
+          ? `TH${requiredTh}`
+          : "Required TH/Level";
+      const clanLevelText =
+        Number.isFinite(clanLevel) && clanLevel > 0 ? `Level ${clanLevel}` : "Clan Level";
+      const clanNameText = tracked.name?.trim() || clan?.name?.trim() || "Clan Name";
+      const defaultSubject =
+        existing?.subject?.trim() ||
+        `[Recruiting] ${clanNameText} | ${formatClanTag(
+          clanTag
+        )} | ${requiredThText} | ${clanLevelText} | FWA | Discord`;
+      const subjectInput = new TextInputBuilder()
+        .setCustomId(REDDIT_SUBJECT_INPUT_ID)
+        .setLabel("Reddit post subject")
+        .setStyle(TextInputStyle.Short)
+        .setRequired(true)
+        .setMaxLength(200)
+        .setValue(defaultSubject);
+      rows.push(new ActionRowBuilder<TextInputBuilder>().addComponents(subjectInput));
+    }
+
+    rows.push(new ActionRowBuilder<TextInputBuilder>().addComponents(bodyInput));
+    rows.push(new ActionRowBuilder<TextInputBuilder>().addComponents(imageUrlsInput));
+    modal.addComponents(...rows);
+
+    await interaction.showModal(modal);
+  } catch (err) {
+    console.error(
+      `[recruitment] edit_setup_failed guildId=${interaction.guildId} clanTag=${clanTag} platform=${platform} userId=${interaction.user.id} error=${formatError(err)}`
+    );
+    const content =
+      "Failed to open recruitment editor. Check recruitment database migration/state and try again.";
+    if (interaction.deferred || interaction.replied) {
+      await interaction.editReply(content);
+      return;
+    }
+    await interaction.reply({ ephemeral: true, content });
   }
-
-  if (platform === "reddit") {
-    const clan = await cocService.getClan(clanTag).catch(() => null);
-    const requiredTh = Number(clan?.requiredTownhallLevel);
-    const clanLevel = Number(clan?.clanLevel);
-    const requiredThText =
-      Number.isFinite(requiredTh) && requiredTh > 0
-        ? `TH${requiredTh}`
-        : "Required TH/Level";
-    const clanLevelText =
-      Number.isFinite(clanLevel) && clanLevel > 0 ? `Level ${clanLevel}` : "Clan Level";
-    const clanNameText = tracked.name?.trim() || clan?.name?.trim() || "Clan Name";
-    const defaultSubject =
-      existing?.subject?.trim() ||
-      `[Recruiting] ${clanNameText} | ${formatClanTag(
-        clanTag
-      )} | ${requiredThText} | ${clanLevelText} | FWA | Discord`;
-    const subjectInput = new TextInputBuilder()
-      .setCustomId(REDDIT_SUBJECT_INPUT_ID)
-      .setLabel("Reddit post subject")
-      .setStyle(TextInputStyle.Short)
-      .setRequired(true)
-      .setMaxLength(200)
-      .setValue(defaultSubject);
-    rows.push(new ActionRowBuilder<TextInputBuilder>().addComponents(subjectInput));
-  }
-
-  rows.push(new ActionRowBuilder<TextInputBuilder>().addComponents(bodyInput));
-  rows.push(new ActionRowBuilder<TextInputBuilder>().addComponents(imageUrlsInput));
-  modal.addComponents(...rows);
-
-  await interaction.showModal(modal);
 }
 
 async function handleCountdownStartSubcommand(

--- a/tests/recruitment.command.test.ts
+++ b/tests/recruitment.command.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const prismaMock = vi.hoisted(() => ({
+  trackedClan: {
+    findFirst: vi.fn(),
+  },
+}));
+
+const recruitmentServiceMock = vi.hoisted(() => ({
+  getRecruitmentTemplate: vi.fn(),
+  upsertRecruitmentTemplate: vi.fn(),
+}));
+
+vi.mock("../src/prisma", () => ({
+  prisma: prismaMock,
+}));
+
+vi.mock("../src/services/RecruitmentService", async () => {
+  const actual = await vi.importActual("../src/services/RecruitmentService");
+  return {
+    ...actual,
+    getRecruitmentTemplate: recruitmentServiceMock.getRecruitmentTemplate,
+    upsertRecruitmentTemplate: recruitmentServiceMock.upsertRecruitmentTemplate,
+  };
+});
+
+import { Recruitment, handleRecruitmentModalSubmit } from "../src/commands/Recruitment";
+
+function createEditInteraction(input?: { clan?: string; platform?: string }) {
+  return {
+    guildId: "guild-1",
+    user: { id: "user-1" },
+    deferred: false,
+    replied: false,
+    options: {
+      getSubcommandGroup: vi.fn().mockReturnValue(null),
+      getSubcommand: vi.fn().mockReturnValue("edit"),
+      getString: vi.fn((name: string) => {
+        if (name === "clan") return input?.clan ?? "PQL0289";
+        if (name === "platform") return input?.platform ?? "band";
+        return null;
+      }),
+    },
+    reply: vi.fn().mockResolvedValue(undefined),
+    editReply: vi.fn().mockResolvedValue(undefined),
+    showModal: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function createBandModalSubmitInteraction() {
+  return {
+    guildId: "guild-1",
+    user: { id: "user-1" },
+    customId: "recruitment-edit:user-1:PQL0289:band",
+    deferred: false,
+    replied: false,
+    reply: vi.fn().mockResolvedValue(undefined),
+    deferReply: vi.fn().mockResolvedValue(undefined),
+    editReply: vi.fn().mockResolvedValue(undefined),
+    fields: {
+      getTextInputValue: vi.fn((name: string) => {
+        if (name === "body") return "Band body";
+        if (name === "image-urls") return "https://img1.example/a.png, https://img2.example/b.png";
+        return "";
+      }),
+    },
+  };
+}
+
+describe("/recruitment command", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prismaMock.trackedClan.findFirst.mockResolvedValue({
+      tag: "#PQL0289",
+      name: "Clan One",
+    });
+    recruitmentServiceMock.getRecruitmentTemplate.mockResolvedValue(null);
+    recruitmentServiceMock.upsertRecruitmentTemplate.mockResolvedValue(undefined);
+  });
+
+  it("opens band edit modal when no guild-scoped template exists yet", async () => {
+    const interaction = createEditInteraction({ platform: "band", clan: "pql0289" });
+
+    await Recruitment.run({} as any, interaction as any, {} as any);
+
+    expect(recruitmentServiceMock.getRecruitmentTemplate).toHaveBeenCalledWith(
+      "guild-1",
+      "PQL0289",
+      "band",
+    );
+    expect(interaction.showModal).toHaveBeenCalledTimes(1);
+    const modal = interaction.showModal.mock.calls[0]?.[0];
+    const payload = modal?.toJSON() as any;
+    const inputIds = (payload?.components ?? []).map(
+      (row: { components?: Array<{ custom_id?: string }> }) => row.components?.[0]?.custom_id,
+    );
+    expect(inputIds).toEqual(["body", "image-urls"]);
+    expect(inputIds).not.toContain("discord-clan-tag");
+    expect(inputIds).not.toContain("reddit-subject");
+    expect(interaction.reply).not.toHaveBeenCalled();
+  });
+
+  it("returns targeted recruitment setup error instead of generic failure when edit setup throws", async () => {
+    recruitmentServiceMock.getRecruitmentTemplate.mockRejectedValue(
+      new Error("duplicate key value violates unique constraint"),
+    );
+    const interaction = createEditInteraction({ platform: "band", clan: "PQL0289" });
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    await Recruitment.run({} as any, interaction as any, {} as any);
+
+    expect(interaction.reply).toHaveBeenCalledWith({
+      ephemeral: true,
+      content:
+        "Failed to open recruitment editor. Check recruitment database migration/state and try again.",
+    });
+    expect(interaction.showModal).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "[recruitment] edit_setup_failed guildId=guild-1 clanTag=PQL0289 platform=band userId=user-1",
+      ),
+    );
+  });
+
+  it("submitting a band recruitment modal creates a guild-scoped template with no subject", async () => {
+    const interaction = createBandModalSubmitInteraction();
+
+    await handleRecruitmentModalSubmit(interaction as any);
+
+    expect(recruitmentServiceMock.upsertRecruitmentTemplate).toHaveBeenCalledWith({
+      guildId: "guild-1",
+      clanTag: "PQL0289",
+      platform: "band",
+      subject: null,
+      body: "Band body",
+      imageUrls: ["https://img1.example/a.png", "https://img2.example/b.png"],
+    });
+    expect(interaction.fields.getTextInputValue).not.toHaveBeenCalledWith("reddit-subject");
+    expect(interaction.fields.getTextInputValue).not.toHaveBeenCalledWith("discord-clan-tag");
+    expect(interaction.editReply).toHaveBeenCalledWith(
+      "Saved band recruitment template for Clan One (#PQL0289).",
+    );
+  });
+});

--- a/tests/recruitment.service.persistence.test.ts
+++ b/tests/recruitment.service.persistence.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from "vitest";
+
+const prismaMock = vi.hoisted(() => ({
+  $executeRaw: vi.fn(),
+}));
+
+vi.mock("@prisma/client", () => ({
+  Prisma: {
+    sql: (strings: TemplateStringsArray, ...values: unknown[]) => ({
+      strings: [...strings],
+      values,
+    }),
+  },
+}));
+
+vi.mock("../src/prisma", () => ({
+  prisma: prismaMock,
+}));
+
+import { upsertRecruitmentTemplate } from "../src/services/RecruitmentService";
+
+describe("RecruitmentService persistence", () => {
+  it("uses guild-scoped conflict identity when upserting templates", async () => {
+    prismaMock.$executeRaw.mockResolvedValue(1);
+
+    await upsertRecruitmentTemplate({
+      guildId: "guild-1",
+      clanTag: "#pql0289",
+      platform: "band",
+      body: "Recruitment body",
+      imageUrls: [],
+    });
+
+    expect(prismaMock.$executeRaw).toHaveBeenCalledTimes(1);
+    const query = prismaMock.$executeRaw.mock.calls[0]?.[0] as {
+      strings: string[];
+      values: unknown[];
+    };
+    const sqlText = query.strings.join(" ");
+    expect(sqlText).toContain('INSERT INTO "RecruitmentTemplate"');
+    expect(sqlText).toContain('ON CONFLICT ("guildId", "clanTag", "platform")');
+    expect(query.values).toContain("guild-1");
+    expect(query.values).toContain("PQL0289");
+    expect(query.values).toContain("band");
+  });
+});


### PR DESCRIPTION
- add safe SQL migration to drop stale global recruitment unique indexes and reassert guild-scoped uniques
- catch recruitment edit setup failures with contextual logs and explicit ephemeral error response
- add regression tests for band edit modal open, band modal submit creation, and setup-failure messaging