### PR TITLE
feat(fwa-compliance): group linked mirror obligations for compliance …

### DIFF
--- a/src/services/WarComplianceService.ts
+++ b/src/services/WarComplianceService.ts
@@ -1,5 +1,9 @@
 import { prisma } from "../prisma";
 import {
+  listPlayerLinksForClanMembers,
+  normalizePlayerTag,
+} from "./PlayerLinkService";
+import {
   type FwaLoseStyle,
   type MatchType,
   type WarComplianceAttack,
@@ -310,6 +314,37 @@ function buildAttackContextByAttack(
     });
   }
   return result;
+}
+
+type LinkedComplianceGroup = {
+  key: string;
+  isLinked: boolean;
+  memberTags: string[];
+  memberTagSet: Set<string>;
+};
+
+/** Purpose: track running clan true-stars totals in deterministic compliance order. */
+function buildStarsAfterByAttackIndex(
+  attacks: WarComplianceAttack[],
+): Map<number, number> {
+  const ordered = sortAttacksForComplianceOrder(attacks);
+  const result = new Map<number, number>();
+  let cumulative = 0;
+  for (let idx = 0; idx < ordered.length; idx += 1) {
+    const attack = ordered[idx];
+    cumulative += Math.max(0, Number(attack.trueStars ?? 0));
+    result.set(idx, cumulative);
+  }
+  return result;
+}
+
+/** Purpose: identify whether a traditional-loss attack row is in the late-window enforcement band. */
+function isLateLoseTraditionalWindow(attack: WarComplianceAttack): boolean {
+  if (!(attack.warEndTime instanceof Date)) return false;
+  const hoursRemaining =
+    (attack.warEndTime.getTime() - attack.attackSeenAt.getTime()) /
+    (60 * 60 * 1000);
+  return Number.isFinite(hoursRemaining) && hoursRemaining < 12;
 }
 
 type NotFollowingReason = {
@@ -1649,6 +1684,347 @@ export class WarComplianceService {
     });
   }
 
+  /** Purpose: resolve linked participant groups from canonical PlayerLink ownership for mirror-obligation substitutions. */
+  private async resolveLinkedComplianceGroups(
+    participants: WarComplianceParticipant[],
+  ): Promise<LinkedComplianceGroup[]> {
+    const participantByTag = new Map<string, WarComplianceParticipant>();
+    const orderedParticipantTags: string[] = [];
+    for (const participant of participants) {
+      const tag = normalizeTag(participant.playerTag);
+      if (!tag || participantByTag.has(tag)) continue;
+      participantByTag.set(tag, participant);
+      orderedParticipantTags.push(tag);
+    }
+
+    const orderedLinkLookupTags = orderedParticipantTags
+      .map((tag) => normalizePlayerTag(tag))
+      .filter(Boolean);
+    const lookupTagsUnique = [...new Set(orderedLinkLookupTags)];
+    const linkedRows =
+      lookupTagsUnique.length >= 2
+        ? await listPlayerLinksForClanMembers({
+            memberTagsInOrder: lookupTagsUnique,
+          }).catch(() => [])
+        : [];
+    const linkedUserByPlayerTag = new Map<string, string>(
+      linkedRows.map((row) => [normalizePlayerTag(row.playerTag), row.discordUserId]),
+    );
+
+    const groupByKey = new Map<
+      string,
+      { key: string; isLinked: boolean; memberTags: string[] }
+    >();
+    for (const tag of orderedParticipantTags) {
+      const strictTag = normalizePlayerTag(tag);
+      const linkedUserId = strictTag
+        ? linkedUserByPlayerTag.get(strictTag) ?? null
+        : null;
+      const key = linkedUserId ? `user:${linkedUserId}` : `tag:${tag}`;
+      const existing = groupByKey.get(key) ?? {
+        key,
+        isLinked: Boolean(linkedUserId),
+        memberTags: [],
+      };
+      existing.memberTags.push(tag);
+      groupByKey.set(key, existing);
+    }
+
+    const sortedPosition = (tag: string): number => {
+      const pos = participantByTag.get(tag)?.playerPosition;
+      return Number.isFinite(Number(pos)) && Number(pos) > 0
+        ? Number(pos)
+        : Number.MAX_SAFE_INTEGER;
+    };
+
+    return [...groupByKey.values()].map((group) => {
+      const memberTags = [...new Set(group.memberTags)].sort((a, b) => {
+        const posDelta = sortedPosition(a) - sortedPosition(b);
+        if (posDelta !== 0) return posDelta;
+        return a.localeCompare(b);
+      });
+      return {
+        key: group.key,
+        isLinked: group.isLinked,
+        memberTags,
+        memberTagSet: new Set(memberTags),
+      };
+    });
+  }
+
+  /** Purpose: evaluate grouped mirror obligations for FWA-WIN strict-window rules using linked-account substitution. */
+  private evaluateFwaWinLinkedGroupViolations(input: {
+    group: LinkedComplianceGroup;
+    orderedAttacks: WarComplianceAttack[];
+    attackContextByAttack: Map<WarComplianceAttack, AttackContext>;
+    participantByTag: Map<string, WarComplianceParticipant>;
+  }): Set<string> {
+    const strictAttackIndexes: number[] = [];
+    const strictSeenByTag = new Set<string>();
+    const mirrorTripleInStrictByTag = new Set<string>();
+    for (let idx = 0; idx < input.orderedAttacks.length; idx += 1) {
+      const attack = input.orderedAttacks[idx];
+      const playerTag = normalizeTag(attack.playerTag);
+      if (!input.group.memberTagSet.has(playerTag)) continue;
+      const context = input.attackContextByAttack.get(attack);
+      if (!context?.isStrictWindow) continue;
+      strictAttackIndexes.push(idx);
+      strictSeenByTag.add(playerTag);
+      if (context.isMirror && Number(attack.stars ?? 0) >= 3) {
+        mirrorTripleInStrictByTag.add(playerTag);
+      }
+    }
+
+    const obligations = [...strictSeenByTag]
+      .map((ownerTag) => ({
+        ownerTag,
+        ownerPosition: input.participantByTag.get(ownerTag)?.playerPosition ?? null,
+      }))
+      .filter(
+        (row): row is { ownerTag: string; ownerPosition: number } =>
+          Number.isFinite(Number(row.ownerPosition)) &&
+          Number(row.ownerPosition) > 0,
+      )
+      .sort((a, b) => {
+        if (a.ownerPosition !== b.ownerPosition) {
+          return a.ownerPosition - b.ownerPosition;
+        }
+        return a.ownerTag.localeCompare(b.ownerTag);
+      });
+
+    const usedAttackIndexes = new Set<number>();
+    const satisfiedOwnerTags = new Set<string>();
+    for (const obligation of obligations) {
+      for (const idx of strictAttackIndexes) {
+        if (usedAttackIndexes.has(idx)) continue;
+        const attack = input.orderedAttacks[idx];
+        const defenderPosition = Number(attack.defenderPosition ?? NaN);
+        if (!Number.isFinite(defenderPosition) || defenderPosition <= 0) continue;
+        if (defenderPosition !== obligation.ownerPosition) continue;
+        if (Number(attack.stars ?? 0) < 3) continue;
+        usedAttackIndexes.add(idx);
+        satisfiedOwnerTags.add(obligation.ownerTag);
+        break;
+      }
+    }
+
+    const violatingTags = new Set<string>();
+    for (const obligation of obligations) {
+      if (!satisfiedOwnerTags.has(obligation.ownerTag)) {
+        violatingTags.add(obligation.ownerTag);
+      }
+    }
+
+    for (const idx of strictAttackIndexes) {
+      const attack = input.orderedAttacks[idx];
+      const context = input.attackContextByAttack.get(attack);
+      if (!context || context.isMirror) continue;
+      const playerTag = normalizeTag(attack.playerTag);
+      const stars = Number(attack.stars ?? 0);
+      const trueStars = Number(attack.trueStars ?? 0);
+      if (stars <= 0) {
+        violatingTags.add(playerTag);
+        continue;
+      }
+      if (stars === 3 && trueStars > 0 && !usedAttackIndexes.has(idx)) {
+        violatingTags.add(playerTag);
+      }
+    }
+
+    for (const playerTag of strictSeenByTag) {
+      const ownerPosition = input.participantByTag.get(playerTag)?.playerPosition;
+      const hasOwnedMirror =
+        Number.isFinite(Number(ownerPosition)) && Number(ownerPosition) > 0;
+      if (hasOwnedMirror) continue;
+      if (!mirrorTripleInStrictByTag.has(playerTag)) {
+        violatingTags.add(playerTag);
+      }
+    }
+
+    return violatingTags;
+  }
+
+  /** Purpose: evaluate grouped mirror obligations for FWA-LOSS_TRADITIONAL late-window mirror rules. */
+  private evaluateFwaLossTraditionalLinkedGroupViolations(input: {
+    group: LinkedComplianceGroup;
+    orderedAttacks: WarComplianceAttack[];
+    starsAfterByAttackIndex: Map<number, number>;
+    participantByTag: Map<string, WarComplianceParticipant>;
+  }): Set<string> {
+    const lateAttackIndexes: number[] = [];
+    const lateSeenByTag = new Set<string>();
+    for (let idx = 0; idx < input.orderedAttacks.length; idx += 1) {
+      const attack = input.orderedAttacks[idx];
+      const playerTag = normalizeTag(attack.playerTag);
+      if (!input.group.memberTagSet.has(playerTag)) continue;
+      if (!isLateLoseTraditionalWindow(attack)) continue;
+      lateAttackIndexes.push(idx);
+      lateSeenByTag.add(playerTag);
+    }
+
+    const obligations = [...lateSeenByTag]
+      .map((ownerTag) => ({
+        ownerTag,
+        ownerPosition: input.participantByTag.get(ownerTag)?.playerPosition ?? null,
+      }))
+      .filter(
+        (row): row is { ownerTag: string; ownerPosition: number } =>
+          Number.isFinite(Number(row.ownerPosition)) &&
+          Number(row.ownerPosition) > 0,
+      )
+      .sort((a, b) => {
+        if (a.ownerPosition !== b.ownerPosition) {
+          return a.ownerPosition - b.ownerPosition;
+        }
+        return a.ownerTag.localeCompare(b.ownerTag);
+      });
+
+    const usedAttackIndexes = new Set<number>();
+    const satisfiedOwnerTags = new Set<string>();
+    for (const obligation of obligations) {
+      for (const idx of lateAttackIndexes) {
+        if (usedAttackIndexes.has(idx)) continue;
+        const attack = input.orderedAttacks[idx];
+        const defenderPosition = Number(attack.defenderPosition ?? NaN);
+        if (!Number.isFinite(defenderPosition) || defenderPosition <= 0) continue;
+        if (defenderPosition !== obligation.ownerPosition) continue;
+        if (Number(attack.stars ?? 0) !== 2) continue;
+        usedAttackIndexes.add(idx);
+        satisfiedOwnerTags.add(obligation.ownerTag);
+        break;
+      }
+    }
+
+    const violatingTags = new Set<string>();
+    for (let idx = 0; idx < input.orderedAttacks.length; idx += 1) {
+      const attack = input.orderedAttacks[idx];
+      const playerTag = normalizeTag(attack.playerTag);
+      if (!input.group.memberTagSet.has(playerTag)) continue;
+      const stars = Number(attack.stars ?? 0);
+
+      if (isLateLoseTraditionalWindow(attack)) {
+        const playerPosition = attack.playerPosition ?? null;
+        const defenderPosition = attack.defenderPosition ?? null;
+        const isMirror =
+          playerPosition !== null &&
+          defenderPosition !== null &&
+          playerPosition === defenderPosition;
+        const validLateAttack =
+          (isMirror && stars === 2) ||
+          (!isMirror && stars === 1) ||
+          (stars === 2 && usedAttackIndexes.has(idx));
+        if (!validLateAttack) {
+          violatingTags.add(playerTag);
+        }
+        continue;
+      }
+
+      if (!(stars === 1 || stars === 2)) {
+        violatingTags.add(playerTag);
+      }
+      if ((input.starsAfterByAttackIndex.get(idx) ?? 0) > 100) {
+        violatingTags.add(playerTag);
+      }
+    }
+
+    for (const obligation of obligations) {
+      if (!satisfiedOwnerTags.has(obligation.ownerTag)) {
+        violatingTags.add(obligation.ownerTag);
+      }
+    }
+
+    return violatingTags;
+  }
+
+  /** Purpose: apply linked-account mirror-obligation substitutions to canonical not-following output without introducing police-only logic. */
+  private async applyLinkedMirrorGroupingToNotFollowingNames(input: {
+    baselineNames: string[];
+    participantByLabel: Map<string, WarComplianceParticipant>;
+    participants: WarComplianceParticipant[];
+    attacks: WarComplianceAttack[];
+    attackContextByAttack: Map<WarComplianceAttack, AttackContext>;
+    matchType: MatchType;
+    expectedOutcome: "WIN" | "LOSE" | null;
+    loseStyle: FwaLoseStyle;
+  }): Promise<string[]> {
+    const baselineNamesUniqueSorted = [...new Set(input.baselineNames)].sort((a, b) =>
+      a.localeCompare(b),
+    );
+    const groupedModeEnabled =
+      input.matchType === "FWA" &&
+      (input.expectedOutcome === "WIN" ||
+        (input.expectedOutcome === "LOSE" && input.loseStyle === "TRADITIONAL"));
+    if (!groupedModeEnabled) return baselineNamesUniqueSorted;
+
+    const groups = await this.resolveLinkedComplianceGroups(input.participants);
+    const hasMultiLinkedGroup = groups.some(
+      (group) => group.isLinked && group.memberTags.length > 1,
+    );
+    if (!hasMultiLinkedGroup) return baselineNamesUniqueSorted;
+
+    const participantByTag = new Map<string, WarComplianceParticipant>();
+    const labelByTag = new Map<string, string>();
+    for (const participant of input.participants) {
+      const tag = normalizeTag(participant.playerTag);
+      if (!tag) continue;
+      participantByTag.set(tag, participant);
+      labelByTag.set(
+        tag,
+        getParticipantLabel({
+          playerName: participant.playerName,
+          playerTag: participant.playerTag,
+        }),
+      );
+    }
+
+    const preservedUnknownNames: string[] = [];
+    const baselineViolationTags = new Set<string>();
+    for (const name of baselineNamesUniqueSorted) {
+      const participant = input.participantByLabel.get(name);
+      const tag = normalizeTag(participant?.playerTag ?? "");
+      if (!tag) {
+        preservedUnknownNames.push(name);
+        continue;
+      }
+      baselineViolationTags.add(tag);
+    }
+
+    const orderedAttacks = sortAttacksForComplianceOrder(input.attacks);
+    const starsAfterByAttackIndex = buildStarsAfterByAttackIndex(input.attacks);
+    for (const group of groups) {
+      if (!group.isLinked || group.memberTags.length <= 1) continue;
+      for (const memberTag of group.memberTags) {
+        baselineViolationTags.delete(memberTag);
+      }
+
+      const groupedViolations =
+        input.expectedOutcome === "WIN"
+          ? this.evaluateFwaWinLinkedGroupViolations({
+              group,
+              orderedAttacks,
+              attackContextByAttack: input.attackContextByAttack,
+              participantByTag,
+            })
+          : this.evaluateFwaLossTraditionalLinkedGroupViolations({
+              group,
+              orderedAttacks,
+              starsAfterByAttackIndex,
+              participantByTag,
+            });
+      for (const tag of groupedViolations) {
+        baselineViolationTags.add(tag);
+      }
+    }
+
+    const mappedNames = [...baselineViolationTags]
+      .map((tag) => labelByTag.get(tag))
+      .filter((name): name is string => Boolean(name))
+      .sort((a, b) => a.localeCompare(b));
+    return [...new Set([...mappedNames, ...preservedUnknownNames])].sort((a, b) =>
+      a.localeCompare(b),
+    );
+  }
+
   /** Purpose: resolve effective FWA-WIN strict-window gate config for command evaluations. */
   private async resolveEffectiveFwaWinGateConfig(
     context: ComplianceContext,
@@ -1760,6 +2136,17 @@ export class WarComplianceService {
       expectedOutcome: context.expectedOutcome,
       loseStyle,
     });
+    const adjustedNotFollowingNames =
+      await this.applyLinkedMirrorGroupingToNotFollowingNames({
+        baselineNames: snapshot.notFollowingPlan,
+        participantByLabel,
+        participants: context.participants,
+        attacks: context.attacks,
+        attackContextByAttack,
+        matchType: context.matchType,
+        expectedOutcome: context.expectedOutcome,
+        loseStyle,
+      });
 
     return {
       clanTag: context.clanTag,
@@ -1783,7 +2170,7 @@ export class WarComplianceService {
         loseStyle,
       }),
       notFollowingPlan: mapNamesToIssues({
-        names: snapshot.notFollowingPlan,
+        names: adjustedNotFollowingNames,
         ruleType: "not_following_plan",
         expectedBehavior: expectedPlanBehavior,
         participantByLabel,

--- a/tests/fwaPolice.service.test.ts
+++ b/tests/fwaPolice.service.test.ts
@@ -239,6 +239,62 @@ describe("FwaPoliceService", () => {
     expect(result.dmSent).toBe(0);
   });
 
+  it("does not send DM or log when canonical compliance returns no remaining violations", async () => {
+    prismaMock.trackedClan.findFirst.mockResolvedValue({
+      tag: "#2QG2C08UP",
+      name: "Alpha",
+      fwaPoliceDmEnabled: true,
+      fwaPoliceLogEnabled: true,
+      logChannelId: "channel-1",
+      notifyChannelId: null,
+      mailChannelId: null,
+    });
+
+    const dmSend = vi.fn().mockResolvedValue({});
+    const logSend = vi.fn().mockResolvedValue({});
+    const client = {
+      users: {
+        fetch: vi.fn().mockResolvedValue({
+          createDM: vi.fn().mockResolvedValue({ send: dmSend }),
+        }),
+      },
+      channels: {
+        fetch: vi.fn().mockResolvedValue({
+          isTextBased: () => true,
+          send: logSend,
+        }),
+      },
+    } as any;
+    const evaluateComplianceForCommand = vi.fn().mockResolvedValue({
+      status: "ok",
+      report: {
+        warId: 12345,
+        clanName: "Alpha",
+        opponentName: "Bravo",
+        notFollowingPlan: [],
+      },
+    });
+
+    const service = new FwaPoliceService();
+    const result = await service.enforceWarViolations({
+      client,
+      guildId: "guild-1",
+      clanTag: "#2QG2C08UP",
+      warId: 12345,
+      warCompliance: { evaluateComplianceForCommand } as any,
+    });
+
+    expect(result).toEqual({
+      evaluatedViolations: 0,
+      created: 0,
+      deduped: 0,
+      dmSent: 0,
+      logSent: 0,
+    });
+    expect(dmSend).not.toHaveBeenCalled();
+    expect(logSend).not.toHaveBeenCalled();
+  });
+
   it("does not resend duplicate handled violations across reevaluations", async () => {
     prismaMock.trackedClan.findFirst.mockResolvedValue({
       tag: "#2QG2C08UP",

--- a/tests/warCompliance.service.test.ts
+++ b/tests/warCompliance.service.test.ts
@@ -3,6 +3,7 @@ import { prisma } from "../src/prisma";
 import { WarComplianceService } from "../src/services/WarComplianceService";
 import { WarEventHistoryService } from "../src/services/war-events/history";
 import { computeWarComplianceForTest } from "../src/services/war-events/core";
+import * as PlayerLinkService from "../src/services/PlayerLinkService";
 
 describe("WarComplianceService", () => {
   afterEach(() => {
@@ -509,6 +510,523 @@ describe("WarComplianceService", () => {
 
     expect(report).not.toBeNull();
     expect(report?.notFollowingPlan).toHaveLength(0);
+  });
+
+  it("treats linked FWA-WIN mirrors as group-owned obligations in strict window", async () => {
+    const warStartTime = new Date("2026-03-01T00:00:00.000Z");
+    const warEndTime = new Date("2026-03-02T00:00:00.000Z");
+    const participants = [
+      {
+        playerName: "p1",
+        playerTag: "#P2YLC8R0",
+        attacksUsed: 2,
+        playerPosition: 4,
+      },
+      {
+        playerName: "p2",
+        playerTag: "#QGRJ2222",
+        attacksUsed: 2,
+        playerPosition: 5,
+      },
+      {
+        playerName: "p3",
+        playerTag: "#2QG2C08UP",
+        attacksUsed: 2,
+        playerPosition: 30,
+      },
+    ];
+    const attacks = [
+      {
+        playerTag: "#2QG2C08UP",
+        playerName: "p3",
+        playerPosition: 30,
+        defenderPosition: 4,
+        stars: 3,
+        trueStars: 3,
+        attackSeenAt: new Date("2026-03-01T01:00:00.000Z"),
+        warEndTime,
+        attackOrder: 1,
+      },
+      {
+        playerTag: "#2QG2C08UP",
+        playerName: "p3",
+        playerPosition: 30,
+        defenderPosition: 5,
+        stars: 3,
+        trueStars: 3,
+        attackSeenAt: new Date("2026-03-01T01:10:00.000Z"),
+        warEndTime,
+        attackOrder: 2,
+      },
+      {
+        playerTag: "#P2YLC8R0",
+        playerName: "p1",
+        playerPosition: 4,
+        defenderPosition: 1,
+        stars: 1,
+        trueStars: 1,
+        attackSeenAt: new Date("2026-03-01T01:20:00.000Z"),
+        warEndTime,
+        attackOrder: 3,
+      },
+      {
+        playerTag: "#P2YLC8R0",
+        playerName: "p1",
+        playerPosition: 4,
+        defenderPosition: 2,
+        stars: 1,
+        trueStars: 1,
+        attackSeenAt: new Date("2026-03-01T01:30:00.000Z"),
+        warEndTime,
+        attackOrder: 4,
+      },
+      {
+        playerTag: "#QGRJ2222",
+        playerName: "p2",
+        playerPosition: 5,
+        defenderPosition: 3,
+        stars: 2,
+        trueStars: 2,
+        attackSeenAt: new Date("2026-03-01T01:40:00.000Z"),
+        warEndTime,
+        attackOrder: 5,
+      },
+      {
+        playerTag: "#QGRJ2222",
+        playerName: "p2",
+        playerPosition: 5,
+        defenderPosition: 30,
+        stars: 3,
+        trueStars: 3,
+        attackSeenAt: new Date("2026-03-01T01:50:00.000Z"),
+        warEndTime,
+        attackOrder: 6,
+      },
+    ];
+
+    vi.spyOn(prisma.warAttacks, "findFirst").mockResolvedValue({
+      warStartTime,
+      warEndTime,
+      warId: 5001,
+    } as any);
+    vi.spyOn(prisma.warAttacks, "findMany")
+      .mockResolvedValueOnce(participants as any)
+      .mockResolvedValueOnce(attacks as any);
+    vi.spyOn(prisma.trackedClan, "findFirst").mockResolvedValue({
+      loseStyle: "TRADITIONAL",
+    } as any);
+    vi.spyOn(prisma.clanWarPlan, "findFirst").mockResolvedValue(null as any);
+    vi.spyOn(PlayerLinkService, "listPlayerLinksForClanMembers").mockResolvedValue([
+      { playerTag: "#P2YLC8R0", discordUserId: "111111111111111111" },
+      { playerTag: "#QGRJ2222", discordUserId: "111111111111111111" },
+      { playerTag: "#2QG2C08UP", discordUserId: "111111111111111111" },
+    ] as any);
+
+    const service = new WarComplianceService();
+    const report = await service.getComplianceReport({
+      clanTag: "#TEST",
+      preferredWarStartTime: warStartTime,
+      matchType: "FWA",
+      expectedOutcome: "WIN",
+    });
+
+    expect(report).not.toBeNull();
+    expect(report?.notFollowingPlan).toHaveLength(0);
+  });
+
+  it("assigns grouped FWA-WIN unmet mirror to the owning account", async () => {
+    const warStartTime = new Date("2026-03-01T00:00:00.000Z");
+    const warEndTime = new Date("2026-03-02T00:00:00.000Z");
+    const participants = [
+      {
+        playerName: "p1",
+        playerTag: "#P2YLC8R0",
+        attacksUsed: 2,
+        playerPosition: 4,
+      },
+      {
+        playerName: "p2",
+        playerTag: "#QGRJ2222",
+        attacksUsed: 2,
+        playerPosition: 5,
+      },
+      {
+        playerName: "p3",
+        playerTag: "#2QG2C08UP",
+        attacksUsed: 2,
+        playerPosition: 30,
+      },
+    ];
+    const attacks = [
+      {
+        playerTag: "#2QG2C08UP",
+        playerName: "p3",
+        playerPosition: 30,
+        defenderPosition: 4,
+        stars: 3,
+        trueStars: 3,
+        attackSeenAt: new Date("2026-03-01T01:00:00.000Z"),
+        warEndTime,
+        attackOrder: 1,
+      },
+      {
+        playerTag: "#2QG2C08UP",
+        playerName: "p3",
+        playerPosition: 30,
+        defenderPosition: 5,
+        stars: 3,
+        trueStars: 3,
+        attackSeenAt: new Date("2026-03-01T01:10:00.000Z"),
+        warEndTime,
+        attackOrder: 2,
+      },
+      {
+        playerTag: "#P2YLC8R0",
+        playerName: "p1",
+        playerPosition: 4,
+        defenderPosition: 1,
+        stars: 1,
+        trueStars: 1,
+        attackSeenAt: new Date("2026-03-01T01:20:00.000Z"),
+        warEndTime,
+        attackOrder: 3,
+      },
+      {
+        playerTag: "#P2YLC8R0",
+        playerName: "p1",
+        playerPosition: 4,
+        defenderPosition: 2,
+        stars: 1,
+        trueStars: 1,
+        attackSeenAt: new Date("2026-03-01T01:30:00.000Z"),
+        warEndTime,
+        attackOrder: 4,
+      },
+      {
+        playerTag: "#QGRJ2222",
+        playerName: "p2",
+        playerPosition: 5,
+        defenderPosition: 3,
+        stars: 2,
+        trueStars: 2,
+        attackSeenAt: new Date("2026-03-01T01:40:00.000Z"),
+        warEndTime,
+        attackOrder: 5,
+      },
+      {
+        playerTag: "#QGRJ2222",
+        playerName: "p2",
+        playerPosition: 5,
+        defenderPosition: 6,
+        stars: 2,
+        trueStars: 2,
+        attackSeenAt: new Date("2026-03-01T01:50:00.000Z"),
+        warEndTime,
+        attackOrder: 6,
+      },
+    ];
+
+    vi.spyOn(prisma.warAttacks, "findFirst").mockResolvedValue({
+      warStartTime,
+      warEndTime,
+      warId: 5002,
+    } as any);
+    vi.spyOn(prisma.warAttacks, "findMany")
+      .mockResolvedValueOnce(participants as any)
+      .mockResolvedValueOnce(attacks as any);
+    vi.spyOn(prisma.trackedClan, "findFirst").mockResolvedValue({
+      loseStyle: "TRADITIONAL",
+    } as any);
+    vi.spyOn(prisma.clanWarPlan, "findFirst").mockResolvedValue(null as any);
+    vi.spyOn(PlayerLinkService, "listPlayerLinksForClanMembers").mockResolvedValue([
+      { playerTag: "#P2YLC8R0", discordUserId: "111111111111111111" },
+      { playerTag: "#QGRJ2222", discordUserId: "111111111111111111" },
+      { playerTag: "#2QG2C08UP", discordUserId: "111111111111111111" },
+    ] as any);
+
+    const service = new WarComplianceService();
+    const report = await service.getComplianceReport({
+      clanTag: "#TEST",
+      preferredWarStartTime: warStartTime,
+      matchType: "FWA",
+      expectedOutcome: "WIN",
+    });
+
+    expect(report).not.toBeNull();
+    const violatedNames = report?.notFollowingPlan.map((row) => row.playerName) ?? [];
+    expect(violatedNames).toEqual(["p3"]);
+    expect(report?.notFollowingPlan[0]?.playerTag).toBe("#2QG2C08UP");
+  });
+
+  it("treats linked FWA-LOSS_TRADITIONAL mirror twos as group-owned obligations", async () => {
+    const warStartTime = new Date("2026-03-01T00:00:00.000Z");
+    const warEndTime = new Date("2026-03-02T00:00:00.000Z");
+    const participants = [
+      {
+        playerName: "p1",
+        playerTag: "#P2YLC8R0",
+        attacksUsed: 2,
+        playerPosition: 4,
+      },
+      {
+        playerName: "p2",
+        playerTag: "#QGRJ2222",
+        attacksUsed: 2,
+        playerPosition: 5,
+      },
+    ];
+    const attacks = [
+      {
+        playerTag: "#P2YLC8R0",
+        playerName: "p1",
+        playerPosition: 4,
+        defenderPosition: 4,
+        stars: 2,
+        trueStars: 2,
+        attackSeenAt: new Date("2026-03-01T13:00:00.000Z"),
+        warEndTime,
+        attackOrder: 1,
+      },
+      {
+        playerTag: "#P2YLC8R0",
+        playerName: "p1",
+        playerPosition: 4,
+        defenderPosition: 5,
+        stars: 2,
+        trueStars: 2,
+        attackSeenAt: new Date("2026-03-01T13:10:00.000Z"),
+        warEndTime,
+        attackOrder: 2,
+      },
+      {
+        playerTag: "#QGRJ2222",
+        playerName: "p2",
+        playerPosition: 5,
+        defenderPosition: 1,
+        stars: 1,
+        trueStars: 1,
+        attackSeenAt: new Date("2026-03-01T13:20:00.000Z"),
+        warEndTime,
+        attackOrder: 3,
+      },
+      {
+        playerTag: "#QGRJ2222",
+        playerName: "p2",
+        playerPosition: 5,
+        defenderPosition: 2,
+        stars: 1,
+        trueStars: 1,
+        attackSeenAt: new Date("2026-03-01T13:30:00.000Z"),
+        warEndTime,
+        attackOrder: 4,
+      },
+    ];
+
+    vi.spyOn(prisma.warAttacks, "findFirst").mockResolvedValue({
+      warStartTime,
+      warEndTime,
+      warId: 5003,
+    } as any);
+    vi.spyOn(prisma.warAttacks, "findMany")
+      .mockResolvedValueOnce(participants as any)
+      .mockResolvedValueOnce(attacks as any);
+    vi.spyOn(prisma.trackedClan, "findFirst").mockResolvedValue({
+      loseStyle: "TRADITIONAL",
+    } as any);
+    vi.spyOn(PlayerLinkService, "listPlayerLinksForClanMembers").mockResolvedValue([
+      { playerTag: "#P2YLC8R0", discordUserId: "111111111111111111" },
+      { playerTag: "#QGRJ2222", discordUserId: "111111111111111111" },
+    ] as any);
+
+    const service = new WarComplianceService();
+    const report = await service.getComplianceReport({
+      clanTag: "#TEST",
+      preferredWarStartTime: warStartTime,
+      matchType: "FWA",
+      expectedOutcome: "LOSE",
+    });
+
+    expect(report).not.toBeNull();
+    expect(report?.loseStyle).toBe("TRADITIONAL");
+    expect(report?.notFollowingPlan).toHaveLength(0);
+  });
+
+  it("keeps grouped LOSS_TRADITIONAL ownership deterministic and does not double-count one attack", async () => {
+    const warStartTime = new Date("2026-03-01T00:00:00.000Z");
+    const warEndTime = new Date("2026-03-02T00:00:00.000Z");
+    const participants = [
+      {
+        playerName: "p1",
+        playerTag: "#P2YLC8R0",
+        attacksUsed: 1,
+        playerPosition: 4,
+      },
+      {
+        playerName: "p2",
+        playerTag: "#QGRJ2222",
+        attacksUsed: 2,
+        playerPosition: 5,
+      },
+    ];
+    const attacks = [
+      {
+        playerTag: "#P2YLC8R0",
+        playerName: "p1",
+        playerPosition: 4,
+        defenderPosition: 4,
+        stars: 2,
+        trueStars: 2,
+        attackSeenAt: new Date("2026-03-01T13:00:00.000Z"),
+        warEndTime,
+        attackOrder: 1,
+      },
+      {
+        playerTag: "#QGRJ2222",
+        playerName: "p2",
+        playerPosition: 5,
+        defenderPosition: 1,
+        stars: 1,
+        trueStars: 1,
+        attackSeenAt: new Date("2026-03-01T13:10:00.000Z"),
+        warEndTime,
+        attackOrder: 2,
+      },
+      {
+        playerTag: "#QGRJ2222",
+        playerName: "p2",
+        playerPosition: 5,
+        defenderPosition: 2,
+        stars: 1,
+        trueStars: 1,
+        attackSeenAt: new Date("2026-03-01T13:20:00.000Z"),
+        warEndTime,
+        attackOrder: 3,
+      },
+    ];
+
+    vi.spyOn(prisma.warAttacks, "findFirst").mockResolvedValue({
+      warStartTime,
+      warEndTime,
+      warId: 5004,
+    } as any);
+    vi.spyOn(prisma.warAttacks, "findMany")
+      .mockResolvedValueOnce(participants as any)
+      .mockResolvedValueOnce(attacks as any);
+    vi.spyOn(prisma.trackedClan, "findFirst").mockResolvedValue({
+      loseStyle: "TRADITIONAL",
+    } as any);
+    vi.spyOn(PlayerLinkService, "listPlayerLinksForClanMembers").mockResolvedValue([
+      { playerTag: "#P2YLC8R0", discordUserId: "111111111111111111" },
+      { playerTag: "#QGRJ2222", discordUserId: "111111111111111111" },
+    ] as any);
+
+    const service = new WarComplianceService();
+    const report = await service.getComplianceReport({
+      clanTag: "#TEST",
+      preferredWarStartTime: warStartTime,
+      matchType: "FWA",
+      expectedOutcome: "LOSE",
+    });
+
+    expect(report).not.toBeNull();
+    const violatedNames = report?.notFollowingPlan.map((row) => row.playerName) ?? [];
+    expect(violatedNames).toEqual(["p2"]);
+    expect(report?.notFollowingPlan[0]?.playerTag).toBe("#QGRJ2222");
+  });
+
+  it("does not allow cross-user mirror substitution between unrelated linked users", async () => {
+    const warStartTime = new Date("2026-03-01T00:00:00.000Z");
+    const warEndTime = new Date("2026-03-02T00:00:00.000Z");
+    const participants = [
+      {
+        playerName: "p1",
+        playerTag: "#P2YLC8R0",
+        attacksUsed: 2,
+        playerPosition: 4,
+      },
+      {
+        playerName: "p2",
+        playerTag: "#QGRJ2222",
+        attacksUsed: 2,
+        playerPosition: 5,
+      },
+    ];
+    const attacks = [
+      {
+        playerTag: "#P2YLC8R0",
+        playerName: "p1",
+        playerPosition: 4,
+        defenderPosition: 4,
+        stars: 3,
+        trueStars: 3,
+        attackSeenAt: new Date("2026-03-01T01:00:00.000Z"),
+        warEndTime,
+        attackOrder: 1,
+      },
+      {
+        playerTag: "#P2YLC8R0",
+        playerName: "p1",
+        playerPosition: 4,
+        defenderPosition: 5,
+        stars: 3,
+        trueStars: 0,
+        attackSeenAt: new Date("2026-03-01T01:10:00.000Z"),
+        warEndTime,
+        attackOrder: 2,
+      },
+      {
+        playerTag: "#QGRJ2222",
+        playerName: "p2",
+        playerPosition: 5,
+        defenderPosition: 1,
+        stars: 1,
+        trueStars: 1,
+        attackSeenAt: new Date("2026-03-01T01:20:00.000Z"),
+        warEndTime,
+        attackOrder: 3,
+      },
+      {
+        playerTag: "#QGRJ2222",
+        playerName: "p2",
+        playerPosition: 5,
+        defenderPosition: 2,
+        stars: 1,
+        trueStars: 1,
+        attackSeenAt: new Date("2026-03-01T01:30:00.000Z"),
+        warEndTime,
+        attackOrder: 4,
+      },
+    ];
+
+    vi.spyOn(prisma.warAttacks, "findFirst").mockResolvedValue({
+      warStartTime,
+      warEndTime,
+      warId: 5005,
+    } as any);
+    vi.spyOn(prisma.warAttacks, "findMany")
+      .mockResolvedValueOnce(participants as any)
+      .mockResolvedValueOnce(attacks as any);
+    vi.spyOn(prisma.trackedClan, "findFirst").mockResolvedValue({
+      loseStyle: "TRADITIONAL",
+    } as any);
+    vi.spyOn(prisma.clanWarPlan, "findFirst").mockResolvedValue(null as any);
+    vi.spyOn(PlayerLinkService, "listPlayerLinksForClanMembers").mockResolvedValue([
+      { playerTag: "#P2YLC8R0", discordUserId: "111111111111111111" },
+      { playerTag: "#QGRJ2222", discordUserId: "222222222222222222" },
+    ] as any);
+
+    const service = new WarComplianceService();
+    const report = await service.getComplianceReport({
+      clanTag: "#TEST",
+      preferredWarStartTime: warStartTime,
+      matchType: "FWA",
+      expectedOutcome: "WIN",
+    });
+
+    expect(report).not.toBeNull();
+    const violatedNames = report?.notFollowingPlan.map((row) => row.playerName) ?? [];
+    expect(violatedNames).toEqual(["p2"]);
+    expect(report?.notFollowingPlan[0]?.playerTag).toBe("#QGRJ2222");
   });
 
   it("returns null report for BL/MM checks without hitting DB", async () => {


### PR DESCRIPTION
…and police

- evaluate FWA WIN and FWA LOSS_TRADITIONAL mirror obligations at linked Discord-user group scope in canonical WarComplianceService
- preserve ownership attribution on unmet mirrors and keep one-attack-per-obligation deterministic matching
- add canonical compliance and fwa police parity tests for grouped satisfaction, ownership, and no-send-on-cleared violations