### PR TITLE
fix(accounts): prefer PlayerLink names and backfill missing linked id…

### DIFF
--- a/src/commands/Accounts.ts
+++ b/src/commands/Accounts.ts
@@ -12,6 +12,10 @@ import {
 import { Command } from "../Command";
 import { prisma } from "../prisma";
 import { CoCService } from "../services/CoCService";
+import {
+  backfillPlayerLinkNameIfMissing,
+  listPlayerLinksForDiscordUser,
+} from "../services/PlayerLinkService";
 
 type AccountRow = {
   tag: string;
@@ -32,6 +36,13 @@ function normalizeTag(input: string): string {
   const trimmed = input.trim().toUpperCase();
   if (!trimmed) return "";
   return trimmed.startsWith("#") ? trimmed : `#${trimmed}`;
+}
+
+function sanitizeDisplayText(input: unknown): string | null {
+  const normalized = String(input ?? "")
+    .replace(/\s+/g, " ")
+    .trim();
+  return normalized.length > 0 ? normalized : null;
 }
 
 function buildGroups(rows: AccountRow[]): ClanGroup[] {
@@ -212,10 +223,8 @@ export const Accounts: Command = {
       sourceLabel = `player tag \`${tag}\` (linked Discord ID \`${linkedDiscordId}\`)`;
     }
 
-    const links = await prisma.playerLink.findMany({
-      where: { discordUserId: targetDiscordUserId },
-      orderBy: { createdAt: "asc" },
-      select: { playerTag: true },
+    const links = await listPlayerLinksForDiscordUser({
+      discordUserId: targetDiscordUserId,
     });
 
     if (links.length === 0) {
@@ -229,6 +238,11 @@ export const Accounts: Command = {
       .map((l) => normalizeTag(l.playerTag))
       .filter((t) => Boolean(t));
     const uniqueTags = [...new Set(tags)];
+    const linkedNameByTag = new Map(
+      links
+        .map((link) => [normalizeTag(link.playerTag), sanitizeDisplayText(link.linkedName)] as const)
+        .filter((entry): entry is [string, string] => Boolean(entry[0] && entry[1]))
+    );
     const activity = await prisma.playerActivity.findMany({
       where: { guildId: interaction.guildId, tag: { in: uniqueTags } },
       select: { tag: true, name: true, clanTag: true },
@@ -237,30 +251,60 @@ export const Accounts: Command = {
       activity.map((a) => [normalizeTag(a.tag), a])
     );
 
-    const fetched = await Promise.allSettled(
-      uniqueTags.map((tag) => cocService.getPlayerRaw(tag))
-    );
+    const tagsNeedingLiveFetch = uniqueTags.filter((tag) => {
+      const hasLinkedName = Boolean(linkedNameByTag.get(tag));
+      const hasLocalFallback = activityByTag.has(tag);
+      return !hasLinkedName || !hasLocalFallback;
+    });
+    const fetchedPlayersByTag = new Map<string, any>();
+    if (tagsNeedingLiveFetch.length > 0) {
+      const fetched = await Promise.allSettled(
+        tagsNeedingLiveFetch.map((tag) => cocService.getPlayerRaw(tag))
+      );
+      for (let i = 0; i < tagsNeedingLiveFetch.length; i += 1) {
+        const tag = tagsNeedingLiveFetch[i];
+        const result = fetched[i];
+        if (result?.status === "fulfilled") {
+          fetchedPlayersByTag.set(tag, result.value);
+        }
+      }
+    }
 
-    const rows: AccountRow[] = uniqueTags.map((tag, idx) => {
-      const result = fetched[idx];
+    const playerNameBackfillTasks: Promise<void>[] = [];
+    const rows: AccountRow[] = uniqueTags.map((tag) => {
+      const linkedName = linkedNameByTag.get(tag) ?? null;
       const fallback = activityByTag.get(tag);
-      if (result.status === "fulfilled") {
-        const player = result.value;
-        return {
-          tag,
-          name: String(player?.name ?? fallback?.name ?? tag),
-          clanTag: player?.clan?.tag ?? fallback?.clanTag ?? null,
-          clanName: player?.clan?.name ?? null,
-        };
+      const livePlayer = fetchedPlayersByTag.get(tag) ?? null;
+      const livePlayerName = sanitizeDisplayText(livePlayer?.name);
+
+      if (!linkedName && livePlayerName) {
+        playerNameBackfillTasks.push(
+          backfillPlayerLinkNameIfMissing({
+            playerTag: tag,
+            playerName: livePlayerName,
+          })
+            .then(() => undefined)
+            .catch((error) => {
+              console.error(
+                `[accounts] player_name_backfill_failed tag=${tag} user=${targetDiscordUserId} error=${String(
+                  (error as { message?: string } | null | undefined)?.message ?? error
+                )}`
+              );
+            })
+        );
       }
 
       return {
         tag,
-        name: fallback?.name ?? tag,
-        clanTag: fallback?.clanTag ?? null,
-        clanName: null,
+        name: linkedName ?? livePlayerName ?? sanitizeDisplayText(fallback?.name) ?? tag,
+        clanTag: livePlayer?.clan?.tag ?? fallback?.clanTag ?? null,
+        clanName: livePlayer?.clan?.name ?? null,
       };
     });
+
+    if (playerNameBackfillTasks.length > 0) {
+      void Promise.allSettled(playerNameBackfillTasks);
+    }
 
     const embeds = buildEmbeds(rows);
     for (const embed of embeds) {

--- a/src/services/PlayerLinkService.ts
+++ b/src/services/PlayerLinkService.ts
@@ -49,6 +49,11 @@ export type DiscordUserPlayerLink = {
   linkedName: string | null;
 };
 
+export type PlayerLinkNameBackfillResult = {
+  playerTag: string;
+  updated: boolean;
+};
+
 export const PLAYER_LINK_DISCORD_USERNAME_FALLBACK = "unknown";
 
 /** Purpose: normalize a player tag into uppercase #TAG format. */
@@ -315,6 +320,29 @@ export async function listPlayerLinksForDiscordUser(input: {
     });
   }
   return ordered;
+}
+
+/** Purpose: persist one linked in-game player name only when PlayerLink.playerName is currently missing. */
+export async function backfillPlayerLinkNameIfMissing(input: {
+  playerTag: string;
+  playerName: string;
+}): Promise<PlayerLinkNameBackfillResult> {
+  const playerTag = normalizePlayerTag(input.playerTag);
+  const playerName = normalizePersistedPlayerName(input.playerName);
+  if (!playerTag || !playerName) {
+    return { playerTag, updated: false };
+  }
+
+  const updateResult = await prisma.playerLink.updateMany({
+    where: {
+      playerTag,
+      OR: [{ playerName: null }, { playerName: "" }],
+    },
+    data: {
+      playerName,
+    },
+  });
+  return { playerTag, updated: updateResult.count > 0 };
 }
 
 /** Purpose: fetch current DB weights for provided player tags and return a deterministic lookup. */

--- a/tests/accounts.command.test.ts
+++ b/tests/accounts.command.test.ts
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const prismaMock = vi.hoisted(() => ({
+  playerLink: {
+    findUnique: vi.fn(),
+    findMany: vi.fn(),
+    updateMany: vi.fn(),
+  },
+  playerActivity: {
+    findMany: vi.fn(),
+  },
+  trackedClan: {
+    findMany: vi.fn(),
+  },
+}));
+
+vi.mock("../src/prisma", () => ({
+  prisma: prismaMock,
+}));
+
+import { Accounts } from "../src/commands/Accounts";
+
+function makeInteraction(input?: {
+  visibility?: string | null;
+  tag?: string | null;
+  discordId?: string | null;
+}) {
+  return {
+    guildId: "123456789012345678",
+    id: "777777777777777777",
+    user: { id: "111111111111111111" },
+    options: {
+      getString: vi.fn((name: string) => {
+        if (name === "visibility") return input?.visibility ?? null;
+        if (name === "tag") return input?.tag ?? null;
+        if (name === "discord-id") return input?.discordId ?? null;
+        return null;
+      }),
+    },
+    deferReply: vi.fn().mockResolvedValue(undefined),
+    editReply: vi.fn().mockResolvedValue({
+      createMessageComponentCollector: vi.fn(),
+    }),
+  };
+}
+
+function getEmbedDescription(interaction: any): string {
+  const payload = interaction.editReply.mock.calls.find(
+    (call: unknown[]) => call[0] && typeof call[0] === "object" && Array.isArray(call[0].embeds)
+  )?.[0] as any;
+  return String(payload?.embeds?.[0]?.toJSON?.().description ?? "");
+}
+
+describe("/accounts command", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    prismaMock.playerLink.findUnique.mockResolvedValue(null);
+    prismaMock.playerLink.findMany.mockResolvedValue([]);
+    prismaMock.playerLink.updateMany.mockResolvedValue({ count: 0 });
+    prismaMock.playerActivity.findMany.mockResolvedValue([]);
+    prismaMock.trackedClan.findMany.mockResolvedValue([]);
+  });
+
+  it("uses PlayerLink.playerName first when present and avoids live fetch for that row", async () => {
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      {
+        playerTag: "#PYLQ0289",
+        playerName: "Linked Alpha",
+        createdAt: new Date("2026-03-01T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.playerActivity.findMany.mockResolvedValue([
+      { tag: "#PYLQ0289", name: "Activity Alpha", clanTag: "#PQL0289" },
+    ]);
+    const cocService = {
+      getPlayerRaw: vi.fn(),
+    };
+    const interaction = makeInteraction();
+
+    await Accounts.run({} as any, interaction as any, cocService as any);
+
+    expect(cocService.getPlayerRaw).not.toHaveBeenCalled();
+    expect(getEmbedDescription(interaction)).toContain("- Linked Alpha `#PYLQ0289`");
+    expect(prismaMock.playerLink.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("fetches live name and backfills PlayerLink.playerName when missing", async () => {
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      {
+        playerTag: "#QGRJ2222",
+        playerName: null,
+        createdAt: new Date("2026-03-01T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.playerActivity.findMany.mockResolvedValue([]);
+    const cocService = {
+      getPlayerRaw: vi.fn().mockResolvedValue({
+        name: "Live Bravo",
+        clan: { tag: "#PQL0289", name: "Clan One" },
+      }),
+    };
+    const interaction = makeInteraction();
+
+    await Accounts.run({} as any, interaction as any, cocService as any);
+    await Promise.resolve();
+
+    expect(cocService.getPlayerRaw).toHaveBeenCalledWith("#QGRJ2222");
+    expect(getEmbedDescription(interaction)).toContain("- Live Bravo `#QGRJ2222`");
+    expect(prismaMock.playerLink.updateMany).toHaveBeenCalledWith({
+      where: {
+        playerTag: "#QGRJ2222",
+        OR: [{ playerName: null }, { playerName: "" }],
+      },
+      data: { playerName: "Live Bravo" },
+    });
+  });
+
+  it("uses local fallback name when live fetch fails and does not write backfill", async () => {
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      {
+        playerTag: "#CUV9082",
+        playerName: "",
+        createdAt: new Date("2026-03-01T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.playerActivity.findMany.mockResolvedValue([
+      { tag: "#CUV9082", name: "Activity Charlie", clanTag: "#2QG2C08UP" },
+    ]);
+    const cocService = {
+      getPlayerRaw: vi.fn().mockRejectedValue(new Error("coc unavailable")),
+    };
+    const interaction = makeInteraction();
+
+    await Accounts.run({} as any, interaction as any, cocService as any);
+
+    expect(getEmbedDescription(interaction)).toContain("- Activity Charlie `#CUV9082`");
+    expect(prismaMock.playerLink.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("falls back to raw tag when no linked/live/activity name exists", async () => {
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      {
+        playerTag: "#LQ9P8R2",
+        playerName: null,
+        createdAt: new Date("2026-03-01T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.playerActivity.findMany.mockResolvedValue([]);
+    const cocService = {
+      getPlayerRaw: vi.fn().mockRejectedValue(new Error("coc unavailable")),
+    };
+    const interaction = makeInteraction();
+
+    await Accounts.run({} as any, interaction as any, cocService as any);
+
+    expect(getEmbedDescription(interaction)).toContain("- #LQ9P8R2 `#LQ9P8R2`");
+    expect(prismaMock.playerLink.updateMany).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
…entities

- use PlayerLink.playerName as primary /accounts display identity and fetch live CoC only when needed
- persist missing PlayerLink.playerName from successful live fetches without blocking command response
- add /accounts regression tests for name precedence, live fallback, and raw-tag fallback