### PR TITLE
feat(todo): add targeted refresh button for snapshot-backed todo views

### DIFF
--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -287,6 +287,7 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
       "Reads precomputed todo snapshots (background-refreshed) for fast command-time rendering.",
       "Always builds WAR, CWL, RAIDS, and GAMES pages in one response.",
       "`type` controls only the initial page shown; use page buttons to switch categories without rerunning.",
+      "Use the `Refresh` button to trigger a targeted snapshot rebuild for the displayed todo user and update the same message in place.",
       "WAR/CWL pages group players by shared active event context and include section headers with phase timing.",
       "RAIDS/GAMES pages use one shared top timer line and then list per-player progress rows.",
       "GAMES page points come from stored activity-signal totals, with cycle baseline/total observability persisted on TodoPlayerSnapshot for DB-first reads.",

--- a/src/commands/Todo.ts
+++ b/src/commands/Todo.ts
@@ -9,6 +9,8 @@ import {
   EmbedBuilder,
 } from "discord.js";
 import { Command } from "../Command";
+import { formatError } from "../helper/formatError";
+import { listPlayerLinksForDiscordUser } from "../services/PlayerLinkService";
 import { CoCService } from "../services/CoCService";
 import {
   buildTodoPagesForUser,
@@ -16,9 +18,28 @@ import {
   TODO_TYPES,
   type TodoType,
 } from "../services/TodoService";
+import { todoSnapshotService } from "../services/TodoSnapshotService";
 
 const TODO_PAGE_BUTTON_PREFIX = "todo-page";
+const TODO_REFRESH_BUTTON_PREFIX = "todo-refresh";
 const TODO_EMBED_COLOR = 0x5865f2;
+const TODO_GUILD_SCOPE_DM = "dm";
+const TODO_REFRESH_ERROR_MESSAGE =
+  "Failed to refresh todo data. Please try again.";
+const todoRefreshInFlightByMessageId = new Set<string>();
+
+type TodoButtonScope = {
+  guildScopeId: string;
+  requesterUserId: string;
+  targetUserId: string;
+};
+
+type ParsedTodoButtonScope = {
+  guildScopeId: string | null;
+  requesterUserId: string;
+  targetUserId: string;
+  type: TodoType;
+};
 
 type TodoRenderResult =
   | {
@@ -30,12 +51,48 @@ type TodoRenderResult =
     }
   | { ok: false; message: string };
 
+/** Purpose: build one stable guild scope token from guild-id or DM context. */
+function resolveTodoGuildScopeId(guildId: string | null | undefined): string {
+  const normalized = String(guildId ?? TODO_GUILD_SCOPE_DM).trim();
+  return normalized.length > 0 ? normalized : TODO_GUILD_SCOPE_DM;
+}
+
+/** Purpose: validate that one parsed guild scope still matches the interaction guild. */
+function isTodoGuildScopeMismatch(
+  parsedGuildScopeId: string | null,
+  interactionGuildId: string | null,
+): boolean {
+  if (!parsedGuildScopeId) return false;
+  return parsedGuildScopeId !== resolveTodoGuildScopeId(interactionGuildId);
+}
+
 /** Purpose: build one stable todo-page button custom-id. */
 export function buildTodoPageButtonCustomId(
   userId: string,
   type: TodoType,
+): string;
+export function buildTodoPageButtonCustomId(
+  input: TodoButtonScope & { type: TodoType },
+): string;
+export function buildTodoPageButtonCustomId(
+  inputOrUserId: (TodoButtonScope & { type: TodoType }) | string,
+  maybeType?: TodoType,
 ): string {
-  return `${TODO_PAGE_BUTTON_PREFIX}:${userId}:${type}`;
+  if (typeof inputOrUserId === "string") {
+    const userId = inputOrUserId;
+    const type = normalizeTodoType(maybeType);
+    return `${TODO_PAGE_BUTTON_PREFIX}:${userId}:${type}`;
+  }
+  const guildScopeId = resolveTodoGuildScopeId(inputOrUserId.guildScopeId);
+  return `${TODO_PAGE_BUTTON_PREFIX}:${guildScopeId}:${inputOrUserId.requesterUserId}:${inputOrUserId.targetUserId}:${normalizeTodoType(inputOrUserId.type)}`;
+}
+
+/** Purpose: build one stable todo-refresh button custom-id for targeted snapshot rebuild. */
+export function buildTodoRefreshButtonCustomId(
+  input: TodoButtonScope & { type: TodoType },
+): string {
+  const guildScopeId = resolveTodoGuildScopeId(input.guildScopeId);
+  return `${TODO_REFRESH_BUTTON_PREFIX}:${guildScopeId}:${input.requesterUserId}:${input.targetUserId}:${normalizeTodoType(input.type)}`;
 }
 
 /** Purpose: guard whether a button custom-id belongs to `/todo` paging. */
@@ -43,29 +100,94 @@ export function isTodoPageButtonCustomId(customId: string): boolean {
   return String(customId ?? "").startsWith(`${TODO_PAGE_BUTTON_PREFIX}:`);
 }
 
-/** Purpose: parse todo-page button custom-id with user scope and page type. */
+/** Purpose: guard whether a button custom-id belongs to `/todo` refresh. */
+export function isTodoRefreshButtonCustomId(customId: string): boolean {
+  return String(customId ?? "").startsWith(`${TODO_REFRESH_BUTTON_PREFIX}:`);
+}
+
+/** Purpose: parse todo-page button custom-id with requester/target scope and page type. */
 function parseTodoPageButtonCustomId(
   customId: string,
-): { userId: string; type: TodoType } | null {
+): ParsedTodoButtonScope | null {
   const parts = String(customId ?? "").split(":");
-  if (parts.length !== 3 || parts[0] !== TODO_PAGE_BUTTON_PREFIX) return null;
-  const userId = parts[1]?.trim() ?? "";
-  if (!userId) return null;
-  return { userId, type: normalizeTodoType(parts[2]) };
+  if (parts[0] !== TODO_PAGE_BUTTON_PREFIX) return null;
+
+  if (parts.length === 3) {
+    const requesterUserId = parts[1]?.trim() ?? "";
+    if (!requesterUserId) return null;
+    return {
+      guildScopeId: null,
+      requesterUserId,
+      targetUserId: requesterUserId,
+      type: normalizeTodoType(parts[2]),
+    };
+  }
+
+  if (parts.length !== 5) return null;
+  const guildScopeId = resolveTodoGuildScopeId(parts[1]);
+  const requesterUserId = parts[2]?.trim() ?? "";
+  const targetUserId = parts[3]?.trim() ?? "";
+  if (!requesterUserId || !targetUserId) return null;
+  return {
+    guildScopeId,
+    requesterUserId,
+    targetUserId,
+    type: normalizeTodoType(parts[4]),
+  };
+}
+
+/** Purpose: parse todo-refresh button custom-id with requester/target scope and selected page type. */
+function parseTodoRefreshButtonCustomId(
+  customId: string,
+): ParsedTodoButtonScope | null {
+  const parts = String(customId ?? "").split(":");
+  if (parts.length !== 5 || parts[0] !== TODO_REFRESH_BUTTON_PREFIX) return null;
+  const guildScopeId = resolveTodoGuildScopeId(parts[1]);
+  const requesterUserId = parts[2]?.trim() ?? "";
+  const targetUserId = parts[3]?.trim() ?? "";
+  if (!requesterUserId || !targetUserId) return null;
+  return {
+    guildScopeId,
+    requesterUserId,
+    targetUserId,
+    type: normalizeTodoType(parts[4]),
+  };
 }
 
 /** Purpose: build todo page-switch buttons with active page highlight. */
-function buildTodoPageButtons(
-  commandUserId: string,
+function buildTodoComponentRows(
+  scope: TodoButtonScope,
   activeType: TodoType,
 ): ActionRowBuilder<ButtonBuilder>[] {
-  const buttons = TODO_TYPES.map((type) =>
+  const pagingButtons = TODO_TYPES.map((type) =>
     new ButtonBuilder()
-      .setCustomId(buildTodoPageButtonCustomId(commandUserId, type))
+      .setCustomId(
+        buildTodoPageButtonCustomId({
+          guildScopeId: scope.guildScopeId,
+          requesterUserId: scope.requesterUserId,
+          targetUserId: scope.targetUserId,
+          type,
+        }),
+      )
       .setLabel(type)
       .setStyle(type === activeType ? ButtonStyle.Primary : ButtonStyle.Secondary),
   );
-  return [new ActionRowBuilder<ButtonBuilder>().addComponents(buttons)];
+  const refreshButton = new ButtonBuilder()
+    .setCustomId(
+      buildTodoRefreshButtonCustomId({
+        guildScopeId: scope.guildScopeId,
+        requesterUserId: scope.requesterUserId,
+        targetUserId: scope.targetUserId,
+        type: activeType,
+      }),
+    )
+    .setLabel("Refresh")
+    .setStyle(ButtonStyle.Secondary);
+
+  return [
+    new ActionRowBuilder<ButtonBuilder>().addComponents(pagingButtons),
+    new ActionRowBuilder<ButtonBuilder>().addComponents(refreshButton),
+  ];
 }
 
 /** Purpose: build one todo embed for the selected page type. */
@@ -87,13 +209,12 @@ function buildTodoEmbed(input: {
 
 /** Purpose: build a rendered todo response payload for one selected page type. */
 async function buildTodoRenderResult(input: {
-  interaction: ChatInputCommandInteraction | ButtonInteraction;
   cocService: CoCService;
   selectedType: TodoType;
-  commandUserId: string;
+  scope: TodoButtonScope;
 }): Promise<TodoRenderResult> {
   const pages = await buildTodoPagesForUser({
-    discordUserId: input.commandUserId,
+    discordUserId: input.scope.targetUserId,
     cocService: input.cocService,
   });
   if (pages.linkedPlayerCount <= 0) {
@@ -115,7 +236,7 @@ async function buildTodoRenderResult(input: {
           pageText: pages.pages[normalizedType],
         }),
       ],
-      components: buildTodoPageButtons(input.commandUserId, normalizedType),
+      components: buildTodoComponentRows(input.scope, normalizedType),
     },
   };
 }
@@ -128,7 +249,15 @@ export async function handleTodoPageButtonInteraction(
   const parsed = parseTodoPageButtonCustomId(interaction.customId);
   if (!parsed) return;
 
-  if (interaction.user.id !== parsed.userId) {
+  if (isTodoGuildScopeMismatch(parsed.guildScopeId, interaction.guildId)) {
+    await interaction.reply({
+      ephemeral: true,
+      content: "This todo view is no longer valid for this guild.",
+    });
+    return;
+  }
+
+  if (interaction.user.id !== parsed.requesterUserId) {
     await interaction.reply({
       ephemeral: true,
       content: "Only the command requester can use this button.",
@@ -137,10 +266,13 @@ export async function handleTodoPageButtonInteraction(
   }
 
   const result = await buildTodoRenderResult({
-    interaction,
     cocService,
     selectedType: parsed.type,
-    commandUserId: parsed.userId,
+    scope: {
+      guildScopeId: parsed.guildScopeId || resolveTodoGuildScopeId(interaction.guildId),
+      requesterUserId: parsed.requesterUserId,
+      targetUserId: parsed.targetUserId,
+    },
   });
   if (!result.ok) {
     await interaction.update({
@@ -155,6 +287,96 @@ export async function handleTodoPageButtonInteraction(
     content: null,
     ...result.payload,
   });
+}
+
+/** Purpose: handle `/todo` refresh button interactions with targeted scoped snapshot rebuild. */
+export async function handleTodoRefreshButtonInteraction(
+  interaction: ButtonInteraction,
+  cocService: CoCService,
+): Promise<void> {
+  const parsed = parseTodoRefreshButtonCustomId(interaction.customId);
+  if (!parsed) return;
+
+  if (isTodoGuildScopeMismatch(parsed.guildScopeId, interaction.guildId)) {
+    await interaction.reply({
+      ephemeral: true,
+      content: "This todo view is no longer valid for this guild.",
+    });
+    return;
+  }
+
+  if (interaction.user.id !== parsed.requesterUserId) {
+    await interaction.reply({
+      ephemeral: true,
+      content: "Only the command requester can use this button.",
+    });
+    return;
+  }
+
+  const messageId = String(interaction.message?.id ?? "");
+  if (messageId && todoRefreshInFlightByMessageId.has(messageId)) {
+    await interaction.reply({
+      ephemeral: true,
+      content: "A refresh is already in progress for this todo view.",
+    });
+    return;
+  }
+
+  if (messageId) {
+    todoRefreshInFlightByMessageId.add(messageId);
+  }
+
+  await interaction.deferUpdate();
+
+  try {
+    const links = await listPlayerLinksForDiscordUser({
+      discordUserId: parsed.targetUserId,
+    });
+    const linkedTags = [...new Set(links.map((row) => row.playerTag))];
+    if (linkedTags.length > 0) {
+      await todoSnapshotService.refreshSnapshotsForPlayerTags({
+        playerTags: linkedTags,
+        cocService,
+      });
+    }
+
+    const result = await buildTodoRenderResult({
+      cocService,
+      selectedType: parsed.type,
+      scope: {
+        guildScopeId: parsed.guildScopeId || resolveTodoGuildScopeId(interaction.guildId),
+        requesterUserId: parsed.requesterUserId,
+        targetUserId: parsed.targetUserId,
+      },
+    });
+    if (!result.ok) {
+      await interaction.editReply({
+        content: result.message,
+        embeds: [],
+        components: [],
+      });
+      return;
+    }
+
+    await interaction.editReply({
+      content: null,
+      ...result.payload,
+    });
+  } catch (err) {
+    console.error(
+      `[todo-refresh] requester=${parsed.requesterUserId} target=${parsed.targetUserId} guild=${parsed.guildScopeId} type=${parsed.type} error=${formatError(err)}`,
+    );
+    await interaction
+      .followUp({
+        ephemeral: true,
+        content: TODO_REFRESH_ERROR_MESSAGE,
+      })
+      .catch(() => undefined);
+  } finally {
+    if (messageId) {
+      todoRefreshInFlightByMessageId.delete(messageId);
+    }
+  }
 }
 
 export const Todo: Command = {
@@ -180,10 +402,13 @@ export const Todo: Command = {
       interaction.options.getString("type", true),
     );
     const result = await buildTodoRenderResult({
-      interaction,
       cocService,
       selectedType,
-      commandUserId: interaction.user.id,
+      scope: {
+        guildScopeId: resolveTodoGuildScopeId(interaction.guildId),
+        requesterUserId: interaction.user.id,
+        targetUserId: interaction.user.id,
+      },
     });
     if (!result.ok) {
       await interaction.editReply(result.message);

--- a/src/listeners/interactionCreate.ts
+++ b/src/listeners/interactionCreate.ts
@@ -90,7 +90,9 @@ import {
 } from "../commands/Link";
 import {
   handleTodoPageButtonInteraction,
+  handleTodoRefreshButtonInteraction,
   isTodoPageButtonCustomId,
+  isTodoRefreshButtonCustomId,
 } from "../commands/Todo";
 import { handleSayModalSubmit, isSayModalCustomId } from "../commands/Say";
 
@@ -320,6 +322,21 @@ const handleButtonInteraction = async (
         await interaction.reply({
           ephemeral: true,
           content: "Failed to update todo page.",
+        });
+      }
+    }
+    return;
+  }
+
+  if (isTodoRefreshButtonCustomId(interaction.customId)) {
+    try {
+      await handleTodoRefreshButtonInteraction(interaction, cocService);
+    } catch (err) {
+      console.error(`Todo refresh button failed: ${formatError(err)}`);
+      if (!interaction.replied && !interaction.deferred) {
+        await interaction.reply({
+          ephemeral: true,
+          content: "Failed to refresh todo data.",
         });
       }
     }

--- a/tests/todo.command.test.ts
+++ b/tests/todo.command.test.ts
@@ -29,6 +29,10 @@ const prismaMock = vi.hoisted(() => ({
   },
   cwlPlayerClanSeason: {
     findMany: vi.fn(),
+    upsert: vi.fn(),
+  },
+  botSetting: {
+    findMany: vi.fn(),
   },
   $transaction: vi.fn(async (arg: any) => {
     if (typeof arg === "function") {
@@ -51,11 +55,14 @@ vi.mock("../src/prisma", () => ({
 }));
 
 import {
+  buildTodoRefreshButtonCustomId,
   buildTodoPageButtonCustomId,
   handleTodoPageButtonInteraction,
+  handleTodoRefreshButtonInteraction,
   Todo,
 } from "../src/commands/Todo";
 import { resetTodoRenderCacheForTest } from "../src/services/TodoService";
+import { todoSnapshotService } from "../src/services/TodoSnapshotService";
 
 type TodoType = "WAR" | "CWL" | "RAIDS" | "GAMES";
 
@@ -73,11 +80,18 @@ function makeTodoInteraction(input: { type: TodoType; userId?: string }) {
 function makeTodoButtonInteraction(input: {
   customId: string;
   userId?: string;
+  messageId?: string;
+  guildId?: string | null;
 }) {
   return {
     customId: input.customId,
     user: { id: input.userId ?? "111111111111111111" },
+    guildId: input.guildId ?? "123456789012345678",
+    message: { id: input.messageId ?? "999999999999999999" },
     update: vi.fn().mockResolvedValue(undefined),
+    deferUpdate: vi.fn().mockResolvedValue(undefined),
+    editReply: vi.fn().mockResolvedValue(undefined),
+    followUp: vi.fn().mockResolvedValue(undefined),
     reply: vi.fn().mockResolvedValue(undefined),
     deferred: false,
     replied: false,
@@ -193,6 +207,8 @@ describe("/todo command", () => {
     prismaMock.trackedClan.findMany.mockReset();
     prismaMock.cwlTrackedClan.findMany.mockReset();
     prismaMock.cwlPlayerClanSeason.findMany.mockReset();
+    prismaMock.cwlPlayerClanSeason.upsert.mockReset();
+    prismaMock.botSetting.findMany.mockReset();
     prismaMock.$transaction.mockClear();
 
     prismaMock.todoPlayerSnapshot.aggregate.mockResolvedValue({
@@ -207,6 +223,8 @@ describe("/todo command", () => {
     prismaMock.trackedClan.findMany.mockResolvedValue([]);
     prismaMock.cwlTrackedClan.findMany.mockResolvedValue([]);
     prismaMock.cwlPlayerClanSeason.findMany.mockResolvedValue([]);
+    prismaMock.cwlPlayerClanSeason.upsert.mockResolvedValue(undefined);
+    prismaMock.botSetting.findMany.mockResolvedValue([]);
   });
 
   afterEach(() => {
@@ -261,6 +279,9 @@ describe("/todo command", () => {
       "CWL",
       "RAIDS",
       "GAMES",
+    ]);
+    expect(payload.components[1].components.map((b: any) => b.toJSON().label)).toEqual([
+      "Refresh",
     ]);
     expect(cocService.getPlayerRaw).not.toHaveBeenCalled();
     expect(cocService.getCurrentWar).not.toHaveBeenCalled();
@@ -712,5 +733,162 @@ describe("/todo pagination buttons", () => {
       content: "Only the command requester can use this button.",
     });
     expect(interaction.update).not.toHaveBeenCalled();
+  });
+});
+
+describe("/todo refresh button", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetTodoRenderCacheForTest();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-26T00:00:00.000Z"));
+
+    prismaMock.playerLink.findMany.mockReset();
+    prismaMock.todoPlayerSnapshot.aggregate.mockReset();
+    prismaMock.todoPlayerSnapshot.findMany.mockReset();
+
+    prismaMock.playerLink.findMany.mockImplementation(async (args: any) => {
+      const userId = String(args?.where?.discordUserId ?? "");
+      if (userId === "222222222222222222") {
+        return [
+          { playerTag: "#PYLQ0289", createdAt: new Date("2026-03-01T00:00:00.000Z") },
+          { playerTag: "#QGRJ2222", createdAt: new Date("2026-03-02T00:00:00.000Z") },
+        ];
+      }
+      return [
+        { playerTag: "#PYLQ0289", createdAt: new Date("2026-03-01T00:00:00.000Z") },
+        { playerTag: "#QGRJ2222", createdAt: new Date("2026-03-02T00:00:00.000Z") },
+      ];
+    });
+    prismaMock.todoPlayerSnapshot.aggregate.mockResolvedValue({
+      _count: { _all: 2 },
+      _max: { updatedAt: new Date("2026-03-26T00:00:00.000Z") },
+    });
+    prismaMock.todoPlayerSnapshot.findMany.mockResolvedValue([
+      makeSnapshotRow({
+        playerTag: "#PYLQ0289",
+        playerName: "Alpha",
+        warAttacksUsed: 1,
+        cwlAttacksUsed: 1,
+        raidAttacksUsed: 3,
+        gamesPoints: 1200,
+      }),
+      makeSnapshotRow({
+        playerTag: "#QGRJ2222",
+        playerName: "Bravo",
+        warAttacksUsed: 2,
+        cwlAttacksUsed: 0,
+        raidAttacksUsed: 0,
+        gamesPoints: 2000,
+      }),
+    ]);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("refreshes the target user snapshots and updates the existing message on the same page", async () => {
+    const refreshSpy = vi
+      .spyOn(todoSnapshotService, "refreshSnapshotsForPlayerTags")
+      .mockResolvedValue({ playerCount: 2, updatedCount: 2 });
+    const interaction = makeTodoButtonInteraction({
+      customId: buildTodoRefreshButtonCustomId({
+        guildScopeId: "123456789012345678",
+        requesterUserId: "111111111111111111",
+        targetUserId: "222222222222222222",
+        type: "GAMES",
+      }),
+      userId: "111111111111111111",
+      guildId: "123456789012345678",
+    });
+
+    await handleTodoRefreshButtonInteraction(interaction as any, makeCocServiceSpy() as any);
+
+    expect(interaction.deferUpdate).toHaveBeenCalledTimes(1);
+    expect(refreshSpy).toHaveBeenCalledWith({
+      playerTags: ["#PYLQ0289", "#QGRJ2222"],
+      cocService: expect.anything(),
+    });
+    expect(interaction.editReply).toHaveBeenCalledTimes(1);
+    const payload = interaction.editReply.mock.calls[0]?.[0] as any;
+    expect(payload.embeds[0].toJSON().title).toBe("Todo - GAMES");
+    expect(payload.components[1].components.map((b: any) => b.toJSON().label)).toEqual([
+      "Refresh",
+    ]);
+    expect(interaction.followUp).not.toHaveBeenCalled();
+  });
+
+  it("uses no-linked-tags behavior when the target user has no links", async () => {
+    const refreshSpy = vi
+      .spyOn(todoSnapshotService, "refreshSnapshotsForPlayerTags")
+      .mockResolvedValue({ playerCount: 0, updatedCount: 0 });
+    prismaMock.playerLink.findMany.mockResolvedValue([]);
+    const interaction = makeTodoButtonInteraction({
+      customId: buildTodoRefreshButtonCustomId({
+        guildScopeId: "123456789012345678",
+        requesterUserId: "111111111111111111",
+        targetUserId: "222222222222222222",
+        type: "WAR",
+      }),
+      userId: "111111111111111111",
+      guildId: "123456789012345678",
+    });
+
+    await handleTodoRefreshButtonInteraction(interaction as any, makeCocServiceSpy() as any);
+
+    expect(refreshSpy).not.toHaveBeenCalled();
+    expect(interaction.editReply).toHaveBeenCalledWith({
+      content:
+        "no_linked_tags: no linked player tags found for your Discord account. Use `/link create player-tag:<tag>` first.",
+      embeds: [],
+      components: [],
+    });
+  });
+
+  it("returns a specific ephemeral error when targeted refresh fails", async () => {
+    vi.spyOn(todoSnapshotService, "refreshSnapshotsForPlayerTags").mockRejectedValue(
+      new Error("refresh failed"),
+    );
+    const interaction = makeTodoButtonInteraction({
+      customId: buildTodoRefreshButtonCustomId({
+        guildScopeId: "123456789012345678",
+        requesterUserId: "111111111111111111",
+        targetUserId: "222222222222222222",
+        type: "RAIDS",
+      }),
+      userId: "111111111111111111",
+      guildId: "123456789012345678",
+    });
+
+    await handleTodoRefreshButtonInteraction(interaction as any, makeCocServiceSpy() as any);
+
+    expect(interaction.followUp).toHaveBeenCalledWith({
+      ephemeral: true,
+      content: "Failed to refresh todo data. Please try again.",
+    });
+    expect(interaction.editReply).not.toHaveBeenCalled();
+  });
+
+  it("rejects refresh clicks from non-requesting users", async () => {
+    const interaction = makeTodoButtonInteraction({
+      customId: buildTodoRefreshButtonCustomId({
+        guildScopeId: "123456789012345678",
+        requesterUserId: "111111111111111111",
+        targetUserId: "222222222222222222",
+        type: "WAR",
+      }),
+      userId: "333333333333333333",
+      guildId: "123456789012345678",
+    });
+
+    await handleTodoRefreshButtonInteraction(interaction as any, makeCocServiceSpy() as any);
+
+    expect(interaction.reply).toHaveBeenCalledWith({
+      ephemeral: true,
+      content: "Only the command requester can use this button.",
+    });
+    expect(interaction.deferUpdate).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
- add scoped todo refresh button + interaction handler with requester ownership and target-user state
- trigger targeted TodoSnapshotService refresh for displayed user links and update the same message/page
- add todo refresh regression tests and update help docs for the new refresh control