### PR TITLE
feat(polling): add mirror mode with prod-to-staging runtime sync

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -23,7 +23,7 @@
 - `/sheet link sheet_id_or_url:<id-or-url> [tab:<tab-name>] [mode:actual|war]` - Link or relink sheet; mode is optional.
 - `/sheet show [mode:actual|war]` - Show linked sheet settings (single mode or all).
 - `/sheet unlink [mode:actual|war]` - Remove one mode link or all links.
-- `/sheet refresh mode:actual|war` - Trigger mode-specific Apps Script raw feed refresh.
+- `/sheet refresh mode:actual|war` - Trigger mode-specific Apps Script raw feed refresh. Disabled when `POLLING_MODE=mirror`.
 - `/compo advice clan:<tracked-clan> [mode:actual|war]` - Pull advice using mode-specific sheet link.
 - `/compo state [mode:actual|war]` - Render AllianceDashboard state as an attached PNG image with mode label. Includes an inline `Refresh Data` button that triggers the shared sheet-refresh flow and rerenders in place.
 - `/compo place weight:<value>` - Suggest placement options from ACTUAL state (vacancy + composition fit). Accepts formats like `145000`, `145,000`, or `145k` and maps to TH weight buckets. Includes an inline `Refresh Data` button that triggers the shared sheet-refresh flow and rerenders in place.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -3,6 +3,9 @@
 ## Deployment Notes
 - Commands are registered as guild commands using `GUILD_ID` on startup.
 - If commands are missing, verify environment (`DISCORD_TOKEN`, `GUILD_ID`) and restart.
+- Polling ownership:
+  - Prod: `POLLING_MODE=active`
+  - Staging: `POLLING_MODE=mirror` with `MIRROR_SOURCE_DATABASE_URL` set to prod DB and `POLLING_ENV=staging`
 
 ## Install Links
 Prod guild install:

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -29,6 +29,32 @@ Behavior:
 ## Optional War Event Poll Setting
 - `WAR_EVENT_LOG_POLL_INTERVAL_MINUTES` - interval for war-state event listener polling (default: `5` minutes).
 
+## Polling Ownership Mode (Prod Polls, Staging Mirrors)
+- `POLLING_MODE` - `active` (default) or `mirror`.
+  - `active`: runs normal external pollers/schedulers.
+  - `mirror`: disables duplicated upstream pollers and runs prod->staging snapshot sync.
+- `MIRROR_SOURCE_DATABASE_URL` - required in `mirror` mode; source/prod DB URL used for one-way sync.
+- `MIRROR_SYNC_INTERVAL_MINUTES` - mirror scheduled sync cadence (default: `15` minutes).
+- `MIRROR_SYNC_BATCH_SIZE` - createMany batch size for mirrored table writes (default: `500`).
+- `POLLING_ENV` (or `DEPLOY_ENV` / `APP_ENV`) - set to `staging` for mirror instances; mirror sync is safety-blocked in `prod`.
+
+Mirror mode behavior:
+- Disables duplicated external polling owners (activity observe, war-event poll, FWA feed scheduler, user-activity reminder scheduler).
+- Runs scheduled full-overwrite sync for mirrored runtime tables:
+  - `TrackedClan`
+  - `CurrentWar`
+  - `WarAttacks`
+  - `ClanPointsSync`
+  - `ClanWarHistory`
+  - `ClanWarParticipation`
+  - `WarLookup`
+- Sync direction is always source/prod -> target/current DATABASE_URL.
+
+Manual sync now:
+```bash
+npm run sync:mirror
+```
+
 ## Optional Optimized Points Polling
 - `FWA_OPTIMIZED_POINTS_POLLING` - enable lifecycle-based routine fetch gating for points checks (default: `true`).
 - `FWA_POST_WAR_CHECK_WINDOW_MINUTES` - how long post-war delayed-update checks may run after war end (default: `240`).

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "lint": "eslint \"src/**/*.ts\" \"tests/**/*.ts\"",
     "lint:fix": "eslint \"src/**/*.ts\" \"tests/**/*.ts\" --fix",
     "seed:fwa-layouts": "ts-node src/scripts/seedFwaLayouts.ts",
+    "sync:mirror": "ts-node src/scripts/mirrorSync.ts",
     "sync:fwa-feeds": "ts-node src/scripts/fwaFeedSync.ts",
     "start": "prisma migrate deploy && node dist/ClashCookies.js",
     "test": "vitest run",

--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -172,7 +172,7 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
     summary: "Link and manage Google Sheet settings.",
     details: [
       "Uses one linked Google Sheet for both ACTUAL/WAR data modes.",
-      "Refresh triggers a shared Apps Script webhook and can target ACTUAL or WAR mode.",
+      "Refresh triggers a shared Apps Script webhook and can target ACTUAL or WAR mode (disabled when POLLING_MODE=mirror).",
       "`link`, `unlink`, `show`, and `refresh` are admin-only by default.",
     ],
     examples: [

--- a/src/listeners/ready.ts
+++ b/src/listeners/ready.ts
@@ -40,6 +40,12 @@ import { ReminderSchedulerService } from "../services/reminders/ReminderSchedule
 import { UserActivityReminderSchedulerService } from "../services/remindme/UserActivityReminderSchedulerService";
 import { cocRequestQueueService } from "../services/CoCRequestQueueService";
 import { PollCycleGuardService } from "../services/PollCycleGuardService";
+import {
+  isActivePollingMode,
+  resolveMirrorSyncIntervalMsFromEnv,
+  resolvePollingMode,
+} from "../services/PollingModeService";
+import { MirrorSyncService } from "../services/MirrorSyncService";
 
 const DEFAULT_OBSERVE_INTERVAL_MINUTES = 30;
 const RECRUITMENT_REMINDER_INTERVAL_MS = 60 * 60 * 1000;
@@ -47,6 +53,7 @@ const DEFERMENT_REMINDER_INTERVAL_MS = 60 * 60 * 1000;
 const DEFAULT_WAR_EVENT_POLL_INTERVAL_MINUTES = 5;
 const TRACKED_MESSAGE_SWEEP_INTERVAL_MS = 60 * 1000;
 const OBSERVE_LAST_RUN_AT_KEY = "activity_observe:last_run_at_ms";
+const MIRROR_SYNC_POLL_GUARD_KEY = "mirror_snapshot_sync_cycle";
 const VISIBILITY_OPTION = {
   name: "visibility",
   description: "Response visibility",
@@ -342,6 +349,10 @@ export default (client: Client, cocService: CoCService): void => {
     const warEventLogService = new WarEventLogService(client, cocService);
     const settings = new SettingsService();
     const pollCycleGuard = new PollCycleGuardService();
+    const pollingMode = resolvePollingMode(process.env);
+    const activePollingEnabled = isActivePollingMode(process.env);
+    const mirrorSyncService = new MirrorSyncService();
+    console.log(`[polling-mode] mode=${pollingMode}`);
 
     const observeTrackedClans = async (): Promise<string[]> => {
       const dbTracked = await prisma.trackedClan.findMany({
@@ -461,33 +472,39 @@ export default (client: Client, cocService: CoCService): void => {
     const intervalMs = Math.floor(intervalMinutes * 60 * 1000);
     const initialObserveDelayMs = await getInitialObserveDelayMs();
 
-    if (initialObserveDelayMs === 0) {
-      await runObservedCycle();
-      setInterval(() => {
-        runObservedCycle().catch((err) => {
-          console.error(`observeTrackedClans loop failed: ${formatError(err)}`);
-        });
-      }, intervalMs);
-    } else {
-      const initialObserveDelayMin = Math.ceil(initialObserveDelayMs / 60000);
-      console.log(
-        `Skipping startup activity observe run; next run in ${initialObserveDelayMin} minute(s).`
-      );
-      setTimeout(() => {
-        runObservedCycle()
-          .catch((err) => {
-            console.error(`observeTrackedClans delayed run failed: ${formatError(err)}`);
-          })
-          .finally(() => {
-            setInterval(() => {
-              runObservedCycle().catch((err) => {
-                console.error(`observeTrackedClans loop failed: ${formatError(err)}`);
-              });
-            }, intervalMs);
+    if (activePollingEnabled) {
+      if (initialObserveDelayMs === 0) {
+        await runObservedCycle();
+        setInterval(() => {
+          runObservedCycle().catch((err) => {
+            console.error(`observeTrackedClans loop failed: ${formatError(err)}`);
           });
-      }, initialObserveDelayMs);
+        }, intervalMs);
+      } else {
+        const initialObserveDelayMin = Math.ceil(initialObserveDelayMs / 60000);
+        console.log(
+          `Skipping startup activity observe run; next run in ${initialObserveDelayMin} minute(s).`
+        );
+        setTimeout(() => {
+          runObservedCycle()
+            .catch((err) => {
+              console.error(`observeTrackedClans delayed run failed: ${formatError(err)}`);
+            })
+            .finally(() => {
+              setInterval(() => {
+                runObservedCycle().catch((err) => {
+                  console.error(`observeTrackedClans loop failed: ${formatError(err)}`);
+                });
+              }, intervalMs);
+            });
+        }, initialObserveDelayMs);
+      }
+      console.log(`Activity observe loop enabled (every ${intervalMinutes} minute(s)).`);
+    } else {
+      console.log(
+        "[polling-mode] event=poller_skipped job=activity_observe_cycle mode=mirror",
+      );
     }
-    console.log(`Activity observe loop enabled (every ${intervalMinutes} minute(s)).`);
 
     const runRecruitmentReminders = async () => {
       await runFetchTelemetryBatch("recruitment_reminder_cycle", async () => {
@@ -574,34 +591,79 @@ export default (client: Client, cocService: CoCService): void => {
       });
     };
 
-    setNextNotifyRefreshAtMs(Date.now() + warEventPollMs);
-    setNextWarMailRefreshAtMs(Date.now() + warEventPollMs);
-    await runWarEventPoll();
-    setInterval(() => {
+    if (activePollingEnabled) {
       setNextNotifyRefreshAtMs(Date.now() + warEventPollMs);
       setNextWarMailRefreshAtMs(Date.now() + warEventPollMs);
-      runWarEventPoll().catch((err) => {
-        console.error(`[war-events] poll interval failed: ${formatError(err)}`);
-      });
-    }, warEventPollMs);
-    console.log(
-      `War event poll + refresh loop enabled (every ${warEventPollMinutes} minute(s)).`
-    );
+      await runWarEventPoll();
+      setInterval(() => {
+        setNextNotifyRefreshAtMs(Date.now() + warEventPollMs);
+        setNextWarMailRefreshAtMs(Date.now() + warEventPollMs);
+        runWarEventPoll().catch((err) => {
+          console.error(`[war-events] poll interval failed: ${formatError(err)}`);
+        });
+      }, warEventPollMs);
+      console.log(
+        `War event poll + refresh loop enabled (every ${warEventPollMinutes} minute(s)).`
+      );
 
-    const fwaFeedScheduler = new FwaFeedSchedulerService();
-    fwaFeedScheduler.start();
-    console.log("FWA feed scheduler loops initialized.");
+      const fwaFeedScheduler = new FwaFeedSchedulerService();
+      fwaFeedScheduler.start();
+      console.log("FWA feed scheduler loops initialized.");
+    } else {
+      console.log(
+        "[polling-mode] event=poller_skipped job=war_event_poll_cycle mode=mirror",
+      );
+      console.log(
+        "[polling-mode] event=poller_skipped job=fwa_feed_scheduler mode=mirror",
+      );
+    }
+
+    if (!activePollingEnabled) {
+      const mirrorSyncIntervalMs = resolveMirrorSyncIntervalMsFromEnv(process.env);
+      const mirrorSyncIntervalMinutes = Math.max(
+        1,
+        Math.trunc(mirrorSyncIntervalMs / 60_000),
+      );
+
+      const runMirrorSyncCycle = async (trigger: "startup" | "scheduled") => {
+        await pollCycleGuard.run(MIRROR_SYNC_POLL_GUARD_KEY, async () => {
+          try {
+            await mirrorSyncService.syncNow("scheduled");
+          } catch (err) {
+            console.error(
+              `[mirror-sync] event=${trigger}_failed error=${formatError(err)}`,
+            );
+          }
+        });
+      };
+
+      await runMirrorSyncCycle("startup");
+      setInterval(() => {
+        runMirrorSyncCycle("scheduled").catch((err) => {
+          console.error(`[mirror-sync] event=scheduled_failed error=${formatError(err)}`);
+        });
+      }, mirrorSyncIntervalMs);
+      console.log(
+        `[mirror-sync] event=scheduler_started interval_minutes=${mirrorSyncIntervalMinutes}`,
+      );
+    }
 
     const reminderScheduler = new ReminderSchedulerService(client);
     reminderScheduler.start();
     console.log("Reminder scheduler loop initialized.");
 
-    const userActivityReminderScheduler = new UserActivityReminderSchedulerService(
-      client,
-      cocService
-    );
-    userActivityReminderScheduler.start();
-    console.log("User activity reminder scheduler loop initialized.");
+    if (activePollingEnabled) {
+      const userActivityReminderScheduler = new UserActivityReminderSchedulerService(
+        client,
+        cocService
+      );
+      userActivityReminderScheduler.start();
+      console.log("User activity reminder scheduler loop initialized.");
+    } else {
+      console.log(
+        "[polling-mode] event=poller_skipped job=user_activity_reminder_scheduler mode=mirror",
+      );
+    }
 
     console.log("ClashCookies is online");
   });

--- a/src/scripts/mirrorSync.ts
+++ b/src/scripts/mirrorSync.ts
@@ -1,0 +1,29 @@
+import "dotenv/config";
+import { MirrorSyncService } from "../services/MirrorSyncService";
+
+/** Purpose: execute one guarded mirror-sync cycle manually for staging on-demand refreshes. */
+async function main(): Promise<void> {
+  const service = new MirrorSyncService();
+  const result = await service.syncNow("manual");
+  process.stdout.write(
+    `${JSON.stringify(
+      {
+        ok: true,
+        trigger: result.trigger,
+        sourceDatabase: result.sourceDatabase,
+        targetDatabase: result.targetDatabase,
+        durationMs: result.durationMs,
+        tableSummaries: result.tableSummaries,
+      },
+      null,
+      2,
+    )}\n`,
+  );
+}
+
+main().catch((error) => {
+  const message = String((error as { message?: string })?.message ?? error);
+  process.stderr.write(`[mirror-sync] ${message}\n`);
+  process.exitCode = 1;
+});
+

--- a/src/services/MirrorSyncService.ts
+++ b/src/services/MirrorSyncService.ts
@@ -1,0 +1,498 @@
+import {
+  PrismaClient,
+  type ClanPointsSync,
+  type ClanWarHistory,
+  type ClanWarParticipation,
+  type CurrentWar,
+  type TrackedClan,
+  type WarAttacks,
+  type WarLookup,
+} from "@prisma/client";
+import { formatError } from "../helper/formatError";
+import { prisma } from "../prisma";
+import {
+  isMirrorPollingMode,
+  resolveDatabaseNameFromUrlForLog,
+  resolvePollingMode,
+  resolveRuntimeEnvironment,
+} from "./PollingModeService";
+
+export const MIRRORED_RUNTIME_TABLES = [
+  "TrackedClan",
+  "CurrentWar",
+  "WarAttacks",
+  "ClanPointsSync",
+  "ClanWarHistory",
+  "ClanWarParticipation",
+  "WarLookup",
+] as const;
+
+type MirrorTableName = (typeof MIRRORED_RUNTIME_TABLES)[number];
+type MirrorSyncTrigger = "scheduled" | "manual";
+
+type MirrorSyncLogger = Pick<Console, "info" | "warn" | "error">;
+
+type MirrorSyncColumnRow = {
+  column_name: string;
+  udt_name: string;
+  is_nullable: "YES" | "NO";
+  column_default: string | null;
+};
+
+type MirrorSyncTableSummary = {
+  table: MirrorTableName;
+  sourceRows: number;
+  deletedRows: number;
+  insertedRows: number;
+};
+
+type MirrorSyncResult = {
+  trigger: MirrorSyncTrigger;
+  sourceDatabase: string;
+  targetDatabase: string;
+  durationMs: number;
+  tableSummaries: MirrorSyncTableSummary[];
+};
+
+type DeleteManyResult = { count: number };
+type CreateManyResult = { count: number };
+
+type MirrorSyncSourceClient = {
+  trackedClan: { findMany: (args?: unknown) => Promise<TrackedClan[]> };
+  currentWar: { findMany: (args?: unknown) => Promise<CurrentWar[]> };
+  warAttacks: { findMany: (args?: unknown) => Promise<WarAttacks[]> };
+  clanPointsSync: { findMany: (args?: unknown) => Promise<ClanPointsSync[]> };
+  clanWarHistory: { findMany: (args?: unknown) => Promise<ClanWarHistory[]> };
+  clanWarParticipation: {
+    findMany: (args?: unknown) => Promise<ClanWarParticipation[]>;
+  };
+  warLookup: { findMany: (args?: unknown) => Promise<WarLookup[]> };
+  $queryRawUnsafe: <T = unknown>(query: string, ...values: unknown[]) => Promise<T>;
+  $disconnect?: () => Promise<void>;
+};
+
+type MirrorSyncTargetClient = {
+  trackedClan: {
+    deleteMany: (args?: unknown) => Promise<DeleteManyResult>;
+    createMany: (args: { data: TrackedClan[] }) => Promise<CreateManyResult>;
+  };
+  currentWar: {
+    deleteMany: (args?: unknown) => Promise<DeleteManyResult>;
+    createMany: (args: { data: CurrentWar[] }) => Promise<CreateManyResult>;
+  };
+  warAttacks: {
+    deleteMany: (args?: unknown) => Promise<DeleteManyResult>;
+    createMany: (args: { data: WarAttacks[] }) => Promise<CreateManyResult>;
+  };
+  clanPointsSync: {
+    deleteMany: (args?: unknown) => Promise<DeleteManyResult>;
+    createMany: (args: { data: ClanPointsSync[] }) => Promise<CreateManyResult>;
+  };
+  clanWarHistory: {
+    deleteMany: (args?: unknown) => Promise<DeleteManyResult>;
+    createMany: (args: { data: ClanWarHistory[] }) => Promise<CreateManyResult>;
+  };
+  clanWarParticipation: {
+    deleteMany: (args?: unknown) => Promise<DeleteManyResult>;
+    createMany: (args: { data: ClanWarParticipation[] }) => Promise<CreateManyResult>;
+  };
+  warLookup: {
+    deleteMany: (args?: unknown) => Promise<DeleteManyResult>;
+    createMany: (args: { data: WarLookup[] }) => Promise<CreateManyResult>;
+  };
+  $queryRawUnsafe: <T = unknown>(query: string, ...values: unknown[]) => Promise<T>;
+  $executeRawUnsafe: (query: string, ...values: unknown[]) => Promise<number>;
+  $transaction: <T>(
+    fn: (tx: MirrorSyncTargetClient) => Promise<T>,
+    options?: { maxWait?: number; timeout?: number },
+  ) => Promise<T>;
+};
+
+type MirrorSyncServiceOptions = {
+  env?: NodeJS.ProcessEnv;
+  logger?: MirrorSyncLogger;
+  targetClient?: MirrorSyncTargetClient;
+  createSourceClient?: (
+    sourceDatabaseUrl: string,
+  ) => MirrorSyncSourceClient | Promise<MirrorSyncSourceClient>;
+  disconnectSourceClient?: boolean;
+};
+
+type SyncSafetyContext = {
+  sourceDatabaseUrl: string;
+  targetDatabaseUrl: string;
+  sourceDatabaseName: string;
+  targetDatabaseName: string;
+};
+
+function resolvePositiveInt(value: unknown, fallback: number): number {
+  const parsed = Math.trunc(Number(value));
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return parsed;
+}
+
+function normalizeConnectionUrl(input: string): string {
+  return input.trim().replace(/\/+$/, "");
+}
+
+function chunkRows<T>(rows: T[], batchSize: number): T[][] {
+  const chunks: T[][] = [];
+  for (let index = 0; index < rows.length; index += batchSize) {
+    chunks.push(rows.slice(index, index + batchSize));
+  }
+  return chunks;
+}
+
+/** Purpose: sync a fixed runtime-table allowlist from prod(source) to staging(target) with full overwrite semantics. */
+export class MirrorSyncService {
+  private readonly env: NodeJS.ProcessEnv;
+  private readonly logger: MirrorSyncLogger;
+  private readonly targetClient: MirrorSyncTargetClient;
+  private readonly createSourceClient: (
+    sourceDatabaseUrl: string,
+  ) => MirrorSyncSourceClient | Promise<MirrorSyncSourceClient>;
+  private readonly disconnectSourceClient: boolean;
+  private readonly batchSize: number;
+  private readonly transactionMaxWaitMs: number;
+  private readonly transactionTimeoutMs: number;
+
+  constructor(options: MirrorSyncServiceOptions = {}) {
+    this.env = options.env ?? process.env;
+    this.logger = options.logger ?? console;
+    this.targetClient =
+      options.targetClient ?? (prisma as unknown as MirrorSyncTargetClient);
+    this.createSourceClient =
+      options.createSourceClient ??
+      ((sourceDatabaseUrl) =>
+        new PrismaClient({
+          datasources: { db: { url: sourceDatabaseUrl } },
+        }) as unknown as MirrorSyncSourceClient);
+    this.disconnectSourceClient = options.disconnectSourceClient ?? true;
+    this.batchSize = resolvePositiveInt(this.env.MIRROR_SYNC_BATCH_SIZE, 500);
+    this.transactionMaxWaitMs = resolvePositiveInt(
+      this.env.MIRROR_SYNC_TRANSACTION_MAX_WAIT_MS,
+      30_000,
+    );
+    this.transactionTimeoutMs = resolvePositiveInt(
+      this.env.MIRROR_SYNC_TRANSACTION_TIMEOUT_MS,
+      600_000,
+    );
+  }
+
+  /** Purpose: run one full prod->staging mirror sync for allowlisted runtime tables. */
+  async syncNow(trigger: MirrorSyncTrigger): Promise<MirrorSyncResult> {
+    const startedAt = Date.now();
+    const safety = this.resolveAndAssertSafety();
+    this.logger.info(
+      `[mirror-sync] event=${trigger}_started source_db=${safety.sourceDatabaseName} target_db=${safety.targetDatabaseName} tables=${MIRRORED_RUNTIME_TABLES.join(",")}`,
+    );
+
+    let sourceClient: MirrorSyncSourceClient | null = null;
+    try {
+      sourceClient = await this.createSourceClient(safety.sourceDatabaseUrl);
+      await this.assertSchemaCompatibility(sourceClient);
+
+      const sourceRows = await this.readAllSourceRows(sourceClient);
+      const tableSummaries = await this.targetClient.$transaction(
+        async (tx) => {
+          const summaries: MirrorSyncTableSummary[] = [];
+          for (const table of MIRRORED_RUNTIME_TABLES) {
+            const summary = await this.replaceTableRows(
+              tx,
+              table,
+              sourceRows[table],
+            );
+            summaries.push(summary);
+          }
+          await this.resetAutoIncrementSequences(tx);
+          return summaries;
+        },
+        {
+          maxWait: this.transactionMaxWaitMs,
+          timeout: this.transactionTimeoutMs,
+        },
+      );
+
+      const durationMs = Date.now() - startedAt;
+      const summaryText = tableSummaries
+        .map(
+          (row) =>
+            `${row.table}:src=${row.sourceRows},del=${row.deletedRows},ins=${row.insertedRows}`,
+        )
+        .join("|");
+      this.logger.info(
+        `[mirror-sync] event=${trigger}_completed source_db=${safety.sourceDatabaseName} target_db=${safety.targetDatabaseName} duration_ms=${durationMs} summary=${summaryText}`,
+      );
+      return {
+        trigger,
+        sourceDatabase: safety.sourceDatabaseName,
+        targetDatabase: safety.targetDatabaseName,
+        durationMs,
+        tableSummaries,
+      };
+    } catch (error) {
+      const durationMs = Date.now() - startedAt;
+      this.logger.error(
+        `[mirror-sync] event=${trigger}_failed duration_ms=${durationMs} reason=${formatError(error)}`,
+      );
+      throw error;
+    } finally {
+      if (sourceClient && this.disconnectSourceClient && sourceClient.$disconnect) {
+        await sourceClient.$disconnect().catch(() => undefined);
+      }
+    }
+  }
+
+  private resolveAndAssertSafety(): SyncSafetyContext {
+    const mode = resolvePollingMode(this.env);
+    if (!isMirrorPollingMode(this.env)) {
+      this.logger.warn(
+        `[mirror-sync] event=safety_block reason=mode_not_mirror mode=${mode}`,
+      );
+      throw new Error("Mirror sync is only allowed when POLLING_MODE=mirror.");
+    }
+
+    const runtimeEnvironment = resolveRuntimeEnvironment(this.env);
+    if (runtimeEnvironment === "prod") {
+      this.logger.warn(
+        `[mirror-sync] event=safety_block reason=runtime_env_prod mode=${mode}`,
+      );
+      throw new Error("Mirror sync is blocked in production runtime environment.");
+    }
+
+    const sourceDatabaseUrl = String(this.env.MIRROR_SOURCE_DATABASE_URL ?? "").trim();
+    if (!sourceDatabaseUrl) {
+      throw new Error("Missing MIRROR_SOURCE_DATABASE_URL for mirror sync.");
+    }
+    const targetDatabaseUrl = String(this.env.DATABASE_URL ?? "").trim();
+    if (!targetDatabaseUrl) {
+      throw new Error("Missing DATABASE_URL for mirror sync target.");
+    }
+
+    const normalizedSourceUrl = normalizeConnectionUrl(sourceDatabaseUrl);
+    const normalizedTargetUrl = normalizeConnectionUrl(targetDatabaseUrl);
+    if (normalizedSourceUrl === normalizedTargetUrl) {
+      this.logger.warn(
+        "[mirror-sync] event=safety_block reason=source_equals_target",
+      );
+      throw new Error("Mirror sync source and target database URLs must be different.");
+    }
+
+    const sourceDatabaseName = resolveDatabaseNameFromUrlForLog(sourceDatabaseUrl);
+    const targetDatabaseName = resolveDatabaseNameFromUrlForLog(targetDatabaseUrl);
+    const targetLooksNonProd = /(staging|stage|stg|test|dev)/i.test(targetDatabaseName);
+    if (runtimeEnvironment === "unknown" && !targetLooksNonProd) {
+      this.logger.warn(
+        `[mirror-sync] event=safety_block reason=target_env_ambiguous target_db=${targetDatabaseName}`,
+      );
+      throw new Error(
+        "Mirror sync target environment is ambiguous. Set POLLING_ENV=staging (or DEPLOY_ENV=staging) to proceed.",
+      );
+    }
+
+    return {
+      sourceDatabaseUrl,
+      targetDatabaseUrl,
+      sourceDatabaseName,
+      targetDatabaseName,
+    };
+  }
+
+  private async assertSchemaCompatibility(
+    sourceClient: MirrorSyncSourceClient,
+  ): Promise<void> {
+    for (const table of MIRRORED_RUNTIME_TABLES) {
+      const sourceColumns = await this.readTableColumns(sourceClient, table);
+      const targetColumns = await this.readTableColumns(this.targetClient, table);
+
+      if (sourceColumns.length <= 0 || targetColumns.length <= 0) {
+        throw new Error(
+          `Schema compatibility check failed for ${table}: table missing on source or target.`,
+        );
+      }
+
+      const sourceByName = new Map(sourceColumns.map((column) => [column.column_name, column]));
+      const targetByName = new Map(targetColumns.map((column) => [column.column_name, column]));
+
+      for (const sourceColumn of sourceColumns) {
+        const targetColumn = targetByName.get(sourceColumn.column_name);
+        if (!targetColumn) {
+          throw new Error(
+            `Schema compatibility check failed for ${table}: target missing column ${sourceColumn.column_name}.`,
+          );
+        }
+        if (targetColumn.udt_name !== sourceColumn.udt_name) {
+          throw new Error(
+            `Schema compatibility check failed for ${table}: column ${sourceColumn.column_name} type mismatch source=${sourceColumn.udt_name} target=${targetColumn.udt_name}.`,
+          );
+        }
+      }
+
+      const requiredTargetColumnsMissingFromSource = targetColumns.filter((column) => {
+        if (sourceByName.has(column.column_name)) return false;
+        const hasDefault = String(column.column_default ?? "").trim().length > 0;
+        return column.is_nullable === "NO" && !hasDefault;
+      });
+      if (requiredTargetColumnsMissingFromSource.length > 0) {
+        throw new Error(
+          `Schema compatibility check failed for ${table}: source missing required target columns ${requiredTargetColumnsMissingFromSource
+            .map((column) => column.column_name)
+            .join(", ")}.`,
+        );
+      }
+    }
+  }
+
+  private async readTableColumns(
+    client: Pick<MirrorSyncSourceClient, "$queryRawUnsafe">,
+    table: MirrorTableName,
+  ): Promise<MirrorSyncColumnRow[]> {
+    return client.$queryRawUnsafe<MirrorSyncColumnRow[]>(
+      `
+        SELECT
+          column_name,
+          udt_name,
+          is_nullable,
+          column_default
+        FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = $1
+        ORDER BY ordinal_position ASC
+      `,
+      table,
+    );
+  }
+
+  private async readAllSourceRows(sourceClient: MirrorSyncSourceClient): Promise<{
+    TrackedClan: TrackedClan[];
+    CurrentWar: CurrentWar[];
+    WarAttacks: WarAttacks[];
+    ClanPointsSync: ClanPointsSync[];
+    ClanWarHistory: ClanWarHistory[];
+    ClanWarParticipation: ClanWarParticipation[];
+    WarLookup: WarLookup[];
+  }> {
+    return {
+      TrackedClan: await sourceClient.trackedClan.findMany({
+        orderBy: [{ id: "asc" }],
+      }),
+      CurrentWar: await sourceClient.currentWar.findMany({
+        orderBy: [{ clanTag: "asc" }, { guildId: "asc" }],
+      }),
+      WarAttacks: await sourceClient.warAttacks.findMany({
+        orderBy: [{ warId: "asc" }, { playerTag: "asc" }, { attackNumber: "asc" }],
+      }),
+      ClanPointsSync: await sourceClient.clanPointsSync.findMany({
+        orderBy: [{ guildId: "asc" }, { clanTag: "asc" }, { warStartTime: "asc" }],
+      }),
+      ClanWarHistory: await sourceClient.clanWarHistory.findMany({
+        orderBy: [{ warId: "asc" }],
+      }),
+      ClanWarParticipation: await sourceClient.clanWarParticipation.findMany({
+        orderBy: [{ guildId: "asc" }, { warId: "asc" }, { playerTag: "asc" }],
+      }),
+      WarLookup: await sourceClient.warLookup.findMany({
+        orderBy: [{ warId: "asc" }],
+      }),
+    };
+  }
+
+  private async replaceTableRows(
+    tx: MirrorSyncTargetClient,
+    table: MirrorTableName,
+    rows:
+      | TrackedClan[]
+      | CurrentWar[]
+      | WarAttacks[]
+      | ClanPointsSync[]
+      | ClanWarHistory[]
+      | ClanWarParticipation[]
+      | WarLookup[],
+  ): Promise<MirrorSyncTableSummary> {
+    if (table === "TrackedClan") {
+      const deletedRows = (await tx.trackedClan.deleteMany()).count;
+      const insertedRows = await this.insertBatches(rows as TrackedClan[], (batch) =>
+        tx.trackedClan.createMany({ data: batch }),
+      );
+      return { table, sourceRows: rows.length, deletedRows, insertedRows };
+    }
+
+    if (table === "CurrentWar") {
+      const deletedRows = (await tx.currentWar.deleteMany()).count;
+      const insertedRows = await this.insertBatches(rows as CurrentWar[], (batch) =>
+        tx.currentWar.createMany({ data: batch }),
+      );
+      return { table, sourceRows: rows.length, deletedRows, insertedRows };
+    }
+
+    if (table === "WarAttacks") {
+      const deletedRows = (await tx.warAttacks.deleteMany()).count;
+      const insertedRows = await this.insertBatches(rows as WarAttacks[], (batch) =>
+        tx.warAttacks.createMany({ data: batch }),
+      );
+      return { table, sourceRows: rows.length, deletedRows, insertedRows };
+    }
+
+    if (table === "ClanPointsSync") {
+      const deletedRows = (await tx.clanPointsSync.deleteMany()).count;
+      const insertedRows = await this.insertBatches(rows as ClanPointsSync[], (batch) =>
+        tx.clanPointsSync.createMany({ data: batch }),
+      );
+      return { table, sourceRows: rows.length, deletedRows, insertedRows };
+    }
+
+    if (table === "ClanWarHistory") {
+      const deletedRows = (await tx.clanWarHistory.deleteMany()).count;
+      const insertedRows = await this.insertBatches(rows as ClanWarHistory[], (batch) =>
+        tx.clanWarHistory.createMany({ data: batch }),
+      );
+      return { table, sourceRows: rows.length, deletedRows, insertedRows };
+    }
+
+    if (table === "ClanWarParticipation") {
+      const deletedRows = (await tx.clanWarParticipation.deleteMany()).count;
+      const insertedRows = await this.insertBatches(
+        rows as ClanWarParticipation[],
+        (batch) => tx.clanWarParticipation.createMany({ data: batch }),
+      );
+      return { table, sourceRows: rows.length, deletedRows, insertedRows };
+    }
+
+    const deletedRows = (await tx.warLookup.deleteMany()).count;
+    const insertedRows = await this.insertBatches(rows as WarLookup[], (batch) =>
+      tx.warLookup.createMany({ data: batch }),
+    );
+    return { table, sourceRows: rows.length, deletedRows, insertedRows };
+  }
+
+  private async insertBatches<T>(
+    rows: T[],
+    writeBatch: (batch: T[]) => Promise<CreateManyResult>,
+  ): Promise<number> {
+    if (rows.length <= 0) return 0;
+    let insertedRows = 0;
+    for (const batch of chunkRows(rows, this.batchSize)) {
+      const result = await writeBatch(batch);
+      insertedRows += Number(result.count ?? 0);
+    }
+    return insertedRows;
+  }
+
+  private async resetAutoIncrementSequences(tx: MirrorSyncTargetClient): Promise<void> {
+    await tx.$executeRawUnsafe(`
+      SELECT setval(
+        pg_get_serial_sequence('"TrackedClan"', 'id'),
+        COALESCE((SELECT MAX("id") FROM "TrackedClan"), 1),
+        COALESCE((SELECT MAX("id") FROM "TrackedClan"), 0) > 0
+      );
+    `);
+    await tx.$executeRawUnsafe(`
+      SELECT setval(
+        pg_get_serial_sequence('"ClanWarHistory"', 'warId'),
+        COALESCE((SELECT MAX("warId") FROM "ClanWarHistory"), 1),
+        COALESCE((SELECT MAX("warId") FROM "ClanWarHistory"), 0) > 0
+      );
+    `);
+  }
+}
+

--- a/src/services/PollingModeService.ts
+++ b/src/services/PollingModeService.ts
@@ -1,0 +1,79 @@
+export type PollingMode = "active" | "mirror";
+export type RuntimeEnvironment = "prod" | "staging" | "dev" | "unknown";
+
+const DEFAULT_MIRROR_SYNC_INTERVAL_MINUTES = 15;
+const MIN_MIRROR_SYNC_INTERVAL_MINUTES = 1;
+
+/** Purpose: normalize polling mode env input into one stable runtime mode. */
+export function resolvePollingMode(
+  env: NodeJS.ProcessEnv = process.env,
+): PollingMode {
+  const raw = String(env.POLLING_MODE ?? "active")
+    .trim()
+    .toLowerCase();
+  return raw === "mirror" ? "mirror" : "active";
+}
+
+/** Purpose: expose explicit active-poller ownership check used by startup schedulers. */
+export function isActivePollingMode(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return resolvePollingMode(env) === "active";
+}
+
+/** Purpose: expose explicit mirror-mode ownership check used by sync schedulers/services. */
+export function isMirrorPollingMode(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return resolvePollingMode(env) === "mirror";
+}
+
+/** Purpose: resolve mirror-sync interval with a guarded minimum to avoid tight-loop retries. */
+export function resolveMirrorSyncIntervalMsFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): number {
+  const parsedMinutes = Number(env.MIRROR_SYNC_INTERVAL_MINUTES);
+  const minutes = Number.isFinite(parsedMinutes)
+    ? Math.max(MIN_MIRROR_SYNC_INTERVAL_MINUTES, Math.trunc(parsedMinutes))
+    : DEFAULT_MIRROR_SYNC_INTERVAL_MINUTES;
+  return minutes * 60 * 1000;
+}
+
+/** Purpose: normalize runtime environment labels for mirror safety checks and observability. */
+export function resolveRuntimeEnvironment(
+  env: NodeJS.ProcessEnv = process.env,
+): RuntimeEnvironment {
+  const candidates = [
+    env.POLLING_ENV,
+    env.DEPLOY_ENV,
+    env.APP_ENV,
+    env.ENVIRONMENT,
+    env.NODE_ENV,
+  ];
+  for (const candidate of candidates) {
+    const normalized = String(candidate ?? "")
+      .trim()
+      .toLowerCase();
+    if (!normalized) continue;
+    if (["prod", "production", "live"].includes(normalized)) return "prod";
+    if (["staging", "stage", "stg", "preprod", "pre-prod"].includes(normalized)) {
+      return "staging";
+    }
+    if (["dev", "development", "local", "test"].includes(normalized)) return "dev";
+  }
+  return "unknown";
+}
+
+/** Purpose: parse postgres connection URLs into sanitized DB names for structured logs only. */
+export function resolveDatabaseNameFromUrlForLog(url: string | null): string {
+  const raw = String(url ?? "").trim();
+  if (!raw) return "unknown";
+  try {
+    const parsed = new URL(raw);
+    const pathname = parsed.pathname.replace(/^\/+/, "");
+    return pathname ? decodeURIComponent(pathname) : "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+

--- a/src/services/SheetRefreshService.ts
+++ b/src/services/SheetRefreshService.ts
@@ -1,6 +1,7 @@
 import axios from "axios";
 import { formatError } from "../helper/formatError";
 import { recordFetchEvent } from "../helper/fetchTelemetry";
+import { isMirrorPollingMode } from "./PollingModeService";
 
 export type SheetRefreshMode = "actual" | "war";
 type SheetRefreshAction = "refreshMembers" | "refreshWar";
@@ -9,7 +10,11 @@ const SHEET_REFRESH_COOLDOWN_MS = 5 * 60 * 1000;
 const SHEET_REFRESH_TIMEOUT_MS = 120000;
 const lastRefreshAtMsByGuild = new Map<string, number>();
 
-type SheetRefreshFlowErrorCode = "INVALID_MODE" | "COOLDOWN_ACTIVE" | "MISSING_WEBHOOK_URL";
+type SheetRefreshFlowErrorCode =
+  | "INVALID_MODE"
+  | "COOLDOWN_ACTIVE"
+  | "MISSING_WEBHOOK_URL"
+  | "MIRROR_MODE_DISABLED";
 
 export class SheetRefreshFlowError extends Error {
   readonly code: SheetRefreshFlowErrorCode;
@@ -82,6 +87,9 @@ async function postRefreshWebhook(
 
 export function mapSheetRefreshFlowErrorToMessage(err: SheetRefreshFlowError): string {
   if (err.code === "INVALID_MODE") return "Invalid mode. Use actual or war.";
+  if (err.code === "MIRROR_MODE_DISABLED") {
+    return "Sheet refresh is disabled while POLLING_MODE=mirror.";
+  }
   if (err.code === "MISSING_WEBHOOK_URL") return "Missing GS_WEBHOOK_URL.";
   if (err.code === "COOLDOWN_ACTIVE" && err.retryAtEpochSeconds) {
     return `Refresh cooldown active. Try again <t:${err.retryAtEpochSeconds}:R>.`;
@@ -113,6 +121,16 @@ export async function triggerSharedSheetRefresh(input: {
   guildId: string | null | undefined;
   mode: SheetRefreshMode;
 }): Promise<{ mode: SheetRefreshMode; resultText: string; durationSeconds: string }> {
+  if (isMirrorPollingMode(process.env)) {
+    console.warn(
+      `[sheet-refresh] event=skipped reason=mirror_mode guild=${input.guildId ?? "dm"}`,
+    );
+    throw new SheetRefreshFlowError(
+      "MIRROR_MODE_DISABLED",
+      "sheet refresh disabled in mirror mode",
+    );
+  }
+
   const mode = input.mode;
   if (mode !== "actual" && mode !== "war") {
     throw new SheetRefreshFlowError("INVALID_MODE", "invalid mode");

--- a/tests/mirrorSync.service.test.ts
+++ b/tests/mirrorSync.service.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, it, vi } from "vitest";
+import { MIRRORED_RUNTIME_TABLES, MirrorSyncService } from "../src/services/MirrorSyncService";
+
+type MirrorTableDataStore = Record<
+  (typeof MIRRORED_RUNTIME_TABLES)[number],
+  Array<Record<string, unknown>>
+>;
+
+type ColumnRow = {
+  column_name: string;
+  udt_name: string;
+  is_nullable: "YES" | "NO";
+  column_default: string | null;
+};
+
+function makeDefaultTableStore(): MirrorTableDataStore {
+  return {
+    TrackedClan: [{ id: 1, tag: "#AAA111", createdAt: new Date("2026-04-01T00:00:00.000Z") }],
+    CurrentWar: [{ guildId: "g1", clanTag: "#AAA111", channelId: "c1", notify: true }],
+    WarAttacks: [{ warId: 1, playerTag: "#P1", attackNumber: 1 }],
+    ClanPointsSync: [{ id: "ps1", guildId: "g1", clanTag: "#AAA111", syncNum: 42 }],
+    ClanWarHistory: [{ warId: 1, clanTag: "#AAA111", warStartTime: new Date("2026-03-30T00:00:00.000Z") }],
+    ClanWarParticipation: [{ id: "p1", guildId: "g1", warId: "1", clanTag: "#AAA111", playerTag: "#P1" }],
+    WarLookup: [{ warId: "1", clanTag: "#AAA111", startTime: new Date("2026-03-30T00:00:00.000Z"), payload: {} }],
+  };
+}
+
+function makeSchemaColumns(
+  override?: Partial<Record<(typeof MIRRORED_RUNTIME_TABLES)[number], ColumnRow[]>>,
+): Record<(typeof MIRRORED_RUNTIME_TABLES)[number], ColumnRow[]> {
+  const defaults = Object.fromEntries(
+    MIRRORED_RUNTIME_TABLES.map((table) => [
+      table,
+      [
+        {
+          column_name: "id",
+          udt_name: "text",
+          is_nullable: "NO" as const,
+          column_default: null,
+        },
+      ],
+    ]),
+  ) as Record<(typeof MIRRORED_RUNTIME_TABLES)[number], ColumnRow[]>;
+  return {
+    ...defaults,
+    ...(override ?? {}),
+  };
+}
+
+function cloneRows(rows: Array<Record<string, unknown>>): Array<Record<string, unknown>> {
+  return rows.map((row) => ({ ...row }));
+}
+
+function buildSourceClient(
+  store: MirrorTableDataStore,
+  schemaColumns: Record<(typeof MIRRORED_RUNTIME_TABLES)[number], ColumnRow[]>,
+) {
+  const disconnect = vi.fn(async () => undefined);
+  return {
+    trackedClan: {
+      findMany: vi.fn(async () => cloneRows(store.TrackedClan)),
+    },
+    currentWar: {
+      findMany: vi.fn(async () => cloneRows(store.CurrentWar)),
+    },
+    warAttacks: {
+      findMany: vi.fn(async () => cloneRows(store.WarAttacks)),
+    },
+    clanPointsSync: {
+      findMany: vi.fn(async () => cloneRows(store.ClanPointsSync)),
+    },
+    clanWarHistory: {
+      findMany: vi.fn(async () => cloneRows(store.ClanWarHistory)),
+    },
+    clanWarParticipation: {
+      findMany: vi.fn(async () => cloneRows(store.ClanWarParticipation)),
+    },
+    warLookup: {
+      findMany: vi.fn(async () => cloneRows(store.WarLookup)),
+    },
+    $queryRawUnsafe: vi.fn(
+      async (_query: string, table: (typeof MIRRORED_RUNTIME_TABLES)[number]) =>
+        schemaColumns[table] ?? [],
+    ),
+    $disconnect: disconnect,
+  };
+}
+
+function buildTargetClient(
+  store: MirrorTableDataStore,
+  schemaColumns: Record<(typeof MIRRORED_RUNTIME_TABLES)[number], ColumnRow[]>,
+) {
+  const deleteMany = (table: (typeof MIRRORED_RUNTIME_TABLES)[number]) =>
+    vi.fn(async () => {
+      const count = store[table].length;
+      store[table] = [];
+      return { count };
+    });
+  const createMany = (table: (typeof MIRRORED_RUNTIME_TABLES)[number]) =>
+    vi.fn(async (args: { data: Array<Record<string, unknown>> }) => {
+      store[table].push(...cloneRows(args.data));
+      return { count: args.data.length };
+    });
+
+  const tx = {
+    trackedClan: { deleteMany: deleteMany("TrackedClan"), createMany: createMany("TrackedClan") },
+    currentWar: { deleteMany: deleteMany("CurrentWar"), createMany: createMany("CurrentWar") },
+    warAttacks: { deleteMany: deleteMany("WarAttacks"), createMany: createMany("WarAttacks") },
+    clanPointsSync: {
+      deleteMany: deleteMany("ClanPointsSync"),
+      createMany: createMany("ClanPointsSync"),
+    },
+    clanWarHistory: {
+      deleteMany: deleteMany("ClanWarHistory"),
+      createMany: createMany("ClanWarHistory"),
+    },
+    clanWarParticipation: {
+      deleteMany: deleteMany("ClanWarParticipation"),
+      createMany: createMany("ClanWarParticipation"),
+    },
+    warLookup: { deleteMany: deleteMany("WarLookup"), createMany: createMany("WarLookup") },
+    $queryRawUnsafe: vi.fn(
+      async (_query: string, table: (typeof MIRRORED_RUNTIME_TABLES)[number]) =>
+        schemaColumns[table] ?? [],
+    ),
+    $executeRawUnsafe: vi.fn(async () => 1),
+  };
+
+  return {
+    ...tx,
+    $transaction: vi.fn(async (fn: (client: typeof tx) => Promise<unknown>) => fn(tx)),
+    __tx: tx,
+  };
+}
+
+describe("MirrorSyncService", () => {
+  it("runs full-overwrite sync for only the allowlisted runtime tables", async () => {
+    const sourceStore = makeDefaultTableStore();
+    const targetStore = makeDefaultTableStore();
+    targetStore.TrackedClan = [{ id: 99, tag: "#OLD" }];
+    const schemaColumns = makeSchemaColumns();
+    const sourceClient = buildSourceClient(sourceStore, schemaColumns);
+    const targetClient = buildTargetClient(targetStore, schemaColumns);
+    const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() };
+
+    const service = new MirrorSyncService({
+      env: {
+        POLLING_MODE: "mirror",
+        POLLING_ENV: "staging",
+        MIRROR_SOURCE_DATABASE_URL:
+          "postgresql://src:pass@127.0.0.1:5432/clashcookies?schema=public",
+        DATABASE_URL:
+          "postgresql://dst:pass@127.0.0.1:5432/clashcookies_staging?schema=public",
+        MIRROR_SYNC_BATCH_SIZE: "2",
+      } as NodeJS.ProcessEnv,
+      logger,
+      targetClient: targetClient as any,
+      createSourceClient: () => sourceClient as any,
+    });
+
+    const result = await service.syncNow("manual");
+
+    expect(result.trigger).toBe("manual");
+    expect(result.tableSummaries).toHaveLength(MIRRORED_RUNTIME_TABLES.length);
+    expect(targetStore.TrackedClan).toEqual(sourceStore.TrackedClan);
+    expect(targetStore.CurrentWar).toEqual(sourceStore.CurrentWar);
+    expect(targetStore.WarAttacks).toEqual(sourceStore.WarAttacks);
+    expect(targetStore.ClanPointsSync).toEqual(sourceStore.ClanPointsSync);
+    expect(targetStore.ClanWarHistory).toEqual(sourceStore.ClanWarHistory);
+    expect(targetStore.ClanWarParticipation).toEqual(sourceStore.ClanWarParticipation);
+    expect(targetStore.WarLookup).toEqual(sourceStore.WarLookup);
+    expect(targetClient.$executeRawUnsafe).toHaveBeenCalledTimes(2);
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining("[mirror-sync] event=manual_completed"),
+    );
+  });
+
+  it("blocks execution when polling mode is not mirror", async () => {
+    const service = new MirrorSyncService({
+      env: {
+        POLLING_MODE: "active",
+        POLLING_ENV: "staging",
+        MIRROR_SOURCE_DATABASE_URL:
+          "postgresql://src:pass@127.0.0.1:5432/clashcookies?schema=public",
+        DATABASE_URL:
+          "postgresql://dst:pass@127.0.0.1:5432/clashcookies_staging?schema=public",
+      } as NodeJS.ProcessEnv,
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    });
+
+    await expect(service.syncNow("manual")).rejects.toThrow(
+      "Mirror sync is only allowed when POLLING_MODE=mirror.",
+    );
+  });
+
+  it("blocks mirror sync when runtime environment resolves to prod", async () => {
+    const service = new MirrorSyncService({
+      env: {
+        POLLING_MODE: "mirror",
+        POLLING_ENV: "prod",
+        MIRROR_SOURCE_DATABASE_URL:
+          "postgresql://src:pass@127.0.0.1:5432/clashcookies?schema=public",
+        DATABASE_URL:
+          "postgresql://dst:pass@127.0.0.1:5432/clashcookies_staging?schema=public",
+      } as NodeJS.ProcessEnv,
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    });
+
+    await expect(service.syncNow("scheduled")).rejects.toThrow(
+      "Mirror sync is blocked in production runtime environment.",
+    );
+  });
+
+  it("fails fast on schema incompatibility before table overwrite begins", async () => {
+    const sourceStore = makeDefaultTableStore();
+    const targetStore = makeDefaultTableStore();
+    const sourceSchema = makeSchemaColumns();
+    const targetSchema = makeSchemaColumns({
+      CurrentWar: [
+        {
+          column_name: "id",
+          udt_name: "int4",
+          is_nullable: "NO",
+          column_default: null,
+        },
+      ],
+    });
+    const sourceClient = buildSourceClient(sourceStore, sourceSchema);
+    const targetClient = buildTargetClient(targetStore, targetSchema);
+
+    const service = new MirrorSyncService({
+      env: {
+        POLLING_MODE: "mirror",
+        POLLING_ENV: "staging",
+        MIRROR_SOURCE_DATABASE_URL:
+          "postgresql://src:pass@127.0.0.1:5432/clashcookies?schema=public",
+        DATABASE_URL:
+          "postgresql://dst:pass@127.0.0.1:5432/clashcookies_staging?schema=public",
+      } as NodeJS.ProcessEnv,
+      logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+      targetClient: targetClient as any,
+      createSourceClient: () => sourceClient as any,
+    });
+
+    await expect(service.syncNow("scheduled")).rejects.toThrow(
+      "Schema compatibility check failed for CurrentWar",
+    );
+    expect(targetClient.$transaction).not.toHaveBeenCalled();
+    expect(targetClient.__tx.currentWar.deleteMany).not.toHaveBeenCalled();
+  });
+});

--- a/tests/pollingMode.service.test.ts
+++ b/tests/pollingMode.service.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+import {
+  isActivePollingMode,
+  isMirrorPollingMode,
+  resolveDatabaseNameFromUrlForLog,
+  resolveMirrorSyncIntervalMsFromEnv,
+  resolvePollingMode,
+  resolveRuntimeEnvironment,
+} from "../src/services/PollingModeService";
+
+describe("PollingModeService", () => {
+  it("defaults to active mode and only enables mirror when explicitly configured", () => {
+    expect(resolvePollingMode({} as NodeJS.ProcessEnv)).toBe("active");
+    expect(resolvePollingMode({ POLLING_MODE: "mirror" } as NodeJS.ProcessEnv)).toBe(
+      "mirror",
+    );
+    expect(resolvePollingMode({ POLLING_MODE: "unexpected" } as NodeJS.ProcessEnv)).toBe(
+      "active",
+    );
+    expect(isActivePollingMode({ POLLING_MODE: "active" } as NodeJS.ProcessEnv)).toBe(
+      true,
+    );
+    expect(isMirrorPollingMode({ POLLING_MODE: "mirror" } as NodeJS.ProcessEnv)).toBe(
+      true,
+    );
+  });
+
+  it("resolves mirror sync interval with sane defaults and minimum clamp", () => {
+    expect(resolveMirrorSyncIntervalMsFromEnv({} as NodeJS.ProcessEnv)).toBe(
+      15 * 60 * 1000,
+    );
+    expect(
+      resolveMirrorSyncIntervalMsFromEnv({
+        MIRROR_SYNC_INTERVAL_MINUTES: "30",
+      } as NodeJS.ProcessEnv),
+    ).toBe(30 * 60 * 1000);
+    expect(
+      resolveMirrorSyncIntervalMsFromEnv({
+        MIRROR_SYNC_INTERVAL_MINUTES: "0",
+      } as NodeJS.ProcessEnv),
+    ).toBe(60 * 1000);
+  });
+
+  it("normalizes runtime environment labels and database names for safety checks/logs", () => {
+    expect(
+      resolveRuntimeEnvironment({ POLLING_ENV: "production" } as NodeJS.ProcessEnv),
+    ).toBe("prod");
+    expect(
+      resolveRuntimeEnvironment({ DEPLOY_ENV: "staging" } as NodeJS.ProcessEnv),
+    ).toBe("staging");
+    expect(resolveRuntimeEnvironment({ NODE_ENV: "development" } as NodeJS.ProcessEnv)).toBe(
+      "dev",
+    );
+    expect(resolveRuntimeEnvironment({} as NodeJS.ProcessEnv)).toBe("unknown");
+
+    expect(
+      resolveDatabaseNameFromUrlForLog(
+        "postgresql://user:pass@127.0.0.1:5432/clashcookies_staging?schema=public",
+      ),
+    ).toBe("clashcookies_staging");
+    expect(resolveDatabaseNameFromUrlForLog("not-a-url")).toBe("unknown");
+  });
+});
+

--- a/tests/sheetRefresh.service.test.ts
+++ b/tests/sheetRefresh.service.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  SheetRefreshFlowError,
+  mapSheetRefreshFlowErrorToMessage,
+  triggerSharedSheetRefresh,
+} from "../src/services/SheetRefreshService";
+
+const originalPollingMode = process.env.POLLING_MODE;
+
+describe("SheetRefreshService mirror-mode guard", () => {
+  afterEach(() => {
+    process.env.POLLING_MODE = originalPollingMode;
+  });
+
+  it("blocks shared sheet refresh calls while polling mode is mirror", async () => {
+    process.env.POLLING_MODE = "mirror";
+    await expect(
+      triggerSharedSheetRefresh({
+        guildId: "guild-1",
+        mode: "actual",
+      }),
+    ).rejects.toMatchObject({
+      name: "SheetRefreshFlowError",
+      code: "MIRROR_MODE_DISABLED",
+    } satisfies Partial<SheetRefreshFlowError>);
+  });
+
+  it("maps mirror-mode guard error to a clear user-facing message", () => {
+    const err = new SheetRefreshFlowError(
+      "MIRROR_MODE_DISABLED",
+      "sheet refresh disabled in mirror mode",
+    );
+    expect(mapSheetRefreshFlowErrorToMessage(err)).toContain(
+      "disabled while POLLING_MODE=mirror",
+    );
+  });
+});
+


### PR DESCRIPTION
- add POLLING_MODE active|mirror gating for startup pollers and mirror scheduler startup
- add guarded full-overwrite MirrorSyncService + manual npm run sync:mirror path for allowlisted runtime tables
- block sheet refresh in mirror mode and update docs/tests for mirror safety and sync behavior