### PR TITLE
feat(fwa): gate mail preview/send behind match confirmation handoff

### DIFF
--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -105,6 +105,7 @@ import {
 } from "../services/PointsDirectFetchGateService";
 import {
   buildFwaMailBackCustomId,
+  buildFwaMailGateResumeCustomId,
   buildFwaBaseSwapSplitPostCustomId,
   createTransientFwaKey,
   buildFwaMailConfirmCustomId,
@@ -124,6 +125,7 @@ import {
   buildOutcomeActionCustomId,
   buildPointsPostButtonCustomId,
   parseFwaMailBackCustomId,
+  parseFwaMailGateResumeCustomId,
   parseFwaBaseSwapSplitPostCustomId,
   parseFwaComplianceViewCustomId,
   parseFwaMailConfirmCustomId,
@@ -200,6 +202,7 @@ export {
   isFwaComplianceViewButtonCustomId,
   isFwaBaseSwapSplitPostButtonCustomId,
   isFwaMailBackButtonCustomId,
+  isFwaMailGateResumeButtonCustomId,
   isFwaMailConfirmButtonCustomId,
   isFwaMailConfirmNoPingButtonCustomId,
   isFwaMailRefreshButtonCustomId,
@@ -1317,6 +1320,13 @@ const MATCHTYPE_WARNING_LEGEND =
 const POINTS_CLAN_NOT_FOUND_STATUS_LINE =
   ":interrobang: Clan not found on points.fwafarm";
 
+/** Purpose: keep mail preview/send entry behavior consistent by routing inferred match-type blocks back to `/fwa match`. */
+function shouldRedirectToFwaMatchForMailGateReason(
+  reason: string | null | undefined,
+): boolean {
+  return reason === INFERRED_MATCHTYPE_MAIL_BLOCK_REASON;
+}
+
 function logFwaMatchTelemetry(event: string, detail: string): void {
   console.log(`[telemetry-fwa-match] event=${event} ${detail}`);
 }
@@ -1502,6 +1512,7 @@ type FwaMatchCopyPayload = {
   currentScope: "alliance" | "single";
   currentTag: string | null;
   revisionDraftByTag: Record<string, MatchRevisionFields>;
+  mailGateResumeTag?: string | null;
 };
 
 type FwaMailPreviewPayload = {
@@ -2157,6 +2168,158 @@ async function rebuildTrackedPayloadForTag(
     revisionDraftByTag: nextRevisionDraftByTag,
     currentScope: "single",
     currentTag: tag,
+  };
+}
+
+function applyMailGateResumeStateToPayload(
+  payload: FwaMatchCopyPayload,
+  tag: string,
+): FwaMatchCopyPayload {
+  const normalizedTag = normalizeTag(tag);
+  return {
+    ...payload,
+    currentScope: "single",
+    currentTag: normalizedTag,
+    mailGateResumeTag: normalizedTag,
+  };
+}
+
+function buildScopedFwaMatchPayload(params: {
+  guildId: string;
+  userId: string;
+  tag: string;
+  includePostButton: boolean;
+  overview: {
+    embed: EmbedBuilder;
+    copyText: string;
+    singleViews: Record<string, MatchView>;
+  };
+  mailGateResumeTag?: string | null;
+}): { payload: FwaMatchCopyPayload; view: MatchView } | null {
+  const normalizedTag = normalizeTag(params.tag);
+  const trackedSingleView = params.overview.singleViews[normalizedTag];
+  if (!trackedSingleView) return null;
+  const payload: FwaMatchCopyPayload = {
+    userId: params.userId,
+    guildId: params.guildId,
+    includePostButton: params.includePostButton,
+    allianceView: {
+      embed: params.overview.embed,
+      copyText: params.overview.copyText,
+      matchTypeAction: null,
+    },
+    allianceViewIsScoped: true,
+    singleViews: params.overview.singleViews,
+    currentScope: "single",
+    currentTag: normalizedTag,
+    revisionDraftByTag: {},
+    mailGateResumeTag: params.mailGateResumeTag
+      ? normalizeTag(params.mailGateResumeTag)
+      : null,
+  };
+  return { payload, view: trackedSingleView };
+}
+
+async function buildScopedFwaMatchPayloadForTag(params: {
+  guildId: string;
+  userId: string;
+  tag: string;
+  includePostButton: boolean;
+  client?: Client | null;
+  mailGateResumeTag?: string | null;
+}): Promise<{ payload: FwaMatchCopyPayload; view: MatchView } | null> {
+  const normalizedTag = normalizeTag(params.tag);
+  const settings = new SettingsService();
+  const sourceSync = await getSourceOfTruthSync(settings, params.guildId);
+  const cocService = new CoCService();
+  const warLookupCache: WarLookupCache = new Map();
+  const overview = await buildTrackedMatchOverview(
+    cocService,
+    sourceSync,
+    params.guildId,
+    warLookupCache,
+    params.client ?? null,
+    { onlyClanTags: [normalizedTag] },
+  );
+  return buildScopedFwaMatchPayload({
+    guildId: params.guildId,
+    userId: params.userId,
+    tag: normalizedTag,
+    includePostButton: params.includePostButton,
+    overview,
+    mailGateResumeTag: params.mailGateResumeTag ?? null,
+  });
+}
+
+async function prepareMailGateResumeMatchPayloadForTag(params: {
+  guildId: string;
+  userId: string;
+  tag: string;
+  sourceMatchPayloadKey?: string;
+  client?: Client | null;
+}): Promise<{ key: string; payload: FwaMatchCopyPayload; view: MatchView } | null> {
+  const normalizedTag = normalizeTag(params.tag);
+  const sourceKey = params.sourceMatchPayloadKey?.trim() ?? "";
+  if (sourceKey) {
+    const existing = fwaMatchCopyPayloads.get(sourceKey);
+    if (existing) {
+      const refreshed = await rebuildTrackedPayloadForTag(
+        existing,
+        params.guildId,
+        normalizedTag,
+        params.client ?? null,
+      ).catch(() => null);
+      const active = refreshed ?? existing;
+      const view = active.singleViews[normalizedTag];
+      if (view) {
+        const nextPayload = applyMailGateResumeStateToPayload(
+          active,
+          normalizedTag,
+        );
+        fwaMatchCopyPayloads.set(sourceKey, nextPayload);
+        return { key: sourceKey, payload: nextPayload, view };
+      }
+    }
+  }
+
+  const scoped = await buildScopedFwaMatchPayloadForTag({
+    guildId: params.guildId,
+    userId: params.userId,
+    tag: normalizedTag,
+    includePostButton: false,
+    client: params.client ?? null,
+    mailGateResumeTag: normalizedTag,
+  });
+  if (!scoped) return null;
+  const key = createTransientFwaKey();
+  fwaMatchCopyPayloads.set(key, scoped.payload);
+  return { key, payload: scoped.payload, view: scoped.view };
+}
+
+function buildFwaMatchViewRenderPayload(params: {
+  payload: FwaMatchCopyPayload;
+  key: string;
+  view: MatchView;
+  showMode: "embed" | "copy";
+}): {
+  content: string | undefined;
+  embeds: EmbedBuilder[];
+  components: Array<
+    ActionRowBuilder<ButtonBuilder> | ActionRowBuilder<StringSelectMenuBuilder>
+  >;
+} {
+  return {
+    content:
+      params.showMode === "copy"
+        ? limitDiscordContent(params.view.copyText)
+        : undefined,
+    embeds: params.showMode === "embed" ? [params.view.embed] : [],
+    components: buildFwaMatchCopyComponents(
+      params.payload,
+      params.payload.userId,
+      params.key,
+      params.showMode,
+    ),
   };
 }
 
@@ -4673,6 +4836,12 @@ function buildFwaMatchCopyComponents(
   const mailAction = view.mailAction ?? null;
   const skipSyncAction = view.skipSyncAction ?? null;
   const undoSkipSyncAction = view.undoSkipSyncAction ?? null;
+  const mailGateResumeActive =
+    payload.currentScope === "single" &&
+    Boolean(payload.currentTag) &&
+    payload.currentTag === payload.mailGateResumeTag &&
+    (Boolean(view.inferredMatchType) ||
+      view.mailAction?.reason === INFERRED_MATCHTYPE_MAIL_BLOCK_REASON);
   const toggleMode = showMode === "embed" ? "copy" : "embed";
   const toggleLabel = showMode === "embed" ? "Copy/Paste View" : "Embed View";
   const baseRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
@@ -4713,8 +4882,42 @@ function buildFwaMatchCopyComponents(
   }
   const rows: Array<
     ActionRowBuilder<ButtonBuilder> | ActionRowBuilder<StringSelectMenuBuilder>
-  > = [baseRow];
-  if (payload.currentScope === "single" && payload.currentTag && mailAction) {
+  > = [];
+  if (mailGateResumeActive && payload.currentTag) {
+    rows.push(
+      new ActionRowBuilder<ButtonBuilder>().addComponents(
+        new ButtonBuilder()
+          .setCustomId(
+            buildFwaMailGateResumeCustomId({
+              userId,
+              key,
+              tag: payload.currentTag,
+              action: "continue",
+            }),
+          )
+          .setLabel("Review match + continue")
+          .setStyle(ButtonStyle.Primary),
+        new ButtonBuilder()
+          .setCustomId(
+            buildFwaMailGateResumeCustomId({
+              userId,
+              key,
+              tag: payload.currentTag,
+              action: "cancel",
+            }),
+          )
+          .setLabel("Cancel")
+          .setStyle(ButtonStyle.Secondary),
+      ),
+    );
+  }
+  rows.push(baseRow);
+  if (
+    payload.currentScope === "single" &&
+    payload.currentTag &&
+    mailAction &&
+    !mailGateResumeActive
+  ) {
     rows.push(
       new ActionRowBuilder<ButtonBuilder>().addComponents(
         new ButtonBuilder()
@@ -6067,6 +6270,52 @@ async function showWarMailPreview(
     fetchReason: "pre_fwa_validation",
     revisionOverride: revisionOverride ?? null,
   });
+  const mailSendGate = rendered.mailRevisionDecision;
+  if (
+    shouldRedirectToFwaMatchForMailGateReason(mailSendGate.mailBlockedReason)
+  ) {
+    const handoff = await prepareMailGateResumeMatchPayloadForTag({
+      guildId,
+      userId,
+      tag,
+      sourceMatchPayloadKey,
+      client: interaction.client,
+    });
+    if (!handoff) {
+      const fallbackMessage = `:warning: ${INFERRED_MATCHTYPE_MAIL_BLOCK_REASON}`;
+      if (interaction.isButton()) {
+        await interaction.update({
+          content: fallbackMessage,
+          embeds: [],
+          components: [],
+        });
+      } else {
+        await interaction.editReply({
+          content: fallbackMessage,
+          embeds: [],
+          components: [],
+        });
+      }
+      return;
+    }
+    const showMode =
+      interaction.isButton() && interaction.message.embeds.length === 0
+        ? "copy"
+        : "embed";
+    const response = buildFwaMatchViewRenderPayload({
+      payload: handoff.payload,
+      key: handoff.key,
+      view: handoff.view,
+      showMode,
+    });
+    if (interaction.isButton()) {
+      await interaction.update(response);
+    } else {
+      await interaction.editReply(response);
+    }
+    return;
+  }
+
   const previewKey = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
   const sourceShowMode =
     interaction.isButton() && interaction.message.embeds.length > 0
@@ -6088,7 +6337,6 @@ async function showWarMailPreview(
     revisionOverride: revisionOverride ?? null,
   });
 
-  const mailSendGate = rendered.mailRevisionDecision;
   const channel = rendered.mailChannelId
     ? await interaction.client.channels
         .fetch(rendered.mailChannelId)
@@ -6222,6 +6470,69 @@ export async function handleFwaMatchSendMailButton(
     cocService,
     parsed.key,
     revisionOverride,
+  );
+}
+
+export async function handleFwaMailGateResumeButton(
+  interaction: ButtonInteraction,
+): Promise<void> {
+  const parsed = parseFwaMailGateResumeCustomId(interaction.customId);
+  if (!parsed) return;
+  if (interaction.user.id !== parsed.userId) {
+    await interaction.reply({
+      ephemeral: true,
+      content: "Only the command requester can use this button.",
+    });
+    return;
+  }
+  const payload = fwaMatchCopyPayloads.get(parsed.key);
+  if (!payload) {
+    await interaction.reply({
+      ephemeral: true,
+      content: "This match view expired. Please run /fwa match again.",
+    });
+    return;
+  }
+  const tag = normalizeTag(parsed.tag);
+  if (parsed.action === "cancel") {
+    fwaMatchCopyPayloads.delete(parsed.key);
+    await interaction.update({
+      content: "Cancelled.",
+      embeds: [],
+      components: [],
+    });
+    return;
+  }
+  const refreshed = await rebuildTrackedPayloadForTag(
+    payload,
+    payload.guildId,
+    tag,
+    interaction.client,
+  ).catch(() => null);
+  const activePayload = refreshed ?? payload;
+  const nextView = activePayload.singleViews[tag];
+  if (!nextView) {
+    await interaction.reply({
+      ephemeral: true,
+      content: "This clan view is no longer available. Please run /fwa match again.",
+    });
+    return;
+  }
+  const nextPayload: FwaMatchCopyPayload = {
+    ...activePayload,
+    currentScope: "single",
+    currentTag: tag,
+    mailGateResumeTag: null,
+  };
+  fwaMatchCopyPayloads.set(parsed.key, nextPayload);
+  const showMode = interaction.message.embeds.length > 0 ? "embed" : "copy";
+  await interaction.update(
+    buildFwaMatchViewRenderPayload({
+      payload: nextPayload,
+      key: parsed.key,
+      view: nextView,
+      showMode,
+    }),
   );
 }
 
@@ -6475,6 +6786,38 @@ async function handleFwaMailConfirmAction(
   }
   const mailSendGate = rendered.mailRevisionDecision;
   if (mailSendGate.mailBlockedReason) {
+    if (
+      shouldRedirectToFwaMatchForMailGateReason(mailSendGate.mailBlockedReason)
+    ) {
+      const handoff = await prepareMailGateResumeMatchPayloadForTag({
+        guildId: payload.guildId,
+        userId: parsed.userId,
+        tag: payload.tag,
+        sourceMatchPayloadKey: payload.sourceMatchPayloadKey,
+        client: interaction.client,
+      });
+      if (!handoff) {
+        await interaction.editReply({
+          content: `Cannot send mail: ${formatMailBlockedReason(mailSendGate.mailBlockedReason) ?? mailSendGate.mailBlockedReason}`,
+          embeds: [],
+          components: [],
+        });
+      } else {
+        const showMode =
+          payload.sourceShowMode ??
+          (interaction.message.embeds.length > 0 ? "embed" : "copy");
+        await interaction.editReply(
+          buildFwaMatchViewRenderPayload({
+            payload: handoff.payload,
+            key: handoff.key,
+            view: handoff.view,
+            showMode,
+          }),
+        );
+      }
+      fwaMailPreviewPayloads.delete(parsed.key);
+      return;
+    }
     await interaction.editReply({
       content: `Cannot send mail: ${
         formatMailBlockedReason(mailSendGate.mailBlockedReason) ??
@@ -7853,6 +8196,8 @@ function applyExplicitOpponentNotFoundFallbackGuard(input: {
 
 export const getMailBlockedReasonFromStatusForTest =
   getMailBlockedReasonFromStatus;
+export const shouldRedirectToFwaMatchForMailGateReasonForTest =
+  shouldRedirectToFwaMatchForMailGateReason;
 export const collectBaseSwapTownhallLevelsForTest =
   collectBaseSwapTownhallLevels;
 export const buildBaseSwapLayoutLinksForTest = buildBaseSwapLayoutLinks;

--- a/src/commands/fwa/customIds.ts
+++ b/src/commands/fwa/customIds.ts
@@ -14,6 +14,7 @@ const FWA_MAIL_CONFIRM_NO_PING_PREFIX = "fwa-mail-confirm-no-ping";
 const FWA_MAIL_BACK_PREFIX = "fwa-mail-back";
 const FWA_MAIL_REFRESH_PREFIX = "fwa-mail-refresh";
 const FWA_MATCH_SEND_MAIL_PREFIX = "fwa-match-send-mail";
+const FWA_MAIL_GATE_RESUME_PREFIX = "fwa-mail-gate-resume";
 const FWA_MATCH_TIEBREAKER_PREFIX = "fwa-match-tiebreaker";
 const FWA_COMPLIANCE_VIEW_PREFIX = "fwa-compliance-view";
 const FWA_BASE_SWAP_SPLIT_POST_PREFIX = "fwa-base-swap-split-post";
@@ -51,6 +52,14 @@ export type FwaMatchTieBreakerParams = {
   userId: string;
   key: string;
   tag: string;
+};
+
+export type FwaMailGateResumeAction = "continue" | "cancel";
+export type FwaMailGateResumeParams = {
+  userId: string;
+  key: string;
+  tag: string;
+  action: FwaMailGateResumeAction;
 };
 
 export type FwaComplianceViewAction = "open_missed" | "open_main" | "prev" | "next";
@@ -381,6 +390,31 @@ export function parseFwaMatchSendMailCustomId(
 /** Purpose: detect send-mail-from-match button prefix. */
 export function isFwaMatchSendMailButtonCustomId(customId: string): boolean {
   return customId.startsWith(`${FWA_MATCH_SEND_MAIL_PREFIX}:`);
+}
+
+/** Purpose: build custom-id for inferred match-type mail gate handoff actions. */
+export function buildFwaMailGateResumeCustomId(
+  params: FwaMailGateResumeParams,
+): string {
+  return `${FWA_MAIL_GATE_RESUME_PREFIX}:${params.userId}:${params.key}:${normalizeTag(params.tag)}:${params.action}`;
+}
+
+/** Purpose: parse inferred match-type mail gate handoff action custom-id payload. */
+export function parseFwaMailGateResumeCustomId(
+  customId: string,
+): FwaMailGateResumeParams | null {
+  const values = parseCustomIdParts(customId, FWA_MAIL_GATE_RESUME_PREFIX, 5);
+  if (!values) return null;
+  const [userId, key, rawTag, rawAction] = values;
+  const action: FwaMailGateResumeAction | null =
+    rawAction === "continue" || rawAction === "cancel" ? rawAction : null;
+  if (!action) return null;
+  return { userId, key, tag: normalizeTag(rawTag), action };
+}
+
+/** Purpose: detect inferred match-type mail gate handoff action button prefix. */
+export function isFwaMailGateResumeButtonCustomId(customId: string): boolean {
+  return customId.startsWith(`${FWA_MAIL_GATE_RESUME_PREFIX}:`);
 }
 
 /** Purpose: build custom-id for single-clan tie-breaker rules button. */

--- a/src/listeners/interactionCreate.ts
+++ b/src/listeners/interactionCreate.ts
@@ -33,6 +33,7 @@ import {
   handleFwaMailConfirmButton,
   handleFwaMailConfirmNoPingButton,
   handleFwaMailBackButton,
+  handleFwaMailGateResumeButton,
   handleFwaMailRefreshButton,
   handleFwaMatchSendMailButton,
   handleFwaMatchTieBreakerButton,
@@ -45,6 +46,7 @@ import {
   isFwaMailConfirmButtonCustomId,
   isFwaMailConfirmNoPingButtonCustomId,
   isFwaMailBackButtonCustomId,
+  isFwaMailGateResumeButtonCustomId,
   isFwaMailRefreshButtonCustomId,
   isFwaMatchSendMailButtonCustomId,
   isFwaMatchTieBreakerButtonCustomId,
@@ -606,6 +608,20 @@ const handleButtonInteraction = async (
         await interaction.reply({
           ephemeral: true,
           content: "Failed to open war mail preview.",
+        });
+      }
+    }
+  }
+
+  if (isFwaMailGateResumeButtonCustomId(interaction.customId)) {
+    try {
+      await handleFwaMailGateResumeButton(interaction);
+    } catch (err) {
+      console.error(`FWA mail gate resume button failed: ${formatError(err)}`);
+      if (!interaction.replied && !interaction.deferred) {
+        await interaction.reply({
+          ephemeral: true,
+          content: "Failed to continue in match view.",
         });
       }
     }

--- a/tests/fwaCustomIds.logic.test.ts
+++ b/tests/fwaCustomIds.logic.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildFwaBaseSwapSplitPostCustomId,
   buildFwaComplianceViewCustomId,
+  buildFwaMailGateResumeCustomId,
   buildFwaMatchSendMailCustomId,
   buildFwaMatchTieBreakerCustomId,
   buildMatchTypeActionCustomId,
@@ -9,11 +10,13 @@ import {
   createTransientFwaKey,
   isFwaBaseSwapSplitPostButtonCustomId,
   isFwaComplianceViewButtonCustomId,
+  isFwaMailGateResumeButtonCustomId,
   isFwaMatchSendMailButtonCustomId,
   isFwaMatchTieBreakerButtonCustomId,
   isPointsPostButtonCustomId,
   parseFwaBaseSwapSplitPostCustomId,
   parseFwaComplianceViewCustomId,
+  parseFwaMailGateResumeCustomId,
   parseFwaMatchSendMailCustomId,
   parseFwaMatchTieBreakerCustomId,
   parseMatchTypeActionCustomId,
@@ -49,6 +52,24 @@ describe("fwa custom-id helpers", () => {
       key: "payload",
       tag: "QWERTY",
     });
+  });
+
+  it("round-trips mail-gate resume ids and supports selector checks", () => {
+    const customId = buildFwaMailGateResumeCustomId({
+      userId: "321",
+      key: "payload",
+      tag: "#qwerty",
+      action: "continue",
+    });
+
+    expect(isFwaMailGateResumeButtonCustomId(customId)).toBe(true);
+    expect(parseFwaMailGateResumeCustomId(customId)).toEqual({
+      userId: "321",
+      key: "payload",
+      tag: "QWERTY",
+      action: "continue",
+    });
+    expect(parseFwaMailGateResumeCustomId("fwa-mail-gate-resume:321:key:QWERTY:bad")).toBeNull();
   });
 
   it("round-trips tie-breaker ids and supports selector checks", () => {

--- a/tests/fwaMatchInference.logic.test.ts
+++ b/tests/fwaMatchInference.logic.test.ts
@@ -3,6 +3,7 @@ import {
   applyExplicitOpponentNotFoundFallbackGuardForTest,
   hasSameWarExplicitFwaConfirmationForTest,
   getMailBlockedReasonFromStatusForTest,
+  shouldRedirectToFwaMatchForMailGateReasonForTest,
   inferMatchTypeFromPointsSnapshotsForTest,
   resolveMatchTypeWithFallbackForTest,
   resolveMatchTypeFromStoredSyncRowForTest,
@@ -280,6 +281,20 @@ describe("fwa mail send gating", () => {
     expect(reason).toBe(
       "Match type is inferred. Confirm match type before sending mail."
     );
+  });
+
+  it("redirects inferred mail blocks back to fwa match flow", () => {
+    expect(
+      shouldRedirectToFwaMatchForMailGateReasonForTest(
+        "Match type is inferred. Confirm match type before sending mail.",
+      ),
+    ).toBe(true);
+    expect(
+      shouldRedirectToFwaMatchForMailGateReasonForTest(
+        "Current mail is already up to date. Change match config before sending again.",
+      ),
+    ).toBe(false);
+    expect(shouldRedirectToFwaMatchForMailGateReasonForTest(null)).toBe(false);
   });
 });
 


### PR DESCRIPTION
- redirect inferred `/fwa mail send` and other mail entry points to single-clan `/fwa match` with review/cancel continuation UX
- add shared inferred-mail gate helper plus reusable match-view handoff rendering so slash/button paths keep one invariant
- add mail-gate resume custom ids/router handling and tests for redirect gating + custom-id parsing