### PR TITLE
fix(reminders): defer create save ack and quiet dedupe logs

### DIFF
--- a/src/commands/Reminders.ts
+++ b/src/commands/Reminders.ts
@@ -42,6 +42,26 @@ function hasSelectedReminderChannel(channelId: string): boolean {
   return /^\d+$/.test(String(channelId ?? "").trim());
 }
 
+/** Purpose: send one ephemeral component message safely before or after a deferred component ack. */
+async function sendComponentEphemeralMessage(
+  component:
+    | ButtonInteraction
+    | StringSelectMenuInteraction,
+  content: string,
+): Promise<void> {
+  if (component.deferred || component.replied) {
+    await component.followUp({
+      ephemeral: true,
+      content,
+    });
+    return;
+  }
+  await component.reply({
+    ephemeral: true,
+    content,
+  });
+}
+
 /** Purpose: format reminder offsets for compact human-readable embed/list sections. */
 function formatOffsetList(offsetsSeconds: number[]): string {
   if (offsetsSeconds.length <= 0) return "not set";
@@ -353,39 +373,39 @@ async function openReminderPanel(input: {
         input.mode === REMINDER_CREATE_MODE &&
         component.customId === `reminders:save:${input.reminderId}`
       ) {
+        await component.deferUpdate();
         reminder = await reminderService.getReminderWithDetails({
           reminderId: input.reminderId,
           guildId: input.interaction.guildId!,
         });
         if (!hasSelectedReminderType(reminder.type)) {
-          await component.reply({
-            ephemeral: true,
-            content: "Select a reminder type before saving this reminder.",
-          });
+          await sendComponentEphemeralMessage(
+            component,
+            "Select a reminder type before saving this reminder.",
+          );
           return;
         }
         if (reminder.offsetsSeconds.length <= 0) {
-          await component.reply({
-            ephemeral: true,
-            content: "Select at least one reminder time before saving this reminder.",
-          });
+          await sendComponentEphemeralMessage(
+            component,
+            "Select at least one reminder time before saving this reminder.",
+          );
           return;
         }
         if (!hasSelectedReminderChannel(reminder.channelId)) {
-          await component.reply({
-            ephemeral: true,
-            content: "Set a reminder channel before saving this reminder.",
-          });
+          await sendComponentEphemeralMessage(
+            component,
+            "Set a reminder channel before saving this reminder.",
+          );
           return;
         }
         if (reminder.targets.length <= 0) {
-          await component.reply({
-            ephemeral: true,
-            content: "Select at least one clan before saving this reminder.",
-          });
+          await sendComponentEphemeralMessage(
+            component,
+            "Select at least one clan before saving this reminder.",
+          );
           return;
         }
-        await component.deferUpdate();
         await reminderService.setReminderEnabled({
           reminderId: input.reminderId,
           guildId: input.interaction.guildId!,
@@ -457,12 +477,10 @@ async function openReminderPanel(input: {
         return;
       }
       console.error(`[reminders] panel interaction failed: ${code}`);
-      if (!component.replied && !component.deferred) {
-        await component.reply({
-          ephemeral: true,
-          content: "Failed to update reminder settings.",
-        });
-      }
+      await sendComponentEphemeralMessage(
+        component,
+        "Failed to update reminder settings.",
+      );
     }
   });
 

--- a/src/services/reminders/ReminderSchedulerService.ts
+++ b/src/services/reminders/ReminderSchedulerService.ts
@@ -199,9 +199,6 @@ export async function runReminderSchedulerCycle(input: {
         });
         if (!fireLog.created) {
           deduped += 1;
-          console.log(
-            `[reminders] deduped reminder_id=${reminder.id} clan=${context.clanTag} offset_s=${offsetSeconds} identity=${context.eventIdentity}`,
-          );
           continue;
         }
 

--- a/tests/reminderScheduler.service.test.ts
+++ b/tests/reminderScheduler.service.test.ts
@@ -365,6 +365,62 @@ describe("ReminderSchedulerService v1 trigger semantics", () => {
     expect(dispatch.dispatchReminder).toHaveBeenCalledTimes(4);
   });
 
+  it("keeps deduped counts but does not emit per-item dedupe log spam by default", async () => {
+    const nowMs = Date.parse("2026-04-05T00:00:00.000Z");
+    prismaMock.reminder.findMany.mockResolvedValue([
+      {
+        id: "rem-raids",
+        guildId: "guild-1",
+        channelId: "channel-raids",
+        type: ReminderType.RAIDS,
+        isEnabled: true,
+        times: [{ offsetSeconds: 60 * 60 }],
+        targetClans: [{ clanTag: "#QGRJ2222", clanType: "FWA" }],
+      },
+    ]);
+    prismaMock.trackedClan.findMany.mockResolvedValue([{ tag: "#QGRJ2222", name: "Raid Clan 1" }]);
+    setTodoSnapshotRows({
+      timedRows: [
+        {
+          clanTag: "#QGRJ2222",
+          clanName: "Raid Clan 1",
+          cwlClanTag: null,
+          cwlClanName: null,
+          raidActive: true,
+          raidEndsAt: new Date(nowMs + 20 * 60 * 1000),
+          gamesActive: false,
+          gamesEndsAt: null,
+          updatedAt: new Date(nowMs),
+        },
+      ],
+    });
+    prismaMock.reminderFireLog.create.mockRejectedValue({ code: "P2002" });
+    const dispatch = {
+      dispatchReminder: vi.fn(),
+    };
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const counts = await runReminderSchedulerCycle({
+      client: {} as any,
+      dispatch: dispatch as any,
+      nowMs,
+      intervalMs: 60_000,
+    });
+
+    expect(counts).toEqual({
+      evaluated: 1,
+      fired: 0,
+      deduped: 1,
+      failed: 0,
+    });
+    expect(dispatch.dispatchReminder).not.toHaveBeenCalled();
+    expect(
+      logSpy.mock.calls.some(([message]) =>
+        String(message).includes("[reminders] deduped reminder_id="),
+      ),
+    ).toBe(false);
+  });
+
   it("does not duplicate sends after disable/re-enable within the same event identity", async () => {
     const nowMs = Date.parse("2026-04-05T00:00:00.000Z");
     prismaMock.reminder.findMany

--- a/tests/reminders.command.test.ts
+++ b/tests/reminders.command.test.ts
@@ -80,6 +80,40 @@ function createInteraction(input: {
   return interaction;
 }
 
+function getCollectHandler(interaction: any) {
+  return interaction.__collector.on.mock.calls.find(
+    ([eventName]: [string]) => eventName === "collect",
+  )?.[1];
+}
+
+function getEndHandler(interaction: any) {
+  return interaction.__collector.on.mock.calls.find(
+    ([eventName]: [string]) => eventName === "end",
+  )?.[1];
+}
+
+function createPanelButtonInteraction(input: {
+  customId: string;
+  userId?: string;
+}) {
+  return {
+    isButton: () => true,
+    isStringSelectMenu: () => false,
+    user: { id: input.userId ?? "user-1" },
+    customId: input.customId,
+    channelId: "channel-1",
+    deferUpdate: vi.fn().mockImplementation(async function (this: any) {
+      this.deferred = true;
+    }),
+    followUp: vi.fn().mockResolvedValue(undefined),
+    reply: vi.fn().mockImplementation(async function (this: any) {
+      this.replied = true;
+    }),
+    replied: false,
+    deferred: false,
+  } as any;
+}
+
 describe("/reminders command", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -227,9 +261,7 @@ describe("/reminders command", () => {
     const interaction = createInteraction({ subcommand: "create" });
     await Reminders.run({} as any, interaction as any, {} as any);
 
-    const collectHandler = interaction.__collector.on.mock.calls.find(
-      ([eventName]: [string]) => eventName === "collect",
-    )?.[1];
+    const collectHandler = getCollectHandler(interaction);
     expect(collectHandler).toBeTypeOf("function");
 
     const firstSelect: any = {
@@ -261,6 +293,124 @@ describe("/reminders command", () => {
       clanTag: "#PQL0289",
       actorUserId: "user-1",
     });
+  });
+
+  it("defers create save before reading reminder details and enabling the reminder", async () => {
+    reminderServiceMock.getReminderWithDetails
+      .mockResolvedValueOnce({
+        id: "reminder-1",
+        guildId: "guild-1",
+        type: ReminderType.WAR_CWL,
+        channelId: "123456789012345678",
+        isEnabled: false,
+        createdByUserId: "user-1",
+        updatedByUserId: "user-1",
+        createdAt: new Date("2026-03-26T00:00:00.000Z"),
+        updatedAt: new Date("2026-03-26T00:00:00.000Z"),
+        offsetsSeconds: [1800],
+        targets: [
+          {
+            clanTag: "#PQL0289",
+            clanType: ReminderTargetClanType.FWA,
+            label: "FWA One (#PQL0289)",
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        id: "reminder-1",
+        guildId: "guild-1",
+        type: ReminderType.WAR_CWL,
+        channelId: "123456789012345678",
+        isEnabled: true,
+        createdByUserId: "user-1",
+        updatedByUserId: "user-1",
+        createdAt: new Date("2026-03-26T00:00:00.000Z"),
+        updatedAt: new Date("2026-03-26T00:00:00.000Z"),
+        offsetsSeconds: [1800],
+        targets: [
+          {
+            clanTag: "#PQL0289",
+            clanType: ReminderTargetClanType.FWA,
+            label: "FWA One (#PQL0289)",
+          },
+        ],
+      })
+      .mockResolvedValue({
+        id: "reminder-1",
+        guildId: "guild-1",
+        type: ReminderType.WAR_CWL,
+        channelId: "123456789012345678",
+        isEnabled: true,
+        createdByUserId: "user-1",
+        updatedByUserId: "user-1",
+        createdAt: new Date("2026-03-26T00:00:00.000Z"),
+        updatedAt: new Date("2026-03-26T00:00:00.000Z"),
+        offsetsSeconds: [1800],
+        targets: [
+          {
+            clanTag: "#PQL0289",
+            clanType: ReminderTargetClanType.FWA,
+            label: "FWA One (#PQL0289)",
+          },
+        ],
+      });
+
+    const interaction = createInteraction({ subcommand: "create" });
+    await Reminders.run({} as any, interaction as any, {} as any);
+
+    const collectHandler = getCollectHandler(interaction);
+    const endHandler = getEndHandler(interaction);
+    expect(collectHandler).toBeTypeOf("function");
+    expect(endHandler).toBeTypeOf("function");
+
+    const saveButton = createPanelButtonInteraction({
+      customId: "reminders:save:reminder-1",
+    });
+    await collectHandler(saveButton);
+    await endHandler(new Map(), "saved");
+
+    expect(saveButton.deferUpdate).toHaveBeenCalledTimes(1);
+    expect(reminderServiceMock.setReminderEnabled).toHaveBeenCalledWith({
+      reminderId: "reminder-1",
+      guildId: "guild-1",
+      isEnabled: true,
+      actorUserId: "user-1",
+    });
+    expect(saveButton.deferUpdate.mock.invocationCallOrder[0]).toBeLessThan(
+      reminderServiceMock.getReminderWithDetails.mock.invocationCallOrder[1],
+    );
+    expect(saveButton.deferUpdate.mock.invocationCallOrder[0]).toBeLessThan(
+      reminderServiceMock.setReminderEnabled.mock.invocationCallOrder[0],
+    );
+    expect(interaction.__collector.stop).toHaveBeenCalledWith("saved");
+    const finalPayload = interaction.editReply.mock.calls.at(-1)?.[0] as any;
+    expect(finalPayload).toEqual(
+      expect.objectContaining({
+        content: "Reminder saved and enabled: reminder-1",
+        components: [],
+      }),
+    );
+  });
+
+  it("keeps create save validation errors working after early defer", async () => {
+    const interaction = createInteraction({ subcommand: "create" });
+    await Reminders.run({} as any, interaction as any, {} as any);
+
+    const collectHandler = getCollectHandler(interaction);
+    expect(collectHandler).toBeTypeOf("function");
+
+    const saveButton = createPanelButtonInteraction({
+      customId: "reminders:save:reminder-1",
+    });
+    await collectHandler(saveButton);
+
+    expect(saveButton.deferUpdate).toHaveBeenCalledTimes(1);
+    expect(saveButton.followUp).toHaveBeenCalledWith({
+      ephemeral: true,
+      content: "Select a reminder type before saving this reminder.",
+    });
+    expect(reminderServiceMock.setReminderEnabled).not.toHaveBeenCalled();
+    expect(interaction.__collector.stop).not.toHaveBeenCalledWith("saved");
   });
 
   it("returns a clear validation error when optional create time_left is provided but invalid", async () => {


### PR DESCRIPTION
- acknowledge create save before reminder validation and preserve validation feedback
- keep scheduler dedupe counts and summary logs while removing per-item dedupe spam