### PR TITLE
fix(war-events): prevent duplicate war cycles after coc outage recovery

### DIFF
--- a/src/services/WarEventLogService.ts
+++ b/src/services/WarEventLogService.ts
@@ -1074,10 +1074,74 @@ function applyWarEndedMaintenanceGuard(input: {
   };
 }
 
+function isActiveWarState(state: WarState): boolean {
+  return state === "preparation" || state === "inWar";
+}
+
+/** Purpose: decide whether the prior active phase should still be running based on last known war timing. */
+function isWarPhaseExpectedActive(input: {
+  state: WarState;
+  knownWarStartTime: Date | null;
+  knownWarEndTime: Date | null;
+  now: Date;
+}): boolean {
+  if (!isActiveWarState(input.state)) return false;
+  const nowMs = input.now.getTime();
+  const knownStartMs =
+    input.knownWarStartTime instanceof Date
+      ? input.knownWarStartTime.getTime()
+      : NaN;
+  const knownEndMs =
+    input.knownWarEndTime instanceof Date
+      ? input.knownWarEndTime.getTime()
+      : NaN;
+
+  if (input.state === "preparation" && Number.isFinite(knownStartMs)) {
+    return nowMs < knownStartMs;
+  }
+  if (input.state === "inWar" && Number.isFinite(knownEndMs)) {
+    return nowMs < knownEndMs;
+  }
+  if (Number.isFinite(knownEndMs)) {
+    return nowMs < knownEndMs;
+  }
+  return true;
+}
+
+/** Purpose: preserve active-war identity when outage recovery only changes timestamps but not lifecycle phase. */
+function shouldPreserveWarIdentityDuringOutageRecovery(input: {
+  previousState: WarState;
+  candidateState: WarState;
+  previousWarStartTime: Date | null;
+  previousWarEndTime: Date | null;
+  warIdentityChanged: boolean;
+  eventDerivedFromIdentityShift: boolean;
+  warFetchFailed: boolean;
+  maintenanceSuspected: boolean;
+  now: Date;
+}): boolean {
+  if (input.warFetchFailed) return false;
+  if (!input.maintenanceSuspected) return false;
+  if (!input.warIdentityChanged) return false;
+  if (!input.eventDerivedFromIdentityShift) return false;
+  if (!isActiveWarState(input.previousState)) return false;
+  if (!isActiveWarState(input.candidateState)) return false;
+
+  return isWarPhaseExpectedActive({
+    state: input.previousState,
+    knownWarStartTime: input.previousWarStartTime,
+    knownWarEndTime: input.previousWarEndTime,
+    now: input.now,
+  });
+}
+
 export const advanceCocWarOutageStateForTest = advanceCocWarOutageState;
 export const resolveActiveWarTimingForTest = resolveActiveWarTiming;
 export const applyWarEndedMaintenanceGuardForTest =
   applyWarEndedMaintenanceGuard;
+export const isWarPhaseExpectedActiveForTest = isWarPhaseExpectedActive;
+export const shouldPreserveWarIdentityDuringOutageRecoveryForTest =
+  shouldPreserveWarIdentityDuringOutageRecovery;
 export const computeWarSnapshotAttackRowsForTest = computeWarSnapshotAttackRows;
 
 export class WarEventLogService {
@@ -2449,9 +2513,17 @@ export class WarEventLogService {
     sub: SubscriptionRow;
     warStartTime: Date | null;
     currentState: WarState;
+    preserveExistingWarId?: boolean;
   }): Promise<number | null> {
     if (params.currentState === "notInWar") return params.sub.warId ?? null;
     if (!params.warStartTime) return params.sub.warId ?? null;
+    if (
+      params.preserveExistingWarId &&
+      params.sub.warId !== null &&
+      params.sub.warId !== undefined
+    ) {
+      return Number(params.sub.warId);
+    }
 
     if (
       params.sub.warId !== null &&
@@ -2555,14 +2627,33 @@ export class WarEventLogService {
     const nextPrepStartTime =
       parseCocTime(war?.preparationStartTime ?? null) ?? sub.prepStartTime;
     const warIdentityChanged = isNewWarCycle(sub.startTime, nextWarStartTime);
+    const pollNow = new Date();
+    const previousPhaseExpectedActive = isWarPhaseExpectedActive({
+      state: prevState,
+      knownWarStartTime: sub.startTime ?? null,
+      knownWarEndTime: sub.endTime ?? null,
+      now: pollNow,
+    });
+    if (
+      warSnapshot.observation.kind === "failure" &&
+      isActiveWarState(prevState) &&
+      previousPhaseExpectedActive
+    ) {
+      console.warn(
+        `[war-events] outage detected guild=${sub.guildId} clan=${sub.clanTag} prev=${prevState} knownStart=${sub.startTime?.toISOString() ?? "unknown"} knownEnd=${sub.endTime?.toISOString() ?? "unknown"} status=${outageState.lastFailureStatusCode ?? "unknown"} failureStreak=${outageState.failureStreak}`,
+      );
+    }
 
     const eventTypeRaw = shouldEmit(prevState, candidateState);
     let eventType = eventTypeRaw;
-    if (!eventType && isNewWarCycle(sub.startTime, nextWarStartTime)) {
+    let eventDerivedFromIdentityShift = false;
+    if (!eventType && warIdentityChanged) {
       if (candidateState === "preparation") {
         eventType = "war_started";
+        eventDerivedFromIdentityShift = true;
       } else if (candidateState === "inWar") {
         eventType = "battle_day";
+        eventDerivedFromIdentityShift = true;
       }
     }
     const warEndedGuard = applyWarEndedMaintenanceGuard({
@@ -2572,13 +2663,36 @@ export class WarEventLogService {
       warFetchFailed: warSnapshot.observation.kind === "failure",
       maintenanceSuspected: outageState.suspected,
       knownWarEndTime: nextWarEndTime,
-      now: new Date(),
+      now: pollNow,
     });
     let currentState: WarState = warEndedGuard.state;
     eventType = warEndedGuard.eventType;
     if (warEndedGuard.suppressReason) {
       console.log(
         `[war-events] war_ended suppressed guild=${sub.guildId} clan=${sub.clanTag} reason=${warEndedGuard.suppressReason} prev=${prevState} current=${candidateState} knownEnd=${nextWarEndTime?.toISOString() ?? "unknown"} maintenanceSuspected=${outageState.suspected} failureStreak=${outageState.failureStreak}${outageState.lastFailureStatusCode ? ` status=${outageState.lastFailureStatusCode}` : ""}`,
+      );
+    }
+    let preserveExistingWarId = false;
+    let effectiveWarIdentityChanged = warIdentityChanged;
+    if (
+      shouldPreserveWarIdentityDuringOutageRecovery({
+        previousState: prevState,
+        candidateState,
+        previousWarStartTime: sub.startTime ?? null,
+        previousWarEndTime: sub.endTime ?? null,
+        warIdentityChanged,
+        eventDerivedFromIdentityShift,
+        warFetchFailed: warSnapshot.observation.kind === "failure",
+        maintenanceSuspected: outageState.suspected,
+        now: pollNow,
+      })
+    ) {
+      preserveExistingWarId = true;
+      effectiveWarIdentityChanged = false;
+      eventType = null;
+      currentState = prevState;
+      console.log(
+        `[war-events] outage recovery reconciled guild=${sub.guildId} clan=${sub.clanTag} action=update_in_place suppress_new_cycle=true prev=${prevState} current=${candidateState} previousStart=${sub.startTime?.toISOString() ?? "unknown"} observedStart=${nextWarStartTime?.toISOString() ?? "unknown"} previousEnd=${sub.endTime?.toISOString() ?? "unknown"} observedEnd=${nextWarEndTime?.toISOString() ?? "unknown"} suspected=${outageState.suspected} failureStreak=${outageState.failureStreak} recoveryStreak=${outageState.recoveryStreak}`,
       );
     }
     if (eventType === "war_ended") {
@@ -2674,10 +2788,10 @@ export class WarEventLogService {
           ? syncContext.previousSync
           : syncContext.activeSync;
 
-    const currentMatchTypeForResolution = warIdentityChanged
+    const currentMatchTypeForResolution = effectiveWarIdentityChanged
       ? null
       : sub.matchType;
-    const currentInferredMatchTypeForResolution = warIdentityChanged
+    const currentInferredMatchTypeForResolution = effectiveWarIdentityChanged
       ? true
       : sub.inferredMatchType;
     const currentWarResolution = resolveCurrentWarMatchTypeSignal({
@@ -2854,6 +2968,7 @@ export class WarEventLogService {
       sub,
       warStartTime: nextWarStartTime,
       currentState,
+      preserveExistingWarId,
     });
     const resolvedWarIdText =
       resolvedWarId !== null && resolvedWarId !== undefined

--- a/tests/warEventLog.logic.test.ts
+++ b/tests/warEventLog.logic.test.ts
@@ -9,11 +9,13 @@ import {
   computeWarSnapshotAttackRowsForTest,
   computeWarComplianceForTest,
   computeWarPointsDeltaForTest,
+  isWarPhaseExpectedActiveForTest,
   isNotifyWarEndedViewButtonCustomId,
   parseNotifyWarEndedViewCustomId,
   resolveEventRenderSyncNumberForTest,
   resolveActiveWarTimingForTest,
   sanitizeWarPlanForEmbedForTest,
+  shouldPreserveWarIdentityDuringOutageRecoveryForTest,
 } from "../src/services/WarEventLogService";
 import {
   resolveParticipationGuildId,
@@ -915,6 +917,71 @@ describe("WarEventLogService.applyWarEndedMaintenanceGuardForTest", () => {
     });
   });
 });
+
+describe("WarEventLogService.isWarPhaseExpectedActiveForTest", () => {
+  it("returns true for preparation before known battle start", () => {
+    expect(
+      isWarPhaseExpectedActiveForTest({
+        state: "preparation",
+        knownWarStartTime: new Date("2026-03-11T14:00:00.000Z"),
+        knownWarEndTime: new Date("2026-03-12T14:00:00.000Z"),
+        now: new Date("2026-03-11T08:00:00.000Z"),
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false for inWar after known battle end", () => {
+    expect(
+      isWarPhaseExpectedActiveForTest({
+        state: "inWar",
+        knownWarStartTime: new Date("2026-03-10T14:00:00.000Z"),
+        knownWarEndTime: new Date("2026-03-11T08:00:00.000Z"),
+        now: new Date("2026-03-11T08:00:01.000Z"),
+      }),
+    ).toBe(false);
+  });
+});
+
+describe(
+  "WarEventLogService.shouldPreserveWarIdentityDuringOutageRecoveryForTest",
+  () => {
+    it("preserves identity for outage recovery timestamp shifts in expected active window", () => {
+      const shouldPreserve = shouldPreserveWarIdentityDuringOutageRecoveryForTest(
+        {
+          previousState: "preparation",
+          candidateState: "preparation",
+          previousWarStartTime: new Date("2026-03-11T14:21:56.000Z"),
+          previousWarEndTime: new Date("2026-03-12T14:21:56.000Z"),
+          warIdentityChanged: true,
+          eventDerivedFromIdentityShift: true,
+          warFetchFailed: false,
+          maintenanceSuspected: true,
+          now: new Date("2026-03-11T08:33:49.914Z"),
+        },
+      );
+
+      expect(shouldPreserve).toBe(true);
+    });
+
+    it("does not preserve identity when active window should already be over", () => {
+      const shouldPreserve = shouldPreserveWarIdentityDuringOutageRecoveryForTest(
+        {
+          previousState: "inWar",
+          candidateState: "inWar",
+          previousWarStartTime: new Date("2026-03-10T14:21:56.000Z"),
+          previousWarEndTime: new Date("2026-03-11T08:30:00.000Z"),
+          warIdentityChanged: true,
+          eventDerivedFromIdentityShift: true,
+          warFetchFailed: false,
+          maintenanceSuspected: true,
+          now: new Date("2026-03-11T08:33:49.914Z"),
+        },
+      );
+
+      expect(shouldPreserve).toBe(false);
+    });
+  },
+);
 
 describe("WarEventLogService.advanceCocWarOutageStateForTest", () => {
   it("marks outage suspected after repeated mixed 503/500 failures", () => {

--- a/tests/warEventLog.warEndPointsReconcile.test.ts
+++ b/tests/warEventLog.warEndPointsReconcile.test.ts
@@ -605,6 +605,235 @@ describe("Match-type confirmation rollover via processSubscription", () => {
   });
 });
 
+describe("War outage recovery reconciliation", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  function buildOutageRecoveryService(input: {
+    subOverrides: Partial<Record<string, unknown>>;
+    snapshots: Array<{ war: Record<string, unknown> | null; observation: { kind: "success" } | { kind: "failure"; statusCode: number | null } }>;
+  }): {
+    service: WarEventLogService;
+    sub: Record<string, unknown>;
+    updateSpy: ReturnType<typeof vi.spyOn>;
+    dispatchSpy: ReturnType<typeof vi.fn>;
+    ensureSpy: ReturnType<typeof vi.spyOn>;
+    allocateSpy: ReturnType<typeof vi.spyOn>;
+  } {
+    const service = new WarEventLogService(
+      { channels: { fetch: vi.fn() } } as unknown as Client,
+      {} as any,
+    );
+    const sub = makeSubscription(input.subOverrides);
+    vi.spyOn(prisma, "$queryRaw").mockResolvedValue([sub] as any);
+    const updateSpy = vi
+      .spyOn(prisma.currentWar, "update")
+      .mockImplementation(async (args: any) => {
+        Object.assign(sub, args?.data ?? {});
+        return {} as any;
+      });
+    (service as any).getCurrentWarSnapshot = vi
+      .fn()
+      .mockImplementation(async () => {
+        const next = input.snapshots.shift();
+        if (!next) return { war: null, observation: { kind: "success" } };
+        return next;
+      });
+    (service as any).hasWarEndRecorded = vi.fn().mockResolvedValue(false);
+    (service as any).syncWarAttacksFromWarSnapshot = vi.fn().mockResolvedValue(0);
+    const dispatchSpy = vi.fn().mockResolvedValue(undefined);
+    (service as any).dispatchDetectedEvent = dispatchSpy;
+    (service as any).reconcileWarEndedPointsDiscrepancy = vi
+      .fn()
+      .mockResolvedValue(undefined);
+    (service as any).pointsGate = {
+      evaluatePollerFetch: vi.fn().mockResolvedValue({
+        allowed: false,
+        fetchReason: "post_war_reconciliation",
+      }),
+    };
+    (service as any).pointsSync = {
+      resetWarStartPointsJob: vi.fn().mockResolvedValue(undefined),
+      maybeRunWarStartPointsCheck: vi.fn().mockResolvedValue(undefined),
+      getPreviousSyncNum: vi.fn().mockResolvedValue(10),
+    };
+    (service as any).currentSyncs = {
+      markNeedsValidation: vi.fn().mockResolvedValue(undefined),
+      getCurrentSyncForClan: vi.fn().mockResolvedValue(null),
+    };
+    const ensureSpy = vi.spyOn(service as any, "ensureCurrentWarId");
+    const allocateSpy = vi.spyOn(service as any, "allocateNextWarId");
+    return {
+      service,
+      sub,
+      updateSpy,
+      dispatchSpy,
+      ensureSpy,
+      allocateSpy,
+    };
+  }
+
+  it("suppresses prep-day outage recovery identity shifts and updates active row in place", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-11T08:00:00.000Z"));
+    const shiftedWar = {
+      state: "preparation",
+      clan: { tag: "#AAA111", name: "Alpha", stars: 0, attacks: 0, destructionPercentage: 0 },
+      opponent: {
+        tag: "#OPP123",
+        name: "Enemy",
+        stars: 0,
+        attacks: 0,
+        destructionPercentage: 0,
+      },
+      preparationStartTime: "20260311T020000.000Z",
+      startTime: "20260312T020000.000Z",
+      endTime: "20260313T020000.000Z",
+      teamSize: 50,
+      attacksPerMember: 2,
+    };
+    const snapshots = [
+      { war: null, observation: { kind: "failure" as const, statusCode: 503 } },
+      { war: null, observation: { kind: "failure" as const, statusCode: 500 } },
+      { war: shiftedWar, observation: { kind: "success" as const } },
+    ];
+    const { service, sub, updateSpy, dispatchSpy, ensureSpy, allocateSpy } =
+      buildOutageRecoveryService({
+        subOverrides: {
+          state: "preparation",
+          warId: 1001,
+          startTime: new Date("2026-03-12T00:00:00.000Z"),
+          endTime: new Date("2026-03-13T00:00:00.000Z"),
+          prepStartTime: new Date("2026-03-11T00:00:00.000Z"),
+        },
+        snapshots,
+      });
+
+    await (service as any).processSubscription("guild-1", "#AAA111", {
+      previousSync: 10,
+      activeSync: 11,
+    });
+    await (service as any).processSubscription("guild-1", "#AAA111", {
+      previousSync: 11,
+      activeSync: 12,
+    });
+    await (service as any).processSubscription("guild-1", "#AAA111", {
+      previousSync: 12,
+      activeSync: 13,
+    });
+
+    expect(dispatchSpy).not.toHaveBeenCalled();
+    expect(allocateSpy).not.toHaveBeenCalled();
+    expect(
+      ensureSpy.mock.calls.some((call) => call?.[0]?.preserveExistingWarId === true),
+    ).toBe(true);
+    expect(updateSpy).toHaveBeenCalled();
+    expect(sub.warId).toBe(1001);
+    expect((sub.startTime as Date).toISOString()).toBe("2026-03-12T02:00:00.000Z");
+  });
+
+  it("suppresses battle-day outage recovery identity shifts without duplicate battle_day emit", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-12T08:00:00.000Z"));
+    const shiftedWar = {
+      state: "inWar",
+      clan: { tag: "#AAA111", name: "Alpha", stars: 100, attacks: 15, destructionPercentage: 70 },
+      opponent: {
+        tag: "#OPP123",
+        name: "Enemy",
+        stars: 99,
+        attacks: 14,
+        destructionPercentage: 69,
+      },
+      preparationStartTime: "20260311T010000.000Z",
+      startTime: "20260312T010000.000Z",
+      endTime: "20260313T010000.000Z",
+      teamSize: 50,
+      attacksPerMember: 2,
+    };
+    const snapshots = [
+      { war: null, observation: { kind: "failure" as const, statusCode: 503 } },
+      { war: null, observation: { kind: "failure" as const, statusCode: 503 } },
+      { war: shiftedWar, observation: { kind: "success" as const } },
+    ];
+    const { service, sub, dispatchSpy, ensureSpy, allocateSpy } =
+      buildOutageRecoveryService({
+        subOverrides: {
+          state: "inWar",
+          warId: 1001,
+          startTime: new Date("2026-03-12T00:00:00.000Z"),
+          endTime: new Date("2026-03-13T00:00:00.000Z"),
+        },
+        snapshots,
+      });
+
+    await (service as any).processSubscription("guild-1", "#AAA111", {
+      previousSync: 10,
+      activeSync: 11,
+    });
+    await (service as any).processSubscription("guild-1", "#AAA111", {
+      previousSync: 11,
+      activeSync: 12,
+    });
+    await (service as any).processSubscription("guild-1", "#AAA111", {
+      previousSync: 12,
+      activeSync: 13,
+    });
+
+    expect(dispatchSpy).not.toHaveBeenCalled();
+    expect(allocateSpy).not.toHaveBeenCalled();
+    expect(
+      ensureSpy.mock.calls.some((call) => call?.[0]?.preserveExistingWarId === true),
+    ).toBe(true);
+    expect(sub.warId).toBe(1001);
+  });
+
+  it("keeps healthy non-outage preparation->inWar transitions emitting once", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-11T08:00:00.000Z"));
+    const snapshots = [
+      {
+        war: {
+          state: "inWar",
+          clan: { tag: "#AAA111", name: "Alpha", stars: 100, attacks: 12, destructionPercentage: 70 },
+          opponent: {
+            tag: "#OPP123",
+            name: "Enemy",
+            stars: 99,
+            attacks: 11,
+            destructionPercentage: 69,
+          },
+          preparationStartTime: "20260311T000000.000Z",
+          startTime: "20260312T000000.000Z",
+          endTime: "20260313T000000.000Z",
+          teamSize: 50,
+          attacksPerMember: 2,
+        },
+        observation: { kind: "success" as const },
+      },
+    ];
+    const { service, dispatchSpy } = buildOutageRecoveryService({
+      subOverrides: {
+        state: "preparation",
+        warId: 1001,
+        startTime: new Date("2026-03-12T00:00:00.000Z"),
+        endTime: new Date("2026-03-13T00:00:00.000Z"),
+      },
+      snapshots,
+    });
+
+    await (service as any).processSubscription("guild-1", "#AAA111", {
+      previousSync: 10,
+      activeSync: 11,
+    });
+
+    expect(dispatchSpy).toHaveBeenCalledTimes(1);
+    expect(dispatchSpy.mock.calls[0]?.[0]?.payload?.eventType).toBe("battle_day");
+  });
+});
+
 describe("FWA police poll-time enforcement", () => {
   afterEach(() => {
     vi.restoreAllMocks();


### PR DESCRIPTION
- preserve active war identity during outage recovery timestamp shifts and suppress fallback cycle events
- keep existing warId in place during maintenance reconciliation to avoid duplicate current-war ids
- add outage diagnostics and regression tests for prep/in-war recovery plus healthy transition behavior