### PR TITLE
fix(todo): avoid discord-handle fallback in linked player identity

### DIFF
--- a/src/services/PlayerLinkService.ts
+++ b/src/services/PlayerLinkService.ts
@@ -81,6 +81,21 @@ export function normalizePersistedDiscordUsername(input: unknown): string | null
   return normalized;
 }
 
+/** Purpose: detect whether one normalized label is likely a Discord username handle (not an in-game player identity). */
+function isLikelyDiscordUsernameLabel(input: string): boolean {
+  if (!input) return false;
+  return /^[A-Za-z0-9._]{2,32}$/.test(input);
+}
+
+/** Purpose: normalize one PlayerLink name-like value for `/todo` player identity fallback use. */
+function normalizeLinkedPlayerNameForTodo(input: unknown): string | null {
+  const normalized = normalizePersistedDiscordUsername(input);
+  if (!normalized) return null;
+  if (normalized.toLowerCase() === PLAYER_LINK_DISCORD_USERNAME_FALLBACK) return null;
+  if (isLikelyDiscordUsernameLabel(normalized)) return null;
+  return normalized;
+}
+
 /** Purpose: normalize persisted usernames with a deterministic fallback. */
 export function sanitizeDiscordUsernameForPersistence(input: unknown): string {
   return normalizePersistedDiscordUsername(input) ?? PLAYER_LINK_DISCORD_USERNAME_FALLBACK;
@@ -304,7 +319,7 @@ export async function listPlayerLinksForDiscordUser(input: {
     ordered.push({
       playerTag,
       linkedAt: row.createdAt,
-      linkedName: normalizePersistedDiscordUsername(row.discordUsername),
+      linkedName: normalizeLinkedPlayerNameForTodo(row.discordUsername),
     });
   }
   return ordered;

--- a/tests/todo.command.test.ts
+++ b/tests/todo.command.test.ts
@@ -802,6 +802,35 @@ describe("/todo command", () => {
     expect(description).toContain("- 🟡 Linked Alias #PYLQ0289 - clan games points: 1200/4000");
     expect(description).toContain("- #QGRJ2222 - clan games points: 0/4000");
   });
+
+  it("does not use discord-handle-like PlayerLink usernames as normal todo player identity fallback", async () => {
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      {
+        playerTag: "#PYLQ0289",
+        discordUsername: "tonyk_2020",
+        createdAt: new Date("2026-03-01T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.todoPlayerSnapshot.aggregate.mockResolvedValue({
+      _count: { _all: 1 },
+      _max: { updatedAt: new Date("2026-03-26T00:00:00.000Z") },
+    });
+    prismaMock.todoPlayerSnapshot.findMany.mockResolvedValue([
+      makeSnapshotRow({
+        playerTag: "#PYLQ0289",
+        playerName: "#PYLQ0289",
+        gamesActive: true,
+        gamesPoints: 1200,
+      }),
+    ]);
+
+    const interaction = makeTodoInteraction({ type: "GAMES" });
+    await Todo.run({} as any, interaction as any, makeCocServiceSpy() as any);
+
+    const description = getReplyDescription(interaction);
+    expect(description).toContain("- 🟡 #PYLQ0289 - clan games points: 1200/4000");
+    expect(description).not.toContain("tonyk_2020");
+  });
 });
 
 describe("/todo pagination buttons", () => {


### PR DESCRIPTION
- filter PlayerLink linked-name fallback values that look like Discord handles
- keep /todo row identity fallback on player-like names or raw tag
- add regression test for non-tracked linked account rendering on GAMES