### PR TITLE
fix(fwa-police): use current-war compliance for live enforcement

### DIFF
--- a/src/services/FwaPoliceService.ts
+++ b/src/services/FwaPoliceService.ts
@@ -13,6 +13,7 @@ import {
   resolveWarPlanComplianceConfig,
 } from "./warPlanComplianceConfig";
 import {
+  type WarComplianceReport,
   type WarComplianceIssue,
   type WarComplianceService,
 } from "./WarComplianceService";
@@ -644,6 +645,38 @@ export class FwaPoliceService {
     return "ok";
   }
 
+  /** Purpose: enforce guardrail that live police checks must evaluate current-war compliance, never historical war-id scope. */
+  private async evaluateLiveCurrentWarCompliance(input: {
+    guildId: string;
+    clanTag: string;
+    warId: number;
+    warCompliance: WarComplianceEvaluator;
+  }): Promise<WarComplianceReport | null> {
+    const evaluation = await input.warCompliance
+      .evaluateComplianceForCommand({
+        guildId: input.guildId,
+        clanTag: input.clanTag,
+        scope: "current",
+        warId: input.warId,
+      })
+      .catch((err) => {
+        console.error(
+          `[fwa-police] compliance_eval_failed guild=${input.guildId} clan=${input.clanTag} warId=${input.warId} path=live_current_war error=${formatError(err)}`,
+        );
+        return null;
+      });
+    if (!evaluation) return null;
+
+    if (evaluation.status !== "ok" || !evaluation.report) {
+      console.warn(
+        `[fwa-police] compliance_eval_non_ok guild=${input.guildId} clan=${input.clanTag} warId=${input.warId} path=live_current_war status=${evaluation.status} source=${evaluation.source ?? "none"} war_resolution_source=${evaluation.warResolutionSource ?? "none"} participants=${evaluation.participantsCount} attacks=${evaluation.attacksCount}`,
+      );
+      return null;
+    }
+
+    return evaluation.report;
+  }
+
   /** Purpose: resolve effective police config and logging behavior for guild-wide or clan-scoped status views. */
   async getStatusReport(input: {
     client: Client;
@@ -1095,24 +1128,16 @@ export class FwaPoliceService {
       return empty;
     }
 
-    const evaluation = await input.warCompliance
-      .evaluateComplianceForCommand({
-        guildId: input.guildId,
-        clanTag: normalizedClanTag,
-        scope: "war_id",
-        warId: normalizedWarId,
-      })
-      .catch((err) => {
-        console.error(
-          `[fwa-police] compliance_eval_failed guild=${input.guildId} clan=${normalizedClanTag} warId=${normalizedWarId} error=${formatError(err)}`,
-        );
-        return null;
-      });
-    if (!evaluation || evaluation.status !== "ok" || !evaluation.report) {
+    const evaluation = await this.evaluateLiveCurrentWarCompliance({
+      guildId: input.guildId,
+      clanTag: normalizedClanTag,
+      warId: normalizedWarId,
+      warCompliance: input.warCompliance,
+    });
+    if (!evaluation) {
       return empty;
     }
-
-    const report = evaluation.report;
+    const report = evaluation;
     const issues = sortViolationsDeterministically(report.notFollowingPlan);
     if (issues.length <= 0) return empty;
 

--- a/tests/fwaPolice.service.test.ts
+++ b/tests/fwaPolice.service.test.ts
@@ -341,6 +341,60 @@ describe("FwaPoliceService", () => {
     }
   });
 
+  it("logs warning when live current-war compliance evaluation returns non-ok status", async () => {
+    prismaMock.trackedClan.findFirst.mockResolvedValue({
+      tag: "#2QG2C08UP",
+      name: "Alpha",
+      loseStyle: "TRIPLE_TOP_30",
+      fwaPoliceDmEnabled: true,
+      fwaPoliceLogEnabled: false,
+      logChannelId: "channel-1",
+      notifyChannelId: null,
+      mailChannelId: null,
+    });
+    const warnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    const evaluateComplianceForCommand = vi.fn().mockResolvedValue({
+      status: "no_active_war",
+      scope: "current",
+      source: "war_attacks",
+      warResolutionSource: "current_war",
+      report: null,
+      participantsCount: 0,
+      attacksCount: 0,
+    });
+
+    const service = new FwaPoliceService();
+    const result = await service.enforceWarViolations({
+      client: {} as any,
+      guildId: "guild-1",
+      clanTag: "#2QG2C08UP",
+      warId: 12345,
+      warCompliance: { evaluateComplianceForCommand } as any,
+    });
+
+    expect(evaluateComplianceForCommand).toHaveBeenCalledWith({
+      guildId: "guild-1",
+      clanTag: "#2QG2C08UP",
+      scope: "current",
+      warId: 12345,
+    });
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "[fwa-police] compliance_eval_non_ok guild=guild-1 clan=#2QG2C08UP warId=12345 path=live_current_war status=no_active_war",
+      ),
+    );
+    expect(result).toEqual({
+      evaluatedViolations: 0,
+      created: 0,
+      deduped: 0,
+      dmSent: 0,
+      logSent: 0,
+    });
+    warnSpy.mockRestore();
+  });
+
   it("uses canonical compliance evaluation and sends DM only when dm toggle is enabled", async () => {
     prismaMock.trackedClan.findFirst.mockResolvedValue({
       tag: "#2QG2C08UP",
@@ -397,7 +451,7 @@ describe("FwaPoliceService", () => {
     expect(evaluateComplianceForCommand).toHaveBeenCalledWith({
       guildId: "guild-1",
       clanTag: "#2QG2C08UP",
-      scope: "war_id",
+      scope: "current",
       warId: 12345,
     });
     expect(dmSend).toHaveBeenCalledTimes(1);


### PR DESCRIPTION
- route live police enforcement through the current-war compliance path instead of historical war_id lookup
- add explicit guardrail helper and warning-level logging for non-ok live evaluation statuses
- update regression tests for current scope enforcement, warning logs, and existing dedupe behavior