### PR TITLE
feat(todo): improve games page indicators, ordering, and name fallback

### DIFF
--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -291,6 +291,8 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
       "WAR/CWL pages group players by shared active event context and include section headers with phase timing.",
       "RAIDS/GAMES pages use one shared top timer line and then list per-player progress rows.",
       "GAMES page points come from stored activity-signal totals, with cycle baseline/total observability persisted on TodoPlayerSnapshot for DB-first reads.",
+      "GAMES rows are sorted by observed `gamesChampionTotal` descending, with stable tie-breakers by player identity.",
+      "GAMES rows use progress indicators: `🟡` (>0), `✅` (>=4000), and `🏆` (>=10000).",
       "When a page has no active context, it renders explicit inactive text instead of a blank list.",
       "Linked players outside active contexts are still shown as neutral rows when active groups exist.",
       "If you have no linked tags, the command returns a clear private error and suggests `/link create`.",

--- a/src/services/PlayerLinkService.ts
+++ b/src/services/PlayerLinkService.ts
@@ -46,6 +46,7 @@ export type ClanScopedPlayerLink = {
 export type DiscordUserPlayerLink = {
   playerTag: string;
   linkedAt: Date;
+  linkedName: string | null;
 };
 
 export const PLAYER_LINK_DISCORD_USERNAME_FALLBACK = "unknown";
@@ -291,7 +292,7 @@ export async function listPlayerLinksForDiscordUser(input: {
   const rows = await prisma.playerLink.findMany({
     where: { discordUserId: normalizedUserId },
     orderBy: [{ createdAt: "asc" }, { playerTag: "asc" }],
-    select: { playerTag: true, createdAt: true },
+    select: { playerTag: true, discordUsername: true, createdAt: true },
   });
 
   const seen = new Set<string>();
@@ -300,7 +301,11 @@ export async function listPlayerLinksForDiscordUser(input: {
     const playerTag = normalizePlayerTag(row.playerTag);
     if (!playerTag || seen.has(playerTag)) continue;
     seen.add(playerTag);
-    ordered.push({ playerTag, linkedAt: row.createdAt });
+    ordered.push({
+      playerTag,
+      linkedAt: row.createdAt,
+      linkedName: normalizePersistedDiscordUsername(row.discordUsername),
+    });
   }
   return ordered;
 }

--- a/src/services/TodoService.ts
+++ b/src/services/TodoService.ts
@@ -50,6 +50,7 @@ const TODO_STALE_ACTIVE_GAMES_MS = 30 * 60 * 1000;
 const TODO_STALE_IDLE_MS = 4 * 60 * 60 * 1000;
 const TODO_DEFAULT_GAMES_TARGET = 4000;
 const TODO_GAMES_COMPLETE_POINTS = 4000;
+const TODO_GAMES_MAX_POINTS = 10_000;
 const todoRenderCacheByKey = new Map<string, CachedTodoRender>();
 
 /** Purpose: normalize `/todo type` input into one safe enum value. */
@@ -114,14 +115,19 @@ export async function buildTodoPagesForUser(input: {
   });
   const snapshotByTag = new Map(snapshotRows.map((row) => [row.playerTag, row]));
 
-  const renderRows = linkedTags.map((playerTag) => {
-    const normalizedTag = normalizePlayerTag(playerTag);
+  const renderRows = links.map((link) => {
+    const normalizedTag = normalizePlayerTag(link.playerTag);
     const snapshot = snapshotByTag.get(normalizedTag) ?? null;
     const missingSnapshot = snapshot === null;
     const staleSnapshot = snapshot ? isSnapshotStale(snapshot, nowMs) : false;
+    const resolvedPlayerName = resolveTodoPlayerDisplayName({
+      playerTag: normalizedTag,
+      snapshotPlayerName: snapshot?.playerName,
+      linkedName: link.linkedName,
+    });
     return {
       playerTag: normalizedTag,
-      playerName: snapshot?.playerName ?? normalizedTag,
+      playerName: resolvedPlayerName,
       clanTag: snapshot?.clanTag ?? null,
       clanName: snapshot?.clanName ?? null,
       cwlClanTag: snapshot?.cwlClanTag ?? null,
@@ -326,10 +332,9 @@ function buildGamesPageDescription(
     lines.push(`**Time remaining:** ${formatRelativeTimestamp(sharedEndsAt)}`);
     lines.push("");
   }
-  for (const row of rows) {
-    lines.push(
-      formatGamesTodoRow(row, getGamesRowStatus(row), isGamesComplete(row)),
-    );
+  const sortedRows = sortGamesRows(rows);
+  for (const row of sortedRows) {
+    lines.push(formatGamesTodoRow(row, getGamesRowStatus(row), getGamesProgressEmoji(row)));
   }
 
   return buildTodoPageDescription({
@@ -440,14 +445,17 @@ function formatTodoRow(row: TodoRenderRow, status: string): string {
 function formatGamesTodoRow(
   row: TodoRenderRow,
   status: string,
-  completed: boolean,
+  progressEmoji: string,
 ): string {
-  const completionPrefix = completed ? ":white_check_mark: " : "";
-  return `- ${completionPrefix}${formatPlayerIdentity(row)} - ${status}`;
+  const progressPrefix = progressEmoji.length > 0 ? `${progressEmoji} ` : "";
+  return `- ${progressPrefix}${formatPlayerIdentity(row)} - ${status}`;
 }
 
 /** Purpose: build one stable player identity token for todo row prefixes. */
 function formatPlayerIdentity(row: TodoRenderRow): string {
+  if (row.playerName === row.playerTag) {
+    return row.playerTag;
+  }
   return `${row.playerName} ${row.playerTag}`;
 }
 
@@ -553,11 +561,66 @@ function getGamesRowStatus(row: TodoRenderRow): string {
   return `clan games points: ${points}/${target}${staleSuffix}`;
 }
 
-/** Purpose: decide whether one player should be marked complete on the GAMES page. */
-function isGamesComplete(row: TodoRenderRow): boolean {
-  if (!row.snapshot) return false;
+/** Purpose: resolve one todo-row player display name with deterministic linked-user fallback ordering. */
+function resolveTodoPlayerDisplayName(input: {
+  playerTag: string;
+  snapshotPlayerName: unknown;
+  linkedName: unknown;
+}): string {
+  const normalizedTag = normalizePlayerTag(input.playerTag);
+  const preferredSnapshotName = sanitizeStatusText(input.snapshotPlayerName);
+  if (preferredSnapshotName && preferredSnapshotName !== normalizedTag) {
+    return preferredSnapshotName;
+  }
+
+  const linkedName = sanitizeStatusText(input.linkedName);
+  if (linkedName) {
+    return linkedName;
+  }
+
+  if (preferredSnapshotName) {
+    return preferredSnapshotName;
+  }
+
+  return normalizedTag;
+}
+
+/** Purpose: sort games rows by champion total desc with stable deterministic tie-breakers. */
+function sortGamesRows(rows: TodoRenderRow[]): TodoRenderRow[] {
+  return rows
+    .map((row, index) => ({ row, index }))
+    .sort((a, b) => {
+      const aTotal = toFiniteIntOrNull(a.row.snapshot?.gamesChampionTotal);
+      const bTotal = toFiniteIntOrNull(b.row.snapshot?.gamesChampionTotal);
+      const normalizedATotal = aTotal === null ? Number.NEGATIVE_INFINITY : aTotal;
+      const normalizedBTotal = bTotal === null ? Number.NEGATIVE_INFINITY : bTotal;
+      if (normalizedATotal !== normalizedBTotal) {
+        return normalizedBTotal - normalizedATotal;
+      }
+
+      const byName = sanitizeStatusText(a.row.playerName).localeCompare(
+        sanitizeStatusText(b.row.playerName),
+        undefined,
+        { sensitivity: "base" },
+      );
+      if (byName !== 0) return byName;
+
+      const byTag = a.row.playerTag.localeCompare(b.row.playerTag);
+      if (byTag !== 0) return byTag;
+
+      return a.index - b.index;
+    })
+    .map((entry) => entry.row);
+}
+
+/** Purpose: map games progress points to deterministic status emoji thresholds. */
+function getGamesProgressEmoji(row: TodoRenderRow): string {
+  if (!row.snapshot || !row.snapshot.gamesActive) return "";
   const points = Math.max(0, toFiniteIntOrNull(row.snapshot.gamesPoints) ?? 0);
-  return points >= TODO_GAMES_COMPLETE_POINTS;
+  if (points <= 0) return "";
+  if (points >= TODO_GAMES_MAX_POINTS) return "🏆";
+  if (points >= TODO_GAMES_COMPLETE_POINTS) return "✅";
+  return "🟡";
 }
 
 /** Purpose: format one date as a Discord relative timestamp token. */

--- a/tests/todo.command.test.ts
+++ b/tests/todo.command.test.ts
@@ -122,6 +122,7 @@ function makeSnapshotRow(input: {
   gamesActive?: boolean;
   gamesPoints?: number | null;
   gamesTarget?: number | null;
+  gamesChampionTotal?: number | null;
   gamesEndsAt?: Date | null;
   lastUpdatedAt?: Date;
   updatedAt?: Date;
@@ -151,6 +152,9 @@ function makeSnapshotRow(input: {
     gamesActive: input.gamesActive ?? true,
     gamesPoints: input.gamesPoints ?? 1200,
     gamesTarget: input.gamesTarget ?? 4000,
+    gamesChampionTotal: input.gamesChampionTotal ?? 1200,
+    gamesSeasonBaseline: 0,
+    gamesCycleKey: "cycle-2026-03",
     gamesEndsAt: input.gamesEndsAt ?? new Date("2026-03-28T08:00:00.000Z"),
     lastUpdatedAt: input.lastUpdatedAt ?? now,
     updatedAt: input.updatedAt ?? now,
@@ -570,36 +574,57 @@ describe("/todo command", () => {
     expect(description).toContain("- Bravo #QGRJ2222 - clan capital raids: 1/6");
   });
 
-  it("renders GAMES with one shared top timer, points, and 4000+ completion marker", async () => {
+  it("renders GAMES emojis by progress threshold and sorts by gamesChampionTotal desc", async () => {
     prismaMock.playerLink.findMany.mockResolvedValue([
       { playerTag: "#PYLQ0289", createdAt: new Date("2026-03-01T00:00:00.000Z") },
       { playerTag: "#QGRJ2222", createdAt: new Date("2026-03-02T00:00:00.000Z") },
       { playerTag: "#CUV9082", createdAt: new Date("2026-03-03T00:00:00.000Z") },
+      { playerTag: "#LQ9P8R2", createdAt: new Date("2026-03-04T00:00:00.000Z") },
+      { playerTag: "#Q2V8P9L2", createdAt: new Date("2026-03-05T00:00:00.000Z") },
     ]);
     prismaMock.todoPlayerSnapshot.aggregate.mockResolvedValue({
-      _count: { _all: 3 },
+      _count: { _all: 5 },
       _max: { updatedAt: new Date("2026-03-26T00:00:00.000Z") },
     });
     prismaMock.todoPlayerSnapshot.findMany.mockResolvedValue([
       makeSnapshotRow({
         playerTag: "#PYLQ0289",
-        playerName: "Alpha",
+        playerName: "Echo",
         gamesActive: true,
-        gamesPoints: 3999,
+        gamesPoints: 0,
+        gamesChampionTotal: 5000,
         gamesEndsAt: new Date("2026-03-28T08:00:00.000Z"),
       }),
       makeSnapshotRow({
         playerTag: "#QGRJ2222",
-        playerName: "Bravo",
+        playerName: "Delta",
         gamesActive: true,
-        gamesPoints: 4000,
+        gamesPoints: 3999,
+        gamesChampionTotal: 6500,
         gamesEndsAt: new Date("2026-03-28T08:00:00.000Z"),
       }),
       makeSnapshotRow({
         playerTag: "#CUV9082",
         playerName: "Charlie",
         gamesActive: true,
+        gamesPoints: 4000,
+        gamesChampionTotal: 8000,
+        gamesEndsAt: new Date("2026-03-28T08:00:00.000Z"),
+      }),
+      makeSnapshotRow({
+        playerTag: "#LQ9P8R2",
+        playerName: "Alpha",
+        gamesActive: true,
+        gamesPoints: 10000,
+        gamesChampionTotal: 15000,
+        gamesEndsAt: new Date("2026-03-28T08:00:00.000Z"),
+      }),
+      makeSnapshotRow({
+        playerTag: "#Q2V8P9L2",
+        playerName: "Bravo",
+        gamesActive: true,
         gamesPoints: 5200,
+        gamesChampionTotal: 8000,
         gamesEndsAt: new Date("2026-03-28T08:00:00.000Z"),
       }),
     ]);
@@ -610,13 +635,66 @@ describe("/todo command", () => {
     const description = getReplyDescription(interaction);
     expect(description).toContain("**Time remaining:** <t:");
     expect(countOccurrences(description, "<t:")).toBe(1);
-    expect(description).toContain("- Alpha #PYLQ0289 - clan games points: 3999/4000");
-    expect(description).toContain(
-      "- :white_check_mark: Bravo #QGRJ2222 - clan games points: 4000/4000",
-    );
-    expect(description).toContain(
-      "- :white_check_mark: Charlie #CUV9082 - clan games points: 5200/4000",
-    );
+    expect(description).toContain("- 🏆 Alpha #LQ9P8R2 - clan games points: 10000/4000");
+    expect(description).toContain("- ✅ Bravo #Q2V8P9L2 - clan games points: 5200/4000");
+    expect(description).toContain("- ✅ Charlie #CUV9082 - clan games points: 4000/4000");
+    expect(description).toContain("- 🟡 Delta #QGRJ2222 - clan games points: 3999/4000");
+    expect(description).toContain("- Echo #PYLQ0289 - clan games points: 0/4000");
+
+    const indexTrophy = description.indexOf("🏆 Alpha #LQ9P8R2");
+    const indexBravo = description.indexOf("✅ Bravo #Q2V8P9L2");
+    const indexCharlie = description.indexOf("✅ Charlie #CUV9082");
+    const indexDelta = description.indexOf("🟡 Delta #QGRJ2222");
+    const indexEcho = description.indexOf("Echo #PYLQ0289");
+    expect(indexTrophy).toBeGreaterThan(-1);
+    expect(indexBravo).toBeGreaterThan(-1);
+    expect(indexCharlie).toBeGreaterThan(-1);
+    expect(indexDelta).toBeGreaterThan(-1);
+    expect(indexEcho).toBeGreaterThan(-1);
+    expect(indexTrophy).toBeLessThan(indexBravo);
+    expect(indexBravo).toBeLessThan(indexCharlie);
+    expect(indexCharlie).toBeLessThan(indexDelta);
+    expect(indexDelta).toBeLessThan(indexEcho);
+  });
+
+  it("falls back to PlayerLink identity for linked rows before final raw-tag fallback", async () => {
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      {
+        playerTag: "#PYLQ0289",
+        discordUsername: "Linked Alias",
+        createdAt: new Date("2026-03-01T00:00:00.000Z"),
+      },
+      {
+        playerTag: "#QGRJ2222",
+        discordUsername: null,
+        createdAt: new Date("2026-03-02T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.todoPlayerSnapshot.aggregate.mockResolvedValue({
+      _count: { _all: 2 },
+      _max: { updatedAt: new Date("2026-03-26T00:00:00.000Z") },
+    });
+    prismaMock.todoPlayerSnapshot.findMany.mockResolvedValue([
+      makeSnapshotRow({
+        playerTag: "#PYLQ0289",
+        playerName: "#PYLQ0289",
+        gamesActive: true,
+        gamesPoints: 1200,
+      }),
+      makeSnapshotRow({
+        playerTag: "#QGRJ2222",
+        playerName: "",
+        gamesActive: true,
+        gamesPoints: 0,
+      }),
+    ]);
+
+    const interaction = makeTodoInteraction({ type: "GAMES" });
+    await Todo.run({} as any, interaction as any, makeCocServiceSpy() as any);
+
+    const description = getReplyDescription(interaction);
+    expect(description).toContain("- 🟡 Linked Alias #PYLQ0289 - clan games points: 1200/4000");
+    expect(description).toContain("- #QGRJ2222 - clan games points: 0/4000");
   });
 });
 


### PR DESCRIPTION
- add games status emojis by progress thresholds and sort games rows by champion total desc with stable ties
- prefer linked PlayerLink identity for todo rows when snapshot names are missing before final raw-tag fallback
- extend todo command coverage for games emoji states, ordering, and linked-name fallback behavior