### PR TITLE
feat(todo): polish war completion rendering

### DIFF
--- a/src/services/TodoService.ts
+++ b/src/services/TodoService.ts
@@ -401,8 +401,11 @@ function buildWarPageDescription(
   }
 
   const grouped = buildEventGroups(activeRows, "war");
+  const unfinishedGroups = grouped.filter((group) => !isWarEventGroupComplete(group));
+  const completedGroups = grouped.filter((group) => isWarEventGroupComplete(group));
+  const groupedByCompletion = [...unfinishedGroups, ...completedGroups];
   const lines: string[] = [];
-  for (const group of grouped) {
+  for (const group of groupedByCompletion) {
     lines.push(`**${buildEventGroupHeader(group)}**`);
     for (const row of group.rows) {
       lines.push(formatWarTodoRow(row, getWarRowStatus(row)));
@@ -628,10 +631,8 @@ function formatTodoRow(row: TodoRenderRow, status: string): string {
 /** Purpose: format one WAR row with lineup position and compact attack-detail suffixes. */
 function formatWarTodoRow(row: TodoRenderRow, status: string): string {
   const identity = formatWarPlayerIdentity(row);
-  const attacksActive = isWarRowAttackPhaseActive(row);
-  const usedAttacks = attacksActive
-    ? clampInt(row.snapshot?.warAttacksUsed, 0, row.snapshot?.warAttacksMax || 2)
-    : 0;
+  const warProgress = getWarRowProgress(row);
+  const usedAttacks = warProgress.used;
   const detailRows =
     usedAttacks > 0
       ? row.warAttackDetails
@@ -641,7 +642,8 @@ function formatWarTodoRow(row: TodoRenderRow, status: string): string {
       : [];
   const detailsSuffix =
     detailRows.length > 0 ? ` | ${detailRows.join(" | ")}` : "";
-  return `- ${identity} - ${status}${detailsSuffix}`;
+  const bullet = warProgress.complete ? ":white_check_mark:" : "-";
+  return `${bullet} ${identity} - ${status}${detailsSuffix}`;
 }
 
 /** Purpose: format one GAMES row with optional completion marker next to player identity text. */
@@ -694,12 +696,31 @@ function getWarRowStatus(row: TodoRenderRow): string {
   if (row.missingSnapshot || !row.snapshot) {
     return "`0 / 2` - snapshot unavailable";
   }
+  const { used, max } = getWarRowProgress(row);
+  const staleSuffix = row.staleSnapshot ? " - stale snapshot" : "";
+  return `\`${used} / ${max}\`${staleSuffix}`;
+}
+
+/** Purpose: compute stable WAR used/max progress and completion flag for row render decisions. */
+function getWarRowProgress(row: TodoRenderRow): {
+  used: number;
+  max: number;
+  complete: boolean;
+} {
+  if (!row.snapshot) {
+    return { used: 0, max: 2, complete: false };
+  }
   const used = isWarRowAttackPhaseActive(row)
     ? clampInt(row.snapshot.warAttacksUsed, 0, row.snapshot.warAttacksMax || 2)
     : 0;
   const max = Math.max(1, clampInt(row.snapshot.warAttacksMax, 1, 2));
-  const staleSuffix = row.staleSnapshot ? " - stale snapshot" : "";
-  return `\`${used} / ${max}\`${staleSuffix}`;
+  return { used, max, complete: used >= max };
+}
+
+/** Purpose: mark one WAR section complete only when every rendered row is complete. */
+function isWarEventGroupComplete(group: TodoEventGroup): boolean {
+  if (group.rows.length <= 0) return false;
+  return group.rows.every((row) => getWarRowProgress(row).complete);
 }
 
 /** Purpose: build active CWL row status text without repeating group-level phase timing details. */

--- a/tests/todo.command.test.ts
+++ b/tests/todo.command.test.ts
@@ -592,6 +592,130 @@ describe("/todo command", () => {
     expect(description).not.toContain("Delta #LQ9P8R2");
   });
 
+  it("uses check-mark bullets for completed WAR rows while keeping unfinished bullets unchanged", async () => {
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      { playerTag: "#PYLQ0289", createdAt: new Date("2026-03-01T00:00:00.000Z") },
+      { playerTag: "#QGRJ2222", createdAt: new Date("2026-03-02T00:00:00.000Z") },
+    ]);
+    prismaMock.todoPlayerSnapshot.aggregate.mockResolvedValue({
+      _count: { _all: 2 },
+      _max: { updatedAt: new Date("2026-03-26T00:00:00.000Z") },
+    });
+    prismaMock.todoPlayerSnapshot.findMany.mockResolvedValue([
+      makeSnapshotRow({
+        playerTag: "#PYLQ0289",
+        playerName: "Alpha",
+        clanTag: "#PQL0289",
+        clanName: "Clan One",
+        warAttacksUsed: 1,
+        warPhase: "battle day",
+      }),
+      makeSnapshotRow({
+        playerTag: "#QGRJ2222",
+        playerName: "Bravo",
+        clanTag: "#PQL0289",
+        clanName: "Clan One",
+        warAttacksUsed: 2,
+        warPhase: "battle day",
+      }),
+    ]);
+    prismaMock.fwaWarMemberCurrent.findMany.mockResolvedValue([
+      {
+        clanTag: "#PQL0289",
+        playerTag: "#PYLQ0289",
+        position: 1,
+        attacks: 1,
+        defender1Position: null,
+        stars1: null,
+        defender2Position: null,
+        stars2: null,
+        sourceSyncedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+      {
+        clanTag: "#PQL0289",
+        playerTag: "#QGRJ2222",
+        position: 2,
+        attacks: 2,
+        defender1Position: null,
+        stars1: null,
+        defender2Position: null,
+        stars2: null,
+        sourceSyncedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+    ]);
+
+    const interaction = makeTodoInteraction({ type: "WAR" });
+    await Todo.run({} as any, interaction as any, makeCocServiceSpy() as any);
+
+    const description = getReplyDescription(interaction);
+    expect(description).toContain("- #1 Alpha - `1 / 2`");
+    expect(description).toContain(":white_check_mark: #2 Bravo - `2 / 2`");
+  });
+
+  it("moves fully completed WAR clans below unfinished clans while preserving subgroup order", async () => {
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      { playerTag: "#PYLQ0289", createdAt: new Date("2026-03-01T00:00:00.000Z") },
+      { playerTag: "#QGRJ2222", createdAt: new Date("2026-03-02T00:00:00.000Z") },
+      { playerTag: "#CUV9082", createdAt: new Date("2026-03-03T00:00:00.000Z") },
+      { playerTag: "#LQ9P8R2", createdAt: new Date("2026-03-04T00:00:00.000Z") },
+    ]);
+    prismaMock.todoPlayerSnapshot.aggregate.mockResolvedValue({
+      _count: { _all: 4 },
+      _max: { updatedAt: new Date("2026-03-26T00:00:00.000Z") },
+    });
+    prismaMock.todoPlayerSnapshot.findMany.mockResolvedValue([
+      makeSnapshotRow({
+        playerTag: "#PYLQ0289",
+        playerName: "Alpha",
+        clanTag: "#PQL0289",
+        clanName: "A Clan",
+        warAttacksUsed: 1,
+        warPhase: "battle day",
+      }),
+      makeSnapshotRow({
+        playerTag: "#QGRJ2222",
+        playerName: "Bravo",
+        clanTag: "#2QG2C08UP",
+        clanName: "B Clan",
+        warAttacksUsed: 2,
+        warPhase: "battle day",
+      }),
+      makeSnapshotRow({
+        playerTag: "#CUV9082",
+        playerName: "Charlie",
+        clanTag: "#Q2V8P9L2",
+        clanName: "C Clan",
+        warAttacksUsed: 1,
+        warPhase: "battle day",
+      }),
+      makeSnapshotRow({
+        playerTag: "#LQ9P8R2",
+        playerName: "Delta",
+        clanTag: "#9C8VY2L2",
+        clanName: "D Clan",
+        warAttacksUsed: 2,
+        warPhase: "battle day",
+      }),
+    ]);
+
+    const interaction = makeTodoInteraction({ type: "WAR" });
+    await Todo.run({} as any, interaction as any, makeCocServiceSpy() as any);
+
+    const description = getReplyDescription(interaction);
+    const indexA = description.indexOf("**A Clan (#PQL0289) :white_circle: - battle day ends <t:");
+    const indexB = description.indexOf("**B Clan (#2QG2C08UP) :white_circle: - battle day ends <t:");
+    const indexC = description.indexOf("**C Clan (#Q2V8P9L2) :white_circle: - battle day ends <t:");
+    const indexD = description.indexOf("**D Clan (#9C8VY2L2) :white_circle: - battle day ends <t:");
+
+    expect(indexA).toBeGreaterThan(-1);
+    expect(indexB).toBeGreaterThan(-1);
+    expect(indexC).toBeGreaterThan(-1);
+    expect(indexD).toBeGreaterThan(-1);
+    expect(indexA).toBeLessThan(indexC);
+    expect(indexC).toBeLessThan(indexB);
+    expect(indexB).toBeLessThan(indexD);
+  });
+
   it("uses safe #? fallback when war lineup position is unavailable", async () => {
     prismaMock.playerLink.findMany.mockResolvedValue([
       { playerTag: "#PYLQ0289", createdAt: new Date("2026-03-01T00:00:00.000Z") },


### PR DESCRIPTION
- render completed WAR rows with :white_check_mark: bullets
- keep unfinished WAR clans first and move fully completed clans below
- add WAR rendering tests for mixed completion and stable section ordering