### PR TITLE
fix(fwa-mail): freeze ended war posts and keep ended match type stable

### DIFF
--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -2624,10 +2624,14 @@ async function buildWarMailEmbedForTag(
     : (sanitizeClanName(String(subscription?.opponentName ?? "")) ??
       opponentName);
   const hasLiveWar = warState !== "notInWar" && Boolean(opponentTag);
+  const hasStoredWarIdentity = Boolean(
+    (subscription?.warId !== null &&
+      subscription?.warId !== undefined &&
+      Number.isFinite(Number(subscription.warId))) ||
+      subscription?.startTime,
+  );
   const freezeRefresh =
-    !hasLiveWar &&
-    Boolean(subscription?.startTime) &&
-    Boolean(effectiveOpponentTag);
+    !hasLiveWar && hasStoredWarIdentity && Boolean(effectiveOpponentTag);
 
   const syncIdentity = resolveCurrentWarSyncIdentity({
     warState,
@@ -2722,7 +2726,7 @@ async function buildWarMailEmbedForTag(
   let primarySnapshot: PointsSnapshot | null = null;
   let opponentSnapshot: PointsSnapshot | null = null;
   let pointsInference: MatchTypeResolution | null = null;
-  if (opponentTag && routineDecision.allowed) {
+  if (opponentTag && hasLiveWar && routineDecision.allowed) {
     primarySnapshot = await getClanPointsCached(
       settings,
       cocService,

--- a/src/services/WarEventLogService.ts
+++ b/src/services/WarEventLogService.ts
@@ -2962,9 +2962,11 @@ export class WarEventLogService {
         warEndFwaPoints: nextWarEndFwaPoints,
         clanStars: nextClanStars,
         opponentStars: nextOpponentStars,
-        prepStartTime: currentState === "notInWar" ? null : nextPrepStartTime,
-        startTime: currentState === "notInWar" ? null : nextWarStartTime,
-        endTime: currentState === "notInWar" ? null : nextWarEndTime,
+        // Preserve ended-war identity timestamps so downstream mail refresh can
+        // reliably recognize and freeze the completed war post.
+        prepStartTime: nextPrepStartTime,
+        startTime: nextWarStartTime,
+        endTime: nextWarEndTime,
         opponentTag: nextOpponentTag || sub.opponentTag,
         opponentName: nextOpponentName || sub.opponentName,
         clanName: nextClanName,

--- a/tests/warEventLog.warEndPointsReconcile.test.ts
+++ b/tests/warEventLog.warEndPointsReconcile.test.ts
@@ -193,7 +193,7 @@ describe("War-end expected points persistence via processSubscription", () => {
       resultLabel: "WIN" | "LOSE" | "TIE" | "UNKNOWN";
     };
     expectedWarEndFwaPoints: number | null;
-  }): Promise<void> {
+  }): Promise<Record<string, unknown> | undefined> {
     vi.restoreAllMocks();
     const service = new WarEventLogService({ channels: { fetch: vi.fn() } } as unknown as Client, {} as any);
     const sub = makeSubscription(input.subOverrides);
@@ -237,6 +237,7 @@ describe("War-end expected points persistence via processSubscription", () => {
     expect(updateSpy).toHaveBeenCalledTimes(1);
     const updateData = updateSpy.mock.calls[0]?.[0]?.data;
     expect(updateData?.warEndFwaPoints).toBe(input.expectedWarEndFwaPoints);
+    return updateData;
   }
 
   it("persists FWA WIN/LOSE/TIE expected points using war-start before points", async () => {
@@ -365,6 +366,32 @@ describe("War-end expected points persistence via processSubscription", () => {
       },
       expectedWarEndFwaPoints: null,
     });
+  });
+
+  it("preserves war identity timestamps on war_ended updates", async () => {
+    const expectedPrepStart = new Date("2026-03-11T00:00:00.000Z");
+    const expectedWarStart = new Date("2026-03-12T00:00:00.000Z");
+    const expectedWarEnd = new Date("2026-03-12T01:00:00.000Z");
+    const updateData = await runProcessSubscriptionCase({
+      subOverrides: {
+        matchType: "BL",
+        prepStartTime: expectedPrepStart,
+        startTime: expectedWarStart,
+        endTime: expectedWarEnd,
+      },
+      finalResult: {
+        clanStars: 10,
+        opponentStars: 11,
+        clanDestruction: 60.01,
+        opponentDestruction: 41,
+        warEndTime: expectedWarEnd,
+        resultLabel: "LOSE",
+      },
+      expectedWarEndFwaPoints: 1202,
+    });
+    expect(updateData?.prepStartTime).toEqual(expectedPrepStart);
+    expect(updateData?.startTime).toEqual(expectedWarStart);
+    expect(updateData?.endTime).toEqual(expectedWarEnd);
   });
 });
 


### PR DESCRIPTION
- preserve ended-war identity timestamps in CurrentWar updates
- skip live points match-type inference when rendering non-active war mail
- add regression coverage for war-ended timestamp preservation