### PR TITLE
fix(todo-snapshot): source raid attacks from live clan raid data

### DIFF
--- a/src/services/CoCService.ts
+++ b/src/services/CoCService.ts
@@ -1,4 +1,4 @@
-import { AxiosError } from "axios";
+import axios, { AxiosError } from "axios";
 import {
   ClanWarLogEntry,
   ClanWar,
@@ -14,19 +14,86 @@ import { toFailureTelemetry } from "./telemetry/ingest";
 export class CoCService {
   private clansApi: ClansApi;
   private playersApi: PlayersApi;
+  private readonly cocApiToken: string;
+  private readonly cocApiBaseUrl: string;
 
   /** Purpose: initialize service dependencies. */
   constructor() {
     const token = process.env.COC_API_TOKEN?.trim();
     if (!token) throw new Error("COC_API_TOKEN missing");
+    this.cocApiToken = token;
+    this.cocApiBaseUrl =
+      (process.env.COC_API_BASE_URL ?? "https://api.clashofclans.com/v1").replace(
+        /\/+$/,
+        "",
+      );
 
     const config = new Configuration({
       apiKey: `Bearer ${token}`,
-      basePath: process.env.COC_API_BASE_URL ?? "https://api.clashofclans.com/v1",
+      basePath: this.cocApiBaseUrl,
     });
 
     this.clansApi = new ClansApi(config);
     this.playersApi = new PlayersApi(config);
+  }
+
+  /** Purpose: get current clan-capital raid seasons for one clan tag (newest first). */
+  async getClanCapitalRaidSeasons(
+    tag: string,
+    limit = 1,
+  ): Promise<ClanCapitalRaidSeason[]> {
+    const clanTag = tag.startsWith("#") ? tag : `#${tag}`;
+    const startedAtMs = Date.now();
+    try {
+      const response = await axios.get(`${this.cocApiBaseUrl}/clans/${encodeURIComponent(clanTag)}/capitalraidseasons`, {
+        headers: {
+          Authorization: `Bearer ${this.cocApiToken}`,
+        },
+        params: {
+          limit: Math.max(1, Math.trunc(Number(limit) || 1)),
+        },
+      });
+      const data = response?.data as { items?: ClanCapitalRaidSeason[] } | undefined;
+      const seasons = Array.isArray(data?.items) ? data.items : [];
+      recordFetchEvent({
+        namespace: "coc",
+        operation: "getClanCapitalRaidSeasons",
+        source: "api",
+        detail: `tag=${clanTag} limit=${limit}`,
+        durationMs: Date.now() - startedAtMs,
+        status: "success",
+      });
+      return seasons;
+    } catch (err) {
+      const status = (err as AxiosError)?.response?.status;
+      const failure = toFailureTelemetry(err);
+      if (status === 404) {
+        recordFetchEvent({
+          namespace: "coc",
+          operation: "getClanCapitalRaidSeasons",
+          source: "api",
+          detail: `tag=${clanTag} status=404`,
+          durationMs: Date.now() - startedAtMs,
+          status: "failure",
+          errorCategory: "validation",
+          errorCode: "HTTP_404",
+        });
+        return [];
+      }
+      recordFetchEvent({
+        namespace: "coc",
+        operation: "getClanCapitalRaidSeasons",
+        source: "api",
+        detail: `tag=${clanTag} status=${status ?? "unknown"} result=error`,
+        durationMs: Date.now() - startedAtMs,
+        status: "failure",
+        errorCategory: failure.errorCategory,
+        errorCode: failure.errorCode,
+        timeout: failure.timeout,
+      });
+      if (status) throw new Error(`CoC API error ${status}`);
+      throw err;
+    }
   }
 
   /** Purpose: get clan. */
@@ -325,3 +392,15 @@ export class CoCService {
     };
   }
 }
+
+export type ClanCapitalRaidSeasonMember = {
+  tag?: string | null;
+  attacks?: number | null;
+};
+
+export type ClanCapitalRaidSeason = {
+  state?: string | null;
+  startTime?: string | null;
+  endTime?: string | null;
+  members?: ClanCapitalRaidSeasonMember[];
+};

--- a/src/services/TodoSnapshotService.ts
+++ b/src/services/TodoSnapshotService.ts
@@ -6,7 +6,7 @@ import {
   extractGamesChampionTotalFromSignalState,
 } from "./ActivitySignalService";
 import { resolveCurrentCwlSeasonKey } from "./CwlRegistryService";
-import { CoCService } from "./CoCService";
+import { CoCService, type ClanCapitalRaidSeason } from "./CoCService";
 import { normalizeClanTag, normalizePlayerTag } from "./PlayerLinkService";
 import {
   buildTrackedWarMemberStateByClanAndPlayer,
@@ -256,6 +256,10 @@ export class TodoSnapshotService {
     const gamesWindow = resolveClanGamesWindow(nowMs);
     const gamesCycleKey = buildClanGamesCycleKey(gamesWindow.startMs);
     const currentCwlSeason = resolveCurrentCwlSeasonKey(nowMs);
+    const liveClanTagByPlayerTag = await loadLiveClanTagsByPlayerTag({
+      cocService: input.cocService,
+      playerTags: normalizedTags,
+    });
 
     const signalStateKeyByTag = new Map(
       normalizedTags.map((playerTag) => [
@@ -326,16 +330,21 @@ export class TodoSnapshotService {
         ),
       ]),
     );
+    const resolvedClanTagByPlayerTag = new Map<string, string | null>();
+    for (const playerTag of normalizedTags) {
+      const liveClanTag = liveClanTagByPlayerTag.get(playerTag) ?? "";
+      const fromMember = latestClanMemberByTag.get(playerTag)?.clanTag ?? "";
+      const fromExisting = existingByTag.get(playerTag)?.clanTag ?? "";
+      const resolvedClanTag =
+        normalizeClanTag(liveClanTag || fromMember || fromExisting) || null;
+      resolvedClanTagByPlayerTag.set(playerTag, resolvedClanTag);
+    }
 
     const clanTags = [
       ...new Set(
-        normalizedTags
-          .map((playerTag) => {
-            const fromMember = latestClanMemberByTag.get(playerTag)?.clanTag ?? "";
-            const fromExisting = existingByTag.get(playerTag)?.clanTag ?? "";
-            return normalizeClanTag(fromMember || fromExisting);
-          })
-          .filter(Boolean),
+        [...resolvedClanTagByPlayerTag.values()].filter(
+          (value): value is string => Boolean(value),
+        ),
       ),
     ];
 
@@ -457,6 +466,12 @@ export class TodoSnapshotService {
       cwlWarByClan,
       trackedCwlTags: cwlTrackedTagSet,
     });
+    const liveRaidAttacksUsedByPlayerTag =
+      await loadLiveRaidAttacksUsedByPlayerTag({
+        cocService: input.cocService,
+        raidWindow,
+        resolvedClanTagByPlayerTag,
+      });
 
     const snapshotUpserts: Array<
       Parameters<typeof prisma.todoPlayerSnapshot.upsert>[0]
@@ -468,10 +483,7 @@ export class TodoSnapshotService {
     for (const playerTag of normalizedTags) {
       const existing = existingByTag.get(playerTag);
       const latestClanMember = latestClanMemberByTag.get(playerTag) ?? null;
-      const resolvedClanTag =
-        normalizeClanTag(latestClanMember?.clanTag ?? "") ||
-        normalizeClanTag(existing?.clanTag ?? "") ||
-        null;
+      const resolvedClanTag = resolvedClanTagByPlayerTag.get(playerTag) ?? null;
       const resolvedClanName =
         (resolvedClanTag ? trackedClanNameByTag.get(resolvedClanTag) : null) ||
         sanitizeDisplayText(existing?.clanName ?? "") ||
@@ -578,7 +590,9 @@ export class TodoSnapshotService {
         cwlPhase,
         cwlEndsAt,
         raidActive: raidWindow.active,
-        raidAttacksUsed: clampInt(existing?.raidAttacksUsed, 0, 6),
+        raidAttacksUsed: raidWindow.active
+          ? clampInt(liveRaidAttacksUsedByPlayerTag.get(playerTag), 0, 6)
+          : 0,
         raidAttacksMax: 6,
         raidEndsAt: new Date(raidWindow.endMs),
         gamesActive: gamesWindow.active,
@@ -1066,6 +1080,124 @@ async function resolveActiveCwlWarForClan(input: {
   }
 
   return null;
+}
+
+/** Purpose: resolve live current-clan tags for player tags when CoC access is available. */
+async function loadLiveClanTagsByPlayerTag(input: {
+  cocService?: CoCService;
+  playerTags: string[];
+}): Promise<Map<string, string>> {
+  if (!input.cocService || typeof input.cocService.getPlayerRaw !== "function") {
+    return new Map();
+  }
+
+  const entries = await Promise.all(
+    input.playerTags.map(async (playerTag) => {
+      const player = await input.cocService!
+        .getPlayerRaw(playerTag, { suppressTelemetry: true })
+        .catch(() => null);
+      const clanTag = normalizeClanTag(String(player?.clan?.tag ?? ""));
+      return [playerTag, clanTag] as const;
+    }),
+  );
+  return new Map(
+    entries.filter((entry): entry is [string, string] => Boolean(entry[0] && entry[1])),
+  );
+}
+
+/** Purpose: fetch active raid-season member attacks once per clan and fan out by player tag. */
+async function loadLiveRaidAttacksUsedByPlayerTag(input: {
+  cocService?: CoCService;
+  raidWindow: TodoWindow;
+  resolvedClanTagByPlayerTag: Map<string, string | null>;
+}): Promise<Map<string, number>> {
+  if (
+    !input.raidWindow.active ||
+    !input.cocService ||
+    typeof input.cocService.getClanCapitalRaidSeasons !== "function"
+  ) {
+    return new Map();
+  }
+
+  const playerTagsByClanTag = new Map<string, string[]>();
+  for (const [playerTag, clanTag] of input.resolvedClanTagByPlayerTag.entries()) {
+    if (!clanTag) continue;
+    const existing = playerTagsByClanTag.get(clanTag);
+    if (existing) {
+      existing.push(playerTag);
+      continue;
+    }
+    playerTagsByClanTag.set(clanTag, [playerTag]);
+  }
+  if (playerTagsByClanTag.size <= 0) return new Map();
+
+  const attacksByPlayerTag = new Map<string, number>();
+  const clanTags = [...playerTagsByClanTag.keys()];
+  const clanMemberMaps = await Promise.all(
+    clanTags.map(async (clanTag) => {
+      const seasons = await input.cocService!
+        .getClanCapitalRaidSeasons(clanTag, 2)
+        .catch(() => []);
+      const season = selectRelevantRaidSeason({
+        seasons,
+        raidWindow: input.raidWindow,
+      });
+      const memberAttacksByTag = new Map<string, number>();
+      for (const member of Array.isArray(season?.members) ? season.members : []) {
+        const memberTag = normalizePlayerTag(String(member?.tag ?? ""));
+        if (!memberTag) continue;
+        memberAttacksByTag.set(memberTag, clampInt(member?.attacks, 0, 6));
+      }
+      return [clanTag, memberAttacksByTag] as const;
+    }),
+  );
+  const memberAttacksByClanTag = new Map(clanMemberMaps);
+
+  for (const [clanTag, playerTags] of playerTagsByClanTag.entries()) {
+    const memberAttacksByTag = memberAttacksByClanTag.get(clanTag) ?? new Map<string, number>();
+    for (const playerTag of playerTags) {
+      attacksByPlayerTag.set(
+        playerTag,
+        clampInt(memberAttacksByTag.get(playerTag), 0, 6),
+      );
+    }
+  }
+
+  return attacksByPlayerTag;
+}
+
+/** Purpose: choose one canonical raid season aligned to the active todo raid window. */
+function selectRelevantRaidSeason(input: {
+  seasons: ClanCapitalRaidSeason[];
+  raidWindow: TodoWindow;
+}): ClanCapitalRaidSeason | null {
+  if (!Array.isArray(input.seasons) || input.seasons.length <= 0) {
+    return null;
+  }
+
+  const withTimes = input.seasons.map((season) => ({
+    season,
+    startMs: parseCocTime(season.startTime ?? null)?.getTime() ?? null,
+    endMs: parseCocTime(season.endTime ?? null)?.getTime() ?? null,
+  }));
+
+  const exact = withTimes.find(
+    (entry) =>
+      entry.startMs === input.raidWindow.startMs ||
+      entry.endMs === input.raidWindow.endMs,
+  );
+  if (exact) return exact.season;
+
+  const nearestByEnd = [...withTimes]
+    .filter((entry): entry is { season: ClanCapitalRaidSeason; startMs: number | null; endMs: number } => entry.endMs !== null)
+    .sort(
+      (a, b) =>
+        Math.abs(a.endMs - input.raidWindow.endMs) -
+        Math.abs(b.endMs - input.raidWindow.endMs),
+    )[0];
+  if (nearestByEnd) return nearestByEnd.season;
+
+  return input.seasons[0];
 }
 
 /** Purpose: compute the current or next raid-weekend window with UTC-safe boundaries. */

--- a/tests/todoSnapshot.service.test.ts
+++ b/tests/todoSnapshot.service.test.ts
@@ -177,6 +177,135 @@ describe("TodoSnapshotService", () => {
     expect(prismaMock.cwlPlayerClanSeason.upsert).toHaveBeenCalledTimes(2);
   });
 
+  it("sources active raid attacks from live clan raid members even for untracked clans", async () => {
+    prismaMock.todoPlayerSnapshot.findMany.mockResolvedValue([
+      buildSnapshotRow({
+        raidActive: true,
+        raidAttacksUsed: 0,
+      }),
+    ]);
+    prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue([]);
+    prismaMock.fwaWarMemberCurrent.findMany.mockResolvedValue([]);
+    prismaMock.currentWar.findMany.mockResolvedValue([]);
+    prismaMock.trackedClan.findMany.mockResolvedValue([]);
+    prismaMock.cwlTrackedClan.findMany.mockResolvedValue([]);
+    prismaMock.cwlPlayerClanSeason.findMany.mockResolvedValue([]);
+    const cocService = {
+      getPlayerRaw: vi.fn().mockResolvedValue({
+        tag: "#PYLQ0289",
+        clan: { tag: "#P2YLC8R0" },
+      }),
+      getClanCapitalRaidSeasons: vi.fn().mockResolvedValue([
+        {
+          startTime: "20260327T070000.000Z",
+          endTime: "20260330T070000.000Z",
+          members: [{ tag: "#PYLQ0289", attacks: 6 }],
+        },
+      ]),
+    };
+
+    await todoSnapshotService.refreshSnapshotsForPlayerTags({
+      playerTags: ["#PYLQ0289"],
+      cocService: cocService as any,
+      nowMs: Date.UTC(2026, 2, 27, 12, 0, 0, 0),
+    });
+
+    expect(cocService.getClanCapitalRaidSeasons).toHaveBeenCalledWith("#P2YLC8R0", 2);
+    expect(prismaMock.todoPlayerSnapshot.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({
+          clanTag: "#P2YLC8R0",
+          raidActive: true,
+          raidAttacksUsed: 6,
+        }),
+      }),
+    );
+  });
+
+  it("fetches raid-season data once per clan and fans out attacks across same-clan linked players", async () => {
+    prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue([]);
+    prismaMock.fwaWarMemberCurrent.findMany.mockResolvedValue([]);
+    prismaMock.currentWar.findMany.mockResolvedValue([]);
+    prismaMock.trackedClan.findMany.mockResolvedValue([]);
+    prismaMock.cwlTrackedClan.findMany.mockResolvedValue([]);
+    prismaMock.cwlPlayerClanSeason.findMany.mockResolvedValue([]);
+    const cocService = {
+      getPlayerRaw: vi.fn().mockImplementation(async (tag: string) => ({
+        tag,
+        clan: { tag: "#P2YLC8R0" },
+      })),
+      getClanCapitalRaidSeasons: vi.fn().mockResolvedValue([
+        {
+          startTime: "20260327T070000.000Z",
+          endTime: "20260330T070000.000Z",
+          members: [
+            { tag: "#PYLQ0289", attacks: 4 },
+            { tag: "#QGRJ2222", attacks: 2 },
+          ],
+        },
+      ]),
+    };
+
+    await todoSnapshotService.refreshSnapshotsForPlayerTags({
+      playerTags: ["#PYLQ0289", "#QGRJ2222"],
+      cocService: cocService as any,
+      nowMs: Date.UTC(2026, 2, 27, 12, 0, 0, 0),
+    });
+
+    expect(cocService.getClanCapitalRaidSeasons).toHaveBeenCalledTimes(1);
+    const upsertByTag = new Map(
+      prismaMock.todoPlayerSnapshot.upsert.mock.calls.map((call: any[]) => [
+        call?.[0]?.where?.playerTag,
+        call?.[0]?.update?.raidAttacksUsed,
+      ]),
+    );
+    expect(upsertByTag.get("#PYLQ0289")).toBe(4);
+    expect(upsertByTag.get("#QGRJ2222")).toBe(2);
+  });
+
+  it("writes raid attacks as zero when player is absent from live raid member list", async () => {
+    prismaMock.todoPlayerSnapshot.findMany.mockResolvedValue([
+      buildSnapshotRow({
+        raidActive: true,
+        raidAttacksUsed: 5,
+      }),
+    ]);
+    prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue([]);
+    prismaMock.fwaWarMemberCurrent.findMany.mockResolvedValue([]);
+    prismaMock.currentWar.findMany.mockResolvedValue([]);
+    prismaMock.trackedClan.findMany.mockResolvedValue([]);
+    prismaMock.cwlTrackedClan.findMany.mockResolvedValue([]);
+    prismaMock.cwlPlayerClanSeason.findMany.mockResolvedValue([]);
+    const cocService = {
+      getPlayerRaw: vi.fn().mockResolvedValue({
+        tag: "#PYLQ0289",
+        clan: { tag: "#P2YLC8R0" },
+      }),
+      getClanCapitalRaidSeasons: vi.fn().mockResolvedValue([
+        {
+          startTime: "20260327T070000.000Z",
+          endTime: "20260330T070000.000Z",
+          members: [{ tag: "#QGRJ2222", attacks: 6 }],
+        },
+      ]),
+    };
+
+    await todoSnapshotService.refreshSnapshotsForPlayerTags({
+      playerTags: ["#PYLQ0289"],
+      cocService: cocService as any,
+      nowMs: Date.UTC(2026, 2, 27, 12, 0, 0, 0),
+    });
+
+    expect(prismaMock.todoPlayerSnapshot.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({
+          raidActive: true,
+          raidAttacksUsed: 0,
+        }),
+      }),
+    );
+  });
+
   it("resolves CWL context from seasonal CWL registry mapping instead of home clan tag", async () => {
     prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue([
       {


### PR DESCRIPTION
- add live clan-capital raid season fetch in CoC service
- rebuild todo raidAttacksUsed from per-clan member attacks with one fetch per clan
- add snapshot tests for untracked clans, deduped clan fetches, and missing-member zero fallback