### PR TITLE
feat(todo): add off-cycle clan games lifetime view

### DIFF
--- a/src/services/TodoService.ts
+++ b/src/services/TodoService.ts
@@ -25,6 +25,7 @@ export type TodoPagesResult = {
 
 type TodoRenderRow = {
   playerTag: string;
+  linkedName: string | null;
   playerName: string;
   defaultIndex: number;
   townHall: number | null;
@@ -106,6 +107,7 @@ const TODO_STALE_IDLE_MS = 4 * 60 * 60 * 1000;
 const TODO_DEFAULT_GAMES_TARGET = 4000;
 const TODO_GAMES_COMPLETE_POINTS = 4000;
 const TODO_GAMES_MAX_POINTS = 10_000;
+const TODO_LOCALE = "en-US";
 const todoRenderCacheByKey = new Map<string, CachedTodoRender>();
 
 /** Purpose: normalize `/todo type` input into one safe enum value. */
@@ -359,6 +361,7 @@ export async function buildTodoPagesForUser(input: {
     });
     return {
       playerTag: normalizedTag,
+      linkedName: sanitizeStatusText(link.linkedName) || null,
       playerName: resolvedPlayerName,
       defaultIndex: index,
       townHall: resolvedTownHall,
@@ -380,10 +383,14 @@ export async function buildTodoPagesForUser(input: {
   const missingOrStaleTags = renderRows
     .filter((row) => row.missingSnapshot || row.staleSnapshot)
     .map((row) => row.playerTag);
-  if (missingOrStaleTags.length > 0) {
+  const gamesBackfillTags = renderRows
+    .filter((row) => needsGamesLifetimeBackfill(row, nowMs))
+    .map((row) => row.playerTag);
+  const refreshTags = [...new Set([...missingOrStaleTags, ...gamesBackfillTags])];
+  if (refreshTags.length > 0) {
     void todoSnapshotService
       .refreshSnapshotsForPlayerTags({
-        playerTags: missingOrStaleTags,
+        playerTags: refreshTags,
       })
       .catch(() => undefined);
   }
@@ -394,7 +401,7 @@ export async function buildTodoPagesForUser(input: {
       WAR: buildWarPageDescription(renderRows, linkedTags.length),
       CWL: buildCwlPageDescription(renderRows, linkedTags.length),
       RAIDS: buildRaidsPageDescription(renderRows, linkedTags.length),
-      GAMES: buildGamesPageDescription(renderRows, linkedTags.length),
+      GAMES: buildGamesPageDescription(renderRows, linkedTags.length, nowMs),
     },
   } satisfies TodoPagesResult;
 
@@ -434,7 +441,9 @@ function isSnapshotStale(snapshot: TodoSnapshotRecord, nowMs: number): boolean {
   if (snapshot.warActive) return ageMs > TODO_STALE_ACTIVE_WAR_MS;
   if (snapshot.cwlActive) return ageMs > TODO_STALE_ACTIVE_CWL_MS;
   if (snapshot.raidActive) return ageMs > TODO_STALE_ACTIVE_RAID_MS;
-  if (snapshot.gamesActive) return ageMs > TODO_STALE_ACTIVE_GAMES_MS;
+  if (isTodoGamesSessionActive(snapshot, nowMs)) {
+    return ageMs > TODO_STALE_ACTIVE_GAMES_MS;
+  }
   return ageMs > TODO_STALE_IDLE_MS;
 }
 
@@ -546,18 +555,22 @@ function buildRaidsPageDescription(
 function buildGamesPageDescription(
   rows: TodoRenderRow[],
   linkedPlayerCount: number,
+  nowMs: number,
 ): string {
-  const hasActive = rows.some((row) => Boolean(row.snapshot?.gamesActive));
+  const hasActive = rows.some((row) =>
+    isTodoGamesSessionActive(row.snapshot, nowMs),
+  );
   if (!hasActive) {
+    const offCycleLines = buildGamesOffCycleLines(rows, nowMs);
     return buildTodoPageDescription({
       heading: "GAMES",
       linkedPlayerCount,
-      lines: ["Clan Games is not active"],
+      lines: offCycleLines,
     });
   }
 
   const lines: string[] = [];
-  const sharedEndsAt = getSharedEndsAt(rows, "games");
+  const sharedEndsAt = getSharedEndsAt(rows, "games", nowMs);
   if (sharedEndsAt) {
     lines.push(`**Time remaining:** ${formatRelativeTimestamp(sharedEndsAt)}`);
     lines.push("");
@@ -660,14 +673,18 @@ function buildGroupClanIdentity(group: {
 }
 
 /** Purpose: find one shared end timestamp for active raid/games contexts to show at page top. */
-function getSharedEndsAt(rows: TodoRenderRow[], mode: "raid" | "games"): Date | null {
+function getSharedEndsAt(
+  rows: TodoRenderRow[],
+  mode: "raid" | "games",
+  nowMs = Date.now(),
+): Date | null {
   const candidates = rows
     .map((row) => {
       if (!row.snapshot) return null;
       if (mode === "raid" && row.snapshot.raidActive) {
         return row.snapshot.raidEndsAt ?? null;
       }
-      if (mode === "games" && row.snapshot.gamesActive) {
+      if (mode === "games" && isTodoGamesSessionActive(row.snapshot, nowMs)) {
         return row.snapshot.gamesEndsAt ?? null;
       }
       return null;
@@ -1098,6 +1115,125 @@ function getGamesProgressEmoji(row: TodoRenderRow): string {
   if (points >= TODO_GAMES_MAX_POINTS) return "🏆";
   if (points >= TODO_GAMES_COMPLETE_POINTS) return "✅";
   return "🟡";
+}
+
+/** Purpose: render one off-cycle Games section with season participants and lifetime totals for linked accounts. */
+function buildGamesOffCycleLines(rows: TodoRenderRow[], nowMs: number): string[] {
+  const sortedRows = sortGamesOffCycleRows(rows);
+  const cycleKey = resolveClanGamesDisplayCycleKey(nowMs);
+  const participants = sortedRows.filter((entry) =>
+    didParticipateInCurrentGamesCycle(entry.row.snapshot, cycleKey),
+  );
+  const lines: string[] = [
+    "Clan Games is not active. Showing lifetime Clan Games totals.",
+    "",
+    "**This season participants (linked accounts):**",
+  ];
+  if (participants.length <= 0) {
+    lines.push("None");
+  } else {
+    for (const entry of participants) {
+      lines.push(buildGamesOffCycleRowText(entry.row, entry.lifetimePoints));
+    }
+  }
+  lines.push("");
+  lines.push("**Linked accounts by lifetime Clan Games points:**");
+  for (const entry of sortedRows) {
+    lines.push(buildGamesOffCycleRowText(entry.row, entry.lifetimePoints));
+  }
+  return lines;
+}
+
+/** Purpose: build one off-cycle Games row using linked-first display-name fallback and comma-separated lifetime points. */
+function buildGamesOffCycleRowText(row: TodoRenderRow, lifetimePoints: number): string {
+  const displayName = resolveGamesOffCycleDisplayName(row);
+  return `${displayName} \`${row.playerTag}\` — ${formatLifetimePoints(lifetimePoints)}`;
+}
+
+/** Purpose: resolve off-cycle display names with PlayerLink name precedence, then existing snapshot fallback behavior. */
+function resolveGamesOffCycleDisplayName(row: TodoRenderRow): string {
+  if (row.linkedName) return row.linkedName;
+  return row.playerName;
+}
+
+/** Purpose: sort off-cycle Games rows by lifetime total desc then stable identity ties for deterministic output. */
+function sortGamesOffCycleRows(
+  rows: TodoRenderRow[],
+): Array<{ row: TodoRenderRow; lifetimePoints: number }> {
+  return rows
+    .map((row, index) => ({
+      row,
+      index,
+      lifetimePoints: Math.max(
+        0,
+        toFiniteIntOrNull(row.snapshot?.gamesChampionTotal) ?? 0,
+      ),
+      displayName: resolveGamesOffCycleDisplayName(row),
+    }))
+    .sort((a, b) => {
+      if (a.lifetimePoints !== b.lifetimePoints) {
+        return b.lifetimePoints - a.lifetimePoints;
+      }
+      const byName = a.displayName.localeCompare(b.displayName, undefined, {
+        sensitivity: "base",
+      });
+      if (byName !== 0) return byName;
+      const byTag = a.row.playerTag.localeCompare(b.row.playerTag);
+      if (byTag !== 0) return byTag;
+      return a.index - b.index;
+    })
+    .map(({ row, lifetimePoints }) => ({ row, lifetimePoints }));
+}
+
+/** Purpose: map lifetime totals to locale-aware comma-separated labels for off-cycle Games rows. */
+function formatLifetimePoints(input: number): string {
+  const normalized = Math.max(0, Math.trunc(Number(input) || 0));
+  return new Intl.NumberFormat(TODO_LOCALE).format(normalized);
+}
+
+/** Purpose: derive the Clan Games cycle key used for this-month off-cycle participant detection. */
+function resolveClanGamesDisplayCycleKey(nowMs: number): string {
+  const now = new Date(nowMs);
+  return String(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 22, 8, 0, 0, 0));
+}
+
+/** Purpose: identify whether one snapshot recorded positive points in the currently displayed Clan Games cycle. */
+function didParticipateInCurrentGamesCycle(
+  snapshot: TodoSnapshotRecord | null,
+  cycleKey: string,
+): boolean {
+  if (!snapshot) return false;
+  if (String(snapshot.gamesCycleKey ?? "") !== cycleKey) return false;
+
+  const championTotal = toFiniteIntOrNull(snapshot.gamesChampionTotal);
+  const baseline = toFiniteIntOrNull(snapshot.gamesSeasonBaseline);
+  if (championTotal !== null && baseline !== null) {
+    return championTotal > baseline;
+  }
+
+  const points = toFiniteIntOrNull(snapshot.gamesPoints);
+  return points !== null && points > 0;
+}
+
+/** Purpose: define when Clan Games is actively earning points for `/todo` render and staleness semantics. */
+function isTodoGamesSessionActive(
+  snapshot: TodoSnapshotRecord | null | undefined,
+  nowMs: number,
+): boolean {
+  if (!snapshot?.gamesActive) return false;
+  const endsAtMs = snapshot.gamesEndsAt?.getTime();
+  if (!Number.isFinite(endsAtMs)) return false;
+  return Number(endsAtMs) > nowMs;
+}
+
+/** Purpose: opportunistically refresh snapshots missing off-cycle lifetime totals so `gamesChampionTotal`/baseline can backfill. */
+function needsGamesLifetimeBackfill(row: TodoRenderRow, nowMs: number): boolean {
+  const snapshot = row.snapshot;
+  if (!snapshot) return false;
+  if (isTodoGamesSessionActive(snapshot, nowMs)) return false;
+  const championTotal = toFiniteIntOrNull(snapshot.gamesChampionTotal);
+  const seasonBaseline = toFiniteIntOrNull(snapshot.gamesSeasonBaseline);
+  return championTotal === null || seasonBaseline === null;
 }
 
 /** Purpose: format one date as a Discord relative timestamp token. */

--- a/src/services/TodoSnapshotService.ts
+++ b/src/services/TodoSnapshotService.ts
@@ -729,11 +729,34 @@ function deriveTodoGamesValues(input: {
   const activeCycleKey = normalizeGamesCycleKey(input.gamesCycleKey);
 
   if (!input.gamesWindowActive) {
+    let resolvedBaseline: number | null = championTotal;
+    if (existingCycleKey && activeCycleKey && existingCycleKey === activeCycleKey) {
+      resolvedBaseline = existingBaseline;
+      if (
+        championTotal !== null &&
+        resolvedBaseline === null &&
+        existingPoints !== null &&
+        existingPoints > 0
+      ) {
+        resolvedBaseline = Math.max(
+          0,
+          championTotal - clampInt(existingPoints, 0, TODO_GAMES_POINTS_MAX),
+        );
+      }
+      if (resolvedBaseline === null) resolvedBaseline = championTotal;
+      if (
+        championTotal !== null &&
+        resolvedBaseline !== null &&
+        championTotal < resolvedBaseline
+      ) {
+        resolvedBaseline = championTotal;
+      }
+    }
     return {
       points: null,
       target: null,
       championTotal,
-      seasonBaseline: championTotal,
+      seasonBaseline: resolvedBaseline,
       cycleKey: activeCycleKey,
     };
   }
@@ -1244,11 +1267,5 @@ function resolveClanGamesWindow(nowMs: number): TodoWindow {
   if (nowMs >= currentStart && nowMs < currentEnd) {
     return { active: true, startMs: currentStart, endMs: currentEnd };
   }
-  if (nowMs < currentStart) {
-    return { active: false, startMs: currentStart, endMs: currentEnd };
-  }
-
-  const nextStart = Date.UTC(year, month + 1, 22, 8, 0, 0, 0);
-  const nextEnd = Date.UTC(year, month + 1, 28, 8, 0, 0, 0);
-  return { active: false, startMs: nextStart, endMs: nextEnd };
+  return { active: false, startMs: currentStart, endMs: currentEnd };
 }

--- a/tests/todo.command.test.ts
+++ b/tests/todo.command.test.ts
@@ -127,6 +127,8 @@ function makeSnapshotRow(input: {
   gamesPoints?: number | null;
   gamesTarget?: number | null;
   gamesChampionTotal?: number | null;
+  gamesSeasonBaseline?: number | null;
+  gamesCycleKey?: string | null;
   gamesEndsAt?: Date | null;
   lastUpdatedAt?: Date;
   updatedAt?: Date;
@@ -154,11 +156,13 @@ function makeSnapshotRow(input: {
     raidAttacksMax: input.raidAttacksMax ?? 6,
     raidEndsAt: input.raidEndsAt ?? new Date("2026-03-29T07:00:00.000Z"),
     gamesActive: input.gamesActive ?? true,
-    gamesPoints: input.gamesPoints ?? 1200,
-    gamesTarget: input.gamesTarget ?? 4000,
-    gamesChampionTotal: input.gamesChampionTotal ?? 1200,
-    gamesSeasonBaseline: 0,
-    gamesCycleKey: "cycle-2026-03",
+    gamesPoints: input.gamesPoints === undefined ? 1200 : input.gamesPoints,
+    gamesTarget: input.gamesTarget === undefined ? 4000 : input.gamesTarget,
+    gamesChampionTotal:
+      input.gamesChampionTotal === undefined ? 1200 : input.gamesChampionTotal,
+    gamesSeasonBaseline:
+      input.gamesSeasonBaseline === undefined ? 0 : input.gamesSeasonBaseline,
+    gamesCycleKey: input.gamesCycleKey === undefined ? "cycle-2026-03" : input.gamesCycleKey,
     gamesEndsAt: input.gamesEndsAt ?? new Date("2026-03-28T08:00:00.000Z"),
     lastUpdatedAt: input.lastUpdatedAt ?? now,
     updatedAt: input.updatedAt ?? now,
@@ -1434,7 +1438,7 @@ describe("/todo command", () => {
     expect(getReplyDescription(interaction)).toContain("No raids active");
   });
 
-  it("shows explicit inactive GAMES page message when clan games is not active", async () => {
+  it("shows off-cycle GAMES view when clan games is not active", async () => {
     prismaMock.playerLink.findMany.mockResolvedValue([
       { playerTag: "#PYLQ0289", createdAt: new Date("2026-03-01T00:00:00.000Z") },
     ]);
@@ -1447,12 +1451,21 @@ describe("/todo command", () => {
         playerTag: "#PYLQ0289",
         playerName: "Alpha",
         gamesActive: false,
+        gamesChampionTotal: 1200,
+        gamesSeasonBaseline: 1200,
+        gamesCycleKey: "1774166400000",
       }),
     ]);
 
     const interaction = makeTodoInteraction({ type: "GAMES" });
     await Todo.run({} as any, interaction as any, makeCocServiceSpy() as any);
-    expect(getReplyDescription(interaction)).toContain("Clan Games is not active");
+    const description = getReplyDescription(interaction);
+    expect(description).toContain(
+      "Clan Games is not active. Showing lifetime Clan Games totals.",
+    );
+    expect(description).toContain("**This season participants (linked accounts):**");
+    expect(description).toContain("**Linked accounts by lifetime Clan Games points:**");
+    expect(description).toContain("Alpha `#PYLQ0289` — 1,200");
   });
 
   it("renders RAIDS markers for complete, active-incomplete, and not-started rows", async () => {
@@ -1792,6 +1805,140 @@ describe("/todo command", () => {
     expect(description).not.toContain(
       "- :black_circle: Bravo #QGRJ2222 - clan games points: 0/4000 - not active",
     );
+  });
+
+  it("renders off-cycle participants first and lifetime ranking for all linked accounts", async () => {
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      {
+        playerTag: "#PYLQ0289",
+        playerName: "Linked Alpha",
+        createdAt: new Date("2026-03-01T00:00:00.000Z"),
+      },
+      {
+        playerTag: "#QGRJ2222",
+        createdAt: new Date("2026-03-02T00:00:00.000Z"),
+      },
+      {
+        playerTag: "#CUV9082",
+        playerName: "Linked Charlie",
+        createdAt: new Date("2026-03-03T00:00:00.000Z"),
+      },
+      {
+        playerTag: "#LQ9P8R2",
+        createdAt: new Date("2026-03-04T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.todoPlayerSnapshot.aggregate.mockResolvedValue({
+      _count: { _all: 4 },
+      _max: { updatedAt: new Date("2026-03-26T00:00:00.000Z") },
+    });
+    prismaMock.todoPlayerSnapshot.findMany.mockResolvedValue([
+      makeSnapshotRow({
+        playerTag: "#PYLQ0289",
+        playerName: "Alpha Snapshot",
+        gamesActive: false,
+        gamesChampionTotal: 24000,
+        gamesSeasonBaseline: 21000,
+        gamesCycleKey: "1774166400000",
+      }),
+      makeSnapshotRow({
+        playerTag: "#QGRJ2222",
+        playerName: "Bravo Snapshot",
+        gamesActive: false,
+        gamesChampionTotal: 30000,
+        gamesSeasonBaseline: 30000,
+        gamesCycleKey: "1774166400000",
+      }),
+      makeSnapshotRow({
+        playerTag: "#CUV9082",
+        playerName: "Charlie Snapshot",
+        gamesActive: false,
+        gamesChampionTotal: 18000,
+        gamesSeasonBaseline: 17000,
+        gamesCycleKey: "1774166400000",
+      }),
+      makeSnapshotRow({
+        playerTag: "#LQ9P8R2",
+        playerName: "Delta Snapshot",
+        gamesActive: false,
+        gamesChampionTotal: null,
+        gamesSeasonBaseline: null,
+        gamesCycleKey: "1774166400000",
+      }),
+    ]);
+
+    const interaction = makeTodoInteraction({ type: "GAMES" });
+    await Todo.run({} as any, interaction as any, makeCocServiceSpy() as any);
+
+    const description = getReplyDescription(interaction);
+    const participantHeaderIndex = description.indexOf(
+      "**This season participants (linked accounts):**",
+    );
+    const lifetimeHeaderIndex = description.indexOf(
+      "**Linked accounts by lifetime Clan Games points:**",
+    );
+    const participantAlphaIndex = description.indexOf(
+      "Linked Alpha `#PYLQ0289` — 24,000",
+    );
+    const participantCharlieIndex = description.indexOf(
+      "Linked Charlie `#CUV9082` — 18,000",
+    );
+    const lifetimeBravoIndex = description.indexOf(
+      "Bravo Snapshot `#QGRJ2222` — 30,000",
+    );
+    const lifetimeAlphaIndex = description.indexOf(
+      "Linked Alpha `#PYLQ0289` — 24,000",
+      lifetimeHeaderIndex,
+    );
+    const lifetimeCharlieIndex = description.indexOf(
+      "Linked Charlie `#CUV9082` — 18,000",
+      lifetimeHeaderIndex,
+    );
+    const lifetimeDeltaIndex = description.indexOf("`#LQ9P8R2`", lifetimeHeaderIndex);
+
+    expect(participantHeaderIndex).toBeGreaterThan(-1);
+    expect(lifetimeHeaderIndex).toBeGreaterThan(participantHeaderIndex);
+    expect(participantAlphaIndex).toBeGreaterThan(participantHeaderIndex);
+    expect(participantCharlieIndex).toBeGreaterThan(participantAlphaIndex);
+    expect(lifetimeBravoIndex).toBeGreaterThan(lifetimeHeaderIndex);
+    expect(lifetimeAlphaIndex).toBeGreaterThan(lifetimeBravoIndex);
+    expect(lifetimeCharlieIndex).toBeGreaterThan(lifetimeAlphaIndex);
+    expect(lifetimeDeltaIndex).toBeGreaterThan(lifetimeCharlieIndex);
+    expect(description).toContain("`#LQ9P8R2` — 0");
+  });
+
+  it("treats reward-claim period as off-cycle even when stale snapshots still mark gamesActive", async () => {
+    vi.setSystemTime(new Date("2026-03-29T12:00:00.000Z"));
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      { playerTag: "#PYLQ0289", createdAt: new Date("2026-03-01T00:00:00.000Z") },
+    ]);
+    prismaMock.todoPlayerSnapshot.aggregate.mockResolvedValue({
+      _count: { _all: 1 },
+      _max: { updatedAt: new Date("2026-03-29T11:40:00.000Z") },
+    });
+    prismaMock.todoPlayerSnapshot.findMany.mockResolvedValue([
+      makeSnapshotRow({
+        playerTag: "#PYLQ0289",
+        playerName: "Alpha",
+        gamesActive: true,
+        gamesPoints: 3900,
+        gamesChampionTotal: 12345,
+        gamesSeasonBaseline: 10000,
+        gamesCycleKey: "1774166400000",
+        gamesEndsAt: new Date("2026-03-28T08:00:00.000Z"),
+        lastUpdatedAt: new Date("2026-03-29T11:40:00.000Z"),
+      }),
+    ]);
+
+    const interaction = makeTodoInteraction({ type: "GAMES" });
+    await Todo.run({} as any, interaction as any, makeCocServiceSpy() as any);
+
+    const description = getReplyDescription(interaction);
+    expect(description).toContain(
+      "Clan Games is not active. Showing lifetime Clan Games totals.",
+    );
+    expect(description).not.toContain("**Time remaining:**");
+    expect(description).not.toContain("clan games points:");
   });
 });
 

--- a/tests/todoSnapshot.service.test.ts
+++ b/tests/todoSnapshot.service.test.ts
@@ -944,4 +944,57 @@ describe("TodoSnapshotService", () => {
     );
     expect(prismaMock.botSetting.upsert).not.toHaveBeenCalled();
   });
+
+  it("keeps ended-cycle key and baseline during post-games off-cycle in the same month", async () => {
+    prismaMock.todoPlayerSnapshot.findMany.mockResolvedValue([
+      buildSnapshotRow({
+        gamesActive: true,
+        gamesPoints: 1300,
+        gamesTarget: 4000,
+        gamesChampionTotal: 14999,
+        gamesSeasonBaseline: 14000,
+        gamesCycleKey: "1774166400000",
+        gamesEndsAt: new Date("2026-03-28T08:00:00.000Z"),
+        lastUpdatedAt: new Date("2026-03-28T08:05:00.000Z"),
+        updatedAt: new Date("2026-03-28T08:05:00.000Z"),
+      }),
+    ]);
+    prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue([
+      {
+        playerTag: "#PYLQ0289",
+        clanTag: "#PQL0289",
+        playerName: "Alpha",
+        sourceSyncedAt: new Date("2026-03-29T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.fwaWarMemberCurrent.findMany.mockResolvedValue([]);
+    prismaMock.currentWar.findMany.mockResolvedValue([]);
+    prismaMock.cwlTrackedClan.findMany.mockResolvedValue([]);
+    prismaMock.cwlPlayerClanSeason.findMany.mockResolvedValue([]);
+    prismaMock.botSetting.findMany.mockResolvedValue([
+      {
+        key: "player_signal_state:#PYLQ0289",
+        value: JSON.stringify({ counters: { gamesChampion: 15000 } }),
+      },
+    ]);
+
+    await todoSnapshotService.refreshSnapshotsForPlayerTags({
+      playerTags: ["#PYLQ0289"],
+      nowMs: Date.UTC(2026, 2, 29, 12, 0, 0, 0),
+    });
+
+    expect(prismaMock.todoPlayerSnapshot.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({
+          gamesActive: false,
+          gamesPoints: null,
+          gamesTarget: null,
+          gamesChampionTotal: 15000,
+          gamesSeasonBaseline: 14000,
+          gamesCycleKey: "1774166400000",
+          gamesEndsAt: new Date("2026-03-28T08:00:00.000Z"),
+        }),
+      }),
+    );
+  });
 });


### PR DESCRIPTION
- render an off-cycle Games section with season participants and lifetime-ranked linked accounts
- treat reward-claim as not in-session for Games rendering and stale handling
- preserve same-month games cycle baseline in snapshot refresh so participation context survives off-cycle