### PR TITLE
feat(todo): add war and cwl completion status sidebar states

### DIFF
--- a/src/commands/Todo.ts
+++ b/src/commands/Todo.ts
@@ -17,6 +17,7 @@ import {
   invalidateTodoRenderCacheForUser,
   normalizeTodoType,
   TODO_TYPES,
+  type TodoSidebarState,
   type TodoType,
 } from "../services/TodoService";
 import { todoSnapshotService } from "../services/TodoSnapshotService";
@@ -24,7 +25,9 @@ import { todoLastViewedTypeService } from "../services/TodoLastViewedTypeService
 
 const TODO_PAGE_BUTTON_PREFIX = "todo-page";
 const TODO_REFRESH_BUTTON_PREFIX = "todo-refresh";
-const TODO_EMBED_COLOR = 0x5865f2;
+const TODO_EMBED_COLOR_DEFAULT = 0x5865f2;
+const TODO_EMBED_COLOR_INCOMPLETE = 0xed4245;
+const TODO_EMBED_COLOR_COMPLETE = 0x57f287;
 const TODO_GUILD_SCOPE_DM = "dm";
 const TODO_REFRESH_ERROR_MESSAGE =
   "Failed to refresh todo data. Please try again.";
@@ -247,16 +250,24 @@ function buildTodoEmbed(input: {
   selectedType: TodoType;
   linkedPlayerCount: number;
   pageText: string;
+  sidebarState: TodoSidebarState;
 }): EmbedBuilder {
   const pageIndex = TODO_TYPES.indexOf(input.selectedType);
   const safeIndex = pageIndex >= 0 ? pageIndex : 0;
   return new EmbedBuilder()
-    .setColor(TODO_EMBED_COLOR)
+    .setColor(resolveTodoEmbedColor(input.sidebarState))
     .setTitle(`Todo - ${input.selectedType}`)
     .setDescription(input.pageText || "No todo rows available.")
     .setFooter({
       text: `Page ${safeIndex + 1}/${TODO_TYPES.length} - Linked players: ${input.linkedPlayerCount}`,
     });
+}
+
+/** Purpose: map shared todo sidebar state into deterministic embed colors for command render. */
+function resolveTodoEmbedColor(sidebarState: TodoSidebarState): number {
+  if (sidebarState === "incomplete") return TODO_EMBED_COLOR_INCOMPLETE;
+  if (sidebarState === "complete") return TODO_EMBED_COLOR_COMPLETE;
+  return TODO_EMBED_COLOR_DEFAULT;
 }
 
 /** Purpose: build a rendered todo response payload for one selected page type. */
@@ -286,6 +297,7 @@ async function buildTodoRenderResult(input: {
           selectedType: normalizedType,
           linkedPlayerCount: pages.linkedPlayerCount,
           pageText: pages.pages[normalizedType],
+          sidebarState: pages.sidebarStateByType[normalizedType] ?? "default",
         }),
       ],
       components: buildTodoComponentRows(input.scope, normalizedType),

--- a/src/services/TodoService.ts
+++ b/src/services/TodoService.ts
@@ -21,7 +21,10 @@ export type TodoType = (typeof TODO_TYPES)[number];
 export type TodoPagesResult = {
   linkedPlayerCount: number;
   pages: Record<TodoType, string>;
+  sidebarStateByType: Record<TodoType, TodoSidebarState>;
 };
+
+export type TodoSidebarState = "default" | "incomplete" | "complete";
 
 type TodoRenderRow = {
   playerTag: string;
@@ -155,6 +158,12 @@ export async function buildTodoPagesForUser(input: {
         CWL: "",
         RAIDS: "",
         GAMES: "",
+      },
+      sidebarStateByType: {
+        WAR: "default",
+        CWL: "default",
+        RAIDS: "default",
+        GAMES: "default",
       },
     };
   }
@@ -393,13 +402,21 @@ export async function buildTodoPagesForUser(input: {
       .catch(() => undefined);
   }
 
+  const warView = buildWarPageDescription(renderRows, linkedTags.length);
+  const cwlView = buildCwlPageDescription(renderRows, linkedTags.length);
   const pages = {
     linkedPlayerCount: linkedTags.length,
     pages: {
-      WAR: buildWarPageDescription(renderRows, linkedTags.length),
-      CWL: buildCwlPageDescription(renderRows, linkedTags.length),
+      WAR: warView.description,
+      CWL: cwlView.description,
       RAIDS: buildRaidsPageDescription(renderRows, linkedTags.length),
       GAMES: buildGamesPageDescription(renderRows, linkedTags.length, nowMs),
+    },
+    sidebarStateByType: {
+      WAR: warView.sidebarState,
+      CWL: cwlView.sidebarState,
+      RAIDS: "default",
+      GAMES: "default",
     },
   } satisfies TodoPagesResult;
 
@@ -449,16 +466,21 @@ function isSnapshotStale(snapshot: TodoSnapshotRecord, nowMs: number): boolean {
 function buildWarPageDescription(
   rows: TodoRenderRow[],
   linkedPlayerCount: number,
-): string {
+): { description: string; sidebarState: TodoSidebarState } {
   const activeRows = rows.filter(
     (row) => Boolean(row.snapshot?.warActive) && row.inValidatedWarMemberSet,
   );
+  const warCompletion = summarizeWarCompletionStatus(activeRows);
   if (activeRows.length <= 0) {
-    return buildTodoPageDescription({
-      heading: "WAR",
-      linkedPlayerCount,
-      lines: ["No war active"],
-    });
+    return {
+      description: buildTodoPageDescription({
+        heading: "WAR",
+        linkedPlayerCount,
+        statusLine: warCompletion.statusLine,
+        lines: ["No war active"],
+      }),
+      sidebarState: warCompletion.sidebarState,
+    };
   }
 
   const grouped = buildEventGroups(activeRows, "war");
@@ -477,25 +499,34 @@ function buildWarPageDescription(
     lines.pop();
   }
 
-  return buildTodoPageDescription({
-    heading: "WAR",
-    linkedPlayerCount,
-    lines,
-  });
+  return {
+    description: buildTodoPageDescription({
+      heading: "WAR",
+      linkedPlayerCount,
+      statusLine: warCompletion.statusLine,
+      lines,
+    }),
+    sidebarState: warCompletion.sidebarState,
+  };
 }
 
 /** Purpose: build the CWL page from grouped active contexts only. */
 function buildCwlPageDescription(
   rows: TodoRenderRow[],
   linkedPlayerCount: number,
-): string {
+): { description: string; sidebarState: TodoSidebarState } {
   const activeRows = rows.filter((row) => Boolean(row.snapshot?.cwlActive));
+  const cwlCompletion = summarizeCwlCompletionStatus(activeRows);
   if (activeRows.length <= 0) {
-    return buildTodoPageDescription({
-      heading: "CWL",
-      linkedPlayerCount,
-      lines: ["No CWL active"],
-    });
+    return {
+      description: buildTodoPageDescription({
+        heading: "CWL",
+        linkedPlayerCount,
+        statusLine: cwlCompletion.statusLine,
+        lines: ["No CWL active"],
+      }),
+      sidebarState: cwlCompletion.sidebarState,
+    };
   }
 
   const grouped = buildEventGroups(activeRows, "cwl");
@@ -511,11 +542,70 @@ function buildCwlPageDescription(
     lines.pop();
   }
 
-  return buildTodoPageDescription({
-    heading: "CWL",
-    linkedPlayerCount,
-    lines,
-  });
+  return {
+    description: buildTodoPageDescription({
+      heading: "CWL",
+      linkedPlayerCount,
+      statusLine: cwlCompletion.statusLine,
+      lines,
+    }),
+    sidebarState: cwlCompletion.sidebarState,
+  };
+}
+
+/** Purpose: compute WAR completion totals and sidebar state from confirmed participating rows. */
+function summarizeWarCompletionStatus(
+  confirmedRows: TodoRenderRow[],
+): { statusLine: string; sidebarState: TodoSidebarState } {
+  const completedAttacks = confirmedRows.reduce(
+    (sum, row) => sum + getWarRowProgress(row).used,
+    0,
+  );
+  const requiredAttacks = confirmedRows.length * 2;
+  const attackPhaseRows = confirmedRows.filter((row) =>
+    isWarRowAttackPhaseActive(row),
+  );
+  if (attackPhaseRows.length <= 0) {
+    return {
+      statusLine: `war status: ${completedAttacks} / ${requiredAttacks} attacks completed`,
+      sidebarState: "default",
+    };
+  }
+  const attackPhaseCompleted = attackPhaseRows.reduce(
+    (sum, row) => sum + getWarRowProgress(row).used,
+    0,
+  );
+  const attackPhaseRequired = attackPhaseRows.length * 2;
+  return {
+    statusLine: `war status: ${completedAttacks} / ${requiredAttacks} attacks completed`,
+    sidebarState:
+      attackPhaseCompleted >= attackPhaseRequired ? "complete" : "incomplete",
+  };
+}
+
+/** Purpose: compute CWL completion totals and sidebar state from confirmed active battle-day participants. */
+function summarizeCwlCompletionStatus(
+  confirmedRows: TodoRenderRow[],
+): { statusLine: string; sidebarState: TodoSidebarState } {
+  const battleDayRows = confirmedRows.filter((row) =>
+    isCwlRowAttackPhaseActive(row),
+  );
+  const completedAttacks = battleDayRows.reduce(
+    (sum, row) => sum + getCwlRowProgress(row).used,
+    0,
+  );
+  const requiredAttacks = battleDayRows.length;
+  if (battleDayRows.length <= 0) {
+    return {
+      statusLine: `cwl status: ${completedAttacks} / ${requiredAttacks} attacks completed`,
+      sidebarState: "default",
+    };
+  }
+  return {
+    statusLine: `cwl status: ${completedAttacks} / ${requiredAttacks} attacks completed`,
+    sidebarState:
+      completedAttacks >= requiredAttacks ? "complete" : "incomplete",
+  };
 }
 
 /** Purpose: build the RAIDS page with one shared timer header and row-level usage only. */
@@ -770,11 +860,13 @@ function formatWarPlayerIdentity(row: TodoRenderRow): string {
 function buildTodoPageDescription(input: {
   heading: TodoType;
   linkedPlayerCount: number;
+  statusLine?: string | null;
   lines: string[];
 }): string {
+  const statusLine = sanitizeStatusText(input.statusLine ?? "");
   const lines = [
     `Type: ${input.heading}`,
-    `Linked players: ${input.linkedPlayerCount}`,
+    statusLine || `Linked players: ${input.linkedPlayerCount}`,
     "",
     ...input.lines,
   ];
@@ -822,10 +914,34 @@ function getCwlRowStatus(row: TodoRenderRow): string {
     return "CWL attacks: 0/1 - snapshot unavailable";
   }
 
-  const used = clampInt(row.snapshot.cwlAttacksUsed, 0, row.snapshot.cwlAttacksMax || 1);
-  const max = Math.max(1, clampInt(row.snapshot.cwlAttacksMax, 1, 1));
+  const { used, max } = getCwlRowProgress(row);
   const staleSuffix = row.staleSnapshot ? " - stale snapshot" : "";
   return `CWL attacks: ${used}/${max}${staleSuffix}`;
+}
+
+/** Purpose: compute stable CWL used/max progress and completion state for one confirmed participant row. */
+function getCwlRowProgress(row: TodoRenderRow): {
+  used: number;
+  max: number;
+  complete: boolean;
+} {
+  if (!row.snapshot) {
+    return { used: 0, max: 1, complete: false };
+  }
+  const used = clampInt(
+    row.snapshot.cwlAttacksUsed,
+    0,
+    row.snapshot.cwlAttacksMax || 1,
+  );
+  const max = Math.max(1, clampInt(row.snapshot.cwlAttacksMax, 1, 1));
+  return { used, max, complete: used >= max };
+}
+
+/** Purpose: treat only CWL battle-day contexts as attack-active for completion coloring. */
+function isCwlRowAttackPhaseActive(row: TodoRenderRow): boolean {
+  if (!row.snapshot?.cwlActive) return false;
+  const phase = sanitizeStatusText(row.snapshot.cwlPhase).toLowerCase();
+  return phase.includes("battle");
 }
 
 /** Purpose: build RAIDS row status text with usage only and without per-row timer duplication. */

--- a/tests/todo.command.test.ts
+++ b/tests/todo.command.test.ts
@@ -69,6 +69,9 @@ import { todoSnapshotService } from "../src/services/TodoSnapshotService";
 import { todoLastViewedTypeService } from "../src/services/TodoLastViewedTypeService";
 
 type TodoType = "WAR" | "CWL" | "RAIDS" | "GAMES";
+const TODO_DEFAULT_EMBED_COLOR = 0x5865f2;
+const TODO_INCOMPLETE_EMBED_COLOR = 0xed4245;
+const TODO_COMPLETE_EMBED_COLOR = 0x57f287;
 
 function makeTodoInteraction(input: {
   type?: TodoType | null;
@@ -194,6 +197,12 @@ function getReplyDescription(interaction: any): string {
 function getReplyTitle(interaction: any): string {
   const payload = interaction.editReply.mock.calls[0]?.[0] as any;
   return String(payload?.embeds?.[0]?.toJSON?.().title ?? "");
+}
+
+function getReplyColor(interaction: any): number | null {
+  const payload = interaction.editReply.mock.calls[0]?.[0] as any;
+  const color = payload?.embeds?.[0]?.toJSON?.().color;
+  return typeof color === "number" ? color : null;
 }
 
 function countOccurrences(haystack: string, needle: string): number {
@@ -671,6 +680,9 @@ describe("/todo command", () => {
 
     const description = getReplyDescription(interaction);
     expect(getReplyTitle(interaction)).toBe("Todo - WAR");
+    expect(getReplyColor(interaction)).toBe(TODO_INCOMPLETE_EMBED_COLOR);
+    expect(description).toContain("war status: 1 / 6 attacks completed");
+    expect(description).not.toContain("Linked players:");
     expect(description).toContain("**:rd: Clan One (#PQL0289) :green_circle: - battle day ends <t:");
     expect(description).toContain("**:ak: Clan Two (#2QG2C08UP) :black_circle: - preparation ends <t:");
     expect(description).toContain("- #8 Alpha - `0 / 2`");
@@ -770,6 +782,142 @@ describe("/todo command", () => {
     const description = getReplyDescription(interaction);
     expect(description).toContain("Alpha - `1 / 2`");
     expect(description).toContain(":white_check_mark: #2 Bravo - `2 / 2`");
+  });
+
+  it("uses green WAR sidebar when all battle-day participant attacks are completed", async () => {
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      { playerTag: "#PYLQ0289", createdAt: new Date("2026-03-01T00:00:00.000Z") },
+      { playerTag: "#QGRJ2222", createdAt: new Date("2026-03-02T00:00:00.000Z") },
+    ]);
+    prismaMock.todoPlayerSnapshot.aggregate.mockResolvedValue({
+      _count: { _all: 2 },
+      _max: { updatedAt: new Date("2026-03-26T00:00:00.000Z") },
+    });
+    prismaMock.todoPlayerSnapshot.findMany.mockResolvedValue([
+      makeSnapshotRow({
+        playerTag: "#PYLQ0289",
+        playerName: "Alpha",
+        clanTag: "#PQL0289",
+        clanName: "Clan One",
+        warAttacksUsed: 2,
+        warPhase: "battle day",
+      }),
+      makeSnapshotRow({
+        playerTag: "#QGRJ2222",
+        playerName: "Bravo",
+        clanTag: "#PQL0289",
+        clanName: "Clan One",
+        warAttacksUsed: 2,
+        warPhase: "battle day",
+      }),
+    ]);
+    prismaMock.trackedClan.findMany.mockResolvedValue([
+      { tag: "#PQL0289", clanBadge: ":rd:" },
+    ]);
+    prismaMock.currentWar.findMany.mockResolvedValue([
+      {
+        clanTag: "#PQL0289",
+        warId: 1001,
+        startTime: new Date("2026-03-25T12:00:00.000Z"),
+        matchType: "FWA",
+        outcome: "WIN",
+        state: "inWar",
+        updatedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.warAttacks.findMany.mockResolvedValue([
+      {
+        clanTag: "#PQL0289",
+        warId: 1001,
+        warStartTime: new Date("2026-03-25T12:00:00.000Z"),
+        playerTag: "#PYLQ0289",
+        playerPosition: 1,
+        attacksUsed: 2,
+        attackOrder: 1,
+        attackNumber: 1,
+        defenderPosition: 10,
+        stars: 3,
+        attackSeenAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+      {
+        clanTag: "#PQL0289",
+        warId: 1001,
+        warStartTime: new Date("2026-03-25T12:00:00.000Z"),
+        playerTag: "#QGRJ2222",
+        playerPosition: 2,
+        attacksUsed: 2,
+        attackOrder: 1,
+        attackNumber: 1,
+        defenderPosition: 8,
+        stars: 3,
+        attackSeenAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+    ]);
+
+    const interaction = makeTodoInteraction({ type: "WAR" });
+    await Todo.run({} as any, interaction as any, makeCocServiceSpy() as any);
+
+    expect(getReplyColor(interaction)).toBe(TODO_COMPLETE_EMBED_COLOR);
+    expect(getReplyDescription(interaction)).toContain(
+      "war status: 4 / 4 attacks completed",
+    );
+  });
+
+  it("keeps WAR sidebar default during preparation-only states", async () => {
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      { playerTag: "#PYLQ0289", createdAt: new Date("2026-03-01T00:00:00.000Z") },
+    ]);
+    prismaMock.todoPlayerSnapshot.aggregate.mockResolvedValue({
+      _count: { _all: 1 },
+      _max: { updatedAt: new Date("2026-03-26T00:00:00.000Z") },
+    });
+    prismaMock.todoPlayerSnapshot.findMany.mockResolvedValue([
+      makeSnapshotRow({
+        playerTag: "#PYLQ0289",
+        playerName: "Alpha",
+        clanTag: "#PQL0289",
+        clanName: "Clan One",
+        warAttacksUsed: 0,
+        warPhase: "preparation",
+      }),
+    ]);
+    prismaMock.trackedClan.findMany.mockResolvedValue([
+      { tag: "#PQL0289", clanBadge: ":rd:" },
+    ]);
+    prismaMock.currentWar.findMany.mockResolvedValue([
+      {
+        clanTag: "#PQL0289",
+        warId: 1001,
+        startTime: new Date("2026-03-25T12:00:00.000Z"),
+        matchType: "FWA",
+        outcome: "WIN",
+        state: "preparation",
+        updatedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.warAttacks.findMany.mockResolvedValue([
+      {
+        clanTag: "#PQL0289",
+        warId: 1001,
+        warStartTime: new Date("2026-03-25T12:00:00.000Z"),
+        playerTag: "#PYLQ0289",
+        playerPosition: 1,
+        attacksUsed: 0,
+        attackOrder: 0,
+        attackNumber: 0,
+        defenderPosition: null,
+        stars: 0,
+        attackSeenAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+    ]);
+
+    const interaction = makeTodoInteraction({ type: "WAR" });
+    await Todo.run({} as any, interaction as any, makeCocServiceSpy() as any);
+
+    expect(getReplyColor(interaction)).toBe(TODO_DEFAULT_EMBED_COLOR);
+    expect(getReplyDescription(interaction)).toContain(
+      "war status: 0 / 2 attacks completed",
+    );
   });
 
   it("moves fully completed WAR clans below unfinished clans while preserving subgroup order", async () => {
@@ -1369,12 +1517,74 @@ describe("/todo command", () => {
 
     const description = getReplyDescription(interaction);
     expect(getReplyTitle(interaction)).toBe("Todo - CWL");
+    expect(getReplyColor(interaction)).toBe(TODO_INCOMPLETE_EMBED_COLOR);
+    expect(description).toContain("cwl status: 1 / 2 attacks completed");
+    expect(description).not.toContain("Linked players:");
     expect(description).toContain("**Clan One (#PQL0289) - battle day ends <t:");
     expect(description).toContain("**Clan Two (#2QG2C08UP) - preparation ends <t:");
     expect(description).toContain("- Alpha #PYLQ0289 - CWL attacks: 1/1");
     expect(description).toContain("- Bravo #QGRJ2222 - CWL attacks: 0/1");
     expect(description).not.toContain("**Not in active CWL**");
     expect(description).not.toContain("Delta #LQ9P8R2");
+  });
+
+  it("uses green CWL sidebar when all active battle-day participants have attacked", async () => {
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      { playerTag: "#PYLQ0289", createdAt: new Date("2026-03-01T00:00:00.000Z") },
+      { playerTag: "#QGRJ2222", createdAt: new Date("2026-03-02T00:00:00.000Z") },
+    ]);
+    prismaMock.todoPlayerSnapshot.aggregate.mockResolvedValue({
+      _count: { _all: 2 },
+      _max: { updatedAt: new Date("2026-03-26T00:00:00.000Z") },
+    });
+    prismaMock.todoPlayerSnapshot.findMany.mockResolvedValue([
+      makeSnapshotRow({
+        playerTag: "#PYLQ0289",
+        playerName: "Alpha",
+        cwlAttacksUsed: 1,
+        cwlPhase: "battle day",
+      }),
+      makeSnapshotRow({
+        playerTag: "#QGRJ2222",
+        playerName: "Bravo",
+        cwlAttacksUsed: 1,
+        cwlPhase: "battle day",
+      }),
+    ]);
+
+    const interaction = makeTodoInteraction({ type: "CWL" });
+    await Todo.run({} as any, interaction as any, makeCocServiceSpy() as any);
+
+    expect(getReplyColor(interaction)).toBe(TODO_COMPLETE_EMBED_COLOR);
+    expect(getReplyDescription(interaction)).toContain(
+      "cwl status: 2 / 2 attacks completed",
+    );
+  });
+
+  it("keeps CWL sidebar default during preparation-only states", async () => {
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      { playerTag: "#PYLQ0289", createdAt: new Date("2026-03-01T00:00:00.000Z") },
+    ]);
+    prismaMock.todoPlayerSnapshot.aggregate.mockResolvedValue({
+      _count: { _all: 1 },
+      _max: { updatedAt: new Date("2026-03-26T00:00:00.000Z") },
+    });
+    prismaMock.todoPlayerSnapshot.findMany.mockResolvedValue([
+      makeSnapshotRow({
+        playerTag: "#PYLQ0289",
+        playerName: "Alpha",
+        cwlAttacksUsed: 0,
+        cwlPhase: "preparation",
+      }),
+    ]);
+
+    const interaction = makeTodoInteraction({ type: "CWL" });
+    await Todo.run({} as any, interaction as any, makeCocServiceSpy() as any);
+
+    expect(getReplyColor(interaction)).toBe(TODO_DEFAULT_EMBED_COLOR);
+    expect(getReplyDescription(interaction)).toContain(
+      "cwl status: 0 / 0 attacks completed",
+    );
   });
 
   it("groups CWL rows by cwlClanTag/cwlClanName when different from home clan", async () => {
@@ -1434,6 +1644,10 @@ describe("/todo command", () => {
 
     const interaction = makeTodoInteraction({ type: "WAR" });
     await Todo.run({} as any, interaction as any, makeCocServiceSpy() as any);
+    expect(getReplyColor(interaction)).toBe(TODO_DEFAULT_EMBED_COLOR);
+    expect(getReplyDescription(interaction)).toContain(
+      "war status: 0 / 0 attacks completed",
+    );
     expect(getReplyDescription(interaction)).toContain("No war active");
   });
 
@@ -1455,6 +1669,10 @@ describe("/todo command", () => {
 
     const interaction = makeTodoInteraction({ type: "CWL" });
     await Todo.run({} as any, interaction as any, makeCocServiceSpy() as any);
+    expect(getReplyColor(interaction)).toBe(TODO_DEFAULT_EMBED_COLOR);
+    expect(getReplyDescription(interaction)).toContain(
+      "cwl status: 0 / 0 attacks completed",
+    );
     expect(getReplyDescription(interaction)).toContain("No CWL active");
   });
 


### PR DESCRIPTION
- replace war/cwl header linked-player line with running attack completion status
- color war/cwl todo embeds red or green during active battle states, default otherwise
- add tests for status totals and default/incomplete/complete color transitions