### PR TITLE
feat(coc): add throttling resilience for pollers and todo

### DIFF
--- a/src/commands/Todo.ts
+++ b/src/commands/Todo.ts
@@ -1,4 +1,4 @@
-import {
+﻿import {
   ActionRowBuilder,
   ApplicationCommandOptionType,
   ButtonBuilder,
@@ -12,6 +12,7 @@ import { Command } from "../Command";
 import { formatError } from "../helper/formatError";
 import { listPlayerLinksForDiscordUser } from "../services/PlayerLinkService";
 import { CoCService } from "../services/CoCService";
+import { cocRequestQueueService } from "../services/CoCRequestQueueService";
 import {
   buildTodoPagesForUser,
   invalidateTodoRenderCacheForUser,
@@ -32,6 +33,7 @@ const TODO_GUILD_SCOPE_DM = "dm";
 const TODO_REFRESH_ERROR_MESSAGE =
   "Failed to refresh todo data. Please try again.";
 const TODO_REFRESH_BUTTON_EMOJI = "🔄";
+const TODO_INITIAL_REFRESH_TIMEOUT_MS = 3000;
 const todoRefreshInFlightByMessageId = new Set<string>();
 
 type TodoButtonScope = {
@@ -56,6 +58,17 @@ type TodoRenderResult =
       };
     }
   | { ok: false; message: string };
+type TodoInitialRefreshOutcome =
+  | { status: "refreshed"; durationMs: number }
+  | {
+      status: "skipped_degraded";
+      spacingMs: number;
+      penaltyMs: number;
+      queueDepth: number;
+      inFlight: number;
+    }
+  | { status: "timeout"; timeoutMs: number }
+  | { status: "failed"; error: unknown };
 
 /** Purpose: persist one remembered `/todo` page type without blocking command UX on storage errors. */
 async function rememberLastViewedTodoType(input: {
@@ -104,6 +117,70 @@ async function refreshTodoSnapshotsForDiscordUser(input: {
     });
   }
   invalidateTodoRenderCacheForUser(input.discordUserId);
+}
+
+/** Purpose: resolve one bounded `/todo` startup refresh timeout to avoid slow startup under upstream pressure. */
+function resolveTodoInitialRefreshTimeoutMs(): number {
+  const configured = Number(
+    process.env.TODO_INITIAL_REFRESH_TIMEOUT_MS ?? TODO_INITIAL_REFRESH_TIMEOUT_MS,
+  );
+  if (!Number.isFinite(configured) || configured <= 0) {
+    return TODO_INITIAL_REFRESH_TIMEOUT_MS;
+  }
+  return Math.max(250, Math.trunc(configured));
+}
+
+/** Purpose: prefer snapshot-first render and only attempt live refresh with bounded wait when queue pressure is healthy. */
+async function tryBoundedInitialTodoRefresh(input: {
+  discordUserId: string;
+  cocService: CoCService;
+}): Promise<TodoInitialRefreshOutcome> {
+  const queueStatus = cocRequestQueueService.getStatus();
+  if (queueStatus.degraded) {
+    return {
+      status: "skipped_degraded",
+      spacingMs: queueStatus.spacingMs,
+      penaltyMs: queueStatus.penaltyMs,
+      queueDepth: queueStatus.queueDepth,
+      inFlight: queueStatus.inFlight,
+    };
+  }
+
+  const timeoutMs = resolveTodoInitialRefreshTimeoutMs();
+  const startedAtMs = Date.now();
+  let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+
+  const refreshPromise = refreshTodoSnapshotsForDiscordUser({
+    discordUserId: input.discordUserId,
+    cocService: input.cocService,
+  })
+    .then(
+      (): TodoInitialRefreshOutcome => ({
+        status: "refreshed",
+        durationMs: Date.now() - startedAtMs,
+      }),
+    )
+    .catch(
+      (error): TodoInitialRefreshOutcome => ({
+        status: "failed",
+        error,
+      }),
+    );
+
+  const timeoutPromise = new Promise<TodoInitialRefreshOutcome>((resolve) => {
+    timeoutHandle = setTimeout(() => {
+      resolve({
+        status: "timeout",
+        timeoutMs,
+      });
+    }, timeoutMs);
+  });
+
+  const outcome = await Promise.race([refreshPromise, timeoutPromise]);
+  if (timeoutHandle) {
+    clearTimeout(timeoutHandle);
+  }
+  return outcome;
 }
 
 /** Purpose: build one stable guild scope token from guild-id or DM context. */
@@ -484,20 +561,7 @@ export const Todo: Command = {
       : await resolveRememberedTodoType(interaction.user.id);
     const selectedType = explicitType ?? rememberedType ?? normalizeTodoType(null);
 
-    try {
-      await refreshTodoSnapshotsForDiscordUser({
-        discordUserId: interaction.user.id,
-        cocService,
-      });
-    } catch (err) {
-      console.error(
-        `[todo-initial-refresh] user=${interaction.user.id} error=${formatError(err)}`,
-      );
-      await interaction.editReply(TODO_REFRESH_ERROR_MESSAGE);
-      return;
-    }
-
-    const result = await buildTodoRenderResult({
+    let result = await buildTodoRenderResult({
       cocService,
       selectedType,
       scope: {
@@ -506,6 +570,38 @@ export const Todo: Command = {
         targetUserId: interaction.user.id,
       },
     });
+
+    if (result.ok) {
+      const initialRefresh = await tryBoundedInitialTodoRefresh({
+        discordUserId: interaction.user.id,
+        cocService,
+      });
+
+      if (initialRefresh.status === "refreshed") {
+        result = await buildTodoRenderResult({
+          cocService,
+          selectedType,
+          scope: {
+            guildScopeId: resolveTodoGuildScopeId(interaction.guildId),
+            requesterUserId: interaction.user.id,
+            targetUserId: interaction.user.id,
+          },
+        });
+      } else if (initialRefresh.status === "skipped_degraded") {
+        console.warn(
+          `[todo] event=snapshot_served reason=coc_degraded user=${interaction.user.id} spacing_ms=${initialRefresh.spacingMs} penalty_ms=${initialRefresh.penaltyMs} queue_depth=${initialRefresh.queueDepth} in_flight=${initialRefresh.inFlight}`,
+        );
+      } else if (initialRefresh.status === "timeout") {
+        console.warn(
+          `[todo] event=snapshot_served reason=bounded_refresh_timeout user=${interaction.user.id} timeout_ms=${initialRefresh.timeoutMs}`,
+        );
+      } else if (initialRefresh.status === "failed") {
+        console.warn(
+          `[todo] event=snapshot_served reason=bounded_refresh_failed user=${interaction.user.id} error=${formatError(initialRefresh.error)}`,
+        );
+      }
+    }
+
     if (!result.ok) {
       await interaction.editReply(result.message);
       return;
@@ -514,3 +610,6 @@ export const Todo: Command = {
     await interaction.editReply(result.payload);
   },
 };
+
+
+

--- a/src/listeners/ready.ts
+++ b/src/listeners/ready.ts
@@ -38,6 +38,8 @@ import { FwaFeedSchedulerService } from "../services/fwa-feeds/FwaFeedSchedulerS
 import { todoSnapshotService } from "../services/TodoSnapshotService";
 import { ReminderSchedulerService } from "../services/reminders/ReminderSchedulerService";
 import { UserActivityReminderSchedulerService } from "../services/remindme/UserActivityReminderSchedulerService";
+import { cocRequestQueueService } from "../services/CoCRequestQueueService";
+import { PollCycleGuardService } from "../services/PollCycleGuardService";
 
 const DEFAULT_OBSERVE_INTERVAL_MINUTES = 30;
 const RECRUITMENT_REMINDER_INTERVAL_MS = 60 * 60 * 1000;
@@ -339,47 +341,37 @@ export default (client: Client, cocService: CoCService): void => {
     const activityService = new ActivityService(cocService);
     const warEventLogService = new WarEventLogService(client, cocService);
     const settings = new SettingsService();
-    let observeInProgress = false;
+    const pollCycleGuard = new PollCycleGuardService();
 
     const observeTrackedClans = async (): Promise<string[]> => {
-      if (observeInProgress) {
-        console.warn("Skipping observe loop because previous run is still in progress.");
+      const dbTracked = await prisma.trackedClan.findMany({
+        orderBy: { createdAt: "asc" },
+      });
+
+      const trackedTags = dbTracked.map((c) => c.tag);
+
+      if (trackedTags.length === 0) {
+        console.warn(
+          "No tracked clans configured. Use /tracked-clan configure."
+        );
         return [];
       }
 
-      observeInProgress = true;
-      try {
-        const dbTracked = await prisma.trackedClan.findMany({
-          orderBy: { createdAt: "asc" },
-        });
-
-        const trackedTags = dbTracked.map((c) => c.tag);
-
-        if (trackedTags.length === 0) {
-          console.warn(
-            "No tracked clans configured. Use /tracked-clan configure."
-          );
-          return [];
-        }
-
-        const observedMemberTags = new Set<string>();
-        for (const tag of trackedTags) {
-          try {
-            const memberTags = await activityService.observeClan(guildId, tag);
-            for (const memberTag of memberTags) {
-              observedMemberTags.add(memberTag);
-            }
-          } catch (err) {
-            console.error(
-              `observeClan failed for ${tag}: ${formatError(err)}`
-            );
+      const observedMemberTags = new Set<string>();
+      for (const tag of trackedTags) {
+        try {
+          const memberTags = await activityService.observeClan(guildId, tag);
+          for (const memberTag of memberTags) {
+            observedMemberTags.add(memberTag);
           }
+        } catch (err) {
+          console.error(
+            `observeClan failed for ${tag}: ${formatError(err)}`
+          );
         }
-
-        return [...observedMemberTags];
-      } finally {
-        observeInProgress = false;
       }
+
+      return [...observedMemberTags];
     };
 
     const markObserveRun = async () => {
@@ -402,28 +394,36 @@ export default (client: Client, cocService: CoCService): void => {
     };
 
     const runObservedCycle = async () => {
-      await runFetchTelemetryBatch("activity_observe_cycle", async () => {
-        const observedTags = await observeTrackedClans();
-        try {
-          const backfill = await backfillMissingDiscordUsernamesForClanMembers({
-            memberTagsInOrder: observedTags,
-            resolveDiscordUsername: resolveDiscordUsernameForBackfill,
-          });
-          if (backfill.candidateLinks > 0) {
-            console.log(
-              `[activity-observe] playerlink_discord_username_backfill candidates=${backfill.candidateLinks} unique_users=${backfill.uniqueUsers} resolved_users=${backfill.resolvedUsers} updated=${backfill.updatedLinks}`
-            );
-          }
-        } catch (err) {
-          console.error(
-            `[activity-observe] playerlink_discord_username_backfill failed: ${formatError(err)}`
+      await pollCycleGuard.run("activity_observe_cycle", async () => {
+        const queueStatus = cocRequestQueueService.getStatus();
+        if (queueStatus.degraded) {
+          console.warn(
+            `[poll-cycle] event=degraded_mode job=activity_observe_cycle spacing_ms=${queueStatus.spacingMs} penalty_ms=${queueStatus.penaltyMs} queue_depth=${queueStatus.queueDepth} in_flight=${queueStatus.inFlight}`,
           );
         }
-        try {
-          await markObserveRun();
-        } catch (err) {
-          console.error(`observe run timestamp write failed: ${formatError(err)}`);
-        }
+        await runFetchTelemetryBatch("activity_observe_cycle", async () => {
+          const observedTags = await observeTrackedClans();
+          try {
+            const backfill = await backfillMissingDiscordUsernamesForClanMembers({
+              memberTagsInOrder: observedTags,
+              resolveDiscordUsername: resolveDiscordUsernameForBackfill,
+            });
+            if (backfill.candidateLinks > 0) {
+              console.log(
+                `[activity-observe] playerlink_discord_username_backfill candidates=${backfill.candidateLinks} unique_users=${backfill.uniqueUsers} resolved_users=${backfill.resolvedUsers} updated=${backfill.updatedLinks}`
+              );
+            }
+          } catch (err) {
+            console.error(
+              `[activity-observe] playerlink_discord_username_backfill failed: ${formatError(err)}`
+            );
+          }
+          try {
+            await markObserveRun();
+          } catch (err) {
+            console.error(`observe run timestamp write failed: ${formatError(err)}`);
+          }
+        });
       });
     };
 
@@ -552,17 +552,25 @@ export default (client: Client, cocService: CoCService): void => {
     const warEventPollMs = Math.floor(warEventPollMinutes * 60 * 1000);
 
     const runWarEventPoll = async () => {
-      await runFetchTelemetryBatch("war_event_poll_cycle", async () => {
-        try {
-          await warEventLogService.poll();
-          await warEventLogService.refreshBattleDayPosts();
-          await refreshAllTrackedWarMailPosts(client);
-          await todoSnapshotService.refreshAllLinkedPlayerSnapshots({
-            cocService,
-          });
-        } catch (err) {
-          console.error(`[war-events] poll loop failed: ${formatError(err)}`);
+      await pollCycleGuard.run("war_event_poll_cycle", async () => {
+        const queueStatus = cocRequestQueueService.getStatus();
+        if (queueStatus.degraded) {
+          console.warn(
+            `[poll-cycle] event=degraded_mode job=war_event_poll_cycle spacing_ms=${queueStatus.spacingMs} penalty_ms=${queueStatus.penaltyMs} queue_depth=${queueStatus.queueDepth} in_flight=${queueStatus.inFlight}`,
+          );
         }
+        await runFetchTelemetryBatch("war_event_poll_cycle", async () => {
+          try {
+            await warEventLogService.poll();
+            await warEventLogService.refreshBattleDayPosts();
+            await refreshAllTrackedWarMailPosts(client);
+            await todoSnapshotService.refreshAllLinkedPlayerSnapshots({
+              cocService,
+            });
+          } catch (err) {
+            console.error(`[war-events] poll loop failed: ${formatError(err)}`);
+          }
+        });
       });
     };
 

--- a/src/services/CoCRequestQueueService.ts
+++ b/src/services/CoCRequestQueueService.ts
@@ -1,0 +1,212 @@
+import { formatError } from "../helper/formatError";
+
+type CoCQueueTask<T> = {
+  operation: string;
+  detail?: string;
+  run: () => Promise<T>;
+};
+
+type CoCQueueStatus = {
+  queueDepth: number;
+  inFlight: number;
+  penaltyMs: number;
+  spacingMs: number;
+  degraded: boolean;
+};
+
+function sleep(ms: number): Promise<void> {
+  if (ms <= 0) return Promise.resolve();
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function toPositiveInt(value: unknown, fallback: number): number {
+  const parsed = Math.trunc(Number(value));
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return parsed;
+}
+
+function resolveHttpStatus(err: unknown): number | null {
+  const asAny = err as any;
+  const responseStatus = Number(asAny?.response?.status);
+  if (Number.isFinite(responseStatus) && responseStatus > 0) {
+    return Math.trunc(responseStatus);
+  }
+  const status = Number(asAny?.status);
+  if (Number.isFinite(status) && status > 0) {
+    return Math.trunc(status);
+  }
+  const message = String(asAny?.message ?? "");
+  const cocStatus = message.match(/CoC API error\s+(\d{3})/i);
+  if (cocStatus) return Math.trunc(Number(cocStatus[1]));
+  const genericStatus = message.match(/HTTP[_\s](\d{3})/i);
+  if (genericStatus) return Math.trunc(Number(genericStatus[1]));
+  return null;
+}
+
+/** Purpose: provide one shared serialized pacing queue for CoC API requests with bounded 429 backoff. */
+export class CoCRequestQueueService {
+  private tail: Promise<void> = Promise.resolve();
+  private nextAllowedAtMs = 0;
+  private queueDepth = 0;
+  private inFlight = 0;
+  private penaltyMs = 0;
+  private lastRateLimitLogAtMs = 0;
+  private lastDegradedDelayLogAtMs = 0;
+  private lastRecoveredLogAtMs = 0;
+
+  private readonly baseSpacingMs = toPositiveInt(
+    process.env.COC_REQUEST_QUEUE_BASE_SPACING_MS,
+    120,
+  );
+  private readonly maxPenaltyMs = toPositiveInt(
+    process.env.COC_REQUEST_QUEUE_MAX_PENALTY_MS,
+    8000,
+  );
+  private readonly min429PenaltyMs = toPositiveInt(
+    process.env.COC_REQUEST_QUEUE_MIN_429_PENALTY_MS,
+    1000,
+  );
+  private readonly recoveryStepMs = toPositiveInt(
+    process.env.COC_REQUEST_QUEUE_RECOVERY_STEP_MS,
+    100,
+  );
+  private readonly degradedDelayLogIntervalMs = toPositiveInt(
+    process.env.COC_REQUEST_QUEUE_DEGRADED_DELAY_LOG_INTERVAL_MS,
+    15_000,
+  );
+  private readonly rateLimitLogIntervalMs = toPositiveInt(
+    process.env.COC_REQUEST_QUEUE_RATE_LIMIT_LOG_INTERVAL_MS,
+    10_000,
+  );
+
+  /** Purpose: enqueue one CoC-bound request and execute it under shared pacing guarantees. */
+  async enqueue<T>(task: CoCQueueTask<T>): Promise<T> {
+    this.queueDepth += 1;
+    return new Promise<T>((resolve, reject) => {
+      const runQueued = async () => {
+        this.queueDepth = Math.max(0, this.queueDepth - 1);
+        this.inFlight += 1;
+        try {
+          await this.waitForTurn(task.operation, task.detail);
+          try {
+            const result = await task.run();
+            this.noteSuccess();
+            resolve(result);
+          } catch (err) {
+            this.noteFailure(err, task.operation, task.detail);
+            reject(err);
+          } finally {
+            this.nextAllowedAtMs =
+              Math.max(this.nextAllowedAtMs, Date.now()) +
+              this.currentSpacingMs();
+          }
+        } finally {
+          this.inFlight = Math.max(0, this.inFlight - 1);
+        }
+      };
+      this.tail = this.tail.then(runQueued, runQueued).then(
+        () => undefined,
+        () => undefined,
+      );
+    });
+  }
+
+  /** Purpose: expose queue health for guarded command/poller behavior during upstream throttling. */
+  getStatus(): CoCQueueStatus {
+    return {
+      queueDepth: this.queueDepth,
+      inFlight: this.inFlight,
+      penaltyMs: this.penaltyMs,
+      spacingMs: this.currentSpacingMs(),
+      degraded: this.penaltyMs > 0,
+    };
+  }
+
+  /** Purpose: provide deterministic reset hook for queue-focused tests. */
+  resetForTest(): void {
+    this.tail = Promise.resolve();
+    this.nextAllowedAtMs = 0;
+    this.queueDepth = 0;
+    this.inFlight = 0;
+    this.penaltyMs = 0;
+    this.lastRateLimitLogAtMs = 0;
+    this.lastDegradedDelayLogAtMs = 0;
+    this.lastRecoveredLogAtMs = 0;
+  }
+
+  private currentSpacingMs(): number {
+    return this.baseSpacingMs + this.penaltyMs;
+  }
+
+  private async waitForTurn(operation: string, detail?: string): Promise<void> {
+    const now = Date.now();
+    const delayMs = Math.max(0, this.nextAllowedAtMs - now);
+    if (delayMs <= 0) return;
+    if (this.penaltyMs > 0) {
+      this.logDegradedDelay({
+        operation,
+        detail,
+        delayMs,
+      });
+    }
+    await sleep(delayMs);
+  }
+
+  private noteSuccess(): void {
+    if (this.penaltyMs <= 0) return;
+    const previousPenalty = this.penaltyMs;
+    this.penaltyMs = Math.max(0, this.penaltyMs - this.recoveryStepMs);
+    if (previousPenalty > 0 && this.penaltyMs === 0) {
+      const now = Date.now();
+      if (now - this.lastRecoveredLogAtMs >= this.rateLimitLogIntervalMs) {
+        this.lastRecoveredLogAtMs = now;
+        console.info("[coc-queue] event=recovered penalty_ms=0 spacing_ms=" + this.currentSpacingMs());
+      }
+    }
+  }
+
+  private noteFailure(err: unknown, operation: string, detail?: string): void {
+    const status = resolveHttpStatus(err);
+    if (status !== 429) return;
+
+    const previousPenalty = this.penaltyMs;
+    const raisedPenalty =
+      previousPenalty <= 0
+        ? this.min429PenaltyMs
+        : Math.max(this.min429PenaltyMs, previousPenalty * 2);
+    this.penaltyMs = Math.min(this.maxPenaltyMs, raisedPenalty);
+    this.nextAllowedAtMs = Math.max(
+      this.nextAllowedAtMs,
+      Date.now() + this.penaltyMs,
+    );
+
+    const now = Date.now();
+    if (
+      this.penaltyMs !== previousPenalty ||
+      now - this.lastRateLimitLogAtMs >= this.rateLimitLogIntervalMs
+    ) {
+      this.lastRateLimitLogAtMs = now;
+      console.warn(
+        `[coc-queue] event=rate_limited status=429 operation=${operation} detail=${detail ?? "none"} penalty_ms=${this.penaltyMs} spacing_ms=${this.currentSpacingMs()} queue_depth=${this.queueDepth} in_flight=${this.inFlight} error=${formatError(err)}`,
+      );
+    }
+  }
+
+  private logDegradedDelay(input: {
+    operation: string;
+    detail?: string;
+    delayMs: number;
+  }): void {
+    const now = Date.now();
+    if (now - this.lastDegradedDelayLogAtMs < this.degradedDelayLogIntervalMs) {
+      return;
+    }
+    this.lastDegradedDelayLogAtMs = now;
+    console.warn(
+      `[coc-queue] event=degraded_delay operation=${input.operation} detail=${input.detail ?? "none"} delay_ms=${input.delayMs} penalty_ms=${this.penaltyMs} spacing_ms=${this.currentSpacingMs()} queue_depth=${this.queueDepth} in_flight=${this.inFlight}`,
+    );
+  }
+}
+
+export const cocRequestQueueService = new CoCRequestQueueService();
+

--- a/src/services/CoCService.ts
+++ b/src/services/CoCService.ts
@@ -10,12 +10,14 @@ import {
 } from "../generated/coc-api";
 import { recordFetchEvent } from "../helper/fetchTelemetry";
 import { toFailureTelemetry } from "./telemetry/ingest";
+import { cocRequestQueueService } from "./CoCRequestQueueService";
 
 export class CoCService {
   private clansApi: ClansApi;
   private playersApi: PlayersApi;
   private readonly cocApiToken: string;
   private readonly cocApiBaseUrl: string;
+  private readonly queue = cocRequestQueueService;
 
   /** Purpose: initialize service dependencies. */
   constructor() {
@@ -37,6 +39,19 @@ export class CoCService {
     this.playersApi = new PlayersApi(config);
   }
 
+  /** Purpose: run one outbound CoC API call through shared queue pacing. */
+  private async runQueuedRequest<T>(input: {
+    operation: string;
+    detail: string;
+    run: () => Promise<T>;
+  }): Promise<T> {
+    return this.queue.enqueue({
+      operation: input.operation,
+      detail: input.detail,
+      run: input.run,
+    });
+  }
+
   /** Purpose: get current clan-capital raid seasons for one clan tag (newest first). */
   async getClanCapitalRaidSeasons(
     tag: string,
@@ -45,13 +60,21 @@ export class CoCService {
     const clanTag = tag.startsWith("#") ? tag : `#${tag}`;
     const startedAtMs = Date.now();
     try {
-      const response = await axios.get(`${this.cocApiBaseUrl}/clans/${encodeURIComponent(clanTag)}/capitalraidseasons`, {
-        headers: {
-          Authorization: `Bearer ${this.cocApiToken}`,
-        },
-        params: {
-          limit: Math.max(1, Math.trunc(Number(limit) || 1)),
-        },
+      const response = await this.runQueuedRequest({
+        operation: "getClanCapitalRaidSeasons",
+        detail: `tag=${clanTag}`,
+        run: () =>
+          axios.get(
+            `${this.cocApiBaseUrl}/clans/${encodeURIComponent(clanTag)}/capitalraidseasons`,
+            {
+              headers: {
+                Authorization: `Bearer ${this.cocApiToken}`,
+              },
+              params: {
+                limit: Math.max(1, Math.trunc(Number(limit) || 1)),
+              },
+            },
+          ),
       });
       const data = response?.data as { items?: ClanCapitalRaidSeason[] } | undefined;
       const seasons = Array.isArray(data?.items) ? data.items : [];
@@ -101,7 +124,11 @@ export class CoCService {
     const clanTag = tag.startsWith("#") ? tag : `#${tag}`;
     const startedAtMs = Date.now();
     try {
-      const { data } = await this.clansApi.getClan(clanTag);
+      const { data } = await this.runQueuedRequest({
+        operation: "getClan",
+        detail: `tag=${clanTag}`,
+        run: () => this.clansApi.getClan(clanTag),
+      });
       recordFetchEvent({
         namespace: "coc",
         operation: "getClan",
@@ -146,7 +173,11 @@ export class CoCService {
     const clanTag = tag.startsWith("#") ? tag : `#${tag}`;
     const startedAtMs = Date.now();
     try {
-      const { data } = await this.clansApi.getCurrentWar(clanTag);
+      const { data } = await this.runQueuedRequest({
+        operation: "getCurrentWar",
+        detail: `tag=${clanTag}`,
+        run: () => this.clansApi.getCurrentWar(clanTag),
+      });
       recordFetchEvent({
         namespace: "coc",
         operation: "getCurrentWar",
@@ -193,7 +224,11 @@ export class CoCService {
     const clanTag = tag.startsWith("#") ? tag : `#${tag}`;
     const startedAtMs = Date.now();
     try {
-      const { data } = await this.clansApi.getClanWarLog(clanTag, limit);
+      const { data } = await this.runQueuedRequest({
+        operation: "getClanWarLog",
+        detail: `tag=${clanTag} limit=${limit}`,
+        run: () => this.clansApi.getClanWarLog(clanTag, limit),
+      });
       recordFetchEvent({
         namespace: "coc",
         operation: "getClanWarLog",
@@ -226,7 +261,11 @@ export class CoCService {
     const clanTag = tag.startsWith("#") ? tag : `#${tag}`;
     const startedAtMs = Date.now();
     try {
-      const { data } = await this.clansApi.getClanWarLeagueGroup(clanTag);
+      const { data } = await this.runQueuedRequest({
+        operation: "getClanWarLeagueGroup",
+        detail: `tag=${clanTag}`,
+        run: () => this.clansApi.getClanWarLeagueGroup(clanTag),
+      });
       recordFetchEvent({
         namespace: "coc",
         operation: "getClanWarLeagueGroup",
@@ -273,7 +312,11 @@ export class CoCService {
     const normalizedWarTag = warTag.startsWith("#") ? warTag : `#${warTag}`;
     const startedAtMs = Date.now();
     try {
-      const { data } = await this.clansApi.getClanWarLeagueWar(normalizedWarTag);
+      const { data } = await this.runQueuedRequest({
+        operation: "getClanWarLeagueWar",
+        detail: `warTag=${normalizedWarTag}`,
+        run: () => this.clansApi.getClanWarLeagueWar(normalizedWarTag),
+      });
       recordFetchEvent({
         namespace: "coc",
         operation: "getClanWarLeagueWar",
@@ -324,7 +367,11 @@ export class CoCService {
     const startedAtMs = Date.now();
 
     try {
-      const { data } = await this.playersApi.getPlayer(playerTag);
+      const { data } = await this.runQueuedRequest({
+        operation: "getPlayerRaw",
+        detail: `tag=${playerTag}`,
+        run: () => this.playersApi.getPlayer(playerTag),
+      });
       if (!options?.suppressTelemetry) {
         recordFetchEvent({
           namespace: "coc",

--- a/src/services/PollCycleGuardService.ts
+++ b/src/services/PollCycleGuardService.ts
@@ -1,0 +1,32 @@
+type PollCycleLogger = Pick<Console, "warn">;
+
+/** Purpose: prevent one scheduled job from running concurrently with itself. */
+export class PollCycleGuardService {
+  private readonly inProgress = new Set<string>();
+
+  constructor(private readonly logger: PollCycleLogger = console) {}
+
+  /** Purpose: run one job only when no prior cycle is still active; otherwise skip/coalesce. */
+  async run<T>(job: string, execute: () => Promise<T>): Promise<{ ran: true; value: T } | { ran: false }> {
+    const key = String(job ?? "").trim() || "unknown";
+    if (this.inProgress.has(key)) {
+      this.logger.warn(`[poll-cycle] event=overlap_skipped job=${key}`);
+      return { ran: false };
+    }
+
+    this.inProgress.add(key);
+    try {
+      const value = await execute();
+      return { ran: true, value };
+    } finally {
+      this.inProgress.delete(key);
+    }
+  }
+
+  /** Purpose: expose current guard state for tests and diagnostics. */
+  isRunning(job: string): boolean {
+    const key = String(job ?? "").trim() || "unknown";
+    return this.inProgress.has(key);
+  }
+}
+

--- a/tests/cocRequestQueue.service.test.ts
+++ b/tests/cocRequestQueue.service.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CoCRequestQueueService } from "../src/services/CoCRequestQueueService";
+
+function snapshotQueueEnv() {
+  return {
+    base: process.env.COC_REQUEST_QUEUE_BASE_SPACING_MS,
+    maxPenalty: process.env.COC_REQUEST_QUEUE_MAX_PENALTY_MS,
+    min429Penalty: process.env.COC_REQUEST_QUEUE_MIN_429_PENALTY_MS,
+    recoveryStep: process.env.COC_REQUEST_QUEUE_RECOVERY_STEP_MS,
+  };
+}
+
+function restoreQueueEnv(snapshot: ReturnType<typeof snapshotQueueEnv>): void {
+  process.env.COC_REQUEST_QUEUE_BASE_SPACING_MS = snapshot.base;
+  process.env.COC_REQUEST_QUEUE_MAX_PENALTY_MS = snapshot.maxPenalty;
+  process.env.COC_REQUEST_QUEUE_MIN_429_PENALTY_MS = snapshot.min429Penalty;
+  process.env.COC_REQUEST_QUEUE_RECOVERY_STEP_MS = snapshot.recoveryStep;
+}
+
+describe("CoCRequestQueueService", () => {
+  const envSnapshot = snapshotQueueEnv();
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-01T00:00:00.000Z"));
+    process.env.COC_REQUEST_QUEUE_BASE_SPACING_MS = "100";
+    process.env.COC_REQUEST_QUEUE_MAX_PENALTY_MS = "1200";
+    process.env.COC_REQUEST_QUEUE_MIN_429_PENALTY_MS = "400";
+    process.env.COC_REQUEST_QUEUE_RECOVERY_STEP_MS = "200";
+  });
+
+  afterEach(() => {
+    restoreQueueEnv(envSnapshot);
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("enforces paced execution for queued work", async () => {
+    const queue = new CoCRequestQueueService();
+    const startedAtMs: number[] = [];
+
+    const enqueueCall = () =>
+      queue.enqueue({
+        operation: "test",
+        detail: "paced",
+        run: async () => {
+          startedAtMs.push(Date.now());
+          return startedAtMs.length;
+        },
+      });
+
+    const pending = [enqueueCall(), enqueueCall(), enqueueCall()];
+    await vi.runAllTimersAsync();
+    const results = await Promise.all(pending);
+
+    expect(results).toEqual([1, 2, 3]);
+    expect(startedAtMs).toHaveLength(3);
+    expect(startedAtMs[1] - startedAtMs[0]).toBeGreaterThanOrEqual(100);
+    expect(startedAtMs[2] - startedAtMs[1]).toBeGreaterThanOrEqual(100);
+  });
+
+  it("raises penalty and reduces pace when a 429 response is observed", async () => {
+    const queue = new CoCRequestQueueService();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    let failureSeenAtMs = 0;
+
+    await expect(
+      queue.enqueue({
+        operation: "test",
+        detail: "429",
+        run: async () => {
+          failureSeenAtMs = Date.now();
+          throw {
+            response: { status: 429 },
+            message: "Request throttling limits exceeded",
+          };
+        },
+      }),
+    ).rejects.toBeTruthy();
+
+    const statusAfter429 = queue.getStatus();
+    expect(statusAfter429.degraded).toBe(true);
+    expect(statusAfter429.penaltyMs).toBeGreaterThanOrEqual(400);
+
+    let nextStartedAtMs = 0;
+    const successPromise = queue.enqueue({
+      operation: "test",
+      detail: "after_429",
+      run: async () => {
+        nextStartedAtMs = Date.now();
+        return "ok";
+      },
+    });
+    await vi.runAllTimersAsync();
+    await expect(successPromise).resolves.toBe("ok");
+
+    expect(nextStartedAtMs - failureSeenAtMs).toBeGreaterThanOrEqual(400);
+    expect(queue.getStatus().penaltyMs).toBeLessThan(statusAfter429.penaltyMs);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[coc-queue] event=rate_limited status=429"),
+    );
+  });
+});
+

--- a/tests/pollCycleGuard.service.test.ts
+++ b/tests/pollCycleGuard.service.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+import { PollCycleGuardService } from "../src/services/PollCycleGuardService";
+
+describe("PollCycleGuardService", () => {
+  it("skips overlapping executions for the same job key", async () => {
+    const logger = { warn: vi.fn() };
+    const guard = new PollCycleGuardService(logger);
+
+    let releaseFirst: (() => void) | null = null;
+    const firstRun = guard.run("war_event_poll_cycle", async () => {
+      await new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+      return "first";
+    });
+    await Promise.resolve();
+
+    const secondRun = await guard.run("war_event_poll_cycle", async () => "second");
+    expect(secondRun).toEqual({ ran: false });
+    expect(guard.isRunning("war_event_poll_cycle")).toBe(true);
+    expect(logger.warn).toHaveBeenCalledWith(
+      "[poll-cycle] event=overlap_skipped job=war_event_poll_cycle",
+    );
+
+    releaseFirst?.();
+    await expect(firstRun).resolves.toEqual({ ran: true, value: "first" });
+    expect(guard.isRunning("war_event_poll_cycle")).toBe(false);
+
+    await expect(
+      guard.run("war_event_poll_cycle", async () => "third"),
+    ).resolves.toEqual({ ran: true, value: "third" });
+  });
+});
+

--- a/tests/todo.command.test.ts
+++ b/tests/todo.command.test.ts
@@ -67,6 +67,7 @@ import {
 import { resetTodoRenderCacheForTest } from "../src/services/TodoService";
 import { todoSnapshotService } from "../src/services/TodoSnapshotService";
 import { todoLastViewedTypeService } from "../src/services/TodoLastViewedTypeService";
+import { cocRequestQueueService } from "../src/services/CoCRequestQueueService";
 
 type TodoType = "WAR" | "CWL" | "RAIDS" | "GAMES";
 const TODO_DEFAULT_EMBED_COLOR = 0x5865f2;
@@ -348,11 +349,93 @@ describe("/todo command", () => {
       playerTags: ["#PYLQ0289", "#QGRJ2222"],
       cocService: expect.anything(),
     });
+    const deferOrder = interaction.deferReply.mock.invocationCallOrder[0] ?? 0;
     const refreshOrder = refreshSpy.mock.invocationCallOrder[0] ?? 0;
     const editOrder = interaction.editReply.mock.invocationCallOrder[0] ?? 0;
+    expect(deferOrder).toBeGreaterThan(0);
+    expect(deferOrder).toBeLessThan(refreshOrder);
     expect(refreshOrder).toBeGreaterThan(0);
     expect(editOrder).toBeGreaterThan(0);
     expect(refreshOrder).toBeLessThan(editOrder);
+  });
+
+  it("serves snapshot output without live refresh when CoC queue is degraded", async () => {
+    const queueSpy = vi.spyOn(cocRequestQueueService, "getStatus").mockReturnValue({
+      queueDepth: 5,
+      inFlight: 1,
+      penaltyMs: 1200,
+      spacingMs: 1320,
+      degraded: true,
+    });
+    const refreshSpy = vi.spyOn(todoSnapshotService, "refreshSnapshotsForPlayerTags");
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      { playerTag: "#PYLQ0289", createdAt: new Date("2026-03-01T00:00:00.000Z") },
+    ]);
+    prismaMock.todoPlayerSnapshot.aggregate.mockResolvedValue({
+      _count: { _all: 1 },
+      _max: { updatedAt: new Date("2026-03-26T00:00:00.000Z") },
+    });
+    prismaMock.todoPlayerSnapshot.findMany.mockResolvedValue([
+      makeSnapshotRow({
+        playerTag: "#PYLQ0289",
+        playerName: "Alpha",
+      }),
+    ]);
+    const interaction = makeTodoInteraction({ type: "WAR" });
+
+    await Todo.run({} as any, interaction as any, makeCocServiceSpy() as any);
+
+    expect(queueSpy).toHaveBeenCalled();
+    expect(refreshSpy).not.toHaveBeenCalled();
+    expect(interaction.editReply).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[todo] event=snapshot_served reason=coc_degraded"),
+    );
+  });
+
+  it("falls back to snapshot output when bounded initial refresh times out", async () => {
+    vi.spyOn(cocRequestQueueService, "getStatus").mockReturnValue({
+      queueDepth: 0,
+      inFlight: 0,
+      penaltyMs: 0,
+      spacingMs: 120,
+      degraded: false,
+    });
+    vi.spyOn(todoSnapshotService, "refreshSnapshotsForPlayerTags").mockImplementation(
+      async () =>
+        await new Promise(() => {
+          // intentionally unresolved to force timeout-path snapshot fallback
+        }),
+    );
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      { playerTag: "#PYLQ0289", createdAt: new Date("2026-03-01T00:00:00.000Z") },
+    ]);
+    prismaMock.todoPlayerSnapshot.aggregate.mockResolvedValue({
+      _count: { _all: 1 },
+      _max: { updatedAt: new Date("2026-03-26T00:00:00.000Z") },
+    });
+    prismaMock.todoPlayerSnapshot.findMany.mockResolvedValue([
+      makeSnapshotRow({
+        playerTag: "#PYLQ0289",
+        playerName: "Alpha",
+      }),
+    ]);
+    const interaction = makeTodoInteraction({ type: "WAR" });
+
+    const runPromise = Todo.run({} as any, interaction as any, makeCocServiceSpy() as any);
+    await vi.advanceTimersByTimeAsync(3_100);
+    await runPromise;
+
+    expect(interaction.editReply).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "[todo] event=snapshot_served reason=bounded_refresh_timeout",
+      ),
+    );
   });
 
   it("builds from snapshots, opens on requested page, and avoids live coc aggregation", async () => {


### PR DESCRIPTION
- route CoC API calls through a shared queued rate limiter with adaptive 429 backoff
- add overlap guards for activity observe and war-event poll cycles with structured skip/degraded logs
- switch /todo startup to snapshot-first with bounded live refresh fallback during queue pressure