### PR TITLE
fix(todo): use tracked current-war truth for WAR snapshots and rendering

### DIFF
--- a/src/services/TodoService.ts
+++ b/src/services/TodoService.ts
@@ -9,6 +9,12 @@ import {
   todoSnapshotService,
   type TodoSnapshotRecord,
 } from "./TodoSnapshotService";
+import {
+  buildTrackedWarMemberStateByClanAndPlayer,
+  buildTrackedWarMemberStateByPlayerTag,
+  isTodoWarStateActive,
+  type TodoTrackedCurrentWarRow,
+} from "./TodoTrackedWarStateService";
 
 export const TODO_TYPES = ["WAR", "CWL", "RAIDS", "GAMES"] as const;
 export type TodoType = (typeof TODO_TYPES)[number];
@@ -65,8 +71,24 @@ type WarMemberCurrentRow = {
   sourceSyncedAt: Date;
 };
 
+type WarAttacksRow = {
+  warId: number;
+  clanTag: string;
+  warStartTime: Date;
+  playerTag: string;
+  playerPosition: number | null;
+  attacksUsed: number;
+  attackOrder: number;
+  attackNumber: number;
+  defenderPosition: number | null;
+  stars: number;
+  attackSeenAt: Date;
+};
+
 type CurrentWarMatchContextRow = {
   clanTag: string;
+  warId: number | null;
+  startTime: Date | null;
   matchType: string | null;
   outcome: string | null;
   state: string | null;
@@ -180,6 +202,8 @@ export async function buildTodoPagesForUser(input: {
           where: { clanTag: { in: clanTags } },
           select: {
             clanTag: true,
+            warId: true,
+            startTime: true,
             matchType: true,
             outcome: true,
             state: true,
@@ -192,6 +216,11 @@ export async function buildTodoPagesForUser(input: {
   const latestWarMemberByClanAndPlayer =
     pickLatestWarMemberByClanAndPlayer(warMemberRows);
   const latestWarMemberByPlayerTag = pickLatestWarMemberByPlayerTag(warMemberRows);
+  const trackedClanTagSet = new Set(
+    trackedClanRows
+      .map((row) => normalizeClanTag(row.tag))
+      .filter(Boolean),
+  );
   const clanBadgeByTag = new Map(
     trackedClanRows
       .map((row) => [normalizeClanTag(row.tag), sanitizeStatusText(row.clanBadge)] as const)
@@ -199,6 +228,48 @@ export async function buildTodoPagesForUser(input: {
   );
   const warMatchContextByClanTag =
     pickLatestCurrentWarMatchContextByClanTag(currentWarRows);
+  const currentWarIdentityByClanTag = pickLatestCurrentWarIdentityByClanTag(currentWarRows);
+  const activeTrackedCurrentWarByClanTag = new Map<string, TodoTrackedCurrentWarRow>();
+  for (const [clanTag, currentWar] of currentWarIdentityByClanTag.entries()) {
+    if (!trackedClanTagSet.has(clanTag)) continue;
+    if (!isTodoWarStateActive(currentWar.state ?? "")) continue;
+    activeTrackedCurrentWarByClanTag.set(clanTag, {
+      clanTag,
+      warId: toFiniteIntOrNull(currentWar.warId),
+      startTime: currentWar.startTime ?? null,
+      state: currentWar.state ?? null,
+    });
+  }
+  const activeTrackedClanTags = [...activeTrackedCurrentWarByClanTag.keys()];
+  const trackedWarAttackRows: WarAttacksRow[] =
+    activeTrackedClanTags.length > 0
+      ? await prisma.warAttacks.findMany({
+          where: {
+            clanTag: { in: activeTrackedClanTags },
+            playerTag: { in: linkedTags },
+          },
+          select: {
+            warId: true,
+            clanTag: true,
+            warStartTime: true,
+            playerTag: true,
+            playerPosition: true,
+            attacksUsed: true,
+            attackOrder: true,
+            attackNumber: true,
+            defenderPosition: true,
+            stars: true,
+            attackSeenAt: true,
+          },
+        })
+      : [];
+  const trackedWarMemberByClanAndPlayer = buildTrackedWarMemberStateByClanAndPlayer({
+    currentWarByClanTag: activeTrackedCurrentWarByClanTag,
+    warAttackRows: trackedWarAttackRows,
+  });
+  const trackedWarMemberByPlayerTag = buildTrackedWarMemberStateByPlayerTag(
+    trackedWarMemberByClanAndPlayer,
+  );
 
   const renderRows = links.map((link, index) => {
     const normalizedTag = normalizePlayerTag(link.playerTag);
@@ -207,11 +278,27 @@ export async function buildTodoPagesForUser(input: {
     const staleSnapshot = snapshot ? isSnapshotStale(snapshot, nowMs) : false;
     const resolvedClanTag = normalizeClanTag(snapshot?.clanTag ?? "") || null;
     const warMemberKey = resolvedClanTag ? `${resolvedClanTag}:${normalizedTag}` : "";
-    const warMember = warMemberKey
+    const warMemberFromFeed = warMemberKey
       ? latestWarMemberByClanAndPlayer.get(warMemberKey) ?? null
       : null;
-    const fallbackWarMember =
-      warMember ?? latestWarMemberByPlayerTag.get(normalizedTag) ?? null;
+    const fallbackWarMemberFromFeed =
+      warMemberFromFeed ?? latestWarMemberByPlayerTag.get(normalizedTag) ?? null;
+    const trackedWarMember = warMemberKey
+      ? trackedWarMemberByClanAndPlayer.get(warMemberKey) ?? null
+      : null;
+    const fallbackTrackedWarMember =
+      trackedWarMember ?? trackedWarMemberByPlayerTag.get(normalizedTag) ?? null;
+    const trackedClanActive = Boolean(
+      resolvedClanTag && trackedClanTagSet.has(resolvedClanTag),
+    );
+    const resolvedWarPosition = trackedClanActive
+      ? toFiniteIntOrNull(
+          fallbackTrackedWarMember?.position ?? fallbackWarMemberFromFeed?.position,
+        )
+      : toFiniteIntOrNull(fallbackWarMemberFromFeed?.position);
+    const resolvedWarAttackDetails = trackedClanActive
+      ? (fallbackTrackedWarMember?.attackDetails ?? [])
+      : resolveWarAttackDetails(fallbackWarMemberFromFeed);
     const matchContext = resolvedClanTag
       ? warMatchContextByClanTag.get(resolvedClanTag) ?? null
       : null;
@@ -228,8 +315,8 @@ export async function buildTodoPagesForUser(input: {
       clanName: snapshot?.clanName ?? null,
       cwlClanTag: snapshot?.cwlClanTag ?? null,
       cwlClanName: snapshot?.cwlClanName ?? null,
-      warPosition: toFiniteIntOrNull(fallbackWarMember?.position),
-      warAttackDetails: resolveWarAttackDetails(fallbackWarMember),
+      warPosition: resolvedWarPosition,
+      warAttackDetails: resolvedWarAttackDetails,
       warHeaderBadge: resolvedClanTag ? clanBadgeByTag.get(resolvedClanTag) ?? null : null,
       warMatchIndicator: resolveWarMatchStatusIndicator(matchContext),
       snapshot,
@@ -842,9 +929,57 @@ function pickLatestCurrentWarMatchContextByClanTag(
     if (!existing || row.updatedAt > existing.updatedAt) {
       latest.set(clanTag, {
         clanTag,
+        warId: toFiniteIntOrNull(row.warId),
+        startTime: row.startTime ?? null,
         matchType: row.matchType,
         outcome: row.outcome,
         state: row.state,
+        updatedAt: row.updatedAt,
+      });
+    }
+  }
+  return latest;
+}
+
+/** Purpose: keep one latest current-war identity row per clan for tracked WarAttacks resolution. */
+function pickLatestCurrentWarIdentityByClanTag(
+  rows: Array<{
+    clanTag: string;
+    warId: number | null;
+    startTime: Date | null;
+    state: string | null;
+    updatedAt: Date;
+  }>,
+): Map<
+  string,
+  {
+    clanTag: string;
+    warId: number | null;
+    startTime: Date | null;
+    state: string | null;
+    updatedAt: Date;
+  }
+> {
+  const latest = new Map<
+    string,
+    {
+      clanTag: string;
+      warId: number | null;
+      startTime: Date | null;
+      state: string | null;
+      updatedAt: Date;
+    }
+  >();
+  for (const row of rows) {
+    const clanTag = normalizeClanTag(row.clanTag);
+    if (!clanTag) continue;
+    const existing = latest.get(clanTag);
+    if (!existing || row.updatedAt > existing.updatedAt) {
+      latest.set(clanTag, {
+        clanTag,
+        warId: toFiniteIntOrNull(row.warId),
+        startTime: row.startTime ?? null,
+        state: row.state ?? null,
         updatedAt: row.updatedAt,
       });
     }

--- a/src/services/TodoSnapshotService.ts
+++ b/src/services/TodoSnapshotService.ts
@@ -8,6 +8,11 @@ import {
 import { resolveCurrentCwlSeasonKey } from "./CwlRegistryService";
 import { CoCService } from "./CoCService";
 import { normalizeClanTag, normalizePlayerTag } from "./PlayerLinkService";
+import {
+  buildTrackedWarMemberStateByClanAndPlayer,
+  isTodoWarStateActive,
+  type TodoTrackedCurrentWarRow,
+} from "./TodoTrackedWarStateService";
 import { parseCocTime } from "./war-events/core";
 
 const TODO_SNAPSHOT_SELECT = {
@@ -75,6 +80,20 @@ type WarMemberCurrentRow = {
   position: number | null;
   attacks: number | null;
   sourceSyncedAt: Date;
+};
+
+type WarAttacksRow = {
+  warId: number;
+  clanTag: string;
+  warStartTime: Date;
+  playerTag: string;
+  playerPosition: number | null;
+  attacksUsed: number;
+  attackOrder: number;
+  attackNumber: number;
+  defenderPosition: number | null;
+  stars: number;
+  attackSeenAt: Date;
 };
 
 type TodoGamesDerivedValues = {
@@ -333,6 +352,7 @@ export class TodoSnapshotService {
             where: { clanTag: { in: clanTags } },
             select: {
               clanTag: true,
+              warId: true,
               state: true,
               startTime: true,
               endTime: true,
@@ -365,6 +385,49 @@ export class TodoSnapshotService {
         .filter((entry): entry is [string, string] => Boolean(entry[0] && entry[1])),
     );
     const currentWarByClanTag = pickLatestCurrentWarByClanTag(currentWarRows);
+    const trackedClanTagSet = new Set(
+      trackedClanRows
+        .map((row) => normalizeClanTag(row.tag))
+        .filter(Boolean),
+    );
+    const activeTrackedCurrentWarByClanTag = new Map<string, TodoTrackedCurrentWarRow>();
+    for (const [clanTag, currentWar] of currentWarByClanTag.entries()) {
+      if (!trackedClanTagSet.has(clanTag)) continue;
+      if (!isTodoWarStateActive(currentWar.state ?? "")) continue;
+      activeTrackedCurrentWarByClanTag.set(clanTag, {
+        clanTag,
+        warId: toFiniteIntOrNull(currentWar.warId),
+        startTime: currentWar.startTime ?? null,
+        state: currentWar.state ?? null,
+      });
+    }
+    const activeTrackedClanTags = [...activeTrackedCurrentWarByClanTag.keys()];
+    const trackedWarAttackRows: WarAttacksRow[] =
+      activeTrackedClanTags.length > 0
+        ? await prisma.warAttacks.findMany({
+            where: {
+              clanTag: { in: activeTrackedClanTags },
+              playerTag: { in: normalizedTags },
+            },
+            select: {
+              warId: true,
+              clanTag: true,
+              warStartTime: true,
+              playerTag: true,
+              playerPosition: true,
+              attacksUsed: true,
+              attackOrder: true,
+              attackNumber: true,
+              defenderPosition: true,
+              stars: true,
+              attackSeenAt: true,
+            },
+          })
+        : [];
+    const trackedWarMemberByClanAndTag = buildTrackedWarMemberStateByClanAndPlayer({
+      currentWarByClanTag: activeTrackedCurrentWarByClanTag,
+      warAttackRows: trackedWarAttackRows,
+    });
     const cwlTrackedTagSet = new Set(
       cwlTrackedClanRows
         .map((row) => normalizeClanTag(row.tag))
@@ -443,13 +506,23 @@ export class TodoSnapshotService {
       const currentWar = resolvedClanTag
         ? currentWarByClanTag.get(resolvedClanTag) ?? null
         : null;
-      const warStateActive = isWarStateActive(currentWar?.state ?? "");
+      const warStateActive = isTodoWarStateActive(currentWar?.state ?? "");
       const warStatePreparation = isWarStatePreparation(currentWar?.state ?? "");
+      const trackedClanActive = Boolean(
+        resolvedClanTag && trackedClanTagSet.has(resolvedClanTag),
+      );
 
       const warMemberKey = resolvedClanTag ? `${resolvedClanTag}:${playerTag}` : "";
-      const warMember = warMemberKey
+      const warMemberFromFeed = warMemberKey
         ? latestWarMemberByClanAndTag.get(warMemberKey) ?? null
         : null;
+      const trackedWarMember =
+        trackedClanActive && warMemberKey
+          ? trackedWarMemberByClanAndTag.get(warMemberKey) ?? null
+          : null;
+      const warMember = trackedClanActive
+        ? trackedWarMember ?? warMemberFromFeed
+        : warMemberFromFeed;
       const warActive = warStateActive && warMember !== null;
       const warPhase = warActive
         ? normalizeWarPhaseLabel(currentWar?.state ?? "")
@@ -459,7 +532,9 @@ export class TodoSnapshotService {
         ? 0
         : warStatePreparation
           ? 0
-          : clampInt(warMember?.attacks, 0, 2);
+          : trackedClanActive
+            ? clampInt(trackedWarMember?.attacksUsed, 0, 2)
+            : clampInt(warMemberFromFeed?.attacks, 0, 2);
 
       const cwlWar = resolvedCwlClanTag
         ? cwlWarByClan.get(resolvedCwlClanTag) ?? null
@@ -777,6 +852,7 @@ function pickLatestWarMemberByClanAndPlayer(
 function pickLatestCurrentWarByClanTag(
   rows: Array<{
     clanTag: string;
+    warId: number | null;
     state: string | null;
     startTime: Date | null;
     endTime: Date | null;
@@ -786,6 +862,7 @@ function pickLatestCurrentWarByClanTag(
   string,
   {
     clanTag: string;
+    warId: number | null;
     state: string | null;
     startTime: Date | null;
     endTime: Date | null;
@@ -796,6 +873,7 @@ function pickLatestCurrentWarByClanTag(
     string,
     {
       clanTag: string;
+      warId: number | null;
       state: string | null;
       startTime: Date | null;
       endTime: Date | null;
@@ -811,6 +889,7 @@ function pickLatestCurrentWarByClanTag(
     if (!existing || row.updatedAt > existing.updatedAt) {
       latest.set(clanTag, {
         clanTag,
+        warId: toFiniteIntOrNull(row.warId),
         state: row.state,
         startTime: row.startTime,
         endTime: row.endTime,
@@ -821,16 +900,15 @@ function pickLatestCurrentWarByClanTag(
   return latest;
 }
 
-/** Purpose: classify war-state strings into active/non-active buckets for todo status. */
-function isWarStateActive(state: unknown): boolean {
-  const normalized = String(state ?? "").toLowerCase();
-  return normalized.includes("preparation") || normalized.includes("inwar");
-}
-
 /** Purpose: detect preparation phase so attacks remain zero until battle day starts. */
 function isWarStatePreparation(state: unknown): boolean {
   const normalized = String(state ?? "").toLowerCase();
   return normalized.includes("preparation");
+}
+
+/** Purpose: keep existing CWL helpers on one shared active-phase classifier. */
+function isWarStateActive(state: unknown): boolean {
+  return isTodoWarStateActive(state);
 }
 
 /** Purpose: map war-state values to user-facing phase labels. */

--- a/src/services/TodoTrackedWarStateService.ts
+++ b/src/services/TodoTrackedWarStateService.ts
@@ -1,0 +1,217 @@
+import { normalizeClanTag, normalizePlayerTag } from "./PlayerLinkService";
+
+export type TodoTrackedCurrentWarRow = {
+  clanTag: string;
+  warId: number | null;
+  startTime: Date | null;
+  state: string | null;
+};
+
+export type TodoTrackedWarAttackRow = {
+  warId: number;
+  clanTag: string;
+  warStartTime: Date;
+  playerTag: string;
+  playerPosition: number | null;
+  attacksUsed: number;
+  attackOrder: number;
+  attackNumber: number;
+  defenderPosition: number | null;
+  stars: number;
+  attackSeenAt: Date;
+};
+
+export type TodoTrackedWarAttackDetail = {
+  defenderPosition: number | null;
+  stars: number | null;
+};
+
+export type TodoTrackedWarMemberState = {
+  playerTag: string;
+  clanTag: string;
+  position: number | null;
+  attacksUsed: number;
+  attackDetails: TodoTrackedWarAttackDetail[];
+};
+
+type MutableTrackedWarMemberState = {
+  playerTag: string;
+  clanTag: string;
+  position: number | null;
+  attacksUsed: number;
+  attackDetails: Array<{
+    order: number;
+    attackNumber: number;
+    seenAtMs: number;
+    defenderPosition: number | null;
+    stars: number | null;
+  }>;
+};
+
+/** Purpose: classify war-state strings into active/non-active buckets for todo status. */
+export function isTodoWarStateActive(state: unknown): boolean {
+  const normalized = String(state ?? "").toLowerCase();
+  return normalized.includes("preparation") || normalized.includes("inwar");
+}
+
+/** Purpose: build tracked-war member state from CurrentWar identity + WarAttacks rows. */
+export function buildTrackedWarMemberStateByClanAndPlayer(input: {
+  currentWarByClanTag: Map<string, TodoTrackedCurrentWarRow>;
+  warAttackRows: TodoTrackedWarAttackRow[];
+}): Map<string, TodoTrackedWarMemberState> {
+  const mapped = new Map<string, MutableTrackedWarMemberState>();
+
+  for (const row of input.warAttackRows) {
+    const clanTag = normalizeClanTag(row.clanTag);
+    const playerTag = normalizePlayerTag(row.playerTag);
+    if (!clanTag || !playerTag) continue;
+
+    const currentWar = input.currentWarByClanTag.get(clanTag);
+    if (!currentWar || !isTodoWarStateActive(currentWar.state)) continue;
+    if (!matchesCurrentWarIdentity(currentWar, row)) continue;
+
+    const key = `${clanTag}:${playerTag}`;
+    const existing = mapped.get(key);
+    const mutable =
+      existing ??
+      ({
+        playerTag,
+        clanTag,
+        position: null,
+        attacksUsed: 0,
+        attackDetails: [],
+      } satisfies MutableTrackedWarMemberState);
+    if (!existing) {
+      mapped.set(key, mutable);
+    }
+
+    const candidatePosition = toFiniteIntOrNull(row.playerPosition);
+    if (
+      mutable.position === null &&
+      candidatePosition !== null &&
+      candidatePosition > 0
+    ) {
+      mutable.position = candidatePosition;
+    }
+    mutable.attacksUsed = Math.max(
+      mutable.attacksUsed,
+      clampInt(row.attacksUsed, 0, 2),
+    );
+
+    const attackOrder = clampInt(row.attackOrder, 0, 2);
+    const attackNumber = clampInt(row.attackNumber, 0, 2);
+    if (attackOrder <= 0 && attackNumber <= 0) {
+      continue;
+    }
+    mutable.attackDetails.push({
+      order: attackOrder > 0 ? attackOrder : attackNumber,
+      attackNumber,
+      seenAtMs: row.attackSeenAt.getTime(),
+      defenderPosition: toFiniteIntOrNull(row.defenderPosition),
+      stars: toFiniteIntOrNull(row.stars),
+    });
+  }
+
+  const finalized = new Map<string, TodoTrackedWarMemberState>();
+  for (const [key, value] of mapped.entries()) {
+    const orderedAttackDetails = [...value.attackDetails]
+      .sort((a, b) => {
+        if (a.order !== b.order) return a.order - b.order;
+        if (a.attackNumber !== b.attackNumber) return a.attackNumber - b.attackNumber;
+        return a.seenAtMs - b.seenAtMs;
+      })
+      .slice(0, 2)
+      .map((detail) => ({
+        defenderPosition: detail.defenderPosition,
+        stars: detail.stars,
+      }));
+    const attacksUsed = Math.max(
+      value.attacksUsed,
+      Math.min(2, orderedAttackDetails.length),
+    );
+    finalized.set(key, {
+      playerTag: value.playerTag,
+      clanTag: value.clanTag,
+      position: value.position,
+      attacksUsed,
+      attackDetails: orderedAttackDetails,
+    });
+  }
+
+  return finalized;
+}
+
+/** Purpose: build one per-player fallback map from tracked war member state rows. */
+export function buildTrackedWarMemberStateByPlayerTag(
+  rows: Map<string, TodoTrackedWarMemberState>,
+): Map<string, TodoTrackedWarMemberState> {
+  const byPlayerTag = new Map<string, TodoTrackedWarMemberState>();
+  for (const row of rows.values()) {
+    const existing = byPlayerTag.get(row.playerTag);
+    if (!existing) {
+      byPlayerTag.set(row.playerTag, row);
+      continue;
+    }
+
+    const existingPos = existing.position ?? Number.MAX_SAFE_INTEGER;
+    const nextPos = row.position ?? Number.MAX_SAFE_INTEGER;
+    if (nextPos < existingPos) {
+      byPlayerTag.set(row.playerTag, row);
+      continue;
+    }
+    if (nextPos > existingPos) continue;
+
+    const existingAttacks = existing.attacksUsed;
+    const nextAttacks = row.attacksUsed;
+    if (nextAttacks > existingAttacks) {
+      byPlayerTag.set(row.playerTag, row);
+      continue;
+    }
+    if (nextAttacks < existingAttacks) continue;
+
+    const existingKey = `${existing.clanTag}:${existing.playerTag}`;
+    const nextKey = `${row.clanTag}:${row.playerTag}`;
+    if (nextKey.localeCompare(existingKey) < 0) {
+      byPlayerTag.set(row.playerTag, row);
+    }
+  }
+  return byPlayerTag;
+}
+
+/** Purpose: prevent previous-war leakage by requiring WarAttacks rows to match CurrentWar identity. */
+function matchesCurrentWarIdentity(
+  currentWar: TodoTrackedCurrentWarRow,
+  attack: Pick<TodoTrackedWarAttackRow, "warId" | "warStartTime">,
+): boolean {
+  const currentWarId = toFiniteIntOrNull(currentWar.warId);
+  if (currentWarId !== null) {
+    const attackWarId = toFiniteIntOrNull(attack.warId);
+    return attackWarId !== null && attackWarId === currentWarId;
+  }
+
+  const currentStartMs =
+    currentWar.startTime instanceof Date ? currentWar.startTime.getTime() : null;
+  const attackStartMs =
+    attack.warStartTime instanceof Date ? attack.warStartTime.getTime() : null;
+  if (currentStartMs === null || attackStartMs === null) {
+    return false;
+  }
+  return currentStartMs === attackStartMs;
+}
+
+/** Purpose: normalize unknown numeric values into one bounded integer range. */
+function clampInt(input: unknown, min: number, max: number): number {
+  const parsed = Number(input);
+  if (!Number.isFinite(parsed)) return min;
+  const truncated = Math.trunc(parsed);
+  return Math.max(min, Math.min(max, truncated));
+}
+
+/** Purpose: map unknown numeric input to finite integer or null for nullable fields. */
+function toFiniteIntOrNull(input: unknown): number | null {
+  if (input === null || input === undefined) return null;
+  if (typeof input === "string" && input.trim().length <= 0) return null;
+  const value = Number(input);
+  if (!Number.isFinite(value)) return null;
+  return Math.trunc(value);
+}

--- a/src/services/fwa-feeds/FwaFeedSchedulerService.ts
+++ b/src/services/fwa-feeds/FwaFeedSchedulerService.ts
@@ -40,9 +40,14 @@ function toBool(input: string | undefined, fallback: boolean): boolean {
 }
 
 function toInt(input: string | undefined, fallback: number): number {
-  const parsed = Number(input ?? "");
+  if (input === undefined) return fallback;
+  const trimmed = input.trim();
+  if (!trimmed) return fallback;
+  const parsed = Number(trimmed);
   return Number.isFinite(parsed) ? Math.trunc(parsed) : fallback;
 }
+
+export const toIntWithFallbackForTest = toInt;
 
 function minutesToMsWithMin(valueMinutes: number, minMinutes: number): number {
   return Math.max(minMinutes, valueMinutes) * 60 * 1000;

--- a/tests/fwaFeedScheduler.config.test.ts
+++ b/tests/fwaFeedScheduler.config.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  FwaFeedSchedulerService,
+  toIntWithFallbackForTest,
+} from "../src/services/fwa-feeds/FwaFeedSchedulerService";
+
+const originalEnv = { ...process.env };
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+});
+
+describe("FwaFeedSchedulerService env integer parsing", () => {
+  it("uses fallback for undefined/empty integer env values", () => {
+    expect(toIntWithFallbackForTest(undefined, 6)).toBe(6);
+    expect(toIntWithFallbackForTest("", 6)).toBe(6);
+    expect(toIntWithFallbackForTest("   ", 6)).toBe(6);
+    expect(toIntWithFallbackForTest("invalid", 6)).toBe(6);
+    expect(toIntWithFallbackForTest("0", 6)).toBe(0);
+  });
+
+  it("keeps WAR_MEMBERS chunk default when env is empty instead of degrading to 1", () => {
+    process.env.FWA_WAR_MEMBERS_SWEEP_CHUNK_SIZE = "";
+    process.env.FWA_FEED_MAX_CONCURRENCY = "";
+
+    const scheduler = new FwaFeedSchedulerService() as unknown as {
+      config: { warMembersSweepChunkSize: number; maxConcurrency: number };
+    };
+
+    expect(scheduler.config.warMembersSweepChunkSize).toBe(6);
+    expect(scheduler.config.maxConcurrency).toBe(4);
+  });
+});

--- a/tests/todo.command.test.ts
+++ b/tests/todo.command.test.ts
@@ -21,6 +21,9 @@ const prismaMock = vi.hoisted(() => ({
   currentWar: {
     findMany: vi.fn(),
   },
+  warAttacks: {
+    findMany: vi.fn(),
+  },
   trackedClan: {
     findMany: vi.fn(),
   },
@@ -208,6 +211,7 @@ describe("/todo command", () => {
     prismaMock.fwaClanMemberCurrent.findMany.mockReset();
     prismaMock.fwaWarMemberCurrent.findMany.mockReset();
     prismaMock.currentWar.findMany.mockReset();
+    prismaMock.warAttacks.findMany.mockReset();
     prismaMock.trackedClan.findMany.mockReset();
     prismaMock.cwlTrackedClan.findMany.mockReset();
     prismaMock.cwlPlayerClanSeason.findMany.mockReset();
@@ -224,6 +228,7 @@ describe("/todo command", () => {
     prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue([]);
     prismaMock.fwaWarMemberCurrent.findMany.mockResolvedValue([]);
     prismaMock.currentWar.findMany.mockResolvedValue([]);
+    prismaMock.warAttacks.findMany.mockResolvedValue([]);
     prismaMock.trackedClan.findMany.mockResolvedValue([]);
     prismaMock.cwlTrackedClan.findMany.mockResolvedValue([]);
     prismaMock.cwlPlayerClanSeason.findMany.mockResolvedValue([]);
@@ -346,15 +351,88 @@ describe("/todo command", () => {
     prismaMock.currentWar.findMany.mockResolvedValue([
       {
         clanTag: "#PQL0289",
+        warId: 1001,
+        startTime: new Date("2026-03-25T12:00:00.000Z"),
         matchType: "FWA",
         outcome: "WIN",
+        state: "inWar",
         updatedAt: new Date("2026-03-26T00:00:00.000Z"),
       },
       {
         clanTag: "#2QG2C08UP",
+        warId: 1002,
+        startTime: new Date("2026-03-25T12:00:00.000Z"),
         matchType: "BL",
         outcome: null,
+        state: "preparation",
         updatedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.warAttacks.findMany.mockResolvedValue([
+      {
+        warId: 1001,
+        clanTag: "#PQL0289",
+        warStartTime: new Date("2026-03-25T12:00:00.000Z"),
+        playerTag: "#PYLQ0289",
+        playerPosition: 8,
+        attacksUsed: 0,
+        attackOrder: 0,
+        attackNumber: 0,
+        defenderPosition: null,
+        stars: 0,
+        attackSeenAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+      {
+        warId: 1001,
+        clanTag: "#PQL0289",
+        warStartTime: new Date("2026-03-25T12:00:00.000Z"),
+        playerTag: "#QGRJ2222",
+        playerPosition: 1,
+        attacksUsed: 1,
+        attackOrder: 0,
+        attackNumber: 0,
+        defenderPosition: null,
+        stars: 0,
+        attackSeenAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+      {
+        warId: 1001,
+        clanTag: "#PQL0289",
+        warStartTime: new Date("2026-03-25T12:00:00.000Z"),
+        playerTag: "#QGRJ2222",
+        playerPosition: 1,
+        attacksUsed: 1,
+        attackOrder: 1,
+        attackNumber: 1,
+        defenderPosition: 8,
+        stars: 3,
+        attackSeenAt: new Date("2026-03-26T00:05:00.000Z"),
+      },
+      {
+        warId: 1002,
+        clanTag: "#2QG2C08UP",
+        warStartTime: new Date("2026-03-25T12:00:00.000Z"),
+        playerTag: "#CUV9082",
+        playerPosition: 9,
+        attacksUsed: 2,
+        attackOrder: 0,
+        attackNumber: 0,
+        defenderPosition: null,
+        stars: 0,
+        attackSeenAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+      {
+        warId: 1002,
+        clanTag: "#2QG2C08UP",
+        warStartTime: new Date("2026-03-25T12:00:00.000Z"),
+        playerTag: "#CUV9082",
+        playerPosition: 9,
+        attacksUsed: 2,
+        attackOrder: 1,
+        attackNumber: 1,
+        defenderPosition: 8,
+        stars: 3,
+        attackSeenAt: new Date("2026-03-26T00:10:00.000Z"),
       },
     ]);
     prismaMock.fwaWarMemberCurrent.findMany.mockResolvedValue([
@@ -374,8 +452,8 @@ describe("/todo command", () => {
         playerTag: "#QGRJ2222",
         position: 1,
         attacks: 1,
-        defender1Position: 8,
-        stars1: 3,
+        defender1Position: 3,
+        stars1: 1,
         defender2Position: null,
         stars2: null,
         sourceSyncedAt: new Date("2026-03-26T00:00:00.000Z"),
@@ -432,9 +510,40 @@ describe("/todo command", () => {
     prismaMock.currentWar.findMany.mockResolvedValue([
       {
         clanTag: "#PQL0289",
+        warId: 1001,
+        startTime: new Date("2026-03-25T12:00:00.000Z"),
         matchType: "FWA",
         outcome: "WIN",
+        state: "inWar",
         updatedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.warAttacks.findMany.mockResolvedValue([
+      {
+        warId: 1001,
+        clanTag: "#PQL0289",
+        warStartTime: new Date("2026-03-25T12:00:00.000Z"),
+        playerTag: "#PYLQ0289",
+        playerPosition: null,
+        attacksUsed: 1,
+        attackOrder: 0,
+        attackNumber: 0,
+        defenderPosition: null,
+        stars: 0,
+        attackSeenAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+      {
+        warId: 1001,
+        clanTag: "#PQL0289",
+        warStartTime: new Date("2026-03-25T12:00:00.000Z"),
+        playerTag: "#PYLQ0289",
+        playerPosition: null,
+        attacksUsed: 1,
+        attackOrder: 1,
+        attackNumber: 1,
+        defenderPosition: null,
+        stars: 2,
+        attackSeenAt: new Date("2026-03-26T00:05:00.000Z"),
       },
     ]);
     prismaMock.fwaWarMemberCurrent.findMany.mockResolvedValue([
@@ -482,9 +591,40 @@ describe("/todo command", () => {
     prismaMock.currentWar.findMany.mockResolvedValue([
       {
         clanTag: "#Q2V8P9L2",
+        warId: 1003,
+        startTime: new Date("2026-03-25T12:00:00.000Z"),
         matchType: "FWA",
         outcome: "WIN",
+        state: "inWar",
         updatedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.warAttacks.findMany.mockResolvedValue([
+      {
+        warId: 1003,
+        clanTag: "#Q2V8P9L2",
+        warStartTime: new Date("2026-03-25T12:00:00.000Z"),
+        playerTag: "#PYLQ0289",
+        playerPosition: 8,
+        attacksUsed: 1,
+        attackOrder: 0,
+        attackNumber: 0,
+        defenderPosition: null,
+        stars: 0,
+        attackSeenAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+      {
+        warId: 1003,
+        clanTag: "#Q2V8P9L2",
+        warStartTime: new Date("2026-03-25T12:00:00.000Z"),
+        playerTag: "#PYLQ0289",
+        playerPosition: 8,
+        attacksUsed: 1,
+        attackOrder: 1,
+        attackNumber: 1,
+        defenderPosition: 7,
+        stars: 2,
+        attackSeenAt: new Date("2026-03-26T00:05:00.000Z"),
       },
     ]);
     prismaMock.fwaWarMemberCurrent.findMany.mockResolvedValue([

--- a/tests/todoSnapshot.service.test.ts
+++ b/tests/todoSnapshot.service.test.ts
@@ -21,6 +21,9 @@ const prismaMock = vi.hoisted(() => ({
   currentWar: {
     findMany: vi.fn(),
   },
+  warAttacks: {
+    findMany: vi.fn(),
+  },
   trackedClan: {
     findMany: vi.fn(),
   },
@@ -124,6 +127,7 @@ describe("TodoSnapshotService", () => {
         updatedAt: new Date("2026-03-26T00:00:00.000Z"),
       },
     ]);
+    prismaMock.warAttacks.findMany.mockResolvedValue([]);
     prismaMock.trackedClan.findMany.mockResolvedValue([
       { tag: "#PQL0289", name: "Clan One" },
     ]);
@@ -278,6 +282,143 @@ describe("TodoSnapshotService", () => {
         update: expect.objectContaining({
           warActive: true,
           warPhase: "preparation",
+          warAttacksUsed: 0,
+        }),
+      }),
+    );
+  });
+
+  it("derives tracked inWar attacks from WarAttacks instead of stale feed attack counters", async () => {
+    prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue([
+      {
+        playerTag: "#PYLQ0289",
+        clanTag: "#PQL0289",
+        playerName: "Alpha",
+        sourceSyncedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.fwaWarMemberCurrent.findMany.mockResolvedValue([
+      {
+        playerTag: "#PYLQ0289",
+        clanTag: "#PQL0289",
+        position: 8,
+        attacks: 2,
+        sourceSyncedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.currentWar.findMany.mockResolvedValue([
+      {
+        clanTag: "#PQL0289",
+        warId: 1001,
+        state: "inWar",
+        startTime: new Date("2026-03-26T12:00:00.000Z"),
+        endTime: new Date("2026-03-27T12:00:00.000Z"),
+        updatedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.warAttacks.findMany.mockResolvedValue([
+      {
+        warId: 1001,
+        clanTag: "#PQL0289",
+        warStartTime: new Date("2026-03-26T12:00:00.000Z"),
+        playerTag: "#PYLQ0289",
+        playerPosition: 8,
+        attacksUsed: 1,
+        attackOrder: 0,
+        attackNumber: 0,
+        defenderPosition: null,
+        stars: 0,
+        attackSeenAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+      {
+        warId: 1001,
+        clanTag: "#PQL0289",
+        warStartTime: new Date("2026-03-26T12:00:00.000Z"),
+        playerTag: "#PYLQ0289",
+        playerPosition: 8,
+        attacksUsed: 1,
+        attackOrder: 1,
+        attackNumber: 1,
+        defenderPosition: 8,
+        stars: 3,
+        attackSeenAt: new Date("2026-03-26T00:10:00.000Z"),
+      },
+    ]);
+    prismaMock.cwlTrackedClan.findMany.mockResolvedValue([]);
+    prismaMock.cwlPlayerClanSeason.findMany.mockResolvedValue([]);
+
+    await todoSnapshotService.refreshSnapshotsForPlayerTags({
+      playerTags: ["#PYLQ0289"],
+      nowMs: Date.UTC(2026, 2, 26, 0, 0, 0, 0),
+    });
+
+    expect(prismaMock.todoPlayerSnapshot.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({
+          warActive: true,
+          warPhase: "battle day",
+          warAttacksUsed: 1,
+        }),
+      }),
+    );
+  });
+
+  it("does not leak stale previous-war feed attacks into tracked current-war snapshots", async () => {
+    prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue([
+      {
+        playerTag: "#PYLQ0289",
+        clanTag: "#PQL0289",
+        playerName: "Alpha",
+        sourceSyncedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.fwaWarMemberCurrent.findMany.mockResolvedValue([
+      {
+        playerTag: "#PYLQ0289",
+        clanTag: "#PQL0289",
+        position: 8,
+        attacks: 2,
+        sourceSyncedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.currentWar.findMany.mockResolvedValue([
+      {
+        clanTag: "#PQL0289",
+        warId: 2002,
+        state: "inWar",
+        startTime: new Date("2026-03-28T12:00:00.000Z"),
+        endTime: new Date("2026-03-29T12:00:00.000Z"),
+        updatedAt: new Date("2026-03-28T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.warAttacks.findMany.mockResolvedValue([
+      {
+        warId: 1001,
+        clanTag: "#PQL0289",
+        warStartTime: new Date("2026-03-26T12:00:00.000Z"),
+        playerTag: "#PYLQ0289",
+        playerPosition: 8,
+        attacksUsed: 2,
+        attackOrder: 0,
+        attackNumber: 0,
+        defenderPosition: null,
+        stars: 0,
+        attackSeenAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.cwlTrackedClan.findMany.mockResolvedValue([]);
+    prismaMock.cwlPlayerClanSeason.findMany.mockResolvedValue([]);
+
+    await todoSnapshotService.refreshSnapshotsForPlayerTags({
+      playerTags: ["#PYLQ0289"],
+      nowMs: Date.UTC(2026, 2, 28, 0, 0, 0, 0),
+    });
+
+    expect(prismaMock.todoPlayerSnapshot.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({
+          warActive: true,
+          warPhase: "battle day",
           warAttacksUsed: 0,
         }),
       }),


### PR DESCRIPTION
- derive tracked WAR membership/attacks from CurrentWar + WarAttacks with identity-safe filtering
- keep FWA war-member data as bounded fallback and prevent stale feed attacks from leaking into tracked rows
- harden scheduler integer env parsing so empty WAR_MEMBERS chunk values keep configured defaults