### PR TITLE
fix(fwa-police): route logs correctly and enforce violations at poll …

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -68,7 +68,7 @@
 - `/fwa police set-default clan:<trackedClanTag> violation:<...> template:<text>` - Save a global default template override for one canonical violation (storage keyed by violation only).
 - `/fwa police reset clan:<trackedClanTag> violation:<...>` - Delete one clan-scoped template override.
 - `/fwa police reset-default clan:<trackedClanTag> violation:<...>` - Delete one global default template override.
-- `/fwa police send clan:<trackedClanTag> show:<DM|LOG> violation:<...>` - Send one rendered sample template through the shared police renderer to DM or clan log channel (`LOG` fails clearly when log channel is not configured).
+- `/fwa police send clan:<trackedClanTag> show:<DM|LOG> violation:<...>` - Send one rendered sample template through the shared police renderer to DM or police log channel (`TrackedClan.logChannelId` first, then `/bot-logs` fallback; `LOG` fails clearly when neither is configured).
 - `/fwa weight-age [visibility:private|public] [tag:<tag>]` - Scrape `https://fwastats.com/Clan/<tag>/Weight` and report last submitted weight age for one clan or all tracked clans. Uses `FWASTATS_WEIGHT_COOKIE` when configured.
 - `/fwa weight-link [visibility:private|public] [tag:<tag>]` - Return FWA Stats weight page link(s) for one clan or all tracked clans.
 - `/fwa weight-health [visibility:private|public] [tag:<tag>]` - Show stale-weight health summary (recent/outdated/severe) using fetched weight-age data; defaults to all tracked clans and shares the same auth flow as `weight-age`.

--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -12493,7 +12493,7 @@ export const Fwa: Command = {
         if (!sendResult.ok) {
           if (sendResult.error === "LOG_CHANNEL_NOT_CONFIGURED") {
             await editReplySafe(
-              `Cannot send LOG sample for ${previewBundle.clanTag}: no clan log channel is configured.`,
+              `Cannot send LOG sample for ${previewBundle.clanTag}: no tracked clan log channel or \`/bot-logs\` fallback channel is configured.`,
             );
             return;
           }

--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -377,7 +377,7 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
       "`/fwa police configure` controls automatic DM/log enforcement toggles for a tracked clan.",
       "`/fwa police show`, `show-default`, and `show-all` render canonical violation templates with source precedence (Custom -> Default -> Built-in), sample output, and warplan-aware applicability context (`show-all` paginates one violation per page).",
       "`/fwa police set`, `set-default`, `reset`, and `reset-default` manage per-violation template overrides using canonical enum keys only.",
-      "`/fwa police send` test-delivers one rendered sample template to your DM or the clan log channel.",
+      "`/fwa police send` test-delivers one rendered sample template to your DM or the police log destination (`TrackedClan.logChannelId` first, then `/bot-logs`).",
       "FWA compliance embeds include a `Warplan` field from the same active plan source used by war mail, show resolved FWA-WIN threshold context (`N`/`H`) from warplan config, and strict-window breach context shows clan stars before the breach attack.",
       "`/fwa weight-age` scrapes the fwastats weight page and reports last submitted weight age (single clan or all tracked clans). Uses `FWASTATS_WEIGHT_COOKIE` when configured.",
       "`/fwa weight-link` returns fwastats weight page URL(s) for one clan or all tracked clans.",

--- a/src/services/FwaPoliceService.ts
+++ b/src/services/FwaPoliceService.ts
@@ -30,6 +30,7 @@ import {
   validateFwaPoliceTemplatePlaceholders,
 } from "./FwaPoliceTemplateCatalog";
 import { emojiResolverService } from "./emoji/EmojiResolverService";
+import { BotLogChannelService } from "./BotLogChannelService";
 
 type TrackedClanPoliceRow = {
   tag: string;
@@ -38,8 +39,6 @@ type TrackedClanPoliceRow = {
   fwaPoliceDmEnabled: boolean;
   fwaPoliceLogEnabled: boolean;
   logChannelId: string | null;
-  notifyChannelId: string | null;
-  mailChannelId: string | null;
 };
 
 type WarComplianceEvaluator = Pick<
@@ -198,12 +197,7 @@ function buildViolationKey(issue: WarComplianceIssue): string {
 }
 
 function resolveClanLogChannelId(clan: TrackedClanPoliceRow): string | null {
-  return (
-    normalizeFwaPoliceText(clan.logChannelId) ||
-    normalizeFwaPoliceText(clan.notifyChannelId) ||
-    normalizeFwaPoliceText(clan.mailChannelId) ||
-    null
-  );
+  return normalizeFwaPoliceText(clan.logChannelId) || null;
 }
 
 function buildOffenderLabel(input: {
@@ -350,6 +344,51 @@ function resolveWarLine(input: {
   return `${input.matchTypeContext} ${input.emojis.white}`;
 }
 
+function formatViolationTimeRemaining(input: {
+  attackSeenAt: Date | null;
+  warEndTime: Date | null;
+}): string | null {
+  if (!(input.attackSeenAt instanceof Date)) return null;
+  if (!(input.warEndTime instanceof Date)) return null;
+  const totalMinutes = Math.max(
+    0,
+    Math.floor((input.warEndTime.getTime() - input.attackSeenAt.getTime()) / (60 * 1000)),
+  );
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return `${hours}h ${minutes}m left`;
+}
+
+function resolveViolationTimeFallbackLabel(raw: string | null | undefined): string | null {
+  const normalized = normalizeFwaPoliceText(raw);
+  if (!normalized) return null;
+  if (!/^\d+h \d+m left$/i.test(normalized)) return null;
+  return normalized;
+}
+
+function resolveWarClanDisplayName(input: {
+  preferredClanName: string | null | undefined;
+  fallbackClanName: string | null | undefined;
+  clanTag: string;
+}): string {
+  return (
+    normalizeFwaPoliceText(input.preferredClanName) ||
+    normalizeFwaPoliceText(input.fallbackClanName) ||
+    normalizeClanTag(input.clanTag) ||
+    String(input.clanTag ?? "").trim() ||
+    "Unknown Clan"
+  );
+}
+
+function resolveBreachAttackOrder(issue: WarComplianceIssue): number | null {
+  const attackDetails = Array.isArray(issue.attackDetails) ? issue.attackDetails : [];
+  const breachDetail = attackDetails.find((row) => Boolean(row?.isBreach)) ?? attackDetails[0] ?? null;
+  if (!breachDetail) return null;
+  if (!Number.isFinite(Number(breachDetail.attackOrder))) return null;
+  const attackOrder = Math.trunc(Number(breachDetail.attackOrder));
+  return attackOrder > 0 ? attackOrder : null;
+}
+
 function buildPoliceMessagePresentation(input: {
   violation: FwaPoliceViolation;
   resolvedTemplate: string;
@@ -357,8 +396,10 @@ function buildPoliceMessagePresentation(input: {
   user: string;
   expectedBehavior: string;
   actualBehavior: string;
+  warClanDisplayName: string;
   matchTypeContext: MatchType;
   expectedOutcome: "WIN" | "LOSE" | null;
+  violationTimeRemaining: string;
   emojis: FwaPoliceResolvedEmojiState;
 }): { renderedTemplate: string; embed: EmbedBuilder } {
   const metadata = FWA_POLICE_VIOLATION_METADATA[input.violation];
@@ -369,12 +410,13 @@ function buildPoliceMessagePresentation(input: {
   });
   const description = [
     `## ${input.emojis.alert} ${input.emojis.alertBlue} FWA Police - Warplan violation detected ${input.emojis.alertBlue} ${input.emojis.alert}`,
-    `**War**: ${resolveWarLine({
+    `**War**: ${input.warClanDisplayName} ${resolveWarLine({
       matchTypeContext: input.matchTypeContext,
       expectedOutcome: input.expectedOutcome,
       emojis: input.emojis,
     })}`,
     `**Violation**: ${metadata.label}`,
+    `**Violation Time**: ${input.violationTimeRemaining}`,
   ].join("\n");
   const embed = new EmbedBuilder()
     .setColor(0xed4245)
@@ -422,8 +464,6 @@ async function resolveTrackedClanByTag(
       fwaPoliceDmEnabled: true,
       fwaPoliceLogEnabled: true,
       logChannelId: true,
-      notifyChannelId: true,
-      mailChannelId: true,
     },
   });
 }
@@ -522,6 +562,84 @@ async function resolveWarplanContextForClan(input: {
 }
 
 export class FwaPoliceService {
+  private readonly botLogChannels: Pick<BotLogChannelService, "getChannelId">;
+
+  /** Purpose: initialize shared dependencies for police delivery behavior. */
+  constructor(botLogChannels?: Pick<BotLogChannelService, "getChannelId">) {
+    this.botLogChannels = botLogChannels ?? new BotLogChannelService();
+  }
+
+  /** Purpose: resolve police log destination via tracked clan log channel first, then guild bot-log fallback. */
+  private async resolvePoliceLogChannelId(input: {
+    guildId: string;
+    tracked: TrackedClanPoliceRow;
+  }): Promise<string | null> {
+    const trackedLogChannelId = resolveClanLogChannelId(input.tracked);
+    if (trackedLogChannelId) return trackedLogChannelId;
+    const botLogChannelId = await this.botLogChannels
+      .getChannelId(input.guildId)
+      .catch(() => null);
+    return normalizeFwaPoliceText(botLogChannelId) || null;
+  }
+
+  /** Purpose: compute a deterministic `Xh Ym left` violation-time label from violating attack timing. */
+  private async resolveViolationTimeRemaining(input: {
+    clanTag: string;
+    warId: number;
+    playerTag: string;
+    issue: WarComplianceIssue;
+    reportWarEndTime: Date | null;
+  }): Promise<string> {
+    const normalizedClanTag = normalizeClanTag(input.clanTag);
+    const normalizedPlayerTag = normalizePlayerTag(input.playerTag);
+    if (!normalizedClanTag || !normalizedPlayerTag) {
+      return (
+        resolveViolationTimeFallbackLabel(input.issue.breachContext?.timeRemaining) ||
+        "unknown left"
+      );
+    }
+    const breachAttackOrder = resolveBreachAttackOrder(input.issue);
+    const baseWhere = {
+      clanTag: normalizedClanTag,
+      warId: Math.trunc(Number(input.warId)),
+      playerTag: normalizedPlayerTag,
+    };
+    const matchingAttackRow =
+      breachAttackOrder !== null
+        ? await prisma.warAttacks.findFirst({
+            where: {
+              ...baseWhere,
+              attackOrder: breachAttackOrder,
+            },
+            select: {
+              attackSeenAt: true,
+              warEndTime: true,
+            },
+          })
+        : null;
+    const fallbackAttackRow =
+      matchingAttackRow ??
+      (await prisma.warAttacks.findFirst({
+        where: {
+          ...baseWhere,
+          attackOrder: { gt: 0 },
+        },
+        orderBy: [{ attackSeenAt: "asc" }, { attackOrder: "asc" }],
+        select: {
+          attackSeenAt: true,
+          warEndTime: true,
+        },
+      }));
+    const computed =
+      formatViolationTimeRemaining({
+        attackSeenAt: fallbackAttackRow?.attackSeenAt ?? null,
+        warEndTime: fallbackAttackRow?.warEndTime ?? input.reportWarEndTime ?? null,
+      }) ||
+      resolveViolationTimeFallbackLabel(input.issue.breachContext?.timeRemaining) ||
+      "unknown left";
+    return computed;
+  }
+
   /** Purpose: persist clan-scoped police automation toggles on the tracked-clan source of truth. */
   async setClanConfig(input: {
     clanTag: string;
@@ -705,6 +823,7 @@ export class FwaPoliceService {
   private async buildPreviewRows(input: {
     client: Client;
     clanTag: string;
+    clanName?: string | null;
     context: FwaPoliceWarplanContext;
     sampleUserId?: string | null;
   }): Promise<FwaPoliceTemplatePreviewRow[]> {
@@ -727,8 +846,14 @@ export class FwaPoliceService {
         user: input.sampleUserId ? `<@${input.sampleUserId}>` : "UNLINKED_USER",
         expectedBehavior: buildSampleExpectedBehavior(resolved.violation),
         actualBehavior: buildSampleActualBehavior(resolved.violation),
+        warClanDisplayName: resolveWarClanDisplayName({
+          preferredClanName: input.clanName ?? null,
+          fallbackClanName: null,
+          clanTag: input.clanTag,
+        }),
         matchTypeContext: input.context.matchTypeContext,
         expectedOutcome: input.context.expectedOutcome,
+        violationTimeRemaining: "23h 15m left",
         emojis,
       });
       const isApplicable = metadata.isApplicable(toApplicabilityContext(input.context));
@@ -768,6 +893,7 @@ export class FwaPoliceService {
     const rows = await this.buildPreviewRows({
       client: input.client,
       clanTag: normalizedClanTag,
+      clanName: tracked.name,
       context,
       sampleUserId: input.sampleUserId ?? null,
     });
@@ -813,8 +939,14 @@ export class FwaPoliceService {
       user: `<@${input.requestingUserId}>`,
       expectedBehavior: buildSampleExpectedBehavior(input.violation),
       actualBehavior: buildSampleActualBehavior(input.violation),
+      warClanDisplayName: resolveWarClanDisplayName({
+        preferredClanName: normalizeFwaPoliceText(tracked.name),
+        fallbackClanName: null,
+        clanTag: normalizedClanTag,
+      }),
       matchTypeContext: context.matchTypeContext,
       expectedOutcome: context.expectedOutcome,
+      violationTimeRemaining: "23h 15m left",
       emojis,
     });
 
@@ -831,11 +963,16 @@ export class FwaPoliceService {
       return { ok: true, deliveredTo: "DM", rendered: presentation.renderedTemplate };
     }
 
-    const strictLogChannelId = normalizeFwaPoliceText(tracked.logChannelId) || null;
-    if (!strictLogChannelId) {
+    const resolvedLogChannelId = await this.resolvePoliceLogChannelId({
+      guildId: input.guildId,
+      tracked,
+    });
+    if (!resolvedLogChannelId) {
       return { ok: false, error: "LOG_CHANNEL_NOT_CONFIGURED" };
     }
-    const channel = await input.client.channels.fetch(strictLogChannelId).catch(() => null);
+    const channel = await input.client.channels
+      .fetch(resolvedLogChannelId)
+      .catch(() => null);
     if (!isTextChannelWithSend(channel)) {
       return { ok: false, error: "LOG_CHANNEL_UNAVAILABLE" };
     }
@@ -903,7 +1040,12 @@ export class FwaPoliceService {
       links.map((link) => [normalizePlayerTag(link.playerTag), link.discordUserId]),
     );
 
-    const resolvedLogChannelId = enableLog ? resolveClanLogChannelId(tracked) : null;
+    const resolvedLogChannelId = enableLog
+      ? await this.resolvePoliceLogChannelId({
+          guildId: input.guildId,
+          tracked,
+        })
+      : null;
     const resolvedLogChannel =
       enableLog && resolvedLogChannelId
         ? await input.client.channels.fetch(resolvedLogChannelId).catch(() => null)
@@ -916,6 +1058,11 @@ export class FwaPoliceService {
     let logSent = 0;
 
     const effectiveWarId = report.warId ?? normalizedWarId;
+    const warClanDisplayName = resolveWarClanDisplayName({
+      preferredClanName: report.clanName,
+      fallbackClanName: tracked.name,
+      clanTag: normalizedClanTag,
+    });
     const context: FwaPoliceApplicabilityContext = {
       matchType: report.matchType,
       expectedOutcome: report.expectedOutcome,
@@ -964,6 +1111,13 @@ export class FwaPoliceService {
       created += 1;
 
       const violation = classifyFwaPoliceViolation({ issue, context });
+      const violationTimeRemaining = await this.resolveViolationTimeRemaining({
+        clanTag: normalizedClanTag,
+        warId: effectiveWarId,
+        playerTag,
+        issue,
+        reportWarEndTime: report.warEndTime ?? null,
+      });
       const templateResolution =
         templateByViolation.get(violation) ??
         (await this.resolveTemplateForViolation({
@@ -981,8 +1135,10 @@ export class FwaPoliceService {
         user: linkedDiscordUserId ? `<@${linkedDiscordUserId}>` : "UNLINKED_USER",
         expectedBehavior: issue.expectedBehavior,
         actualBehavior: issue.actualBehavior,
+        warClanDisplayName,
         matchTypeContext: report.matchType,
         expectedOutcome: report.expectedOutcome,
+        violationTimeRemaining,
         emojis,
       });
 

--- a/src/services/WarEventLogService.ts
+++ b/src/services/WarEventLogService.ts
@@ -2973,12 +2973,35 @@ export class WarEventLogService {
         updatedAt: new Date(),
       },
     });
-    await this.syncWarAttacksFromWarSnapshot({
+    const newAttackRowsObserved = await this.syncWarAttacksFromWarSnapshot({
       war,
       clanTag: sub.clanTag,
       resolvedWarId,
       fallbackWarStartTime: nextWarStartTime,
     });
+    if (
+      currentState === "inWar" &&
+      newAttackRowsObserved > 0 &&
+      resolvedWarId !== null &&
+      resolvedWarId !== undefined &&
+      Number.isFinite(Number(resolvedWarId)) &&
+      Math.trunc(Number(resolvedWarId)) > 0
+    ) {
+      const policeWarId = Math.trunc(Number(resolvedWarId));
+      await this.fwaPolice
+        .enforceWarViolations({
+          client: this.client,
+          guildId: sub.guildId,
+          clanTag: sub.clanTag,
+          warId: policeWarId,
+          warCompliance: this.warCompliance,
+        })
+        .catch((err) => {
+          console.error(
+            `[fwa-police] enforce_failed guild=${sub.guildId} clan=${sub.clanTag} warId=${policeWarId} source=poll_cycle error=${formatError(err)}`,
+          );
+        });
+    }
     if (detectedEventPayload) {
       await this.dispatchDetectedEvent({
         sub,
@@ -3009,18 +3032,18 @@ export class WarEventLogService {
     clanTag: string;
     resolvedWarId: number | null;
     fallbackWarStartTime: Date | null;
-  }): Promise<void> {
+  }): Promise<number> {
     if (
       params.resolvedWarId === null ||
       params.resolvedWarId === undefined ||
       !Number.isFinite(Number(params.resolvedWarId))
     ) {
-      return;
+      return 0;
     }
     const war = params.war;
     const ownClanTag = normalizeTag(war?.clan?.tag ?? params.clanTag);
-    if (!ownClanTag) return;
-    if (!war?.clan?.tag || !war?.startTime) return;
+    if (!ownClanTag) return 0;
+    if (!war?.clan?.tag || !war?.startTime) return 0;
 
     const ownClanName =
       String(war.clan.name ?? ownClanTag).trim() || ownClanTag;
@@ -3029,7 +3052,7 @@ export class WarEventLogService {
       String(war.opponent?.name ?? opponentClanTag).trim() || opponentClanTag;
     const warStartTime =
       parseCocTime(war.startTime) ?? params.fallbackWarStartTime;
-    if (!warStartTime) return;
+    if (!warStartTime) return 0;
     const warEndTime = parseCocTime(war.endTime ?? null);
     const warState = String(war.state ?? "").trim() || null;
     const observedAt = new Date();
@@ -3086,7 +3109,30 @@ export class WarEventLogService {
       ownMembers,
       opponentMembers,
     });
+    const existingAttackRows = await prisma.warAttacks.findMany({
+      where: {
+        clanTag: ownClanTag,
+        warStartTime,
+        attackOrder: { gt: 0 },
+      },
+      select: {
+        playerTag: true,
+        attackOrder: true,
+      },
+    });
+    const existingAttackKeys = new Set(
+      existingAttackRows.map(
+        (row) => `${normalizeTag(row.playerTag)}:${Math.trunc(Number(row.attackOrder))}`,
+      ),
+    );
+    let newAttackRowsObserved = 0;
     for (const row of computedAttackRows) {
+      const attackOrder = Math.trunc(Number(row.attackOrder));
+      const attackKey = `${normalizeTag(row.playerTag)}:${attackOrder}`;
+      if (attackOrder > 0 && !existingAttackKeys.has(attackKey)) {
+        existingAttackKeys.add(attackKey);
+        newAttackRowsObserved += 1;
+      }
       await prisma.$executeRaw(
         Prisma.sql`
           INSERT INTO "WarAttacks"
@@ -3116,6 +3162,7 @@ export class WarEventLogService {
         `,
       );
     }
+    return newAttackRowsObserved;
   }
 
   private async dispatchDetectedEvent(params: {
@@ -3179,28 +3226,6 @@ export class WarEventLogService {
           });
       }
 
-      const policeWarId =
-        resolvedWarIdForDelivery !== null &&
-        resolvedWarIdForDelivery !== undefined &&
-        Number.isFinite(Number(resolvedWarIdForDelivery)) &&
-        Math.trunc(Number(resolvedWarIdForDelivery)) > 0
-          ? Math.trunc(Number(resolvedWarIdForDelivery))
-          : null;
-      if (policeWarId !== null) {
-        await this.fwaPolice
-          .enforceWarViolations({
-            client: this.client,
-            guildId: params.sub.guildId,
-            clanTag: payloadForDelivery.clanTag,
-            warId: policeWarId,
-            warCompliance: this.warCompliance,
-          })
-          .catch((err) => {
-            console.error(
-              `[fwa-police] enforce_failed guild=${params.sub.guildId} clan=${params.sub.clanTag} warId=${policeWarId} error=${formatError(err)}`,
-            );
-          });
-      }
     }
     if (!params.sub.notify || !params.sub.channelId) return;
     const reserved = await this.reserveEventDelivery({

--- a/tests/fwaPolice.commandOutput.test.ts
+++ b/tests/fwaPolice.commandOutput.test.ts
@@ -213,7 +213,8 @@ describe("/fwa police command output", () => {
     await Fwa.run({} as any, run.interaction as any, {} as any);
 
     const content = String(run.editReply.mock.calls[0]?.[0]?.content ?? "");
-    expect(content).toContain("no clan log channel is configured");
+    expect(content).toContain("no tracked clan log channel");
+    expect(content).toContain("/bot-logs");
   });
 
   it("renders show output with effective source and rendered sample", async () => {

--- a/tests/fwaPolice.service.test.ts
+++ b/tests/fwaPolice.service.test.ts
@@ -25,10 +25,17 @@ const prismaMock = vi.hoisted(() => ({
     create: vi.fn(),
     update: vi.fn(),
   },
+  warAttacks: {
+    findFirst: vi.fn(),
+  },
 }));
 
 const playerLinkServiceMock = vi.hoisted(() => ({
   listPlayerLinksForClanMembers: vi.fn(),
+}));
+
+const botLogServiceMock = vi.hoisted(() => ({
+  getChannelId: vi.fn(),
 }));
 
 vi.mock("../src/prisma", () => ({
@@ -43,6 +50,12 @@ vi.mock("../src/services/PlayerLinkService", async () => {
       playerLinkServiceMock.listPlayerLinksForClanMembers,
   };
 });
+
+vi.mock("../src/services/BotLogChannelService", () => ({
+  BotLogChannelService: vi.fn().mockImplementation(() => ({
+    getChannelId: botLogServiceMock.getChannelId,
+  })),
+}));
 
 import { FwaPoliceService } from "../src/services/FwaPoliceService";
 
@@ -99,6 +112,11 @@ describe("FwaPoliceService", () => {
     prismaMock.fwaPoliceClanTemplate.deleteMany.mockResolvedValue({});
     prismaMock.fwaPoliceDefaultTemplate.deleteMany.mockResolvedValue({});
     playerLinkServiceMock.listPlayerLinksForClanMembers.mockResolvedValue([]);
+    botLogServiceMock.getChannelId.mockResolvedValue(null);
+    prismaMock.warAttacks.findFirst.mockResolvedValue({
+      attackSeenAt: new Date("2026-03-12T00:45:00.000Z"),
+      warEndTime: new Date("2026-03-13T00:00:00.000Z"),
+    });
   });
 
   it("persists clan police config on tracked clan rows", async () => {
@@ -189,6 +207,89 @@ describe("FwaPoliceService", () => {
       ok: false,
       error: "LOG_CHANNEL_NOT_CONFIGURED",
     });
+  });
+
+  it("uses /bot-logs fallback for LOG sample send when tracked log channel is missing", async () => {
+    prismaMock.trackedClan.findFirst.mockResolvedValue({
+      tag: "#2QG2C08UP",
+      name: "Alpha",
+      loseStyle: "TRIPLE_TOP_30",
+      fwaPoliceDmEnabled: true,
+      fwaPoliceLogEnabled: true,
+      logChannelId: null,
+      notifyChannelId: null,
+      mailChannelId: null,
+    });
+    botLogServiceMock.getChannelId.mockResolvedValue("channel-bot-log");
+    const logSend = vi.fn().mockResolvedValue({});
+    const client = {
+      channels: {
+        fetch: vi.fn().mockResolvedValue({
+          isTextBased: () => true,
+          send: logSend,
+        }),
+      },
+      users: {
+        fetch: vi.fn(),
+      },
+    } as any;
+
+    const service = new FwaPoliceService();
+    const result = await service.sendSampleMessage({
+      client,
+      guildId: "guild-1",
+      clanTag: "#2QG2C08UP",
+      violation: "EARLY_NON_MIRROR_TRIPLE",
+      destination: "LOG",
+      requestingUserId: "111111111111111111",
+    });
+
+    expect(botLogServiceMock.getChannelId).toHaveBeenCalledWith("guild-1");
+    expect(client.channels.fetch).toHaveBeenCalledWith("channel-bot-log");
+    expect(logSend).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      ok: true,
+      deliveredTo: "LOG",
+      rendered: expect.any(String),
+    });
+  });
+
+  it("does not fall back to notify/mail channels for police LOG sample send", async () => {
+    prismaMock.trackedClan.findFirst.mockResolvedValue({
+      tag: "#2QG2C08UP",
+      name: "Alpha",
+      loseStyle: "TRIPLE_TOP_30",
+      fwaPoliceDmEnabled: true,
+      fwaPoliceLogEnabled: true,
+      logChannelId: null,
+      notifyChannelId: "channel-notify",
+      mailChannelId: "channel-mail",
+    });
+    botLogServiceMock.getChannelId.mockResolvedValue(null);
+    const client = {
+      channels: {
+        fetch: vi.fn(),
+      },
+      users: {
+        fetch: vi.fn(),
+      },
+    } as any;
+
+    const service = new FwaPoliceService();
+    const result = await service.sendSampleMessage({
+      client,
+      guildId: "guild-1",
+      clanTag: "#2QG2C08UP",
+      violation: "EARLY_NON_MIRROR_TRIPLE",
+      destination: "LOG",
+      requestingUserId: "111111111111111111",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      error: "LOG_CHANNEL_NOT_CONFIGURED",
+    });
+    expect(client.channels.fetch).not.toHaveBeenCalled();
   });
 
   it("uses canonical compliance evaluation and sends DM only when dm toggle is enabled", async () => {
@@ -328,7 +429,10 @@ describe("FwaPoliceService", () => {
     expect(String(embedJson?.description ?? "")).toContain(
       "FWA Police - Warplan violation detected",
     );
-    expect(String(embedJson?.description ?? "")).toContain("**War**: FWA-WIN");
+    expect(String(embedJson?.description ?? "")).toContain("**War**: Alpha FWA-WIN");
+    expect(String(embedJson?.description ?? "")).toContain(
+      "**Violation Time**: 23h 15m left",
+    );
     expect(String(embedJson?.fields?.[0]?.name ?? "")).toBe("**Message**");
     expect(String(embedJson?.fields?.[1]?.name ?? "")).toBe(
       "**:yes: Expected**",
@@ -339,8 +443,69 @@ describe("FwaPoliceService", () => {
     expect(String(embedJson?.fields?.[0]?.value ?? "")).toContain(
       "<@222222222222222222>",
     );
+    expect(botLogServiceMock.getChannelId).not.toHaveBeenCalled();
     expect(result.logSent).toBe(1);
     expect(result.dmSent).toBe(0);
+  });
+
+  it("falls back to /bot-logs for live police log delivery when tracked log channel is missing", async () => {
+    prismaMock.trackedClan.findFirst.mockResolvedValue({
+      tag: "#2QG2C08UP",
+      name: "Alpha",
+      loseStyle: "TRIPLE_TOP_30",
+      fwaPoliceDmEnabled: false,
+      fwaPoliceLogEnabled: true,
+      logChannelId: null,
+      notifyChannelId: "channel-notify",
+      mailChannelId: "channel-mail",
+    });
+    botLogServiceMock.getChannelId.mockResolvedValue("channel-bot-log");
+    playerLinkServiceMock.listPlayerLinksForClanMembers.mockResolvedValue([
+      {
+        playerTag: "#P2YLC8R0",
+        discordUserId: "222222222222222222",
+      },
+    ]);
+
+    const logSend = vi.fn().mockResolvedValue({});
+    const client = {
+      users: {
+        fetch: vi.fn(),
+      },
+      channels: {
+        fetch: vi.fn().mockResolvedValue({
+          isTextBased: () => true,
+          send: logSend,
+        }),
+      },
+    } as any;
+    const evaluateComplianceForCommand = vi.fn().mockResolvedValue({
+      status: "ok",
+      report: {
+        warId: 12345,
+        clanName: "Alpha",
+        opponentName: "Bravo",
+        matchType: "FWA",
+        expectedOutcome: "WIN",
+        loseStyle: "TRIPLE_TOP_30",
+        warEndTime: new Date("2026-03-13T00:00:00.000Z"),
+        notFollowingPlan: [buildIssue()],
+      },
+    });
+
+    const service = new FwaPoliceService();
+    const result = await service.enforceWarViolations({
+      client,
+      guildId: "guild-1",
+      clanTag: "#2QG2C08UP",
+      warId: 12345,
+      warCompliance: { evaluateComplianceForCommand } as any,
+    });
+
+    expect(botLogServiceMock.getChannelId).toHaveBeenCalledWith("guild-1");
+    expect(client.channels.fetch).toHaveBeenCalledWith("channel-bot-log");
+    expect(logSend).toHaveBeenCalledTimes(1);
+    expect(result.logSent).toBe(1);
   });
 
   it("does not send DM or log when canonical compliance returns no remaining violations", async () => {

--- a/tests/warEventLog.warEndPointsReconcile.test.ts
+++ b/tests/warEventLog.warEndPointsReconcile.test.ts
@@ -605,6 +605,176 @@ describe("Match-type confirmation rollover via processSubscription", () => {
   });
 });
 
+describe("FWA police poll-time enforcement", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function buildInWarSnapshot(): Record<string, unknown> {
+    return {
+      state: "inWar",
+      startTime: "20260312T000000.000Z",
+      preparationStartTime: "20260311T000000.000Z",
+      endTime: "20260313T000000.000Z",
+      teamSize: 50,
+      attacksPerMember: 2,
+      clan: {
+        tag: "#AAA111",
+        name: "Alpha",
+        stars: 100,
+        attacks: 10,
+        destructionPercentage: 70,
+        members: [],
+      },
+      opponent: {
+        tag: "#OPP123",
+        name: "Enemy",
+        stars: 99,
+        attacks: 10,
+        destructionPercentage: 69,
+        members: [],
+      },
+    };
+  }
+
+  function buildProcessSubscriptionService(syncResults: number[]): {
+    service: WarEventLogService;
+    enforceSpy: ReturnType<typeof vi.spyOn>;
+  } {
+    const service = new WarEventLogService(
+      { channels: { fetch: vi.fn() } } as unknown as Client,
+      {} as any,
+    );
+    const sub = makeSubscription({
+      guildId: "guild-1",
+      clanTag: "#AAA111",
+      state: "inWar",
+      startTime: new Date("2026-03-12T00:00:00.000Z"),
+      endTime: new Date("2026-03-13T00:00:00.000Z"),
+      opponentTag: "#OPP123",
+      opponentName: "Enemy",
+    });
+
+    vi.spyOn(prisma, "$queryRaw").mockResolvedValue([sub] as any);
+    vi.spyOn(prisma.currentWar, "update").mockResolvedValue({} as any);
+    (service as any).getCurrentWarSnapshot = vi.fn().mockResolvedValue({
+      war: buildInWarSnapshot(),
+      observation: { kind: "success" },
+    });
+    (service as any).hasWarEndRecorded = vi.fn().mockResolvedValue(false);
+    (service as any).ensureCurrentWarId = vi.fn().mockResolvedValue(1001);
+    (service as any).syncWarAttacksFromWarSnapshot = vi
+      .fn()
+      .mockImplementation(async () => syncResults.shift() ?? 0);
+    (service as any).dispatchDetectedEvent = vi.fn().mockResolvedValue(undefined);
+    (service as any).reconcileWarEndedPointsDiscrepancy = vi
+      .fn()
+      .mockResolvedValue(undefined);
+    (service as any).pointsGate = {
+      evaluatePollerFetch: vi.fn().mockReturnValue({
+        allowed: false,
+        fetchReason: "post_war_reconciliation",
+      }),
+    };
+    (service as any).pointsSync = {
+      resetWarStartPointsJob: vi.fn().mockResolvedValue(undefined),
+      maybeRunWarStartPointsCheck: vi.fn().mockResolvedValue(undefined),
+      getPreviousSyncNum: vi.fn().mockResolvedValue(10),
+    };
+    (service as any).currentSyncs = {
+      markNeedsValidation: vi.fn().mockResolvedValue(undefined),
+      getCurrentSyncForClan: vi.fn().mockResolvedValue(null),
+    };
+    const enforceSpy = vi
+      .spyOn((service as any).fwaPolice, "enforceWarViolations")
+      .mockResolvedValue({
+        evaluatedViolations: 1,
+        created: 1,
+        deduped: 0,
+        dmSent: 0,
+        logSent: 1,
+      });
+    return { service, enforceSpy };
+  }
+
+  it("enforces police immediately in poll cycle after new attack rows are synced", async () => {
+    const { service, enforceSpy } = buildProcessSubscriptionService([1]);
+    await (service as any).processSubscription("guild-1", "#AAA111", {
+      previousSync: 10,
+      activeSync: 11,
+    });
+
+    expect(enforceSpy).toHaveBeenCalledTimes(1);
+    expect(enforceSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        guildId: "guild-1",
+        clanTag: "#AAA111",
+        warId: 1001,
+      }),
+    );
+  });
+
+  it("does not re-enforce on later polls when no new attack rows are observed", async () => {
+    const { service, enforceSpy } = buildProcessSubscriptionService([1, 0]);
+    await (service as any).processSubscription("guild-1", "#AAA111", {
+      previousSync: 10,
+      activeSync: 11,
+    });
+    await (service as any).processSubscription("guild-1", "#AAA111", {
+      previousSync: 11,
+      activeSync: 12,
+    });
+
+    expect(enforceSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not trigger police delivery from war-ended dispatch flow", async () => {
+    const service = new WarEventLogService(
+      { channels: { fetch: vi.fn() } } as unknown as Client,
+      {} as any,
+    );
+    const enforceSpy = vi
+      .spyOn((service as any).fwaPolice, "enforceWarViolations")
+      .mockResolvedValue({
+        evaluatedViolations: 0,
+        created: 0,
+        deduped: 0,
+        dmSent: 0,
+        logSent: 0,
+      });
+
+    (service as any).history = {
+      persistWarEndHistory: vi.fn().mockResolvedValue(undefined),
+      resolveCanonicalWarEndedContext: vi.fn().mockResolvedValue(null),
+      getWarEndResultSnapshot: vi.fn().mockResolvedValue({
+        clanStars: 100,
+        opponentStars: 99,
+        clanDestruction: 70,
+        opponentDestruction: 69,
+        warEndTime: new Date("2026-03-10T00:00:00.000Z"),
+        resultLabel: "WIN",
+      }),
+    };
+
+    await (service as any).dispatchDetectedEvent({
+      sub: makeSubscription({
+        guildId: "guild-1",
+        clanTag: "#AAA111",
+        notify: false,
+      }),
+      payload: buildBasePayload({
+        eventType: "war_ended",
+        clanTag: "#AAA111",
+        warStartTime: new Date("2026-03-09T00:00:00.000Z"),
+        warEndTime: new Date("2026-03-10T00:00:00.000Z"),
+      }),
+      resolvedWarId: 1001,
+    });
+
+    expect(enforceSpy).not.toHaveBeenCalled();
+  });
+});
+
 describe("War-end points reconciliation", () => {
   afterEach(() => {
     vi.restoreAllMocks();


### PR DESCRIPTION
…time

- resolve police LOG delivery via tracked-clan log channel first with /bot-logs fallback
- add war/violation/violation-time context to police embeds using attackSeenAt vs warEndTime
- trigger police enforcement immediately after new attack-row sync and remove war-ended trigger
- add regression tests for fallback order, sample/log behavior, embed timing, and poll-time gating