### PR TITLE
feat(todo): prioritize games points sorting and linked player name fa…

### DIFF
--- a/prisma/migrations/20260327110000_add_player_link_player_name/migration.sql
+++ b/prisma/migrations/20260327110000_add_player_link_player_name/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "PlayerLink"
+ADD COLUMN "playerName" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -60,6 +60,7 @@ model PlayerLink {
   playerTag     String   @id
   discordUserId String
   discordUsername String?
+  playerName    String?
   createdAt     DateTime @default(now())
   updatedAt     DateTime @updatedAt
 }

--- a/src/services/PlayerLinkService.ts
+++ b/src/services/PlayerLinkService.ts
@@ -81,18 +81,10 @@ export function normalizePersistedDiscordUsername(input: unknown): string | null
   return normalized;
 }
 
-/** Purpose: detect whether one normalized label is likely a Discord username handle (not an in-game player identity). */
-function isLikelyDiscordUsernameLabel(input: string): boolean {
-  if (!input) return false;
-  return /^[A-Za-z0-9._]{2,32}$/.test(input);
-}
-
-/** Purpose: normalize one PlayerLink name-like value for `/todo` player identity fallback use. */
-function normalizeLinkedPlayerNameForTodo(input: unknown): string | null {
-  const normalized = normalizePersistedDiscordUsername(input);
+/** Purpose: normalize persisted in-game player names for deterministic identity fallback use. */
+export function normalizePersistedPlayerName(input: unknown): string | null {
+  const normalized = String(input ?? "").replace(/\s+/g, " ").trim();
   if (!normalized) return null;
-  if (normalized.toLowerCase() === PLAYER_LINK_DISCORD_USERNAME_FALLBACK) return null;
-  if (isLikelyDiscordUsernameLabel(normalized)) return null;
   return normalized;
 }
 
@@ -307,7 +299,7 @@ export async function listPlayerLinksForDiscordUser(input: {
   const rows = await prisma.playerLink.findMany({
     where: { discordUserId: normalizedUserId },
     orderBy: [{ createdAt: "asc" }, { playerTag: "asc" }],
-    select: { playerTag: true, discordUsername: true, createdAt: true },
+    select: { playerTag: true, playerName: true, createdAt: true },
   });
 
   const seen = new Set<string>();
@@ -319,7 +311,7 @@ export async function listPlayerLinksForDiscordUser(input: {
     ordered.push({
       playerTag,
       linkedAt: row.createdAt,
-      linkedName: normalizeLinkedPlayerNameForTodo(row.discordUsername),
+      linkedName: normalizePersistedPlayerName(row.playerName),
     });
   }
   return ordered;

--- a/src/services/TodoService.ts
+++ b/src/services/TodoService.ts
@@ -852,11 +852,17 @@ function pickLatestCurrentWarMatchContextByClanTag(
   return latest;
 }
 
-/** Purpose: sort games rows by champion total desc with stable deterministic tie-breakers. */
+/** Purpose: sort games rows by current-cycle points first, then champion total, then stable ties. */
 function sortGamesRows(rows: TodoRenderRow[]): TodoRenderRow[] {
   return rows
     .map((row, index) => ({ row, index }))
     .sort((a, b) => {
+      const aPoints = Math.max(0, toFiniteIntOrNull(a.row.snapshot?.gamesPoints) ?? 0);
+      const bPoints = Math.max(0, toFiniteIntOrNull(b.row.snapshot?.gamesPoints) ?? 0);
+      if (aPoints !== bPoints) {
+        return bPoints - aPoints;
+      }
+
       const aTotal = toFiniteIntOrNull(a.row.snapshot?.gamesChampionTotal);
       const bTotal = toFiniteIntOrNull(b.row.snapshot?.gamesChampionTotal);
       const normalizedATotal = aTotal === null ? Number.NEGATIVE_INFINITY : aTotal;

--- a/src/services/fwa-feeds/FwaClanMembersSyncService.ts
+++ b/src/services/fwa-feeds/FwaClanMembersSyncService.ts
@@ -5,6 +5,7 @@ import { normalizeFwaTag } from "./normalize";
 import { FwaStatsClient } from "./FwaStatsClient";
 import { FwaFeedSyncStateService } from "./FwaFeedSyncStateService";
 import { mapWithConcurrency } from "./concurrency";
+import { normalizePersistedPlayerName } from "../PlayerLinkService";
 import type { FwaSyncResult } from "./types";
 
 type SyncOptions = {
@@ -106,6 +107,19 @@ export class FwaClanMembersSyncService {
 
       const changedRowCount = await prisma.$transaction(async (tx) => {
         const playerTags = rows.map((row) => row.playerTag);
+        const linkedPlayerRows =
+          playerTags.length > 0
+            ? await tx.playerLink.findMany({
+                where: { playerTag: { in: playerTags } },
+                select: { playerTag: true, playerName: true },
+              })
+            : [];
+        const linkedPlayerNameByTag = new Map(
+          linkedPlayerRows.map((row) => [
+            row.playerTag,
+            normalizePersistedPlayerName(row.playerName),
+          ]),
+        );
         const staleDelete = await tx.fwaClanMemberCurrent.deleteMany({
           where: {
             clanTag: normalizedClanTag,
@@ -171,6 +185,21 @@ export class FwaClanMembersSyncService {
               lastSyncedAt: now,
             },
           });
+
+          if (linkedPlayerNameByTag.has(row.playerTag)) {
+            const observedPlayerName = normalizePersistedPlayerName(row.playerName);
+            const existingLinkedName =
+              linkedPlayerNameByTag.get(row.playerTag) ?? null;
+            if (observedPlayerName && observedPlayerName !== existingLinkedName) {
+              const updated = await tx.playerLink.updateMany({
+                where: { playerTag: row.playerTag },
+                data: { playerName: observedPlayerName },
+              });
+              if (updated.count > 0) {
+                linkedPlayerNameByTag.set(row.playerTag, observedPlayerName);
+              }
+            }
+          }
         }
         return staleDelete.count + rows.length;
       });

--- a/src/services/fwa-feeds/FwaWarMembersSyncService.ts
+++ b/src/services/fwa-feeds/FwaWarMembersSyncService.ts
@@ -8,6 +8,7 @@ import { FwaFeedSyncStateService } from "./FwaFeedSyncStateService";
 import { mapWithConcurrency } from "./concurrency";
 import { selectDistributedSweepChunk } from "./sweep";
 import type { FwaSyncResult } from "./types";
+import { normalizePersistedPlayerName } from "../PlayerLinkService";
 
 type SyncOptions = {
   force?: boolean;
@@ -65,6 +66,19 @@ export class FwaWarMembersSyncService {
 
       const changedRowCount = await prisma.$transaction(async (tx) => {
         const playerTags = rows.map((row) => row.playerTag);
+        const linkedPlayerRows =
+          playerTags.length > 0
+            ? await tx.playerLink.findMany({
+                where: { playerTag: { in: playerTags } },
+                select: { playerTag: true, playerName: true },
+              })
+            : [];
+        const linkedPlayerNameByTag = new Map(
+          linkedPlayerRows.map((row) => [
+            row.playerTag,
+            normalizePersistedPlayerName(row.playerName),
+          ]),
+        );
         const staleDelete = await tx.fwaWarMemberCurrent.deleteMany({
           where: {
             clanTag: normalizedClanTag,
@@ -146,6 +160,21 @@ export class FwaWarMembersSyncService {
               lastSyncedAt: now,
             },
           });
+
+          if (linkedPlayerNameByTag.has(row.playerTag)) {
+            const observedPlayerName = normalizePersistedPlayerName(row.playerName);
+            const existingLinkedName =
+              linkedPlayerNameByTag.get(row.playerTag) ?? null;
+            if (observedPlayerName && observedPlayerName !== existingLinkedName) {
+              const updated = await tx.playerLink.updateMany({
+                where: { playerTag: row.playerTag },
+                data: { playerName: observedPlayerName },
+              });
+              if (updated.count > 0) {
+                linkedPlayerNameByTag.set(row.playerTag, observedPlayerName);
+              }
+            }
+          }
         }
         return staleDelete.count + rows.length;
       });

--- a/tests/fwaFeed.membersSync.test.ts
+++ b/tests/fwaFeed.membersSync.test.ts
@@ -10,6 +10,10 @@ const txMock = vi.hoisted(() => ({
   fwaPlayerCatalog: {
     upsert: vi.fn(),
   },
+  playerLink: {
+    findMany: vi.fn(),
+    updateMany: vi.fn(),
+  },
 }));
 
 const prismaMock = vi.hoisted(() => ({
@@ -70,6 +74,11 @@ describe("FwaClanMembersSyncService", () => {
 
     prismaMock.fwaFeedSyncState.findUnique.mockResolvedValue(null);
     txMock.fwaClanMemberCurrent.deleteMany.mockResolvedValue({ count: 1 });
+    txMock.playerLink.findMany.mockResolvedValue([
+      { playerTag: "#P1", playerName: null },
+      { playerTag: "#P2", playerName: "Two" },
+    ]);
+    txMock.playerLink.updateMany.mockResolvedValue({ count: 1 });
 
     const service = new FwaClanMembersSyncService(client);
     const result = await service.syncTrackedClan("#aaa111", { force: true });
@@ -85,9 +94,57 @@ describe("FwaClanMembersSyncService", () => {
     );
     expect(txMock.fwaClanMemberCurrent.upsert).toHaveBeenCalledTimes(2);
     expect(txMock.fwaPlayerCatalog.upsert).toHaveBeenCalledTimes(2);
+    expect(txMock.playerLink.findMany).toHaveBeenCalledWith({
+      where: { playerTag: { in: ["#P1", "#P2"] } },
+      select: { playerTag: true, playerName: true },
+    });
+    expect(txMock.playerLink.updateMany).toHaveBeenCalledTimes(1);
+    expect(txMock.playerLink.updateMany).toHaveBeenCalledWith({
+      where: { playerTag: "#P1" },
+      data: { playerName: "One" },
+    });
     expect(result.status).toBe("SUCCESS");
     expect(result.rowCount).toBe(2);
     expect(result.changedRowCount).toBe(3);
+  });
+
+  it("updates linked playerName when observed name changes", async () => {
+    const client = {
+      fetchClanMembers: vi.fn().mockResolvedValue([
+        {
+          clanTag: "#AAA111",
+          playerTag: "#P1",
+          playerName: "One Renamed",
+          role: "leader",
+          level: 10,
+          donated: 1,
+          received: 2,
+          rank: 1,
+          trophies: 1000,
+          league: "Gold",
+          townHall: 14,
+          weight: 120000,
+          inWar: true,
+        },
+      ]),
+    } as any;
+
+    prismaMock.fwaFeedSyncState.findUnique.mockResolvedValue(null);
+    txMock.fwaClanMemberCurrent.deleteMany.mockResolvedValue({ count: 0 });
+    txMock.playerLink.findMany.mockResolvedValue([
+      { playerTag: "#P1", playerName: "One" },
+    ]);
+    txMock.playerLink.updateMany.mockResolvedValue({ count: 1 });
+
+    const service = new FwaClanMembersSyncService(client);
+    const result = await service.syncTrackedClan("#AAA111", { force: true });
+
+    expect(txMock.playerLink.updateMany).toHaveBeenCalledTimes(1);
+    expect(txMock.playerLink.updateMany).toHaveBeenCalledWith({
+      where: { playerTag: "#P1" },
+      data: { playerName: "One Renamed" },
+    });
+    expect(result.status).toBe("SUCCESS");
   });
 
   it("returns NOOP when payload hash is unchanged", async () => {

--- a/tests/fwaFeed.warMembersSync.test.ts
+++ b/tests/fwaFeed.warMembersSync.test.ts
@@ -1,0 +1,146 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FwaWarMembersSyncService } from "../src/services/fwa-feeds/FwaWarMembersSyncService";
+import { computeFeedContentHash } from "../src/services/fwa-feeds/hash";
+
+const txMock = vi.hoisted(() => ({
+  fwaWarMemberCurrent: {
+    deleteMany: vi.fn(),
+    upsert: vi.fn(),
+  },
+  fwaPlayerCatalog: {
+    upsert: vi.fn(),
+  },
+  playerLink: {
+    findMany: vi.fn(),
+    updateMany: vi.fn(),
+  },
+}));
+
+const prismaMock = vi.hoisted(() => ({
+  fwaFeedSyncState: {
+    findUnique: vi.fn(),
+    upsert: vi.fn(),
+  },
+  $transaction: vi.fn(async (callback: (tx: typeof txMock) => Promise<unknown>) => callback(txMock)),
+}));
+
+vi.mock("../src/prisma", () => ({
+  prisma: prismaMock,
+}));
+
+function makeWarRow(input: {
+  clanTag: string;
+  playerTag: string;
+  playerName: string;
+  position: number;
+  attacks: number;
+}) {
+  return {
+    clanTag: input.clanTag,
+    playerTag: input.playerTag,
+    playerName: input.playerName,
+    position: input.position,
+    townHall: 14,
+    weight: 120000,
+    opponentTag: null,
+    opponentName: null,
+    attacks: input.attacks,
+    defender1Tag: null,
+    defender1Name: null,
+    defender1TownHall: null,
+    defender1Position: null,
+    stars1: null,
+    destructionPercentage1: null,
+    defender2Tag: null,
+    defender2Name: null,
+    defender2TownHall: null,
+    defender2Position: null,
+    stars2: null,
+    destructionPercentage2: null,
+  };
+}
+
+describe("FwaWarMembersSyncService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("syncs one clan and updates missing linked playerName from observed war roster names", async () => {
+    const client = {
+      fetchWarMembers: vi.fn().mockResolvedValue([
+        makeWarRow({ clanTag: "#AAA111", playerTag: "#P1", playerName: "One", position: 1, attacks: 0 }),
+        makeWarRow({ clanTag: "#AAA111", playerTag: "#P2", playerName: "Two", position: 2, attacks: 1 }),
+      ]),
+    } as any;
+    prismaMock.fwaFeedSyncState.findUnique.mockResolvedValue(null);
+    txMock.fwaWarMemberCurrent.deleteMany.mockResolvedValue({ count: 1 });
+    txMock.playerLink.findMany.mockResolvedValue([
+      { playerTag: "#P1", playerName: null },
+      { playerTag: "#P2", playerName: "Two" },
+    ]);
+    txMock.playerLink.updateMany.mockResolvedValue({ count: 1 });
+
+    const service = new FwaWarMembersSyncService(client);
+    const result = await service.syncClan("#aaa111", { force: true });
+
+    expect(client.fetchWarMembers).toHaveBeenCalledWith("#AAA111");
+    expect(txMock.fwaWarMemberCurrent.upsert).toHaveBeenCalledTimes(2);
+    expect(txMock.fwaPlayerCatalog.upsert).toHaveBeenCalledTimes(2);
+    expect(txMock.playerLink.findMany).toHaveBeenCalledWith({
+      where: { playerTag: { in: ["#P1", "#P2"] } },
+      select: { playerTag: true, playerName: true },
+    });
+    expect(txMock.playerLink.updateMany).toHaveBeenCalledTimes(1);
+    expect(txMock.playerLink.updateMany).toHaveBeenCalledWith({
+      where: { playerTag: "#P1" },
+      data: { playerName: "One" },
+    });
+    expect(result.status).toBe("SUCCESS");
+    expect(result.rowCount).toBe(2);
+    expect(result.changedRowCount).toBe(3);
+  });
+
+  it("updates linked playerName when observed war roster name changed", async () => {
+    const client = {
+      fetchWarMembers: vi.fn().mockResolvedValue([
+        makeWarRow({
+          clanTag: "#AAA111",
+          playerTag: "#P1",
+          playerName: "One Renamed",
+          position: 1,
+          attacks: 0,
+        }),
+      ]),
+    } as any;
+    prismaMock.fwaFeedSyncState.findUnique.mockResolvedValue(null);
+    txMock.fwaWarMemberCurrent.deleteMany.mockResolvedValue({ count: 0 });
+    txMock.playerLink.findMany.mockResolvedValue([{ playerTag: "#P1", playerName: "One" }]);
+    txMock.playerLink.updateMany.mockResolvedValue({ count: 1 });
+
+    const service = new FwaWarMembersSyncService(client);
+    const result = await service.syncClan("#AAA111", { force: true });
+
+    expect(txMock.playerLink.updateMany).toHaveBeenCalledTimes(1);
+    expect(txMock.playerLink.updateMany).toHaveBeenCalledWith({
+      where: { playerTag: "#P1" },
+      data: { playerName: "One Renamed" },
+    });
+    expect(result.status).toBe("SUCCESS");
+  });
+
+  it("returns NOOP when payload hash is unchanged", async () => {
+    const rows = [makeWarRow({ clanTag: "#AAA111", playerTag: "#P1", playerName: "One", position: 1, attacks: 0 })];
+    const hash = computeFeedContentHash(rows);
+    const client = {
+      fetchWarMembers: vi.fn().mockResolvedValue(rows),
+    } as any;
+    prismaMock.fwaFeedSyncState.findUnique.mockResolvedValue({ lastContentHash: hash });
+
+    const service = new FwaWarMembersSyncService(client);
+    const result = await service.syncClan("#AAA111", { force: true });
+
+    expect(result.status).toBe("NOOP");
+    expect(result.changedRowCount).toBe(0);
+    expect(prismaMock.$transaction).not.toHaveBeenCalled();
+  });
+});

--- a/tests/playerLink.service.test.ts
+++ b/tests/playerLink.service.test.ts
@@ -21,11 +21,13 @@ import {
   backfillMissingDiscordUsernamesForClanMembers,
   listCurrentWeightsForClanMembers,
   listPlayerLinksForClanMembers,
+  listPlayerLinksForDiscordUser,
   sanitizeDiscordUsernameForPersistence,
   normalizePersistedDiscordUsername,
+  normalizePersistedPlayerName,
 } from "../src/services/PlayerLinkService";
 
-describe("PlayerLinkService discordUsername", () => {
+describe("PlayerLinkService link identity", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     prismaMock.playerLink.findUnique.mockReset();
@@ -40,6 +42,49 @@ describe("PlayerLinkService discordUsername", () => {
     expect(normalizePersistedDiscordUsername("\n\t")).toBeNull();
     expect(normalizePersistedDiscordUsername(null)).toBeNull();
     expect(sanitizeDiscordUsernameForPersistence("\n\t")).toBe("unknown");
+  });
+
+  it("normalizes persisted player name text deterministically", () => {
+    expect(normalizePersistedPlayerName("  a   b  ")).toBe("a b");
+    expect(normalizePersistedPlayerName("\n\t")).toBeNull();
+    expect(normalizePersistedPlayerName(null)).toBeNull();
+  });
+
+  it("returns user-scoped links with linkedName from persisted playerName", async () => {
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      {
+        playerTag: "#PYLQ0289",
+        playerName: "  Alpha One  ",
+        createdAt: new Date("2026-03-15T09:07:00.000Z"),
+      },
+      {
+        playerTag: "#QGRJ2222",
+        playerName: " ",
+        createdAt: new Date("2026-03-15T09:08:00.000Z"),
+      },
+    ]);
+
+    const links = await listPlayerLinksForDiscordUser({
+      discordUserId: "111111111111111111",
+    });
+
+    expect(prismaMock.playerLink.findMany).toHaveBeenCalledWith({
+      where: { discordUserId: "111111111111111111" },
+      orderBy: [{ createdAt: "asc" }, { playerTag: "asc" }],
+      select: { playerTag: true, playerName: true, createdAt: true },
+    });
+    expect(links).toEqual([
+      {
+        playerTag: "#PYLQ0289",
+        linkedAt: new Date("2026-03-15T09:07:00.000Z"),
+        linkedName: "Alpha One",
+      },
+      {
+        playerTag: "#QGRJ2222",
+        linkedAt: new Date("2026-03-15T09:08:00.000Z"),
+        linkedName: null,
+      },
+    ]);
   });
 
   it("returns clan-scoped links with persisted discordUsername", async () => {

--- a/tests/todo.command.test.ts
+++ b/tests/todo.command.test.ts
@@ -729,16 +729,17 @@ describe("/todo command", () => {
     expect(description).toContain("- Bravo #QGRJ2222 - clan capital raids: 1/6");
   });
 
-  it("renders GAMES emojis by progress threshold and sorts by gamesChampionTotal desc", async () => {
+  it("renders GAMES emojis by progress threshold and sorts by gamesPoints desc then gamesChampionTotal desc", async () => {
     prismaMock.playerLink.findMany.mockResolvedValue([
       { playerTag: "#PYLQ0289", createdAt: new Date("2026-03-01T00:00:00.000Z") },
       { playerTag: "#QGRJ2222", createdAt: new Date("2026-03-02T00:00:00.000Z") },
       { playerTag: "#CUV9082", createdAt: new Date("2026-03-03T00:00:00.000Z") },
       { playerTag: "#LQ9P8R2", createdAt: new Date("2026-03-04T00:00:00.000Z") },
       { playerTag: "#Q2V8P9L2", createdAt: new Date("2026-03-05T00:00:00.000Z") },
+      { playerTag: "#9C8VY2L2", createdAt: new Date("2026-03-06T00:00:00.000Z") },
     ]);
     prismaMock.todoPlayerSnapshot.aggregate.mockResolvedValue({
-      _count: { _all: 5 },
+      _count: { _all: 6 },
       _max: { updatedAt: new Date("2026-03-26T00:00:00.000Z") },
     });
     prismaMock.todoPlayerSnapshot.findMany.mockResolvedValue([
@@ -762,8 +763,8 @@ describe("/todo command", () => {
         playerTag: "#CUV9082",
         playerName: "Charlie",
         gamesActive: true,
-        gamesPoints: 4000,
-        gamesChampionTotal: 8000,
+        gamesPoints: 5200,
+        gamesChampionTotal: 7000,
         gamesEndsAt: new Date("2026-03-28T08:00:00.000Z"),
       }),
       makeSnapshotRow({
@@ -778,8 +779,16 @@ describe("/todo command", () => {
         playerTag: "#Q2V8P9L2",
         playerName: "Bravo",
         gamesActive: true,
-        gamesPoints: 5200,
+        gamesPoints: 4000,
         gamesChampionTotal: 8000,
+        gamesEndsAt: new Date("2026-03-28T08:00:00.000Z"),
+      }),
+      makeSnapshotRow({
+        playerTag: "#9C8VY2L2",
+        playerName: "Foxtrot",
+        gamesActive: true,
+        gamesPoints: 3999,
+        gamesChampionTotal: 5000,
         gamesEndsAt: new Date("2026-03-28T08:00:00.000Z"),
       }),
     ]);
@@ -790,38 +799,41 @@ describe("/todo command", () => {
     const description = getReplyDescription(interaction);
     expect(description).toContain("**Time remaining:** <t:");
     expect(countOccurrences(description, "<t:")).toBe(1);
-    expect(description).toContain("- 🏆 Alpha #LQ9P8R2 - clan games points: 10000/4000");
-    expect(description).toContain("- ✅ Bravo #Q2V8P9L2 - clan games points: 5200/4000");
-    expect(description).toContain("- ✅ Charlie #CUV9082 - clan games points: 4000/4000");
-    expect(description).toContain("- 🟡 Delta #QGRJ2222 - clan games points: 3999/4000");
+    expect(description).toContain("Alpha #LQ9P8R2 - clan games points: 10000/4000");
+    expect(description).toContain("Bravo #Q2V8P9L2 - clan games points: 4000/4000");
+    expect(description).toContain("Charlie #CUV9082 - clan games points: 5200/4000");
+    expect(description).toContain("Delta #QGRJ2222 - clan games points: 3999/4000");
+    expect(description).toContain("Foxtrot #9C8VY2L2 - clan games points: 3999/4000");
     expect(description).toContain("- Echo #PYLQ0289 - clan games points: 0/4000");
 
-    const indexTrophy = description.indexOf("🏆 Alpha #LQ9P8R2");
-    const indexBravo = description.indexOf("✅ Bravo #Q2V8P9L2");
-    const indexCharlie = description.indexOf("✅ Charlie #CUV9082");
-    const indexDelta = description.indexOf("🟡 Delta #QGRJ2222");
+    const indexTrophy = description.indexOf("Alpha #LQ9P8R2");
+    const indexBravo = description.indexOf("Bravo #Q2V8P9L2");
+    const indexCharlie = description.indexOf("Charlie #CUV9082");
+    const indexDelta = description.indexOf("Delta #QGRJ2222");
+    const indexFoxtrot = description.indexOf("Foxtrot #9C8VY2L2");
     const indexEcho = description.indexOf("Echo #PYLQ0289");
     expect(indexTrophy).toBeGreaterThan(-1);
     expect(indexBravo).toBeGreaterThan(-1);
     expect(indexCharlie).toBeGreaterThan(-1);
     expect(indexDelta).toBeGreaterThan(-1);
+    expect(indexFoxtrot).toBeGreaterThan(-1);
     expect(indexEcho).toBeGreaterThan(-1);
-    expect(indexTrophy).toBeLessThan(indexBravo);
-    expect(indexBravo).toBeLessThan(indexCharlie);
-    expect(indexCharlie).toBeLessThan(indexDelta);
-    expect(indexDelta).toBeLessThan(indexEcho);
+    expect(indexTrophy).toBeLessThan(indexCharlie);
+    expect(indexCharlie).toBeLessThan(indexBravo);
+    expect(indexBravo).toBeLessThan(indexDelta);
+    expect(indexDelta).toBeLessThan(indexFoxtrot);
+    expect(indexFoxtrot).toBeLessThan(indexEcho);
   });
-
   it("falls back to PlayerLink identity for linked rows before final raw-tag fallback", async () => {
     prismaMock.playerLink.findMany.mockResolvedValue([
       {
         playerTag: "#PYLQ0289",
-        discordUsername: "Linked Alias",
+        playerName: "Linked Alias",
         createdAt: new Date("2026-03-01T00:00:00.000Z"),
       },
       {
         playerTag: "#QGRJ2222",
-        discordUsername: null,
+        playerName: null,
         createdAt: new Date("2026-03-02T00:00:00.000Z"),
       },
     ]);
@@ -852,11 +864,12 @@ describe("/todo command", () => {
     expect(description).toContain("- #QGRJ2222 - clan games points: 0/4000");
   });
 
-  it("does not use discord-handle-like PlayerLink usernames as normal todo player identity fallback", async () => {
+  it("does not use discordUsername as normal todo player identity fallback", async () => {
     prismaMock.playerLink.findMany.mockResolvedValue([
       {
         playerTag: "#PYLQ0289",
         discordUsername: "tonyk_2020",
+        playerName: null,
         createdAt: new Date("2026-03-01T00:00:00.000Z"),
       },
     ]);
@@ -1154,4 +1167,5 @@ describe("/todo refresh button", () => {
     expect(interaction.deferUpdate).not.toHaveBeenCalled();
   });
 });
+
 


### PR DESCRIPTION
…llback

- add PlayerLink.playerName with migration and use it for /todo linked-name fallback
- update members/war feed sync jobs to upsert PlayerLink.playerName only when missing or changed
- sort /todo GAMES rows by gamesPoints desc then gamesChampionTotal desc with stable tie-breakers
- add regression tests for todo ordering/fallback and feed-driven playerName updates