### PR TITLE
ClashCookies — Todo + linked identity polish

### DIFF
--- a/prisma/migrations/20260327110000_add_player_link_player_name/migration.sql
+++ b/prisma/migrations/20260327110000_add_player_link_player_name/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "PlayerLink"
+ADD COLUMN "playerName" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -60,6 +60,7 @@ model PlayerLink {
   playerTag     String   @id
   discordUserId String
   discordUsername String?
+  playerName    String?
   createdAt     DateTime @default(now())
   updatedAt     DateTime @updatedAt
 }

--- a/src/commands/Accounts.ts
+++ b/src/commands/Accounts.ts
@@ -12,6 +12,10 @@ import {
 import { Command } from "../Command";
 import { prisma } from "../prisma";
 import { CoCService } from "../services/CoCService";
+import {
+  backfillPlayerLinkNameIfMissing,
+  listPlayerLinksForDiscordUser,
+} from "../services/PlayerLinkService";
 
 type AccountRow = {
   tag: string;
@@ -32,6 +36,13 @@ function normalizeTag(input: string): string {
   const trimmed = input.trim().toUpperCase();
   if (!trimmed) return "";
   return trimmed.startsWith("#") ? trimmed : `#${trimmed}`;
+}
+
+function sanitizeDisplayText(input: unknown): string | null {
+  const normalized = String(input ?? "")
+    .replace(/\s+/g, " ")
+    .trim();
+  return normalized.length > 0 ? normalized : null;
 }
 
 function buildGroups(rows: AccountRow[]): ClanGroup[] {
@@ -212,10 +223,8 @@ export const Accounts: Command = {
       sourceLabel = `player tag \`${tag}\` (linked Discord ID \`${linkedDiscordId}\`)`;
     }
 
-    const links = await prisma.playerLink.findMany({
-      where: { discordUserId: targetDiscordUserId },
-      orderBy: { createdAt: "asc" },
-      select: { playerTag: true },
+    const links = await listPlayerLinksForDiscordUser({
+      discordUserId: targetDiscordUserId,
     });
 
     if (links.length === 0) {
@@ -229,6 +238,11 @@ export const Accounts: Command = {
       .map((l) => normalizeTag(l.playerTag))
       .filter((t) => Boolean(t));
     const uniqueTags = [...new Set(tags)];
+    const linkedNameByTag = new Map(
+      links
+        .map((link) => [normalizeTag(link.playerTag), sanitizeDisplayText(link.linkedName)] as const)
+        .filter((entry): entry is [string, string] => Boolean(entry[0] && entry[1]))
+    );
     const activity = await prisma.playerActivity.findMany({
       where: { guildId: interaction.guildId, tag: { in: uniqueTags } },
       select: { tag: true, name: true, clanTag: true },
@@ -237,30 +251,60 @@ export const Accounts: Command = {
       activity.map((a) => [normalizeTag(a.tag), a])
     );
 
-    const fetched = await Promise.allSettled(
-      uniqueTags.map((tag) => cocService.getPlayerRaw(tag))
-    );
+    const tagsNeedingLiveFetch = uniqueTags.filter((tag) => {
+      const hasLinkedName = Boolean(linkedNameByTag.get(tag));
+      const hasLocalFallback = activityByTag.has(tag);
+      return !hasLinkedName || !hasLocalFallback;
+    });
+    const fetchedPlayersByTag = new Map<string, any>();
+    if (tagsNeedingLiveFetch.length > 0) {
+      const fetched = await Promise.allSettled(
+        tagsNeedingLiveFetch.map((tag) => cocService.getPlayerRaw(tag))
+      );
+      for (let i = 0; i < tagsNeedingLiveFetch.length; i += 1) {
+        const tag = tagsNeedingLiveFetch[i];
+        const result = fetched[i];
+        if (result?.status === "fulfilled") {
+          fetchedPlayersByTag.set(tag, result.value);
+        }
+      }
+    }
 
-    const rows: AccountRow[] = uniqueTags.map((tag, idx) => {
-      const result = fetched[idx];
+    const playerNameBackfillTasks: Promise<void>[] = [];
+    const rows: AccountRow[] = uniqueTags.map((tag) => {
+      const linkedName = linkedNameByTag.get(tag) ?? null;
       const fallback = activityByTag.get(tag);
-      if (result.status === "fulfilled") {
-        const player = result.value;
-        return {
-          tag,
-          name: String(player?.name ?? fallback?.name ?? tag),
-          clanTag: player?.clan?.tag ?? fallback?.clanTag ?? null,
-          clanName: player?.clan?.name ?? null,
-        };
+      const livePlayer = fetchedPlayersByTag.get(tag) ?? null;
+      const livePlayerName = sanitizeDisplayText(livePlayer?.name);
+
+      if (!linkedName && livePlayerName) {
+        playerNameBackfillTasks.push(
+          backfillPlayerLinkNameIfMissing({
+            playerTag: tag,
+            playerName: livePlayerName,
+          })
+            .then(() => undefined)
+            .catch((error) => {
+              console.error(
+                `[accounts] player_name_backfill_failed tag=${tag} user=${targetDiscordUserId} error=${String(
+                  (error as { message?: string } | null | undefined)?.message ?? error
+                )}`
+              );
+            })
+        );
       }
 
       return {
         tag,
-        name: fallback?.name ?? tag,
-        clanTag: fallback?.clanTag ?? null,
-        clanName: null,
+        name: linkedName ?? livePlayerName ?? sanitizeDisplayText(fallback?.name) ?? tag,
+        clanTag: livePlayer?.clan?.tag ?? fallback?.clanTag ?? null,
+        clanName: livePlayer?.clan?.name ?? null,
       };
     });
+
+    if (playerNameBackfillTasks.length > 0) {
+      void Promise.allSettled(playerNameBackfillTasks);
+    }
 
     const embeds = buildEmbeds(rows);
     for (const embed of embeds) {

--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -291,6 +291,8 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
       "WAR/CWL pages group players by shared active event context and include section headers with phase timing.",
       "RAIDS/GAMES pages use one shared top timer line and then list per-player progress rows.",
       "GAMES page points come from stored activity-signal totals, with cycle baseline/total observability persisted on TodoPlayerSnapshot for DB-first reads.",
+      "GAMES rows are sorted by observed `gamesChampionTotal` descending, with stable tie-breakers by player identity.",
+      "GAMES rows use progress indicators: `🟡` (>0), `✅` (>=4000), and `🏆` (>=10000).",
       "When a page has no active context, it renders explicit inactive text instead of a blank list.",
       "Linked players outside active contexts are still shown as neutral rows when active groups exist.",
       "If you have no linked tags, the command returns a clear private error and suggests `/link create`.",

--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -287,6 +287,7 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
       "Reads precomputed todo snapshots (background-refreshed) for fast command-time rendering.",
       "Always builds WAR, CWL, RAIDS, and GAMES pages in one response.",
       "`type` controls only the initial page shown; use page buttons to switch categories without rerunning.",
+      "Use the `Refresh` button to trigger a targeted snapshot rebuild for the displayed todo user and update the same message in place.",
       "WAR/CWL pages group players by shared active event context and include section headers with phase timing.",
       "RAIDS/GAMES pages use one shared top timer line and then list per-player progress rows.",
       "GAMES page points come from stored activity-signal totals, with cycle baseline/total observability persisted on TodoPlayerSnapshot for DB-first reads.",

--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -289,6 +289,7 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
       "`type` controls only the initial page shown; use page buttons to switch categories without rerunning.",
       "Use the `Refresh` button to trigger a targeted snapshot rebuild for the displayed todo user and update the same message in place.",
       "WAR/CWL pages group players by shared active event context and include section headers with phase timing.",
+      "WAR section headers include tracked clan badge + match-state indicator, and WAR rows show lineup position with compact used-attack detail.",
       "RAIDS/GAMES pages use one shared top timer line and then list per-player progress rows.",
       "GAMES page points come from stored activity-signal totals, with cycle baseline/total observability persisted on TodoPlayerSnapshot for DB-first reads.",
       "GAMES rows are sorted by observed `gamesChampionTotal` descending, with stable tie-breakers by player identity.",

--- a/src/commands/Todo.ts
+++ b/src/commands/Todo.ts
@@ -9,6 +9,8 @@ import {
   EmbedBuilder,
 } from "discord.js";
 import { Command } from "../Command";
+import { formatError } from "../helper/formatError";
+import { listPlayerLinksForDiscordUser } from "../services/PlayerLinkService";
 import { CoCService } from "../services/CoCService";
 import {
   buildTodoPagesForUser,
@@ -16,9 +18,28 @@ import {
   TODO_TYPES,
   type TodoType,
 } from "../services/TodoService";
+import { todoSnapshotService } from "../services/TodoSnapshotService";
 
 const TODO_PAGE_BUTTON_PREFIX = "todo-page";
+const TODO_REFRESH_BUTTON_PREFIX = "todo-refresh";
 const TODO_EMBED_COLOR = 0x5865f2;
+const TODO_GUILD_SCOPE_DM = "dm";
+const TODO_REFRESH_ERROR_MESSAGE =
+  "Failed to refresh todo data. Please try again.";
+const todoRefreshInFlightByMessageId = new Set<string>();
+
+type TodoButtonScope = {
+  guildScopeId: string;
+  requesterUserId: string;
+  targetUserId: string;
+};
+
+type ParsedTodoButtonScope = {
+  guildScopeId: string | null;
+  requesterUserId: string;
+  targetUserId: string;
+  type: TodoType;
+};
 
 type TodoRenderResult =
   | {
@@ -30,12 +51,48 @@ type TodoRenderResult =
     }
   | { ok: false; message: string };
 
+/** Purpose: build one stable guild scope token from guild-id or DM context. */
+function resolveTodoGuildScopeId(guildId: string | null | undefined): string {
+  const normalized = String(guildId ?? TODO_GUILD_SCOPE_DM).trim();
+  return normalized.length > 0 ? normalized : TODO_GUILD_SCOPE_DM;
+}
+
+/** Purpose: validate that one parsed guild scope still matches the interaction guild. */
+function isTodoGuildScopeMismatch(
+  parsedGuildScopeId: string | null,
+  interactionGuildId: string | null,
+): boolean {
+  if (!parsedGuildScopeId) return false;
+  return parsedGuildScopeId !== resolveTodoGuildScopeId(interactionGuildId);
+}
+
 /** Purpose: build one stable todo-page button custom-id. */
 export function buildTodoPageButtonCustomId(
   userId: string,
   type: TodoType,
+): string;
+export function buildTodoPageButtonCustomId(
+  input: TodoButtonScope & { type: TodoType },
+): string;
+export function buildTodoPageButtonCustomId(
+  inputOrUserId: (TodoButtonScope & { type: TodoType }) | string,
+  maybeType?: TodoType,
 ): string {
-  return `${TODO_PAGE_BUTTON_PREFIX}:${userId}:${type}`;
+  if (typeof inputOrUserId === "string") {
+    const userId = inputOrUserId;
+    const type = normalizeTodoType(maybeType);
+    return `${TODO_PAGE_BUTTON_PREFIX}:${userId}:${type}`;
+  }
+  const guildScopeId = resolveTodoGuildScopeId(inputOrUserId.guildScopeId);
+  return `${TODO_PAGE_BUTTON_PREFIX}:${guildScopeId}:${inputOrUserId.requesterUserId}:${inputOrUserId.targetUserId}:${normalizeTodoType(inputOrUserId.type)}`;
+}
+
+/** Purpose: build one stable todo-refresh button custom-id for targeted snapshot rebuild. */
+export function buildTodoRefreshButtonCustomId(
+  input: TodoButtonScope & { type: TodoType },
+): string {
+  const guildScopeId = resolveTodoGuildScopeId(input.guildScopeId);
+  return `${TODO_REFRESH_BUTTON_PREFIX}:${guildScopeId}:${input.requesterUserId}:${input.targetUserId}:${normalizeTodoType(input.type)}`;
 }
 
 /** Purpose: guard whether a button custom-id belongs to `/todo` paging. */
@@ -43,29 +100,94 @@ export function isTodoPageButtonCustomId(customId: string): boolean {
   return String(customId ?? "").startsWith(`${TODO_PAGE_BUTTON_PREFIX}:`);
 }
 
-/** Purpose: parse todo-page button custom-id with user scope and page type. */
+/** Purpose: guard whether a button custom-id belongs to `/todo` refresh. */
+export function isTodoRefreshButtonCustomId(customId: string): boolean {
+  return String(customId ?? "").startsWith(`${TODO_REFRESH_BUTTON_PREFIX}:`);
+}
+
+/** Purpose: parse todo-page button custom-id with requester/target scope and page type. */
 function parseTodoPageButtonCustomId(
   customId: string,
-): { userId: string; type: TodoType } | null {
+): ParsedTodoButtonScope | null {
   const parts = String(customId ?? "").split(":");
-  if (parts.length !== 3 || parts[0] !== TODO_PAGE_BUTTON_PREFIX) return null;
-  const userId = parts[1]?.trim() ?? "";
-  if (!userId) return null;
-  return { userId, type: normalizeTodoType(parts[2]) };
+  if (parts[0] !== TODO_PAGE_BUTTON_PREFIX) return null;
+
+  if (parts.length === 3) {
+    const requesterUserId = parts[1]?.trim() ?? "";
+    if (!requesterUserId) return null;
+    return {
+      guildScopeId: null,
+      requesterUserId,
+      targetUserId: requesterUserId,
+      type: normalizeTodoType(parts[2]),
+    };
+  }
+
+  if (parts.length !== 5) return null;
+  const guildScopeId = resolveTodoGuildScopeId(parts[1]);
+  const requesterUserId = parts[2]?.trim() ?? "";
+  const targetUserId = parts[3]?.trim() ?? "";
+  if (!requesterUserId || !targetUserId) return null;
+  return {
+    guildScopeId,
+    requesterUserId,
+    targetUserId,
+    type: normalizeTodoType(parts[4]),
+  };
+}
+
+/** Purpose: parse todo-refresh button custom-id with requester/target scope and selected page type. */
+function parseTodoRefreshButtonCustomId(
+  customId: string,
+): ParsedTodoButtonScope | null {
+  const parts = String(customId ?? "").split(":");
+  if (parts.length !== 5 || parts[0] !== TODO_REFRESH_BUTTON_PREFIX) return null;
+  const guildScopeId = resolveTodoGuildScopeId(parts[1]);
+  const requesterUserId = parts[2]?.trim() ?? "";
+  const targetUserId = parts[3]?.trim() ?? "";
+  if (!requesterUserId || !targetUserId) return null;
+  return {
+    guildScopeId,
+    requesterUserId,
+    targetUserId,
+    type: normalizeTodoType(parts[4]),
+  };
 }
 
 /** Purpose: build todo page-switch buttons with active page highlight. */
-function buildTodoPageButtons(
-  commandUserId: string,
+function buildTodoComponentRows(
+  scope: TodoButtonScope,
   activeType: TodoType,
 ): ActionRowBuilder<ButtonBuilder>[] {
-  const buttons = TODO_TYPES.map((type) =>
+  const pagingButtons = TODO_TYPES.map((type) =>
     new ButtonBuilder()
-      .setCustomId(buildTodoPageButtonCustomId(commandUserId, type))
+      .setCustomId(
+        buildTodoPageButtonCustomId({
+          guildScopeId: scope.guildScopeId,
+          requesterUserId: scope.requesterUserId,
+          targetUserId: scope.targetUserId,
+          type,
+        }),
+      )
       .setLabel(type)
       .setStyle(type === activeType ? ButtonStyle.Primary : ButtonStyle.Secondary),
   );
-  return [new ActionRowBuilder<ButtonBuilder>().addComponents(buttons)];
+  const refreshButton = new ButtonBuilder()
+    .setCustomId(
+      buildTodoRefreshButtonCustomId({
+        guildScopeId: scope.guildScopeId,
+        requesterUserId: scope.requesterUserId,
+        targetUserId: scope.targetUserId,
+        type: activeType,
+      }),
+    )
+    .setLabel("Refresh")
+    .setStyle(ButtonStyle.Secondary);
+
+  return [
+    new ActionRowBuilder<ButtonBuilder>().addComponents(pagingButtons),
+    new ActionRowBuilder<ButtonBuilder>().addComponents(refreshButton),
+  ];
 }
 
 /** Purpose: build one todo embed for the selected page type. */
@@ -87,13 +209,12 @@ function buildTodoEmbed(input: {
 
 /** Purpose: build a rendered todo response payload for one selected page type. */
 async function buildTodoRenderResult(input: {
-  interaction: ChatInputCommandInteraction | ButtonInteraction;
   cocService: CoCService;
   selectedType: TodoType;
-  commandUserId: string;
+  scope: TodoButtonScope;
 }): Promise<TodoRenderResult> {
   const pages = await buildTodoPagesForUser({
-    discordUserId: input.commandUserId,
+    discordUserId: input.scope.targetUserId,
     cocService: input.cocService,
   });
   if (pages.linkedPlayerCount <= 0) {
@@ -115,7 +236,7 @@ async function buildTodoRenderResult(input: {
           pageText: pages.pages[normalizedType],
         }),
       ],
-      components: buildTodoPageButtons(input.commandUserId, normalizedType),
+      components: buildTodoComponentRows(input.scope, normalizedType),
     },
   };
 }
@@ -128,7 +249,15 @@ export async function handleTodoPageButtonInteraction(
   const parsed = parseTodoPageButtonCustomId(interaction.customId);
   if (!parsed) return;
 
-  if (interaction.user.id !== parsed.userId) {
+  if (isTodoGuildScopeMismatch(parsed.guildScopeId, interaction.guildId)) {
+    await interaction.reply({
+      ephemeral: true,
+      content: "This todo view is no longer valid for this guild.",
+    });
+    return;
+  }
+
+  if (interaction.user.id !== parsed.requesterUserId) {
     await interaction.reply({
       ephemeral: true,
       content: "Only the command requester can use this button.",
@@ -137,10 +266,13 @@ export async function handleTodoPageButtonInteraction(
   }
 
   const result = await buildTodoRenderResult({
-    interaction,
     cocService,
     selectedType: parsed.type,
-    commandUserId: parsed.userId,
+    scope: {
+      guildScopeId: parsed.guildScopeId || resolveTodoGuildScopeId(interaction.guildId),
+      requesterUserId: parsed.requesterUserId,
+      targetUserId: parsed.targetUserId,
+    },
   });
   if (!result.ok) {
     await interaction.update({
@@ -155,6 +287,96 @@ export async function handleTodoPageButtonInteraction(
     content: null,
     ...result.payload,
   });
+}
+
+/** Purpose: handle `/todo` refresh button interactions with targeted scoped snapshot rebuild. */
+export async function handleTodoRefreshButtonInteraction(
+  interaction: ButtonInteraction,
+  cocService: CoCService,
+): Promise<void> {
+  const parsed = parseTodoRefreshButtonCustomId(interaction.customId);
+  if (!parsed) return;
+
+  if (isTodoGuildScopeMismatch(parsed.guildScopeId, interaction.guildId)) {
+    await interaction.reply({
+      ephemeral: true,
+      content: "This todo view is no longer valid for this guild.",
+    });
+    return;
+  }
+
+  if (interaction.user.id !== parsed.requesterUserId) {
+    await interaction.reply({
+      ephemeral: true,
+      content: "Only the command requester can use this button.",
+    });
+    return;
+  }
+
+  const messageId = String(interaction.message?.id ?? "");
+  if (messageId && todoRefreshInFlightByMessageId.has(messageId)) {
+    await interaction.reply({
+      ephemeral: true,
+      content: "A refresh is already in progress for this todo view.",
+    });
+    return;
+  }
+
+  if (messageId) {
+    todoRefreshInFlightByMessageId.add(messageId);
+  }
+
+  await interaction.deferUpdate();
+
+  try {
+    const links = await listPlayerLinksForDiscordUser({
+      discordUserId: parsed.targetUserId,
+    });
+    const linkedTags = [...new Set(links.map((row) => row.playerTag))];
+    if (linkedTags.length > 0) {
+      await todoSnapshotService.refreshSnapshotsForPlayerTags({
+        playerTags: linkedTags,
+        cocService,
+      });
+    }
+
+    const result = await buildTodoRenderResult({
+      cocService,
+      selectedType: parsed.type,
+      scope: {
+        guildScopeId: parsed.guildScopeId || resolveTodoGuildScopeId(interaction.guildId),
+        requesterUserId: parsed.requesterUserId,
+        targetUserId: parsed.targetUserId,
+      },
+    });
+    if (!result.ok) {
+      await interaction.editReply({
+        content: result.message,
+        embeds: [],
+        components: [],
+      });
+      return;
+    }
+
+    await interaction.editReply({
+      content: null,
+      ...result.payload,
+    });
+  } catch (err) {
+    console.error(
+      `[todo-refresh] requester=${parsed.requesterUserId} target=${parsed.targetUserId} guild=${parsed.guildScopeId} type=${parsed.type} error=${formatError(err)}`,
+    );
+    await interaction
+      .followUp({
+        ephemeral: true,
+        content: TODO_REFRESH_ERROR_MESSAGE,
+      })
+      .catch(() => undefined);
+  } finally {
+    if (messageId) {
+      todoRefreshInFlightByMessageId.delete(messageId);
+    }
+  }
 }
 
 export const Todo: Command = {
@@ -180,10 +402,13 @@ export const Todo: Command = {
       interaction.options.getString("type", true),
     );
     const result = await buildTodoRenderResult({
-      interaction,
       cocService,
       selectedType,
-      commandUserId: interaction.user.id,
+      scope: {
+        guildScopeId: resolveTodoGuildScopeId(interaction.guildId),
+        requesterUserId: interaction.user.id,
+        targetUserId: interaction.user.id,
+      },
     });
     if (!result.ok) {
       await interaction.editReply(result.message);

--- a/src/listeners/interactionCreate.ts
+++ b/src/listeners/interactionCreate.ts
@@ -90,7 +90,9 @@ import {
 } from "../commands/Link";
 import {
   handleTodoPageButtonInteraction,
+  handleTodoRefreshButtonInteraction,
   isTodoPageButtonCustomId,
+  isTodoRefreshButtonCustomId,
 } from "../commands/Todo";
 import { handleSayModalSubmit, isSayModalCustomId } from "../commands/Say";
 
@@ -320,6 +322,21 @@ const handleButtonInteraction = async (
         await interaction.reply({
           ephemeral: true,
           content: "Failed to update todo page.",
+        });
+      }
+    }
+    return;
+  }
+
+  if (isTodoRefreshButtonCustomId(interaction.customId)) {
+    try {
+      await handleTodoRefreshButtonInteraction(interaction, cocService);
+    } catch (err) {
+      console.error(`Todo refresh button failed: ${formatError(err)}`);
+      if (!interaction.replied && !interaction.deferred) {
+        await interaction.reply({
+          ephemeral: true,
+          content: "Failed to refresh todo data.",
         });
       }
     }

--- a/src/services/PlayerLinkService.ts
+++ b/src/services/PlayerLinkService.ts
@@ -46,6 +46,7 @@ export type ClanScopedPlayerLink = {
 export type DiscordUserPlayerLink = {
   playerTag: string;
   linkedAt: Date;
+  linkedName: string | null;
 };
 
 export const PLAYER_LINK_DISCORD_USERNAME_FALLBACK = "unknown";
@@ -291,7 +292,7 @@ export async function listPlayerLinksForDiscordUser(input: {
   const rows = await prisma.playerLink.findMany({
     where: { discordUserId: normalizedUserId },
     orderBy: [{ createdAt: "asc" }, { playerTag: "asc" }],
-    select: { playerTag: true, createdAt: true },
+    select: { playerTag: true, discordUsername: true, createdAt: true },
   });
 
   const seen = new Set<string>();
@@ -300,7 +301,11 @@ export async function listPlayerLinksForDiscordUser(input: {
     const playerTag = normalizePlayerTag(row.playerTag);
     if (!playerTag || seen.has(playerTag)) continue;
     seen.add(playerTag);
-    ordered.push({ playerTag, linkedAt: row.createdAt });
+    ordered.push({
+      playerTag,
+      linkedAt: row.createdAt,
+      linkedName: normalizePersistedDiscordUsername(row.discordUsername),
+    });
   }
   return ordered;
 }

--- a/src/services/PlayerLinkService.ts
+++ b/src/services/PlayerLinkService.ts
@@ -81,6 +81,21 @@ export function normalizePersistedDiscordUsername(input: unknown): string | null
   return normalized;
 }
 
+/** Purpose: detect whether one normalized label is likely a Discord username handle (not an in-game player identity). */
+function isLikelyDiscordUsernameLabel(input: string): boolean {
+  if (!input) return false;
+  return /^[A-Za-z0-9._]{2,32}$/.test(input);
+}
+
+/** Purpose: normalize one PlayerLink name-like value for `/todo` player identity fallback use. */
+function normalizeLinkedPlayerNameForTodo(input: unknown): string | null {
+  const normalized = normalizePersistedDiscordUsername(input);
+  if (!normalized) return null;
+  if (normalized.toLowerCase() === PLAYER_LINK_DISCORD_USERNAME_FALLBACK) return null;
+  if (isLikelyDiscordUsernameLabel(normalized)) return null;
+  return normalized;
+}
+
 /** Purpose: normalize persisted usernames with a deterministic fallback. */
 export function sanitizeDiscordUsernameForPersistence(input: unknown): string {
   return normalizePersistedDiscordUsername(input) ?? PLAYER_LINK_DISCORD_USERNAME_FALLBACK;
@@ -304,7 +319,7 @@ export async function listPlayerLinksForDiscordUser(input: {
     ordered.push({
       playerTag,
       linkedAt: row.createdAt,
-      linkedName: normalizePersistedDiscordUsername(row.discordUsername),
+      linkedName: normalizeLinkedPlayerNameForTodo(row.discordUsername),
     });
   }
   return ordered;

--- a/src/services/PlayerLinkService.ts
+++ b/src/services/PlayerLinkService.ts
@@ -81,18 +81,10 @@ export function normalizePersistedDiscordUsername(input: unknown): string | null
   return normalized;
 }
 
-/** Purpose: detect whether one normalized label is likely a Discord username handle (not an in-game player identity). */
-function isLikelyDiscordUsernameLabel(input: string): boolean {
-  if (!input) return false;
-  return /^[A-Za-z0-9._]{2,32}$/.test(input);
-}
-
-/** Purpose: normalize one PlayerLink name-like value for `/todo` player identity fallback use. */
-function normalizeLinkedPlayerNameForTodo(input: unknown): string | null {
-  const normalized = normalizePersistedDiscordUsername(input);
+/** Purpose: normalize persisted in-game player names for deterministic identity fallback use. */
+export function normalizePersistedPlayerName(input: unknown): string | null {
+  const normalized = String(input ?? "").replace(/\s+/g, " ").trim();
   if (!normalized) return null;
-  if (normalized.toLowerCase() === PLAYER_LINK_DISCORD_USERNAME_FALLBACK) return null;
-  if (isLikelyDiscordUsernameLabel(normalized)) return null;
   return normalized;
 }
 
@@ -307,7 +299,7 @@ export async function listPlayerLinksForDiscordUser(input: {
   const rows = await prisma.playerLink.findMany({
     where: { discordUserId: normalizedUserId },
     orderBy: [{ createdAt: "asc" }, { playerTag: "asc" }],
-    select: { playerTag: true, discordUsername: true, createdAt: true },
+    select: { playerTag: true, playerName: true, createdAt: true },
   });
 
   const seen = new Set<string>();
@@ -319,7 +311,7 @@ export async function listPlayerLinksForDiscordUser(input: {
     ordered.push({
       playerTag,
       linkedAt: row.createdAt,
-      linkedName: normalizeLinkedPlayerNameForTodo(row.discordUsername),
+      linkedName: normalizePersistedPlayerName(row.playerName),
     });
   }
   return ordered;

--- a/src/services/PlayerLinkService.ts
+++ b/src/services/PlayerLinkService.ts
@@ -49,6 +49,11 @@ export type DiscordUserPlayerLink = {
   linkedName: string | null;
 };
 
+export type PlayerLinkNameBackfillResult = {
+  playerTag: string;
+  updated: boolean;
+};
+
 export const PLAYER_LINK_DISCORD_USERNAME_FALLBACK = "unknown";
 
 /** Purpose: normalize a player tag into uppercase #TAG format. */
@@ -315,6 +320,29 @@ export async function listPlayerLinksForDiscordUser(input: {
     });
   }
   return ordered;
+}
+
+/** Purpose: persist one linked in-game player name only when PlayerLink.playerName is currently missing. */
+export async function backfillPlayerLinkNameIfMissing(input: {
+  playerTag: string;
+  playerName: string;
+}): Promise<PlayerLinkNameBackfillResult> {
+  const playerTag = normalizePlayerTag(input.playerTag);
+  const playerName = normalizePersistedPlayerName(input.playerName);
+  if (!playerTag || !playerName) {
+    return { playerTag, updated: false };
+  }
+
+  const updateResult = await prisma.playerLink.updateMany({
+    where: {
+      playerTag,
+      OR: [{ playerName: null }, { playerName: "" }],
+    },
+    data: {
+      playerName,
+    },
+  });
+  return { playerTag, updated: updateResult.count > 0 };
 }
 
 /** Purpose: fetch current DB weights for provided player tags and return a deterministic lookup. */

--- a/src/services/TodoService.ts
+++ b/src/services/TodoService.ts
@@ -1,8 +1,10 @@
 import { CoCService } from "./CoCService";
 import {
   listPlayerLinksForDiscordUser,
+  normalizeClanTag,
   normalizePlayerTag,
 } from "./PlayerLinkService";
+import { prisma } from "../prisma";
 import {
   todoSnapshotService,
   type TodoSnapshotRecord,
@@ -19,10 +21,18 @@ export type TodoPagesResult = {
 type TodoRenderRow = {
   playerTag: string;
   playerName: string;
+  defaultIndex: number;
   clanTag: string | null;
   clanName: string | null;
   cwlClanTag: string | null;
   cwlClanName: string | null;
+  warPosition: number | null;
+  warAttackDetails: Array<{
+    defenderPosition: number | null;
+    stars: number | null;
+  }>;
+  warHeaderBadge: string | null;
+  warMatchIndicator: string;
   snapshot: TodoSnapshotRecord | null;
   missingSnapshot: boolean;
   staleSnapshot: boolean;
@@ -31,6 +41,8 @@ type TodoRenderRow = {
 type TodoEventGroup = {
   clanTag: string | null;
   clanName: string | null;
+  clanBadge: string | null;
+  matchIndicator: string;
   phase: string;
   phaseEndsAt: Date | null;
   rows: TodoRenderRow[];
@@ -39,6 +51,25 @@ type TodoEventGroup = {
 type CachedTodoRender = {
   expiresAtMs: number;
   pages: TodoPagesResult;
+};
+
+type WarMemberCurrentRow = {
+  clanTag: string;
+  playerTag: string;
+  position: number | null;
+  attacks: number | null;
+  defender1Position: number | null;
+  stars1: number | null;
+  defender2Position: number | null;
+  stars2: number | null;
+  sourceSyncedAt: Date;
+};
+
+type CurrentWarMatchContextRow = {
+  clanTag: string;
+  matchType: string | null;
+  outcome: string | null;
+  updatedAt: Date;
 };
 
 const DISCORD_DESCRIPTION_LIMIT = 4096;
@@ -114,12 +145,67 @@ export async function buildTodoPagesForUser(input: {
     playerTags: linkedTags,
   });
   const snapshotByTag = new Map(snapshotRows.map((row) => [row.playerTag, row]));
+  const clanTags = [
+    ...new Set(
+      snapshotRows
+        .map((row) => normalizeClanTag(row.clanTag ?? ""))
+        .filter(Boolean),
+    ),
+  ];
 
-  const renderRows = links.map((link) => {
+  const [warMemberRows, trackedClanRows, currentWarRows] = await Promise.all([
+    prisma.fwaWarMemberCurrent.findMany({
+      where: { playerTag: { in: linkedTags } },
+      select: {
+        clanTag: true,
+        playerTag: true,
+        position: true,
+        attacks: true,
+        defender1Position: true,
+        stars1: true,
+        defender2Position: true,
+        stars2: true,
+        sourceSyncedAt: true,
+      },
+    }),
+    clanTags.length > 0
+      ? prisma.trackedClan.findMany({
+          where: { tag: { in: clanTags } },
+          select: { tag: true, clanBadge: true },
+        })
+      : Promise.resolve([]),
+    clanTags.length > 0
+      ? prisma.currentWar.findMany({
+          where: { clanTag: { in: clanTags } },
+          select: { clanTag: true, matchType: true, outcome: true, updatedAt: true },
+        })
+      : Promise.resolve([]),
+  ]);
+
+  const latestWarMemberByClanAndPlayer =
+    pickLatestWarMemberByClanAndPlayer(warMemberRows);
+  const clanBadgeByTag = new Map(
+    trackedClanRows
+      .map((row) => [normalizeClanTag(row.tag), sanitizeStatusText(row.clanBadge)] as const)
+      .filter((entry): entry is [string, string] => Boolean(entry[0] && entry[1])),
+  );
+  const warMatchContextByClanTag =
+    pickLatestCurrentWarMatchContextByClanTag(currentWarRows);
+
+  const renderRows = links.map((link, index) => {
     const normalizedTag = normalizePlayerTag(link.playerTag);
     const snapshot = snapshotByTag.get(normalizedTag) ?? null;
     const missingSnapshot = snapshot === null;
     const staleSnapshot = snapshot ? isSnapshotStale(snapshot, nowMs) : false;
+    const resolvedClanTag = normalizeClanTag(snapshot?.clanTag ?? "") || null;
+    const warMemberKey = resolvedClanTag ? `${resolvedClanTag}:${normalizedTag}` : "";
+    const warMember = warMemberKey
+      ? latestWarMemberByClanAndPlayer.get(warMemberKey) ?? null
+      : null;
+    const warAttackDetails = resolveWarAttackDetails(warMember);
+    const matchContext = resolvedClanTag
+      ? warMatchContextByClanTag.get(resolvedClanTag) ?? null
+      : null;
     const resolvedPlayerName = resolveTodoPlayerDisplayName({
       playerTag: normalizedTag,
       snapshotPlayerName: snapshot?.playerName,
@@ -128,10 +214,15 @@ export async function buildTodoPagesForUser(input: {
     return {
       playerTag: normalizedTag,
       playerName: resolvedPlayerName,
-      clanTag: snapshot?.clanTag ?? null,
+      defaultIndex: index,
+      clanTag: resolvedClanTag,
       clanName: snapshot?.clanName ?? null,
       cwlClanTag: snapshot?.cwlClanTag ?? null,
       cwlClanName: snapshot?.cwlClanName ?? null,
+      warPosition: toFiniteIntOrNull(warMember?.position),
+      warAttackDetails,
+      warHeaderBadge: resolvedClanTag ? clanBadgeByTag.get(resolvedClanTag) ?? null : null,
+      warMatchIndicator: resolveWarMatchStatusIndicator(matchContext),
       snapshot,
       missingSnapshot,
       staleSnapshot,
@@ -219,7 +310,7 @@ function buildWarPageDescription(
   for (const group of grouped) {
     lines.push(`**${buildEventGroupHeader(group)}**`);
     for (const row of group.rows) {
-      lines.push(formatTodoRow(row, getWarRowStatus(row)));
+      lines.push(formatWarTodoRow(row, getWarRowStatus(row)));
     }
     lines.push("");
   }
@@ -375,6 +466,8 @@ function buildEventGroups(
     grouped.set(key, {
       clanTag: groupedClanTag ?? null,
       clanName: groupedClanName ?? null,
+      clanBadge: mode === "war" ? row.warHeaderBadge : null,
+      matchIndicator: mode === "war" ? row.warMatchIndicator : "",
       phase,
       phaseEndsAt: phaseEndsAt ?? null,
       rows: [row],
@@ -384,9 +477,12 @@ function buildEventGroups(
   return [...grouped.values()]
     .map((group) => ({
       ...group,
-      rows: [...group.rows].sort((a, b) =>
-        formatPlayerIdentity(a).localeCompare(formatPlayerIdentity(b)),
-      ),
+      rows:
+        mode === "war"
+          ? [...group.rows].sort(compareWarRowsForRendering)
+          : [...group.rows].sort((a, b) =>
+              formatPlayerIdentity(a).localeCompare(formatPlayerIdentity(b)),
+            ),
     }))
     .sort((a, b) => {
       const nameCompare = buildGroupClanIdentity(a).localeCompare(
@@ -399,11 +495,17 @@ function buildEventGroups(
 
 /** Purpose: build one compact active-event header line with clan and phase timing context. */
 function buildEventGroupHeader(group: TodoEventGroup): string {
+  const badgePrefix = sanitizeStatusText(group.clanBadge);
   const clan = buildGroupClanIdentity(group);
+  const matchIndicator = sanitizeStatusText(group.matchIndicator);
   const endsAt = group.phaseEndsAt
     ? ` ends ${formatRelativeTimestamp(group.phaseEndsAt)}`
     : "";
-  return `${clan} - ${group.phase}${endsAt}`;
+  const prefixedClan = badgePrefix ? `${badgePrefix} ${clan}` : clan;
+  const clanWithIndicator = matchIndicator
+    ? `${prefixedClan} ${matchIndicator}`
+    : prefixedClan;
+  return `${clanWithIndicator} - ${group.phase}${endsAt}`;
 }
 
 /** Purpose: build stable clan identity text for grouped section headings. */
@@ -441,6 +543,22 @@ function formatTodoRow(row: TodoRenderRow, status: string): string {
   return `- ${formatPlayerIdentity(row)} - ${status}`;
 }
 
+/** Purpose: format one WAR row with lineup position and compact attack-detail suffixes. */
+function formatWarTodoRow(row: TodoRenderRow, status: string): string {
+  const identity = formatWarPlayerIdentity(row);
+  const usedAttacks = clampInt(row.snapshot?.warAttacksUsed, 0, row.snapshot?.warAttacksMax || 2);
+  const detailRows =
+    usedAttacks > 0
+      ? row.warAttackDetails
+          .slice(0, usedAttacks)
+          .map((detail) => formatWarAttackDetail(detail))
+          .filter(Boolean)
+      : [];
+  const detailsSuffix =
+    detailRows.length > 0 ? ` | ${detailRows.join(" | ")}` : "";
+  return `- ${identity} - ${status}${detailsSuffix}`;
+}
+
 /** Purpose: format one GAMES row with optional completion marker next to player identity text. */
 function formatGamesTodoRow(
   row: TodoRenderRow,
@@ -457,6 +575,15 @@ function formatPlayerIdentity(row: TodoRenderRow): string {
     return row.playerTag;
   }
   return `${row.playerName} ${row.playerTag}`;
+}
+
+/** Purpose: format one WAR player identity with lineup position fallback when unavailable. */
+function formatWarPlayerIdentity(row: TodoRenderRow): string {
+  const positionLabel =
+    row.warPosition !== null && row.warPosition > 0
+      ? `#${row.warPosition}`
+      : "#?";
+  return `${positionLabel} ${row.playerName}`;
 }
 
 /** Purpose: build one bounded embed description block for a todo page. */
@@ -480,12 +607,12 @@ function buildTodoPageDescription(input: {
 /** Purpose: build active WAR row status text without repeating group-level phase timing details. */
 function getWarRowStatus(row: TodoRenderRow): string {
   if (row.missingSnapshot || !row.snapshot) {
-    return "war attacks: 0/2 - snapshot unavailable";
+    return "`0 / 2` - snapshot unavailable";
   }
   const used = clampInt(row.snapshot.warAttacksUsed, 0, row.snapshot.warAttacksMax || 2);
   const max = Math.max(1, clampInt(row.snapshot.warAttacksMax, 1, 2));
   const staleSuffix = row.staleSnapshot ? " - stale snapshot" : "";
-  return `war attacks: ${used}/${max}${staleSuffix}`;
+  return `\`${used} / ${max}\`${staleSuffix}`;
 }
 
 /** Purpose: build neutral WAR row status text for linked players outside active war groups. */
@@ -583,6 +710,134 @@ function resolveTodoPlayerDisplayName(input: {
   }
 
   return normalizedTag;
+}
+
+/** Purpose: compare WAR rows by actual lineup position first to keep rendering aligned with war roster order. */
+function compareWarRowsForRendering(a: TodoRenderRow, b: TodoRenderRow): number {
+  const aHasPos = a.warPosition !== null && a.warPosition > 0;
+  const bHasPos = b.warPosition !== null && b.warPosition > 0;
+  if (aHasPos && bHasPos && a.warPosition !== b.warPosition) {
+    return Number(a.warPosition) - Number(b.warPosition);
+  }
+  if (aHasPos !== bHasPos) return aHasPos ? -1 : 1;
+
+  const byName = sanitizeStatusText(a.playerName).localeCompare(
+    sanitizeStatusText(b.playerName),
+    undefined,
+    { sensitivity: "base" },
+  );
+  if (byName !== 0) return byName;
+
+  const byTag = a.playerTag.localeCompare(b.playerTag);
+  if (byTag !== 0) return byTag;
+
+  return a.defaultIndex - b.defaultIndex;
+}
+
+/** Purpose: extract compact first/second attack details from one latest war-member row. */
+function resolveWarAttackDetails(
+  row: Pick<
+    WarMemberCurrentRow,
+    "defender1Position" | "stars1" | "defender2Position" | "stars2"
+  > | null,
+): Array<{ defenderPosition: number | null; stars: number | null }> {
+  if (!row) return [];
+  return [
+    {
+      defenderPosition: toFiniteIntOrNull(row.defender1Position),
+      stars: toFiniteIntOrNull(row.stars1),
+    },
+    {
+      defenderPosition: toFiniteIntOrNull(row.defender2Position),
+      stars: toFiniteIntOrNull(row.stars2),
+    },
+  ];
+}
+
+/** Purpose: render one compact WAR attack detail segment for embed-friendly row suffixes. */
+function formatWarAttackDetail(input: {
+  defenderPosition: number | null;
+  stars: number | null;
+}): string {
+  const defenderLabel =
+    input.defenderPosition !== null && input.defenderPosition > 0
+      ? `#${input.defenderPosition}`
+      : "#?";
+  return `:dagger: ${defenderLabel} ${formatWarStarTriplet(input.stars)}`;
+}
+
+/** Purpose: render star counts as compact visual triplets used by WAR attack detail rows. */
+function formatWarStarTriplet(stars: number | null | undefined): string {
+  const normalized = Math.max(0, Math.min(3, Number(stars ?? 0)));
+  if (normalized >= 3) return "★ ★ ★";
+  if (normalized >= 2) return "★ ★ ☆";
+  if (normalized >= 1) return "★ ☆ ☆";
+  return "☆ ☆ ☆";
+}
+
+/** Purpose: map clan match type/outcome into the same effective status-color semantics used by match views. */
+function resolveWarMatchStatusIndicator(
+  context: Pick<CurrentWarMatchContextRow, "matchType" | "outcome"> | null,
+): string {
+  const matchType = sanitizeStatusText(context?.matchType).toUpperCase();
+  const outcome = sanitizeStatusText(context?.outcome).toUpperCase();
+  if (matchType === "BL") return ":black_circle:";
+  if (matchType === "MM") return ":white_circle:";
+  if (matchType === "SKIP") return ":yellow_circle:";
+  if (matchType === "FWA") {
+    if (outcome === "LOSE") return ":red_circle:";
+    return ":green_circle:";
+  }
+  return ":white_circle:";
+}
+
+/** Purpose: keep only the freshest war-member row for each clan+player pair. */
+function pickLatestWarMemberByClanAndPlayer(
+  rows: WarMemberCurrentRow[],
+): Map<string, WarMemberCurrentRow> {
+  const latest = new Map<string, WarMemberCurrentRow>();
+  for (const row of rows) {
+    const clanTag = normalizeClanTag(row.clanTag);
+    const playerTag = normalizePlayerTag(row.playerTag);
+    if (!clanTag || !playerTag) continue;
+    const key = `${clanTag}:${playerTag}`;
+    const existing = latest.get(key);
+    if (!existing || row.sourceSyncedAt > existing.sourceSyncedAt) {
+      latest.set(key, {
+        clanTag,
+        playerTag,
+        position: toFiniteIntOrNull(row.position),
+        attacks: toFiniteIntOrNull(row.attacks),
+        defender1Position: toFiniteIntOrNull(row.defender1Position),
+        stars1: toFiniteIntOrNull(row.stars1),
+        defender2Position: toFiniteIntOrNull(row.defender2Position),
+        stars2: toFiniteIntOrNull(row.stars2),
+        sourceSyncedAt: row.sourceSyncedAt,
+      });
+    }
+  }
+  return latest;
+}
+
+/** Purpose: keep one latest current-war match context row per clan for header indicator rendering. */
+function pickLatestCurrentWarMatchContextByClanTag(
+  rows: CurrentWarMatchContextRow[],
+): Map<string, CurrentWarMatchContextRow> {
+  const latest = new Map<string, CurrentWarMatchContextRow>();
+  for (const row of rows) {
+    const clanTag = normalizeClanTag(row.clanTag);
+    if (!clanTag) continue;
+    const existing = latest.get(clanTag);
+    if (!existing || row.updatedAt > existing.updatedAt) {
+      latest.set(clanTag, {
+        clanTag,
+        matchType: row.matchType,
+        outcome: row.outcome,
+        updatedAt: row.updatedAt,
+      });
+    }
+  }
+  return latest;
 }
 
 /** Purpose: sort games rows by champion total desc with stable deterministic tie-breakers. */

--- a/src/services/TodoService.ts
+++ b/src/services/TodoService.ts
@@ -50,6 +50,7 @@ const TODO_STALE_ACTIVE_GAMES_MS = 30 * 60 * 1000;
 const TODO_STALE_IDLE_MS = 4 * 60 * 60 * 1000;
 const TODO_DEFAULT_GAMES_TARGET = 4000;
 const TODO_GAMES_COMPLETE_POINTS = 4000;
+const TODO_GAMES_MAX_POINTS = 10_000;
 const todoRenderCacheByKey = new Map<string, CachedTodoRender>();
 
 /** Purpose: normalize `/todo type` input into one safe enum value. */
@@ -114,14 +115,19 @@ export async function buildTodoPagesForUser(input: {
   });
   const snapshotByTag = new Map(snapshotRows.map((row) => [row.playerTag, row]));
 
-  const renderRows = linkedTags.map((playerTag) => {
-    const normalizedTag = normalizePlayerTag(playerTag);
+  const renderRows = links.map((link) => {
+    const normalizedTag = normalizePlayerTag(link.playerTag);
     const snapshot = snapshotByTag.get(normalizedTag) ?? null;
     const missingSnapshot = snapshot === null;
     const staleSnapshot = snapshot ? isSnapshotStale(snapshot, nowMs) : false;
+    const resolvedPlayerName = resolveTodoPlayerDisplayName({
+      playerTag: normalizedTag,
+      snapshotPlayerName: snapshot?.playerName,
+      linkedName: link.linkedName,
+    });
     return {
       playerTag: normalizedTag,
-      playerName: snapshot?.playerName ?? normalizedTag,
+      playerName: resolvedPlayerName,
       clanTag: snapshot?.clanTag ?? null,
       clanName: snapshot?.clanName ?? null,
       cwlClanTag: snapshot?.cwlClanTag ?? null,
@@ -326,10 +332,9 @@ function buildGamesPageDescription(
     lines.push(`**Time remaining:** ${formatRelativeTimestamp(sharedEndsAt)}`);
     lines.push("");
   }
-  for (const row of rows) {
-    lines.push(
-      formatGamesTodoRow(row, getGamesRowStatus(row), isGamesComplete(row)),
-    );
+  const sortedRows = sortGamesRows(rows);
+  for (const row of sortedRows) {
+    lines.push(formatGamesTodoRow(row, getGamesRowStatus(row), getGamesProgressEmoji(row)));
   }
 
   return buildTodoPageDescription({
@@ -440,14 +445,17 @@ function formatTodoRow(row: TodoRenderRow, status: string): string {
 function formatGamesTodoRow(
   row: TodoRenderRow,
   status: string,
-  completed: boolean,
+  progressEmoji: string,
 ): string {
-  const completionPrefix = completed ? ":white_check_mark: " : "";
-  return `- ${completionPrefix}${formatPlayerIdentity(row)} - ${status}`;
+  const progressPrefix = progressEmoji.length > 0 ? `${progressEmoji} ` : "";
+  return `- ${progressPrefix}${formatPlayerIdentity(row)} - ${status}`;
 }
 
 /** Purpose: build one stable player identity token for todo row prefixes. */
 function formatPlayerIdentity(row: TodoRenderRow): string {
+  if (row.playerName === row.playerTag) {
+    return row.playerTag;
+  }
   return `${row.playerName} ${row.playerTag}`;
 }
 
@@ -553,11 +561,66 @@ function getGamesRowStatus(row: TodoRenderRow): string {
   return `clan games points: ${points}/${target}${staleSuffix}`;
 }
 
-/** Purpose: decide whether one player should be marked complete on the GAMES page. */
-function isGamesComplete(row: TodoRenderRow): boolean {
-  if (!row.snapshot) return false;
+/** Purpose: resolve one todo-row player display name with deterministic linked-user fallback ordering. */
+function resolveTodoPlayerDisplayName(input: {
+  playerTag: string;
+  snapshotPlayerName: unknown;
+  linkedName: unknown;
+}): string {
+  const normalizedTag = normalizePlayerTag(input.playerTag);
+  const preferredSnapshotName = sanitizeStatusText(input.snapshotPlayerName);
+  if (preferredSnapshotName && preferredSnapshotName !== normalizedTag) {
+    return preferredSnapshotName;
+  }
+
+  const linkedName = sanitizeStatusText(input.linkedName);
+  if (linkedName) {
+    return linkedName;
+  }
+
+  if (preferredSnapshotName) {
+    return preferredSnapshotName;
+  }
+
+  return normalizedTag;
+}
+
+/** Purpose: sort games rows by champion total desc with stable deterministic tie-breakers. */
+function sortGamesRows(rows: TodoRenderRow[]): TodoRenderRow[] {
+  return rows
+    .map((row, index) => ({ row, index }))
+    .sort((a, b) => {
+      const aTotal = toFiniteIntOrNull(a.row.snapshot?.gamesChampionTotal);
+      const bTotal = toFiniteIntOrNull(b.row.snapshot?.gamesChampionTotal);
+      const normalizedATotal = aTotal === null ? Number.NEGATIVE_INFINITY : aTotal;
+      const normalizedBTotal = bTotal === null ? Number.NEGATIVE_INFINITY : bTotal;
+      if (normalizedATotal !== normalizedBTotal) {
+        return normalizedBTotal - normalizedATotal;
+      }
+
+      const byName = sanitizeStatusText(a.row.playerName).localeCompare(
+        sanitizeStatusText(b.row.playerName),
+        undefined,
+        { sensitivity: "base" },
+      );
+      if (byName !== 0) return byName;
+
+      const byTag = a.row.playerTag.localeCompare(b.row.playerTag);
+      if (byTag !== 0) return byTag;
+
+      return a.index - b.index;
+    })
+    .map((entry) => entry.row);
+}
+
+/** Purpose: map games progress points to deterministic status emoji thresholds. */
+function getGamesProgressEmoji(row: TodoRenderRow): string {
+  if (!row.snapshot || !row.snapshot.gamesActive) return "";
   const points = Math.max(0, toFiniteIntOrNull(row.snapshot.gamesPoints) ?? 0);
-  return points >= TODO_GAMES_COMPLETE_POINTS;
+  if (points <= 0) return "";
+  if (points >= TODO_GAMES_MAX_POINTS) return "🏆";
+  if (points >= TODO_GAMES_COMPLETE_POINTS) return "✅";
+  return "🟡";
 }
 
 /** Purpose: format one date as a Discord relative timestamp token. */

--- a/src/services/TodoService.ts
+++ b/src/services/TodoService.ts
@@ -852,11 +852,17 @@ function pickLatestCurrentWarMatchContextByClanTag(
   return latest;
 }
 
-/** Purpose: sort games rows by champion total desc with stable deterministic tie-breakers. */
+/** Purpose: sort games rows by current-cycle points first, then champion total, then stable ties. */
 function sortGamesRows(rows: TodoRenderRow[]): TodoRenderRow[] {
   return rows
     .map((row, index) => ({ row, index }))
     .sort((a, b) => {
+      const aPoints = Math.max(0, toFiniteIntOrNull(a.row.snapshot?.gamesPoints) ?? 0);
+      const bPoints = Math.max(0, toFiniteIntOrNull(b.row.snapshot?.gamesPoints) ?? 0);
+      if (aPoints !== bPoints) {
+        return bPoints - aPoints;
+      }
+
       const aTotal = toFiniteIntOrNull(a.row.snapshot?.gamesChampionTotal);
       const bTotal = toFiniteIntOrNull(b.row.snapshot?.gamesChampionTotal);
       const normalizedATotal = aTotal === null ? Number.NEGATIVE_INFINITY : aTotal;

--- a/src/services/TodoService.ts
+++ b/src/services/TodoService.ts
@@ -9,6 +9,12 @@ import {
   todoSnapshotService,
   type TodoSnapshotRecord,
 } from "./TodoSnapshotService";
+import {
+  buildTrackedWarMemberStateByClanAndPlayer,
+  buildTrackedWarMemberStateByPlayerTag,
+  isTodoWarStateActive,
+  type TodoTrackedCurrentWarRow,
+} from "./TodoTrackedWarStateService";
 
 export const TODO_TYPES = ["WAR", "CWL", "RAIDS", "GAMES"] as const;
 export type TodoType = (typeof TODO_TYPES)[number];
@@ -65,8 +71,24 @@ type WarMemberCurrentRow = {
   sourceSyncedAt: Date;
 };
 
+type WarAttacksRow = {
+  warId: number;
+  clanTag: string;
+  warStartTime: Date;
+  playerTag: string;
+  playerPosition: number | null;
+  attacksUsed: number;
+  attackOrder: number;
+  attackNumber: number;
+  defenderPosition: number | null;
+  stars: number;
+  attackSeenAt: Date;
+};
+
 type CurrentWarMatchContextRow = {
   clanTag: string;
+  warId: number | null;
+  startTime: Date | null;
   matchType: string | null;
   outcome: string | null;
   state: string | null;
@@ -180,6 +202,8 @@ export async function buildTodoPagesForUser(input: {
           where: { clanTag: { in: clanTags } },
           select: {
             clanTag: true,
+            warId: true,
+            startTime: true,
             matchType: true,
             outcome: true,
             state: true,
@@ -192,6 +216,11 @@ export async function buildTodoPagesForUser(input: {
   const latestWarMemberByClanAndPlayer =
     pickLatestWarMemberByClanAndPlayer(warMemberRows);
   const latestWarMemberByPlayerTag = pickLatestWarMemberByPlayerTag(warMemberRows);
+  const trackedClanTagSet = new Set(
+    trackedClanRows
+      .map((row) => normalizeClanTag(row.tag))
+      .filter(Boolean),
+  );
   const clanBadgeByTag = new Map(
     trackedClanRows
       .map((row) => [normalizeClanTag(row.tag), sanitizeStatusText(row.clanBadge)] as const)
@@ -199,6 +228,48 @@ export async function buildTodoPagesForUser(input: {
   );
   const warMatchContextByClanTag =
     pickLatestCurrentWarMatchContextByClanTag(currentWarRows);
+  const currentWarIdentityByClanTag = pickLatestCurrentWarIdentityByClanTag(currentWarRows);
+  const activeTrackedCurrentWarByClanTag = new Map<string, TodoTrackedCurrentWarRow>();
+  for (const [clanTag, currentWar] of currentWarIdentityByClanTag.entries()) {
+    if (!trackedClanTagSet.has(clanTag)) continue;
+    if (!isTodoWarStateActive(currentWar.state ?? "")) continue;
+    activeTrackedCurrentWarByClanTag.set(clanTag, {
+      clanTag,
+      warId: toFiniteIntOrNull(currentWar.warId),
+      startTime: currentWar.startTime ?? null,
+      state: currentWar.state ?? null,
+    });
+  }
+  const activeTrackedClanTags = [...activeTrackedCurrentWarByClanTag.keys()];
+  const trackedWarAttackRows: WarAttacksRow[] =
+    activeTrackedClanTags.length > 0
+      ? await prisma.warAttacks.findMany({
+          where: {
+            clanTag: { in: activeTrackedClanTags },
+            playerTag: { in: linkedTags },
+          },
+          select: {
+            warId: true,
+            clanTag: true,
+            warStartTime: true,
+            playerTag: true,
+            playerPosition: true,
+            attacksUsed: true,
+            attackOrder: true,
+            attackNumber: true,
+            defenderPosition: true,
+            stars: true,
+            attackSeenAt: true,
+          },
+        })
+      : [];
+  const trackedWarMemberByClanAndPlayer = buildTrackedWarMemberStateByClanAndPlayer({
+    currentWarByClanTag: activeTrackedCurrentWarByClanTag,
+    warAttackRows: trackedWarAttackRows,
+  });
+  const trackedWarMemberByPlayerTag = buildTrackedWarMemberStateByPlayerTag(
+    trackedWarMemberByClanAndPlayer,
+  );
 
   const renderRows = links.map((link, index) => {
     const normalizedTag = normalizePlayerTag(link.playerTag);
@@ -207,11 +278,27 @@ export async function buildTodoPagesForUser(input: {
     const staleSnapshot = snapshot ? isSnapshotStale(snapshot, nowMs) : false;
     const resolvedClanTag = normalizeClanTag(snapshot?.clanTag ?? "") || null;
     const warMemberKey = resolvedClanTag ? `${resolvedClanTag}:${normalizedTag}` : "";
-    const warMember = warMemberKey
+    const warMemberFromFeed = warMemberKey
       ? latestWarMemberByClanAndPlayer.get(warMemberKey) ?? null
       : null;
-    const fallbackWarMember =
-      warMember ?? latestWarMemberByPlayerTag.get(normalizedTag) ?? null;
+    const fallbackWarMemberFromFeed =
+      warMemberFromFeed ?? latestWarMemberByPlayerTag.get(normalizedTag) ?? null;
+    const trackedWarMember = warMemberKey
+      ? trackedWarMemberByClanAndPlayer.get(warMemberKey) ?? null
+      : null;
+    const fallbackTrackedWarMember =
+      trackedWarMember ?? trackedWarMemberByPlayerTag.get(normalizedTag) ?? null;
+    const trackedClanActive = Boolean(
+      resolvedClanTag && trackedClanTagSet.has(resolvedClanTag),
+    );
+    const resolvedWarPosition = trackedClanActive
+      ? toFiniteIntOrNull(
+          fallbackTrackedWarMember?.position ?? fallbackWarMemberFromFeed?.position,
+        )
+      : toFiniteIntOrNull(fallbackWarMemberFromFeed?.position);
+    const resolvedWarAttackDetails = trackedClanActive
+      ? (fallbackTrackedWarMember?.attackDetails ?? [])
+      : resolveWarAttackDetails(fallbackWarMemberFromFeed);
     const matchContext = resolvedClanTag
       ? warMatchContextByClanTag.get(resolvedClanTag) ?? null
       : null;
@@ -228,8 +315,8 @@ export async function buildTodoPagesForUser(input: {
       clanName: snapshot?.clanName ?? null,
       cwlClanTag: snapshot?.cwlClanTag ?? null,
       cwlClanName: snapshot?.cwlClanName ?? null,
-      warPosition: toFiniteIntOrNull(fallbackWarMember?.position),
-      warAttackDetails: resolveWarAttackDetails(fallbackWarMember),
+      warPosition: resolvedWarPosition,
+      warAttackDetails: resolvedWarAttackDetails,
       warHeaderBadge: resolvedClanTag ? clanBadgeByTag.get(resolvedClanTag) ?? null : null,
       warMatchIndicator: resolveWarMatchStatusIndicator(matchContext),
       snapshot,
@@ -842,9 +929,57 @@ function pickLatestCurrentWarMatchContextByClanTag(
     if (!existing || row.updatedAt > existing.updatedAt) {
       latest.set(clanTag, {
         clanTag,
+        warId: toFiniteIntOrNull(row.warId),
+        startTime: row.startTime ?? null,
         matchType: row.matchType,
         outcome: row.outcome,
         state: row.state,
+        updatedAt: row.updatedAt,
+      });
+    }
+  }
+  return latest;
+}
+
+/** Purpose: keep one latest current-war identity row per clan for tracked WarAttacks resolution. */
+function pickLatestCurrentWarIdentityByClanTag(
+  rows: Array<{
+    clanTag: string;
+    warId: number | null;
+    startTime: Date | null;
+    state: string | null;
+    updatedAt: Date;
+  }>,
+): Map<
+  string,
+  {
+    clanTag: string;
+    warId: number | null;
+    startTime: Date | null;
+    state: string | null;
+    updatedAt: Date;
+  }
+> {
+  const latest = new Map<
+    string,
+    {
+      clanTag: string;
+      warId: number | null;
+      startTime: Date | null;
+      state: string | null;
+      updatedAt: Date;
+    }
+  >();
+  for (const row of rows) {
+    const clanTag = normalizeClanTag(row.clanTag);
+    if (!clanTag) continue;
+    const existing = latest.get(clanTag);
+    if (!existing || row.updatedAt > existing.updatedAt) {
+      latest.set(clanTag, {
+        clanTag,
+        warId: toFiniteIntOrNull(row.warId),
+        startTime: row.startTime ?? null,
+        state: row.state ?? null,
         updatedAt: row.updatedAt,
       });
     }

--- a/src/services/TodoService.ts
+++ b/src/services/TodoService.ts
@@ -69,6 +69,7 @@ type CurrentWarMatchContextRow = {
   clanTag: string;
   matchType: string | null;
   outcome: string | null;
+  state: string | null;
   updatedAt: Date;
 };
 
@@ -177,13 +178,20 @@ export async function buildTodoPagesForUser(input: {
     clanTags.length > 0
       ? prisma.currentWar.findMany({
           where: { clanTag: { in: clanTags } },
-          select: { clanTag: true, matchType: true, outcome: true, updatedAt: true },
+          select: {
+            clanTag: true,
+            matchType: true,
+            outcome: true,
+            state: true,
+            updatedAt: true,
+          },
         })
       : Promise.resolve([]),
   ]);
 
   const latestWarMemberByClanAndPlayer =
     pickLatestWarMemberByClanAndPlayer(warMemberRows);
+  const latestWarMemberByPlayerTag = pickLatestWarMemberByPlayerTag(warMemberRows);
   const clanBadgeByTag = new Map(
     trackedClanRows
       .map((row) => [normalizeClanTag(row.tag), sanitizeStatusText(row.clanBadge)] as const)
@@ -202,7 +210,8 @@ export async function buildTodoPagesForUser(input: {
     const warMember = warMemberKey
       ? latestWarMemberByClanAndPlayer.get(warMemberKey) ?? null
       : null;
-    const warAttackDetails = resolveWarAttackDetails(warMember);
+    const fallbackWarMember =
+      warMember ?? latestWarMemberByPlayerTag.get(normalizedTag) ?? null;
     const matchContext = resolvedClanTag
       ? warMatchContextByClanTag.get(resolvedClanTag) ?? null
       : null;
@@ -219,8 +228,8 @@ export async function buildTodoPagesForUser(input: {
       clanName: snapshot?.clanName ?? null,
       cwlClanTag: snapshot?.cwlClanTag ?? null,
       cwlClanName: snapshot?.cwlClanName ?? null,
-      warPosition: toFiniteIntOrNull(warMember?.position),
-      warAttackDetails,
+      warPosition: toFiniteIntOrNull(fallbackWarMember?.position),
+      warAttackDetails: resolveWarAttackDetails(fallbackWarMember),
       warHeaderBadge: resolvedClanTag ? clanBadgeByTag.get(resolvedClanTag) ?? null : null,
       warMatchIndicator: resolveWarMatchStatusIndicator(matchContext),
       snapshot,
@@ -290,7 +299,7 @@ function isSnapshotStale(snapshot: TodoSnapshotRecord, nowMs: number): boolean {
   return ageMs > TODO_STALE_IDLE_MS;
 }
 
-/** Purpose: build the WAR page using grouped active contexts and explicit inactive fallback. */
+/** Purpose: build the WAR page from grouped active contexts only. */
 function buildWarPageDescription(
   rows: TodoRenderRow[],
   linkedPlayerCount: number,
@@ -305,7 +314,6 @@ function buildWarPageDescription(
   }
 
   const grouped = buildEventGroups(activeRows, "war");
-  const inactiveRows = rows.filter((row) => !row.snapshot?.warActive);
   const lines: string[] = [];
   for (const group of grouped) {
     lines.push(`**${buildEventGroupHeader(group)}**`);
@@ -314,13 +322,7 @@ function buildWarPageDescription(
     }
     lines.push("");
   }
-
-  if (inactiveRows.length > 0) {
-    lines.push("**Not in active war**");
-    for (const row of inactiveRows) {
-      lines.push(formatTodoRow(row, getWarNeutralStatus(row)));
-    }
-  } else if (lines.at(-1) === "") {
+  if (lines.at(-1) === "") {
     lines.pop();
   }
 
@@ -331,7 +333,7 @@ function buildWarPageDescription(
   });
 }
 
-/** Purpose: build the CWL page using grouped active contexts and explicit inactive fallback. */
+/** Purpose: build the CWL page from grouped active contexts only. */
 function buildCwlPageDescription(
   rows: TodoRenderRow[],
   linkedPlayerCount: number,
@@ -346,7 +348,6 @@ function buildCwlPageDescription(
   }
 
   const grouped = buildEventGroups(activeRows, "cwl");
-  const inactiveRows = rows.filter((row) => !row.snapshot?.cwlActive);
   const lines: string[] = [];
   for (const group of grouped) {
     lines.push(`**${buildEventGroupHeader(group)}**`);
@@ -355,13 +356,7 @@ function buildCwlPageDescription(
     }
     lines.push("");
   }
-
-  if (inactiveRows.length > 0) {
-    lines.push("**Not in active CWL**");
-    for (const row of inactiveRows) {
-      lines.push(formatTodoRow(row, getCwlNeutralStatus(row)));
-    }
-  } else if (lines.at(-1) === "") {
+  if (lines.at(-1) === "") {
     lines.pop();
   }
 
@@ -546,7 +541,10 @@ function formatTodoRow(row: TodoRenderRow, status: string): string {
 /** Purpose: format one WAR row with lineup position and compact attack-detail suffixes. */
 function formatWarTodoRow(row: TodoRenderRow, status: string): string {
   const identity = formatWarPlayerIdentity(row);
-  const usedAttacks = clampInt(row.snapshot?.warAttacksUsed, 0, row.snapshot?.warAttacksMax || 2);
+  const attacksActive = isWarRowAttackPhaseActive(row);
+  const usedAttacks = attacksActive
+    ? clampInt(row.snapshot?.warAttacksUsed, 0, row.snapshot?.warAttacksMax || 2)
+    : 0;
   const detailRows =
     usedAttacks > 0
       ? row.warAttackDetails
@@ -609,22 +607,12 @@ function getWarRowStatus(row: TodoRenderRow): string {
   if (row.missingSnapshot || !row.snapshot) {
     return "`0 / 2` - snapshot unavailable";
   }
-  const used = clampInt(row.snapshot.warAttacksUsed, 0, row.snapshot.warAttacksMax || 2);
+  const used = isWarRowAttackPhaseActive(row)
+    ? clampInt(row.snapshot.warAttacksUsed, 0, row.snapshot.warAttacksMax || 2)
+    : 0;
   const max = Math.max(1, clampInt(row.snapshot.warAttacksMax, 1, 2));
   const staleSuffix = row.staleSnapshot ? " - stale snapshot" : "";
   return `\`${used} / ${max}\`${staleSuffix}`;
-}
-
-/** Purpose: build neutral WAR row status text for linked players outside active war groups. */
-function getWarNeutralStatus(row: TodoRenderRow): string {
-  if (row.missingSnapshot || !row.snapshot) {
-    return "war attacks: 0/2 - snapshot unavailable";
-  }
-
-  const used = clampInt(row.snapshot.warAttacksUsed, 0, row.snapshot.warAttacksMax || 2);
-  const max = Math.max(1, clampInt(row.snapshot.warAttacksMax, 1, 2));
-  const staleSuffix = row.staleSnapshot ? " - stale snapshot" : "";
-  return `war attacks: ${used}/${max} - not in active war${staleSuffix}`;
 }
 
 /** Purpose: build active CWL row status text without repeating group-level phase timing details. */
@@ -637,18 +625,6 @@ function getCwlRowStatus(row: TodoRenderRow): string {
   const max = Math.max(1, clampInt(row.snapshot.cwlAttacksMax, 1, 1));
   const staleSuffix = row.staleSnapshot ? " - stale snapshot" : "";
   return `CWL attacks: ${used}/${max}${staleSuffix}`;
-}
-
-/** Purpose: build neutral CWL row status text for linked players outside active CWL groups. */
-function getCwlNeutralStatus(row: TodoRenderRow): string {
-  if (row.missingSnapshot || !row.snapshot) {
-    return "CWL attacks: 0/1 - snapshot unavailable";
-  }
-
-  const used = clampInt(row.snapshot.cwlAttacksUsed, 0, row.snapshot.cwlAttacksMax || 1);
-  const max = Math.max(1, clampInt(row.snapshot.cwlAttacksMax, 1, 1));
-  const staleSuffix = row.staleSnapshot ? " - stale snapshot" : "";
-  return `CWL attacks: ${used}/${max} - not in active CWL war${staleSuffix}`;
 }
 
 /** Purpose: build RAIDS row status text with usage only and without per-row timer duplication. */
@@ -732,6 +708,14 @@ function compareWarRowsForRendering(a: TodoRenderRow, b: TodoRenderRow): number 
   if (byTag !== 0) return byTag;
 
   return a.defaultIndex - b.defaultIndex;
+}
+
+/** Purpose: treat preparation phase as attack-inactive so stale prior-war attacks never render. */
+function isWarRowAttackPhaseActive(row: TodoRenderRow): boolean {
+  if (!row.snapshot?.warActive) return false;
+  const phase = sanitizeStatusText(row.snapshot.warPhase).toLowerCase();
+  if (phase.includes("preparation")) return false;
+  return true;
 }
 
 /** Purpose: extract compact first/second attack details from one latest war-member row. */
@@ -819,6 +803,33 @@ function pickLatestWarMemberByClanAndPlayer(
   return latest;
 }
 
+/** Purpose: keep one freshest war-member row per player tag as fallback when clan-tag joins are stale. */
+function pickLatestWarMemberByPlayerTag(
+  rows: WarMemberCurrentRow[],
+): Map<string, WarMemberCurrentRow> {
+  const latest = new Map<string, WarMemberCurrentRow>();
+  for (const row of rows) {
+    const clanTag = normalizeClanTag(row.clanTag);
+    const playerTag = normalizePlayerTag(row.playerTag);
+    if (!clanTag || !playerTag) continue;
+    const existing = latest.get(playerTag);
+    if (!existing || row.sourceSyncedAt > existing.sourceSyncedAt) {
+      latest.set(playerTag, {
+        clanTag,
+        playerTag,
+        position: toFiniteIntOrNull(row.position),
+        attacks: toFiniteIntOrNull(row.attacks),
+        defender1Position: toFiniteIntOrNull(row.defender1Position),
+        stars1: toFiniteIntOrNull(row.stars1),
+        defender2Position: toFiniteIntOrNull(row.defender2Position),
+        stars2: toFiniteIntOrNull(row.stars2),
+        sourceSyncedAt: row.sourceSyncedAt,
+      });
+    }
+  }
+  return latest;
+}
+
 /** Purpose: keep one latest current-war match context row per clan for header indicator rendering. */
 function pickLatestCurrentWarMatchContextByClanTag(
   rows: CurrentWarMatchContextRow[],
@@ -833,6 +844,7 @@ function pickLatestCurrentWarMatchContextByClanTag(
         clanTag,
         matchType: row.matchType,
         outcome: row.outcome,
+        state: row.state,
         updatedAt: row.updatedAt,
       });
     }

--- a/src/services/TodoSnapshotService.ts
+++ b/src/services/TodoSnapshotService.ts
@@ -72,6 +72,7 @@ type ClanMemberCurrentRow = {
 type WarMemberCurrentRow = {
   playerTag: string;
   clanTag: string;
+  position: number | null;
   attacks: number | null;
   sourceSyncedAt: Date;
 };
@@ -271,6 +272,7 @@ export class TodoSnapshotService {
         select: {
           playerTag: true,
           clanTag: true,
+          position: true,
           attacks: true,
           sourceSyncedAt: true,
         },
@@ -441,31 +443,38 @@ export class TodoSnapshotService {
       const currentWar = resolvedClanTag
         ? currentWarByClanTag.get(resolvedClanTag) ?? null
         : null;
-      const warActive = isWarStateActive(currentWar?.state ?? "");
-      const warPhase = warActive
-        ? normalizeWarPhaseLabel(currentWar?.state ?? "")
-        : null;
-      const warEndsAt = warActive ? resolveCurrentWarPhaseEnd(currentWar) : null;
+      const warStateActive = isWarStateActive(currentWar?.state ?? "");
+      const warStatePreparation = isWarStatePreparation(currentWar?.state ?? "");
 
       const warMemberKey = resolvedClanTag ? `${resolvedClanTag}:${playerTag}` : "";
       const warMember = warMemberKey
         ? latestWarMemberByClanAndTag.get(warMemberKey) ?? null
         : null;
-      const warAttacksUsed = warActive ? clampInt(warMember?.attacks, 0, 2) : 0;
+      const warActive = warStateActive && warMember !== null;
+      const warPhase = warActive
+        ? normalizeWarPhaseLabel(currentWar?.state ?? "")
+        : null;
+      const warEndsAt = warActive ? resolveCurrentWarPhaseEnd(currentWar) : null;
+      const warAttacksUsed = !warActive
+        ? 0
+        : warStatePreparation
+          ? 0
+          : clampInt(warMember?.attacks, 0, 2);
 
       const cwlWar = resolvedCwlClanTag
         ? cwlWarByClan.get(resolvedCwlClanTag) ?? null
         : null;
-      const cwlActive = isWarStateActive(cwlWar?.state ?? "");
+      const cwlParticipant =
+        !!resolvedCwlClanTag &&
+        activeCwlClanByPlayerTag.get(playerTag) === resolvedCwlClanTag;
+      const cwlActive = isWarStateActive(cwlWar?.state ?? "") && cwlParticipant;
       const cwlPhase = cwlActive
         ? normalizeWarPhaseLabel(cwlWar?.state ?? "")
         : null;
       const cwlEndsAt = cwlActive ? resolveCwlPhaseEnd(cwlWar) : null;
       const cwlAttacksUsed = cwlActive
         ? clampInt(findWarAttacksUsed(cwlWar, playerTag), 0, 1)
-        : !input.cocService && existing
-          ? clampInt(existing.cwlAttacksUsed, 0, 1)
-          : 0;
+        : 0;
 
       const derivedGames = deriveTodoGamesValues({
         gamesWindowActive: gamesWindow.active,
@@ -755,6 +764,7 @@ function pickLatestWarMemberByClanAndPlayer(
       latest.set(key, {
         playerTag,
         clanTag,
+        position: toFiniteIntOrNull(row.position),
         attacks: toFiniteIntOrNull(row.attacks),
         sourceSyncedAt: row.sourceSyncedAt,
       });
@@ -815,6 +825,12 @@ function pickLatestCurrentWarByClanTag(
 function isWarStateActive(state: unknown): boolean {
   const normalized = String(state ?? "").toLowerCase();
   return normalized.includes("preparation") || normalized.includes("inwar");
+}
+
+/** Purpose: detect preparation phase so attacks remain zero until battle day starts. */
+function isWarStatePreparation(state: unknown): boolean {
+  const normalized = String(state ?? "").toLowerCase();
+  return normalized.includes("preparation");
 }
 
 /** Purpose: map war-state values to user-facing phase labels. */

--- a/src/services/TodoSnapshotService.ts
+++ b/src/services/TodoSnapshotService.ts
@@ -8,6 +8,11 @@ import {
 import { resolveCurrentCwlSeasonKey } from "./CwlRegistryService";
 import { CoCService } from "./CoCService";
 import { normalizeClanTag, normalizePlayerTag } from "./PlayerLinkService";
+import {
+  buildTrackedWarMemberStateByClanAndPlayer,
+  isTodoWarStateActive,
+  type TodoTrackedCurrentWarRow,
+} from "./TodoTrackedWarStateService";
 import { parseCocTime } from "./war-events/core";
 
 const TODO_SNAPSHOT_SELECT = {
@@ -75,6 +80,20 @@ type WarMemberCurrentRow = {
   position: number | null;
   attacks: number | null;
   sourceSyncedAt: Date;
+};
+
+type WarAttacksRow = {
+  warId: number;
+  clanTag: string;
+  warStartTime: Date;
+  playerTag: string;
+  playerPosition: number | null;
+  attacksUsed: number;
+  attackOrder: number;
+  attackNumber: number;
+  defenderPosition: number | null;
+  stars: number;
+  attackSeenAt: Date;
 };
 
 type TodoGamesDerivedValues = {
@@ -333,6 +352,7 @@ export class TodoSnapshotService {
             where: { clanTag: { in: clanTags } },
             select: {
               clanTag: true,
+              warId: true,
               state: true,
               startTime: true,
               endTime: true,
@@ -365,6 +385,49 @@ export class TodoSnapshotService {
         .filter((entry): entry is [string, string] => Boolean(entry[0] && entry[1])),
     );
     const currentWarByClanTag = pickLatestCurrentWarByClanTag(currentWarRows);
+    const trackedClanTagSet = new Set(
+      trackedClanRows
+        .map((row) => normalizeClanTag(row.tag))
+        .filter(Boolean),
+    );
+    const activeTrackedCurrentWarByClanTag = new Map<string, TodoTrackedCurrentWarRow>();
+    for (const [clanTag, currentWar] of currentWarByClanTag.entries()) {
+      if (!trackedClanTagSet.has(clanTag)) continue;
+      if (!isTodoWarStateActive(currentWar.state ?? "")) continue;
+      activeTrackedCurrentWarByClanTag.set(clanTag, {
+        clanTag,
+        warId: toFiniteIntOrNull(currentWar.warId),
+        startTime: currentWar.startTime ?? null,
+        state: currentWar.state ?? null,
+      });
+    }
+    const activeTrackedClanTags = [...activeTrackedCurrentWarByClanTag.keys()];
+    const trackedWarAttackRows: WarAttacksRow[] =
+      activeTrackedClanTags.length > 0
+        ? await prisma.warAttacks.findMany({
+            where: {
+              clanTag: { in: activeTrackedClanTags },
+              playerTag: { in: normalizedTags },
+            },
+            select: {
+              warId: true,
+              clanTag: true,
+              warStartTime: true,
+              playerTag: true,
+              playerPosition: true,
+              attacksUsed: true,
+              attackOrder: true,
+              attackNumber: true,
+              defenderPosition: true,
+              stars: true,
+              attackSeenAt: true,
+            },
+          })
+        : [];
+    const trackedWarMemberByClanAndTag = buildTrackedWarMemberStateByClanAndPlayer({
+      currentWarByClanTag: activeTrackedCurrentWarByClanTag,
+      warAttackRows: trackedWarAttackRows,
+    });
     const cwlTrackedTagSet = new Set(
       cwlTrackedClanRows
         .map((row) => normalizeClanTag(row.tag))
@@ -443,13 +506,23 @@ export class TodoSnapshotService {
       const currentWar = resolvedClanTag
         ? currentWarByClanTag.get(resolvedClanTag) ?? null
         : null;
-      const warStateActive = isWarStateActive(currentWar?.state ?? "");
+      const warStateActive = isTodoWarStateActive(currentWar?.state ?? "");
       const warStatePreparation = isWarStatePreparation(currentWar?.state ?? "");
+      const trackedClanActive = Boolean(
+        resolvedClanTag && trackedClanTagSet.has(resolvedClanTag),
+      );
 
       const warMemberKey = resolvedClanTag ? `${resolvedClanTag}:${playerTag}` : "";
-      const warMember = warMemberKey
+      const warMemberFromFeed = warMemberKey
         ? latestWarMemberByClanAndTag.get(warMemberKey) ?? null
         : null;
+      const trackedWarMember =
+        trackedClanActive && warMemberKey
+          ? trackedWarMemberByClanAndTag.get(warMemberKey) ?? null
+          : null;
+      const warMember = trackedClanActive
+        ? trackedWarMember ?? warMemberFromFeed
+        : warMemberFromFeed;
       const warActive = warStateActive && warMember !== null;
       const warPhase = warActive
         ? normalizeWarPhaseLabel(currentWar?.state ?? "")
@@ -459,7 +532,9 @@ export class TodoSnapshotService {
         ? 0
         : warStatePreparation
           ? 0
-          : clampInt(warMember?.attacks, 0, 2);
+          : trackedClanActive
+            ? clampInt(trackedWarMember?.attacksUsed, 0, 2)
+            : clampInt(warMemberFromFeed?.attacks, 0, 2);
 
       const cwlWar = resolvedCwlClanTag
         ? cwlWarByClan.get(resolvedCwlClanTag) ?? null
@@ -777,6 +852,7 @@ function pickLatestWarMemberByClanAndPlayer(
 function pickLatestCurrentWarByClanTag(
   rows: Array<{
     clanTag: string;
+    warId: number | null;
     state: string | null;
     startTime: Date | null;
     endTime: Date | null;
@@ -786,6 +862,7 @@ function pickLatestCurrentWarByClanTag(
   string,
   {
     clanTag: string;
+    warId: number | null;
     state: string | null;
     startTime: Date | null;
     endTime: Date | null;
@@ -796,6 +873,7 @@ function pickLatestCurrentWarByClanTag(
     string,
     {
       clanTag: string;
+      warId: number | null;
       state: string | null;
       startTime: Date | null;
       endTime: Date | null;
@@ -811,6 +889,7 @@ function pickLatestCurrentWarByClanTag(
     if (!existing || row.updatedAt > existing.updatedAt) {
       latest.set(clanTag, {
         clanTag,
+        warId: toFiniteIntOrNull(row.warId),
         state: row.state,
         startTime: row.startTime,
         endTime: row.endTime,
@@ -821,16 +900,15 @@ function pickLatestCurrentWarByClanTag(
   return latest;
 }
 
-/** Purpose: classify war-state strings into active/non-active buckets for todo status. */
-function isWarStateActive(state: unknown): boolean {
-  const normalized = String(state ?? "").toLowerCase();
-  return normalized.includes("preparation") || normalized.includes("inwar");
-}
-
 /** Purpose: detect preparation phase so attacks remain zero until battle day starts. */
 function isWarStatePreparation(state: unknown): boolean {
   const normalized = String(state ?? "").toLowerCase();
   return normalized.includes("preparation");
+}
+
+/** Purpose: keep existing CWL helpers on one shared active-phase classifier. */
+function isWarStateActive(state: unknown): boolean {
+  return isTodoWarStateActive(state);
 }
 
 /** Purpose: map war-state values to user-facing phase labels. */

--- a/src/services/TodoTrackedWarStateService.ts
+++ b/src/services/TodoTrackedWarStateService.ts
@@ -1,0 +1,217 @@
+import { normalizeClanTag, normalizePlayerTag } from "./PlayerLinkService";
+
+export type TodoTrackedCurrentWarRow = {
+  clanTag: string;
+  warId: number | null;
+  startTime: Date | null;
+  state: string | null;
+};
+
+export type TodoTrackedWarAttackRow = {
+  warId: number;
+  clanTag: string;
+  warStartTime: Date;
+  playerTag: string;
+  playerPosition: number | null;
+  attacksUsed: number;
+  attackOrder: number;
+  attackNumber: number;
+  defenderPosition: number | null;
+  stars: number;
+  attackSeenAt: Date;
+};
+
+export type TodoTrackedWarAttackDetail = {
+  defenderPosition: number | null;
+  stars: number | null;
+};
+
+export type TodoTrackedWarMemberState = {
+  playerTag: string;
+  clanTag: string;
+  position: number | null;
+  attacksUsed: number;
+  attackDetails: TodoTrackedWarAttackDetail[];
+};
+
+type MutableTrackedWarMemberState = {
+  playerTag: string;
+  clanTag: string;
+  position: number | null;
+  attacksUsed: number;
+  attackDetails: Array<{
+    order: number;
+    attackNumber: number;
+    seenAtMs: number;
+    defenderPosition: number | null;
+    stars: number | null;
+  }>;
+};
+
+/** Purpose: classify war-state strings into active/non-active buckets for todo status. */
+export function isTodoWarStateActive(state: unknown): boolean {
+  const normalized = String(state ?? "").toLowerCase();
+  return normalized.includes("preparation") || normalized.includes("inwar");
+}
+
+/** Purpose: build tracked-war member state from CurrentWar identity + WarAttacks rows. */
+export function buildTrackedWarMemberStateByClanAndPlayer(input: {
+  currentWarByClanTag: Map<string, TodoTrackedCurrentWarRow>;
+  warAttackRows: TodoTrackedWarAttackRow[];
+}): Map<string, TodoTrackedWarMemberState> {
+  const mapped = new Map<string, MutableTrackedWarMemberState>();
+
+  for (const row of input.warAttackRows) {
+    const clanTag = normalizeClanTag(row.clanTag);
+    const playerTag = normalizePlayerTag(row.playerTag);
+    if (!clanTag || !playerTag) continue;
+
+    const currentWar = input.currentWarByClanTag.get(clanTag);
+    if (!currentWar || !isTodoWarStateActive(currentWar.state)) continue;
+    if (!matchesCurrentWarIdentity(currentWar, row)) continue;
+
+    const key = `${clanTag}:${playerTag}`;
+    const existing = mapped.get(key);
+    const mutable =
+      existing ??
+      ({
+        playerTag,
+        clanTag,
+        position: null,
+        attacksUsed: 0,
+        attackDetails: [],
+      } satisfies MutableTrackedWarMemberState);
+    if (!existing) {
+      mapped.set(key, mutable);
+    }
+
+    const candidatePosition = toFiniteIntOrNull(row.playerPosition);
+    if (
+      mutable.position === null &&
+      candidatePosition !== null &&
+      candidatePosition > 0
+    ) {
+      mutable.position = candidatePosition;
+    }
+    mutable.attacksUsed = Math.max(
+      mutable.attacksUsed,
+      clampInt(row.attacksUsed, 0, 2),
+    );
+
+    const attackOrder = clampInt(row.attackOrder, 0, 2);
+    const attackNumber = clampInt(row.attackNumber, 0, 2);
+    if (attackOrder <= 0 && attackNumber <= 0) {
+      continue;
+    }
+    mutable.attackDetails.push({
+      order: attackOrder > 0 ? attackOrder : attackNumber,
+      attackNumber,
+      seenAtMs: row.attackSeenAt.getTime(),
+      defenderPosition: toFiniteIntOrNull(row.defenderPosition),
+      stars: toFiniteIntOrNull(row.stars),
+    });
+  }
+
+  const finalized = new Map<string, TodoTrackedWarMemberState>();
+  for (const [key, value] of mapped.entries()) {
+    const orderedAttackDetails = [...value.attackDetails]
+      .sort((a, b) => {
+        if (a.order !== b.order) return a.order - b.order;
+        if (a.attackNumber !== b.attackNumber) return a.attackNumber - b.attackNumber;
+        return a.seenAtMs - b.seenAtMs;
+      })
+      .slice(0, 2)
+      .map((detail) => ({
+        defenderPosition: detail.defenderPosition,
+        stars: detail.stars,
+      }));
+    const attacksUsed = Math.max(
+      value.attacksUsed,
+      Math.min(2, orderedAttackDetails.length),
+    );
+    finalized.set(key, {
+      playerTag: value.playerTag,
+      clanTag: value.clanTag,
+      position: value.position,
+      attacksUsed,
+      attackDetails: orderedAttackDetails,
+    });
+  }
+
+  return finalized;
+}
+
+/** Purpose: build one per-player fallback map from tracked war member state rows. */
+export function buildTrackedWarMemberStateByPlayerTag(
+  rows: Map<string, TodoTrackedWarMemberState>,
+): Map<string, TodoTrackedWarMemberState> {
+  const byPlayerTag = new Map<string, TodoTrackedWarMemberState>();
+  for (const row of rows.values()) {
+    const existing = byPlayerTag.get(row.playerTag);
+    if (!existing) {
+      byPlayerTag.set(row.playerTag, row);
+      continue;
+    }
+
+    const existingPos = existing.position ?? Number.MAX_SAFE_INTEGER;
+    const nextPos = row.position ?? Number.MAX_SAFE_INTEGER;
+    if (nextPos < existingPos) {
+      byPlayerTag.set(row.playerTag, row);
+      continue;
+    }
+    if (nextPos > existingPos) continue;
+
+    const existingAttacks = existing.attacksUsed;
+    const nextAttacks = row.attacksUsed;
+    if (nextAttacks > existingAttacks) {
+      byPlayerTag.set(row.playerTag, row);
+      continue;
+    }
+    if (nextAttacks < existingAttacks) continue;
+
+    const existingKey = `${existing.clanTag}:${existing.playerTag}`;
+    const nextKey = `${row.clanTag}:${row.playerTag}`;
+    if (nextKey.localeCompare(existingKey) < 0) {
+      byPlayerTag.set(row.playerTag, row);
+    }
+  }
+  return byPlayerTag;
+}
+
+/** Purpose: prevent previous-war leakage by requiring WarAttacks rows to match CurrentWar identity. */
+function matchesCurrentWarIdentity(
+  currentWar: TodoTrackedCurrentWarRow,
+  attack: Pick<TodoTrackedWarAttackRow, "warId" | "warStartTime">,
+): boolean {
+  const currentWarId = toFiniteIntOrNull(currentWar.warId);
+  if (currentWarId !== null) {
+    const attackWarId = toFiniteIntOrNull(attack.warId);
+    return attackWarId !== null && attackWarId === currentWarId;
+  }
+
+  const currentStartMs =
+    currentWar.startTime instanceof Date ? currentWar.startTime.getTime() : null;
+  const attackStartMs =
+    attack.warStartTime instanceof Date ? attack.warStartTime.getTime() : null;
+  if (currentStartMs === null || attackStartMs === null) {
+    return false;
+  }
+  return currentStartMs === attackStartMs;
+}
+
+/** Purpose: normalize unknown numeric values into one bounded integer range. */
+function clampInt(input: unknown, min: number, max: number): number {
+  const parsed = Number(input);
+  if (!Number.isFinite(parsed)) return min;
+  const truncated = Math.trunc(parsed);
+  return Math.max(min, Math.min(max, truncated));
+}
+
+/** Purpose: map unknown numeric input to finite integer or null for nullable fields. */
+function toFiniteIntOrNull(input: unknown): number | null {
+  if (input === null || input === undefined) return null;
+  if (typeof input === "string" && input.trim().length <= 0) return null;
+  const value = Number(input);
+  if (!Number.isFinite(value)) return null;
+  return Math.trunc(value);
+}

--- a/src/services/fwa-feeds/FwaClanMembersSyncService.ts
+++ b/src/services/fwa-feeds/FwaClanMembersSyncService.ts
@@ -5,6 +5,7 @@ import { normalizeFwaTag } from "./normalize";
 import { FwaStatsClient } from "./FwaStatsClient";
 import { FwaFeedSyncStateService } from "./FwaFeedSyncStateService";
 import { mapWithConcurrency } from "./concurrency";
+import { normalizePersistedPlayerName } from "../PlayerLinkService";
 import type { FwaSyncResult } from "./types";
 
 type SyncOptions = {
@@ -106,6 +107,19 @@ export class FwaClanMembersSyncService {
 
       const changedRowCount = await prisma.$transaction(async (tx) => {
         const playerTags = rows.map((row) => row.playerTag);
+        const linkedPlayerRows =
+          playerTags.length > 0
+            ? await tx.playerLink.findMany({
+                where: { playerTag: { in: playerTags } },
+                select: { playerTag: true, playerName: true },
+              })
+            : [];
+        const linkedPlayerNameByTag = new Map(
+          linkedPlayerRows.map((row) => [
+            row.playerTag,
+            normalizePersistedPlayerName(row.playerName),
+          ]),
+        );
         const staleDelete = await tx.fwaClanMemberCurrent.deleteMany({
           where: {
             clanTag: normalizedClanTag,
@@ -171,6 +185,21 @@ export class FwaClanMembersSyncService {
               lastSyncedAt: now,
             },
           });
+
+          if (linkedPlayerNameByTag.has(row.playerTag)) {
+            const observedPlayerName = normalizePersistedPlayerName(row.playerName);
+            const existingLinkedName =
+              linkedPlayerNameByTag.get(row.playerTag) ?? null;
+            if (observedPlayerName && observedPlayerName !== existingLinkedName) {
+              const updated = await tx.playerLink.updateMany({
+                where: { playerTag: row.playerTag },
+                data: { playerName: observedPlayerName },
+              });
+              if (updated.count > 0) {
+                linkedPlayerNameByTag.set(row.playerTag, observedPlayerName);
+              }
+            }
+          }
         }
         return staleDelete.count + rows.length;
       });

--- a/src/services/fwa-feeds/FwaFeedSchedulerService.ts
+++ b/src/services/fwa-feeds/FwaFeedSchedulerService.ts
@@ -40,9 +40,14 @@ function toBool(input: string | undefined, fallback: boolean): boolean {
 }
 
 function toInt(input: string | undefined, fallback: number): number {
-  const parsed = Number(input ?? "");
+  if (input === undefined) return fallback;
+  const trimmed = input.trim();
+  if (!trimmed) return fallback;
+  const parsed = Number(trimmed);
   return Number.isFinite(parsed) ? Math.trunc(parsed) : fallback;
 }
+
+export const toIntWithFallbackForTest = toInt;
 
 function minutesToMsWithMin(valueMinutes: number, minMinutes: number): number {
   return Math.max(minMinutes, valueMinutes) * 60 * 1000;

--- a/src/services/fwa-feeds/FwaWarMembersSyncService.ts
+++ b/src/services/fwa-feeds/FwaWarMembersSyncService.ts
@@ -8,6 +8,7 @@ import { FwaFeedSyncStateService } from "./FwaFeedSyncStateService";
 import { mapWithConcurrency } from "./concurrency";
 import { selectDistributedSweepChunk } from "./sweep";
 import type { FwaSyncResult } from "./types";
+import { normalizePersistedPlayerName } from "../PlayerLinkService";
 
 type SyncOptions = {
   force?: boolean;
@@ -65,6 +66,19 @@ export class FwaWarMembersSyncService {
 
       const changedRowCount = await prisma.$transaction(async (tx) => {
         const playerTags = rows.map((row) => row.playerTag);
+        const linkedPlayerRows =
+          playerTags.length > 0
+            ? await tx.playerLink.findMany({
+                where: { playerTag: { in: playerTags } },
+                select: { playerTag: true, playerName: true },
+              })
+            : [];
+        const linkedPlayerNameByTag = new Map(
+          linkedPlayerRows.map((row) => [
+            row.playerTag,
+            normalizePersistedPlayerName(row.playerName),
+          ]),
+        );
         const staleDelete = await tx.fwaWarMemberCurrent.deleteMany({
           where: {
             clanTag: normalizedClanTag,
@@ -146,6 +160,21 @@ export class FwaWarMembersSyncService {
               lastSyncedAt: now,
             },
           });
+
+          if (linkedPlayerNameByTag.has(row.playerTag)) {
+            const observedPlayerName = normalizePersistedPlayerName(row.playerName);
+            const existingLinkedName =
+              linkedPlayerNameByTag.get(row.playerTag) ?? null;
+            if (observedPlayerName && observedPlayerName !== existingLinkedName) {
+              const updated = await tx.playerLink.updateMany({
+                where: { playerTag: row.playerTag },
+                data: { playerName: observedPlayerName },
+              });
+              if (updated.count > 0) {
+                linkedPlayerNameByTag.set(row.playerTag, observedPlayerName);
+              }
+            }
+          }
         }
         return staleDelete.count + rows.length;
       });

--- a/tests/accounts.command.test.ts
+++ b/tests/accounts.command.test.ts
@@ -1,0 +1,160 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const prismaMock = vi.hoisted(() => ({
+  playerLink: {
+    findUnique: vi.fn(),
+    findMany: vi.fn(),
+    updateMany: vi.fn(),
+  },
+  playerActivity: {
+    findMany: vi.fn(),
+  },
+  trackedClan: {
+    findMany: vi.fn(),
+  },
+}));
+
+vi.mock("../src/prisma", () => ({
+  prisma: prismaMock,
+}));
+
+import { Accounts } from "../src/commands/Accounts";
+
+function makeInteraction(input?: {
+  visibility?: string | null;
+  tag?: string | null;
+  discordId?: string | null;
+}) {
+  return {
+    guildId: "123456789012345678",
+    id: "777777777777777777",
+    user: { id: "111111111111111111" },
+    options: {
+      getString: vi.fn((name: string) => {
+        if (name === "visibility") return input?.visibility ?? null;
+        if (name === "tag") return input?.tag ?? null;
+        if (name === "discord-id") return input?.discordId ?? null;
+        return null;
+      }),
+    },
+    deferReply: vi.fn().mockResolvedValue(undefined),
+    editReply: vi.fn().mockResolvedValue({
+      createMessageComponentCollector: vi.fn(),
+    }),
+  };
+}
+
+function getEmbedDescription(interaction: any): string {
+  const payload = interaction.editReply.mock.calls.find(
+    (call: unknown[]) => call[0] && typeof call[0] === "object" && Array.isArray(call[0].embeds)
+  )?.[0] as any;
+  return String(payload?.embeds?.[0]?.toJSON?.().description ?? "");
+}
+
+describe("/accounts command", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    prismaMock.playerLink.findUnique.mockResolvedValue(null);
+    prismaMock.playerLink.findMany.mockResolvedValue([]);
+    prismaMock.playerLink.updateMany.mockResolvedValue({ count: 0 });
+    prismaMock.playerActivity.findMany.mockResolvedValue([]);
+    prismaMock.trackedClan.findMany.mockResolvedValue([]);
+  });
+
+  it("uses PlayerLink.playerName first when present and avoids live fetch for that row", async () => {
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      {
+        playerTag: "#PYLQ0289",
+        playerName: "Linked Alpha",
+        createdAt: new Date("2026-03-01T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.playerActivity.findMany.mockResolvedValue([
+      { tag: "#PYLQ0289", name: "Activity Alpha", clanTag: "#PQL0289" },
+    ]);
+    const cocService = {
+      getPlayerRaw: vi.fn(),
+    };
+    const interaction = makeInteraction();
+
+    await Accounts.run({} as any, interaction as any, cocService as any);
+
+    expect(cocService.getPlayerRaw).not.toHaveBeenCalled();
+    expect(getEmbedDescription(interaction)).toContain("- Linked Alpha `#PYLQ0289`");
+    expect(prismaMock.playerLink.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("fetches live name and backfills PlayerLink.playerName when missing", async () => {
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      {
+        playerTag: "#QGRJ2222",
+        playerName: null,
+        createdAt: new Date("2026-03-01T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.playerActivity.findMany.mockResolvedValue([]);
+    const cocService = {
+      getPlayerRaw: vi.fn().mockResolvedValue({
+        name: "Live Bravo",
+        clan: { tag: "#PQL0289", name: "Clan One" },
+      }),
+    };
+    const interaction = makeInteraction();
+
+    await Accounts.run({} as any, interaction as any, cocService as any);
+    await Promise.resolve();
+
+    expect(cocService.getPlayerRaw).toHaveBeenCalledWith("#QGRJ2222");
+    expect(getEmbedDescription(interaction)).toContain("- Live Bravo `#QGRJ2222`");
+    expect(prismaMock.playerLink.updateMany).toHaveBeenCalledWith({
+      where: {
+        playerTag: "#QGRJ2222",
+        OR: [{ playerName: null }, { playerName: "" }],
+      },
+      data: { playerName: "Live Bravo" },
+    });
+  });
+
+  it("uses local fallback name when live fetch fails and does not write backfill", async () => {
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      {
+        playerTag: "#CUV9082",
+        playerName: "",
+        createdAt: new Date("2026-03-01T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.playerActivity.findMany.mockResolvedValue([
+      { tag: "#CUV9082", name: "Activity Charlie", clanTag: "#2QG2C08UP" },
+    ]);
+    const cocService = {
+      getPlayerRaw: vi.fn().mockRejectedValue(new Error("coc unavailable")),
+    };
+    const interaction = makeInteraction();
+
+    await Accounts.run({} as any, interaction as any, cocService as any);
+
+    expect(getEmbedDescription(interaction)).toContain("- Activity Charlie `#CUV9082`");
+    expect(prismaMock.playerLink.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("falls back to raw tag when no linked/live/activity name exists", async () => {
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      {
+        playerTag: "#LQ9P8R2",
+        playerName: null,
+        createdAt: new Date("2026-03-01T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.playerActivity.findMany.mockResolvedValue([]);
+    const cocService = {
+      getPlayerRaw: vi.fn().mockRejectedValue(new Error("coc unavailable")),
+    };
+    const interaction = makeInteraction();
+
+    await Accounts.run({} as any, interaction as any, cocService as any);
+
+    expect(getEmbedDescription(interaction)).toContain("- #LQ9P8R2 `#LQ9P8R2`");
+    expect(prismaMock.playerLink.updateMany).not.toHaveBeenCalled();
+  });
+});

--- a/tests/fwaFeed.membersSync.test.ts
+++ b/tests/fwaFeed.membersSync.test.ts
@@ -10,6 +10,10 @@ const txMock = vi.hoisted(() => ({
   fwaPlayerCatalog: {
     upsert: vi.fn(),
   },
+  playerLink: {
+    findMany: vi.fn(),
+    updateMany: vi.fn(),
+  },
 }));
 
 const prismaMock = vi.hoisted(() => ({
@@ -70,6 +74,11 @@ describe("FwaClanMembersSyncService", () => {
 
     prismaMock.fwaFeedSyncState.findUnique.mockResolvedValue(null);
     txMock.fwaClanMemberCurrent.deleteMany.mockResolvedValue({ count: 1 });
+    txMock.playerLink.findMany.mockResolvedValue([
+      { playerTag: "#P1", playerName: null },
+      { playerTag: "#P2", playerName: "Two" },
+    ]);
+    txMock.playerLink.updateMany.mockResolvedValue({ count: 1 });
 
     const service = new FwaClanMembersSyncService(client);
     const result = await service.syncTrackedClan("#aaa111", { force: true });
@@ -85,9 +94,57 @@ describe("FwaClanMembersSyncService", () => {
     );
     expect(txMock.fwaClanMemberCurrent.upsert).toHaveBeenCalledTimes(2);
     expect(txMock.fwaPlayerCatalog.upsert).toHaveBeenCalledTimes(2);
+    expect(txMock.playerLink.findMany).toHaveBeenCalledWith({
+      where: { playerTag: { in: ["#P1", "#P2"] } },
+      select: { playerTag: true, playerName: true },
+    });
+    expect(txMock.playerLink.updateMany).toHaveBeenCalledTimes(1);
+    expect(txMock.playerLink.updateMany).toHaveBeenCalledWith({
+      where: { playerTag: "#P1" },
+      data: { playerName: "One" },
+    });
     expect(result.status).toBe("SUCCESS");
     expect(result.rowCount).toBe(2);
     expect(result.changedRowCount).toBe(3);
+  });
+
+  it("updates linked playerName when observed name changes", async () => {
+    const client = {
+      fetchClanMembers: vi.fn().mockResolvedValue([
+        {
+          clanTag: "#AAA111",
+          playerTag: "#P1",
+          playerName: "One Renamed",
+          role: "leader",
+          level: 10,
+          donated: 1,
+          received: 2,
+          rank: 1,
+          trophies: 1000,
+          league: "Gold",
+          townHall: 14,
+          weight: 120000,
+          inWar: true,
+        },
+      ]),
+    } as any;
+
+    prismaMock.fwaFeedSyncState.findUnique.mockResolvedValue(null);
+    txMock.fwaClanMemberCurrent.deleteMany.mockResolvedValue({ count: 0 });
+    txMock.playerLink.findMany.mockResolvedValue([
+      { playerTag: "#P1", playerName: "One" },
+    ]);
+    txMock.playerLink.updateMany.mockResolvedValue({ count: 1 });
+
+    const service = new FwaClanMembersSyncService(client);
+    const result = await service.syncTrackedClan("#AAA111", { force: true });
+
+    expect(txMock.playerLink.updateMany).toHaveBeenCalledTimes(1);
+    expect(txMock.playerLink.updateMany).toHaveBeenCalledWith({
+      where: { playerTag: "#P1" },
+      data: { playerName: "One Renamed" },
+    });
+    expect(result.status).toBe("SUCCESS");
   });
 
   it("returns NOOP when payload hash is unchanged", async () => {

--- a/tests/fwaFeed.warMembersSync.test.ts
+++ b/tests/fwaFeed.warMembersSync.test.ts
@@ -1,0 +1,146 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FwaWarMembersSyncService } from "../src/services/fwa-feeds/FwaWarMembersSyncService";
+import { computeFeedContentHash } from "../src/services/fwa-feeds/hash";
+
+const txMock = vi.hoisted(() => ({
+  fwaWarMemberCurrent: {
+    deleteMany: vi.fn(),
+    upsert: vi.fn(),
+  },
+  fwaPlayerCatalog: {
+    upsert: vi.fn(),
+  },
+  playerLink: {
+    findMany: vi.fn(),
+    updateMany: vi.fn(),
+  },
+}));
+
+const prismaMock = vi.hoisted(() => ({
+  fwaFeedSyncState: {
+    findUnique: vi.fn(),
+    upsert: vi.fn(),
+  },
+  $transaction: vi.fn(async (callback: (tx: typeof txMock) => Promise<unknown>) => callback(txMock)),
+}));
+
+vi.mock("../src/prisma", () => ({
+  prisma: prismaMock,
+}));
+
+function makeWarRow(input: {
+  clanTag: string;
+  playerTag: string;
+  playerName: string;
+  position: number;
+  attacks: number;
+}) {
+  return {
+    clanTag: input.clanTag,
+    playerTag: input.playerTag,
+    playerName: input.playerName,
+    position: input.position,
+    townHall: 14,
+    weight: 120000,
+    opponentTag: null,
+    opponentName: null,
+    attacks: input.attacks,
+    defender1Tag: null,
+    defender1Name: null,
+    defender1TownHall: null,
+    defender1Position: null,
+    stars1: null,
+    destructionPercentage1: null,
+    defender2Tag: null,
+    defender2Name: null,
+    defender2TownHall: null,
+    defender2Position: null,
+    stars2: null,
+    destructionPercentage2: null,
+  };
+}
+
+describe("FwaWarMembersSyncService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("syncs one clan and updates missing linked playerName from observed war roster names", async () => {
+    const client = {
+      fetchWarMembers: vi.fn().mockResolvedValue([
+        makeWarRow({ clanTag: "#AAA111", playerTag: "#P1", playerName: "One", position: 1, attacks: 0 }),
+        makeWarRow({ clanTag: "#AAA111", playerTag: "#P2", playerName: "Two", position: 2, attacks: 1 }),
+      ]),
+    } as any;
+    prismaMock.fwaFeedSyncState.findUnique.mockResolvedValue(null);
+    txMock.fwaWarMemberCurrent.deleteMany.mockResolvedValue({ count: 1 });
+    txMock.playerLink.findMany.mockResolvedValue([
+      { playerTag: "#P1", playerName: null },
+      { playerTag: "#P2", playerName: "Two" },
+    ]);
+    txMock.playerLink.updateMany.mockResolvedValue({ count: 1 });
+
+    const service = new FwaWarMembersSyncService(client);
+    const result = await service.syncClan("#aaa111", { force: true });
+
+    expect(client.fetchWarMembers).toHaveBeenCalledWith("#AAA111");
+    expect(txMock.fwaWarMemberCurrent.upsert).toHaveBeenCalledTimes(2);
+    expect(txMock.fwaPlayerCatalog.upsert).toHaveBeenCalledTimes(2);
+    expect(txMock.playerLink.findMany).toHaveBeenCalledWith({
+      where: { playerTag: { in: ["#P1", "#P2"] } },
+      select: { playerTag: true, playerName: true },
+    });
+    expect(txMock.playerLink.updateMany).toHaveBeenCalledTimes(1);
+    expect(txMock.playerLink.updateMany).toHaveBeenCalledWith({
+      where: { playerTag: "#P1" },
+      data: { playerName: "One" },
+    });
+    expect(result.status).toBe("SUCCESS");
+    expect(result.rowCount).toBe(2);
+    expect(result.changedRowCount).toBe(3);
+  });
+
+  it("updates linked playerName when observed war roster name changed", async () => {
+    const client = {
+      fetchWarMembers: vi.fn().mockResolvedValue([
+        makeWarRow({
+          clanTag: "#AAA111",
+          playerTag: "#P1",
+          playerName: "One Renamed",
+          position: 1,
+          attacks: 0,
+        }),
+      ]),
+    } as any;
+    prismaMock.fwaFeedSyncState.findUnique.mockResolvedValue(null);
+    txMock.fwaWarMemberCurrent.deleteMany.mockResolvedValue({ count: 0 });
+    txMock.playerLink.findMany.mockResolvedValue([{ playerTag: "#P1", playerName: "One" }]);
+    txMock.playerLink.updateMany.mockResolvedValue({ count: 1 });
+
+    const service = new FwaWarMembersSyncService(client);
+    const result = await service.syncClan("#AAA111", { force: true });
+
+    expect(txMock.playerLink.updateMany).toHaveBeenCalledTimes(1);
+    expect(txMock.playerLink.updateMany).toHaveBeenCalledWith({
+      where: { playerTag: "#P1" },
+      data: { playerName: "One Renamed" },
+    });
+    expect(result.status).toBe("SUCCESS");
+  });
+
+  it("returns NOOP when payload hash is unchanged", async () => {
+    const rows = [makeWarRow({ clanTag: "#AAA111", playerTag: "#P1", playerName: "One", position: 1, attacks: 0 })];
+    const hash = computeFeedContentHash(rows);
+    const client = {
+      fetchWarMembers: vi.fn().mockResolvedValue(rows),
+    } as any;
+    prismaMock.fwaFeedSyncState.findUnique.mockResolvedValue({ lastContentHash: hash });
+
+    const service = new FwaWarMembersSyncService(client);
+    const result = await service.syncClan("#AAA111", { force: true });
+
+    expect(result.status).toBe("NOOP");
+    expect(result.changedRowCount).toBe(0);
+    expect(prismaMock.$transaction).not.toHaveBeenCalled();
+  });
+});

--- a/tests/fwaFeedScheduler.config.test.ts
+++ b/tests/fwaFeedScheduler.config.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  FwaFeedSchedulerService,
+  toIntWithFallbackForTest,
+} from "../src/services/fwa-feeds/FwaFeedSchedulerService";
+
+const originalEnv = { ...process.env };
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+});
+
+describe("FwaFeedSchedulerService env integer parsing", () => {
+  it("uses fallback for undefined/empty integer env values", () => {
+    expect(toIntWithFallbackForTest(undefined, 6)).toBe(6);
+    expect(toIntWithFallbackForTest("", 6)).toBe(6);
+    expect(toIntWithFallbackForTest("   ", 6)).toBe(6);
+    expect(toIntWithFallbackForTest("invalid", 6)).toBe(6);
+    expect(toIntWithFallbackForTest("0", 6)).toBe(0);
+  });
+
+  it("keeps WAR_MEMBERS chunk default when env is empty instead of degrading to 1", () => {
+    process.env.FWA_WAR_MEMBERS_SWEEP_CHUNK_SIZE = "";
+    process.env.FWA_FEED_MAX_CONCURRENCY = "";
+
+    const scheduler = new FwaFeedSchedulerService() as unknown as {
+      config: { warMembersSweepChunkSize: number; maxConcurrency: number };
+    };
+
+    expect(scheduler.config.warMembersSweepChunkSize).toBe(6);
+    expect(scheduler.config.maxConcurrency).toBe(4);
+  });
+});

--- a/tests/playerLink.service.test.ts
+++ b/tests/playerLink.service.test.ts
@@ -21,11 +21,13 @@ import {
   backfillMissingDiscordUsernamesForClanMembers,
   listCurrentWeightsForClanMembers,
   listPlayerLinksForClanMembers,
+  listPlayerLinksForDiscordUser,
   sanitizeDiscordUsernameForPersistence,
   normalizePersistedDiscordUsername,
+  normalizePersistedPlayerName,
 } from "../src/services/PlayerLinkService";
 
-describe("PlayerLinkService discordUsername", () => {
+describe("PlayerLinkService link identity", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     prismaMock.playerLink.findUnique.mockReset();
@@ -40,6 +42,49 @@ describe("PlayerLinkService discordUsername", () => {
     expect(normalizePersistedDiscordUsername("\n\t")).toBeNull();
     expect(normalizePersistedDiscordUsername(null)).toBeNull();
     expect(sanitizeDiscordUsernameForPersistence("\n\t")).toBe("unknown");
+  });
+
+  it("normalizes persisted player name text deterministically", () => {
+    expect(normalizePersistedPlayerName("  a   b  ")).toBe("a b");
+    expect(normalizePersistedPlayerName("\n\t")).toBeNull();
+    expect(normalizePersistedPlayerName(null)).toBeNull();
+  });
+
+  it("returns user-scoped links with linkedName from persisted playerName", async () => {
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      {
+        playerTag: "#PYLQ0289",
+        playerName: "  Alpha One  ",
+        createdAt: new Date("2026-03-15T09:07:00.000Z"),
+      },
+      {
+        playerTag: "#QGRJ2222",
+        playerName: " ",
+        createdAt: new Date("2026-03-15T09:08:00.000Z"),
+      },
+    ]);
+
+    const links = await listPlayerLinksForDiscordUser({
+      discordUserId: "111111111111111111",
+    });
+
+    expect(prismaMock.playerLink.findMany).toHaveBeenCalledWith({
+      where: { discordUserId: "111111111111111111" },
+      orderBy: [{ createdAt: "asc" }, { playerTag: "asc" }],
+      select: { playerTag: true, playerName: true, createdAt: true },
+    });
+    expect(links).toEqual([
+      {
+        playerTag: "#PYLQ0289",
+        linkedAt: new Date("2026-03-15T09:07:00.000Z"),
+        linkedName: "Alpha One",
+      },
+      {
+        playerTag: "#QGRJ2222",
+        linkedAt: new Date("2026-03-15T09:08:00.000Z"),
+        linkedName: null,
+      },
+    ]);
   });
 
   it("returns clan-scoped links with persisted discordUsername", async () => {

--- a/tests/todo.command.test.ts
+++ b/tests/todo.command.test.ts
@@ -29,6 +29,10 @@ const prismaMock = vi.hoisted(() => ({
   },
   cwlPlayerClanSeason: {
     findMany: vi.fn(),
+    upsert: vi.fn(),
+  },
+  botSetting: {
+    findMany: vi.fn(),
   },
   $transaction: vi.fn(async (arg: any) => {
     if (typeof arg === "function") {
@@ -51,11 +55,14 @@ vi.mock("../src/prisma", () => ({
 }));
 
 import {
+  buildTodoRefreshButtonCustomId,
   buildTodoPageButtonCustomId,
   handleTodoPageButtonInteraction,
+  handleTodoRefreshButtonInteraction,
   Todo,
 } from "../src/commands/Todo";
 import { resetTodoRenderCacheForTest } from "../src/services/TodoService";
+import { todoSnapshotService } from "../src/services/TodoSnapshotService";
 
 type TodoType = "WAR" | "CWL" | "RAIDS" | "GAMES";
 
@@ -73,11 +80,18 @@ function makeTodoInteraction(input: { type: TodoType; userId?: string }) {
 function makeTodoButtonInteraction(input: {
   customId: string;
   userId?: string;
+  messageId?: string;
+  guildId?: string | null;
 }) {
   return {
     customId: input.customId,
     user: { id: input.userId ?? "111111111111111111" },
+    guildId: input.guildId ?? "123456789012345678",
+    message: { id: input.messageId ?? "999999999999999999" },
     update: vi.fn().mockResolvedValue(undefined),
+    deferUpdate: vi.fn().mockResolvedValue(undefined),
+    editReply: vi.fn().mockResolvedValue(undefined),
+    followUp: vi.fn().mockResolvedValue(undefined),
     reply: vi.fn().mockResolvedValue(undefined),
     deferred: false,
     replied: false,
@@ -193,6 +207,8 @@ describe("/todo command", () => {
     prismaMock.trackedClan.findMany.mockReset();
     prismaMock.cwlTrackedClan.findMany.mockReset();
     prismaMock.cwlPlayerClanSeason.findMany.mockReset();
+    prismaMock.cwlPlayerClanSeason.upsert.mockReset();
+    prismaMock.botSetting.findMany.mockReset();
     prismaMock.$transaction.mockClear();
 
     prismaMock.todoPlayerSnapshot.aggregate.mockResolvedValue({
@@ -207,6 +223,8 @@ describe("/todo command", () => {
     prismaMock.trackedClan.findMany.mockResolvedValue([]);
     prismaMock.cwlTrackedClan.findMany.mockResolvedValue([]);
     prismaMock.cwlPlayerClanSeason.findMany.mockResolvedValue([]);
+    prismaMock.cwlPlayerClanSeason.upsert.mockResolvedValue(undefined);
+    prismaMock.botSetting.findMany.mockResolvedValue([]);
   });
 
   afterEach(() => {
@@ -261,6 +279,9 @@ describe("/todo command", () => {
       "CWL",
       "RAIDS",
       "GAMES",
+    ]);
+    expect(payload.components[1].components.map((b: any) => b.toJSON().label)).toEqual([
+      "Refresh",
     ]);
     expect(cocService.getPlayerRaw).not.toHaveBeenCalled();
     expect(cocService.getCurrentWar).not.toHaveBeenCalled();
@@ -712,5 +733,162 @@ describe("/todo pagination buttons", () => {
       content: "Only the command requester can use this button.",
     });
     expect(interaction.update).not.toHaveBeenCalled();
+  });
+});
+
+describe("/todo refresh button", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetTodoRenderCacheForTest();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-26T00:00:00.000Z"));
+
+    prismaMock.playerLink.findMany.mockReset();
+    prismaMock.todoPlayerSnapshot.aggregate.mockReset();
+    prismaMock.todoPlayerSnapshot.findMany.mockReset();
+
+    prismaMock.playerLink.findMany.mockImplementation(async (args: any) => {
+      const userId = String(args?.where?.discordUserId ?? "");
+      if (userId === "222222222222222222") {
+        return [
+          { playerTag: "#PYLQ0289", createdAt: new Date("2026-03-01T00:00:00.000Z") },
+          { playerTag: "#QGRJ2222", createdAt: new Date("2026-03-02T00:00:00.000Z") },
+        ];
+      }
+      return [
+        { playerTag: "#PYLQ0289", createdAt: new Date("2026-03-01T00:00:00.000Z") },
+        { playerTag: "#QGRJ2222", createdAt: new Date("2026-03-02T00:00:00.000Z") },
+      ];
+    });
+    prismaMock.todoPlayerSnapshot.aggregate.mockResolvedValue({
+      _count: { _all: 2 },
+      _max: { updatedAt: new Date("2026-03-26T00:00:00.000Z") },
+    });
+    prismaMock.todoPlayerSnapshot.findMany.mockResolvedValue([
+      makeSnapshotRow({
+        playerTag: "#PYLQ0289",
+        playerName: "Alpha",
+        warAttacksUsed: 1,
+        cwlAttacksUsed: 1,
+        raidAttacksUsed: 3,
+        gamesPoints: 1200,
+      }),
+      makeSnapshotRow({
+        playerTag: "#QGRJ2222",
+        playerName: "Bravo",
+        warAttacksUsed: 2,
+        cwlAttacksUsed: 0,
+        raidAttacksUsed: 0,
+        gamesPoints: 2000,
+      }),
+    ]);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("refreshes the target user snapshots and updates the existing message on the same page", async () => {
+    const refreshSpy = vi
+      .spyOn(todoSnapshotService, "refreshSnapshotsForPlayerTags")
+      .mockResolvedValue({ playerCount: 2, updatedCount: 2 });
+    const interaction = makeTodoButtonInteraction({
+      customId: buildTodoRefreshButtonCustomId({
+        guildScopeId: "123456789012345678",
+        requesterUserId: "111111111111111111",
+        targetUserId: "222222222222222222",
+        type: "GAMES",
+      }),
+      userId: "111111111111111111",
+      guildId: "123456789012345678",
+    });
+
+    await handleTodoRefreshButtonInteraction(interaction as any, makeCocServiceSpy() as any);
+
+    expect(interaction.deferUpdate).toHaveBeenCalledTimes(1);
+    expect(refreshSpy).toHaveBeenCalledWith({
+      playerTags: ["#PYLQ0289", "#QGRJ2222"],
+      cocService: expect.anything(),
+    });
+    expect(interaction.editReply).toHaveBeenCalledTimes(1);
+    const payload = interaction.editReply.mock.calls[0]?.[0] as any;
+    expect(payload.embeds[0].toJSON().title).toBe("Todo - GAMES");
+    expect(payload.components[1].components.map((b: any) => b.toJSON().label)).toEqual([
+      "Refresh",
+    ]);
+    expect(interaction.followUp).not.toHaveBeenCalled();
+  });
+
+  it("uses no-linked-tags behavior when the target user has no links", async () => {
+    const refreshSpy = vi
+      .spyOn(todoSnapshotService, "refreshSnapshotsForPlayerTags")
+      .mockResolvedValue({ playerCount: 0, updatedCount: 0 });
+    prismaMock.playerLink.findMany.mockResolvedValue([]);
+    const interaction = makeTodoButtonInteraction({
+      customId: buildTodoRefreshButtonCustomId({
+        guildScopeId: "123456789012345678",
+        requesterUserId: "111111111111111111",
+        targetUserId: "222222222222222222",
+        type: "WAR",
+      }),
+      userId: "111111111111111111",
+      guildId: "123456789012345678",
+    });
+
+    await handleTodoRefreshButtonInteraction(interaction as any, makeCocServiceSpy() as any);
+
+    expect(refreshSpy).not.toHaveBeenCalled();
+    expect(interaction.editReply).toHaveBeenCalledWith({
+      content:
+        "no_linked_tags: no linked player tags found for your Discord account. Use `/link create player-tag:<tag>` first.",
+      embeds: [],
+      components: [],
+    });
+  });
+
+  it("returns a specific ephemeral error when targeted refresh fails", async () => {
+    vi.spyOn(todoSnapshotService, "refreshSnapshotsForPlayerTags").mockRejectedValue(
+      new Error("refresh failed"),
+    );
+    const interaction = makeTodoButtonInteraction({
+      customId: buildTodoRefreshButtonCustomId({
+        guildScopeId: "123456789012345678",
+        requesterUserId: "111111111111111111",
+        targetUserId: "222222222222222222",
+        type: "RAIDS",
+      }),
+      userId: "111111111111111111",
+      guildId: "123456789012345678",
+    });
+
+    await handleTodoRefreshButtonInteraction(interaction as any, makeCocServiceSpy() as any);
+
+    expect(interaction.followUp).toHaveBeenCalledWith({
+      ephemeral: true,
+      content: "Failed to refresh todo data. Please try again.",
+    });
+    expect(interaction.editReply).not.toHaveBeenCalled();
+  });
+
+  it("rejects refresh clicks from non-requesting users", async () => {
+    const interaction = makeTodoButtonInteraction({
+      customId: buildTodoRefreshButtonCustomId({
+        guildScopeId: "123456789012345678",
+        requesterUserId: "111111111111111111",
+        targetUserId: "222222222222222222",
+        type: "WAR",
+      }),
+      userId: "333333333333333333",
+      guildId: "123456789012345678",
+    });
+
+    await handleTodoRefreshButtonInteraction(interaction as any, makeCocServiceSpy() as any);
+
+    expect(interaction.reply).toHaveBeenCalledWith({
+      ephemeral: true,
+      content: "Only the command requester can use this button.",
+    });
+    expect(interaction.deferUpdate).not.toHaveBeenCalled();
   });
 });

--- a/tests/todo.command.test.ts
+++ b/tests/todo.command.test.ts
@@ -293,7 +293,7 @@ describe("/todo command", () => {
     expect(cocService.getClanWarLeagueWar).not.toHaveBeenCalled();
   });
 
-  it("renders WAR grouped sections by shared context with neutral non-active rows", async () => {
+  it("renders WAR headers with badge + match indicator and row-level attack detail", async () => {
     prismaMock.playerLink.findMany.mockResolvedValue([
       { playerTag: "#PYLQ0289", createdAt: new Date("2026-03-01T00:00:00.000Z") },
       { playerTag: "#QGRJ2222", createdAt: new Date("2026-03-02T00:00:00.000Z") },
@@ -310,7 +310,7 @@ describe("/todo command", () => {
         playerName: "Alpha",
         clanTag: "#PQL0289",
         clanName: "Clan One",
-        warAttacksUsed: 1,
+        warAttacksUsed: 0,
         warPhase: "battle day",
       }),
       makeSnapshotRow({
@@ -318,7 +318,7 @@ describe("/todo command", () => {
         playerName: "Bravo",
         clanTag: "#PQL0289",
         clanName: "Clan One",
-        warAttacksUsed: 2,
+        warAttacksUsed: 1,
         warPhase: "battle day",
       }),
       makeSnapshotRow({
@@ -326,7 +326,7 @@ describe("/todo command", () => {
         playerName: "Charlie",
         clanTag: "#2QG2C08UP",
         clanName: "Clan Two",
-        warAttacksUsed: 0,
+        warAttacksUsed: 2,
         warPhase: "preparation",
         warEndsAt: new Date("2026-03-30T18:00:00.000Z"),
       }),
@@ -339,18 +339,124 @@ describe("/todo command", () => {
         warAttacksUsed: 0,
       }),
     ]);
+    prismaMock.trackedClan.findMany.mockResolvedValue([
+      { tag: "#PQL0289", clanBadge: ":rd:" },
+      { tag: "#2QG2C08UP", clanBadge: ":ak:" },
+    ]);
+    prismaMock.currentWar.findMany.mockResolvedValue([
+      {
+        clanTag: "#PQL0289",
+        matchType: "FWA",
+        outcome: "WIN",
+        updatedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+      {
+        clanTag: "#2QG2C08UP",
+        matchType: "BL",
+        outcome: null,
+        updatedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.fwaWarMemberCurrent.findMany.mockResolvedValue([
+      {
+        clanTag: "#PQL0289",
+        playerTag: "#PYLQ0289",
+        position: 8,
+        attacks: 0,
+        defender1Position: null,
+        stars1: null,
+        defender2Position: null,
+        stars2: null,
+        sourceSyncedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+      {
+        clanTag: "#PQL0289",
+        playerTag: "#QGRJ2222",
+        position: 1,
+        attacks: 1,
+        defender1Position: 8,
+        stars1: 3,
+        defender2Position: null,
+        stars2: null,
+        sourceSyncedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+      {
+        clanTag: "#2QG2C08UP",
+        playerTag: "#CUV9082",
+        position: 9,
+        attacks: 2,
+        defender1Position: 8,
+        stars1: 3,
+        defender2Position: 1,
+        stars2: 1,
+        sourceSyncedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+    ]);
 
     const interaction = makeTodoInteraction({ type: "WAR" });
     await Todo.run({} as any, interaction as any, makeCocServiceSpy() as any);
 
     const description = getReplyDescription(interaction);
     expect(getReplyTitle(interaction)).toBe("Todo - WAR");
-    expect(description).toContain("**Clan One (#PQL0289) - battle day ends <t:");
-    expect(description).toContain("**Clan Two (#2QG2C08UP) - preparation ends <t:");
-    expect(description).toContain("- Alpha #PYLQ0289 - war attacks: 1/2");
-    expect(description).toContain("- Bravo #QGRJ2222 - war attacks: 2/2");
+    expect(description).toContain("**:rd: Clan One (#PQL0289) :green_circle: - battle day ends <t:");
+    expect(description).toContain("**:ak: Clan Two (#2QG2C08UP) :black_circle: - preparation ends <t:");
+    expect(description).toContain("- #8 Alpha - `0 / 2`");
+    expect(description).toContain("- #1 Bravo - `1 / 2` | :dagger: #8 ★ ★ ★");
+    expect(description).toContain(
+      "- #9 Charlie - `2 / 2` | :dagger: #8 ★ ★ ★ | :dagger: #1 ★ ☆ ☆",
+    );
     expect(description).toContain("**Not in active war**");
     expect(description).toContain("- Delta #LQ9P8R2 - war attacks: 0/2 - not in active war");
+  });
+
+  it("uses safe #? fallback when war lineup position is unavailable", async () => {
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      { playerTag: "#PYLQ0289", createdAt: new Date("2026-03-01T00:00:00.000Z") },
+    ]);
+    prismaMock.todoPlayerSnapshot.aggregate.mockResolvedValue({
+      _count: { _all: 1 },
+      _max: { updatedAt: new Date("2026-03-26T00:00:00.000Z") },
+    });
+    prismaMock.todoPlayerSnapshot.findMany.mockResolvedValue([
+      makeSnapshotRow({
+        playerTag: "#PYLQ0289",
+        playerName: "Alpha",
+        clanTag: "#PQL0289",
+        clanName: "Clan One",
+        warAttacksUsed: 1,
+        warPhase: "battle day",
+      }),
+    ]);
+    prismaMock.trackedClan.findMany.mockResolvedValue([
+      { tag: "#PQL0289", clanBadge: ":rd:" },
+    ]);
+    prismaMock.currentWar.findMany.mockResolvedValue([
+      {
+        clanTag: "#PQL0289",
+        matchType: "FWA",
+        outcome: "WIN",
+        updatedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.fwaWarMemberCurrent.findMany.mockResolvedValue([
+      {
+        clanTag: "#PQL0289",
+        playerTag: "#PYLQ0289",
+        position: null,
+        attacks: 1,
+        defender1Position: null,
+        stars1: 2,
+        defender2Position: null,
+        stars2: null,
+        sourceSyncedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+    ]);
+
+    const interaction = makeTodoInteraction({ type: "WAR" });
+    await Todo.run({} as any, interaction as any, makeCocServiceSpy() as any);
+
+    const description = getReplyDescription(interaction);
+    expect(description).toContain("- #? Alpha - `1 / 2` | :dagger: #? ★ ★ ☆");
   });
 
   it("renders CWL grouped sections by shared context with neutral non-active rows", async () => {
@@ -743,7 +849,7 @@ describe("/todo pagination buttons", () => {
 
   it("paginates across WAR/CWL/RAIDS/GAMES with user-scoped access", async () => {
     const checks: Array<{ type: TodoType; contains: string }> = [
-      { type: "WAR", contains: "war attacks:" },
+      { type: "WAR", contains: "`1 / 2`" },
       { type: "CWL", contains: "CWL attacks:" },
       { type: "RAIDS", contains: "clan capital raids:" },
       { type: "GAMES", contains: "clan games points:" },

--- a/tests/todo.command.test.ts
+++ b/tests/todo.command.test.ts
@@ -293,7 +293,7 @@ describe("/todo command", () => {
     expect(cocService.getClanWarLeagueWar).not.toHaveBeenCalled();
   });
 
-  it("renders WAR headers with badge + match indicator and row-level attack detail", async () => {
+  it("renders WAR headers with badge + match indicator and suppresses preparation attack detail", async () => {
     prismaMock.playerLink.findMany.mockResolvedValue([
       { playerTag: "#PYLQ0289", createdAt: new Date("2026-03-01T00:00:00.000Z") },
       { playerTag: "#QGRJ2222", createdAt: new Date("2026-03-02T00:00:00.000Z") },
@@ -402,11 +402,10 @@ describe("/todo command", () => {
     expect(description).toContain("**:ak: Clan Two (#2QG2C08UP) :black_circle: - preparation ends <t:");
     expect(description).toContain("- #8 Alpha - `0 / 2`");
     expect(description).toContain("- #1 Bravo - `1 / 2` | :dagger: #8 ★ ★ ★");
-    expect(description).toContain(
-      "- #9 Charlie - `2 / 2` | :dagger: #8 ★ ★ ★ | :dagger: #1 ★ ☆ ☆",
-    );
-    expect(description).toContain("**Not in active war**");
-    expect(description).toContain("- Delta #LQ9P8R2 - war attacks: 0/2 - not in active war");
+    expect(description).toContain("- #9 Charlie - `0 / 2`");
+    expect(description).not.toContain("- #9 Charlie - `2 / 2`");
+    expect(description).not.toContain("**Not in active war**");
+    expect(description).not.toContain("Delta #LQ9P8R2");
   });
 
   it("uses safe #? fallback when war lineup position is unavailable", async () => {
@@ -459,7 +458,59 @@ describe("/todo command", () => {
     expect(description).toContain("- #? Alpha - `1 / 2` | :dagger: #? ★ ★ ☆");
   });
 
-  it("renders CWL grouped sections by shared context with neutral non-active rows", async () => {
+  it("uses player-tag fallback for war position when snapshot clan tag is stale", async () => {
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      { playerTag: "#PYLQ0289", createdAt: new Date("2026-03-01T00:00:00.000Z") },
+    ]);
+    prismaMock.todoPlayerSnapshot.aggregate.mockResolvedValue({
+      _count: { _all: 1 },
+      _max: { updatedAt: new Date("2026-03-26T00:00:00.000Z") },
+    });
+    prismaMock.todoPlayerSnapshot.findMany.mockResolvedValue([
+      makeSnapshotRow({
+        playerTag: "#PYLQ0289",
+        playerName: "Alpha",
+        clanTag: "#Q2V8P9L2",
+        clanName: "Stale Clan",
+        warAttacksUsed: 1,
+        warPhase: "battle day",
+      }),
+    ]);
+    prismaMock.trackedClan.findMany.mockResolvedValue([
+      { tag: "#Q2V8P9L2", clanBadge: ":rd:" },
+    ]);
+    prismaMock.currentWar.findMany.mockResolvedValue([
+      {
+        clanTag: "#Q2V8P9L2",
+        matchType: "FWA",
+        outcome: "WIN",
+        updatedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.fwaWarMemberCurrent.findMany.mockResolvedValue([
+      {
+        clanTag: "#PQL0289",
+        playerTag: "#PYLQ0289",
+        position: 8,
+        attacks: 1,
+        defender1Position: 7,
+        stars1: 2,
+        defender2Position: null,
+        stars2: null,
+        sourceSyncedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+    ]);
+
+    const interaction = makeTodoInteraction({ type: "WAR" });
+    await Todo.run({} as any, interaction as any, makeCocServiceSpy() as any);
+
+    const description = getReplyDescription(interaction);
+    expect(description).toContain("- #8 Alpha - `1 / 2`");
+    expect(description).toContain("| :dagger: #7 ★ ★ ☆");
+    expect(description).not.toContain("- #? Alpha -");
+  });
+
+  it("renders CWL grouped sections by shared context and omits non-active linked rows", async () => {
     prismaMock.playerLink.findMany.mockResolvedValue([
       { playerTag: "#PYLQ0289", createdAt: new Date("2026-03-01T00:00:00.000Z") },
       { playerTag: "#QGRJ2222", createdAt: new Date("2026-03-02T00:00:00.000Z") },
@@ -515,10 +566,8 @@ describe("/todo command", () => {
     expect(description).toContain("**Clan Two (#2QG2C08UP) - preparation ends <t:");
     expect(description).toContain("- Alpha #PYLQ0289 - CWL attacks: 1/1");
     expect(description).toContain("- Bravo #QGRJ2222 - CWL attacks: 0/1");
-    expect(description).toContain("**Not in active CWL**");
-    expect(description).toContain(
-      "- Delta #LQ9P8R2 - CWL attacks: 0/1 - not in active CWL war",
-    );
+    expect(description).not.toContain("**Not in active CWL**");
+    expect(description).not.toContain("Delta #LQ9P8R2");
   });
 
   it("groups CWL rows by cwlClanTag/cwlClanName when different from home clan", async () => {
@@ -1105,3 +1154,4 @@ describe("/todo refresh button", () => {
     expect(interaction.deferUpdate).not.toHaveBeenCalled();
   });
 });
+

--- a/tests/todo.command.test.ts
+++ b/tests/todo.command.test.ts
@@ -122,6 +122,7 @@ function makeSnapshotRow(input: {
   gamesActive?: boolean;
   gamesPoints?: number | null;
   gamesTarget?: number | null;
+  gamesChampionTotal?: number | null;
   gamesEndsAt?: Date | null;
   lastUpdatedAt?: Date;
   updatedAt?: Date;
@@ -151,6 +152,9 @@ function makeSnapshotRow(input: {
     gamesActive: input.gamesActive ?? true,
     gamesPoints: input.gamesPoints ?? 1200,
     gamesTarget: input.gamesTarget ?? 4000,
+    gamesChampionTotal: input.gamesChampionTotal ?? 1200,
+    gamesSeasonBaseline: 0,
+    gamesCycleKey: "cycle-2026-03",
     gamesEndsAt: input.gamesEndsAt ?? new Date("2026-03-28T08:00:00.000Z"),
     lastUpdatedAt: input.lastUpdatedAt ?? now,
     updatedAt: input.updatedAt ?? now,
@@ -570,36 +574,57 @@ describe("/todo command", () => {
     expect(description).toContain("- Bravo #QGRJ2222 - clan capital raids: 1/6");
   });
 
-  it("renders GAMES with one shared top timer, points, and 4000+ completion marker", async () => {
+  it("renders GAMES emojis by progress threshold and sorts by gamesChampionTotal desc", async () => {
     prismaMock.playerLink.findMany.mockResolvedValue([
       { playerTag: "#PYLQ0289", createdAt: new Date("2026-03-01T00:00:00.000Z") },
       { playerTag: "#QGRJ2222", createdAt: new Date("2026-03-02T00:00:00.000Z") },
       { playerTag: "#CUV9082", createdAt: new Date("2026-03-03T00:00:00.000Z") },
+      { playerTag: "#LQ9P8R2", createdAt: new Date("2026-03-04T00:00:00.000Z") },
+      { playerTag: "#Q2V8P9L2", createdAt: new Date("2026-03-05T00:00:00.000Z") },
     ]);
     prismaMock.todoPlayerSnapshot.aggregate.mockResolvedValue({
-      _count: { _all: 3 },
+      _count: { _all: 5 },
       _max: { updatedAt: new Date("2026-03-26T00:00:00.000Z") },
     });
     prismaMock.todoPlayerSnapshot.findMany.mockResolvedValue([
       makeSnapshotRow({
         playerTag: "#PYLQ0289",
-        playerName: "Alpha",
+        playerName: "Echo",
         gamesActive: true,
-        gamesPoints: 3999,
+        gamesPoints: 0,
+        gamesChampionTotal: 5000,
         gamesEndsAt: new Date("2026-03-28T08:00:00.000Z"),
       }),
       makeSnapshotRow({
         playerTag: "#QGRJ2222",
-        playerName: "Bravo",
+        playerName: "Delta",
         gamesActive: true,
-        gamesPoints: 4000,
+        gamesPoints: 3999,
+        gamesChampionTotal: 6500,
         gamesEndsAt: new Date("2026-03-28T08:00:00.000Z"),
       }),
       makeSnapshotRow({
         playerTag: "#CUV9082",
         playerName: "Charlie",
         gamesActive: true,
+        gamesPoints: 4000,
+        gamesChampionTotal: 8000,
+        gamesEndsAt: new Date("2026-03-28T08:00:00.000Z"),
+      }),
+      makeSnapshotRow({
+        playerTag: "#LQ9P8R2",
+        playerName: "Alpha",
+        gamesActive: true,
+        gamesPoints: 10000,
+        gamesChampionTotal: 15000,
+        gamesEndsAt: new Date("2026-03-28T08:00:00.000Z"),
+      }),
+      makeSnapshotRow({
+        playerTag: "#Q2V8P9L2",
+        playerName: "Bravo",
+        gamesActive: true,
         gamesPoints: 5200,
+        gamesChampionTotal: 8000,
         gamesEndsAt: new Date("2026-03-28T08:00:00.000Z"),
       }),
     ]);
@@ -610,13 +635,66 @@ describe("/todo command", () => {
     const description = getReplyDescription(interaction);
     expect(description).toContain("**Time remaining:** <t:");
     expect(countOccurrences(description, "<t:")).toBe(1);
-    expect(description).toContain("- Alpha #PYLQ0289 - clan games points: 3999/4000");
-    expect(description).toContain(
-      "- :white_check_mark: Bravo #QGRJ2222 - clan games points: 4000/4000",
-    );
-    expect(description).toContain(
-      "- :white_check_mark: Charlie #CUV9082 - clan games points: 5200/4000",
-    );
+    expect(description).toContain("- 🏆 Alpha #LQ9P8R2 - clan games points: 10000/4000");
+    expect(description).toContain("- ✅ Bravo #Q2V8P9L2 - clan games points: 5200/4000");
+    expect(description).toContain("- ✅ Charlie #CUV9082 - clan games points: 4000/4000");
+    expect(description).toContain("- 🟡 Delta #QGRJ2222 - clan games points: 3999/4000");
+    expect(description).toContain("- Echo #PYLQ0289 - clan games points: 0/4000");
+
+    const indexTrophy = description.indexOf("🏆 Alpha #LQ9P8R2");
+    const indexBravo = description.indexOf("✅ Bravo #Q2V8P9L2");
+    const indexCharlie = description.indexOf("✅ Charlie #CUV9082");
+    const indexDelta = description.indexOf("🟡 Delta #QGRJ2222");
+    const indexEcho = description.indexOf("Echo #PYLQ0289");
+    expect(indexTrophy).toBeGreaterThan(-1);
+    expect(indexBravo).toBeGreaterThan(-1);
+    expect(indexCharlie).toBeGreaterThan(-1);
+    expect(indexDelta).toBeGreaterThan(-1);
+    expect(indexEcho).toBeGreaterThan(-1);
+    expect(indexTrophy).toBeLessThan(indexBravo);
+    expect(indexBravo).toBeLessThan(indexCharlie);
+    expect(indexCharlie).toBeLessThan(indexDelta);
+    expect(indexDelta).toBeLessThan(indexEcho);
+  });
+
+  it("falls back to PlayerLink identity for linked rows before final raw-tag fallback", async () => {
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      {
+        playerTag: "#PYLQ0289",
+        discordUsername: "Linked Alias",
+        createdAt: new Date("2026-03-01T00:00:00.000Z"),
+      },
+      {
+        playerTag: "#QGRJ2222",
+        discordUsername: null,
+        createdAt: new Date("2026-03-02T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.todoPlayerSnapshot.aggregate.mockResolvedValue({
+      _count: { _all: 2 },
+      _max: { updatedAt: new Date("2026-03-26T00:00:00.000Z") },
+    });
+    prismaMock.todoPlayerSnapshot.findMany.mockResolvedValue([
+      makeSnapshotRow({
+        playerTag: "#PYLQ0289",
+        playerName: "#PYLQ0289",
+        gamesActive: true,
+        gamesPoints: 1200,
+      }),
+      makeSnapshotRow({
+        playerTag: "#QGRJ2222",
+        playerName: "",
+        gamesActive: true,
+        gamesPoints: 0,
+      }),
+    ]);
+
+    const interaction = makeTodoInteraction({ type: "GAMES" });
+    await Todo.run({} as any, interaction as any, makeCocServiceSpy() as any);
+
+    const description = getReplyDescription(interaction);
+    expect(description).toContain("- 🟡 Linked Alias #PYLQ0289 - clan games points: 1200/4000");
+    expect(description).toContain("- #QGRJ2222 - clan games points: 0/4000");
   });
 });
 

--- a/tests/todo.command.test.ts
+++ b/tests/todo.command.test.ts
@@ -729,16 +729,17 @@ describe("/todo command", () => {
     expect(description).toContain("- Bravo #QGRJ2222 - clan capital raids: 1/6");
   });
 
-  it("renders GAMES emojis by progress threshold and sorts by gamesChampionTotal desc", async () => {
+  it("renders GAMES emojis by progress threshold and sorts by gamesPoints desc then gamesChampionTotal desc", async () => {
     prismaMock.playerLink.findMany.mockResolvedValue([
       { playerTag: "#PYLQ0289", createdAt: new Date("2026-03-01T00:00:00.000Z") },
       { playerTag: "#QGRJ2222", createdAt: new Date("2026-03-02T00:00:00.000Z") },
       { playerTag: "#CUV9082", createdAt: new Date("2026-03-03T00:00:00.000Z") },
       { playerTag: "#LQ9P8R2", createdAt: new Date("2026-03-04T00:00:00.000Z") },
       { playerTag: "#Q2V8P9L2", createdAt: new Date("2026-03-05T00:00:00.000Z") },
+      { playerTag: "#9C8VY2L2", createdAt: new Date("2026-03-06T00:00:00.000Z") },
     ]);
     prismaMock.todoPlayerSnapshot.aggregate.mockResolvedValue({
-      _count: { _all: 5 },
+      _count: { _all: 6 },
       _max: { updatedAt: new Date("2026-03-26T00:00:00.000Z") },
     });
     prismaMock.todoPlayerSnapshot.findMany.mockResolvedValue([
@@ -762,8 +763,8 @@ describe("/todo command", () => {
         playerTag: "#CUV9082",
         playerName: "Charlie",
         gamesActive: true,
-        gamesPoints: 4000,
-        gamesChampionTotal: 8000,
+        gamesPoints: 5200,
+        gamesChampionTotal: 7000,
         gamesEndsAt: new Date("2026-03-28T08:00:00.000Z"),
       }),
       makeSnapshotRow({
@@ -778,8 +779,16 @@ describe("/todo command", () => {
         playerTag: "#Q2V8P9L2",
         playerName: "Bravo",
         gamesActive: true,
-        gamesPoints: 5200,
+        gamesPoints: 4000,
         gamesChampionTotal: 8000,
+        gamesEndsAt: new Date("2026-03-28T08:00:00.000Z"),
+      }),
+      makeSnapshotRow({
+        playerTag: "#9C8VY2L2",
+        playerName: "Foxtrot",
+        gamesActive: true,
+        gamesPoints: 3999,
+        gamesChampionTotal: 5000,
         gamesEndsAt: new Date("2026-03-28T08:00:00.000Z"),
       }),
     ]);
@@ -790,38 +799,41 @@ describe("/todo command", () => {
     const description = getReplyDescription(interaction);
     expect(description).toContain("**Time remaining:** <t:");
     expect(countOccurrences(description, "<t:")).toBe(1);
-    expect(description).toContain("- 🏆 Alpha #LQ9P8R2 - clan games points: 10000/4000");
-    expect(description).toContain("- ✅ Bravo #Q2V8P9L2 - clan games points: 5200/4000");
-    expect(description).toContain("- ✅ Charlie #CUV9082 - clan games points: 4000/4000");
-    expect(description).toContain("- 🟡 Delta #QGRJ2222 - clan games points: 3999/4000");
+    expect(description).toContain("Alpha #LQ9P8R2 - clan games points: 10000/4000");
+    expect(description).toContain("Bravo #Q2V8P9L2 - clan games points: 4000/4000");
+    expect(description).toContain("Charlie #CUV9082 - clan games points: 5200/4000");
+    expect(description).toContain("Delta #QGRJ2222 - clan games points: 3999/4000");
+    expect(description).toContain("Foxtrot #9C8VY2L2 - clan games points: 3999/4000");
     expect(description).toContain("- Echo #PYLQ0289 - clan games points: 0/4000");
 
-    const indexTrophy = description.indexOf("🏆 Alpha #LQ9P8R2");
-    const indexBravo = description.indexOf("✅ Bravo #Q2V8P9L2");
-    const indexCharlie = description.indexOf("✅ Charlie #CUV9082");
-    const indexDelta = description.indexOf("🟡 Delta #QGRJ2222");
+    const indexTrophy = description.indexOf("Alpha #LQ9P8R2");
+    const indexBravo = description.indexOf("Bravo #Q2V8P9L2");
+    const indexCharlie = description.indexOf("Charlie #CUV9082");
+    const indexDelta = description.indexOf("Delta #QGRJ2222");
+    const indexFoxtrot = description.indexOf("Foxtrot #9C8VY2L2");
     const indexEcho = description.indexOf("Echo #PYLQ0289");
     expect(indexTrophy).toBeGreaterThan(-1);
     expect(indexBravo).toBeGreaterThan(-1);
     expect(indexCharlie).toBeGreaterThan(-1);
     expect(indexDelta).toBeGreaterThan(-1);
+    expect(indexFoxtrot).toBeGreaterThan(-1);
     expect(indexEcho).toBeGreaterThan(-1);
-    expect(indexTrophy).toBeLessThan(indexBravo);
-    expect(indexBravo).toBeLessThan(indexCharlie);
-    expect(indexCharlie).toBeLessThan(indexDelta);
-    expect(indexDelta).toBeLessThan(indexEcho);
+    expect(indexTrophy).toBeLessThan(indexCharlie);
+    expect(indexCharlie).toBeLessThan(indexBravo);
+    expect(indexBravo).toBeLessThan(indexDelta);
+    expect(indexDelta).toBeLessThan(indexFoxtrot);
+    expect(indexFoxtrot).toBeLessThan(indexEcho);
   });
-
   it("falls back to PlayerLink identity for linked rows before final raw-tag fallback", async () => {
     prismaMock.playerLink.findMany.mockResolvedValue([
       {
         playerTag: "#PYLQ0289",
-        discordUsername: "Linked Alias",
+        playerName: "Linked Alias",
         createdAt: new Date("2026-03-01T00:00:00.000Z"),
       },
       {
         playerTag: "#QGRJ2222",
-        discordUsername: null,
+        playerName: null,
         createdAt: new Date("2026-03-02T00:00:00.000Z"),
       },
     ]);
@@ -852,11 +864,12 @@ describe("/todo command", () => {
     expect(description).toContain("- #QGRJ2222 - clan games points: 0/4000");
   });
 
-  it("does not use discord-handle-like PlayerLink usernames as normal todo player identity fallback", async () => {
+  it("does not use discordUsername as normal todo player identity fallback", async () => {
     prismaMock.playerLink.findMany.mockResolvedValue([
       {
         playerTag: "#PYLQ0289",
         discordUsername: "tonyk_2020",
+        playerName: null,
         createdAt: new Date("2026-03-01T00:00:00.000Z"),
       },
     ]);
@@ -1154,4 +1167,5 @@ describe("/todo refresh button", () => {
     expect(interaction.deferUpdate).not.toHaveBeenCalled();
   });
 });
+
 

--- a/tests/todo.command.test.ts
+++ b/tests/todo.command.test.ts
@@ -802,6 +802,35 @@ describe("/todo command", () => {
     expect(description).toContain("- 🟡 Linked Alias #PYLQ0289 - clan games points: 1200/4000");
     expect(description).toContain("- #QGRJ2222 - clan games points: 0/4000");
   });
+
+  it("does not use discord-handle-like PlayerLink usernames as normal todo player identity fallback", async () => {
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      {
+        playerTag: "#PYLQ0289",
+        discordUsername: "tonyk_2020",
+        createdAt: new Date("2026-03-01T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.todoPlayerSnapshot.aggregate.mockResolvedValue({
+      _count: { _all: 1 },
+      _max: { updatedAt: new Date("2026-03-26T00:00:00.000Z") },
+    });
+    prismaMock.todoPlayerSnapshot.findMany.mockResolvedValue([
+      makeSnapshotRow({
+        playerTag: "#PYLQ0289",
+        playerName: "#PYLQ0289",
+        gamesActive: true,
+        gamesPoints: 1200,
+      }),
+    ]);
+
+    const interaction = makeTodoInteraction({ type: "GAMES" });
+    await Todo.run({} as any, interaction as any, makeCocServiceSpy() as any);
+
+    const description = getReplyDescription(interaction);
+    expect(description).toContain("- 🟡 #PYLQ0289 - clan games points: 1200/4000");
+    expect(description).not.toContain("tonyk_2020");
+  });
 });
 
 describe("/todo pagination buttons", () => {

--- a/tests/todo.command.test.ts
+++ b/tests/todo.command.test.ts
@@ -21,6 +21,9 @@ const prismaMock = vi.hoisted(() => ({
   currentWar: {
     findMany: vi.fn(),
   },
+  warAttacks: {
+    findMany: vi.fn(),
+  },
   trackedClan: {
     findMany: vi.fn(),
   },
@@ -208,6 +211,7 @@ describe("/todo command", () => {
     prismaMock.fwaClanMemberCurrent.findMany.mockReset();
     prismaMock.fwaWarMemberCurrent.findMany.mockReset();
     prismaMock.currentWar.findMany.mockReset();
+    prismaMock.warAttacks.findMany.mockReset();
     prismaMock.trackedClan.findMany.mockReset();
     prismaMock.cwlTrackedClan.findMany.mockReset();
     prismaMock.cwlPlayerClanSeason.findMany.mockReset();
@@ -224,6 +228,7 @@ describe("/todo command", () => {
     prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue([]);
     prismaMock.fwaWarMemberCurrent.findMany.mockResolvedValue([]);
     prismaMock.currentWar.findMany.mockResolvedValue([]);
+    prismaMock.warAttacks.findMany.mockResolvedValue([]);
     prismaMock.trackedClan.findMany.mockResolvedValue([]);
     prismaMock.cwlTrackedClan.findMany.mockResolvedValue([]);
     prismaMock.cwlPlayerClanSeason.findMany.mockResolvedValue([]);
@@ -346,15 +351,88 @@ describe("/todo command", () => {
     prismaMock.currentWar.findMany.mockResolvedValue([
       {
         clanTag: "#PQL0289",
+        warId: 1001,
+        startTime: new Date("2026-03-25T12:00:00.000Z"),
         matchType: "FWA",
         outcome: "WIN",
+        state: "inWar",
         updatedAt: new Date("2026-03-26T00:00:00.000Z"),
       },
       {
         clanTag: "#2QG2C08UP",
+        warId: 1002,
+        startTime: new Date("2026-03-25T12:00:00.000Z"),
         matchType: "BL",
         outcome: null,
+        state: "preparation",
         updatedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.warAttacks.findMany.mockResolvedValue([
+      {
+        warId: 1001,
+        clanTag: "#PQL0289",
+        warStartTime: new Date("2026-03-25T12:00:00.000Z"),
+        playerTag: "#PYLQ0289",
+        playerPosition: 8,
+        attacksUsed: 0,
+        attackOrder: 0,
+        attackNumber: 0,
+        defenderPosition: null,
+        stars: 0,
+        attackSeenAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+      {
+        warId: 1001,
+        clanTag: "#PQL0289",
+        warStartTime: new Date("2026-03-25T12:00:00.000Z"),
+        playerTag: "#QGRJ2222",
+        playerPosition: 1,
+        attacksUsed: 1,
+        attackOrder: 0,
+        attackNumber: 0,
+        defenderPosition: null,
+        stars: 0,
+        attackSeenAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+      {
+        warId: 1001,
+        clanTag: "#PQL0289",
+        warStartTime: new Date("2026-03-25T12:00:00.000Z"),
+        playerTag: "#QGRJ2222",
+        playerPosition: 1,
+        attacksUsed: 1,
+        attackOrder: 1,
+        attackNumber: 1,
+        defenderPosition: 8,
+        stars: 3,
+        attackSeenAt: new Date("2026-03-26T00:05:00.000Z"),
+      },
+      {
+        warId: 1002,
+        clanTag: "#2QG2C08UP",
+        warStartTime: new Date("2026-03-25T12:00:00.000Z"),
+        playerTag: "#CUV9082",
+        playerPosition: 9,
+        attacksUsed: 2,
+        attackOrder: 0,
+        attackNumber: 0,
+        defenderPosition: null,
+        stars: 0,
+        attackSeenAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+      {
+        warId: 1002,
+        clanTag: "#2QG2C08UP",
+        warStartTime: new Date("2026-03-25T12:00:00.000Z"),
+        playerTag: "#CUV9082",
+        playerPosition: 9,
+        attacksUsed: 2,
+        attackOrder: 1,
+        attackNumber: 1,
+        defenderPosition: 8,
+        stars: 3,
+        attackSeenAt: new Date("2026-03-26T00:10:00.000Z"),
       },
     ]);
     prismaMock.fwaWarMemberCurrent.findMany.mockResolvedValue([
@@ -374,8 +452,8 @@ describe("/todo command", () => {
         playerTag: "#QGRJ2222",
         position: 1,
         attacks: 1,
-        defender1Position: 8,
-        stars1: 3,
+        defender1Position: 3,
+        stars1: 1,
         defender2Position: null,
         stars2: null,
         sourceSyncedAt: new Date("2026-03-26T00:00:00.000Z"),
@@ -432,9 +510,40 @@ describe("/todo command", () => {
     prismaMock.currentWar.findMany.mockResolvedValue([
       {
         clanTag: "#PQL0289",
+        warId: 1001,
+        startTime: new Date("2026-03-25T12:00:00.000Z"),
         matchType: "FWA",
         outcome: "WIN",
+        state: "inWar",
         updatedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.warAttacks.findMany.mockResolvedValue([
+      {
+        warId: 1001,
+        clanTag: "#PQL0289",
+        warStartTime: new Date("2026-03-25T12:00:00.000Z"),
+        playerTag: "#PYLQ0289",
+        playerPosition: null,
+        attacksUsed: 1,
+        attackOrder: 0,
+        attackNumber: 0,
+        defenderPosition: null,
+        stars: 0,
+        attackSeenAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+      {
+        warId: 1001,
+        clanTag: "#PQL0289",
+        warStartTime: new Date("2026-03-25T12:00:00.000Z"),
+        playerTag: "#PYLQ0289",
+        playerPosition: null,
+        attacksUsed: 1,
+        attackOrder: 1,
+        attackNumber: 1,
+        defenderPosition: null,
+        stars: 2,
+        attackSeenAt: new Date("2026-03-26T00:05:00.000Z"),
       },
     ]);
     prismaMock.fwaWarMemberCurrent.findMany.mockResolvedValue([
@@ -482,9 +591,40 @@ describe("/todo command", () => {
     prismaMock.currentWar.findMany.mockResolvedValue([
       {
         clanTag: "#Q2V8P9L2",
+        warId: 1003,
+        startTime: new Date("2026-03-25T12:00:00.000Z"),
         matchType: "FWA",
         outcome: "WIN",
+        state: "inWar",
         updatedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.warAttacks.findMany.mockResolvedValue([
+      {
+        warId: 1003,
+        clanTag: "#Q2V8P9L2",
+        warStartTime: new Date("2026-03-25T12:00:00.000Z"),
+        playerTag: "#PYLQ0289",
+        playerPosition: 8,
+        attacksUsed: 1,
+        attackOrder: 0,
+        attackNumber: 0,
+        defenderPosition: null,
+        stars: 0,
+        attackSeenAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+      {
+        warId: 1003,
+        clanTag: "#Q2V8P9L2",
+        warStartTime: new Date("2026-03-25T12:00:00.000Z"),
+        playerTag: "#PYLQ0289",
+        playerPosition: 8,
+        attacksUsed: 1,
+        attackOrder: 1,
+        attackNumber: 1,
+        defenderPosition: 7,
+        stars: 2,
+        attackSeenAt: new Date("2026-03-26T00:05:00.000Z"),
       },
     ]);
     prismaMock.fwaWarMemberCurrent.findMany.mockResolvedValue([

--- a/tests/todoSnapshot.service.test.ts
+++ b/tests/todoSnapshot.service.test.ts
@@ -238,6 +238,90 @@ describe("TodoSnapshotService", () => {
     );
   });
 
+  it("writes zero war attacks during preparation even when member attack state is non-zero", async () => {
+    prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue([
+      {
+        playerTag: "#PYLQ0289",
+        clanTag: "#PQL0289",
+        playerName: "Alpha",
+        sourceSyncedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.fwaWarMemberCurrent.findMany.mockResolvedValue([
+      {
+        playerTag: "#PYLQ0289",
+        clanTag: "#PQL0289",
+        position: 8,
+        attacks: 2,
+        sourceSyncedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.currentWar.findMany.mockResolvedValue([
+      {
+        clanTag: "#PQL0289",
+        state: "preparation",
+        startTime: new Date("2026-03-26T12:00:00.000Z"),
+        endTime: new Date("2026-03-27T12:00:00.000Z"),
+        updatedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.cwlTrackedClan.findMany.mockResolvedValue([]);
+    prismaMock.cwlPlayerClanSeason.findMany.mockResolvedValue([]);
+
+    await todoSnapshotService.refreshSnapshotsForPlayerTags({
+      playerTags: ["#PYLQ0289"],
+      nowMs: Date.UTC(2026, 2, 26, 0, 0, 0, 0),
+    });
+
+    expect(prismaMock.todoPlayerSnapshot.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({
+          warActive: true,
+          warPhase: "preparation",
+          warAttacksUsed: 0,
+        }),
+      }),
+    );
+  });
+
+  it("marks WAR inactive for players missing from active-war membership", async () => {
+    prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue([
+      {
+        playerTag: "#PYLQ0289",
+        clanTag: "#PQL0289",
+        playerName: "Alpha",
+        sourceSyncedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.fwaWarMemberCurrent.findMany.mockResolvedValue([]);
+    prismaMock.currentWar.findMany.mockResolvedValue([
+      {
+        clanTag: "#PQL0289",
+        state: "inWar",
+        startTime: new Date("2026-03-25T12:00:00.000Z"),
+        endTime: new Date("2026-03-26T12:00:00.000Z"),
+        updatedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.cwlTrackedClan.findMany.mockResolvedValue([]);
+    prismaMock.cwlPlayerClanSeason.findMany.mockResolvedValue([]);
+
+    await todoSnapshotService.refreshSnapshotsForPlayerTags({
+      playerTags: ["#PYLQ0289"],
+      nowMs: Date.UTC(2026, 2, 26, 0, 0, 0, 0),
+    });
+
+    expect(prismaMock.todoPlayerSnapshot.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({
+          warActive: false,
+          warPhase: null,
+          warAttacksUsed: 0,
+        }),
+      }),
+    );
+  });
+
   it("derives active Clan Games points from stored signal totals and cycle baseline", async () => {
     prismaMock.todoPlayerSnapshot.findMany.mockResolvedValue([
       buildSnapshotRow({

--- a/tests/todoSnapshot.service.test.ts
+++ b/tests/todoSnapshot.service.test.ts
@@ -21,6 +21,9 @@ const prismaMock = vi.hoisted(() => ({
   currentWar: {
     findMany: vi.fn(),
   },
+  warAttacks: {
+    findMany: vi.fn(),
+  },
   trackedClan: {
     findMany: vi.fn(),
   },
@@ -124,6 +127,7 @@ describe("TodoSnapshotService", () => {
         updatedAt: new Date("2026-03-26T00:00:00.000Z"),
       },
     ]);
+    prismaMock.warAttacks.findMany.mockResolvedValue([]);
     prismaMock.trackedClan.findMany.mockResolvedValue([
       { tag: "#PQL0289", name: "Clan One" },
     ]);
@@ -278,6 +282,143 @@ describe("TodoSnapshotService", () => {
         update: expect.objectContaining({
           warActive: true,
           warPhase: "preparation",
+          warAttacksUsed: 0,
+        }),
+      }),
+    );
+  });
+
+  it("derives tracked inWar attacks from WarAttacks instead of stale feed attack counters", async () => {
+    prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue([
+      {
+        playerTag: "#PYLQ0289",
+        clanTag: "#PQL0289",
+        playerName: "Alpha",
+        sourceSyncedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.fwaWarMemberCurrent.findMany.mockResolvedValue([
+      {
+        playerTag: "#PYLQ0289",
+        clanTag: "#PQL0289",
+        position: 8,
+        attacks: 2,
+        sourceSyncedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.currentWar.findMany.mockResolvedValue([
+      {
+        clanTag: "#PQL0289",
+        warId: 1001,
+        state: "inWar",
+        startTime: new Date("2026-03-26T12:00:00.000Z"),
+        endTime: new Date("2026-03-27T12:00:00.000Z"),
+        updatedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.warAttacks.findMany.mockResolvedValue([
+      {
+        warId: 1001,
+        clanTag: "#PQL0289",
+        warStartTime: new Date("2026-03-26T12:00:00.000Z"),
+        playerTag: "#PYLQ0289",
+        playerPosition: 8,
+        attacksUsed: 1,
+        attackOrder: 0,
+        attackNumber: 0,
+        defenderPosition: null,
+        stars: 0,
+        attackSeenAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+      {
+        warId: 1001,
+        clanTag: "#PQL0289",
+        warStartTime: new Date("2026-03-26T12:00:00.000Z"),
+        playerTag: "#PYLQ0289",
+        playerPosition: 8,
+        attacksUsed: 1,
+        attackOrder: 1,
+        attackNumber: 1,
+        defenderPosition: 8,
+        stars: 3,
+        attackSeenAt: new Date("2026-03-26T00:10:00.000Z"),
+      },
+    ]);
+    prismaMock.cwlTrackedClan.findMany.mockResolvedValue([]);
+    prismaMock.cwlPlayerClanSeason.findMany.mockResolvedValue([]);
+
+    await todoSnapshotService.refreshSnapshotsForPlayerTags({
+      playerTags: ["#PYLQ0289"],
+      nowMs: Date.UTC(2026, 2, 26, 0, 0, 0, 0),
+    });
+
+    expect(prismaMock.todoPlayerSnapshot.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({
+          warActive: true,
+          warPhase: "battle day",
+          warAttacksUsed: 1,
+        }),
+      }),
+    );
+  });
+
+  it("does not leak stale previous-war feed attacks into tracked current-war snapshots", async () => {
+    prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue([
+      {
+        playerTag: "#PYLQ0289",
+        clanTag: "#PQL0289",
+        playerName: "Alpha",
+        sourceSyncedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.fwaWarMemberCurrent.findMany.mockResolvedValue([
+      {
+        playerTag: "#PYLQ0289",
+        clanTag: "#PQL0289",
+        position: 8,
+        attacks: 2,
+        sourceSyncedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.currentWar.findMany.mockResolvedValue([
+      {
+        clanTag: "#PQL0289",
+        warId: 2002,
+        state: "inWar",
+        startTime: new Date("2026-03-28T12:00:00.000Z"),
+        endTime: new Date("2026-03-29T12:00:00.000Z"),
+        updatedAt: new Date("2026-03-28T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.warAttacks.findMany.mockResolvedValue([
+      {
+        warId: 1001,
+        clanTag: "#PQL0289",
+        warStartTime: new Date("2026-03-26T12:00:00.000Z"),
+        playerTag: "#PYLQ0289",
+        playerPosition: 8,
+        attacksUsed: 2,
+        attackOrder: 0,
+        attackNumber: 0,
+        defenderPosition: null,
+        stars: 0,
+        attackSeenAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.cwlTrackedClan.findMany.mockResolvedValue([]);
+    prismaMock.cwlPlayerClanSeason.findMany.mockResolvedValue([]);
+
+    await todoSnapshotService.refreshSnapshotsForPlayerTags({
+      playerTags: ["#PYLQ0289"],
+      nowMs: Date.UTC(2026, 2, 28, 0, 0, 0, 0),
+    });
+
+    expect(prismaMock.todoPlayerSnapshot.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({
+          warActive: true,
+          warPhase: "battle day",
           warAttacksUsed: 0,
         }),
       }),


### PR DESCRIPTION
This release is mainly a **Todo reliability + linked-identity cleanup** drop. It improves `/todo` refreshability, Games readability, WAR correctness, and linked-player naming consistency, while also tightening the tracked WAR truth source and improving `/accounts` identity resolution.


### Release scope

* Base: `main`
* Target: `dev`
* Compare: `main...dev`
* Commits in range: `16`
* Files changed: `20` 

## Highlights

### 1. `/todo` now supports targeted manual refresh

* Added a scoped **Refresh** button to `/todo` so users can trigger a targeted snapshot refresh for the displayed user’s linked accounts and update the same message/page in place.
* Includes requester ownership/state handling and regression coverage for the refresh interaction. 

### 2. Clan Games `/todo` page got a UX overhaul

* Added progress indicators for Clan Games states.
* Improved ordering so Games rows are easier to scan.
* Tightened linked-name fallback behavior for `/todo` rows when snapshot names are missing. 

### 3. `/todo` WAR page is richer and more readable

* Active WAR group headers now include tracked-clan badge + match-status indicator.
* WAR rows now show lineup position and compact used-attack detail.
* Added test coverage for badge headers, match headers, attack-detail variants, and position fallback. 

### 4. Linked-player identity fallback was corrected

* Fixed `/todo` so linked fallback values that look like Discord handles are no longer treated as player identities.
* Non-tracked linked accounts now stay on player-like names or final raw-tag fallback instead of leaking Discord-style labels into the UI. 

### 5. WAR/CWL active-row correctness was fixed

* Suppressed WAR attack usage/details during **preparation** so rows do not inherit stale prior-war hits.
* WAR/CWL pages now render only active participating members.
* Includes regressions for preparation attacks, active-member filtering, and position carry-through.

### 6. `/todo` Games now uses better linked identity + better ranking

* Added `PlayerLink.playerName` with migration support.
* Feed/member sync jobs now upsert linked player names when missing or changed.
* `/todo` GAMES rows now sort by **gamesPoints desc**, then **gamesChampionTotal desc**, with stable tie-breakers. 

### 7. `/todo` WAR now uses the tracked current-war truth source

* Tracked WAR membership/attacks now derive from **`CurrentWar + WarAttacks`** with identity-safe filtering.
* `FwaWarMemberCurrent` is now bounded fallback only, preventing stale feed attacks from leaking into tracked WAR rows.
* Also hardened scheduler integer env parsing so empty `WAR_MEMBERS` chunk values keep defaults instead of degrading behavior. 

### 8. `/accounts` now prefers linked stored names

* `/accounts` now uses `PlayerLink.playerName` as its primary display identity.
* Falls back to live CoC fetch only when needed.
* Persists missing linked names from successful live fetches without blocking the response.
* Includes regression coverage for precedence and fallback behavior. 

