### PR TITLE
fix(build): generate prisma client before typecheck

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "vitest": "^0.34.6"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "prisma generate && tsc",
     "lint": "eslint \"src/**/*.ts\" \"tests/**/*.ts\"",
     "lint:fix": "eslint \"src/**/*.ts\" \"tests/**/*.ts\" --fix",
     "seed:fwa-layouts": "ts-node src/scripts/seedFwaLayouts.ts",


### PR DESCRIPTION
- run prisma generate as part of the build script so new schema models are always available
- keep staging and local typecheck aligned with the unlinked alert schema/client contract