### PR TITLE
fix(fwa-police): gate strict-window violations to real breach context

### DIFF
--- a/src/services/FwaPoliceService.ts
+++ b/src/services/FwaPoliceService.ts
@@ -1129,8 +1129,30 @@ export class FwaPoliceService {
     const issues = sortViolationsDeterministically(report.notFollowingPlan);
     if (issues.length <= 0) return empty;
 
+    const context: FwaPoliceApplicabilityContext = {
+      matchType: report.matchType,
+      expectedOutcome: report.expectedOutcome,
+      loseStyle: report.loseStyle,
+    };
+    const classifiedIssues = issues
+      .map((issue) => ({
+        issue,
+        violation: classifyFwaPoliceViolation({ issue, context }),
+      }))
+      .filter(
+        (
+          row,
+        ): row is {
+          issue: (typeof issues)[number];
+          violation: FwaPoliceViolation;
+        } => row.violation !== null,
+      );
+    if (classifiedIssues.length <= 0) return empty;
+
     const links = await listPlayerLinksForClanMembers({
-      memberTagsInOrder: issues.map((issue) => normalizePlayerTag(issue.playerTag)),
+      memberTagsInOrder: classifiedIssues.map((row) =>
+        normalizePlayerTag(row.issue.playerTag),
+      ),
     });
     const discordUserIdByTag = new Map(
       links.map((link) => [normalizePlayerTag(link.playerTag), link.discordUserId]),
@@ -1160,11 +1182,6 @@ export class FwaPoliceService {
       fallbackClanName: tracked.name,
       clanTag: normalizedClanTag,
     });
-    const context: FwaPoliceApplicabilityContext = {
-      matchType: report.matchType,
-      expectedOutcome: report.expectedOutcome,
-      loseStyle: report.loseStyle,
-    };
     const emojis = await resolveFwaPolicePresentationEmojis(input.client);
     const templateByViolation = new Map<FwaPoliceViolation, string>(
       FWA_POLICE_VIOLATIONS.map((violation) => [
@@ -1172,7 +1189,9 @@ export class FwaPoliceService {
         resolveStandardTemplateForViolation(violation),
       ]),
     );
-    for (const issue of issues) {
+    for (const classified of classifiedIssues) {
+      const issue = classified.issue;
+      const violation = classified.violation;
       const playerTag = normalizePlayerTag(issue.playerTag);
       if (!playerTag) continue;
 
@@ -1200,7 +1219,6 @@ export class FwaPoliceService {
       }
       created += 1;
 
-      const violation = classifyFwaPoliceViolation({ issue, context });
       const violationPresentation = await this.resolveViolationPresentationContext({
         clanTag: normalizedClanTag,
         warId: effectiveWarId,
@@ -1285,7 +1303,7 @@ export class FwaPoliceService {
     }
 
     return {
-      evaluatedViolations: issues.length,
+      evaluatedViolations: classifiedIssues.length,
       created,
       deduped,
       dmSent,

--- a/src/services/FwaPoliceTemplateCatalog.ts
+++ b/src/services/FwaPoliceTemplateCatalog.ts
@@ -140,13 +140,31 @@ function isMirrorAttack(
   );
 }
 
+function hasStrictWindowBreachContext(issue: WarComplianceIssue): boolean {
+  const breach = issue.breachContext;
+  if (!breach) return false;
+  const starsAtBreach = Number(breach.starsAtBreach);
+  const timeRemaining = normalizeFwaPoliceText(breach.timeRemaining ?? "");
+  return Number.isFinite(starsAtBreach) && starsAtBreach >= 0 && timeRemaining.length > 0;
+}
+
 /** Purpose: map one canonical compliance issue to the single supported police violation enum used by template resolution. */
 export function classifyFwaPoliceViolation(input: {
   issue: WarComplianceIssue;
   context: FwaPoliceApplicabilityContext;
-}): FwaPoliceViolation {
+}): FwaPoliceViolation | null {
   const fromLabel = classifyUsingReasonLabel(input.issue.reasonLabel ?? "");
-  if (fromLabel) return fromLabel;
+  const hasStrictWindowContext = hasStrictWindowBreachContext(input.issue);
+  if (fromLabel) {
+    if (
+      (fromLabel === "STRICT_WINDOW_MIRROR_MISS_WIN" ||
+        fromLabel === "STRICT_WINDOW_MIRROR_MISS_LOSS") &&
+      !hasStrictWindowContext
+    ) {
+      return null;
+    }
+    return fromLabel;
+  }
 
   const details =
     input.issue.attackDetails?.filter((row) => row?.isBreach) ??
@@ -167,7 +185,7 @@ export function classifyFwaPoliceViolation(input: {
   if (input.context.matchType === "FWA" && input.context.expectedOutcome === "WIN") {
     if (hasNonMirrorTriple) return "EARLY_NON_MIRROR_TRIPLE";
     if (hasNonMirrorTwoStar) return "EARLY_NON_MIRROR_2STAR";
-    return "STRICT_WINDOW_MIRROR_MISS_WIN";
+    return hasStrictWindowContext ? "STRICT_WINDOW_MIRROR_MISS_WIN" : null;
   }
 
   if (
@@ -184,8 +202,8 @@ export function classifyFwaPoliceViolation(input: {
     input.context.loseStyle === "TRADITIONAL"
   ) {
     if (hasAnyThreeStar) return "ANY_3STAR";
-    return "STRICT_WINDOW_MIRROR_MISS_LOSS";
+    return hasStrictWindowContext ? "STRICT_WINDOW_MIRROR_MISS_LOSS" : null;
   }
 
-  return "STRICT_WINDOW_MIRROR_MISS_WIN";
+  return null;
 }

--- a/tests/fwaPolice.service.test.ts
+++ b/tests/fwaPolice.service.test.ts
@@ -561,6 +561,360 @@ describe("FwaPoliceService", () => {
     expect(result.dmSent).toBe(0);
   });
 
+  it("skips generic FWA-WIN non-strict-window issues without emitting police messages", async () => {
+    prismaMock.trackedClan.findFirst.mockResolvedValue({
+      tag: "#2QG2C08UP",
+      name: "Alpha",
+      loseStyle: "TRIPLE_TOP_30",
+      fwaPoliceDmEnabled: false,
+      fwaPoliceLogEnabled: true,
+      logChannelId: "channel-1",
+      notifyChannelId: null,
+      mailChannelId: null,
+    });
+
+    const logSend = vi.fn().mockResolvedValue({});
+    const client = {
+      users: {
+        fetch: vi.fn(),
+      },
+      channels: {
+        fetch: vi.fn().mockResolvedValue({
+          isTextBased: () => true,
+          send: logSend,
+        }),
+      },
+    } as any;
+    const evaluateComplianceForCommand = vi.fn().mockResolvedValue({
+      status: "ok",
+      report: {
+        warId: 12345,
+        clanName: "Alpha",
+        opponentName: "Bravo",
+        matchType: "FWA",
+        expectedOutcome: "WIN",
+        loseStyle: "TRIPLE_TOP_30",
+        notFollowingPlan: [
+          buildIssue({
+            reasonLabel: "generic plan mismatch",
+            actualBehavior: "#1 (2-star) : late mirror",
+            attackDetails: [
+              {
+                defenderPosition: 1,
+                stars: 2,
+                attackOrder: 15,
+                isBreach: true,
+              },
+            ],
+            breachContext: null,
+          }),
+        ],
+      },
+    });
+
+    const service = new FwaPoliceService();
+    const result = await service.enforceWarViolations({
+      client,
+      guildId: "guild-1",
+      clanTag: "#2QG2C08UP",
+      warId: 12345,
+      warCompliance: { evaluateComplianceForCommand } as any,
+    });
+
+    expect(result).toEqual({
+      evaluatedViolations: 0,
+      created: 0,
+      deduped: 0,
+      dmSent: 0,
+      logSent: 0,
+    });
+    expect(prismaMock.fwaPoliceHandledViolation.create).not.toHaveBeenCalled();
+    expect(logSend).not.toHaveBeenCalled();
+  });
+
+  it("emits STRICT_WINDOW_MIRROR_MISS_WIN only when strict-window breach context exists", async () => {
+    prismaMock.trackedClan.findFirst.mockResolvedValue({
+      tag: "#2QG2C08UP",
+      name: "Alpha",
+      loseStyle: "TRIPLE_TOP_30",
+      fwaPoliceDmEnabled: false,
+      fwaPoliceLogEnabled: true,
+      logChannelId: "channel-1",
+      notifyChannelId: null,
+      mailChannelId: null,
+    });
+
+    const logSend = vi.fn().mockResolvedValue({});
+    const client = {
+      users: {
+        fetch: vi.fn(),
+      },
+      channels: {
+        fetch: vi.fn().mockResolvedValue({
+          isTextBased: () => true,
+          send: logSend,
+        }),
+      },
+    } as any;
+    const evaluateComplianceForCommand = vi.fn().mockResolvedValue({
+      status: "ok",
+      report: {
+        warId: 12345,
+        clanName: "Alpha",
+        opponentName: "Bravo",
+        matchType: "FWA",
+        expectedOutcome: "WIN",
+        loseStyle: "TRIPLE_TOP_30",
+        notFollowingPlan: [
+          buildIssue({
+            reasonLabel: "didn't triple mirror in strict window",
+            actualBehavior: "#1 (2-star) : missed mirror",
+            attackDetails: [
+              {
+                defenderPosition: 1,
+                stars: 2,
+                attackOrder: 4,
+                isBreach: true,
+              },
+            ],
+            breachContext: {
+              starsAtBreach: 12,
+              timeRemaining: "6h 0m left",
+            },
+          }),
+        ],
+      },
+    });
+
+    const service = new FwaPoliceService();
+    const result = await service.enforceWarViolations({
+      client,
+      guildId: "guild-1",
+      clanTag: "#2QG2C08UP",
+      warId: 12345,
+      warCompliance: { evaluateComplianceForCommand } as any,
+    });
+
+    expect(logSend).toHaveBeenCalledTimes(1);
+    const sentPayload = logSend.mock.calls[0]?.[0];
+    expect(String(sentPayload?.content ?? "")).toContain(
+      "missed a required mirror triple during the strict window",
+    );
+    expect(result).toEqual({
+      evaluatedViolations: 1,
+      created: 1,
+      deduped: 0,
+      dmSent: 0,
+      logSent: 1,
+    });
+  });
+
+  it("still emits EARLY_NON_MIRROR_2STAR in FWA-WIN", async () => {
+    prismaMock.trackedClan.findFirst.mockResolvedValue({
+      tag: "#2QG2C08UP",
+      name: "Alpha",
+      loseStyle: "TRIPLE_TOP_30",
+      fwaPoliceDmEnabled: false,
+      fwaPoliceLogEnabled: true,
+      logChannelId: "channel-1",
+      notifyChannelId: null,
+      mailChannelId: null,
+    });
+
+    const logSend = vi.fn().mockResolvedValue({});
+    const client = {
+      users: {
+        fetch: vi.fn(),
+      },
+      channels: {
+        fetch: vi.fn().mockResolvedValue({
+          isTextBased: () => true,
+          send: logSend,
+        }),
+      },
+    } as any;
+    const evaluateComplianceForCommand = vi.fn().mockResolvedValue({
+      status: "ok",
+      report: {
+        warId: 12345,
+        clanName: "Alpha",
+        opponentName: "Bravo",
+        matchType: "FWA",
+        expectedOutcome: "WIN",
+        loseStyle: "TRIPLE_TOP_30",
+        notFollowingPlan: [
+          buildIssue({
+            reasonLabel: null,
+            actualBehavior: "#14 (2-star) : non-mirror",
+            attackDetails: [
+              {
+                defenderPosition: 14,
+                stars: 2,
+                attackOrder: 2,
+                isBreach: true,
+              },
+            ],
+          }),
+        ],
+      },
+    });
+
+    const service = new FwaPoliceService();
+    const result = await service.enforceWarViolations({
+      client,
+      guildId: "guild-1",
+      clanTag: "#2QG2C08UP",
+      warId: 12345,
+      warCompliance: { evaluateComplianceForCommand } as any,
+    });
+
+    expect(logSend).toHaveBeenCalledTimes(1);
+    const sentPayload = logSend.mock.calls[0]?.[0];
+    expect(String(sentPayload?.content ?? "")).toContain(
+      "took an early non-mirror 2-star before the FFA window",
+    );
+    expect(result.logSent).toBe(1);
+  });
+
+  it("keeps FWA-LOSS traditional ANY_3STAR enforceable even without strict-window breach context", async () => {
+    prismaMock.trackedClan.findFirst.mockResolvedValue({
+      tag: "#2QG2C08UP",
+      name: "Alpha",
+      loseStyle: "TRADITIONAL",
+      fwaPoliceDmEnabled: false,
+      fwaPoliceLogEnabled: true,
+      logChannelId: "channel-1",
+      notifyChannelId: null,
+      mailChannelId: null,
+    });
+
+    const logSend = vi.fn().mockResolvedValue({});
+    const client = {
+      users: {
+        fetch: vi.fn(),
+      },
+      channels: {
+        fetch: vi.fn().mockResolvedValue({
+          isTextBased: () => true,
+          send: logSend,
+        }),
+      },
+    } as any;
+    const evaluateComplianceForCommand = vi.fn().mockResolvedValue({
+      status: "ok",
+      report: {
+        warId: 12345,
+        clanName: "Alpha",
+        opponentName: "Bravo",
+        matchType: "FWA",
+        expectedOutcome: "LOSE",
+        loseStyle: "TRADITIONAL",
+        notFollowingPlan: [
+          buildIssue({
+            reasonLabel: null,
+            actualBehavior: "#1 (3-star) : mirrored triple",
+            attackDetails: [
+              {
+                defenderPosition: 1,
+                stars: 3,
+                attackOrder: 18,
+                isBreach: true,
+              },
+            ],
+            breachContext: null,
+          }),
+        ],
+      },
+    });
+
+    const service = new FwaPoliceService();
+    const result = await service.enforceWarViolations({
+      client,
+      guildId: "guild-1",
+      clanTag: "#2QG2C08UP",
+      warId: 12345,
+      warCompliance: { evaluateComplianceForCommand } as any,
+    });
+
+    expect(logSend).toHaveBeenCalledTimes(1);
+    const sentPayload = logSend.mock.calls[0]?.[0];
+    expect(String(sentPayload?.content ?? "")).toContain(
+      "recorded a 3-star in a traditional FWA-loss plan",
+    );
+    expect(result.logSent).toBe(1);
+  });
+
+  it("skips FWA-LOSS traditional non-triple generic non-strict-window issues", async () => {
+    prismaMock.trackedClan.findFirst.mockResolvedValue({
+      tag: "#2QG2C08UP",
+      name: "Alpha",
+      loseStyle: "TRADITIONAL",
+      fwaPoliceDmEnabled: false,
+      fwaPoliceLogEnabled: true,
+      logChannelId: "channel-1",
+      notifyChannelId: null,
+      mailChannelId: null,
+    });
+
+    const logSend = vi.fn().mockResolvedValue({});
+    const client = {
+      users: {
+        fetch: vi.fn(),
+      },
+      channels: {
+        fetch: vi.fn().mockResolvedValue({
+          isTextBased: () => true,
+          send: logSend,
+        }),
+      },
+    } as any;
+    const evaluateComplianceForCommand = vi.fn().mockResolvedValue({
+      status: "ok",
+      report: {
+        warId: 12345,
+        clanName: "Alpha",
+        opponentName: "Bravo",
+        matchType: "FWA",
+        expectedOutcome: "LOSE",
+        loseStyle: "TRADITIONAL",
+        notFollowingPlan: [
+          buildIssue({
+            reasonLabel: "generic loss mismatch",
+            actualBehavior: "#1 (2-star) : late mirror",
+            attackDetails: [
+              {
+                defenderPosition: 1,
+                stars: 2,
+                attackOrder: 18,
+                isBreach: true,
+              },
+            ],
+            breachContext: null,
+          }),
+        ],
+      },
+    });
+
+    const service = new FwaPoliceService();
+    const result = await service.enforceWarViolations({
+      client,
+      guildId: "guild-1",
+      clanTag: "#2QG2C08UP",
+      warId: 12345,
+      warCompliance: { evaluateComplianceForCommand } as any,
+    });
+
+    expect(result).toEqual({
+      evaluatedViolations: 0,
+      created: 0,
+      deduped: 0,
+      dmSent: 0,
+      logSent: 0,
+    });
+    expect(prismaMock.fwaPoliceHandledViolation.create).not.toHaveBeenCalled();
+    expect(logSend).not.toHaveBeenCalled();
+  });
+
   it("renders unknown stars-before-hit when breach chronology is unavailable", async () => {
     prismaMock.trackedClan.findFirst.mockResolvedValue({
       tag: "#2QG2C08UP",

--- a/tests/fwaPoliceTemplateCatalog.test.ts
+++ b/tests/fwaPoliceTemplateCatalog.test.ts
@@ -53,4 +53,123 @@ describe("FwaPoliceTemplateCatalog", () => {
     });
     expect(violation).toBe("EARLY_NON_MIRROR_2STAR");
   });
+
+  it("does not classify generic FWA-WIN non-strict-window issues as strict-window violations", () => {
+    const violation = classifyFwaPoliceViolation({
+      issue: {
+        playerTag: "#P2YLC8R0",
+        playerName: "Player One",
+        playerPosition: 1,
+        ruleType: "not_following_plan",
+        expectedBehavior: "Mirror triple in strict window.",
+        actualBehavior: "#14 (1-star) : generic miss",
+        reasonLabel: "generic plan mismatch",
+        attackDetails: [
+          {
+            defenderPosition: 14,
+            stars: 1,
+            attackOrder: 8,
+            isBreach: true,
+          },
+        ],
+        breachContext: null,
+      },
+      context: {
+        matchType: "FWA",
+        expectedOutcome: "WIN",
+        loseStyle: "TRIPLE_TOP_30",
+      },
+    });
+    expect(violation).toBeNull();
+  });
+
+  it("classifies strict-window mirror miss in FWA-WIN only when strict-window context exists", () => {
+    const violation = classifyFwaPoliceViolation({
+      issue: {
+        playerTag: "#P2YLC8R0",
+        playerName: "Player One",
+        playerPosition: 1,
+        ruleType: "not_following_plan",
+        expectedBehavior: "Mirror triple in strict window.",
+        actualBehavior: "#1 (2-star) : missed mirror",
+        reasonLabel: "didn't triple mirror in strict window",
+        attackDetails: [
+          {
+            defenderPosition: 1,
+            stars: 2,
+            attackOrder: 3,
+            isBreach: true,
+          },
+        ],
+        breachContext: {
+          starsAtBreach: 10,
+          timeRemaining: "6h 30m left",
+        },
+      },
+      context: {
+        matchType: "FWA",
+        expectedOutcome: "WIN",
+        loseStyle: "TRIPLE_TOP_30",
+      },
+    });
+    expect(violation).toBe("STRICT_WINDOW_MIRROR_MISS_WIN");
+  });
+
+  it("keeps FWA-LOSS traditional any-3star as a valid police violation even without strict-window context", () => {
+    const violation = classifyFwaPoliceViolation({
+      issue: {
+        playerTag: "#P2YLC8R0",
+        playerName: "Player One",
+        playerPosition: 1,
+        ruleType: "not_following_plan",
+        expectedBehavior: "No triples in traditional loss flow.",
+        actualBehavior: "#1 (3-star) : tripled mirror",
+        reasonLabel: null,
+        attackDetails: [
+          {
+            defenderPosition: 1,
+            stars: 3,
+            attackOrder: 15,
+            isBreach: true,
+          },
+        ],
+        breachContext: null,
+      },
+      context: {
+        matchType: "FWA",
+        expectedOutcome: "LOSE",
+        loseStyle: "TRADITIONAL",
+      },
+    });
+    expect(violation).toBe("ANY_3STAR");
+  });
+
+  it("does not classify generic FWA-LOSS traditional non-triple issues without strict-window context", () => {
+    const violation = classifyFwaPoliceViolation({
+      issue: {
+        playerTag: "#P2YLC8R0",
+        playerName: "Player One",
+        playerPosition: 1,
+        ruleType: "not_following_plan",
+        expectedBehavior: "Mirror in strict window.",
+        actualBehavior: "#1 (2-star) : late mirror",
+        reasonLabel: "generic plan mismatch",
+        attackDetails: [
+          {
+            defenderPosition: 1,
+            stars: 2,
+            attackOrder: 15,
+            isBreach: true,
+          },
+        ],
+        breachContext: null,
+      },
+      context: {
+        matchType: "FWA",
+        expectedOutcome: "LOSE",
+        loseStyle: "TRADITIONAL",
+      },
+    });
+    expect(violation).toBeNull();
+  });
 });


### PR DESCRIPTION
- return no applicable violation for generic non-strict-window notFollowingPlan issues
- classify and filter police violations before dedupe/send, preserving delivery and dedupe behavior for real violations