### PR TITLE
fix(accounts): persist player activity clan names for fallback

### DIFF
--- a/prisma/migrations/20260328190000_add_player_activity_clan_name/migration.sql
+++ b/prisma/migrations/20260328190000_add_player_activity_clan_name/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "PlayerActivity"
+ADD COLUMN "clanName" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -12,6 +12,7 @@ model PlayerActivity {
   tag     String
   name    String
   clanTag String
+  clanName String?
 
   lastDonationAt DateTime?
   lastCapitalAt  DateTime?

--- a/src/commands/Accounts.ts
+++ b/src/commands/Accounts.ts
@@ -245,16 +245,37 @@ export const Accounts: Command = {
     );
     const activity = await prisma.playerActivity.findMany({
       where: { guildId: interaction.guildId, tag: { in: uniqueTags } },
-      select: { tag: true, name: true, clanTag: true },
+      select: { tag: true, name: true, clanTag: true, clanName: true },
     });
     const activityByTag = new Map(
       activity.map((a) => [normalizeTag(a.tag), a])
     );
+    const candidateClanTags = [...new Set(
+      activity
+        .map((row) => (row.clanTag ? normalizeTag(row.clanTag) : ""))
+        .filter(Boolean)
+    )];
+    const trackedClanRows =
+      candidateClanTags.length > 0
+        ? await prisma.trackedClan.findMany({
+            where: { tag: { in: candidateClanTags } },
+            select: { tag: true, name: true },
+          })
+        : [];
+    const trackedClanNameByTag = new Map(
+      trackedClanRows
+        .map((row) => [normalizeTag(row.tag), sanitizeDisplayText(row.name)] as const)
+        .filter((entry): entry is [string, string] => Boolean(entry[0] && entry[1]))
+    );
 
     const tagsNeedingLiveFetch = uniqueTags.filter((tag) => {
       const hasLinkedName = Boolean(linkedNameByTag.get(tag));
-      const hasLocalFallback = activityByTag.has(tag);
-      return !hasLinkedName || !hasLocalFallback;
+      const localFallback = activityByTag.get(tag);
+      const hasLocalFallback = Boolean(localFallback);
+      const hasIncompleteLocalClanContext = Boolean(
+        localFallback?.clanTag && !sanitizeDisplayText(localFallback.clanName)
+      );
+      return !hasLinkedName || !hasLocalFallback || hasIncompleteLocalClanContext;
     });
     const fetchedPlayersByTag = new Map<string, any>();
     if (tagsNeedingLiveFetch.length > 0) {
@@ -276,6 +297,12 @@ export const Accounts: Command = {
       const fallback = activityByTag.get(tag);
       const livePlayer = fetchedPlayersByTag.get(tag) ?? null;
       const livePlayerName = sanitizeDisplayText(livePlayer?.name);
+      const fallbackClanTag = fallback?.clanTag ? normalizeTag(fallback.clanTag) : null;
+      const clanTag = normalizeTag(livePlayer?.clan?.tag ?? fallbackClanTag ?? "");
+      const clanName =
+        sanitizeDisplayText(livePlayer?.clan?.name) ??
+        sanitizeDisplayText(fallback?.clanName) ??
+        (clanTag ? trackedClanNameByTag.get(clanTag) ?? null : null);
 
       if (!linkedName && livePlayerName) {
         playerNameBackfillTasks.push(
@@ -297,8 +324,8 @@ export const Accounts: Command = {
       return {
         tag,
         name: linkedName ?? livePlayerName ?? sanitizeDisplayText(fallback?.name) ?? tag,
-        clanTag: livePlayer?.clan?.tag ?? fallback?.clanTag ?? null,
-        clanName: livePlayer?.clan?.name ?? null,
+        clanTag: clanTag || null,
+        clanName,
       };
     });
 

--- a/src/commands/LastSeen.ts
+++ b/src/commands/LastSeen.ts
@@ -232,6 +232,7 @@ export const LastSeen: Command = {
           update: {
             name: player.name,
             clanTag: player.clan?.tag ?? "UNKNOWN",
+            clanName: player.clan?.name ?? null,
             lastSeenAt: inferredAt,
           },
           create: {
@@ -239,6 +240,7 @@ export const LastSeen: Command = {
             tag,
             name: player.name,
             clanTag: player.clan?.tag ?? "UNKNOWN",
+            clanName: player.clan?.name ?? null,
             lastSeenAt: inferredAt,
           },
         });

--- a/src/services/ActivityService.ts
+++ b/src/services/ActivityService.ts
@@ -34,7 +34,8 @@ export class ActivityService {
         guildId,
         tag: player.tag,
         name: player.name,
-        clanTag: clan.tag,
+        clanTag: player.clan?.tag ?? clan.tag,
+        clanName: player.clan?.name ?? clan.name ?? null,
         trophies: player.trophies,
         donations: player.donations,
         donationsReceived: player.donationsReceived ?? 0,
@@ -76,6 +77,7 @@ export class ActivityService {
     tag: string;
     name: string;
     clanTag: string;
+    clanName: string | null;
     trophies: number;
     donations: number;
     donationsReceived: number;
@@ -106,6 +108,7 @@ export class ActivityService {
     const updates: any = {
       name: input.name,
       clanTag: input.clanTag,
+      clanName: input.clanName,
     };
 
     const processed = await this.signalService.processPlayer({

--- a/tests/accounts.command.test.ts
+++ b/tests/accounts.command.test.ts
@@ -71,7 +71,7 @@ describe("/accounts command", () => {
       },
     ]);
     prismaMock.playerActivity.findMany.mockResolvedValue([
-      { tag: "#PYLQ0289", name: "Activity Alpha", clanTag: "#PQL0289" },
+      { tag: "#PYLQ0289", name: "Activity Alpha", clanTag: "#PQL0289", clanName: "Stored Clan" },
     ]);
     const cocService = {
       getPlayerRaw: vi.fn(),
@@ -156,5 +156,52 @@ describe("/accounts command", () => {
 
     expect(getEmbedDescription(interaction)).toContain("- #LQ9P8R2 `#LQ9P8R2`");
     expect(prismaMock.playerLink.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("uses PlayerActivity clan name in output without live fetch when local clan context is complete", async () => {
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      {
+        playerTag: "#PYLQ0289",
+        playerName: "Linked Delta",
+        createdAt: new Date("2026-03-01T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.playerActivity.findMany.mockResolvedValue([
+      { tag: "#PYLQ0289", name: "Activity Delta", clanTag: "#PQL0289", clanName: "Saved Clan Name" },
+    ]);
+    const cocService = {
+      getPlayerRaw: vi.fn(),
+    };
+    const interaction = makeInteraction();
+
+    await Accounts.run({} as any, interaction as any, cocService as any);
+
+    expect(cocService.getPlayerRaw).not.toHaveBeenCalled();
+    expect(getEmbedDescription(interaction)).toContain("**Saved Clan Name (#PQL0289)**");
+  });
+
+  it("treats clanTag-only local context as incomplete, live-fetches, then falls back to tracked clan name", async () => {
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      {
+        playerTag: "#QGRJ2222",
+        playerName: "Linked Echo",
+        createdAt: new Date("2026-03-01T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.playerActivity.findMany.mockResolvedValue([
+      { tag: "#QGRJ2222", name: "Activity Echo", clanTag: "#2QG2C08UP", clanName: null },
+    ]);
+    prismaMock.trackedClan.findMany.mockResolvedValue([
+      { tag: "#2QG2C08UP", name: "Tracked Clan Name" },
+    ]);
+    const cocService = {
+      getPlayerRaw: vi.fn().mockRejectedValue(new Error("coc unavailable")),
+    };
+    const interaction = makeInteraction();
+
+    await Accounts.run({} as any, interaction as any, cocService as any);
+
+    expect(cocService.getPlayerRaw).toHaveBeenCalledWith("#QGRJ2222");
+    expect(getEmbedDescription(interaction)).toContain("**Tracked Clan Name (#2QG2C08UP)**");
   });
 });


### PR DESCRIPTION
- add PlayerActivity.clanName schema column and migration
- persist clanName in PlayerActivity upsert paths used by activity observation and lastseen bootstrap
- update /accounts clan fallback precedence and hydration gating, with tests for local and tracked-clan fallback behavior