### PR TITLE
dev to main

### DIFF
--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -105,6 +105,7 @@ import {
 } from "../services/PointsDirectFetchGateService";
 import {
   buildFwaMailBackCustomId,
+  buildFwaMailGateResumeCustomId,
   buildFwaBaseSwapSplitPostCustomId,
   createTransientFwaKey,
   buildFwaMailConfirmCustomId,
@@ -124,6 +125,7 @@ import {
   buildOutcomeActionCustomId,
   buildPointsPostButtonCustomId,
   parseFwaMailBackCustomId,
+  parseFwaMailGateResumeCustomId,
   parseFwaBaseSwapSplitPostCustomId,
   parseFwaComplianceViewCustomId,
   parseFwaMailConfirmCustomId,
@@ -200,6 +202,7 @@ export {
   isFwaComplianceViewButtonCustomId,
   isFwaBaseSwapSplitPostButtonCustomId,
   isFwaMailBackButtonCustomId,
+  isFwaMailGateResumeButtonCustomId,
   isFwaMailConfirmButtonCustomId,
   isFwaMailConfirmNoPingButtonCustomId,
   isFwaMailRefreshButtonCustomId,
@@ -1317,6 +1320,13 @@ const MATCHTYPE_WARNING_LEGEND =
 const POINTS_CLAN_NOT_FOUND_STATUS_LINE =
   ":interrobang: Clan not found on points.fwafarm";
 
+/** Purpose: keep mail preview/send entry behavior consistent by routing inferred match-type blocks back to `/fwa match`. */
+function shouldRedirectToFwaMatchForMailGateReason(
+  reason: string | null | undefined,
+): boolean {
+  return reason === INFERRED_MATCHTYPE_MAIL_BLOCK_REASON;
+}
+
 function logFwaMatchTelemetry(event: string, detail: string): void {
   console.log(`[telemetry-fwa-match] event=${event} ${detail}`);
 }
@@ -1502,6 +1512,7 @@ type FwaMatchCopyPayload = {
   currentScope: "alliance" | "single";
   currentTag: string | null;
   revisionDraftByTag: Record<string, MatchRevisionFields>;
+  mailGateResumeTag?: string | null;
 };
 
 type FwaMailPreviewPayload = {
@@ -2157,6 +2168,158 @@ async function rebuildTrackedPayloadForTag(
     revisionDraftByTag: nextRevisionDraftByTag,
     currentScope: "single",
     currentTag: tag,
+  };
+}
+
+function applyMailGateResumeStateToPayload(
+  payload: FwaMatchCopyPayload,
+  tag: string,
+): FwaMatchCopyPayload {
+  const normalizedTag = normalizeTag(tag);
+  return {
+    ...payload,
+    currentScope: "single",
+    currentTag: normalizedTag,
+    mailGateResumeTag: normalizedTag,
+  };
+}
+
+function buildScopedFwaMatchPayload(params: {
+  guildId: string;
+  userId: string;
+  tag: string;
+  includePostButton: boolean;
+  overview: {
+    embed: EmbedBuilder;
+    copyText: string;
+    singleViews: Record<string, MatchView>;
+  };
+  mailGateResumeTag?: string | null;
+}): { payload: FwaMatchCopyPayload; view: MatchView } | null {
+  const normalizedTag = normalizeTag(params.tag);
+  const trackedSingleView = params.overview.singleViews[normalizedTag];
+  if (!trackedSingleView) return null;
+  const payload: FwaMatchCopyPayload = {
+    userId: params.userId,
+    guildId: params.guildId,
+    includePostButton: params.includePostButton,
+    allianceView: {
+      embed: params.overview.embed,
+      copyText: params.overview.copyText,
+      matchTypeAction: null,
+    },
+    allianceViewIsScoped: true,
+    singleViews: params.overview.singleViews,
+    currentScope: "single",
+    currentTag: normalizedTag,
+    revisionDraftByTag: {},
+    mailGateResumeTag: params.mailGateResumeTag
+      ? normalizeTag(params.mailGateResumeTag)
+      : null,
+  };
+  return { payload, view: trackedSingleView };
+}
+
+async function buildScopedFwaMatchPayloadForTag(params: {
+  guildId: string;
+  userId: string;
+  tag: string;
+  includePostButton: boolean;
+  client?: Client | null;
+  mailGateResumeTag?: string | null;
+}): Promise<{ payload: FwaMatchCopyPayload; view: MatchView } | null> {
+  const normalizedTag = normalizeTag(params.tag);
+  const settings = new SettingsService();
+  const sourceSync = await getSourceOfTruthSync(settings, params.guildId);
+  const cocService = new CoCService();
+  const warLookupCache: WarLookupCache = new Map();
+  const overview = await buildTrackedMatchOverview(
+    cocService,
+    sourceSync,
+    params.guildId,
+    warLookupCache,
+    params.client ?? null,
+    { onlyClanTags: [normalizedTag] },
+  );
+  return buildScopedFwaMatchPayload({
+    guildId: params.guildId,
+    userId: params.userId,
+    tag: normalizedTag,
+    includePostButton: params.includePostButton,
+    overview,
+    mailGateResumeTag: params.mailGateResumeTag ?? null,
+  });
+}
+
+async function prepareMailGateResumeMatchPayloadForTag(params: {
+  guildId: string;
+  userId: string;
+  tag: string;
+  sourceMatchPayloadKey?: string;
+  client?: Client | null;
+}): Promise<{ key: string; payload: FwaMatchCopyPayload; view: MatchView } | null> {
+  const normalizedTag = normalizeTag(params.tag);
+  const sourceKey = params.sourceMatchPayloadKey?.trim() ?? "";
+  if (sourceKey) {
+    const existing = fwaMatchCopyPayloads.get(sourceKey);
+    if (existing) {
+      const refreshed = await rebuildTrackedPayloadForTag(
+        existing,
+        params.guildId,
+        normalizedTag,
+        params.client ?? null,
+      ).catch(() => null);
+      const active = refreshed ?? existing;
+      const view = active.singleViews[normalizedTag];
+      if (view) {
+        const nextPayload = applyMailGateResumeStateToPayload(
+          active,
+          normalizedTag,
+        );
+        fwaMatchCopyPayloads.set(sourceKey, nextPayload);
+        return { key: sourceKey, payload: nextPayload, view };
+      }
+    }
+  }
+
+  const scoped = await buildScopedFwaMatchPayloadForTag({
+    guildId: params.guildId,
+    userId: params.userId,
+    tag: normalizedTag,
+    includePostButton: false,
+    client: params.client ?? null,
+    mailGateResumeTag: normalizedTag,
+  });
+  if (!scoped) return null;
+  const key = createTransientFwaKey();
+  fwaMatchCopyPayloads.set(key, scoped.payload);
+  return { key, payload: scoped.payload, view: scoped.view };
+}
+
+function buildFwaMatchViewRenderPayload(params: {
+  payload: FwaMatchCopyPayload;
+  key: string;
+  view: MatchView;
+  showMode: "embed" | "copy";
+}): {
+  content: string | undefined;
+  embeds: EmbedBuilder[];
+  components: Array<
+    ActionRowBuilder<ButtonBuilder> | ActionRowBuilder<StringSelectMenuBuilder>
+  >;
+} {
+  return {
+    content:
+      params.showMode === "copy"
+        ? limitDiscordContent(params.view.copyText)
+        : undefined,
+    embeds: params.showMode === "embed" ? [params.view.embed] : [],
+    components: buildFwaMatchCopyComponents(
+      params.payload,
+      params.payload.userId,
+      params.key,
+      params.showMode,
+    ),
   };
 }
 
@@ -4673,6 +4836,12 @@ function buildFwaMatchCopyComponents(
   const mailAction = view.mailAction ?? null;
   const skipSyncAction = view.skipSyncAction ?? null;
   const undoSkipSyncAction = view.undoSkipSyncAction ?? null;
+  const mailGateResumeActive =
+    payload.currentScope === "single" &&
+    Boolean(payload.currentTag) &&
+    payload.currentTag === payload.mailGateResumeTag &&
+    (Boolean(view.inferredMatchType) ||
+      view.mailAction?.reason === INFERRED_MATCHTYPE_MAIL_BLOCK_REASON);
   const toggleMode = showMode === "embed" ? "copy" : "embed";
   const toggleLabel = showMode === "embed" ? "Copy/Paste View" : "Embed View";
   const baseRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
@@ -4713,8 +4882,42 @@ function buildFwaMatchCopyComponents(
   }
   const rows: Array<
     ActionRowBuilder<ButtonBuilder> | ActionRowBuilder<StringSelectMenuBuilder>
-  > = [baseRow];
-  if (payload.currentScope === "single" && payload.currentTag && mailAction) {
+  > = [];
+  if (mailGateResumeActive && payload.currentTag) {
+    rows.push(
+      new ActionRowBuilder<ButtonBuilder>().addComponents(
+        new ButtonBuilder()
+          .setCustomId(
+            buildFwaMailGateResumeCustomId({
+              userId,
+              key,
+              tag: payload.currentTag,
+              action: "continue",
+            }),
+          )
+          .setLabel("Review match + continue")
+          .setStyle(ButtonStyle.Primary),
+        new ButtonBuilder()
+          .setCustomId(
+            buildFwaMailGateResumeCustomId({
+              userId,
+              key,
+              tag: payload.currentTag,
+              action: "cancel",
+            }),
+          )
+          .setLabel("Cancel")
+          .setStyle(ButtonStyle.Secondary),
+      ),
+    );
+  }
+  rows.push(baseRow);
+  if (
+    payload.currentScope === "single" &&
+    payload.currentTag &&
+    mailAction &&
+    !mailGateResumeActive
+  ) {
     rows.push(
       new ActionRowBuilder<ButtonBuilder>().addComponents(
         new ButtonBuilder()
@@ -6067,6 +6270,52 @@ async function showWarMailPreview(
     fetchReason: "pre_fwa_validation",
     revisionOverride: revisionOverride ?? null,
   });
+  const mailSendGate = rendered.mailRevisionDecision;
+  if (
+    shouldRedirectToFwaMatchForMailGateReason(mailSendGate.mailBlockedReason)
+  ) {
+    const handoff = await prepareMailGateResumeMatchPayloadForTag({
+      guildId,
+      userId,
+      tag,
+      sourceMatchPayloadKey,
+      client: interaction.client,
+    });
+    if (!handoff) {
+      const fallbackMessage = `:warning: ${INFERRED_MATCHTYPE_MAIL_BLOCK_REASON}`;
+      if (interaction.isButton()) {
+        await interaction.update({
+          content: fallbackMessage,
+          embeds: [],
+          components: [],
+        });
+      } else {
+        await interaction.editReply({
+          content: fallbackMessage,
+          embeds: [],
+          components: [],
+        });
+      }
+      return;
+    }
+    const showMode =
+      interaction.isButton() && interaction.message.embeds.length === 0
+        ? "copy"
+        : "embed";
+    const response = buildFwaMatchViewRenderPayload({
+      payload: handoff.payload,
+      key: handoff.key,
+      view: handoff.view,
+      showMode,
+    });
+    if (interaction.isButton()) {
+      await interaction.update(response);
+    } else {
+      await interaction.editReply(response);
+    }
+    return;
+  }
+
   const previewKey = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 8)}`;
   const sourceShowMode =
     interaction.isButton() && interaction.message.embeds.length > 0
@@ -6088,7 +6337,6 @@ async function showWarMailPreview(
     revisionOverride: revisionOverride ?? null,
   });
 
-  const mailSendGate = rendered.mailRevisionDecision;
   const channel = rendered.mailChannelId
     ? await interaction.client.channels
         .fetch(rendered.mailChannelId)
@@ -6222,6 +6470,69 @@ export async function handleFwaMatchSendMailButton(
     cocService,
     parsed.key,
     revisionOverride,
+  );
+}
+
+export async function handleFwaMailGateResumeButton(
+  interaction: ButtonInteraction,
+): Promise<void> {
+  const parsed = parseFwaMailGateResumeCustomId(interaction.customId);
+  if (!parsed) return;
+  if (interaction.user.id !== parsed.userId) {
+    await interaction.reply({
+      ephemeral: true,
+      content: "Only the command requester can use this button.",
+    });
+    return;
+  }
+  const payload = fwaMatchCopyPayloads.get(parsed.key);
+  if (!payload) {
+    await interaction.reply({
+      ephemeral: true,
+      content: "This match view expired. Please run /fwa match again.",
+    });
+    return;
+  }
+  const tag = normalizeTag(parsed.tag);
+  if (parsed.action === "cancel") {
+    fwaMatchCopyPayloads.delete(parsed.key);
+    await interaction.update({
+      content: "Cancelled.",
+      embeds: [],
+      components: [],
+    });
+    return;
+  }
+  const refreshed = await rebuildTrackedPayloadForTag(
+    payload,
+    payload.guildId,
+    tag,
+    interaction.client,
+  ).catch(() => null);
+  const activePayload = refreshed ?? payload;
+  const nextView = activePayload.singleViews[tag];
+  if (!nextView) {
+    await interaction.reply({
+      ephemeral: true,
+      content: "This clan view is no longer available. Please run /fwa match again.",
+    });
+    return;
+  }
+  const nextPayload: FwaMatchCopyPayload = {
+    ...activePayload,
+    currentScope: "single",
+    currentTag: tag,
+    mailGateResumeTag: null,
+  };
+  fwaMatchCopyPayloads.set(parsed.key, nextPayload);
+  const showMode = interaction.message.embeds.length > 0 ? "embed" : "copy";
+  await interaction.update(
+    buildFwaMatchViewRenderPayload({
+      payload: nextPayload,
+      key: parsed.key,
+      view: nextView,
+      showMode,
+    }),
   );
 }
 
@@ -6475,6 +6786,38 @@ async function handleFwaMailConfirmAction(
   }
   const mailSendGate = rendered.mailRevisionDecision;
   if (mailSendGate.mailBlockedReason) {
+    if (
+      shouldRedirectToFwaMatchForMailGateReason(mailSendGate.mailBlockedReason)
+    ) {
+      const handoff = await prepareMailGateResumeMatchPayloadForTag({
+        guildId: payload.guildId,
+        userId: parsed.userId,
+        tag: payload.tag,
+        sourceMatchPayloadKey: payload.sourceMatchPayloadKey,
+        client: interaction.client,
+      });
+      if (!handoff) {
+        await interaction.editReply({
+          content: `Cannot send mail: ${formatMailBlockedReason(mailSendGate.mailBlockedReason) ?? mailSendGate.mailBlockedReason}`,
+          embeds: [],
+          components: [],
+        });
+      } else {
+        const showMode =
+          payload.sourceShowMode ??
+          (interaction.message.embeds.length > 0 ? "embed" : "copy");
+        await interaction.editReply(
+          buildFwaMatchViewRenderPayload({
+            payload: handoff.payload,
+            key: handoff.key,
+            view: handoff.view,
+            showMode,
+          }),
+        );
+      }
+      fwaMailPreviewPayloads.delete(parsed.key);
+      return;
+    }
     await interaction.editReply({
       content: `Cannot send mail: ${
         formatMailBlockedReason(mailSendGate.mailBlockedReason) ??
@@ -7853,6 +8196,8 @@ function applyExplicitOpponentNotFoundFallbackGuard(input: {
 
 export const getMailBlockedReasonFromStatusForTest =
   getMailBlockedReasonFromStatus;
+export const shouldRedirectToFwaMatchForMailGateReasonForTest =
+  shouldRedirectToFwaMatchForMailGateReason;
 export const collectBaseSwapTownhallLevelsForTest =
   collectBaseSwapTownhallLevels;
 export const buildBaseSwapLayoutLinksForTest = buildBaseSwapLayoutLinks;

--- a/src/commands/Todo.ts
+++ b/src/commands/Todo.ts
@@ -446,13 +446,26 @@ export const Todo: Command = {
       required: false,
       choices: TODO_TYPES.map((type) => ({ name: type, value: type })),
     },
+    {
+      name: "visibility",
+      description: "Response visibility",
+      type: ApplicationCommandOptionType.String,
+      required: false,
+      choices: [
+        { name: "private", value: "private" },
+        { name: "public", value: "public" },
+      ],
+    },
   ],
   run: async (
     _client: Client,
     interaction: ChatInputCommandInteraction,
     cocService: CoCService,
   ) => {
-    await interaction.deferReply({ ephemeral: true });
+    const visibility =
+      interaction.options.getString("visibility", false) ?? "private";
+    const isPublic = visibility === "public";
+    await interaction.deferReply({ ephemeral: !isPublic });
 
     const explicitTypeInput = interaction.options.getString("type", false);
     const explicitType = explicitTypeInput

--- a/src/commands/Todo.ts
+++ b/src/commands/Todo.ts
@@ -17,6 +17,7 @@ import {
   invalidateTodoRenderCacheForUser,
   normalizeTodoType,
   TODO_TYPES,
+  type TodoSidebarState,
   type TodoType,
 } from "../services/TodoService";
 import { todoSnapshotService } from "../services/TodoSnapshotService";
@@ -24,7 +25,9 @@ import { todoLastViewedTypeService } from "../services/TodoLastViewedTypeService
 
 const TODO_PAGE_BUTTON_PREFIX = "todo-page";
 const TODO_REFRESH_BUTTON_PREFIX = "todo-refresh";
-const TODO_EMBED_COLOR = 0x5865f2;
+const TODO_EMBED_COLOR_DEFAULT = 0x5865f2;
+const TODO_EMBED_COLOR_INCOMPLETE = 0xed4245;
+const TODO_EMBED_COLOR_COMPLETE = 0x57f287;
 const TODO_GUILD_SCOPE_DM = "dm";
 const TODO_REFRESH_ERROR_MESSAGE =
   "Failed to refresh todo data. Please try again.";
@@ -247,16 +250,24 @@ function buildTodoEmbed(input: {
   selectedType: TodoType;
   linkedPlayerCount: number;
   pageText: string;
+  sidebarState: TodoSidebarState;
 }): EmbedBuilder {
   const pageIndex = TODO_TYPES.indexOf(input.selectedType);
   const safeIndex = pageIndex >= 0 ? pageIndex : 0;
   return new EmbedBuilder()
-    .setColor(TODO_EMBED_COLOR)
+    .setColor(resolveTodoEmbedColor(input.sidebarState))
     .setTitle(`Todo - ${input.selectedType}`)
     .setDescription(input.pageText || "No todo rows available.")
     .setFooter({
       text: `Page ${safeIndex + 1}/${TODO_TYPES.length} - Linked players: ${input.linkedPlayerCount}`,
     });
+}
+
+/** Purpose: map shared todo sidebar state into deterministic embed colors for command render. */
+function resolveTodoEmbedColor(sidebarState: TodoSidebarState): number {
+  if (sidebarState === "incomplete") return TODO_EMBED_COLOR_INCOMPLETE;
+  if (sidebarState === "complete") return TODO_EMBED_COLOR_COMPLETE;
+  return TODO_EMBED_COLOR_DEFAULT;
 }
 
 /** Purpose: build a rendered todo response payload for one selected page type. */
@@ -286,6 +297,7 @@ async function buildTodoRenderResult(input: {
           selectedType: normalizedType,
           linkedPlayerCount: pages.linkedPlayerCount,
           pageText: pages.pages[normalizedType],
+          sidebarState: pages.sidebarStateByType[normalizedType] ?? "default",
         }),
       ],
       components: buildTodoComponentRows(input.scope, normalizedType),

--- a/src/commands/Todo.ts
+++ b/src/commands/Todo.ts
@@ -446,16 +446,6 @@ export const Todo: Command = {
       required: false,
       choices: TODO_TYPES.map((type) => ({ name: type, value: type })),
     },
-    {
-      name: "visibility",
-      description: "Response visibility",
-      type: ApplicationCommandOptionType.String,
-      required: false,
-      choices: [
-        { name: "private", value: "private" },
-        { name: "public", value: "public" },
-      ],
-    },
   ],
   run: async (
     _client: Client,

--- a/src/commands/fwa/customIds.ts
+++ b/src/commands/fwa/customIds.ts
@@ -14,6 +14,7 @@ const FWA_MAIL_CONFIRM_NO_PING_PREFIX = "fwa-mail-confirm-no-ping";
 const FWA_MAIL_BACK_PREFIX = "fwa-mail-back";
 const FWA_MAIL_REFRESH_PREFIX = "fwa-mail-refresh";
 const FWA_MATCH_SEND_MAIL_PREFIX = "fwa-match-send-mail";
+const FWA_MAIL_GATE_RESUME_PREFIX = "fwa-mail-gate-resume";
 const FWA_MATCH_TIEBREAKER_PREFIX = "fwa-match-tiebreaker";
 const FWA_COMPLIANCE_VIEW_PREFIX = "fwa-compliance-view";
 const FWA_BASE_SWAP_SPLIT_POST_PREFIX = "fwa-base-swap-split-post";
@@ -51,6 +52,14 @@ export type FwaMatchTieBreakerParams = {
   userId: string;
   key: string;
   tag: string;
+};
+
+export type FwaMailGateResumeAction = "continue" | "cancel";
+export type FwaMailGateResumeParams = {
+  userId: string;
+  key: string;
+  tag: string;
+  action: FwaMailGateResumeAction;
 };
 
 export type FwaComplianceViewAction = "open_missed" | "open_main" | "prev" | "next";
@@ -381,6 +390,31 @@ export function parseFwaMatchSendMailCustomId(
 /** Purpose: detect send-mail-from-match button prefix. */
 export function isFwaMatchSendMailButtonCustomId(customId: string): boolean {
   return customId.startsWith(`${FWA_MATCH_SEND_MAIL_PREFIX}:`);
+}
+
+/** Purpose: build custom-id for inferred match-type mail gate handoff actions. */
+export function buildFwaMailGateResumeCustomId(
+  params: FwaMailGateResumeParams,
+): string {
+  return `${FWA_MAIL_GATE_RESUME_PREFIX}:${params.userId}:${params.key}:${normalizeTag(params.tag)}:${params.action}`;
+}
+
+/** Purpose: parse inferred match-type mail gate handoff action custom-id payload. */
+export function parseFwaMailGateResumeCustomId(
+  customId: string,
+): FwaMailGateResumeParams | null {
+  const values = parseCustomIdParts(customId, FWA_MAIL_GATE_RESUME_PREFIX, 5);
+  if (!values) return null;
+  const [userId, key, rawTag, rawAction] = values;
+  const action: FwaMailGateResumeAction | null =
+    rawAction === "continue" || rawAction === "cancel" ? rawAction : null;
+  if (!action) return null;
+  return { userId, key, tag: normalizeTag(rawTag), action };
+}
+
+/** Purpose: detect inferred match-type mail gate handoff action button prefix. */
+export function isFwaMailGateResumeButtonCustomId(customId: string): boolean {
+  return customId.startsWith(`${FWA_MAIL_GATE_RESUME_PREFIX}:`);
 }
 
 /** Purpose: build custom-id for single-clan tie-breaker rules button. */

--- a/src/listeners/interactionCreate.ts
+++ b/src/listeners/interactionCreate.ts
@@ -33,6 +33,7 @@ import {
   handleFwaMailConfirmButton,
   handleFwaMailConfirmNoPingButton,
   handleFwaMailBackButton,
+  handleFwaMailGateResumeButton,
   handleFwaMailRefreshButton,
   handleFwaMatchSendMailButton,
   handleFwaMatchTieBreakerButton,
@@ -45,6 +46,7 @@ import {
   isFwaMailConfirmButtonCustomId,
   isFwaMailConfirmNoPingButtonCustomId,
   isFwaMailBackButtonCustomId,
+  isFwaMailGateResumeButtonCustomId,
   isFwaMailRefreshButtonCustomId,
   isFwaMatchSendMailButtonCustomId,
   isFwaMatchTieBreakerButtonCustomId,
@@ -606,6 +608,20 @@ const handleButtonInteraction = async (
         await interaction.reply({
           ephemeral: true,
           content: "Failed to open war mail preview.",
+        });
+      }
+    }
+  }
+
+  if (isFwaMailGateResumeButtonCustomId(interaction.customId)) {
+    try {
+      await handleFwaMailGateResumeButton(interaction);
+    } catch (err) {
+      console.error(`FWA mail gate resume button failed: ${formatError(err)}`);
+      if (!interaction.replied && !interaction.deferred) {
+        await interaction.reply({
+          ephemeral: true,
+          content: "Failed to continue in match view.",
         });
       }
     }

--- a/src/services/TodoService.ts
+++ b/src/services/TodoService.ts
@@ -21,7 +21,10 @@ export type TodoType = (typeof TODO_TYPES)[number];
 export type TodoPagesResult = {
   linkedPlayerCount: number;
   pages: Record<TodoType, string>;
+  sidebarStateByType: Record<TodoType, TodoSidebarState>;
 };
+
+export type TodoSidebarState = "default" | "incomplete" | "complete";
 
 type TodoRenderRow = {
   playerTag: string;
@@ -155,6 +158,12 @@ export async function buildTodoPagesForUser(input: {
         CWL: "",
         RAIDS: "",
         GAMES: "",
+      },
+      sidebarStateByType: {
+        WAR: "default",
+        CWL: "default",
+        RAIDS: "default",
+        GAMES: "default",
       },
     };
   }
@@ -393,13 +402,21 @@ export async function buildTodoPagesForUser(input: {
       .catch(() => undefined);
   }
 
+  const warView = buildWarPageDescription(renderRows, linkedTags.length);
+  const cwlView = buildCwlPageDescription(renderRows, linkedTags.length);
   const pages = {
     linkedPlayerCount: linkedTags.length,
     pages: {
-      WAR: buildWarPageDescription(renderRows, linkedTags.length),
-      CWL: buildCwlPageDescription(renderRows, linkedTags.length),
+      WAR: warView.description,
+      CWL: cwlView.description,
       RAIDS: buildRaidsPageDescription(renderRows, linkedTags.length),
       GAMES: buildGamesPageDescription(renderRows, linkedTags.length, nowMs),
+    },
+    sidebarStateByType: {
+      WAR: warView.sidebarState,
+      CWL: cwlView.sidebarState,
+      RAIDS: "default",
+      GAMES: "default",
     },
   } satisfies TodoPagesResult;
 
@@ -449,16 +466,21 @@ function isSnapshotStale(snapshot: TodoSnapshotRecord, nowMs: number): boolean {
 function buildWarPageDescription(
   rows: TodoRenderRow[],
   linkedPlayerCount: number,
-): string {
+): { description: string; sidebarState: TodoSidebarState } {
   const activeRows = rows.filter(
     (row) => Boolean(row.snapshot?.warActive) && row.inValidatedWarMemberSet,
   );
+  const warCompletion = summarizeWarCompletionStatus(activeRows);
   if (activeRows.length <= 0) {
-    return buildTodoPageDescription({
-      heading: "WAR",
-      linkedPlayerCount,
-      lines: ["No war active"],
-    });
+    return {
+      description: buildTodoPageDescription({
+        heading: "WAR",
+        linkedPlayerCount,
+        statusLine: warCompletion.statusLine,
+        lines: ["No war active"],
+      }),
+      sidebarState: warCompletion.sidebarState,
+    };
   }
 
   const grouped = buildEventGroups(activeRows, "war");
@@ -477,25 +499,34 @@ function buildWarPageDescription(
     lines.pop();
   }
 
-  return buildTodoPageDescription({
-    heading: "WAR",
-    linkedPlayerCount,
-    lines,
-  });
+  return {
+    description: buildTodoPageDescription({
+      heading: "WAR",
+      linkedPlayerCount,
+      statusLine: warCompletion.statusLine,
+      lines,
+    }),
+    sidebarState: warCompletion.sidebarState,
+  };
 }
 
 /** Purpose: build the CWL page from grouped active contexts only. */
 function buildCwlPageDescription(
   rows: TodoRenderRow[],
   linkedPlayerCount: number,
-): string {
+): { description: string; sidebarState: TodoSidebarState } {
   const activeRows = rows.filter((row) => Boolean(row.snapshot?.cwlActive));
+  const cwlCompletion = summarizeCwlCompletionStatus(activeRows);
   if (activeRows.length <= 0) {
-    return buildTodoPageDescription({
-      heading: "CWL",
-      linkedPlayerCount,
-      lines: ["No CWL active"],
-    });
+    return {
+      description: buildTodoPageDescription({
+        heading: "CWL",
+        linkedPlayerCount,
+        statusLine: cwlCompletion.statusLine,
+        lines: ["No CWL active"],
+      }),
+      sidebarState: cwlCompletion.sidebarState,
+    };
   }
 
   const grouped = buildEventGroups(activeRows, "cwl");
@@ -511,11 +542,70 @@ function buildCwlPageDescription(
     lines.pop();
   }
 
-  return buildTodoPageDescription({
-    heading: "CWL",
-    linkedPlayerCount,
-    lines,
-  });
+  return {
+    description: buildTodoPageDescription({
+      heading: "CWL",
+      linkedPlayerCount,
+      statusLine: cwlCompletion.statusLine,
+      lines,
+    }),
+    sidebarState: cwlCompletion.sidebarState,
+  };
+}
+
+/** Purpose: compute WAR completion totals and sidebar state from confirmed participating rows. */
+function summarizeWarCompletionStatus(
+  confirmedRows: TodoRenderRow[],
+): { statusLine: string; sidebarState: TodoSidebarState } {
+  const completedAttacks = confirmedRows.reduce(
+    (sum, row) => sum + getWarRowProgress(row).used,
+    0,
+  );
+  const requiredAttacks = confirmedRows.length * 2;
+  const attackPhaseRows = confirmedRows.filter((row) =>
+    isWarRowAttackPhaseActive(row),
+  );
+  if (attackPhaseRows.length <= 0) {
+    return {
+      statusLine: `war status: ${completedAttacks} / ${requiredAttacks} attacks completed`,
+      sidebarState: "default",
+    };
+  }
+  const attackPhaseCompleted = attackPhaseRows.reduce(
+    (sum, row) => sum + getWarRowProgress(row).used,
+    0,
+  );
+  const attackPhaseRequired = attackPhaseRows.length * 2;
+  return {
+    statusLine: `war status: ${completedAttacks} / ${requiredAttacks} attacks completed`,
+    sidebarState:
+      attackPhaseCompleted >= attackPhaseRequired ? "complete" : "incomplete",
+  };
+}
+
+/** Purpose: compute CWL completion totals and sidebar state from confirmed active battle-day participants. */
+function summarizeCwlCompletionStatus(
+  confirmedRows: TodoRenderRow[],
+): { statusLine: string; sidebarState: TodoSidebarState } {
+  const battleDayRows = confirmedRows.filter((row) =>
+    isCwlRowAttackPhaseActive(row),
+  );
+  const completedAttacks = battleDayRows.reduce(
+    (sum, row) => sum + getCwlRowProgress(row).used,
+    0,
+  );
+  const requiredAttacks = battleDayRows.length;
+  if (battleDayRows.length <= 0) {
+    return {
+      statusLine: `cwl status: ${completedAttacks} / ${requiredAttacks} attacks completed`,
+      sidebarState: "default",
+    };
+  }
+  return {
+    statusLine: `cwl status: ${completedAttacks} / ${requiredAttacks} attacks completed`,
+    sidebarState:
+      completedAttacks >= requiredAttacks ? "complete" : "incomplete",
+  };
 }
 
 /** Purpose: build the RAIDS page with one shared timer header and row-level usage only. */
@@ -770,11 +860,13 @@ function formatWarPlayerIdentity(row: TodoRenderRow): string {
 function buildTodoPageDescription(input: {
   heading: TodoType;
   linkedPlayerCount: number;
+  statusLine?: string | null;
   lines: string[];
 }): string {
+  const statusLine = sanitizeStatusText(input.statusLine ?? "");
   const lines = [
     `Type: ${input.heading}`,
-    `Linked players: ${input.linkedPlayerCount}`,
+    statusLine || `Linked players: ${input.linkedPlayerCount}`,
     "",
     ...input.lines,
   ];
@@ -822,10 +914,34 @@ function getCwlRowStatus(row: TodoRenderRow): string {
     return "CWL attacks: 0/1 - snapshot unavailable";
   }
 
-  const used = clampInt(row.snapshot.cwlAttacksUsed, 0, row.snapshot.cwlAttacksMax || 1);
-  const max = Math.max(1, clampInt(row.snapshot.cwlAttacksMax, 1, 1));
+  const { used, max } = getCwlRowProgress(row);
   const staleSuffix = row.staleSnapshot ? " - stale snapshot" : "";
   return `CWL attacks: ${used}/${max}${staleSuffix}`;
+}
+
+/** Purpose: compute stable CWL used/max progress and completion state for one confirmed participant row. */
+function getCwlRowProgress(row: TodoRenderRow): {
+  used: number;
+  max: number;
+  complete: boolean;
+} {
+  if (!row.snapshot) {
+    return { used: 0, max: 1, complete: false };
+  }
+  const used = clampInt(
+    row.snapshot.cwlAttacksUsed,
+    0,
+    row.snapshot.cwlAttacksMax || 1,
+  );
+  const max = Math.max(1, clampInt(row.snapshot.cwlAttacksMax, 1, 1));
+  return { used, max, complete: used >= max };
+}
+
+/** Purpose: treat only CWL battle-day contexts as attack-active for completion coloring. */
+function isCwlRowAttackPhaseActive(row: TodoRenderRow): boolean {
+  if (!row.snapshot?.cwlActive) return false;
+  const phase = sanitizeStatusText(row.snapshot.cwlPhase).toLowerCase();
+  return phase.includes("battle");
 }
 
 /** Purpose: build RAIDS row status text with usage only and without per-row timer duplication. */

--- a/tests/fwaCustomIds.logic.test.ts
+++ b/tests/fwaCustomIds.logic.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   buildFwaBaseSwapSplitPostCustomId,
   buildFwaComplianceViewCustomId,
+  buildFwaMailGateResumeCustomId,
   buildFwaMatchSendMailCustomId,
   buildFwaMatchTieBreakerCustomId,
   buildMatchTypeActionCustomId,
@@ -9,11 +10,13 @@ import {
   createTransientFwaKey,
   isFwaBaseSwapSplitPostButtonCustomId,
   isFwaComplianceViewButtonCustomId,
+  isFwaMailGateResumeButtonCustomId,
   isFwaMatchSendMailButtonCustomId,
   isFwaMatchTieBreakerButtonCustomId,
   isPointsPostButtonCustomId,
   parseFwaBaseSwapSplitPostCustomId,
   parseFwaComplianceViewCustomId,
+  parseFwaMailGateResumeCustomId,
   parseFwaMatchSendMailCustomId,
   parseFwaMatchTieBreakerCustomId,
   parseMatchTypeActionCustomId,
@@ -49,6 +52,24 @@ describe("fwa custom-id helpers", () => {
       key: "payload",
       tag: "QWERTY",
     });
+  });
+
+  it("round-trips mail-gate resume ids and supports selector checks", () => {
+    const customId = buildFwaMailGateResumeCustomId({
+      userId: "321",
+      key: "payload",
+      tag: "#qwerty",
+      action: "continue",
+    });
+
+    expect(isFwaMailGateResumeButtonCustomId(customId)).toBe(true);
+    expect(parseFwaMailGateResumeCustomId(customId)).toEqual({
+      userId: "321",
+      key: "payload",
+      tag: "QWERTY",
+      action: "continue",
+    });
+    expect(parseFwaMailGateResumeCustomId("fwa-mail-gate-resume:321:key:QWERTY:bad")).toBeNull();
   });
 
   it("round-trips tie-breaker ids and supports selector checks", () => {

--- a/tests/fwaMatchInference.logic.test.ts
+++ b/tests/fwaMatchInference.logic.test.ts
@@ -3,6 +3,7 @@ import {
   applyExplicitOpponentNotFoundFallbackGuardForTest,
   hasSameWarExplicitFwaConfirmationForTest,
   getMailBlockedReasonFromStatusForTest,
+  shouldRedirectToFwaMatchForMailGateReasonForTest,
   inferMatchTypeFromPointsSnapshotsForTest,
   resolveMatchTypeWithFallbackForTest,
   resolveMatchTypeFromStoredSyncRowForTest,
@@ -280,6 +281,20 @@ describe("fwa mail send gating", () => {
     expect(reason).toBe(
       "Match type is inferred. Confirm match type before sending mail."
     );
+  });
+
+  it("redirects inferred mail blocks back to fwa match flow", () => {
+    expect(
+      shouldRedirectToFwaMatchForMailGateReasonForTest(
+        "Match type is inferred. Confirm match type before sending mail.",
+      ),
+    ).toBe(true);
+    expect(
+      shouldRedirectToFwaMatchForMailGateReasonForTest(
+        "Current mail is already up to date. Change match config before sending again.",
+      ),
+    ).toBe(false);
+    expect(shouldRedirectToFwaMatchForMailGateReasonForTest(null)).toBe(false);
   });
 });
 

--- a/tests/todo.command.test.ts
+++ b/tests/todo.command.test.ts
@@ -70,11 +70,19 @@ import { todoLastViewedTypeService } from "../src/services/TodoLastViewedTypeSer
 
 type TodoType = "WAR" | "CWL" | "RAIDS" | "GAMES";
 
-function makeTodoInteraction(input: { type?: TodoType | null; userId?: string }) {
+function makeTodoInteraction(input: {
+  type?: TodoType | null;
+  visibility?: "private" | "public" | null;
+  userId?: string;
+}) {
   return {
     user: { id: input.userId ?? "111111111111111111" },
     options: {
-      getString: vi.fn((name: string) => (name === "type" ? (input.type ?? null) : null)),
+      getString: vi.fn((name: string) => {
+        if (name === "type") return input.type ?? null;
+        if (name === "visibility") return input.visibility ?? null;
+        return null;
+      }),
     },
     deferReply: vi.fn().mockResolvedValue(undefined),
     editReply: vi.fn().mockResolvedValue(undefined),
@@ -253,6 +261,18 @@ describe("/todo command", () => {
     vi.useRealTimers();
   });
 
+  it("registers the standard visibility option", () => {
+    const visibilityOption = (Todo.options ?? []).find(
+      (option: any) => option?.name === "visibility",
+    ) as any;
+    expect(visibilityOption).toBeTruthy();
+    expect(visibilityOption.required).toBe(false);
+    expect(visibilityOption.choices).toEqual([
+      { name: "private", value: "private" },
+      { name: "public", value: "public" },
+    ]);
+  });
+
   it("returns a clear error when the invoking user has no linked tags", async () => {
     prismaMock.playerLink.findMany.mockResolvedValue([]);
     const refreshSpy = vi.spyOn(todoSnapshotService, "refreshSnapshotsForPlayerTags");
@@ -265,6 +285,39 @@ describe("/todo command", () => {
       expect.stringContaining("no_linked_tags"),
     );
     expect(refreshSpy).not.toHaveBeenCalled();
+  });
+
+  it("defers publicly when /todo visibility:public is requested", async () => {
+    prismaMock.playerLink.findMany.mockResolvedValue([]);
+    const interaction = makeTodoInteraction({
+      type: "WAR",
+      visibility: "public",
+    });
+
+    await Todo.run({} as any, interaction as any, makeCocServiceSpy() as any);
+
+    expect(interaction.deferReply).toHaveBeenCalledWith({ ephemeral: false });
+  });
+
+  it("defers ephemerally when /todo visibility:private is requested", async () => {
+    prismaMock.playerLink.findMany.mockResolvedValue([]);
+    const interaction = makeTodoInteraction({
+      type: "WAR",
+      visibility: "private",
+    });
+
+    await Todo.run({} as any, interaction as any, makeCocServiceSpy() as any);
+
+    expect(interaction.deferReply).toHaveBeenCalledWith({ ephemeral: true });
+  });
+
+  it("defaults /todo visibility to private when omitted", async () => {
+    prismaMock.playerLink.findMany.mockResolvedValue([]);
+    const interaction = makeTodoInteraction({ type: "WAR" });
+
+    await Todo.run({} as any, interaction as any, makeCocServiceSpy() as any);
+
+    expect(interaction.deferReply).toHaveBeenCalledWith({ ephemeral: true });
   });
 
   it("rebuilds invoking-user snapshots before initial /todo render", async () => {

--- a/tests/todo.command.test.ts
+++ b/tests/todo.command.test.ts
@@ -261,18 +261,6 @@ describe("/todo command", () => {
     vi.useRealTimers();
   });
 
-  it("registers the standard visibility option", () => {
-    const visibilityOption = (Todo.options ?? []).find(
-      (option: any) => option?.name === "visibility",
-    ) as any;
-    expect(visibilityOption).toBeTruthy();
-    expect(visibilityOption.required).toBe(false);
-    expect(visibilityOption.choices).toEqual([
-      { name: "private", value: "private" },
-      { name: "public", value: "public" },
-    ]);
-  });
-
   it("returns a clear error when the invoking user has no linked tags", async () => {
     prismaMock.playerLink.findMany.mockResolvedValue([]);
     const refreshSpy = vi.spyOn(todoSnapshotService, "refreshSnapshotsForPlayerTags");

--- a/tests/todo.command.test.ts
+++ b/tests/todo.command.test.ts
@@ -69,6 +69,9 @@ import { todoSnapshotService } from "../src/services/TodoSnapshotService";
 import { todoLastViewedTypeService } from "../src/services/TodoLastViewedTypeService";
 
 type TodoType = "WAR" | "CWL" | "RAIDS" | "GAMES";
+const TODO_DEFAULT_EMBED_COLOR = 0x5865f2;
+const TODO_INCOMPLETE_EMBED_COLOR = 0xed4245;
+const TODO_COMPLETE_EMBED_COLOR = 0x57f287;
 
 function makeTodoInteraction(input: {
   type?: TodoType | null;
@@ -194,6 +197,12 @@ function getReplyDescription(interaction: any): string {
 function getReplyTitle(interaction: any): string {
   const payload = interaction.editReply.mock.calls[0]?.[0] as any;
   return String(payload?.embeds?.[0]?.toJSON?.().title ?? "");
+}
+
+function getReplyColor(interaction: any): number | null {
+  const payload = interaction.editReply.mock.calls[0]?.[0] as any;
+  const color = payload?.embeds?.[0]?.toJSON?.().color;
+  return typeof color === "number" ? color : null;
 }
 
 function countOccurrences(haystack: string, needle: string): number {
@@ -671,6 +680,9 @@ describe("/todo command", () => {
 
     const description = getReplyDescription(interaction);
     expect(getReplyTitle(interaction)).toBe("Todo - WAR");
+    expect(getReplyColor(interaction)).toBe(TODO_INCOMPLETE_EMBED_COLOR);
+    expect(description).toContain("war status: 1 / 6 attacks completed");
+    expect(description).not.toContain("Linked players:");
     expect(description).toContain("**:rd: Clan One (#PQL0289) :green_circle: - battle day ends <t:");
     expect(description).toContain("**:ak: Clan Two (#2QG2C08UP) :black_circle: - preparation ends <t:");
     expect(description).toContain("- #8 Alpha - `0 / 2`");
@@ -770,6 +782,142 @@ describe("/todo command", () => {
     const description = getReplyDescription(interaction);
     expect(description).toContain("Alpha - `1 / 2`");
     expect(description).toContain(":white_check_mark: #2 Bravo - `2 / 2`");
+  });
+
+  it("uses green WAR sidebar when all battle-day participant attacks are completed", async () => {
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      { playerTag: "#PYLQ0289", createdAt: new Date("2026-03-01T00:00:00.000Z") },
+      { playerTag: "#QGRJ2222", createdAt: new Date("2026-03-02T00:00:00.000Z") },
+    ]);
+    prismaMock.todoPlayerSnapshot.aggregate.mockResolvedValue({
+      _count: { _all: 2 },
+      _max: { updatedAt: new Date("2026-03-26T00:00:00.000Z") },
+    });
+    prismaMock.todoPlayerSnapshot.findMany.mockResolvedValue([
+      makeSnapshotRow({
+        playerTag: "#PYLQ0289",
+        playerName: "Alpha",
+        clanTag: "#PQL0289",
+        clanName: "Clan One",
+        warAttacksUsed: 2,
+        warPhase: "battle day",
+      }),
+      makeSnapshotRow({
+        playerTag: "#QGRJ2222",
+        playerName: "Bravo",
+        clanTag: "#PQL0289",
+        clanName: "Clan One",
+        warAttacksUsed: 2,
+        warPhase: "battle day",
+      }),
+    ]);
+    prismaMock.trackedClan.findMany.mockResolvedValue([
+      { tag: "#PQL0289", clanBadge: ":rd:" },
+    ]);
+    prismaMock.currentWar.findMany.mockResolvedValue([
+      {
+        clanTag: "#PQL0289",
+        warId: 1001,
+        startTime: new Date("2026-03-25T12:00:00.000Z"),
+        matchType: "FWA",
+        outcome: "WIN",
+        state: "inWar",
+        updatedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.warAttacks.findMany.mockResolvedValue([
+      {
+        clanTag: "#PQL0289",
+        warId: 1001,
+        warStartTime: new Date("2026-03-25T12:00:00.000Z"),
+        playerTag: "#PYLQ0289",
+        playerPosition: 1,
+        attacksUsed: 2,
+        attackOrder: 1,
+        attackNumber: 1,
+        defenderPosition: 10,
+        stars: 3,
+        attackSeenAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+      {
+        clanTag: "#PQL0289",
+        warId: 1001,
+        warStartTime: new Date("2026-03-25T12:00:00.000Z"),
+        playerTag: "#QGRJ2222",
+        playerPosition: 2,
+        attacksUsed: 2,
+        attackOrder: 1,
+        attackNumber: 1,
+        defenderPosition: 8,
+        stars: 3,
+        attackSeenAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+    ]);
+
+    const interaction = makeTodoInteraction({ type: "WAR" });
+    await Todo.run({} as any, interaction as any, makeCocServiceSpy() as any);
+
+    expect(getReplyColor(interaction)).toBe(TODO_COMPLETE_EMBED_COLOR);
+    expect(getReplyDescription(interaction)).toContain(
+      "war status: 4 / 4 attacks completed",
+    );
+  });
+
+  it("keeps WAR sidebar default during preparation-only states", async () => {
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      { playerTag: "#PYLQ0289", createdAt: new Date("2026-03-01T00:00:00.000Z") },
+    ]);
+    prismaMock.todoPlayerSnapshot.aggregate.mockResolvedValue({
+      _count: { _all: 1 },
+      _max: { updatedAt: new Date("2026-03-26T00:00:00.000Z") },
+    });
+    prismaMock.todoPlayerSnapshot.findMany.mockResolvedValue([
+      makeSnapshotRow({
+        playerTag: "#PYLQ0289",
+        playerName: "Alpha",
+        clanTag: "#PQL0289",
+        clanName: "Clan One",
+        warAttacksUsed: 0,
+        warPhase: "preparation",
+      }),
+    ]);
+    prismaMock.trackedClan.findMany.mockResolvedValue([
+      { tag: "#PQL0289", clanBadge: ":rd:" },
+    ]);
+    prismaMock.currentWar.findMany.mockResolvedValue([
+      {
+        clanTag: "#PQL0289",
+        warId: 1001,
+        startTime: new Date("2026-03-25T12:00:00.000Z"),
+        matchType: "FWA",
+        outcome: "WIN",
+        state: "preparation",
+        updatedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.warAttacks.findMany.mockResolvedValue([
+      {
+        clanTag: "#PQL0289",
+        warId: 1001,
+        warStartTime: new Date("2026-03-25T12:00:00.000Z"),
+        playerTag: "#PYLQ0289",
+        playerPosition: 1,
+        attacksUsed: 0,
+        attackOrder: 0,
+        attackNumber: 0,
+        defenderPosition: null,
+        stars: 0,
+        attackSeenAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+    ]);
+
+    const interaction = makeTodoInteraction({ type: "WAR" });
+    await Todo.run({} as any, interaction as any, makeCocServiceSpy() as any);
+
+    expect(getReplyColor(interaction)).toBe(TODO_DEFAULT_EMBED_COLOR);
+    expect(getReplyDescription(interaction)).toContain(
+      "war status: 0 / 2 attacks completed",
+    );
   });
 
   it("moves fully completed WAR clans below unfinished clans while preserving subgroup order", async () => {
@@ -1369,12 +1517,74 @@ describe("/todo command", () => {
 
     const description = getReplyDescription(interaction);
     expect(getReplyTitle(interaction)).toBe("Todo - CWL");
+    expect(getReplyColor(interaction)).toBe(TODO_INCOMPLETE_EMBED_COLOR);
+    expect(description).toContain("cwl status: 1 / 2 attacks completed");
+    expect(description).not.toContain("Linked players:");
     expect(description).toContain("**Clan One (#PQL0289) - battle day ends <t:");
     expect(description).toContain("**Clan Two (#2QG2C08UP) - preparation ends <t:");
     expect(description).toContain("- Alpha #PYLQ0289 - CWL attacks: 1/1");
     expect(description).toContain("- Bravo #QGRJ2222 - CWL attacks: 0/1");
     expect(description).not.toContain("**Not in active CWL**");
     expect(description).not.toContain("Delta #LQ9P8R2");
+  });
+
+  it("uses green CWL sidebar when all active battle-day participants have attacked", async () => {
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      { playerTag: "#PYLQ0289", createdAt: new Date("2026-03-01T00:00:00.000Z") },
+      { playerTag: "#QGRJ2222", createdAt: new Date("2026-03-02T00:00:00.000Z") },
+    ]);
+    prismaMock.todoPlayerSnapshot.aggregate.mockResolvedValue({
+      _count: { _all: 2 },
+      _max: { updatedAt: new Date("2026-03-26T00:00:00.000Z") },
+    });
+    prismaMock.todoPlayerSnapshot.findMany.mockResolvedValue([
+      makeSnapshotRow({
+        playerTag: "#PYLQ0289",
+        playerName: "Alpha",
+        cwlAttacksUsed: 1,
+        cwlPhase: "battle day",
+      }),
+      makeSnapshotRow({
+        playerTag: "#QGRJ2222",
+        playerName: "Bravo",
+        cwlAttacksUsed: 1,
+        cwlPhase: "battle day",
+      }),
+    ]);
+
+    const interaction = makeTodoInteraction({ type: "CWL" });
+    await Todo.run({} as any, interaction as any, makeCocServiceSpy() as any);
+
+    expect(getReplyColor(interaction)).toBe(TODO_COMPLETE_EMBED_COLOR);
+    expect(getReplyDescription(interaction)).toContain(
+      "cwl status: 2 / 2 attacks completed",
+    );
+  });
+
+  it("keeps CWL sidebar default during preparation-only states", async () => {
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      { playerTag: "#PYLQ0289", createdAt: new Date("2026-03-01T00:00:00.000Z") },
+    ]);
+    prismaMock.todoPlayerSnapshot.aggregate.mockResolvedValue({
+      _count: { _all: 1 },
+      _max: { updatedAt: new Date("2026-03-26T00:00:00.000Z") },
+    });
+    prismaMock.todoPlayerSnapshot.findMany.mockResolvedValue([
+      makeSnapshotRow({
+        playerTag: "#PYLQ0289",
+        playerName: "Alpha",
+        cwlAttacksUsed: 0,
+        cwlPhase: "preparation",
+      }),
+    ]);
+
+    const interaction = makeTodoInteraction({ type: "CWL" });
+    await Todo.run({} as any, interaction as any, makeCocServiceSpy() as any);
+
+    expect(getReplyColor(interaction)).toBe(TODO_DEFAULT_EMBED_COLOR);
+    expect(getReplyDescription(interaction)).toContain(
+      "cwl status: 0 / 0 attacks completed",
+    );
   });
 
   it("groups CWL rows by cwlClanTag/cwlClanName when different from home clan", async () => {
@@ -1434,6 +1644,10 @@ describe("/todo command", () => {
 
     const interaction = makeTodoInteraction({ type: "WAR" });
     await Todo.run({} as any, interaction as any, makeCocServiceSpy() as any);
+    expect(getReplyColor(interaction)).toBe(TODO_DEFAULT_EMBED_COLOR);
+    expect(getReplyDescription(interaction)).toContain(
+      "war status: 0 / 0 attacks completed",
+    );
     expect(getReplyDescription(interaction)).toContain("No war active");
   });
 
@@ -1455,6 +1669,10 @@ describe("/todo command", () => {
 
     const interaction = makeTodoInteraction({ type: "CWL" });
     await Todo.run({} as any, interaction as any, makeCocServiceSpy() as any);
+    expect(getReplyColor(interaction)).toBe(TODO_DEFAULT_EMBED_COLOR);
+    expect(getReplyDescription(interaction)).toContain(
+      "cwl status: 0 / 0 attacks completed",
+    );
     expect(getReplyDescription(interaction)).toContain("No CWL active");
   });
 


### PR DESCRIPTION
## Summary

This PR updates the FWA mail/send flow so mail can no longer bypass match-type confirmation, and improves `/todo` with visibility support plus clearer war/CWL completion status and coloring.

## Highlights

### FWA mail flow hardening

* Tightens the mail-send flow so sending mail requires confirmed match type.
* Adds shared FWA mail/match interaction wiring and custom IDs to support safer gated behavior.
* Updates interaction routing for the new FWA button/action flow.
* Expands FWA logic coverage with tests around match inference and custom-id handling.

### `/todo` visibility support

* `/todo` now honors the `visibility` option instead of always forcing private/ephemeral replies.
* Public and private defer behavior is covered by tests.

### `/todo` war and CWL status improvements

* War and CWL views now compute attack-completion progress from confirmed participants only.
* Adds running status text for war/CWL completion totals.
* Updates sidebar state/color behavior to reflect incomplete vs complete states for active war/CWL views.

## Files touched

* `src/commands/Fwa.ts`
* `src/commands/Todo.ts`
* `src/commands/fwa/customIds.ts`
* `src/listeners/interactionCreate.ts`
* `src/services/TodoService.ts`

## Test coverage

* `tests/fwaCustomIds.logic.test.ts`
* `tests/fwaMatchInference.logic.test.ts`
* `tests/todo.command.test.ts`

## Suggested reviewer focus

* Confirm there is now a single shared invariant for “match type must be confirmed before sending mail.”
* Verify `/fwa mail send` and any other mail-entry paths no longer bypass confirmation.
* Verify `/todo visibility:public` is truly public and not duplicating an existing shared visibility option mechanism.
* Verify war/CWL completion totals exclude unknown/non-participants and only turn red/green in active attack-remaining/completed states.

## Risk areas

* FWA interaction/button routing regressions
* Duplicate or drifted visibility option handling in `/todo`
* `/todo` refresh/render behavior after the new visibility and status-state changes

