### PR TITLE
chore(unlinked): trace list hot path timings

### DIFF
--- a/src/commands/Unlinked.ts
+++ b/src/commands/Unlinked.ts
@@ -217,7 +217,17 @@ export const Unlinked: Command = {
         return;
       }
 
-      const clanTag = normalizeClanTag(interaction.options.getString("clan", false) ?? "");
+      const rawClanFilter = interaction.options.getString("clan", false) ?? "";
+      logUnlinkedCommandStage("scope_resolution_started", {
+        guild: interaction.guildId,
+        clan_filter: rawClanFilter,
+      });
+      const clanTag = normalizeClanTag(rawClanFilter);
+      logUnlinkedCommandStage("scope_resolution_completed", {
+        guild: interaction.guildId,
+        clan_filter: rawClanFilter,
+        normalized_clan: clanTag || "all",
+      });
       logUnlinkedCommandStage("member_fetch_started", {
         guild: interaction.guildId,
         clan: clanTag || "all",

--- a/src/services/UnlinkedMemberAlertService.ts
+++ b/src/services/UnlinkedMemberAlertService.ts
@@ -295,6 +295,9 @@ async function loadLiveFwaMembers(input: {
       };
     }),
   );
+  console.info(
+    `[unlinked] stage=tracked_clan_members_summary clan_count=${trackedClans.length} live_clan_count=${clans.filter((clan) => clan?.clanTag).length}`,
+  );
 
   return clans.flatMap((clan) => {
     if (!clan?.clanTag) return [];
@@ -370,6 +373,9 @@ async function loadLiveCwlMembers(input: {
   const trackedTags = cwlTrackedClans
     .map((row) => normalizeClanTag(row.tag))
     .filter(Boolean);
+  console.info(
+    `[unlinked] stage=cwl_tracked_clan_summary season=${season} tracked_clan_count=${trackedTags.length}`,
+  );
   if (trackedTags.length <= 0) return [];
 
   const warsByClan = await runBoundedUnlinkedStage({
@@ -382,6 +388,9 @@ async function loadLiveCwlMembers(input: {
     cwlWarByClan: warsByClan,
     trackedCwlTags: new Set(trackedTags),
   });
+  console.info(
+    `[unlinked] stage=cwl_war_fetch_summary season=${season} tracked_clan_count=${trackedTags.length} active_member_count=${activeMembersByPlayerTag.size}`,
+  );
 
   return cwlTrackedClans.flatMap((tracked) => {
     const clanTag = normalizeClanTag(tracked.tag);
@@ -496,6 +505,9 @@ export class UnlinkedMemberAlertService {
           },
         }),
     });
+    console.info(
+      `[unlinked] stage=player_link_query_summary guild=${guildId} player_count=${currentMembers.length} row_count=${linkedRows.length}`,
+    );
     const linkedTagSet = new Set(
       linkedRows
         .filter((row) => normalizeDiscordUserId(row.discordUserId) !== null)
@@ -503,9 +515,14 @@ export class UnlinkedMemberAlertService {
         .filter(Boolean),
     );
 
-    return currentMembers
-      .filter((member) => !linkedTagSet.has(member.playerTag))
-      .map((member) => ({
+    const unresolvedMembers = currentMembers.filter(
+      (member) => !linkedTagSet.has(member.playerTag),
+    );
+    console.info(
+      `[unlinked] stage=current_unlinked_summary guild=${guildId} current_member_count=${currentMembers.length} unresolved_count=${unresolvedMembers.length}`,
+    );
+
+    return unresolvedMembers.map((member) => ({
         playerTag: member.playerTag,
         playerName: member.playerName,
         clanTag: member.clanTag,
@@ -578,6 +595,9 @@ export class UnlinkedMemberAlertService {
     );
     const currentUnlinked = currentMembers.filter(
       (member) => !linkedTagSet.has(member.playerTag),
+    );
+    console.info(
+      `[unlinked] stage=current_unlinked_summary guild=${guildId} current_member_count=${currentMembers.length} unresolved_count=${currentUnlinked.length}`,
     );
     const currentByTag = new Map(
       currentUnlinked.map((member) => [member.playerTag, member] as const),

--- a/tests/unlinked.command.test.ts
+++ b/tests/unlinked.command.test.ts
@@ -101,6 +101,12 @@ describe("/unlinked command", () => {
       expect.stringContaining("[unlinked] stage=interaction_deferred"),
     );
     expect(infoSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[unlinked] stage=scope_resolution_started"),
+    );
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[unlinked] stage=scope_resolution_completed"),
+    );
+    expect(infoSpy).toHaveBeenCalledWith(
       expect.stringContaining("[unlinked] stage=member_fetch_started"),
     );
     expect(infoSpy).toHaveBeenCalledWith(

--- a/tests/unlinkedMemberAlert.service.test.ts
+++ b/tests/unlinkedMemberAlert.service.test.ts
@@ -142,6 +142,56 @@ describe("UnlinkedMemberAlertService", () => {
     ]);
   });
 
+  it("logs the read-path stages and avoids unresolved-state writes while listing", async () => {
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => undefined);
+    prismaMock.trackedClan.findMany.mockResolvedValue([
+      { tag: "#2QG2C08UP", name: "Alpha Clan", logChannelId: "222222222222222222" },
+    ]);
+    prismaMock.cwlTrackedClan.findMany.mockResolvedValue([]);
+    const getClan = vi.fn().mockResolvedValue({
+      tag: "#2QG2C08UP",
+      name: "Alpha Clan",
+      members: [{ tag: "#PYLQ0289", name: "One" }],
+    });
+    const service = new UnlinkedMemberAlertService();
+
+    const result = await service.listCurrentUnlinkedMembers({
+      guildId: "guild-1",
+      cocService: {
+        getClan,
+      } as any,
+    });
+
+    expect(result).toEqual([
+      {
+        playerTag: "#PYLQ0289",
+        playerName: "One",
+        clanTag: "#2QG2C08UP",
+        clanName: "Alpha Clan",
+      },
+    ]);
+    expect(getClan).toHaveBeenCalledTimes(1);
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[unlinked] stage=tracked_clan_members_query status=completed"),
+    );
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[unlinked] stage=tracked_clan_members_summary clan_count=1 live_clan_count=1"),
+    );
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[unlinked] stage=cwl_tracked_clan_summary season="),
+    );
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[unlinked] stage=player_link_query_summary guild=guild-1 player_count=1 row_count=0"),
+    );
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[unlinked] stage=current_unlinked_summary guild=guild-1 current_member_count=1 unresolved_count=1"),
+    );
+    expect(prismaMock.unlinkedPlayer.findMany).not.toHaveBeenCalled();
+    expect(prismaMock.unlinkedPlayer.deleteMany).not.toHaveBeenCalled();
+    expect(prismaMock.unlinkedPlayer.upsert).not.toHaveBeenCalled();
+    expect(prismaMock.unlinkedPlayer.update).not.toHaveBeenCalled();
+  });
+
   it("treats PlayerLink rows without a Discord user as unlinked", async () => {
     prismaMock.trackedClan.findMany.mockResolvedValue([
       { tag: "#2QG2C08UP", name: "Alpha Clan", logChannelId: "222222222222222222" },


### PR DESCRIPTION
- log the read-path stages and row counts for /unlinked list
- add tests proving the command is live-read-only, not write-heavy