### PR TITLE
fix(unlinked): bound list lookup stages

### DIFF
--- a/src/commands/Unlinked.ts
+++ b/src/commands/Unlinked.ts
@@ -12,7 +12,10 @@ import { prisma } from "../prisma";
 import { CoCService } from "../services/CoCService";
 import { resolveCurrentCwlSeasonKey } from "../services/CwlRegistryService";
 import { normalizeClanTag } from "../services/PlayerLinkService";
-import { unlinkedMemberAlertService } from "../services/UnlinkedMemberAlertService";
+import {
+  UnlinkedStageTimeoutError,
+  unlinkedMemberAlertService,
+} from "../services/UnlinkedMemberAlertService";
 
 const UNLINKED_ALERT_SUPPORTED_CHANNEL_TYPES = [
   ChannelType.GuildText,
@@ -59,6 +62,20 @@ function buildUnlinkedListLines(input: {
         )
       : ["- none"];
   return [header, ...body];
+}
+
+function formatUnlinkedCommandLog(input: Record<string, string | number | boolean | null | undefined>): string {
+  return Object.entries(input)
+    .map(([key, value]) => `${key}=${String(value)}`)
+    .join(" ");
+}
+
+function logUnlinkedCommandStage(
+  stage: string,
+  details: Record<string, string | number | boolean | null | undefined> = {},
+): void {
+  const line = `[unlinked] stage=${stage} ${formatUnlinkedCommandLog(details)}`.trim();
+  console.info(line);
 }
 
 async function autocompleteTrackedClanChoice(
@@ -150,10 +167,24 @@ export const Unlinked: Command = {
     interaction: ChatInputCommandInteraction,
     cocService: CoCService,
   ) => {
+    let terminalOutcome: "success" | "error" | "timeout" = "success";
     try {
+      logUnlinkedCommandStage("handler_entered", {
+        guild: interaction.guildId ?? "DM",
+        user: interaction.user.id,
+      });
       await interaction.deferReply({ ephemeral: true });
+      logUnlinkedCommandStage("interaction_deferred", {
+        guild: interaction.guildId ?? "DM",
+        user: interaction.user.id,
+      });
       if (!interaction.inGuild() || !interaction.guildId) {
         await interaction.editReply("This command can only be used in a server.");
+        logUnlinkedCommandStage("reply_sent", {
+          method: "editReply",
+          status: "success",
+          reason: "not_in_guild",
+        });
         return;
       }
 
@@ -178,14 +209,33 @@ export const Unlinked: Command = {
         await interaction.editReply(
           `Saved the unlinked-player alert channel: <#${requestedChannel.id}>.`,
         );
+        logUnlinkedCommandStage("reply_sent", {
+          method: "editReply",
+          status: "success",
+          subcommand,
+        });
         return;
       }
 
       const clanTag = normalizeClanTag(interaction.options.getString("clan", false) ?? "");
+      logUnlinkedCommandStage("member_fetch_started", {
+        guild: interaction.guildId,
+        clan: clanTag || "all",
+      });
       const entries = await unlinkedMemberAlertService.listCurrentUnlinkedMembers({
         guildId: interaction.guildId,
         cocService,
         clanTag: clanTag || null,
+      });
+      logUnlinkedCommandStage("member_fetch_completed", {
+        guild: interaction.guildId,
+        clan: clanTag || "all",
+        count: entries.length,
+      });
+      logUnlinkedCommandStage("list_render_started", {
+        guild: interaction.guildId,
+        clan: clanTag || "all",
+        count: entries.length,
       });
       const messages = splitDiscordLineMessages({
         lines: buildUnlinkedListLines({
@@ -194,21 +244,68 @@ export const Unlinked: Command = {
         }),
         maxMessages: 3,
       });
+      logUnlinkedCommandStage("list_render_completed", {
+        guild: interaction.guildId,
+        clan: clanTag || "all",
+        message_count: messages.length,
+      });
       if (messages.length <= 0) {
         await interaction.editReply("Current unresolved unlinked players:\n- none");
+        logUnlinkedCommandStage("reply_sent", {
+          method: "editReply",
+          status: "success",
+          messages: 0,
+        });
         return;
       }
 
       await interaction.editReply(messages[0]);
+      logUnlinkedCommandStage("reply_sent", {
+        method: "editReply",
+        status: "success",
+        part: 1,
+        total_parts: messages.length,
+      });
       for (const message of messages.slice(1)) {
         await interaction.followUp({
           ephemeral: true,
           content: message,
         });
+        logUnlinkedCommandStage("reply_sent", {
+          method: "followUp",
+          status: "success",
+          total_parts: messages.length,
+        });
       }
+      terminalOutcome = "success";
     } catch (err) {
-      console.error(`unlinked command failed: ${formatError(err)}`);
-      await interaction.editReply("Failed to load unlinked-player data. Please try again.");
+      terminalOutcome = err instanceof UnlinkedStageTimeoutError ? "timeout" : "error";
+      const timeout = err instanceof UnlinkedStageTimeoutError;
+      console.error(
+        `[unlinked] stage=terminal_error status=${terminalOutcome} error=${formatError(err)}`,
+      );
+      const message = timeout
+        ? "Unlinked-player lookup timed out while loading live clan data. Please try again."
+        : "Failed to load unlinked-player data. Please try again.";
+      const replyMethod = interaction.deferred || interaction.replied ? "editReply" : "reply";
+      if (interaction.deferred || interaction.replied) {
+        await interaction.editReply(message);
+      } else {
+        await interaction.reply({
+          ephemeral: true,
+          content: message,
+        });
+      }
+      logUnlinkedCommandStage("reply_sent", {
+        method: replyMethod,
+        status: terminalOutcome,
+      });
+    } finally {
+      logUnlinkedCommandStage("terminal", {
+        status: terminalOutcome,
+        guild: interaction.guildId ?? "DM",
+        user: interaction.user.id,
+      });
     }
   },
   autocomplete: async (interaction: AutocompleteInteraction) => {

--- a/src/services/UnlinkedMemberAlertService.ts
+++ b/src/services/UnlinkedMemberAlertService.ts
@@ -38,12 +38,94 @@ type LiveTrackedClanMember = {
   logChannelId: string | null;
 };
 
+export const UNLINKED_DB_STAGE_TIMEOUT_MS = 5_000;
+export const UNLINKED_EXTERNAL_STAGE_TIMEOUT_MS = 15_000;
+
 export type CurrentUnlinkedTrackedMember = {
   playerTag: string;
   playerName: string;
   clanTag: string;
   clanName: string;
 };
+
+type UnlinkedStageDetailValue = string | number | boolean | null | undefined;
+
+type UnlinkedStageDetails = Record<string, UnlinkedStageDetailValue>;
+
+export class UnlinkedStageTimeoutError extends Error {
+  readonly stage: string;
+  readonly timeoutMs: number;
+
+  constructor(stage: string, timeoutMs: number, details?: string) {
+    super(
+      details
+        ? `Unlinked stage timed out: ${stage} after ${timeoutMs}ms (${details})`
+        : `Unlinked stage timed out: ${stage} after ${timeoutMs}ms`,
+    );
+    this.name = "UnlinkedStageTimeoutError";
+    this.stage = stage;
+    this.timeoutMs = timeoutMs;
+  }
+}
+
+function formatStageDetails(details?: UnlinkedStageDetails): string {
+  if (!details) return "";
+  const parts = Object.entries(details)
+    .map(([key, value]) => `${key}=${String(value)}`)
+    .filter((value) => !value.endsWith("=undefined"));
+  return parts.length > 0 ? ` ${parts.join(" ")}` : "";
+}
+
+async function runBoundedUnlinkedStage<T>(input: {
+  stage: string;
+  timeoutMs: number;
+  details?: UnlinkedStageDetails;
+  action: () => Promise<T>;
+}): Promise<T> {
+  const startedAtMs = Date.now();
+  const detailText = formatStageDetails(input.details);
+  console.info(
+    `[unlinked] stage=${input.stage} status=started timeout_ms=${input.timeoutMs}${detailText}`,
+  );
+
+  let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+  try {
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timeoutHandle = setTimeout(() => {
+        reject(
+          new UnlinkedStageTimeoutError(
+            input.stage,
+            input.timeoutMs,
+            detailText.trim(),
+          ),
+        );
+      }, input.timeoutMs);
+    });
+    const result = (await Promise.race([
+      input.action(),
+      timeoutPromise,
+    ])) as T;
+    console.info(
+      `[unlinked] stage=${input.stage} status=completed duration_ms=${
+        Date.now() - startedAtMs
+      }${detailText}`,
+    );
+    return result;
+  } catch (err) {
+    const timeout = err instanceof UnlinkedStageTimeoutError;
+    const level = timeout ? console.error : console.error;
+    level(
+      `[unlinked] stage=${input.stage} status=${timeout ? "timeout" : "failed"} duration_ms=${
+        Date.now() - startedAtMs
+      } timeout_ms=${input.timeoutMs}${detailText}${
+        timeout ? "" : ` error=${formatError(err)}`
+      }`,
+    );
+    throw err;
+  } finally {
+    if (timeoutHandle) clearTimeout(timeoutHandle);
+  }
+}
 
 export function buildUnlinkedAlertContent(input: {
   playerName: string;
@@ -124,12 +206,17 @@ async function resolveSendableGuildChannel(input: {
 }
 
 async function loadTrackedClanLogChannelByTag(): Promise<Map<string, string | null>> {
-  const trackedClans = await prisma.trackedClan.findMany({
-    orderBy: [{ createdAt: "asc" }, { tag: "asc" }],
-    select: {
-      tag: true,
-      logChannelId: true,
-    },
+  const trackedClans = await runBoundedUnlinkedStage({
+    stage: "tracked_clan_log_channel_query",
+    timeoutMs: UNLINKED_DB_STAGE_TIMEOUT_MS,
+    action: () =>
+      prisma.trackedClan.findMany({
+        orderBy: [{ createdAt: "asc" }, { tag: "asc" }],
+        select: {
+          tag: true,
+          logChannelId: true,
+        },
+      }),
   });
   return new Map(
     trackedClans.map((row) => [
@@ -141,7 +228,7 @@ async function loadTrackedClanLogChannelByTag(): Promise<Map<string, string | nu
 
 async function loadLiveFwaMembers(input: {
   cocService: CoCService;
-  trackedClanLogChannelByTag: Map<string, string | null>;
+  trackedClanLogChannelByTag?: Map<string, string | null>;
   observedFwaClans?: ObservedFwaClan[];
 }): Promise<LiveTrackedClanMember[]> {
   const observed = input.observedFwaClans;
@@ -152,7 +239,7 @@ async function loadLiveFwaMembers(input: {
       const clanName = normalizeDisplayText(clan.clanName, clanTag);
       const logChannelId =
         normalizeChannelId(clan.logChannelId) ??
-        input.trackedClanLogChannelByTag.get(clanTag) ??
+        input.trackedClanLogChannelByTag?.get(clanTag) ??
         null;
       return clan.members
         .map((member) => {
@@ -166,41 +253,46 @@ async function loadLiveFwaMembers(input: {
             logChannelId,
           };
         })
-        .filter((value): value is LiveTrackedClanMember => value !== null);
+      .filter((value): value is LiveTrackedClanMember => value !== null);
     });
   }
 
-  const trackedClans = await prisma.trackedClan.findMany({
-    orderBy: [{ createdAt: "asc" }, { tag: "asc" }],
-    select: {
-      tag: true,
-      name: true,
-      logChannelId: true,
-    },
+  const trackedClans = await runBoundedUnlinkedStage({
+    stage: "tracked_clan_members_query",
+    timeoutMs: UNLINKED_DB_STAGE_TIMEOUT_MS,
+    action: () =>
+      prisma.trackedClan.findMany({
+        orderBy: [{ createdAt: "asc" }, { tag: "asc" }],
+        select: {
+          tag: true,
+          name: true,
+          logChannelId: true,
+        },
+      }),
   });
 
   const clans = await Promise.all(
     trackedClans.map(async (tracked) => {
-      try {
-        const clan = await input.cocService.getClan(tracked.tag);
-        return {
-          clanTag: normalizeClanTag(tracked.tag),
-          clanName: normalizeDisplayText(
-            String(clan?.name ?? tracked.name ?? ""),
-            normalizeClanTag(tracked.tag) || tracked.tag,
-          ),
-          logChannelId:
-            normalizeChannelId(tracked.logChannelId) ??
-            input.trackedClanLogChannelByTag.get(normalizeClanTag(tracked.tag)) ??
-            null,
-          members: Array.isArray(clan?.members) ? clan.members : [],
-        };
-      } catch (err) {
-        console.error(
-          `[unlinked] load_fwa_members_failed clan=${tracked.tag} error=${formatError(err)}`,
-        );
-        return null;
-      }
+      const clanTag = normalizeClanTag(tracked.tag);
+      if (!clanTag) return null;
+      const clan = await runBoundedUnlinkedStage({
+        stage: "fwa_member_fetch",
+        timeoutMs: UNLINKED_EXTERNAL_STAGE_TIMEOUT_MS,
+        details: { clan: clanTag },
+        action: () => input.cocService.getClan(tracked.tag),
+      });
+      return {
+        clanTag,
+        clanName: normalizeDisplayText(
+          String(clan?.name ?? tracked.name ?? ""),
+          clanTag || tracked.tag,
+        ),
+        logChannelId:
+          normalizeChannelId(tracked.logChannelId) ??
+          input.trackedClanLogChannelByTag?.get(clanTag) ??
+          null,
+        members: Array.isArray(clan?.members) ? clan.members : [],
+      };
     }),
   );
 
@@ -258,23 +350,34 @@ function resolveTrackedCwlSideMembers(input: {
 
 async function loadLiveCwlMembers(input: {
   cocService: CoCService;
-  trackedClanLogChannelByTag: Map<string, string | null>;
+  trackedClanLogChannelByTag?: Map<string, string | null>;
 }): Promise<LiveTrackedClanMember[]> {
   const season = resolveCurrentCwlSeasonKey();
-  const cwlTrackedClans = await prisma.cwlTrackedClan.findMany({
-    where: { season },
-    orderBy: [{ createdAt: "asc" }, { tag: "asc" }],
-    select: {
-      tag: true,
-      name: true,
-    },
+  const cwlTrackedClans = await runBoundedUnlinkedStage({
+    stage: "cwl_tracked_clan_query",
+    timeoutMs: UNLINKED_DB_STAGE_TIMEOUT_MS,
+    details: { season },
+    action: () =>
+      prisma.cwlTrackedClan.findMany({
+        where: { season },
+        orderBy: [{ createdAt: "asc" }, { tag: "asc" }],
+        select: {
+          tag: true,
+          name: true,
+        },
+      }),
   });
   const trackedTags = cwlTrackedClans
     .map((row) => normalizeClanTag(row.tag))
     .filter(Boolean);
   if (trackedTags.length <= 0) return [];
 
-  const warsByClan = await loadActiveCwlWarsByClan(input.cocService, trackedTags);
+  const warsByClan = await runBoundedUnlinkedStage({
+    stage: "cwl_war_fetch",
+    timeoutMs: UNLINKED_EXTERNAL_STAGE_TIMEOUT_MS,
+    details: { season, clan_count: trackedTags.length },
+    action: () => loadActiveCwlWarsByClan(input.cocService, trackedTags),
+  });
   const activeMembersByPlayerTag = buildActiveCwlClanByPlayerTag({
     cwlWarByClan: warsByClan,
     trackedCwlTags: new Set(trackedTags),
@@ -294,7 +397,7 @@ async function loadLiveCwlMembers(input: {
         playerName: member.playerName,
         clanTag,
         clanName: normalizeDisplayText(member.clanName, tracked.name ?? clanTag),
-        logChannelId: input.trackedClanLogChannelByTag.get(clanTag) ?? null,
+        logChannelId: input.trackedClanLogChannelByTag?.get(clanTag) ?? null,
       }));
   });
 }
@@ -357,16 +460,13 @@ export class UnlinkedMemberAlertService {
     const guildId = normalizeGuildId(input.guildId);
     if (!guildId) return [];
 
-    const trackedClanLogChannelByTag = await loadTrackedClanLogChannelByTag();
     const [fwaMembers, cwlMembers] = await Promise.all([
       loadLiveFwaMembers({
         cocService: input.cocService,
-        trackedClanLogChannelByTag,
         observedFwaClans: input.observedFwaClans,
       }),
       loadLiveCwlMembers({
         cocService: input.cocService,
-        trackedClanLogChannelByTag,
       }),
     ]);
 
@@ -378,14 +478,23 @@ export class UnlinkedMemberAlertService {
       return [];
     }
 
-    const linkedRows = await prisma.playerLink.findMany({
-      where: {
-        playerTag: { in: currentMembers.map((member) => member.playerTag) },
+    const linkedRows = await runBoundedUnlinkedStage({
+      stage: "player_link_query",
+      timeoutMs: UNLINKED_DB_STAGE_TIMEOUT_MS,
+      details: {
+        guild: guildId,
+        player_count: currentMembers.length,
       },
-      select: {
-        playerTag: true,
-        discordUserId: true,
-      },
+      action: () =>
+        prisma.playerLink.findMany({
+          where: {
+            playerTag: { in: currentMembers.map((member) => member.playerTag) },
+          },
+          select: {
+            playerTag: true,
+            discordUserId: true,
+          },
+        }),
     });
     const linkedTagSet = new Set(
       linkedRows
@@ -442,14 +551,23 @@ export class UnlinkedMemberAlertService {
     const currentMembers = dedupeTrackedMembers([...fwaMembers, ...cwlMembers]);
     const linkedRows =
       currentMembers.length > 0
-        ? await prisma.playerLink.findMany({
-            where: {
-              playerTag: { in: currentMembers.map((member) => member.playerTag) },
+        ? await runBoundedUnlinkedStage({
+            stage: "player_link_query",
+            timeoutMs: UNLINKED_DB_STAGE_TIMEOUT_MS,
+            details: {
+              guild: guildId,
+              player_count: currentMembers.length,
             },
-            select: {
-              playerTag: true,
-              discordUserId: true,
-            },
+            action: () =>
+              prisma.playerLink.findMany({
+                where: {
+                  playerTag: { in: currentMembers.map((member) => member.playerTag) },
+                },
+                select: {
+                  playerTag: true,
+                  discordUserId: true,
+                },
+              }),
           })
         : [];
     const linkedTagSet = new Set(

--- a/tests/unlinked.command.test.ts
+++ b/tests/unlinked.command.test.ts
@@ -1,7 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ChannelType } from "discord.js";
 import { Unlinked } from "../src/commands/Unlinked";
-import { unlinkedMemberAlertService } from "../src/services/UnlinkedMemberAlertService";
+import {
+  UnlinkedStageTimeoutError,
+  unlinkedMemberAlertService,
+} from "../src/services/UnlinkedMemberAlertService";
 
 type InteractionInput = {
   subcommand: "set-alert" | "list";
@@ -11,11 +14,13 @@ type InteractionInput = {
 };
 
 function createInteraction(input: InteractionInput) {
-  return {
+  const interaction: any = {
     inGuild: vi.fn().mockReturnValue(true),
     guildId: input.guildId ?? "guild-1",
+    user: { id: "111111111111111111" },
     deferred: false,
     replied: false,
+    reply: vi.fn().mockResolvedValue(undefined),
     options: {
       getSubcommand: vi.fn().mockReturnValue(input.subcommand),
       getChannel: vi.fn((name: string) => (name === "channel" ? (input.channel ?? null) : null)),
@@ -24,7 +29,15 @@ function createInteraction(input: InteractionInput) {
     deferReply: vi.fn().mockResolvedValue(undefined),
     editReply: vi.fn().mockResolvedValue(undefined),
     followUp: vi.fn().mockResolvedValue(undefined),
+    reply: vi.fn().mockResolvedValue(undefined),
   };
+  interaction.deferReply.mockImplementation(async () => {
+    interaction.deferred = true;
+  });
+  interaction.reply.mockImplementation(async () => {
+    interaction.replied = true;
+  });
+  return interaction;
 }
 
 describe("/unlinked command", () => {
@@ -57,6 +70,7 @@ describe("/unlinked command", () => {
   });
 
   it("lists current unresolved unlinked players and supports clan filtering", async () => {
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => undefined);
     vi.spyOn(unlinkedMemberAlertService, "listCurrentUnlinkedMembers").mockResolvedValue([
       {
         playerTag: "#P1",
@@ -80,6 +94,30 @@ describe("/unlinked command", () => {
     expect(interaction.editReply).toHaveBeenCalledWith(
       "Current unresolved unlinked players in #2QG2C08UP:\n- One (`#P1`) | Alpha Clan #2QG2C08UP",
     );
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[unlinked] stage=handler_entered"),
+    );
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[unlinked] stage=interaction_deferred"),
+    );
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[unlinked] stage=member_fetch_started"),
+    );
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[unlinked] stage=member_fetch_completed"),
+    );
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[unlinked] stage=list_render_started"),
+    );
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[unlinked] stage=list_render_completed"),
+    );
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[unlinked] stage=reply_sent"),
+    );
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[unlinked] stage=terminal status=success"),
+    );
   });
 
   it("returns a clear empty-state list when no unresolved players remain", async () => {
@@ -92,6 +130,37 @@ describe("/unlinked command", () => {
 
     expect(interaction.editReply).toHaveBeenCalledWith(
       "Current unresolved unlinked players:\n- none",
+    );
+  });
+
+  it("surfaces a visible timeout when live member lookup stalls", async () => {
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => undefined);
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.spyOn(unlinkedMemberAlertService, "listCurrentUnlinkedMembers").mockRejectedValue(
+      new UnlinkedStageTimeoutError("fwa_member_fetch", 15_000, "clan=#2QG2C08UP"),
+    );
+    const interaction = createInteraction({
+      subcommand: "list",
+      clan: "#2QG2C08UP",
+    });
+
+    await Unlinked.run({} as any, interaction as any, {} as any);
+
+    expect(interaction.deferReply).toHaveBeenCalledWith({ ephemeral: true });
+    expect(interaction.editReply).toHaveBeenCalledWith(
+      "Unlinked-player lookup timed out while loading live clan data. Please try again.",
+    );
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[unlinked] stage=handler_entered"),
+    );
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[unlinked] stage=interaction_deferred"),
+    );
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[unlinked] stage=terminal_error status=timeout"),
+    );
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[unlinked] stage=terminal status=timeout"),
     );
   });
 });

--- a/tests/unlinkedMemberAlert.service.test.ts
+++ b/tests/unlinkedMemberAlert.service.test.ts
@@ -1,4 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  UNLINKED_DB_STAGE_TIMEOUT_MS,
+  UNLINKED_EXTERNAL_STAGE_TIMEOUT_MS,
+  UnlinkedStageTimeoutError,
+} from "../src/services/UnlinkedMemberAlertService";
 
 const prismaMock = vi.hoisted(() => ({
   trackedClan: {
@@ -159,6 +164,100 @@ describe("UnlinkedMemberAlertService", () => {
 
     expect(result).toHaveLength(1);
     expect(result[0]?.playerTag).toBe("#PYLQ0289");
+  });
+
+  it("times out a stalled live clan fetch and logs the slow stage", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-01T00:00:00.000Z"));
+    try {
+      const infoSpy = vi.spyOn(console, "info").mockImplementation(() => undefined);
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+      prismaMock.trackedClan.findMany.mockResolvedValue([
+        { tag: "#2QG2C08UP", name: "Alpha Clan", logChannelId: "222222222222222222" },
+      ]);
+      prismaMock.cwlTrackedClan.findMany.mockResolvedValue([]);
+      prismaMock.playerLink.findMany.mockResolvedValue([]);
+      const service = new UnlinkedMemberAlertService();
+
+      const outcomePromise = service
+        .listCurrentUnlinkedMembers({
+        guildId: "guild-1",
+        cocService: {
+          getClan: vi.fn(
+            () =>
+              new Promise(() => {
+                // intentionally unresolved to exercise the bounded stage timeout
+              }),
+          ),
+        } as any,
+        })
+        .then(
+          () => ({ ok: true as const, error: null as null }),
+          (error) => ({ ok: false as const, error }),
+        );
+
+      await vi.advanceTimersByTimeAsync(UNLINKED_EXTERNAL_STAGE_TIMEOUT_MS + 1);
+      const outcome = await outcomePromise;
+      expect(outcome.ok).toBe(false);
+      expect(outcome.error).toBeInstanceOf(UnlinkedStageTimeoutError);
+      expect(infoSpy).toHaveBeenCalledWith(
+        expect.stringContaining("[unlinked] stage=tracked_clan_members_query status=started"),
+      );
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("[unlinked] stage=fwa_member_fetch status=timeout"),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("times out a stalled player-link query and logs the slow stage", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-01T00:00:00.000Z"));
+    try {
+      const infoSpy = vi.spyOn(console, "info").mockImplementation(() => undefined);
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+      prismaMock.trackedClan.findMany.mockResolvedValue([
+        { tag: "#2QG2C08UP", name: "Alpha Clan", logChannelId: "222222222222222222" },
+      ]);
+      prismaMock.cwlTrackedClan.findMany.mockResolvedValue([]);
+      prismaMock.playerLink.findMany.mockImplementation(
+        () =>
+          new Promise(() => {
+            // intentionally unresolved to exercise the bounded DB timeout
+          }),
+      );
+      const service = new UnlinkedMemberAlertService();
+
+      const outcomePromise = service
+        .listCurrentUnlinkedMembers({
+        guildId: "guild-1",
+        cocService: {
+          getClan: vi.fn().mockResolvedValue({
+            tag: "#2QG2C08UP",
+            name: "Alpha Clan",
+            members: [{ tag: "#PYLQ0289", name: "One" }],
+          }),
+        } as any,
+        })
+        .then(
+          () => ({ ok: true as const, error: null as null }),
+          (error) => ({ ok: false as const, error }),
+        );
+
+      await vi.advanceTimersByTimeAsync(UNLINKED_DB_STAGE_TIMEOUT_MS + 1);
+      const outcome = await outcomePromise;
+      expect(outcome.ok).toBe(false);
+      expect(outcome.error).toBeInstanceOf(UnlinkedStageTimeoutError);
+      expect(infoSpy).toHaveBeenCalledWith(
+        expect.stringContaining("[unlinked] stage=player_link_query status=started"),
+      );
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining("[unlinked] stage=player_link_query status=timeout"),
+      );
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("posts one alert for a newly observed unresolved join", async () => {


### PR DESCRIPTION
- add stage-level logging and timeouts across the `/unlinked list` fetch, query, render, and reply path
- surface clean timeout replies while keeping the shared alert service as the single source of truth