### PR TITLE
feat(reminders): add send-time attacks-left roster in reminder delivery

### DIFF
--- a/src/services/reminders/ReminderDispatchService.ts
+++ b/src/services/reminders/ReminderDispatchService.ts
@@ -1,6 +1,11 @@
 import { ReminderType } from "@prisma/client";
 import { Client, EmbedBuilder } from "discord.js";
+import type { ClanWar } from "../../generated/coc-api";
 import { formatError } from "../../helper/formatError";
+import { prisma } from "../../prisma";
+import { CoCService, type ClanCapitalRaidSeason } from "../CoCService";
+import { normalizeClanTag, normalizePlayerTag } from "../PlayerLinkService";
+import { parseCocTime } from "../war-events/core";
 
 export type ReminderDispatchInput = {
   guildId: string;
@@ -23,10 +28,39 @@ export type ReminderDispatchResult =
   | {
       status: "failed";
       errorMessage: string;
-    };
+  };
+
+type ReminderDispatchCoCClient = Pick<
+  CoCService,
+  "getClanWarLeagueGroup" | "getClanWarLeagueWar" | "getClanCapitalRaidSeasons" | "getClan"
+>;
+
+type ReminderDispatchDependencies = {
+  cocService?: ReminderDispatchCoCClient | null;
+  nowMsProvider?: () => number;
+};
+
+type ReminderRosterSemantic = "WAR" | "CWL" | "RAIDS" | "OTHER";
+
+type ReminderRosterEntry = {
+  playerTag: string;
+  playerName: string;
+  position: number | null;
+  attacksRemaining: number;
+  attacksMax: number;
+};
+
+const DISCORD_EMBED_DESCRIPTION_LIMIT = 4096;
+const MAX_REMINDER_EMBEDS = 2;
 
 /** Purpose: send one reminder embed message to configured channels with deterministic type-aware content. */
 export class ReminderDispatchService {
+  private resolvedDefaultCoCService = false;
+  private cachedDefaultCoCService: ReminderDispatchCoCClient | null = null;
+
+  /** Purpose: initialize optional runtime dependencies used by send-time roster enrichment. */
+  constructor(private readonly deps: ReminderDispatchDependencies = {}) {}
+
   /** Purpose: dispatch one reminder notification and return sent/failed metadata for fire-log persistence. */
   async dispatchReminder(client: Client, input: ReminderDispatchInput): Promise<ReminderDispatchResult> {
     try {
@@ -38,9 +72,16 @@ export class ReminderDispatchService {
         };
       }
 
-      const embed = buildReminderDispatchEmbed(input);
+      const embeds = await buildReminderDispatchEmbeds({
+        input,
+        nowMs: this.getNowMs(),
+        cocService: this.getCoCService(),
+      });
       const sent = await channel.send({
-        embeds: [embed],
+        embeds,
+        allowedMentions: {
+          parse: ["users"],
+        },
       });
       return {
         status: "sent",
@@ -53,35 +94,509 @@ export class ReminderDispatchService {
       };
     }
   }
+
+  /** Purpose: resolve one deterministic "now" timestamp source for all render math in this send call. */
+  private getNowMs(): number {
+    return this.deps.nowMsProvider ? this.deps.nowMsProvider() : Date.now();
+  }
+
+  /** Purpose: resolve one optional CoC client for CWL/RAIDS roster lookups without hard-failing when env is missing. */
+  private getCoCService(): ReminderDispatchCoCClient | null {
+    if (this.deps.cocService !== undefined) {
+      return this.deps.cocService;
+    }
+    if (this.resolvedDefaultCoCService) {
+      return this.cachedDefaultCoCService;
+    }
+    this.resolvedDefaultCoCService = true;
+    try {
+      this.cachedDefaultCoCService = new CoCService();
+    } catch {
+      this.cachedDefaultCoCService = null;
+    }
+    return this.cachedDefaultCoCService;
+  }
 }
 
 /** Purpose: expose one shared reminder dispatch service singleton. */
 export const reminderDispatchService = new ReminderDispatchService();
 
-/** Purpose: build concise reminder embed content keyed by reminder type and event timing context. */
-function buildReminderDispatchEmbed(input: ReminderDispatchInput): EmbedBuilder {
-  const clanLabel = input.clanName
-    ? `${input.clanName} (${input.clanTag})`
-    : input.clanTag;
-  const offsetLabel = formatOffsetLabel(input.offsetSeconds);
-  const remainingSeconds = Math.max(0, Math.floor((input.eventEndsAt.getTime() - Date.now()) / 1000));
-  const remainingLabel = `<t:${Math.floor(input.eventEndsAt.getTime() / 1000)}:R>`;
-  const titlePrefix = getReminderTitlePrefix(input.type);
-  const color = getReminderTypeColor(input.type);
+/** Purpose: build one or two embeds with optional attack-remaining roster continuation for send-time reminder posts. */
+async function buildReminderDispatchEmbeds(input: {
+  input: ReminderDispatchInput;
+  nowMs: number;
+  cocService: ReminderDispatchCoCClient | null;
+}): Promise<EmbedBuilder[]> {
+  const payload = input.input;
+  const color = getReminderTypeColor(payload.type);
+  const titlePrefix = getReminderTitlePrefix(payload.type);
+  const headerLines = buildReminderDispatchHeaderLines({
+    input: payload,
+    nowMs: input.nowMs,
+  });
+  const semantic = resolveReminderRosterSemantic({
+    reminderType: payload.type,
+    eventIdentity: payload.eventIdentity,
+  });
+  const rosterLines = await resolveReminderRosterLines({
+    input: payload,
+    semantic,
+    cocService: input.cocService,
+    nowMs: input.nowMs,
+  });
+  return buildReminderEmbedsWithRosterOverflow({
+    title: `${titlePrefix} Reminder`,
+    color,
+    footerText: `reminder:${payload.reminderId} | identity:${payload.eventIdentity}`,
+    timestamp: new Date(input.nowMs),
+    headerLines,
+    rosterLines,
+  });
+}
 
-  return new EmbedBuilder()
-    .setColor(color)
-    .setTitle(`${titlePrefix} Reminder`)
-    .setDescription([
-      `Clan: **${clanLabel}**`,
-      `Configured offset: **${offsetLabel}**`,
-      `Event timing: **${input.eventLabel}**`,
-      `Time remaining: ${remainingLabel} (${remainingSeconds}s)`,
-    ].join("\n"))
-    .setFooter({
-      text: `reminder:${input.reminderId} | identity:${input.eventIdentity}`,
+/** Purpose: build deterministic core reminder header lines shared by all reminder dispatch embeds. */
+function buildReminderDispatchHeaderLines(input: {
+  input: ReminderDispatchInput;
+  nowMs: number;
+}): string[] {
+  const payload = input.input;
+  const clanLabel = payload.clanName
+    ? `${payload.clanName} (${payload.clanTag})`
+    : payload.clanTag;
+  const offsetLabel = formatOffsetLabel(payload.offsetSeconds);
+  const remainingSeconds = Math.max(
+    0,
+    Math.floor((payload.eventEndsAt.getTime() - input.nowMs) / 1000),
+  );
+  const remainingLabel = `<t:${Math.floor(payload.eventEndsAt.getTime() / 1000)}:R>`;
+
+  return [
+    `Clan: **${clanLabel}**`,
+    `Configured offset: **${offsetLabel}**`,
+    `Event timing: **${payload.eventLabel}**`,
+    `Time remaining: ${remainingLabel} (${remainingSeconds}s)`,
+  ];
+}
+
+/** Purpose: resolve roster semantics for WAR/CWL/RAIDS reminder sends, using event identity to split WAR vs CWL paths. */
+function resolveReminderRosterSemantic(input: {
+  reminderType: ReminderType;
+  eventIdentity: string;
+}): ReminderRosterSemantic {
+  if (input.reminderType === ReminderType.RAIDS) return "RAIDS";
+  if (input.reminderType !== ReminderType.WAR_CWL) return "OTHER";
+  return String(input.eventIdentity).startsWith("CWL:") ? "CWL" : "WAR";
+}
+
+/** Purpose: resolve and format all send-time roster lines with linked-user mentions for eligible members with attacks remaining. */
+async function resolveReminderRosterLines(input: {
+  input: ReminderDispatchInput;
+  semantic: ReminderRosterSemantic;
+  cocService: ReminderDispatchCoCClient | null;
+  nowMs: number;
+}): Promise<string[]> {
+  if (input.semantic === "OTHER") return [];
+
+  let roster: ReminderRosterEntry[] = [];
+  if (input.semantic === "WAR") {
+    roster = await resolveWarReminderRoster({
+      clanTag: input.input.clanTag,
+    });
+  } else if (input.semantic === "CWL") {
+    roster = await resolveCwlReminderRoster({
+      clanTag: input.input.clanTag,
+      cocService: input.cocService,
+    });
+  } else if (input.semantic === "RAIDS") {
+    roster = await resolveRaidsReminderRoster({
+      clanTag: input.input.clanTag,
+      cocService: input.cocService,
+      nowMs: input.nowMs,
+      eventEndsAt: input.input.eventEndsAt,
+    });
+  }
+
+  if (roster.length <= 0) return [];
+
+  const tags = [...new Set(roster.map((entry) => entry.playerTag).filter(Boolean))];
+  const linkRows =
+    tags.length > 0
+      ? await prisma.playerLink.findMany({
+          where: { playerTag: { in: tags } },
+          select: {
+            playerTag: true,
+            discordUserId: true,
+          },
+        })
+      : [];
+  const linkedDiscordIdByTag = new Map(
+    linkRows
+      .map((row) => [normalizePlayerTag(row.playerTag), String(row.discordUserId)] as const)
+      .filter((entry): entry is [string, string] => Boolean(entry[0] && entry[1])),
+  );
+
+  return roster.map((entry) => {
+    const mention = linkedDiscordIdByTag.get(entry.playerTag) ?? null;
+    if (input.semantic === "RAIDS") {
+      if (mention) {
+        return `${entry.playerName} - <@${mention}> - ${entry.attacksRemaining} / ${entry.attacksMax}`;
+      }
+      return `:no: ${entry.playerName} - ${entry.attacksRemaining} / ${entry.attacksMax}`;
+    }
+
+    const positionLabel =
+      entry.position !== null && entry.position > 0 ? `#${entry.position}` : "#?";
+    if (mention) {
+      return `${positionLabel} - ${entry.playerName} - <@${mention}> - ${entry.attacksRemaining} / ${entry.attacksMax}`;
+    }
+    return `${positionLabel} - :no: ${entry.playerName} - ${entry.attacksRemaining} / ${entry.attacksMax}`;
+  });
+}
+
+/** Purpose: resolve WAR roster entries from current war-member feed rows and keep only members with attacks remaining. */
+async function resolveWarReminderRoster(input: {
+  clanTag: string;
+}): Promise<ReminderRosterEntry[]> {
+  const clanTag = normalizeClanTag(input.clanTag);
+  if (!clanTag) return [];
+
+  const rows = await prisma.fwaWarMemberCurrent.findMany({
+    where: { clanTag },
+    select: {
+      playerTag: true,
+      playerName: true,
+      position: true,
+      attacks: true,
+    },
+  });
+
+  return rows
+    .map((row) => {
+      const playerTag = normalizePlayerTag(row.playerTag);
+      if (!playerTag) return null;
+      const playerName = sanitizeReminderPlayerName(row.playerName, playerTag);
+      const attacksUsed = clampInt(row.attacks, 0, 2);
+      const attacksRemaining = Math.max(0, 2 - attacksUsed);
+      return {
+        playerTag,
+        playerName,
+        position: toFiniteIntOrNull(row.position),
+        attacksRemaining,
+        attacksMax: 2,
+      } satisfies ReminderRosterEntry;
     })
-    .setTimestamp(new Date());
+    .filter((entry): entry is ReminderRosterEntry => Boolean(entry && entry.attacksRemaining > 0))
+    .sort(compareRosterByPositionThenName);
+}
+
+/** Purpose: resolve CWL roster entries from the currently active CWL war roster for the tracked clan side only. */
+async function resolveCwlReminderRoster(input: {
+  clanTag: string;
+  cocService: ReminderDispatchCoCClient | null;
+}): Promise<ReminderRosterEntry[]> {
+  const clanTag = normalizeClanTag(input.clanTag);
+  if (!clanTag || !input.cocService) return [];
+
+  const war = await resolveActiveCwlWarForClan({
+    clanTag,
+    cocService: input.cocService,
+  });
+  if (!war) return [];
+
+  const members = resolveTrackedWarMembers({
+    war,
+    trackedClanTag: clanTag,
+  });
+  return members
+    .map((member) => {
+      const playerTag = normalizePlayerTag(String(member?.tag ?? ""));
+      if (!playerTag) return null;
+      const playerName = sanitizeReminderPlayerName(member?.name, playerTag);
+      const attacksUsed = Array.isArray(member?.attacks) ? member.attacks.length : 0;
+      const attacksRemaining = Math.max(0, 1 - clampInt(attacksUsed, 0, 1));
+      return {
+        playerTag,
+        playerName,
+        position: toFiniteIntOrNull(member?.mapPosition),
+        attacksRemaining,
+        attacksMax: 1,
+      } satisfies ReminderRosterEntry;
+    })
+    .filter((entry): entry is ReminderRosterEntry => Boolean(entry && entry.attacksRemaining > 0))
+    .sort(compareRosterByPositionThenName);
+}
+
+/** Purpose: resolve RAIDS roster entries from the current active raid-season member eligibility set for one tracked clan. */
+async function resolveRaidsReminderRoster(input: {
+  clanTag: string;
+  cocService: ReminderDispatchCoCClient | null;
+  nowMs: number;
+  eventEndsAt: Date;
+}): Promise<ReminderRosterEntry[]> {
+  const clanTag = normalizeClanTag(input.clanTag);
+  if (!clanTag || !input.cocService) return [];
+
+  const seasons = await input.cocService
+    .getClanCapitalRaidSeasons(clanTag, 2)
+    .catch(() => []);
+  const activeSeason = selectActiveRaidSeasonForReminder({
+    seasons,
+    nowMs: input.nowMs,
+    eventEndsAt: input.eventEndsAt,
+  });
+  if (!activeSeason) return [];
+
+  const clan = await input.cocService.getClan(clanTag).catch(() => null);
+  const clanMembers = Array.isArray(clan?.members)
+    ? (clan.members as Array<{ tag?: unknown; name?: unknown }>)
+    : [];
+  const clanMemberNameByTag = new Map(
+    clanMembers
+      .map((member) => {
+        const playerTag = normalizePlayerTag(String(member?.tag ?? ""));
+        const playerName = sanitizeReminderPlayerName(member?.name, playerTag);
+        return [playerTag, playerName] as const;
+      })
+      .filter((entry): entry is [string, string] => Boolean(entry[0] && entry[1])),
+  );
+
+  const raidMembers = Array.isArray(activeSeason.members)
+    ? (activeSeason.members as Array<{ tag?: unknown; name?: unknown; attacks?: unknown }>)
+    : [];
+  const roster: ReminderRosterEntry[] = [];
+  for (const member of raidMembers) {
+    const playerTag = normalizePlayerTag(String(member?.tag ?? ""));
+    if (!playerTag) continue;
+    const playerName = sanitizeReminderPlayerName(
+      member?.name ?? clanMemberNameByTag.get(playerTag),
+      playerTag,
+    );
+    const attacksUsed = clampInt(member?.attacks, 0, 6);
+    const attacksRemaining = Math.max(0, 6 - attacksUsed);
+    if (attacksRemaining <= 0) continue;
+    roster.push({
+      playerTag,
+      playerName,
+      position: null,
+      attacksRemaining,
+      attacksMax: 6,
+    });
+  }
+
+  return roster.sort((a, b) => {
+      if (a.attacksRemaining !== b.attacksRemaining) {
+        return a.attacksRemaining - b.attacksRemaining;
+      }
+      const byName = a.playerName.localeCompare(b.playerName, undefined, {
+        sensitivity: "base",
+      });
+      if (byName !== 0) return byName;
+      return a.playerTag.localeCompare(b.playerTag);
+    });
+}
+
+/** Purpose: select one raid season aligned to active-window or event-end timing so send-time roster resolution stays deterministic. */
+function selectActiveRaidSeasonForReminder(input: {
+  seasons: ClanCapitalRaidSeason[];
+  nowMs: number;
+  eventEndsAt: Date;
+}): ClanCapitalRaidSeason | null {
+  if (!Array.isArray(input.seasons) || input.seasons.length <= 0) return null;
+  const targetEndMs = input.eventEndsAt.getTime();
+
+  const candidates = input.seasons.map((season) => {
+    const startMs = parseCocTime(season.startTime ?? null)?.getTime() ?? null;
+    const endMs = parseCocTime(season.endTime ?? null)?.getTime() ?? null;
+    return {
+      season,
+      startMs,
+      endMs,
+    };
+  });
+
+  const active = candidates.find((candidate) => {
+    if (!Number.isFinite(candidate.startMs) || !Number.isFinite(candidate.endMs)) return false;
+    return input.nowMs >= Number(candidate.startMs) && input.nowMs < Number(candidate.endMs);
+  });
+  if (active) return active.season;
+
+  const nearestByEnd = candidates
+    .filter(
+      (candidate): candidate is { season: ClanCapitalRaidSeason; startMs: number | null; endMs: number } =>
+        Number.isFinite(candidate.endMs),
+    )
+    .sort((a, b) => Math.abs(a.endMs - targetEndMs) - Math.abs(b.endMs - targetEndMs))[0];
+  if (nearestByEnd) return nearestByEnd.season;
+
+  return input.seasons[0] ?? null;
+}
+
+/** Purpose: resolve the tracked clan side member list from one CWL war payload. */
+function resolveTrackedWarMembers(input: {
+  war: ClanWar;
+  trackedClanTag: string;
+}): Array<{
+  tag?: string;
+  name?: string;
+  mapPosition?: number;
+  attacks?: unknown[] | null;
+}> {
+  const trackedClanTag = normalizeClanTag(input.trackedClanTag);
+  const warClanTag = normalizeClanTag(String(input.war?.clan?.tag ?? ""));
+  const warOpponentTag = normalizeClanTag(String(input.war?.opponent?.tag ?? ""));
+  if (trackedClanTag && trackedClanTag === warClanTag) {
+    return Array.isArray(input.war?.clan?.members)
+      ? input.war.clan.members
+      : [];
+  }
+  if (trackedClanTag && trackedClanTag === warOpponentTag) {
+    return Array.isArray(input.war?.opponent?.members)
+      ? input.war.opponent.members
+      : [];
+  }
+  return [];
+}
+
+/** Purpose: resolve one active CWL war for a clan by traversing league rounds newest-first with shared war-tag fetches. */
+async function resolveActiveCwlWarForClan(input: {
+  clanTag: string;
+  cocService: ReminderDispatchCoCClient;
+}): Promise<ClanWar | null> {
+  const group = await input.cocService.getClanWarLeagueGroup(input.clanTag).catch(() => null);
+  if (!group || !isActiveWarState(group.state)) return null;
+
+  const rounds = Array.isArray(group.rounds) ? [...group.rounds].reverse() : [];
+  for (const round of rounds) {
+    const warTags = [
+      ...new Set(
+        (Array.isArray(round?.warTags) ? round.warTags : [])
+          .map((warTag) => String(warTag ?? "").trim())
+          .filter((warTag) => warTag.length > 0 && warTag !== "#0"),
+      ),
+    ];
+    if (warTags.length <= 0) continue;
+
+    const wars = await Promise.all(
+      warTags.map((warTag) =>
+        input.cocService.getClanWarLeagueWar(warTag).catch(() => null),
+      ),
+    );
+
+    const active = wars.find((war) => {
+      if (!war || !isActiveWarState(war.state)) return false;
+      const warClanTag = normalizeClanTag(String(war.clan?.tag ?? ""));
+      const warOpponentTag = normalizeClanTag(String(war.opponent?.tag ?? ""));
+      return warClanTag === input.clanTag || warOpponentTag === input.clanTag;
+    });
+    if (active) return active;
+  }
+
+  return null;
+}
+
+/** Purpose: build final one-or-two embed output with line-safe overflow handling and hard cap at two embeds. */
+function buildReminderEmbedsWithRosterOverflow(input: {
+  title: string;
+  color: number;
+  footerText: string;
+  timestamp: Date;
+  headerLines: string[];
+  rosterLines: string[];
+}): EmbedBuilder[] {
+  const headerDescription = input.headerLines.join("\n");
+  const firstEmbed = new EmbedBuilder()
+    .setColor(input.color)
+    .setTitle(input.title)
+    .setFooter({ text: input.footerText })
+    .setTimestamp(input.timestamp);
+
+  if (input.rosterLines.length <= 0) {
+    firstEmbed.setDescription(headerDescription);
+    return [firstEmbed];
+  }
+
+  const firstSeed = [...input.headerLines, "", "**Players With Attacks Remaining:**"].join("\n");
+  let firstDescription =
+    firstSeed.length <= DISCORD_EMBED_DESCRIPTION_LIMIT ? firstSeed : headerDescription;
+  let secondDescription = "";
+
+  for (const line of input.rosterLines) {
+    if (canAppendDescriptionLine(firstDescription, line)) {
+      firstDescription = appendDescriptionLine(firstDescription, line);
+      continue;
+    }
+    if (canAppendDescriptionLine(secondDescription, line)) {
+      secondDescription = appendDescriptionLine(secondDescription, line);
+      continue;
+    }
+    break;
+  }
+
+  firstEmbed.setDescription(firstDescription);
+  if (!secondDescription || MAX_REMINDER_EMBEDS <= 1) {
+    return [firstEmbed];
+  }
+
+  const secondEmbed = new EmbedBuilder()
+    .setColor(input.color)
+    .setDescription(secondDescription);
+  return [firstEmbed, secondEmbed].slice(0, MAX_REMINDER_EMBEDS);
+}
+
+/** Purpose: append one line to a description block using newline joins while preserving exact line boundaries. */
+function appendDescriptionLine(current: string, line: string): string {
+  if (!current) return line;
+  return `${current}\n${line}`;
+}
+
+/** Purpose: check if one full line can fit in the target description buffer without splitting across embeds. */
+function canAppendDescriptionLine(current: string, line: string): boolean {
+  return appendDescriptionLine(current, line).length <= DISCORD_EMBED_DESCRIPTION_LIMIT;
+}
+
+/** Purpose: compare roster rows by lineup position first, then stable name/tag fallback ordering. */
+function compareRosterByPositionThenName(a: ReminderRosterEntry, b: ReminderRosterEntry): number {
+  const aHasPos = a.position !== null && a.position > 0;
+  const bHasPos = b.position !== null && b.position > 0;
+  if (aHasPos && bHasPos && a.position !== b.position) {
+    return Number(a.position) - Number(b.position);
+  }
+  if (aHasPos !== bHasPos) return aHasPos ? -1 : 1;
+
+  const byName = a.playerName.localeCompare(b.playerName, undefined, {
+    sensitivity: "base",
+  });
+  if (byName !== 0) return byName;
+  return a.playerTag.localeCompare(b.playerTag);
+}
+
+/** Purpose: normalize one player display name into compact deterministic text with player-tag fallback. */
+function sanitizeReminderPlayerName(input: unknown, fallbackTag: string): string {
+  const normalized = String(input ?? "")
+    .replace(/\s+/g, " ")
+    .trim();
+  return normalized.length > 0 ? normalized : fallbackTag;
+}
+
+/** Purpose: convert unknown number-like values into bounded integers for deterministic attack and position math. */
+function clampInt(input: unknown, min: number, max: number): number {
+  const parsed = Number(input);
+  if (!Number.isFinite(parsed)) return min;
+  const truncated = Math.trunc(parsed);
+  return Math.max(min, Math.min(max, truncated));
+}
+
+/** Purpose: convert unknown values to finite integers for nullable position fields. */
+function toFiniteIntOrNull(input: unknown): number | null {
+  const parsed = Number(input);
+  if (!Number.isFinite(parsed)) return null;
+  return Math.trunc(parsed);
+}
+
+/** Purpose: classify war-state text values into active/non-active buckets used by CWL roster resolution. */
+function isActiveWarState(state: unknown): boolean {
+  const normalized = String(state ?? "").toLowerCase();
+  return normalized.includes("preparation") || normalized.includes("inwar");
 }
 
 /** Purpose: map reminder types to stable friendly heading prefixes. */
@@ -109,3 +624,5 @@ function formatOffsetLabel(offsetSeconds: number): string {
   if (minutes <= 0) return `${hours}h`;
   return `${hours}h${minutes}m`;
 }
+
+export const buildReminderDispatchEmbedsForTest = buildReminderDispatchEmbeds;

--- a/tests/reminderDispatch.service.test.ts
+++ b/tests/reminderDispatch.service.test.ts
@@ -1,0 +1,233 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ReminderType } from "@prisma/client";
+
+const prismaMock = vi.hoisted(() => ({
+  playerLink: {
+    findMany: vi.fn(),
+  },
+  fwaWarMemberCurrent: {
+    findMany: vi.fn(),
+  },
+}));
+
+vi.mock("../src/prisma", () => ({
+  prisma: prismaMock,
+}));
+
+import { buildReminderDispatchEmbedsForTest } from "../src/services/reminders/ReminderDispatchService";
+
+describe("ReminderDispatchService roster rendering", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prismaMock.playerLink.findMany.mockResolvedValue([]);
+    prismaMock.fwaWarMemberCurrent.findMany.mockResolvedValue([]);
+  });
+
+  it("renders WAR remaining-attacks roster with position sort and linked/unlinked formats", async () => {
+    prismaMock.fwaWarMemberCurrent.findMany.mockResolvedValue([
+      { playerTag: "#PYLG", playerName: "Bravo", position: 2, attacks: 1 },
+      { playerTag: "#PYLQ", playerName: "Alpha", position: 1, attacks: 0 },
+      { playerTag: "#PYLR", playerName: "Charlie", position: 3, attacks: 0 },
+      { playerTag: "#PYLC", playerName: "Done", position: 4, attacks: 2 },
+    ]);
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      { playerTag: "#PYLQ", discordUserId: "111" },
+      { playerTag: "#PYLR", discordUserId: "333" },
+    ]);
+
+    const embeds = await buildReminderDispatchEmbedsForTest({
+      input: {
+        guildId: "guild-1",
+        channelId: "channel-1",
+        reminderId: "rem-1",
+        type: ReminderType.WAR_CWL,
+        clanTag: "#PYLQ",
+        clanName: "Alpha Clan",
+        offsetSeconds: 3600,
+        eventIdentity: "WAR:war-id:9",
+        eventEndsAt: new Date("2026-04-10T01:00:00.000Z"),
+        eventLabel: "war end",
+      },
+      nowMs: Date.parse("2026-04-10T00:30:00.000Z"),
+      cocService: null,
+    });
+
+    expect(embeds).toHaveLength(1);
+    const description = String(embeds[0].toJSON().description ?? "");
+    const rosterLines = description
+      .split("\n")
+      .filter((line) => line.startsWith("#"));
+    expect(rosterLines).toEqual([
+      "#1 - Alpha - <@111> - 2 / 2",
+      "#2 - :no: Bravo - 1 / 2",
+      "#3 - Charlie - <@333> - 2 / 2",
+    ]);
+    expect(description).not.toContain("Done");
+  });
+
+  it("renders CWL roster from active CWL war participants only and sorts by map position", async () => {
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      { playerTag: "#PYLG", discordUserId: "222" },
+    ]);
+    const cocService = {
+      getClanWarLeagueGroup: vi.fn().mockResolvedValue({
+        state: "inWar",
+        rounds: [{ warTags: ["#WAR1"] }],
+      }),
+      getClanWarLeagueWar: vi.fn().mockResolvedValue({
+        state: "inWar",
+        clan: {
+          tag: "#PYLG",
+          members: [{ tag: "#PYLV", name: "Outside", mapPosition: 1, attacks: [] }],
+        },
+        opponent: {
+          tag: "#PYLQ",
+          members: [
+            { tag: "#PYLQ", name: "One", mapPosition: 1, attacks: [] },
+            { tag: "#PYLG", name: "Two", mapPosition: 2, attacks: [] },
+            { tag: "#PYLR", name: "Done", mapPosition: 3, attacks: [{}, {}] },
+          ],
+        },
+      }),
+      getClanCapitalRaidSeasons: vi.fn(),
+      getClan: vi.fn(),
+    };
+
+    const embeds = await buildReminderDispatchEmbedsForTest({
+      input: {
+        guildId: "guild-1",
+        channelId: "channel-1",
+        reminderId: "rem-1",
+        type: ReminderType.WAR_CWL,
+        clanTag: "#PYLQ",
+        clanName: "CWL Clan",
+        offsetSeconds: 3600,
+        eventIdentity: "CWL:#PYLQ:1712700000000",
+        eventEndsAt: new Date("2026-04-10T01:00:00.000Z"),
+        eventLabel: "cwl war end",
+      },
+      nowMs: Date.parse("2026-04-10T00:30:00.000Z"),
+      cocService,
+    });
+
+    const description = String(embeds[0].toJSON().description ?? "");
+    const rosterLines = description
+      .split("\n")
+      .filter((line) => line.startsWith("#"));
+    expect(rosterLines).toEqual([
+      "#1 - :no: One - 1 / 1",
+      "#2 - Two - <@222> - 1 / 1",
+    ]);
+    expect(description).not.toContain("Outside");
+    expect(description).not.toContain("Done");
+  });
+
+  it("renders RAIDS roster sorted by remaining attacks then player name and excludes non-season members", async () => {
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      { playerTag: "#PYLG", discordUserId: "222" },
+      { playerTag: "#PYLR", discordUserId: "333" },
+    ]);
+    const cocService = {
+      getClanWarLeagueGroup: vi.fn(),
+      getClanWarLeagueWar: vi.fn(),
+      getClanCapitalRaidSeasons: vi.fn().mockResolvedValue([
+        {
+          startTime: "20260410T070000.000Z",
+          endTime: "20260413T070000.000Z",
+          members: [
+            { tag: "#PYLQ", name: "Zulu", attacks: 5 },
+            { tag: "#PYLG", name: "Bravo", attacks: 0 },
+            { tag: "#PYLR", name: "Alpha", attacks: 5 },
+            { tag: "#PYLC", name: "Spent", attacks: 6 },
+          ],
+        },
+      ]),
+      getClan: vi.fn().mockResolvedValue({
+        members: [
+          { tag: "#PYLQ", name: "Zulu" },
+          { tag: "#PYLG", name: "Bravo" },
+          { tag: "#PYLR", name: "Alpha" },
+          { tag: "#PYLV", name: "IneligibleElsewhere" },
+        ],
+      }),
+    };
+
+    const embeds = await buildReminderDispatchEmbedsForTest({
+      input: {
+        guildId: "guild-1",
+        channelId: "channel-1",
+        reminderId: "rem-1",
+        type: ReminderType.RAIDS,
+        clanTag: "#PYLQ",
+        clanName: "Raid Clan",
+        offsetSeconds: 1800,
+        eventIdentity: "RAIDS:FWA|#PYLQ:1712700000000",
+        eventEndsAt: new Date("2026-04-13T07:00:00.000Z"),
+        eventLabel: "raid weekend",
+      },
+      nowMs: Date.parse("2026-04-11T00:00:00.000Z"),
+      cocService,
+    });
+
+    const description = String(embeds[0].toJSON().description ?? "");
+    const rosterLines = description
+      .split("\n")
+      .filter((line) => line.includes("/ 6"));
+    expect(rosterLines).toEqual([
+      "Alpha - <@333> - 1 / 6",
+      ":no: Zulu - 1 / 6",
+      "Bravo - <@222> - 6 / 6",
+    ]);
+    expect(description).not.toContain("Spent");
+    expect(description).not.toContain("IneligibleElsewhere");
+    expect(description).not.toContain("#1 -");
+  });
+
+  it("splits long roster output into at most two embeds with continuation-only second embed", async () => {
+    prismaMock.fwaWarMemberCurrent.findMany.mockResolvedValue(
+      Array.from({ length: 80 }, (_, index) => ({
+        playerTag: "#PYLQ",
+        playerName: `Player_${String(index + 1).padStart(2, "0")}_${"X".repeat(120)}`,
+        position: index + 1,
+        attacks: 0,
+      })),
+    );
+
+    const embeds = await buildReminderDispatchEmbedsForTest({
+      input: {
+        guildId: "guild-1",
+        channelId: "channel-1",
+        reminderId: "rem-1",
+        type: ReminderType.WAR_CWL,
+        clanTag: "#PYLQ",
+        clanName: "Overflow Clan",
+        offsetSeconds: 3600,
+        eventIdentity: "WAR:war-id:55",
+        eventEndsAt: new Date("2026-04-10T01:00:00.000Z"),
+        eventLabel: "war end",
+      },
+      nowMs: Date.parse("2026-04-10T00:30:00.000Z"),
+      cocService: null,
+    });
+
+    expect(embeds).toHaveLength(2);
+    const first = embeds[0].toJSON();
+    const second = embeds[1].toJSON();
+    expect(first.color).toBe(second.color);
+    expect(second.title).toBeUndefined();
+    expect(String(second.description ?? "")).not.toContain("Clan: **");
+    expect(String(second.description ?? "")).not.toContain("Players With Attacks Remaining");
+
+    const combinedRosterLines = [
+      ...String(first.description ?? "").split("\n"),
+      ...String(second.description ?? "").split("\n"),
+    ].filter((line) => line.startsWith("#"));
+    expect(combinedRosterLines.length).toBeGreaterThan(0);
+    expect(combinedRosterLines.length).toBeLessThan(80);
+    expect(
+      combinedRosterLines.every((line) =>
+        /^#\d+ - :no: Player_\d{2}_X+ - 2 \/ 2$/.test(line),
+      ),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
- render WAR/CWL/RAIDS remaining-attacks roster lines with linked mentions on sent reminder messages
- split long roster output across at most two embeds with line-safe overflow and silent truncation
- add reminder dispatch regression tests for sorting, formatting, eligibility filtering, and overflow behavior