### PR TITLE
fix(todo): correct war and cwl active-row rendering

### DIFF
--- a/src/services/TodoService.ts
+++ b/src/services/TodoService.ts
@@ -69,6 +69,7 @@ type CurrentWarMatchContextRow = {
   clanTag: string;
   matchType: string | null;
   outcome: string | null;
+  state: string | null;
   updatedAt: Date;
 };
 
@@ -177,13 +178,20 @@ export async function buildTodoPagesForUser(input: {
     clanTags.length > 0
       ? prisma.currentWar.findMany({
           where: { clanTag: { in: clanTags } },
-          select: { clanTag: true, matchType: true, outcome: true, updatedAt: true },
+          select: {
+            clanTag: true,
+            matchType: true,
+            outcome: true,
+            state: true,
+            updatedAt: true,
+          },
         })
       : Promise.resolve([]),
   ]);
 
   const latestWarMemberByClanAndPlayer =
     pickLatestWarMemberByClanAndPlayer(warMemberRows);
+  const latestWarMemberByPlayerTag = pickLatestWarMemberByPlayerTag(warMemberRows);
   const clanBadgeByTag = new Map(
     trackedClanRows
       .map((row) => [normalizeClanTag(row.tag), sanitizeStatusText(row.clanBadge)] as const)
@@ -202,7 +210,8 @@ export async function buildTodoPagesForUser(input: {
     const warMember = warMemberKey
       ? latestWarMemberByClanAndPlayer.get(warMemberKey) ?? null
       : null;
-    const warAttackDetails = resolveWarAttackDetails(warMember);
+    const fallbackWarMember =
+      warMember ?? latestWarMemberByPlayerTag.get(normalizedTag) ?? null;
     const matchContext = resolvedClanTag
       ? warMatchContextByClanTag.get(resolvedClanTag) ?? null
       : null;
@@ -219,8 +228,8 @@ export async function buildTodoPagesForUser(input: {
       clanName: snapshot?.clanName ?? null,
       cwlClanTag: snapshot?.cwlClanTag ?? null,
       cwlClanName: snapshot?.cwlClanName ?? null,
-      warPosition: toFiniteIntOrNull(warMember?.position),
-      warAttackDetails,
+      warPosition: toFiniteIntOrNull(fallbackWarMember?.position),
+      warAttackDetails: resolveWarAttackDetails(fallbackWarMember),
       warHeaderBadge: resolvedClanTag ? clanBadgeByTag.get(resolvedClanTag) ?? null : null,
       warMatchIndicator: resolveWarMatchStatusIndicator(matchContext),
       snapshot,
@@ -290,7 +299,7 @@ function isSnapshotStale(snapshot: TodoSnapshotRecord, nowMs: number): boolean {
   return ageMs > TODO_STALE_IDLE_MS;
 }
 
-/** Purpose: build the WAR page using grouped active contexts and explicit inactive fallback. */
+/** Purpose: build the WAR page from grouped active contexts only. */
 function buildWarPageDescription(
   rows: TodoRenderRow[],
   linkedPlayerCount: number,
@@ -305,7 +314,6 @@ function buildWarPageDescription(
   }
 
   const grouped = buildEventGroups(activeRows, "war");
-  const inactiveRows = rows.filter((row) => !row.snapshot?.warActive);
   const lines: string[] = [];
   for (const group of grouped) {
     lines.push(`**${buildEventGroupHeader(group)}**`);
@@ -314,13 +322,7 @@ function buildWarPageDescription(
     }
     lines.push("");
   }
-
-  if (inactiveRows.length > 0) {
-    lines.push("**Not in active war**");
-    for (const row of inactiveRows) {
-      lines.push(formatTodoRow(row, getWarNeutralStatus(row)));
-    }
-  } else if (lines.at(-1) === "") {
+  if (lines.at(-1) === "") {
     lines.pop();
   }
 
@@ -331,7 +333,7 @@ function buildWarPageDescription(
   });
 }
 
-/** Purpose: build the CWL page using grouped active contexts and explicit inactive fallback. */
+/** Purpose: build the CWL page from grouped active contexts only. */
 function buildCwlPageDescription(
   rows: TodoRenderRow[],
   linkedPlayerCount: number,
@@ -346,7 +348,6 @@ function buildCwlPageDescription(
   }
 
   const grouped = buildEventGroups(activeRows, "cwl");
-  const inactiveRows = rows.filter((row) => !row.snapshot?.cwlActive);
   const lines: string[] = [];
   for (const group of grouped) {
     lines.push(`**${buildEventGroupHeader(group)}**`);
@@ -355,13 +356,7 @@ function buildCwlPageDescription(
     }
     lines.push("");
   }
-
-  if (inactiveRows.length > 0) {
-    lines.push("**Not in active CWL**");
-    for (const row of inactiveRows) {
-      lines.push(formatTodoRow(row, getCwlNeutralStatus(row)));
-    }
-  } else if (lines.at(-1) === "") {
+  if (lines.at(-1) === "") {
     lines.pop();
   }
 
@@ -546,7 +541,10 @@ function formatTodoRow(row: TodoRenderRow, status: string): string {
 /** Purpose: format one WAR row with lineup position and compact attack-detail suffixes. */
 function formatWarTodoRow(row: TodoRenderRow, status: string): string {
   const identity = formatWarPlayerIdentity(row);
-  const usedAttacks = clampInt(row.snapshot?.warAttacksUsed, 0, row.snapshot?.warAttacksMax || 2);
+  const attacksActive = isWarRowAttackPhaseActive(row);
+  const usedAttacks = attacksActive
+    ? clampInt(row.snapshot?.warAttacksUsed, 0, row.snapshot?.warAttacksMax || 2)
+    : 0;
   const detailRows =
     usedAttacks > 0
       ? row.warAttackDetails
@@ -609,22 +607,12 @@ function getWarRowStatus(row: TodoRenderRow): string {
   if (row.missingSnapshot || !row.snapshot) {
     return "`0 / 2` - snapshot unavailable";
   }
-  const used = clampInt(row.snapshot.warAttacksUsed, 0, row.snapshot.warAttacksMax || 2);
+  const used = isWarRowAttackPhaseActive(row)
+    ? clampInt(row.snapshot.warAttacksUsed, 0, row.snapshot.warAttacksMax || 2)
+    : 0;
   const max = Math.max(1, clampInt(row.snapshot.warAttacksMax, 1, 2));
   const staleSuffix = row.staleSnapshot ? " - stale snapshot" : "";
   return `\`${used} / ${max}\`${staleSuffix}`;
-}
-
-/** Purpose: build neutral WAR row status text for linked players outside active war groups. */
-function getWarNeutralStatus(row: TodoRenderRow): string {
-  if (row.missingSnapshot || !row.snapshot) {
-    return "war attacks: 0/2 - snapshot unavailable";
-  }
-
-  const used = clampInt(row.snapshot.warAttacksUsed, 0, row.snapshot.warAttacksMax || 2);
-  const max = Math.max(1, clampInt(row.snapshot.warAttacksMax, 1, 2));
-  const staleSuffix = row.staleSnapshot ? " - stale snapshot" : "";
-  return `war attacks: ${used}/${max} - not in active war${staleSuffix}`;
 }
 
 /** Purpose: build active CWL row status text without repeating group-level phase timing details. */
@@ -637,18 +625,6 @@ function getCwlRowStatus(row: TodoRenderRow): string {
   const max = Math.max(1, clampInt(row.snapshot.cwlAttacksMax, 1, 1));
   const staleSuffix = row.staleSnapshot ? " - stale snapshot" : "";
   return `CWL attacks: ${used}/${max}${staleSuffix}`;
-}
-
-/** Purpose: build neutral CWL row status text for linked players outside active CWL groups. */
-function getCwlNeutralStatus(row: TodoRenderRow): string {
-  if (row.missingSnapshot || !row.snapshot) {
-    return "CWL attacks: 0/1 - snapshot unavailable";
-  }
-
-  const used = clampInt(row.snapshot.cwlAttacksUsed, 0, row.snapshot.cwlAttacksMax || 1);
-  const max = Math.max(1, clampInt(row.snapshot.cwlAttacksMax, 1, 1));
-  const staleSuffix = row.staleSnapshot ? " - stale snapshot" : "";
-  return `CWL attacks: ${used}/${max} - not in active CWL war${staleSuffix}`;
 }
 
 /** Purpose: build RAIDS row status text with usage only and without per-row timer duplication. */
@@ -732,6 +708,14 @@ function compareWarRowsForRendering(a: TodoRenderRow, b: TodoRenderRow): number 
   if (byTag !== 0) return byTag;
 
   return a.defaultIndex - b.defaultIndex;
+}
+
+/** Purpose: treat preparation phase as attack-inactive so stale prior-war attacks never render. */
+function isWarRowAttackPhaseActive(row: TodoRenderRow): boolean {
+  if (!row.snapshot?.warActive) return false;
+  const phase = sanitizeStatusText(row.snapshot.warPhase).toLowerCase();
+  if (phase.includes("preparation")) return false;
+  return true;
 }
 
 /** Purpose: extract compact first/second attack details from one latest war-member row. */
@@ -819,6 +803,33 @@ function pickLatestWarMemberByClanAndPlayer(
   return latest;
 }
 
+/** Purpose: keep one freshest war-member row per player tag as fallback when clan-tag joins are stale. */
+function pickLatestWarMemberByPlayerTag(
+  rows: WarMemberCurrentRow[],
+): Map<string, WarMemberCurrentRow> {
+  const latest = new Map<string, WarMemberCurrentRow>();
+  for (const row of rows) {
+    const clanTag = normalizeClanTag(row.clanTag);
+    const playerTag = normalizePlayerTag(row.playerTag);
+    if (!clanTag || !playerTag) continue;
+    const existing = latest.get(playerTag);
+    if (!existing || row.sourceSyncedAt > existing.sourceSyncedAt) {
+      latest.set(playerTag, {
+        clanTag,
+        playerTag,
+        position: toFiniteIntOrNull(row.position),
+        attacks: toFiniteIntOrNull(row.attacks),
+        defender1Position: toFiniteIntOrNull(row.defender1Position),
+        stars1: toFiniteIntOrNull(row.stars1),
+        defender2Position: toFiniteIntOrNull(row.defender2Position),
+        stars2: toFiniteIntOrNull(row.stars2),
+        sourceSyncedAt: row.sourceSyncedAt,
+      });
+    }
+  }
+  return latest;
+}
+
 /** Purpose: keep one latest current-war match context row per clan for header indicator rendering. */
 function pickLatestCurrentWarMatchContextByClanTag(
   rows: CurrentWarMatchContextRow[],
@@ -833,6 +844,7 @@ function pickLatestCurrentWarMatchContextByClanTag(
         clanTag,
         matchType: row.matchType,
         outcome: row.outcome,
+        state: row.state,
         updatedAt: row.updatedAt,
       });
     }

--- a/src/services/TodoSnapshotService.ts
+++ b/src/services/TodoSnapshotService.ts
@@ -72,6 +72,7 @@ type ClanMemberCurrentRow = {
 type WarMemberCurrentRow = {
   playerTag: string;
   clanTag: string;
+  position: number | null;
   attacks: number | null;
   sourceSyncedAt: Date;
 };
@@ -271,6 +272,7 @@ export class TodoSnapshotService {
         select: {
           playerTag: true,
           clanTag: true,
+          position: true,
           attacks: true,
           sourceSyncedAt: true,
         },
@@ -441,31 +443,38 @@ export class TodoSnapshotService {
       const currentWar = resolvedClanTag
         ? currentWarByClanTag.get(resolvedClanTag) ?? null
         : null;
-      const warActive = isWarStateActive(currentWar?.state ?? "");
-      const warPhase = warActive
-        ? normalizeWarPhaseLabel(currentWar?.state ?? "")
-        : null;
-      const warEndsAt = warActive ? resolveCurrentWarPhaseEnd(currentWar) : null;
+      const warStateActive = isWarStateActive(currentWar?.state ?? "");
+      const warStatePreparation = isWarStatePreparation(currentWar?.state ?? "");
 
       const warMemberKey = resolvedClanTag ? `${resolvedClanTag}:${playerTag}` : "";
       const warMember = warMemberKey
         ? latestWarMemberByClanAndTag.get(warMemberKey) ?? null
         : null;
-      const warAttacksUsed = warActive ? clampInt(warMember?.attacks, 0, 2) : 0;
+      const warActive = warStateActive && warMember !== null;
+      const warPhase = warActive
+        ? normalizeWarPhaseLabel(currentWar?.state ?? "")
+        : null;
+      const warEndsAt = warActive ? resolveCurrentWarPhaseEnd(currentWar) : null;
+      const warAttacksUsed = !warActive
+        ? 0
+        : warStatePreparation
+          ? 0
+          : clampInt(warMember?.attacks, 0, 2);
 
       const cwlWar = resolvedCwlClanTag
         ? cwlWarByClan.get(resolvedCwlClanTag) ?? null
         : null;
-      const cwlActive = isWarStateActive(cwlWar?.state ?? "");
+      const cwlParticipant =
+        !!resolvedCwlClanTag &&
+        activeCwlClanByPlayerTag.get(playerTag) === resolvedCwlClanTag;
+      const cwlActive = isWarStateActive(cwlWar?.state ?? "") && cwlParticipant;
       const cwlPhase = cwlActive
         ? normalizeWarPhaseLabel(cwlWar?.state ?? "")
         : null;
       const cwlEndsAt = cwlActive ? resolveCwlPhaseEnd(cwlWar) : null;
       const cwlAttacksUsed = cwlActive
         ? clampInt(findWarAttacksUsed(cwlWar, playerTag), 0, 1)
-        : !input.cocService && existing
-          ? clampInt(existing.cwlAttacksUsed, 0, 1)
-          : 0;
+        : 0;
 
       const derivedGames = deriveTodoGamesValues({
         gamesWindowActive: gamesWindow.active,
@@ -755,6 +764,7 @@ function pickLatestWarMemberByClanAndPlayer(
       latest.set(key, {
         playerTag,
         clanTag,
+        position: toFiniteIntOrNull(row.position),
         attacks: toFiniteIntOrNull(row.attacks),
         sourceSyncedAt: row.sourceSyncedAt,
       });
@@ -815,6 +825,12 @@ function pickLatestCurrentWarByClanTag(
 function isWarStateActive(state: unknown): boolean {
   const normalized = String(state ?? "").toLowerCase();
   return normalized.includes("preparation") || normalized.includes("inwar");
+}
+
+/** Purpose: detect preparation phase so attacks remain zero until battle day starts. */
+function isWarStatePreparation(state: unknown): boolean {
+  const normalized = String(state ?? "").toLowerCase();
+  return normalized.includes("preparation");
 }
 
 /** Purpose: map war-state values to user-facing phase labels. */

--- a/tests/todo.command.test.ts
+++ b/tests/todo.command.test.ts
@@ -293,7 +293,7 @@ describe("/todo command", () => {
     expect(cocService.getClanWarLeagueWar).not.toHaveBeenCalled();
   });
 
-  it("renders WAR headers with badge + match indicator and row-level attack detail", async () => {
+  it("renders WAR headers with badge + match indicator and suppresses preparation attack detail", async () => {
     prismaMock.playerLink.findMany.mockResolvedValue([
       { playerTag: "#PYLQ0289", createdAt: new Date("2026-03-01T00:00:00.000Z") },
       { playerTag: "#QGRJ2222", createdAt: new Date("2026-03-02T00:00:00.000Z") },
@@ -402,11 +402,10 @@ describe("/todo command", () => {
     expect(description).toContain("**:ak: Clan Two (#2QG2C08UP) :black_circle: - preparation ends <t:");
     expect(description).toContain("- #8 Alpha - `0 / 2`");
     expect(description).toContain("- #1 Bravo - `1 / 2` | :dagger: #8 ★ ★ ★");
-    expect(description).toContain(
-      "- #9 Charlie - `2 / 2` | :dagger: #8 ★ ★ ★ | :dagger: #1 ★ ☆ ☆",
-    );
-    expect(description).toContain("**Not in active war**");
-    expect(description).toContain("- Delta #LQ9P8R2 - war attacks: 0/2 - not in active war");
+    expect(description).toContain("- #9 Charlie - `0 / 2`");
+    expect(description).not.toContain("- #9 Charlie - `2 / 2`");
+    expect(description).not.toContain("**Not in active war**");
+    expect(description).not.toContain("Delta #LQ9P8R2");
   });
 
   it("uses safe #? fallback when war lineup position is unavailable", async () => {
@@ -459,7 +458,59 @@ describe("/todo command", () => {
     expect(description).toContain("- #? Alpha - `1 / 2` | :dagger: #? ★ ★ ☆");
   });
 
-  it("renders CWL grouped sections by shared context with neutral non-active rows", async () => {
+  it("uses player-tag fallback for war position when snapshot clan tag is stale", async () => {
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      { playerTag: "#PYLQ0289", createdAt: new Date("2026-03-01T00:00:00.000Z") },
+    ]);
+    prismaMock.todoPlayerSnapshot.aggregate.mockResolvedValue({
+      _count: { _all: 1 },
+      _max: { updatedAt: new Date("2026-03-26T00:00:00.000Z") },
+    });
+    prismaMock.todoPlayerSnapshot.findMany.mockResolvedValue([
+      makeSnapshotRow({
+        playerTag: "#PYLQ0289",
+        playerName: "Alpha",
+        clanTag: "#Q2V8P9L2",
+        clanName: "Stale Clan",
+        warAttacksUsed: 1,
+        warPhase: "battle day",
+      }),
+    ]);
+    prismaMock.trackedClan.findMany.mockResolvedValue([
+      { tag: "#Q2V8P9L2", clanBadge: ":rd:" },
+    ]);
+    prismaMock.currentWar.findMany.mockResolvedValue([
+      {
+        clanTag: "#Q2V8P9L2",
+        matchType: "FWA",
+        outcome: "WIN",
+        updatedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.fwaWarMemberCurrent.findMany.mockResolvedValue([
+      {
+        clanTag: "#PQL0289",
+        playerTag: "#PYLQ0289",
+        position: 8,
+        attacks: 1,
+        defender1Position: 7,
+        stars1: 2,
+        defender2Position: null,
+        stars2: null,
+        sourceSyncedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+    ]);
+
+    const interaction = makeTodoInteraction({ type: "WAR" });
+    await Todo.run({} as any, interaction as any, makeCocServiceSpy() as any);
+
+    const description = getReplyDescription(interaction);
+    expect(description).toContain("- #8 Alpha - `1 / 2`");
+    expect(description).toContain("| :dagger: #7 ★ ★ ☆");
+    expect(description).not.toContain("- #? Alpha -");
+  });
+
+  it("renders CWL grouped sections by shared context and omits non-active linked rows", async () => {
     prismaMock.playerLink.findMany.mockResolvedValue([
       { playerTag: "#PYLQ0289", createdAt: new Date("2026-03-01T00:00:00.000Z") },
       { playerTag: "#QGRJ2222", createdAt: new Date("2026-03-02T00:00:00.000Z") },
@@ -515,10 +566,8 @@ describe("/todo command", () => {
     expect(description).toContain("**Clan Two (#2QG2C08UP) - preparation ends <t:");
     expect(description).toContain("- Alpha #PYLQ0289 - CWL attacks: 1/1");
     expect(description).toContain("- Bravo #QGRJ2222 - CWL attacks: 0/1");
-    expect(description).toContain("**Not in active CWL**");
-    expect(description).toContain(
-      "- Delta #LQ9P8R2 - CWL attacks: 0/1 - not in active CWL war",
-    );
+    expect(description).not.toContain("**Not in active CWL**");
+    expect(description).not.toContain("Delta #LQ9P8R2");
   });
 
   it("groups CWL rows by cwlClanTag/cwlClanName when different from home clan", async () => {
@@ -1105,3 +1154,4 @@ describe("/todo refresh button", () => {
     expect(interaction.deferUpdate).not.toHaveBeenCalled();
   });
 });
+

--- a/tests/todoSnapshot.service.test.ts
+++ b/tests/todoSnapshot.service.test.ts
@@ -238,6 +238,90 @@ describe("TodoSnapshotService", () => {
     );
   });
 
+  it("writes zero war attacks during preparation even when member attack state is non-zero", async () => {
+    prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue([
+      {
+        playerTag: "#PYLQ0289",
+        clanTag: "#PQL0289",
+        playerName: "Alpha",
+        sourceSyncedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.fwaWarMemberCurrent.findMany.mockResolvedValue([
+      {
+        playerTag: "#PYLQ0289",
+        clanTag: "#PQL0289",
+        position: 8,
+        attacks: 2,
+        sourceSyncedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.currentWar.findMany.mockResolvedValue([
+      {
+        clanTag: "#PQL0289",
+        state: "preparation",
+        startTime: new Date("2026-03-26T12:00:00.000Z"),
+        endTime: new Date("2026-03-27T12:00:00.000Z"),
+        updatedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.cwlTrackedClan.findMany.mockResolvedValue([]);
+    prismaMock.cwlPlayerClanSeason.findMany.mockResolvedValue([]);
+
+    await todoSnapshotService.refreshSnapshotsForPlayerTags({
+      playerTags: ["#PYLQ0289"],
+      nowMs: Date.UTC(2026, 2, 26, 0, 0, 0, 0),
+    });
+
+    expect(prismaMock.todoPlayerSnapshot.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({
+          warActive: true,
+          warPhase: "preparation",
+          warAttacksUsed: 0,
+        }),
+      }),
+    );
+  });
+
+  it("marks WAR inactive for players missing from active-war membership", async () => {
+    prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue([
+      {
+        playerTag: "#PYLQ0289",
+        clanTag: "#PQL0289",
+        playerName: "Alpha",
+        sourceSyncedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.fwaWarMemberCurrent.findMany.mockResolvedValue([]);
+    prismaMock.currentWar.findMany.mockResolvedValue([
+      {
+        clanTag: "#PQL0289",
+        state: "inWar",
+        startTime: new Date("2026-03-25T12:00:00.000Z"),
+        endTime: new Date("2026-03-26T12:00:00.000Z"),
+        updatedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.cwlTrackedClan.findMany.mockResolvedValue([]);
+    prismaMock.cwlPlayerClanSeason.findMany.mockResolvedValue([]);
+
+    await todoSnapshotService.refreshSnapshotsForPlayerTags({
+      playerTags: ["#PYLQ0289"],
+      nowMs: Date.UTC(2026, 2, 26, 0, 0, 0, 0),
+    });
+
+    expect(prismaMock.todoPlayerSnapshot.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({
+          warActive: false,
+          warPhase: null,
+          warAttacksUsed: 0,
+        }),
+      }),
+    );
+  });
+
   it("derives active Clan Games points from stored signal totals and cycle baseline", async () => {
     prismaMock.todoPlayerSnapshot.findMany.mockResolvedValue([
       buildSnapshotRow({


### PR DESCRIPTION
- suppress WAR attack usage/details during preparation and keep attacks zero
- mark WAR/CWL active only for participating members in snapshot refresh
- render WAR/CWL pages with active members only and retain war-position fallback
- add regressions for preparation attacks, active-member filtering, and position carry-through