### PR TITLE
fix(fwa-compliance): align violation gating with taken-mirror policy

### DIFF
--- a/src/commands/fwa/complianceEmbedView.ts
+++ b/src/commands/fwa/complianceEmbedView.ts
@@ -238,9 +238,7 @@ function renderViolationBlock(issue: WarComplianceIssue): string {
         }))
       : buildFallbackAttackDetails(issue, parsed);
 
-  if (details.length <= 0) {
-    lines.push("→ No targets logged.");
-  } else {
+  if (details.length > 0) {
     for (const detail of details) {
       const target = detail.defenderPosition !== null ? `#${detail.defenderPosition}` : "#?";
       lines.push(

--- a/src/services/WarComplianceService.ts
+++ b/src/services/WarComplianceService.ts
@@ -1759,15 +1759,17 @@ export class WarComplianceService {
     attackContextByAttack: Map<WarComplianceAttack, AttackContext>;
     participantByTag: Map<string, WarComplianceParticipant>;
   }): Set<string> {
+    const allStrictAttackIndexes: number[] = [];
     const strictAttackIndexes: number[] = [];
     const strictSeenByTag = new Set<string>();
     const mirrorTripleInStrictByTag = new Set<string>();
     for (let idx = 0; idx < input.orderedAttacks.length; idx += 1) {
       const attack = input.orderedAttacks[idx];
-      const playerTag = normalizeTag(attack.playerTag);
-      if (!input.group.memberTagSet.has(playerTag)) continue;
       const context = input.attackContextByAttack.get(attack);
       if (!context?.isStrictWindow) continue;
+      allStrictAttackIndexes.push(idx);
+      const playerTag = normalizeTag(attack.playerTag);
+      if (!input.group.memberTagSet.has(playerTag)) continue;
       strictAttackIndexes.push(idx);
       strictSeenByTag.add(playerTag);
       if (context.isMirror && Number(attack.stars ?? 0) >= 3) {
@@ -1795,7 +1797,7 @@ export class WarComplianceService {
     const usedAttackIndexes = new Set<number>();
     const satisfiedOwnerTags = new Set<string>();
     for (const obligation of obligations) {
-      for (const idx of strictAttackIndexes) {
+      for (const idx of allStrictAttackIndexes) {
         if (usedAttackIndexes.has(idx)) continue;
         const attack = input.orderedAttacks[idx];
         const defenderPosition = Number(attack.defenderPosition ?? NaN);
@@ -1810,6 +1812,10 @@ export class WarComplianceService {
 
     const violatingTags = new Set<string>();
     for (const obligation of obligations) {
+      const ownerAttacksUsed = Number(
+        input.participantByTag.get(obligation.ownerTag)?.attacksUsed ?? 0,
+      );
+      if (ownerAttacksUsed < 2) continue;
       if (!satisfiedOwnerTags.has(obligation.ownerTag)) {
         violatingTags.add(obligation.ownerTag);
       }
@@ -1851,15 +1857,15 @@ export class WarComplianceService {
     starsAfterByAttackIndex: Map<number, number>;
     participantByTag: Map<string, WarComplianceParticipant>;
   }): Set<string> {
+    const allLateAttackIndexes: number[] = [];
     const lateAttackIndexes: number[] = [];
-    const lateSeenByTag = new Set<string>();
     for (let idx = 0; idx < input.orderedAttacks.length; idx += 1) {
       const attack = input.orderedAttacks[idx];
+      if (!isLateLoseTraditionalWindow(attack)) continue;
+      allLateAttackIndexes.push(idx);
       const playerTag = normalizeTag(attack.playerTag);
       if (!input.group.memberTagSet.has(playerTag)) continue;
-      if (!isLateLoseTraditionalWindow(attack)) continue;
       lateAttackIndexes.push(idx);
-      lateSeenByTag.add(playerTag);
     }
 
     const obligations = input.group.memberTags
@@ -1882,13 +1888,13 @@ export class WarComplianceService {
     const usedAttackIndexes = new Set<number>();
     const satisfiedOwnerTags = new Set<string>();
     for (const obligation of obligations) {
-      for (const idx of lateAttackIndexes) {
+      for (const idx of allLateAttackIndexes) {
         if (usedAttackIndexes.has(idx)) continue;
         const attack = input.orderedAttacks[idx];
         const defenderPosition = Number(attack.defenderPosition ?? NaN);
         if (!Number.isFinite(defenderPosition) || defenderPosition <= 0) continue;
         if (defenderPosition !== obligation.ownerPosition) continue;
-        if (Number(attack.stars ?? 0) !== 2) continue;
+        if (Number(attack.stars ?? 0) < 2) continue;
         usedAttackIndexes.add(idx);
         satisfiedOwnerTags.add(obligation.ownerTag);
         break;
@@ -1928,6 +1934,10 @@ export class WarComplianceService {
     }
 
     for (const obligation of obligations) {
+      const ownerAttacksUsed = Number(
+        input.participantByTag.get(obligation.ownerTag)?.attacksUsed ?? 0,
+      );
+      if (ownerAttacksUsed < 2) continue;
       if (!satisfiedOwnerTags.has(obligation.ownerTag)) {
         violatingTags.add(obligation.ownerTag);
       }

--- a/src/services/war-events/core.ts
+++ b/src/services/war-events/core.ts
@@ -255,10 +255,18 @@ export function computeWarComplianceForTest(input: {
     .filter(Boolean);
 
   const labelForTag = new Map<string, string>();
+  const playerPositionByTag = new Map<string, number>();
+  const attacksUsedByTag = new Map<string, number>();
   for (const p of participants) {
     const playerTag = normalizeTag(p.playerTag);
     const label = String(p.playerName ?? p.playerTag).trim();
     if (playerTag && label) labelForTag.set(playerTag, label);
+    if (playerTag && Number.isFinite(Number(p.playerPosition))) {
+      playerPositionByTag.set(playerTag, Number(p.playerPosition));
+    }
+    if (playerTag) {
+      attacksUsedByTag.set(playerTag, Math.max(0, Number(p.attacksUsed ?? 0)));
+    }
   }
   const notFollowing = new Set<string>();
   const addViolation = (playerTagRaw: string | null | undefined, fallbackName: string | null | undefined) => {
@@ -290,6 +298,7 @@ export function computeWarComplianceForTest(input: {
         Math.trunc(Number(input.winGateConfig?.allBasesOpenHoursLeft ?? 12))
       );
       const mirrorTripleByPlayer = new Map<string, boolean>();
+      const mirrorTripleByOwnedPosition = new Map<number, boolean>();
       const strictWindowSeenByPlayer = new Map<string, boolean>();
       for (let i = 0; i < attacks.length; i += 1) {
         const attack = attacks[i];
@@ -313,6 +322,9 @@ export function computeWarComplianceForTest(input: {
         const isStrictWindow = starsGateActive && isTimeGateActive;
         if (isStrictWindow) {
           strictWindowSeenByPlayer.set(playerTag, true);
+          if (defenderPos !== null && stars >= 3) {
+            mirrorTripleByOwnedPosition.set(defenderPos, true);
+          }
           const isMirror = playerPos !== null && defenderPos !== null && playerPos === defenderPos;
           if (isMirror && stars >= 3) {
             mirrorTripleByPlayer.set(playerTag, true);
@@ -325,7 +337,16 @@ export function computeWarComplianceForTest(input: {
       }
       for (const [playerTag, seenStrict] of strictWindowSeenByPlayer.entries()) {
         if (!seenStrict) continue;
-        if (!mirrorTripleByPlayer.get(playerTag)) {
+        const attacksUsed = attacksUsedByTag.get(playerTag) ?? 0;
+        if (attacksUsed < 2) continue;
+        const ownerPosition = playerPositionByTag.get(playerTag);
+        const mirrorAlreadyTripledByAnyone =
+          Number.isFinite(Number(ownerPosition)) &&
+          mirrorTripleByOwnedPosition.get(Number(ownerPosition)) === true;
+        if (
+          !mirrorTripleByPlayer.get(playerTag) &&
+          !mirrorAlreadyTripledByAnyone
+        ) {
           addViolation(playerTag, labelForTag.get(playerTag) ?? playerTag);
         }
       }

--- a/tests/fwaComplianceEmbedView.logic.test.ts
+++ b/tests/fwaComplianceEmbedView.logic.test.ts
@@ -143,6 +143,37 @@ describe("buildFwaComplianceEmbedView", () => {
     expect(plan).toContain("49★ | 21h 27m left");
   });
 
+  it("does not render a no-targets placeholder when violation details are empty", () => {
+    const rendered = buildFwaComplianceEmbedView({
+      userId: "123",
+      key: "payload",
+      isFwa: true,
+      clanName: "Rocky Road",
+      warPlanText: "No warplan details",
+      warId: 777,
+      expectedOutcome: "WIN",
+      warStartTime: null,
+      warEndTime: null,
+      participantsCount: 50,
+      attacksCount: 53,
+      missedBoth: [],
+      notFollowingPlan: [
+        makeViolation(3, "NoDetail", {
+          actualBehavior: "",
+          attackDetails: [],
+          breachContext: null,
+        }),
+      ],
+      activeView: "fwa_main",
+      mainPage: 0,
+      missedPage: 0,
+    });
+
+    const plan = toEmbedJson(rendered.embed).fields?.[2]?.value ?? "";
+    expect(plan).toContain("#3 NoDetail");
+    expect(plan).not.toContain("No targets logged");
+  });
+
   it("disables missed-attacks toggle when there are no missed-both players", () => {
     const rendered = buildFwaComplianceEmbedView({
       userId: "123",

--- a/tests/warCompliance.service.test.ts
+++ b/tests/warCompliance.service.test.ts
@@ -734,6 +734,161 @@ describe("WarComplianceService", () => {
     expect(report?.notFollowingPlan).toHaveLength(0);
   });
 
+  it("clears FWA-WIN mirror obligation when someone else already tripled that mirror", async () => {
+    const warStartTime = new Date("2026-03-01T00:00:00.000Z");
+    const warEndTime = new Date("2026-03-02T00:00:00.000Z");
+    const participants = [
+      {
+        playerName: "owner",
+        playerTag: "#OWNER",
+        attacksUsed: 2,
+        playerPosition: 5,
+      },
+      {
+        playerName: "thief",
+        playerTag: "#THIEF",
+        attacksUsed: 1,
+        playerPosition: 10,
+      },
+    ];
+    const attacks = [
+      {
+        playerTag: "#OWNER",
+        playerName: "owner",
+        playerPosition: 5,
+        defenderPosition: 1,
+        stars: 1,
+        trueStars: 1,
+        attackSeenAt: new Date("2026-03-01T01:00:00.000Z"),
+        warEndTime,
+        attackOrder: 1,
+      },
+      {
+        playerTag: "#THIEF",
+        playerName: "thief",
+        playerPosition: 10,
+        defenderPosition: 5,
+        stars: 3,
+        trueStars: 3,
+        attackSeenAt: new Date("2026-03-01T01:05:00.000Z"),
+        warEndTime,
+        attackOrder: 2,
+      },
+      {
+        playerTag: "#OWNER",
+        playerName: "owner",
+        playerPosition: 5,
+        defenderPosition: 2,
+        stars: 1,
+        trueStars: 1,
+        attackSeenAt: new Date("2026-03-01T01:10:00.000Z"),
+        warEndTime,
+        attackOrder: 3,
+      },
+    ];
+
+    vi.spyOn(prisma.warAttacks, "findFirst").mockResolvedValue({
+      warStartTime,
+      warEndTime,
+      warId: 50012,
+    } as any);
+    vi.spyOn(prisma.warAttacks, "findMany")
+      .mockResolvedValueOnce(participants as any)
+      .mockResolvedValueOnce(attacks as any);
+    vi.spyOn(prisma.trackedClan, "findFirst").mockResolvedValue({
+      loseStyle: "TRADITIONAL",
+    } as any);
+    vi.spyOn(prisma.clanWarPlan, "findFirst").mockResolvedValue(null as any);
+    vi.spyOn(PlayerLinkService, "listPlayerLinksForClanMembers").mockResolvedValue(
+      [] as any,
+    );
+
+    const service = new WarComplianceService();
+    const report = await service.getComplianceReport({
+      clanTag: "#TEST",
+      preferredWarStartTime: warStartTime,
+      matchType: "FWA",
+      expectedOutcome: "WIN",
+    });
+
+    expect(report).not.toBeNull();
+    const violatedTags = report?.notFollowingPlan.map((row) => row.playerTag) ?? [];
+    expect(violatedTags).toContain("#THIEF");
+    expect(violatedTags).not.toContain("#OWNER");
+  });
+
+  it("keeps one-attack FWA-WIN players off the violation list until a real breach occurs", async () => {
+    const warStartTime = new Date("2026-03-01T00:00:00.000Z");
+    const warEndTime = new Date("2026-03-02T00:00:00.000Z");
+    const participants = [
+      {
+        playerName: "safe_one_attack",
+        playerTag: "#SAFE1",
+        attacksUsed: 1,
+        playerPosition: 5,
+      },
+      {
+        playerName: "violator_one_attack",
+        playerTag: "#BAD1",
+        attacksUsed: 1,
+        playerPosition: 6,
+      },
+    ];
+    const attacks = [
+      {
+        playerTag: "#SAFE1",
+        playerName: "safe_one_attack",
+        playerPosition: 5,
+        defenderPosition: 5,
+        stars: 1,
+        trueStars: 1,
+        attackSeenAt: new Date("2026-03-01T01:00:00.000Z"),
+        warEndTime,
+        attackOrder: 1,
+      },
+      {
+        playerTag: "#BAD1",
+        playerName: "violator_one_attack",
+        playerPosition: 6,
+        defenderPosition: 11,
+        stars: 3,
+        trueStars: 3,
+        attackSeenAt: new Date("2026-03-01T01:05:00.000Z"),
+        warEndTime,
+        attackOrder: 2,
+      },
+    ];
+
+    vi.spyOn(prisma.warAttacks, "findFirst").mockResolvedValue({
+      warStartTime,
+      warEndTime,
+      warId: 50013,
+    } as any);
+    vi.spyOn(prisma.warAttacks, "findMany")
+      .mockResolvedValueOnce(participants as any)
+      .mockResolvedValueOnce(attacks as any);
+    vi.spyOn(prisma.trackedClan, "findFirst").mockResolvedValue({
+      loseStyle: "TRADITIONAL",
+    } as any);
+    vi.spyOn(prisma.clanWarPlan, "findFirst").mockResolvedValue(null as any);
+    vi.spyOn(PlayerLinkService, "listPlayerLinksForClanMembers").mockResolvedValue(
+      [] as any,
+    );
+
+    const service = new WarComplianceService();
+    const report = await service.getComplianceReport({
+      clanTag: "#TEST",
+      preferredWarStartTime: warStartTime,
+      matchType: "FWA",
+      expectedOutcome: "WIN",
+    });
+
+    expect(report).not.toBeNull();
+    const violatedTags = report?.notFollowingPlan.map((row) => row.playerTag) ?? [];
+    expect(violatedTags).toContain("#BAD1");
+    expect(violatedTags).not.toContain("#SAFE1");
+  });
+
   it("assigns grouped FWA-WIN unmet mirror to the owning account", async () => {
     const warStartTime = new Date("2026-03-01T00:00:00.000Z");
     const warEndTime = new Date("2026-03-02T00:00:00.000Z");
@@ -1022,6 +1177,95 @@ describe("WarComplianceService", () => {
     expect(report?.notFollowingPlan).toHaveLength(0);
   });
 
+  it("clears FWA-LOSS_TRADITIONAL mirror obligation when someone else already 2-stars that mirror", async () => {
+    const warStartTime = new Date("2026-03-01T00:00:00.000Z");
+    const warEndTime = new Date("2026-03-02T00:00:00.000Z");
+    const participants = [
+      {
+        playerName: "owner",
+        playerTag: "#LROWNER",
+        attacksUsed: 2,
+        playerPosition: 5,
+      },
+      {
+        playerName: "linked_idle",
+        playerTag: "#LRLINK",
+        attacksUsed: 0,
+        playerPosition: 6,
+      },
+      {
+        playerName: "outsider",
+        playerTag: "#LROUT",
+        attacksUsed: 1,
+        playerPosition: 10,
+      },
+    ];
+    const attacks = [
+      {
+        playerTag: "#LROWNER",
+        playerName: "owner",
+        playerPosition: 5,
+        defenderPosition: 1,
+        stars: 1,
+        trueStars: 1,
+        attackSeenAt: new Date("2026-03-01T13:00:00.000Z"),
+        warEndTime,
+        attackOrder: 1,
+      },
+      {
+        playerTag: "#LROUT",
+        playerName: "outsider",
+        playerPosition: 10,
+        defenderPosition: 5,
+        stars: 2,
+        trueStars: 2,
+        attackSeenAt: new Date("2026-03-01T13:05:00.000Z"),
+        warEndTime,
+        attackOrder: 2,
+      },
+      {
+        playerTag: "#LROWNER",
+        playerName: "owner",
+        playerPosition: 5,
+        defenderPosition: 2,
+        stars: 1,
+        trueStars: 1,
+        attackSeenAt: new Date("2026-03-01T13:10:00.000Z"),
+        warEndTime,
+        attackOrder: 3,
+      },
+    ];
+
+    vi.spyOn(prisma.warAttacks, "findFirst").mockResolvedValue({
+      warStartTime,
+      warEndTime,
+      warId: 50032,
+    } as any);
+    vi.spyOn(prisma.warAttacks, "findMany")
+      .mockResolvedValueOnce(participants as any)
+      .mockResolvedValueOnce(attacks as any);
+    vi.spyOn(prisma.trackedClan, "findFirst").mockResolvedValue({
+      loseStyle: "TRADITIONAL",
+    } as any);
+    vi.spyOn(PlayerLinkService, "listPlayerLinksForClanMembers").mockResolvedValue([
+      { playerTag: "#LROWNER", discordUserId: "111111111111111111" },
+      { playerTag: "#LRLINK", discordUserId: "111111111111111111" },
+    ] as any);
+
+    const service = new WarComplianceService();
+    const report = await service.getComplianceReport({
+      clanTag: "#TEST",
+      preferredWarStartTime: warStartTime,
+      matchType: "FWA",
+      expectedOutcome: "LOSE",
+    });
+
+    expect(report).not.toBeNull();
+    const violatedTags = report?.notFollowingPlan.map((row) => row.playerTag) ?? [];
+    expect(violatedTags).toContain("#LROUT");
+    expect(violatedTags).not.toContain("#LROWNER");
+  });
+
   it("keeps grouped LOSS_TRADITIONAL ownership deterministic and does not double-count one attack", async () => {
     const warStartTime = new Date("2026-03-01T00:00:00.000Z");
     const warEndTime = new Date("2026-03-02T00:00:00.000Z");
@@ -1139,8 +1383,8 @@ describe("WarComplianceService", () => {
         playerName: "p1",
         playerPosition: 4,
         defenderPosition: 5,
-        stars: 3,
-        trueStars: 0,
+        stars: 2,
+        trueStars: 2,
         attackSeenAt: new Date("2026-03-01T01:10:00.000Z"),
         warEndTime,
         attackOrder: 2,


### PR DESCRIPTION
- clear WIN/LOSE mirror obligations when the owned mirror target was already satisfied by another attack
- avoid unmet-mirror violations for members with only one used attack while still flagging real attack-rule breaches
- remove the No targets logged placeholder from FWA violation rendering and add focused regressions