### PR TITLE
fix(fwa-mail): remove next-refresh text when war mail freezes

### DIFF
--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -3950,6 +3950,9 @@ function buildWarMailRefreshEditPayload(
   existingPostedContent: string | null | undefined,
   planText: string | null | undefined,
   nowMs?: number,
+  options?: {
+    includeNextRefresh?: boolean;
+  },
 ): {
   content: string;
   allowedMentions: { parse: [] };
@@ -3960,6 +3963,7 @@ function buildWarMailRefreshEditPayload(
   return {
     content: buildWarMailPostedContent(persistedMentionRoleId, nowMs, {
       planText: String(planText ?? ""),
+      includeNextRefresh: options?.includeNextRefresh !== false,
     }),
     allowedMentions: { parse: [] },
   };
@@ -4350,17 +4354,17 @@ async function refreshWarMailPostByResolvedTarget(params: {
         ? Number(nextWarIdText)
         : null,
     );
-  const refreshEditPayload = rendered.freezeRefresh
-    ? null
-    : buildWarMailRefreshEditPayload(
-        String(message?.content ?? ""),
-        rendered.planText,
-      );
+  const refreshEditPayload = buildWarMailRefreshEditPayload(
+    String(message?.content ?? ""),
+    rendered.planText,
+    undefined,
+    {
+      includeNextRefresh: !rendered.freezeRefresh,
+    },
+  );
   await message.edit({
-    content: rendered.freezeRefresh ? undefined : refreshEditPayload?.content,
-    allowedMentions: rendered.freezeRefresh
-      ? undefined
-      : refreshEditPayload?.allowedMentions,
+    content: refreshEditPayload.content,
+    allowedMentions: refreshEditPayload.allowedMentions,
     embeds: [rendered.embed],
     components: rendered.freezeRefresh
       ? []

--- a/tests/fwaMailDownstream.logic.test.ts
+++ b/tests/fwaMailDownstream.logic.test.ts
@@ -191,4 +191,16 @@ describe("fwa war-mail refresh edit payload", () => {
 
     expect(payload.content).toBe("New plan\n\nNext refresh <t:1200:R>");
   });
+
+  it("removes stale next-refresh text when refresh is frozen", () => {
+    const payload = buildWarMailRefreshEditPayloadForTest(
+      "Old plan\n\n<@&123456789>\n\nNext refresh <t:999:R>",
+      "New plan",
+      0,
+      { includeNextRefresh: false },
+    );
+
+    expect(payload.content).toBe("New plan\n\n<@&123456789>");
+    expect(payload.allowedMentions).toEqual({ parse: [] });
+  });
 });


### PR DESCRIPTION
- rewrite frozen refresh edits so stale "Next refresh" content is removed
- keep active mail refresh content unchanged and add regression coverage