### PR TITLE
feat(todo): enrich war page headers and player attack rows

### DIFF
--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -289,6 +289,7 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
       "`type` controls only the initial page shown; use page buttons to switch categories without rerunning.",
       "Use the `Refresh` button to trigger a targeted snapshot rebuild for the displayed todo user and update the same message in place.",
       "WAR/CWL pages group players by shared active event context and include section headers with phase timing.",
+      "WAR section headers include tracked clan badge + match-state indicator, and WAR rows show lineup position with compact used-attack detail.",
       "RAIDS/GAMES pages use one shared top timer line and then list per-player progress rows.",
       "GAMES page points come from stored activity-signal totals, with cycle baseline/total observability persisted on TodoPlayerSnapshot for DB-first reads.",
       "GAMES rows are sorted by observed `gamesChampionTotal` descending, with stable tie-breakers by player identity.",

--- a/src/services/TodoService.ts
+++ b/src/services/TodoService.ts
@@ -1,8 +1,10 @@
 import { CoCService } from "./CoCService";
 import {
   listPlayerLinksForDiscordUser,
+  normalizeClanTag,
   normalizePlayerTag,
 } from "./PlayerLinkService";
+import { prisma } from "../prisma";
 import {
   todoSnapshotService,
   type TodoSnapshotRecord,
@@ -19,10 +21,18 @@ export type TodoPagesResult = {
 type TodoRenderRow = {
   playerTag: string;
   playerName: string;
+  defaultIndex: number;
   clanTag: string | null;
   clanName: string | null;
   cwlClanTag: string | null;
   cwlClanName: string | null;
+  warPosition: number | null;
+  warAttackDetails: Array<{
+    defenderPosition: number | null;
+    stars: number | null;
+  }>;
+  warHeaderBadge: string | null;
+  warMatchIndicator: string;
   snapshot: TodoSnapshotRecord | null;
   missingSnapshot: boolean;
   staleSnapshot: boolean;
@@ -31,6 +41,8 @@ type TodoRenderRow = {
 type TodoEventGroup = {
   clanTag: string | null;
   clanName: string | null;
+  clanBadge: string | null;
+  matchIndicator: string;
   phase: string;
   phaseEndsAt: Date | null;
   rows: TodoRenderRow[];
@@ -39,6 +51,25 @@ type TodoEventGroup = {
 type CachedTodoRender = {
   expiresAtMs: number;
   pages: TodoPagesResult;
+};
+
+type WarMemberCurrentRow = {
+  clanTag: string;
+  playerTag: string;
+  position: number | null;
+  attacks: number | null;
+  defender1Position: number | null;
+  stars1: number | null;
+  defender2Position: number | null;
+  stars2: number | null;
+  sourceSyncedAt: Date;
+};
+
+type CurrentWarMatchContextRow = {
+  clanTag: string;
+  matchType: string | null;
+  outcome: string | null;
+  updatedAt: Date;
 };
 
 const DISCORD_DESCRIPTION_LIMIT = 4096;
@@ -114,12 +145,67 @@ export async function buildTodoPagesForUser(input: {
     playerTags: linkedTags,
   });
   const snapshotByTag = new Map(snapshotRows.map((row) => [row.playerTag, row]));
+  const clanTags = [
+    ...new Set(
+      snapshotRows
+        .map((row) => normalizeClanTag(row.clanTag ?? ""))
+        .filter(Boolean),
+    ),
+  ];
 
-  const renderRows = links.map((link) => {
+  const [warMemberRows, trackedClanRows, currentWarRows] = await Promise.all([
+    prisma.fwaWarMemberCurrent.findMany({
+      where: { playerTag: { in: linkedTags } },
+      select: {
+        clanTag: true,
+        playerTag: true,
+        position: true,
+        attacks: true,
+        defender1Position: true,
+        stars1: true,
+        defender2Position: true,
+        stars2: true,
+        sourceSyncedAt: true,
+      },
+    }),
+    clanTags.length > 0
+      ? prisma.trackedClan.findMany({
+          where: { tag: { in: clanTags } },
+          select: { tag: true, clanBadge: true },
+        })
+      : Promise.resolve([]),
+    clanTags.length > 0
+      ? prisma.currentWar.findMany({
+          where: { clanTag: { in: clanTags } },
+          select: { clanTag: true, matchType: true, outcome: true, updatedAt: true },
+        })
+      : Promise.resolve([]),
+  ]);
+
+  const latestWarMemberByClanAndPlayer =
+    pickLatestWarMemberByClanAndPlayer(warMemberRows);
+  const clanBadgeByTag = new Map(
+    trackedClanRows
+      .map((row) => [normalizeClanTag(row.tag), sanitizeStatusText(row.clanBadge)] as const)
+      .filter((entry): entry is [string, string] => Boolean(entry[0] && entry[1])),
+  );
+  const warMatchContextByClanTag =
+    pickLatestCurrentWarMatchContextByClanTag(currentWarRows);
+
+  const renderRows = links.map((link, index) => {
     const normalizedTag = normalizePlayerTag(link.playerTag);
     const snapshot = snapshotByTag.get(normalizedTag) ?? null;
     const missingSnapshot = snapshot === null;
     const staleSnapshot = snapshot ? isSnapshotStale(snapshot, nowMs) : false;
+    const resolvedClanTag = normalizeClanTag(snapshot?.clanTag ?? "") || null;
+    const warMemberKey = resolvedClanTag ? `${resolvedClanTag}:${normalizedTag}` : "";
+    const warMember = warMemberKey
+      ? latestWarMemberByClanAndPlayer.get(warMemberKey) ?? null
+      : null;
+    const warAttackDetails = resolveWarAttackDetails(warMember);
+    const matchContext = resolvedClanTag
+      ? warMatchContextByClanTag.get(resolvedClanTag) ?? null
+      : null;
     const resolvedPlayerName = resolveTodoPlayerDisplayName({
       playerTag: normalizedTag,
       snapshotPlayerName: snapshot?.playerName,
@@ -128,10 +214,15 @@ export async function buildTodoPagesForUser(input: {
     return {
       playerTag: normalizedTag,
       playerName: resolvedPlayerName,
-      clanTag: snapshot?.clanTag ?? null,
+      defaultIndex: index,
+      clanTag: resolvedClanTag,
       clanName: snapshot?.clanName ?? null,
       cwlClanTag: snapshot?.cwlClanTag ?? null,
       cwlClanName: snapshot?.cwlClanName ?? null,
+      warPosition: toFiniteIntOrNull(warMember?.position),
+      warAttackDetails,
+      warHeaderBadge: resolvedClanTag ? clanBadgeByTag.get(resolvedClanTag) ?? null : null,
+      warMatchIndicator: resolveWarMatchStatusIndicator(matchContext),
       snapshot,
       missingSnapshot,
       staleSnapshot,
@@ -219,7 +310,7 @@ function buildWarPageDescription(
   for (const group of grouped) {
     lines.push(`**${buildEventGroupHeader(group)}**`);
     for (const row of group.rows) {
-      lines.push(formatTodoRow(row, getWarRowStatus(row)));
+      lines.push(formatWarTodoRow(row, getWarRowStatus(row)));
     }
     lines.push("");
   }
@@ -375,6 +466,8 @@ function buildEventGroups(
     grouped.set(key, {
       clanTag: groupedClanTag ?? null,
       clanName: groupedClanName ?? null,
+      clanBadge: mode === "war" ? row.warHeaderBadge : null,
+      matchIndicator: mode === "war" ? row.warMatchIndicator : "",
       phase,
       phaseEndsAt: phaseEndsAt ?? null,
       rows: [row],
@@ -384,9 +477,12 @@ function buildEventGroups(
   return [...grouped.values()]
     .map((group) => ({
       ...group,
-      rows: [...group.rows].sort((a, b) =>
-        formatPlayerIdentity(a).localeCompare(formatPlayerIdentity(b)),
-      ),
+      rows:
+        mode === "war"
+          ? [...group.rows].sort(compareWarRowsForRendering)
+          : [...group.rows].sort((a, b) =>
+              formatPlayerIdentity(a).localeCompare(formatPlayerIdentity(b)),
+            ),
     }))
     .sort((a, b) => {
       const nameCompare = buildGroupClanIdentity(a).localeCompare(
@@ -399,11 +495,17 @@ function buildEventGroups(
 
 /** Purpose: build one compact active-event header line with clan and phase timing context. */
 function buildEventGroupHeader(group: TodoEventGroup): string {
+  const badgePrefix = sanitizeStatusText(group.clanBadge);
   const clan = buildGroupClanIdentity(group);
+  const matchIndicator = sanitizeStatusText(group.matchIndicator);
   const endsAt = group.phaseEndsAt
     ? ` ends ${formatRelativeTimestamp(group.phaseEndsAt)}`
     : "";
-  return `${clan} - ${group.phase}${endsAt}`;
+  const prefixedClan = badgePrefix ? `${badgePrefix} ${clan}` : clan;
+  const clanWithIndicator = matchIndicator
+    ? `${prefixedClan} ${matchIndicator}`
+    : prefixedClan;
+  return `${clanWithIndicator} - ${group.phase}${endsAt}`;
 }
 
 /** Purpose: build stable clan identity text for grouped section headings. */
@@ -441,6 +543,22 @@ function formatTodoRow(row: TodoRenderRow, status: string): string {
   return `- ${formatPlayerIdentity(row)} - ${status}`;
 }
 
+/** Purpose: format one WAR row with lineup position and compact attack-detail suffixes. */
+function formatWarTodoRow(row: TodoRenderRow, status: string): string {
+  const identity = formatWarPlayerIdentity(row);
+  const usedAttacks = clampInt(row.snapshot?.warAttacksUsed, 0, row.snapshot?.warAttacksMax || 2);
+  const detailRows =
+    usedAttacks > 0
+      ? row.warAttackDetails
+          .slice(0, usedAttacks)
+          .map((detail) => formatWarAttackDetail(detail))
+          .filter(Boolean)
+      : [];
+  const detailsSuffix =
+    detailRows.length > 0 ? ` | ${detailRows.join(" | ")}` : "";
+  return `- ${identity} - ${status}${detailsSuffix}`;
+}
+
 /** Purpose: format one GAMES row with optional completion marker next to player identity text. */
 function formatGamesTodoRow(
   row: TodoRenderRow,
@@ -457,6 +575,15 @@ function formatPlayerIdentity(row: TodoRenderRow): string {
     return row.playerTag;
   }
   return `${row.playerName} ${row.playerTag}`;
+}
+
+/** Purpose: format one WAR player identity with lineup position fallback when unavailable. */
+function formatWarPlayerIdentity(row: TodoRenderRow): string {
+  const positionLabel =
+    row.warPosition !== null && row.warPosition > 0
+      ? `#${row.warPosition}`
+      : "#?";
+  return `${positionLabel} ${row.playerName}`;
 }
 
 /** Purpose: build one bounded embed description block for a todo page. */
@@ -480,12 +607,12 @@ function buildTodoPageDescription(input: {
 /** Purpose: build active WAR row status text without repeating group-level phase timing details. */
 function getWarRowStatus(row: TodoRenderRow): string {
   if (row.missingSnapshot || !row.snapshot) {
-    return "war attacks: 0/2 - snapshot unavailable";
+    return "`0 / 2` - snapshot unavailable";
   }
   const used = clampInt(row.snapshot.warAttacksUsed, 0, row.snapshot.warAttacksMax || 2);
   const max = Math.max(1, clampInt(row.snapshot.warAttacksMax, 1, 2));
   const staleSuffix = row.staleSnapshot ? " - stale snapshot" : "";
-  return `war attacks: ${used}/${max}${staleSuffix}`;
+  return `\`${used} / ${max}\`${staleSuffix}`;
 }
 
 /** Purpose: build neutral WAR row status text for linked players outside active war groups. */
@@ -583,6 +710,134 @@ function resolveTodoPlayerDisplayName(input: {
   }
 
   return normalizedTag;
+}
+
+/** Purpose: compare WAR rows by actual lineup position first to keep rendering aligned with war roster order. */
+function compareWarRowsForRendering(a: TodoRenderRow, b: TodoRenderRow): number {
+  const aHasPos = a.warPosition !== null && a.warPosition > 0;
+  const bHasPos = b.warPosition !== null && b.warPosition > 0;
+  if (aHasPos && bHasPos && a.warPosition !== b.warPosition) {
+    return Number(a.warPosition) - Number(b.warPosition);
+  }
+  if (aHasPos !== bHasPos) return aHasPos ? -1 : 1;
+
+  const byName = sanitizeStatusText(a.playerName).localeCompare(
+    sanitizeStatusText(b.playerName),
+    undefined,
+    { sensitivity: "base" },
+  );
+  if (byName !== 0) return byName;
+
+  const byTag = a.playerTag.localeCompare(b.playerTag);
+  if (byTag !== 0) return byTag;
+
+  return a.defaultIndex - b.defaultIndex;
+}
+
+/** Purpose: extract compact first/second attack details from one latest war-member row. */
+function resolveWarAttackDetails(
+  row: Pick<
+    WarMemberCurrentRow,
+    "defender1Position" | "stars1" | "defender2Position" | "stars2"
+  > | null,
+): Array<{ defenderPosition: number | null; stars: number | null }> {
+  if (!row) return [];
+  return [
+    {
+      defenderPosition: toFiniteIntOrNull(row.defender1Position),
+      stars: toFiniteIntOrNull(row.stars1),
+    },
+    {
+      defenderPosition: toFiniteIntOrNull(row.defender2Position),
+      stars: toFiniteIntOrNull(row.stars2),
+    },
+  ];
+}
+
+/** Purpose: render one compact WAR attack detail segment for embed-friendly row suffixes. */
+function formatWarAttackDetail(input: {
+  defenderPosition: number | null;
+  stars: number | null;
+}): string {
+  const defenderLabel =
+    input.defenderPosition !== null && input.defenderPosition > 0
+      ? `#${input.defenderPosition}`
+      : "#?";
+  return `:dagger: ${defenderLabel} ${formatWarStarTriplet(input.stars)}`;
+}
+
+/** Purpose: render star counts as compact visual triplets used by WAR attack detail rows. */
+function formatWarStarTriplet(stars: number | null | undefined): string {
+  const normalized = Math.max(0, Math.min(3, Number(stars ?? 0)));
+  if (normalized >= 3) return "★ ★ ★";
+  if (normalized >= 2) return "★ ★ ☆";
+  if (normalized >= 1) return "★ ☆ ☆";
+  return "☆ ☆ ☆";
+}
+
+/** Purpose: map clan match type/outcome into the same effective status-color semantics used by match views. */
+function resolveWarMatchStatusIndicator(
+  context: Pick<CurrentWarMatchContextRow, "matchType" | "outcome"> | null,
+): string {
+  const matchType = sanitizeStatusText(context?.matchType).toUpperCase();
+  const outcome = sanitizeStatusText(context?.outcome).toUpperCase();
+  if (matchType === "BL") return ":black_circle:";
+  if (matchType === "MM") return ":white_circle:";
+  if (matchType === "SKIP") return ":yellow_circle:";
+  if (matchType === "FWA") {
+    if (outcome === "LOSE") return ":red_circle:";
+    return ":green_circle:";
+  }
+  return ":white_circle:";
+}
+
+/** Purpose: keep only the freshest war-member row for each clan+player pair. */
+function pickLatestWarMemberByClanAndPlayer(
+  rows: WarMemberCurrentRow[],
+): Map<string, WarMemberCurrentRow> {
+  const latest = new Map<string, WarMemberCurrentRow>();
+  for (const row of rows) {
+    const clanTag = normalizeClanTag(row.clanTag);
+    const playerTag = normalizePlayerTag(row.playerTag);
+    if (!clanTag || !playerTag) continue;
+    const key = `${clanTag}:${playerTag}`;
+    const existing = latest.get(key);
+    if (!existing || row.sourceSyncedAt > existing.sourceSyncedAt) {
+      latest.set(key, {
+        clanTag,
+        playerTag,
+        position: toFiniteIntOrNull(row.position),
+        attacks: toFiniteIntOrNull(row.attacks),
+        defender1Position: toFiniteIntOrNull(row.defender1Position),
+        stars1: toFiniteIntOrNull(row.stars1),
+        defender2Position: toFiniteIntOrNull(row.defender2Position),
+        stars2: toFiniteIntOrNull(row.stars2),
+        sourceSyncedAt: row.sourceSyncedAt,
+      });
+    }
+  }
+  return latest;
+}
+
+/** Purpose: keep one latest current-war match context row per clan for header indicator rendering. */
+function pickLatestCurrentWarMatchContextByClanTag(
+  rows: CurrentWarMatchContextRow[],
+): Map<string, CurrentWarMatchContextRow> {
+  const latest = new Map<string, CurrentWarMatchContextRow>();
+  for (const row of rows) {
+    const clanTag = normalizeClanTag(row.clanTag);
+    if (!clanTag) continue;
+    const existing = latest.get(clanTag);
+    if (!existing || row.updatedAt > existing.updatedAt) {
+      latest.set(clanTag, {
+        clanTag,
+        matchType: row.matchType,
+        outcome: row.outcome,
+        updatedAt: row.updatedAt,
+      });
+    }
+  }
+  return latest;
 }
 
 /** Purpose: sort games rows by champion total desc with stable deterministic tie-breakers. */

--- a/tests/todo.command.test.ts
+++ b/tests/todo.command.test.ts
@@ -293,7 +293,7 @@ describe("/todo command", () => {
     expect(cocService.getClanWarLeagueWar).not.toHaveBeenCalled();
   });
 
-  it("renders WAR grouped sections by shared context with neutral non-active rows", async () => {
+  it("renders WAR headers with badge + match indicator and row-level attack detail", async () => {
     prismaMock.playerLink.findMany.mockResolvedValue([
       { playerTag: "#PYLQ0289", createdAt: new Date("2026-03-01T00:00:00.000Z") },
       { playerTag: "#QGRJ2222", createdAt: new Date("2026-03-02T00:00:00.000Z") },
@@ -310,7 +310,7 @@ describe("/todo command", () => {
         playerName: "Alpha",
         clanTag: "#PQL0289",
         clanName: "Clan One",
-        warAttacksUsed: 1,
+        warAttacksUsed: 0,
         warPhase: "battle day",
       }),
       makeSnapshotRow({
@@ -318,7 +318,7 @@ describe("/todo command", () => {
         playerName: "Bravo",
         clanTag: "#PQL0289",
         clanName: "Clan One",
-        warAttacksUsed: 2,
+        warAttacksUsed: 1,
         warPhase: "battle day",
       }),
       makeSnapshotRow({
@@ -326,7 +326,7 @@ describe("/todo command", () => {
         playerName: "Charlie",
         clanTag: "#2QG2C08UP",
         clanName: "Clan Two",
-        warAttacksUsed: 0,
+        warAttacksUsed: 2,
         warPhase: "preparation",
         warEndsAt: new Date("2026-03-30T18:00:00.000Z"),
       }),
@@ -339,18 +339,124 @@ describe("/todo command", () => {
         warAttacksUsed: 0,
       }),
     ]);
+    prismaMock.trackedClan.findMany.mockResolvedValue([
+      { tag: "#PQL0289", clanBadge: ":rd:" },
+      { tag: "#2QG2C08UP", clanBadge: ":ak:" },
+    ]);
+    prismaMock.currentWar.findMany.mockResolvedValue([
+      {
+        clanTag: "#PQL0289",
+        matchType: "FWA",
+        outcome: "WIN",
+        updatedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+      {
+        clanTag: "#2QG2C08UP",
+        matchType: "BL",
+        outcome: null,
+        updatedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.fwaWarMemberCurrent.findMany.mockResolvedValue([
+      {
+        clanTag: "#PQL0289",
+        playerTag: "#PYLQ0289",
+        position: 8,
+        attacks: 0,
+        defender1Position: null,
+        stars1: null,
+        defender2Position: null,
+        stars2: null,
+        sourceSyncedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+      {
+        clanTag: "#PQL0289",
+        playerTag: "#QGRJ2222",
+        position: 1,
+        attacks: 1,
+        defender1Position: 8,
+        stars1: 3,
+        defender2Position: null,
+        stars2: null,
+        sourceSyncedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+      {
+        clanTag: "#2QG2C08UP",
+        playerTag: "#CUV9082",
+        position: 9,
+        attacks: 2,
+        defender1Position: 8,
+        stars1: 3,
+        defender2Position: 1,
+        stars2: 1,
+        sourceSyncedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+    ]);
 
     const interaction = makeTodoInteraction({ type: "WAR" });
     await Todo.run({} as any, interaction as any, makeCocServiceSpy() as any);
 
     const description = getReplyDescription(interaction);
     expect(getReplyTitle(interaction)).toBe("Todo - WAR");
-    expect(description).toContain("**Clan One (#PQL0289) - battle day ends <t:");
-    expect(description).toContain("**Clan Two (#2QG2C08UP) - preparation ends <t:");
-    expect(description).toContain("- Alpha #PYLQ0289 - war attacks: 1/2");
-    expect(description).toContain("- Bravo #QGRJ2222 - war attacks: 2/2");
+    expect(description).toContain("**:rd: Clan One (#PQL0289) :green_circle: - battle day ends <t:");
+    expect(description).toContain("**:ak: Clan Two (#2QG2C08UP) :black_circle: - preparation ends <t:");
+    expect(description).toContain("- #8 Alpha - `0 / 2`");
+    expect(description).toContain("- #1 Bravo - `1 / 2` | :dagger: #8 ★ ★ ★");
+    expect(description).toContain(
+      "- #9 Charlie - `2 / 2` | :dagger: #8 ★ ★ ★ | :dagger: #1 ★ ☆ ☆",
+    );
     expect(description).toContain("**Not in active war**");
     expect(description).toContain("- Delta #LQ9P8R2 - war attacks: 0/2 - not in active war");
+  });
+
+  it("uses safe #? fallback when war lineup position is unavailable", async () => {
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      { playerTag: "#PYLQ0289", createdAt: new Date("2026-03-01T00:00:00.000Z") },
+    ]);
+    prismaMock.todoPlayerSnapshot.aggregate.mockResolvedValue({
+      _count: { _all: 1 },
+      _max: { updatedAt: new Date("2026-03-26T00:00:00.000Z") },
+    });
+    prismaMock.todoPlayerSnapshot.findMany.mockResolvedValue([
+      makeSnapshotRow({
+        playerTag: "#PYLQ0289",
+        playerName: "Alpha",
+        clanTag: "#PQL0289",
+        clanName: "Clan One",
+        warAttacksUsed: 1,
+        warPhase: "battle day",
+      }),
+    ]);
+    prismaMock.trackedClan.findMany.mockResolvedValue([
+      { tag: "#PQL0289", clanBadge: ":rd:" },
+    ]);
+    prismaMock.currentWar.findMany.mockResolvedValue([
+      {
+        clanTag: "#PQL0289",
+        matchType: "FWA",
+        outcome: "WIN",
+        updatedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.fwaWarMemberCurrent.findMany.mockResolvedValue([
+      {
+        clanTag: "#PQL0289",
+        playerTag: "#PYLQ0289",
+        position: null,
+        attacks: 1,
+        defender1Position: null,
+        stars1: 2,
+        defender2Position: null,
+        stars2: null,
+        sourceSyncedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+    ]);
+
+    const interaction = makeTodoInteraction({ type: "WAR" });
+    await Todo.run({} as any, interaction as any, makeCocServiceSpy() as any);
+
+    const description = getReplyDescription(interaction);
+    expect(description).toContain("- #? Alpha - `1 / 2` | :dagger: #? ★ ★ ☆");
   });
 
   it("renders CWL grouped sections by shared context with neutral non-active rows", async () => {
@@ -743,7 +849,7 @@ describe("/todo pagination buttons", () => {
 
   it("paginates across WAR/CWL/RAIDS/GAMES with user-scoped access", async () => {
     const checks: Array<{ type: TodoType; contains: string }> = [
-      { type: "WAR", contains: "war attacks:" },
+      { type: "WAR", contains: "`1 / 2`" },
       { type: "CWL", contains: "CWL attacks:" },
       { type: "RAIDS", contains: "clan capital raids:" },
       { type: "GAMES", contains: "clan games points:" },


### PR DESCRIPTION
- add tracked-clan badge and war match-status indicator to active war group headers
- render war lineup position with compact used-attack detail segments on active war rows
- expand todo war tests for badge/match headers, attack detail variants, and position fallback