### PR TITLE
fix(deploy): cache droplet yarn installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ npm start
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development guidelines and architecture documentation.
 FWA command internals are split under `src/commands/fwa/` helper modules to keep `Fwa.ts` orchestration-focused and unit-testable.
 Run `npm run seed:fwa-layouts` after migrations when you want to upsert the canonical layout seed rows.
+Droplet deploys use cached Yarn dependency volumes and only rerun locked installs when `package.json` or `yarn.lock` changes.
 
 ## FWAStats Feed Ingestion (Phase 1)
 Endpoints wired:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -7,6 +7,15 @@
   - Prod: `POLLING_MODE=active`
   - Staging: `POLLING_MODE=mirror` with `MIRROR_SOURCE_DATABASE_URL` set to prod DB and `POLLING_ENV=staging`
 - Observability is documented separately in `docs/observability.md` and is intended to stay localhost-only by default on the droplet.
+- Droplet app deploys use the Yarn path (`yarn.lock`) for deterministic installs.
+
+## Droplet Dependency Cache
+- The droplet app containers use persistent `node_modules` and Yarn cache volumes so code-only deploys can skip a full reinstall.
+- On container start, `ops/deploy/ensure-yarn-deps.sh` hashes `package.json` and `yarn.lock` and only runs `yarn install --frozen-lockfile` when that manifest hash changed or the dependency volume is missing.
+- Deploys still run `yarn build` and `yarn start` after the dependency check, so runtime startup/migration ownership stays unchanged.
+
+Operator note:
+- The dependency cache is invalidated by changes to `package.json` or `yarn.lock`, by deleting the `node_modules` volume, or by losing `.yarn-integrity` / the stored manifest hash file inside that volume.
 
 ## Install Links
 Prod guild install:

--- a/ops/deploy/container-start.sh
+++ b/ops/deploy/container-start.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+./ops/deploy/ensure-yarn-deps.sh
+yarn build
+yarn start

--- a/ops/deploy/ensure-yarn-deps.sh
+++ b/ops/deploy/ensure-yarn-deps.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+HASH_FILE="node_modules/.clashcookies-yarn-manifest.sha256"
+INTEGRITY_FILE="node_modules/.yarn-integrity"
+
+if [ ! -f package.json ]; then
+  echo "[deploy:deps] missing package.json" >&2
+  exit 1
+fi
+
+if [ ! -f yarn.lock ]; then
+  echo "[deploy:deps] missing yarn.lock" >&2
+  exit 1
+fi
+
+mkdir -p node_modules
+
+current_hash="$(
+  sha256sum package.json yarn.lock \
+    | sha256sum \
+    | awk '{print $1}'
+)"
+previous_hash=""
+if [ -f "${HASH_FILE}" ]; then
+  previous_hash="$(cat "${HASH_FILE}")"
+fi
+
+needs_install="0"
+reason="manifest_unchanged"
+
+if [ ! -f "${INTEGRITY_FILE}" ]; then
+  needs_install="1"
+  reason="missing_yarn_integrity"
+elif [ ! -f "${HASH_FILE}" ]; then
+  needs_install="1"
+  reason="missing_manifest_hash"
+elif [ "${previous_hash}" != "${current_hash}" ]; then
+  needs_install="1"
+  reason="manifest_changed"
+fi
+
+if [ "${needs_install}" = "1" ]; then
+  echo "[deploy:deps] action=install reason=${reason}"
+  corepack enable
+  yarn install --frozen-lockfile
+  printf '%s\n' "${current_hash}" > "${HASH_FILE}"
+  exit 0
+fi
+
+echo "[deploy:deps] action=skip reason=${reason}"


### PR DESCRIPTION
- add manifest-hash deploy helpers to skip installs when yarn inputs are unchanged
- document droplet dependency cache behavior and invalidation rules