### PR TITLE
feat(todo): refine raids and games status markers

### DIFF
--- a/src/services/TodoService.ts
+++ b/src/services/TodoService.ts
@@ -27,6 +27,7 @@ type TodoRenderRow = {
   playerTag: string;
   playerName: string;
   defaultIndex: number;
+  townHall: number | null;
   clanTag: string | null;
   clanName: string | null;
   cwlClanTag: string | null;
@@ -81,6 +82,18 @@ type CurrentWarMatchContextRow = {
   outcome: string | null;
   state: string | null;
   updatedAt: Date;
+};
+
+type FwaClanMemberTownHallRow = {
+  playerTag: string;
+  clanTag: string;
+  townHall: number | null;
+  sourceSyncedAt: Date;
+};
+
+type FwaPlayerCatalogTownHallRow = {
+  playerTag: string;
+  latestTownHall: number | null;
 };
 
 const DISCORD_DESCRIPTION_LIMIT = 4096;
@@ -174,7 +187,8 @@ export async function buildTodoPagesForUser(input: {
     ),
   ];
 
-  const [trackedClanRows, currentWarRows] = await Promise.all([
+  const [trackedClanRows, currentWarRows, clanMemberTownHallRows, playerCatalogTownHallRows] =
+    await Promise.all([
     clanTags.length > 0
       ? prisma.trackedClan.findMany({
           where: { tag: { in: clanTags } },
@@ -195,7 +209,63 @@ export async function buildTodoPagesForUser(input: {
           },
         })
       : Promise.resolve([]),
-  ]);
+    linkedTags.length > 0
+      ? prisma.fwaClanMemberCurrent.findMany({
+          where: { playerTag: { in: linkedTags } },
+          select: {
+            playerTag: true,
+            clanTag: true,
+            townHall: true,
+            sourceSyncedAt: true,
+          },
+        })
+      : Promise.resolve([]),
+    linkedTags.length > 0
+      ? prisma.fwaPlayerCatalog.findMany({
+          where: { playerTag: { in: linkedTags } },
+          select: {
+            playerTag: true,
+            latestTownHall: true,
+          },
+        })
+      : Promise.resolve([]),
+    ]);
+
+  const townHallByClanAndPlayer = new Map<string, number>();
+  const latestTownHallByClanAndPlayer = new Map<string, Date>();
+  const townHallByPlayerTag = new Map<string, number>();
+  const latestTownHallByPlayerTag = new Map<string, Date>();
+  for (const row of clanMemberTownHallRows as FwaClanMemberTownHallRow[]) {
+    const playerTag = normalizePlayerTag(row.playerTag);
+    if (!playerTag) continue;
+    const normalizedTownHall = toFiniteIntOrNull(row.townHall);
+    if (normalizedTownHall === null || normalizedTownHall <= 0) continue;
+
+    const clanTag = normalizeClanTag(row.clanTag);
+    if (clanTag) {
+      const clanPlayerKey = `${clanTag}:${playerTag}`;
+      const existingSyncedAt = latestTownHallByClanAndPlayer.get(clanPlayerKey);
+      if (!existingSyncedAt || row.sourceSyncedAt > existingSyncedAt) {
+        latestTownHallByClanAndPlayer.set(clanPlayerKey, row.sourceSyncedAt);
+        townHallByClanAndPlayer.set(clanPlayerKey, normalizedTownHall);
+      }
+    }
+
+    const existingPlayerSyncedAt = latestTownHallByPlayerTag.get(playerTag);
+    if (!existingPlayerSyncedAt || row.sourceSyncedAt > existingPlayerSyncedAt) {
+      latestTownHallByPlayerTag.set(playerTag, row.sourceSyncedAt);
+      townHallByPlayerTag.set(playerTag, normalizedTownHall);
+    }
+  }
+
+  const townHallByPlayerCatalogTag = new Map<string, number>();
+  for (const row of playerCatalogTownHallRows as FwaPlayerCatalogTownHallRow[]) {
+    const playerTag = normalizePlayerTag(row.playerTag);
+    if (!playerTag) continue;
+    const townHall = toFiniteIntOrNull(row.latestTownHall);
+    if (townHall === null || townHall <= 0) continue;
+    townHallByPlayerCatalogTag.set(playerTag, townHall);
+  }
 
   const trackedClanTagSet = new Set(
     trackedClanRows
@@ -268,6 +338,17 @@ export async function buildTodoPagesForUser(input: {
     const resolvedWarAttackDetails = trackedClanActive
       ? (trackedWarMember?.attackDetails ?? [])
       : [];
+    const resolvedTownHall = (() => {
+      if (warMemberKey) {
+        const clanScoped = townHallByClanAndPlayer.get(warMemberKey);
+        if (clanScoped !== undefined) return clanScoped;
+      }
+      const playerScoped = townHallByPlayerTag.get(normalizedTag);
+      if (playerScoped !== undefined) return playerScoped;
+      const catalogScoped = townHallByPlayerCatalogTag.get(normalizedTag);
+      if (catalogScoped !== undefined) return catalogScoped;
+      return null;
+    })();
     const matchContext = resolvedClanTag
       ? warMatchContextByClanTag.get(resolvedClanTag) ?? null
       : null;
@@ -280,6 +361,7 @@ export async function buildTodoPagesForUser(input: {
       playerTag: normalizedTag,
       playerName: resolvedPlayerName,
       defaultIndex: index,
+      townHall: resolvedTownHall,
       clanTag: resolvedClanTag,
       clanName: snapshot?.clanName ?? null,
       cwlClanTag: snapshot?.cwlClanTag ?? null,
@@ -449,7 +531,7 @@ function buildRaidsPageDescription(
     lines.push(`**Time remaining:** ${formatRelativeTimestamp(sharedEndsAt)}`);
     lines.push("");
   }
-  for (const row of rows) {
+  for (const row of sortRaidsRows(rows)) {
     lines.push(formatRaidsTodoRow(row, getRaidRowStatus(row)));
   }
 
@@ -624,6 +706,9 @@ function formatGamesTodoRow(
   status: string,
   progressEmoji: string,
 ): string {
+  if (row.snapshot && !row.snapshot.gamesActive) {
+    return `:black_circle: ${formatPlayerIdentity(row)} - ${status}`;
+  }
   const progressPrefix = progressEmoji.length > 0 ? `${progressEmoji} ` : "";
   if (progressPrefix) {
     return `${progressPrefix}${formatPlayerIdentity(row)} - ${status}`;
@@ -633,8 +718,7 @@ function formatGamesTodoRow(
 
 /** Purpose: format one RAIDS row with completion marker emojis and unchanged status text. */
 function formatRaidsTodoRow(row: TodoRenderRow, status: string): string {
-  const progress = getRaidRowProgress(row);
-  const marker = progress.complete ? ":white_check_mark:" : ":yellow_circle:";
+  const marker = getRaidRowMarker(row);
   return `${marker} ${formatPlayerIdentity(row)} - ${status}`;
 }
 
@@ -748,6 +832,18 @@ function getRaidRowProgress(row: TodoRenderRow): {
   );
   const max = Math.max(1, clampInt(row.snapshot.raidAttacksMax, 1, 6));
   return { used, max, complete: used >= max };
+}
+
+/** Purpose: map one RAIDS row into marker semantics for complete/active/not-started states. */
+function getRaidRowMarker(row: TodoRenderRow): string {
+  if (!row.snapshot || !row.snapshot.raidActive) {
+    return ":black_circle:";
+  }
+  const progress = getRaidRowProgress(row);
+  if (progress.complete) {
+    return ":white_check_mark:";
+  }
+  return ":yellow_circle:";
 }
 
 /** Purpose: build GAMES row status text with points and completion marker, without per-row timer duplication. */
@@ -957,6 +1053,37 @@ function sortGamesRows(rows: TodoRenderRow[]): TodoRenderRow[] {
       const byTag = a.row.playerTag.localeCompare(b.row.playerTag);
       if (byTag !== 0) return byTag;
 
+      return a.index - b.index;
+    })
+    .map((entry) => entry.row);
+}
+
+/** Purpose: sort RAIDS rows by used attacks desc, then TH desc, then stable prior order. */
+function sortRaidsRows(rows: TodoRenderRow[]): TodoRenderRow[] {
+  return rows
+    .map((row, index) => ({ row, index }))
+    .sort((a, b) => {
+      const aUsed = getRaidRowProgress(a.row).used;
+      const bUsed = getRaidRowProgress(b.row).used;
+      if (aUsed !== bUsed) {
+        return bUsed - aUsed;
+      }
+
+      const aTownHall =
+        a.row.townHall !== null && a.row.townHall > 0
+          ? a.row.townHall
+          : Number.NEGATIVE_INFINITY;
+      const bTownHall =
+        b.row.townHall !== null && b.row.townHall > 0
+          ? b.row.townHall
+          : Number.NEGATIVE_INFINITY;
+      if (aTownHall !== bTownHall) {
+        return bTownHall - aTownHall;
+      }
+
+      if (a.row.defaultIndex !== b.row.defaultIndex) {
+        return a.row.defaultIndex - b.row.defaultIndex;
+      }
       return a.index - b.index;
     })
     .map((entry) => entry.row);

--- a/tests/todo.command.test.ts
+++ b/tests/todo.command.test.ts
@@ -1455,13 +1455,14 @@ describe("/todo command", () => {
     expect(getReplyDescription(interaction)).toContain("Clan Games is not active");
   });
 
-  it("renders RAIDS with one shared top timer and per-player usage rows", async () => {
+  it("renders RAIDS markers for complete, active-incomplete, and not-started rows", async () => {
     prismaMock.playerLink.findMany.mockResolvedValue([
       { playerTag: "#PYLQ0289", createdAt: new Date("2026-03-01T00:00:00.000Z") },
       { playerTag: "#QGRJ2222", createdAt: new Date("2026-03-02T00:00:00.000Z") },
+      { playerTag: "#LQ9P8R2", createdAt: new Date("2026-03-03T00:00:00.000Z") },
     ]);
     prismaMock.todoPlayerSnapshot.aggregate.mockResolvedValue({
-      _count: { _all: 2 },
+      _count: { _all: 3 },
       _max: { updatedAt: new Date("2026-03-26T00:00:00.000Z") },
     });
     prismaMock.todoPlayerSnapshot.findMany.mockResolvedValue([
@@ -1479,6 +1480,12 @@ describe("/todo command", () => {
         raidAttacksUsed: 1,
         raidEndsAt: new Date("2026-03-29T07:00:00.000Z"),
       }),
+      makeSnapshotRow({
+        playerTag: "#LQ9P8R2",
+        playerName: "Charlie",
+        raidActive: false,
+        raidAttacksUsed: 0,
+      }),
     ]);
 
     const interaction = makeTodoInteraction({ type: "RAIDS" });
@@ -1489,6 +1496,91 @@ describe("/todo command", () => {
     expect(countOccurrences(description, "<t:")).toBe(1);
     expect(description).toContain(":white_check_mark: Alpha #PYLQ0289 - clan capital raids: 6/6");
     expect(description).toContain(":yellow_circle: Bravo #QGRJ2222 - clan capital raids: 1/6");
+    expect(description).toContain(
+      ":black_circle: Charlie #LQ9P8R2 - clan capital raids: 0/6 - not active",
+    );
+  });
+
+  it("sorts RAIDS rows by attacks used desc, then TH desc, then deterministic fallback order", async () => {
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      { playerTag: "#PQQQ0000", createdAt: new Date("2026-03-01T00:00:00.000Z") },
+      { playerTag: "#PYLL0002", createdAt: new Date("2026-03-02T00:00:00.000Z") },
+      { playerTag: "#QGRJ2008", createdAt: new Date("2026-03-03T00:00:00.000Z") },
+      { playerTag: "#CUV9900", createdAt: new Date("2026-03-04T00:00:00.000Z") },
+    ]);
+    prismaMock.todoPlayerSnapshot.aggregate.mockResolvedValue({
+      _count: { _all: 4 },
+      _max: { updatedAt: new Date("2026-03-26T00:00:00.000Z") },
+    });
+    prismaMock.todoPlayerSnapshot.findMany.mockResolvedValue([
+      makeSnapshotRow({
+        playerTag: "#PQQQ0000",
+        playerName: "Delta",
+        raidActive: true,
+        raidAttacksUsed: 3,
+      }),
+      makeSnapshotRow({
+        playerTag: "#PYLL0002",
+        playerName: "Charlie",
+        raidActive: true,
+        raidAttacksUsed: 3,
+      }),
+      makeSnapshotRow({
+        playerTag: "#QGRJ2008",
+        playerName: "Bravo",
+        raidActive: true,
+        raidAttacksUsed: 3,
+      }),
+      makeSnapshotRow({
+        playerTag: "#CUV9900",
+        playerName: "Alpha",
+        raidActive: true,
+        raidAttacksUsed: 1,
+      }),
+    ]);
+    prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue([
+      {
+        playerTag: "#PQQQ0000",
+        clanTag: "#PQL0289",
+        townHall: 15,
+        sourceSyncedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+      {
+        playerTag: "#PYLL0002",
+        clanTag: "#PQL0289",
+        townHall: 15,
+        sourceSyncedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+      {
+        playerTag: "#QGRJ2008",
+        clanTag: "#PQL0289",
+        townHall: 13,
+        sourceSyncedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+      {
+        playerTag: "#CUV9900",
+        clanTag: "#PQL0289",
+        townHall: 16,
+        sourceSyncedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+    ]);
+
+    const interaction = makeTodoInteraction({ type: "RAIDS" });
+    await Todo.run({} as any, interaction as any, makeCocServiceSpy() as any);
+
+    const description = getReplyDescription(interaction);
+    const indexDelta = description.indexOf("Delta #PQQQ0000 - clan capital raids: 3/6");
+    const indexCharlie = description.indexOf("Charlie #PYLL0002 - clan capital raids: 3/6");
+    const indexBravo = description.indexOf("Bravo #QGRJ2008 - clan capital raids: 3/6");
+    const indexAlpha = description.indexOf("Alpha #CUV9900 - clan capital raids: 1/6");
+
+    expect(indexDelta).toBeGreaterThan(-1);
+    expect(indexCharlie).toBeGreaterThan(-1);
+    expect(indexBravo).toBeGreaterThan(-1);
+    expect(indexAlpha).toBeGreaterThan(-1);
+    expect(indexDelta).toBeLessThan(indexCharlie);
+    expect(indexCharlie).toBeLessThan(indexBravo);
+    expect(indexBravo).toBeLessThan(indexAlpha);
   });
 
   it("renders GAMES emojis by progress threshold and sorts by gamesPoints desc then gamesChampionTotal desc", async () => {
@@ -1662,6 +1754,44 @@ describe("/todo command", () => {
     expect(description).toContain("🟡 #PYLQ0289 - clan games points: 1200/4000");
     expect(description).not.toContain("- 🟡 #PYLQ0289 - clan games points: 1200/4000");
     expect(description).not.toContain("tonyk_2020");
+  });
+
+  it("renders GAMES not-started rows with :black_circle: and no extra bullet prefix", async () => {
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      { playerTag: "#PYLQ0289", createdAt: new Date("2026-03-01T00:00:00.000Z") },
+      { playerTag: "#QGRJ2222", createdAt: new Date("2026-03-02T00:00:00.000Z") },
+    ]);
+    prismaMock.todoPlayerSnapshot.aggregate.mockResolvedValue({
+      _count: { _all: 2 },
+      _max: { updatedAt: new Date("2026-03-26T00:00:00.000Z") },
+    });
+    prismaMock.todoPlayerSnapshot.findMany.mockResolvedValue([
+      makeSnapshotRow({
+        playerTag: "#PYLQ0289",
+        playerName: "Alpha",
+        gamesActive: true,
+        gamesPoints: 1200,
+        gamesChampionTotal: 1200,
+      }),
+      makeSnapshotRow({
+        playerTag: "#QGRJ2222",
+        playerName: "Bravo",
+        gamesActive: false,
+        gamesPoints: 0,
+        gamesChampionTotal: 0,
+      }),
+    ]);
+
+    const interaction = makeTodoInteraction({ type: "GAMES" });
+    await Todo.run({} as any, interaction as any, makeCocServiceSpy() as any);
+
+    const description = getReplyDescription(interaction);
+    expect(description).toContain(
+      ":black_circle: Bravo #QGRJ2222 - clan games points: 0/4000 - not active",
+    );
+    expect(description).not.toContain(
+      "- :black_circle: Bravo #QGRJ2222 - clan games points: 0/4000 - not active",
+    );
   });
 });
 


### PR DESCRIPTION
- render black-circle markers for not-started raids and games rows
- sort raids rows by attacks used desc then town hall desc with stable ties
- add todo tests for marker semantics and raids ordering