### PR TITLE
feat(fwa): unify police output into shared red embed format

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -63,7 +63,7 @@
 - `/fwa police configure clan:<trackedClanTag> enable-dm:<true|false> enable-log:<true|false>` - Configure automated warplan-violation enforcement toggles for one tracked clan.
 - `/fwa police show clan:<trackedClanTag> violation:<EARLY_NON_MIRROR_TRIPLE|STRICT_WINDOW_MIRROR_MISS_WIN|STRICT_WINDOW_MIRROR_MISS_LOSS|EARLY_NON_MIRROR_2STAR|ANY_3STAR|LOWER20_ANY_STARS>` - Show clan custom raw template (if present), effective source (`Custom`/`Default`/`Built-in`), rendered sample output, and warplan-aware applicability/context.
 - `/fwa police show-default clan:<trackedClanTag> violation:<...>` - Show raw global default template (if present) plus effective source/sample/applicability for the selected clan context.
-- `/fwa police show-all clan:<trackedClanTag>` - Render all 6 canonical violations in one embed with source, sample output, and applicability status for each (defaults private).
+- `/fwa police show-all clan:<trackedClanTag>` - Render paginated canonical police previews (one violation per embed page) with source, sample output, and applicability status (defaults private).
 - `/fwa police set clan:<trackedClanTag> violation:<...> template:<text>` - Save a clan-scoped template override for one canonical violation. Valid placeholders: `{offender}`, `{user}`.
 - `/fwa police set-default clan:<trackedClanTag> violation:<...> template:<text>` - Save a global default template override for one canonical violation (storage keyed by violation only).
 - `/fwa police reset clan:<trackedClanTag> violation:<...>` - Delete one clan-scoped template override.

--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -9,6 +9,7 @@ import {
   ButtonStyle,
   ChatInputCommandInteraction,
   Client,
+  ComponentType,
   EmbedBuilder,
   PermissionFlagsBits,
   StringSelectMenuBuilder,
@@ -12237,9 +12238,7 @@ export const Fwa: Command = {
         : null;
 
       const formatTemplateText = (value: string | null): string =>
-        value ? `\`\`\`\n${value.slice(0, 950)}\n\`\`\`` : "_Not set_";
-      const formatSampleText = (value: string): string =>
-        `\`\`\`\n${value.slice(0, 850)}\n\`\`\``;
+        value ? `\`\`\`\n${value.slice(0, 980)}\n\`\`\`` : "_Not set_";
 
       if (subcommand === "configure") {
         const enableDm = interaction.options.getBoolean("enable-dm", true);
@@ -12271,6 +12270,7 @@ export const Fwa: Command = {
       }
 
       const previewBundle = await fwaPoliceService.getTemplatePreviewBundle({
+        client: interaction.client,
         guildId: interaction.guildId,
         clanTag,
         sampleUserId: interaction.user.id,
@@ -12280,27 +12280,90 @@ export const Fwa: Command = {
         return;
       }
 
-      if (subcommand === "show-all") {
-        const embed = new EmbedBuilder()
-          .setTitle(
-            `FWA Police Templates - ${previewBundle.clanName ?? previewBundle.clanTag} (${previewBundle.clanTag})`,
-          )
-          .setDescription(`Context: ${previewBundle.contextSummary}`)
-          .setColor(0x5865f2);
-        for (const row of previewBundle.rows) {
-          embed.addFields({
-            name: `${row.label} (${row.violation})`,
-            value: [
-              `Source: **${row.effectiveSource}**`,
-              `Applicability: **${row.applicabilityText}**`,
-              `Context: ${previewBundle.contextSummary}`,
-              `Template: ${row.effectiveTemplate.slice(0, 220)}`,
-              `Sample:\n${formatSampleText(row.renderedSample)}`,
-            ].join("\n"),
+      const buildPoliceTemplatePreviewEmbed = (
+        row: (typeof previewBundle.rows)[number],
+      ): EmbedBuilder => {
+        const embed = EmbedBuilder.from(row.sampleEmbed).addFields(
+          {
+            name: "**Template Source**",
+            value: `**${row.effectiveSource}**`,
             inline: false,
+          },
+          {
+            name: "**Applicability**",
+            value: row.isApplicable
+              ? row.applicabilityText
+              : "Not applicable under current warplan",
+            inline: false,
+          },
+          {
+            name: "**Warplan Context**",
+            value: previewBundle.contextSummary.slice(0, 1024),
+            inline: false,
+          },
+        );
+        return embed;
+      };
+
+      if (subcommand === "show-all") {
+        const embeds = previewBundle.rows.map((row, index) =>
+          buildPoliceTemplatePreviewEmbed(row).setFooter({
+            text: `${previewBundle.clanName ?? previewBundle.clanTag} (${previewBundle.clanTag}) | ${row.violation} | Page ${index + 1}/${previewBundle.rows.length}`,
+          }),
+        );
+        const prefix = `fwa-police-show-all:${interaction.id}`;
+        const buildPaginationRow = (
+          page: number,
+          totalPages: number,
+        ): ActionRowBuilder<ButtonBuilder> =>
+          new ActionRowBuilder<ButtonBuilder>().addComponents(
+            new ButtonBuilder()
+              .setCustomId(`${prefix}:prev`)
+              .setLabel("Prev")
+              .setStyle(ButtonStyle.Secondary)
+              .setDisabled(page <= 0),
+            new ButtonBuilder()
+              .setCustomId(`${prefix}:next`)
+              .setLabel("Next")
+              .setStyle(ButtonStyle.Secondary)
+              .setDisabled(page >= totalPages - 1),
+          );
+        let page = 0;
+        const reply = await interaction.editReply({
+          content: "",
+          embeds: [embeds[page]],
+          components:
+            embeds.length > 1 ? [buildPaginationRow(page, embeds.length)] : [],
+        });
+        if (embeds.length <= 1) return;
+
+        const collector = reply.createMessageComponentCollector({
+          componentType: ComponentType.Button,
+          time: 5 * 60 * 1000,
+          filter: (btn) =>
+            btn.user.id === interaction.user.id &&
+            (btn.customId === `${prefix}:prev` || btn.customId === `${prefix}:next`),
+        });
+        collector.on("collect", async (btn: ButtonInteraction) => {
+          if (btn.customId.endsWith(":prev")) {
+            page = Math.max(0, page - 1);
+          } else if (btn.customId.endsWith(":next")) {
+            page = Math.min(embeds.length - 1, page + 1);
+          }
+          await btn.update({
+            embeds: [embeds[page]],
+            components: [buildPaginationRow(page, embeds.length)],
           });
-        }
-        await interaction.editReply({ content: "", embeds: [embed], components: [] });
+        });
+        collector.on("end", async () => {
+          await interaction
+            .editReply({
+              content: "",
+              embeds: [embeds[page]],
+              components: [],
+            })
+            .catch(() => undefined);
+        });
         return;
       }
 
@@ -12325,35 +12388,15 @@ export const Fwa: Command = {
           subcommand === "show"
             ? "Raw Clan Custom Template"
             : "Raw Global Default Template";
-        const embed = new EmbedBuilder()
-          .setTitle(
-            `FWA Police ${subcommand === "show" ? "Template" : "Default Template"} - ${selectedRow.label}`,
-          )
-          .setDescription(
-            [
-              `Clan: **${previewBundle.clanName ?? previewBundle.clanTag}** (${previewBundle.clanTag})`,
-              `Violation: \`${selectedRow.violation}\``,
-              `Effective source: **${selectedRow.effectiveSource}**`,
-              `Applicability: **${selectedRow.applicabilityText}**`,
-              selectedRow.isApplicable ? "" : "Not applicable under current warplan.",
-              `Context: ${previewBundle.contextSummary}`,
-            ]
-              .filter(Boolean)
-              .join("\n"),
-          )
-          .setColor(0x5865f2)
-          .addFields(
-            {
-              name: rawTitle,
-              value: formatTemplateText(rawTemplateText),
-              inline: false,
-            },
-            {
-              name: "Rendered Sample",
-              value: formatSampleText(selectedRow.renderedSample),
-              inline: false,
-            },
-          );
+        const embed = buildPoliceTemplatePreviewEmbed(selectedRow)
+          .addFields({
+            name: `**${rawTitle}**`,
+            value: formatTemplateText(rawTemplateText),
+            inline: false,
+          })
+          .setFooter({
+            text: `${previewBundle.clanName ?? previewBundle.clanTag} (${previewBundle.clanTag}) | ${selectedRow.violation}`,
+          });
         await interaction.editReply({ content: "", embeds: [embed], components: [] });
         return;
       }

--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -375,7 +375,7 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
       "`/fwa base-swap` posts a tracked acknowledgment message for war-base/base-error positions, includes deduped TH-specific `RISINGDAWN` layout links for listed players, and DMs the invoker copy/paste in-game ping lines (active-war + TH-grouped base errors). If the full post exceeds one Discord message, it prompts the requester to publish exactly 2 linked posts instead of truncating required lines.",
       "`/fwa compliance` runs war-plan compliance checks on demand for a tracked clan (defaults to current active war; use `war-id:current` or numeric `war-id` for historical checks).",
       "`/fwa police configure` controls automatic DM/log enforcement toggles for a tracked clan.",
-      "`/fwa police show`, `show-default`, and `show-all` render canonical violation templates with source precedence (Custom -> Default -> Built-in), sample output, and warplan-aware applicability context.",
+      "`/fwa police show`, `show-default`, and `show-all` render canonical violation templates with source precedence (Custom -> Default -> Built-in), sample output, and warplan-aware applicability context (`show-all` paginates one violation per page).",
       "`/fwa police set`, `set-default`, `reset`, and `reset-default` manage per-violation template overrides using canonical enum keys only.",
       "`/fwa police send` test-delivers one rendered sample template to your DM or the clan log channel.",
       "FWA compliance embeds include a `Warplan` field from the same active plan source used by war mail, show resolved FWA-WIN threshold context (`N`/`H`) from warplan config, and strict-window breach context shows clan stars before the breach attack.",

--- a/src/services/FwaPoliceService.ts
+++ b/src/services/FwaPoliceService.ts
@@ -1,5 +1,5 @@
 import { createHash } from "crypto";
-import { Client } from "discord.js";
+import { Client, EmbedBuilder, type APIEmbed } from "discord.js";
 import { formatError } from "../helper/formatError";
 import { prisma } from "../prisma";
 import {
@@ -29,6 +29,7 @@ import {
   type FwaPoliceViolation,
   validateFwaPoliceTemplatePlaceholders,
 } from "./FwaPoliceTemplateCatalog";
+import { emojiResolverService } from "./emoji/EmojiResolverService";
 
 type TrackedClanPoliceRow = {
   tag: string;
@@ -89,6 +90,7 @@ export type FwaPoliceTemplatePreviewRow = {
   rawDefaultTemplate: string | null;
   effectiveTemplate: string;
   renderedSample: string;
+  sampleEmbed: APIEmbed;
   isApplicable: boolean;
   applicabilityText: string;
 };
@@ -112,6 +114,30 @@ export type FwaPoliceSendSampleResult =
         | "LOG_CHANNEL_UNAVAILABLE";
     };
 
+type FwaPoliceResolvedEmojiState = {
+  alert: string;
+  alertBlue: string;
+  yes: string;
+  no: string;
+  green: string;
+  red: string;
+  black: string;
+  white: string;
+  yellow: string;
+};
+
+const FWA_POLICE_EMOJI_FALLBACKS: FwaPoliceResolvedEmojiState = {
+  alert: ":rotating_light:",
+  alertBlue: ":oncoming_police_car:",
+  yes: ":yes:",
+  no: ":no:",
+  green: ":green_circle:",
+  red: ":red_circle:",
+  black: ":black_circle:",
+  white: ":white_circle:",
+  yellow: ":yellow_circle:",
+};
+
 function sortViolationsDeterministically(
   issues: WarComplianceIssue[],
 ): WarComplianceIssue[] {
@@ -132,8 +158,9 @@ function sortViolationsDeterministically(
   });
 }
 
-function clampText(input: unknown, maxLen: number): string {
-  const value = normalizeFwaPoliceText(input);
+function clampEmbedFieldValue(input: unknown, maxLen = 1024): string {
+  const value = String(input ?? "").trim();
+  if (!value) return "_(none)_";
   if (value.length <= maxLen) return value;
   return `${value.slice(0, Math.max(0, maxLen - 3))}...`;
 }
@@ -179,10 +206,6 @@ function resolveClanLogChannelId(clan: TrackedClanPoliceRow): string | null {
   );
 }
 
-function buildClanLabel(clanName: string | null, clanTag: string): string {
-  return clanName ? `${clanName} (${clanTag})` : clanTag;
-}
-
 function buildOffenderLabel(input: {
   playerPosition?: number | null;
   playerName?: string | null;
@@ -205,8 +228,9 @@ function isTextChannelWithSend(
 ): channel is {
   isTextBased: () => boolean;
   send: (input: {
-    content: string;
-    allowedMentions: { users: string[] };
+    content?: string;
+    embeds?: EmbedBuilder[];
+    allowedMentions?: { users?: string[] };
   }) => Promise<unknown>;
 } {
   if (!channel || typeof channel !== "object") return false;
@@ -254,50 +278,128 @@ function buildSampleExpectedBehavior(violation: FwaPoliceViolation): string {
 
 function buildSampleActualBehavior(violation: FwaPoliceViolation): string {
   if (violation === "EARLY_NON_MIRROR_TRIPLE") {
-    return "#14 (★ ★ ★) : tripled non-mirror before FFA window";
+    return "#14 (* * *) : tripled non-mirror before FFA window";
   }
   if (violation === "STRICT_WINDOW_MIRROR_MISS_WIN") {
-    return "#15 (★ ★ ☆) : missed mirror triple during strict window";
+    return "#15 (* * -) : missed mirror triple during strict window";
   }
   if (violation === "STRICT_WINDOW_MIRROR_MISS_LOSS") {
-    return "#15 (★ ☆ ☆) : mirror strict-window miss in loss-traditional flow";
+    return "#15 (* - -) : mirror strict-window miss in loss-traditional flow";
   }
   if (violation === "EARLY_NON_MIRROR_2STAR") {
-    return "#18 (★ ★ ☆) : early non-mirror 2-star before FFA window";
+    return "#18 (* * -) : early non-mirror 2-star before FFA window";
   }
   if (violation === "ANY_3STAR") {
-    return "#16 (★ ★ ★) : 3-star in loss-traditional flow";
+    return "#16 (* * *) : 3-star in loss-traditional flow";
   }
-  return "#41 (★ ☆ ☆) : starred lower-20 base in triple-top-30 loss";
+  return "#41 (* - -) : starred lower-20 base in triple-top-30 loss";
 }
 
-function buildPoliceMessage(input: {
-  clanTag: string;
-  clanName: string | null;
-  warLabel: string;
+async function resolveFwaPolicePresentationEmojis(
+  client: Client,
+): Promise<FwaPoliceResolvedEmojiState> {
+  const inventory = await emojiResolverService
+    .fetchApplicationEmojiInventory(client)
+    .catch(() => null);
+  if (!inventory?.ok) {
+    return FWA_POLICE_EMOJI_FALLBACKS;
+  }
+  const resolveByName = (name: string, fallback: string): string => {
+    const exact = inventory.snapshot.exactByName.get(name);
+    if (exact?.rendered) return exact.rendered;
+    const lower = inventory.snapshot.lowercaseByName.get(name.toLowerCase());
+    if (lower?.rendered) return lower.rendered;
+    return fallback;
+  };
+  return {
+    alert: resolveByName("alert", FWA_POLICE_EMOJI_FALLBACKS.alert),
+    alertBlue: resolveByName("alert_blue", FWA_POLICE_EMOJI_FALLBACKS.alertBlue),
+    yes: resolveByName("yes", FWA_POLICE_EMOJI_FALLBACKS.yes),
+    no: resolveByName("no", FWA_POLICE_EMOJI_FALLBACKS.no),
+    green: resolveByName("green_circle", FWA_POLICE_EMOJI_FALLBACKS.green),
+    red: resolveByName("red_circle", FWA_POLICE_EMOJI_FALLBACKS.red),
+    black: resolveByName("black_circle", FWA_POLICE_EMOJI_FALLBACKS.black),
+    white: resolveByName("white_circle", FWA_POLICE_EMOJI_FALLBACKS.white),
+    yellow: resolveByName("yellow_circle", FWA_POLICE_EMOJI_FALLBACKS.yellow),
+  };
+}
+
+function resolveWarLine(input: {
+  matchTypeContext: MatchType;
+  expectedOutcome: "WIN" | "LOSE" | null;
+  emojis: FwaPoliceResolvedEmojiState;
+}): string {
+  if (input.matchTypeContext === "FWA") {
+    if (input.expectedOutcome === "WIN") {
+      return `FWA-WIN ${input.emojis.green}`;
+    }
+    if (input.expectedOutcome === "LOSE") {
+      return `FWA-LOSE ${input.emojis.red}`;
+    }
+    return `FWA ${input.emojis.white}`;
+  }
+  if (input.matchTypeContext === "BL") {
+    return `BL ${input.emojis.black}`;
+  }
+  if (input.matchTypeContext === "MM") {
+    return `MM ${input.emojis.white}`;
+  }
+  if (input.matchTypeContext === "SKIP") {
+    return `SKIP ${input.emojis.yellow}`;
+  }
+  return `${input.matchTypeContext} ${input.emojis.white}`;
+}
+
+function buildPoliceMessagePresentation(input: {
   violation: FwaPoliceViolation;
   resolvedTemplate: string;
   offender: string;
   user: string;
   expectedBehavior: string;
   actualBehavior: string;
-}): string {
+  matchTypeContext: MatchType;
+  expectedOutcome: "WIN" | "LOSE" | null;
+  emojis: FwaPoliceResolvedEmojiState;
+}): { renderedTemplate: string; embed: EmbedBuilder } {
   const metadata = FWA_POLICE_VIOLATION_METADATA[input.violation];
   const renderedTemplate = renderFwaPoliceTemplate({
     template: input.resolvedTemplate,
     offender: input.offender,
     user: input.user,
   });
-
-  return [
-    "FWA Police - Warplan violation detected",
-    `Clan: ${buildClanLabel(input.clanName, input.clanTag)}`,
-    `War: ${input.warLabel}`,
-    `Violation: ${metadata.label}`,
-    `Message: ${renderedTemplate}`,
-    `Expected: ${clampText(input.expectedBehavior, 500)}`,
-    `Actual: ${clampText(input.actualBehavior, 500)}`,
+  const description = [
+    `## ${input.emojis.alert} ${input.emojis.alertBlue} FWA Police - Warplan violation detected ${input.emojis.alertBlue} ${input.emojis.alert}`,
+    `**War**: ${resolveWarLine({
+      matchTypeContext: input.matchTypeContext,
+      expectedOutcome: input.expectedOutcome,
+      emojis: input.emojis,
+    })}`,
+    `**Violation**: ${metadata.label}`,
   ].join("\n");
+  const embed = new EmbedBuilder()
+    .setColor(0xed4245)
+    .setDescription(description)
+    .addFields(
+      {
+        name: "**Message**",
+        value: clampEmbedFieldValue(renderedTemplate),
+        inline: false,
+      },
+      {
+        name: `**${input.emojis.yes} Expected**`,
+        value: clampEmbedFieldValue(input.expectedBehavior),
+        inline: false,
+      },
+      {
+        name: `**${input.emojis.no} Actual**`,
+        value: clampEmbedFieldValue(input.actualBehavior),
+        inline: false,
+      },
+    );
+  return {
+    renderedTemplate,
+    embed,
+  };
 }
 
 async function resolveTrackedClanByTag(
@@ -601,10 +703,12 @@ export class FwaPoliceService {
 
   /** Purpose: build preview rows for all canonical violations using shared template resolution + renderer logic. */
   private async buildPreviewRows(input: {
+    client: Client;
     clanTag: string;
     context: FwaPoliceWarplanContext;
     sampleUserId?: string | null;
   }): Promise<FwaPoliceTemplatePreviewRow[]> {
+    const emojis = await resolveFwaPolicePresentationEmojis(input.client);
     const templateResolutions = await Promise.all(
       FWA_POLICE_VIOLATIONS.map((violation) =>
         this.resolveTemplateForViolation({
@@ -616,16 +720,16 @@ export class FwaPoliceService {
 
     return templateResolutions.map((resolved) => {
       const metadata = FWA_POLICE_VIOLATION_METADATA[resolved.violation];
-      const renderedSample = buildPoliceMessage({
-        clanTag: normalizeClanTag(input.clanTag),
-        clanName: "Sample Clan",
-        warLabel: "sample-war vs Sample Opponent",
+      const presentation = buildPoliceMessagePresentation({
         violation: resolved.violation,
         resolvedTemplate: resolved.effectiveTemplate,
         offender: FWA_POLICE_SAMPLE_OFFENDER,
         user: input.sampleUserId ? `<@${input.sampleUserId}>` : "UNLINKED_USER",
         expectedBehavior: buildSampleExpectedBehavior(resolved.violation),
         actualBehavior: buildSampleActualBehavior(resolved.violation),
+        matchTypeContext: input.context.matchTypeContext,
+        expectedOutcome: input.context.expectedOutcome,
+        emojis,
       });
       const isApplicable = metadata.isApplicable(toApplicabilityContext(input.context));
       return {
@@ -635,7 +739,8 @@ export class FwaPoliceService {
         rawCustomTemplate: resolved.rawCustomTemplate,
         rawDefaultTemplate: resolved.rawDefaultTemplate,
         effectiveTemplate: resolved.effectiveTemplate,
-        renderedSample,
+        renderedSample: presentation.renderedTemplate,
+        sampleEmbed: presentation.embed.toJSON(),
         isApplicable,
         applicabilityText: isApplicable
           ? "Applicable"
@@ -646,6 +751,7 @@ export class FwaPoliceService {
 
   /** Purpose: build one full preview bundle for a tracked clan, including warplan-aware applicability context. */
   async getTemplatePreviewBundle(input: {
+    client: Client;
     guildId: string;
     clanTag: string;
     sampleUserId?: string | null;
@@ -660,6 +766,7 @@ export class FwaPoliceService {
       loseStyle: tracked.loseStyle,
     });
     const rows = await this.buildPreviewRows({
+      client: input.client,
       clanTag: normalizedClanTag,
       context,
       sampleUserId: input.sampleUserId ?? null,
@@ -683,27 +790,32 @@ export class FwaPoliceService {
     destination: "DM" | "LOG";
     requestingUserId: string;
   }): Promise<FwaPoliceSendSampleResult> {
-    void input.guildId;
     const tracked = await resolveTrackedClanByTag(input.clanTag);
     if (!tracked) {
       return { ok: false, error: "CLAN_NOT_TRACKED" };
     }
 
     const normalizedClanTag = normalizeClanTag(tracked.tag);
+    const context = await resolveWarplanContextForClan({
+      guildId: input.guildId,
+      clanTag: normalizedClanTag,
+      loseStyle: tracked.loseStyle,
+    });
+    const emojis = await resolveFwaPolicePresentationEmojis(input.client);
     const resolution = await this.resolveTemplateForViolation({
       clanTag: normalizedClanTag,
       violation: input.violation,
     });
-    const rendered = buildPoliceMessage({
-      clanTag: normalizedClanTag,
-      clanName: normalizeFwaPoliceText(tracked.name) || null,
-      warLabel: "sample-war vs Sample Opponent",
+    const presentation = buildPoliceMessagePresentation({
       violation: input.violation,
       resolvedTemplate: resolution.effectiveTemplate,
       offender: FWA_POLICE_SAMPLE_OFFENDER,
       user: `<@${input.requestingUserId}>`,
       expectedBehavior: buildSampleExpectedBehavior(input.violation),
       actualBehavior: buildSampleActualBehavior(input.violation),
+      matchTypeContext: context.matchTypeContext,
+      expectedOutcome: context.expectedOutcome,
+      emojis,
     });
 
     if (input.destination === "DM") {
@@ -712,8 +824,11 @@ export class FwaPoliceService {
       if (!dm) {
         return { ok: false, error: "DM_UNAVAILABLE" };
       }
-      await dm.send({ content: rendered });
-      return { ok: true, deliveredTo: "DM", rendered };
+      await dm.send({
+        embeds: [presentation.embed],
+        allowedMentions: { users: [input.requestingUserId] },
+      });
+      return { ok: true, deliveredTo: "DM", rendered: presentation.renderedTemplate };
     }
 
     const strictLogChannelId = normalizeFwaPoliceText(tracked.logChannelId) || null;
@@ -725,10 +840,10 @@ export class FwaPoliceService {
       return { ok: false, error: "LOG_CHANNEL_UNAVAILABLE" };
     }
     await channel.send({
-      content: rendered,
+      embeds: [presentation.embed],
       allowedMentions: { users: [input.requestingUserId] },
     });
-    return { ok: true, deliveredTo: "LOG", rendered };
+    return { ok: true, deliveredTo: "LOG", rendered: presentation.renderedTemplate };
   }
 
   /** Purpose: evaluate canonical compliance and enforce one-time police notifications per unique violation fingerprint. */
@@ -806,6 +921,7 @@ export class FwaPoliceService {
       expectedOutcome: report.expectedOutcome,
       loseStyle: report.loseStyle,
     };
+    const emojis = await resolveFwaPolicePresentationEmojis(input.client);
     const templateByViolation = new Map<FwaPoliceViolation, FwaPoliceTemplateResolution>(
       (
         await Promise.all(
@@ -854,12 +970,7 @@ export class FwaPoliceService {
           clanTag: normalizedClanTag,
           violation,
         }));
-      const content = buildPoliceMessage({
-        clanTag: normalizedClanTag,
-        clanName: normalizeFwaPoliceText(report.clanName) || normalizeFwaPoliceText(tracked.name) || null,
-        warLabel: normalizeFwaPoliceText(report.opponentName)
-          ? `${effectiveWarId} vs ${normalizeFwaPoliceText(report.opponentName)}`
-          : String(effectiveWarId),
+      const presentation = buildPoliceMessagePresentation({
         violation,
         resolvedTemplate: templateResolution.effectiveTemplate,
         offender: buildOffenderLabel({
@@ -870,6 +981,9 @@ export class FwaPoliceService {
         user: linkedDiscordUserId ? `<@${linkedDiscordUserId}>` : "UNLINKED_USER",
         expectedBehavior: issue.expectedBehavior,
         actualBehavior: issue.actualBehavior,
+        matchTypeContext: report.matchType,
+        expectedOutcome: report.expectedOutcome,
+        emojis,
       });
 
       let dmSentAt: Date | null = null;
@@ -882,7 +996,12 @@ export class FwaPoliceService {
             .catch(() => null);
           const dm = await user?.createDM().catch(() => null);
           if (dm) {
-            await dm.send({ content });
+            await dm.send({
+              embeds: [presentation.embed],
+              allowedMentions: {
+                users: linkedDiscordUserId ? [linkedDiscordUserId] : [],
+              },
+            });
             dmSentAt = new Date();
             dmSent += 1;
           }
@@ -895,9 +1014,8 @@ export class FwaPoliceService {
 
       if (enableLog && canSendLog) {
         try {
-          const prefix = linkedDiscordUserId ? `<@${linkedDiscordUserId}> ` : "";
           await resolvedLogChannel.send({
-            content: `${prefix}${content}`.trim(),
+            embeds: [presentation.embed],
             allowedMentions: {
               users: linkedDiscordUserId ? [linkedDiscordUserId] : [],
             },
@@ -933,3 +1051,4 @@ export class FwaPoliceService {
 }
 
 export const fwaPoliceService = new FwaPoliceService();
+

--- a/tests/fwaPolice.commandOutput.test.ts
+++ b/tests/fwaPolice.commandOutput.test.ts
@@ -109,7 +109,29 @@ describe("/fwa police command output", () => {
           rawCustomTemplate: null,
           rawDefaultTemplate: null,
           effectiveTemplate: "{offender} sample",
-          renderedSample: "FWA Police - sample",
+          renderedSample: "#15 - Tilonius sample",
+          sampleEmbed: {
+            color: 0xed4245,
+            description:
+              "## :rotating_light: :oncoming_police_car: FWA Police - Warplan violation detected :oncoming_police_car: :rotating_light:\n**War**: FWA-WIN :green_circle:\n**Violation**: Early non-mirror triple before FFA window",
+            fields: [
+              {
+                name: "**Message**",
+                value: "#15 - Tilonius sample",
+                inline: false,
+              },
+              {
+                name: "**:yes: Expected**",
+                value: "Wait for FFA window before any non-mirror triple.",
+                inline: false,
+              },
+              {
+                name: "**:no: Actual**",
+                value: "#14 (* * *) : tripled non-mirror before FFA window",
+                inline: false,
+              },
+            ],
+          },
           isApplicable: true,
           applicabilityText: "Applicable",
         },
@@ -205,11 +227,85 @@ describe("/fwa police command output", () => {
 
     const payload = run.editReply.mock.calls[0]?.[0];
     const embedJson = payload?.embeds?.[0]?.toJSON?.() ?? null;
+    expect(Number(embedJson?.color ?? 0)).toBe(0xed4245);
     expect(String(embedJson?.description ?? "")).toContain(
-      "Effective source: **Built-in**",
+      "FWA Police - Warplan violation detected",
     );
-    expect(String(embedJson?.fields?.[1]?.value ?? "")).toContain(
-      "FWA Police - sample",
+    expect(String(embedJson?.fields?.[0]?.name ?? "")).toBe("**Message**");
+    expect(String(embedJson?.fields?.[3]?.name ?? "")).toBe(
+      "**Template Source**",
     );
+    expect(String(embedJson?.fields?.[3]?.value ?? "")).toContain("Built-in");
+  });
+
+  it("renders show-all as one-violation-per-page pagination", async () => {
+    fwaPoliceServiceMock.getTemplatePreviewBundle.mockResolvedValue({
+      clanTag: "#2QG2C08UP",
+      clanName: "Alpha",
+      contextSummary:
+        "Match type context: FWA WIN | Lose style: TRIPLE_TOP_30 | Free-for-all star threshold: 101 | Free-for-all time threshold: 0h",
+      rows: [
+        {
+          violation: "EARLY_NON_MIRROR_TRIPLE",
+          label: "Early non-mirror triple before FFA window",
+          effectiveSource: "Built-in",
+          rawCustomTemplate: null,
+          rawDefaultTemplate: null,
+          effectiveTemplate: "{offender} sample",
+          renderedSample: "#15 - Tilonius sample",
+          sampleEmbed: {
+            color: 0xed4245,
+            description:
+              "## :rotating_light: :oncoming_police_car: FWA Police - Warplan violation detected :oncoming_police_car: :rotating_light:\n**War**: FWA-WIN :green_circle:\n**Violation**: Early non-mirror triple before FFA window",
+            fields: [
+              { name: "**Message**", value: "sample 1", inline: false },
+              { name: "**:yes: Expected**", value: "expected 1", inline: false },
+              { name: "**:no: Actual**", value: "actual 1", inline: false },
+            ],
+          },
+          isApplicable: true,
+          applicabilityText: "Applicable",
+        },
+        {
+          violation: "ANY_3STAR",
+          label: "Any 3-star in FWA loss (traditional)",
+          effectiveSource: "Default",
+          rawCustomTemplate: null,
+          rawDefaultTemplate: "{offender}",
+          effectiveTemplate: "{offender}",
+          renderedSample: "#15 - Tilonius",
+          sampleEmbed: {
+            color: 0xed4245,
+            description:
+              "## :rotating_light: :oncoming_police_car: FWA Police - Warplan violation detected :oncoming_police_car: :rotating_light:\n**War**: FWA-LOSE :red_circle:\n**Violation**: Any 3-star in FWA loss (traditional)",
+            fields: [
+              { name: "**Message**", value: "sample 2", inline: false },
+              { name: "**:yes: Expected**", value: "expected 2", inline: false },
+              { name: "**:no: Actual**", value: "actual 2", inline: false },
+            ],
+          },
+          isApplicable: true,
+          applicabilityText: "Applicable",
+        },
+      ],
+    });
+    const collector = { on: vi.fn() };
+    const run = makeInteraction({
+      subcommand: "show-all",
+      clan: "#2QG2C08UP",
+    });
+    const createMessageComponentCollector = vi.fn().mockReturnValue(collector);
+    run.editReply.mockResolvedValueOnce({
+      createMessageComponentCollector,
+    } as any);
+
+    await Fwa.run({} as any, run.interaction as any, {} as any);
+
+    const payload = run.editReply.mock.calls[0]?.[0];
+    expect(payload?.components?.length ?? 0).toBe(1);
+    expect(
+      String(payload?.embeds?.[0]?.toJSON?.()?.footer?.text ?? ""),
+    ).toContain("Page 1/2");
+    expect(createMessageComponentCollector).toHaveBeenCalledTimes(1);
   });
 });

--- a/tests/fwaPolice.service.test.ts
+++ b/tests/fwaPolice.service.test.ts
@@ -152,6 +152,7 @@ describe("FwaPoliceService", () => {
 
     const service = new FwaPoliceService();
     const bundle = await service.getTemplatePreviewBundle({
+      client: {} as any,
       guildId: "guild-1",
       clanTag: "#2QG2C08UP",
       sampleUserId: "111111111111111111",
@@ -320,17 +321,23 @@ describe("FwaPoliceService", () => {
     });
 
     expect(logSend).toHaveBeenCalledTimes(1);
-    expect(String(logSend.mock.calls[0]?.[0]?.content ?? "")).toContain(
+    const sentPayload = logSend.mock.calls[0]?.[0];
+    const embedJson = sentPayload?.embeds?.[0]?.toJSON?.() ?? null;
+    expect(embedJson?.title ?? null).toBeNull();
+    expect(Number(embedJson?.color ?? 0)).toBe(0xed4245);
+    expect(String(embedJson?.description ?? "")).toContain(
+      "FWA Police - Warplan violation detected",
+    );
+    expect(String(embedJson?.description ?? "")).toContain("**War**: FWA-WIN");
+    expect(String(embedJson?.fields?.[0]?.name ?? "")).toBe("**Message**");
+    expect(String(embedJson?.fields?.[1]?.name ?? "")).toBe(
+      "**:yes: Expected**",
+    );
+    expect(String(embedJson?.fields?.[2]?.name ?? "")).toBe(
+      "**:no: Actual**",
+    );
+    expect(String(embedJson?.fields?.[0]?.value ?? "")).toContain(
       "<@222222222222222222>",
-    );
-    expect(String(logSend.mock.calls[0]?.[0]?.content ?? "")).toContain(
-      "Expected:",
-    );
-    expect(String(logSend.mock.calls[0]?.[0]?.content ?? "")).toContain(
-      "Actual:",
-    );
-    expect(String(logSend.mock.calls[0]?.[0]?.content ?? "")).toContain(
-      "Violation:",
     );
     expect(result.logSent).toBe(1);
     expect(result.dmSent).toBe(0);


### PR DESCRIPTION
- route live dispatch and preview/send flows through one shared police embed presenter with emoji resolution and fallback
- add war/outcome banner formatting plus structured Message, Expected, and Actual embed fields
- paginate /fwa police show-all as one violation per page and update docs/tests for the new presentation contract