### PR TITLE
fix(unlinked): make /unlinked list db-first

### DIFF
--- a/src/commands/Unlinked.ts
+++ b/src/commands/Unlinked.ts
@@ -165,7 +165,7 @@ export const Unlinked: Command = {
   run: async (
     _client: Client,
     interaction: ChatInputCommandInteraction,
-    cocService: CoCService,
+    _cocService: CoCService,
   ) => {
     let terminalOutcome: "success" | "error" | "timeout" = "success";
     try {
@@ -228,16 +228,15 @@ export const Unlinked: Command = {
         clan_filter: rawClanFilter,
         normalized_clan: clanTag || "all",
       });
-      logUnlinkedCommandStage("member_fetch_started", {
+      logUnlinkedCommandStage("persisted_unlinked_query_started", {
         guild: interaction.guildId,
         clan: clanTag || "all",
       });
-      const entries = await unlinkedMemberAlertService.listCurrentUnlinkedMembers({
+      const entries = await unlinkedMemberAlertService.listPersistedUnlinkedMembers({
         guildId: interaction.guildId,
-        cocService,
         clanTag: clanTag || null,
       });
-      logUnlinkedCommandStage("member_fetch_completed", {
+      logUnlinkedCommandStage("persisted_unlinked_query_completed", {
         guild: interaction.guildId,
         clan: clanTag || "all",
         count: entries.length,
@@ -288,14 +287,14 @@ export const Unlinked: Command = {
         });
       }
       terminalOutcome = "success";
-    } catch (err) {
-      terminalOutcome = err instanceof UnlinkedStageTimeoutError ? "timeout" : "error";
-      const timeout = err instanceof UnlinkedStageTimeoutError;
-      console.error(
-        `[unlinked] stage=terminal_error status=${terminalOutcome} error=${formatError(err)}`,
-      );
-      const message = timeout
-        ? "Unlinked-player lookup timed out while loading live clan data. Please try again."
+      } catch (err) {
+        terminalOutcome = err instanceof UnlinkedStageTimeoutError ? "timeout" : "error";
+        const timeout = err instanceof UnlinkedStageTimeoutError;
+        console.error(
+          `[unlinked] stage=terminal_error status=${terminalOutcome} error=${formatError(err)}`,
+        );
+        const message = timeout
+        ? "Unlinked-player lookup timed out while loading persisted unresolved data. Please try again."
         : "Failed to load unlinked-player data. Please try again.";
       const replyMethod = interaction.deferred || interaction.replied ? "editReply" : "reply";
       if (interaction.deferred || interaction.replied) {

--- a/src/services/UnlinkedMemberAlertService.ts
+++ b/src/services/UnlinkedMemberAlertService.ts
@@ -48,6 +48,13 @@ export type CurrentUnlinkedTrackedMember = {
   clanName: string;
 };
 
+export type PersistedUnlinkedTrackedMember = {
+  playerTag: string;
+  playerName: string;
+  clanTag: string;
+  clanName: string;
+};
+
 type UnlinkedStageDetailValue = string | number | boolean | null | undefined;
 
 type UnlinkedStageDetails = Record<string, UnlinkedStageDetailValue>;
@@ -528,6 +535,55 @@ export class UnlinkedMemberAlertService {
         clanTag: member.clanTag,
         clanName: member.clanName,
       }));
+  }
+
+  /** Purpose: read the persisted unresolved unlinked-member snapshot for a guild. */
+  async listPersistedUnlinkedMembers(input: {
+    guildId: string;
+    clanTag?: string | null;
+  }): Promise<PersistedUnlinkedTrackedMember[]> {
+    const guildId = normalizeGuildId(input.guildId);
+    if (!guildId) return [];
+
+    const normalizedClanTag = normalizeClanTag(input.clanTag ?? "");
+    const rows = await runBoundedUnlinkedStage({
+      stage: "persisted_unlinked_query",
+      timeoutMs: UNLINKED_DB_STAGE_TIMEOUT_MS,
+      details: {
+        guild: guildId,
+        clan: normalizedClanTag || "all",
+      },
+      action: () =>
+        prisma.unlinkedPlayer.findMany({
+          where: {
+            guildId,
+            ...(normalizedClanTag ? { clanTag: normalizedClanTag } : {}),
+          },
+          orderBy: [{ createdAt: "asc" }, { playerTag: "asc" }],
+          select: {
+            playerTag: true,
+            playerName: true,
+            clanTag: true,
+            clanName: true,
+          },
+        }),
+    });
+    console.info(
+      `[unlinked] stage=persisted_unlinked_query_summary guild=${guildId} clan=${normalizedClanTag || "all"} row_count=${rows.length}`,
+    );
+    return rows.flatMap((row) => {
+      const playerTag = normalizePlayerTag(row.playerTag);
+      const clanTag = normalizeClanTag(row.clanTag);
+      if (!playerTag || !clanTag) return [];
+      return [
+        {
+          playerTag,
+          playerName: normalizeDisplayText(row.playerName, playerTag),
+          clanTag,
+          clanName: normalizeDisplayText(row.clanName, clanTag),
+        },
+      ];
+    });
   }
 
   /** Purpose: reconcile persisted unresolved state with the current live unlinked-member set and send first-seen alerts once. */

--- a/tests/unlinked.command.test.ts
+++ b/tests/unlinked.command.test.ts
@@ -71,7 +71,8 @@ describe("/unlinked command", () => {
 
   it("lists current unresolved unlinked players and supports clan filtering", async () => {
     const infoSpy = vi.spyOn(console, "info").mockImplementation(() => undefined);
-    vi.spyOn(unlinkedMemberAlertService, "listCurrentUnlinkedMembers").mockResolvedValue([
+    const liveSpy = vi.spyOn(unlinkedMemberAlertService, "listCurrentUnlinkedMembers");
+    vi.spyOn(unlinkedMemberAlertService, "listPersistedUnlinkedMembers").mockResolvedValue([
       {
         playerTag: "#P1",
         playerName: "One",
@@ -86,11 +87,11 @@ describe("/unlinked command", () => {
 
     await Unlinked.run({} as any, interaction as any, {} as any);
 
-    expect(unlinkedMemberAlertService.listCurrentUnlinkedMembers).toHaveBeenCalledWith({
+    expect(unlinkedMemberAlertService.listPersistedUnlinkedMembers).toHaveBeenCalledWith({
       guildId: "guild-1",
-      cocService: {},
       clanTag: "#2QG2C08UP",
     });
+    expect(liveSpy).not.toHaveBeenCalled();
     expect(interaction.editReply).toHaveBeenCalledWith(
       "Current unresolved unlinked players in #2QG2C08UP:\n- One (`#P1`) | Alpha Clan #2QG2C08UP",
     );
@@ -107,10 +108,10 @@ describe("/unlinked command", () => {
       expect.stringContaining("[unlinked] stage=scope_resolution_completed"),
     );
     expect(infoSpy).toHaveBeenCalledWith(
-      expect.stringContaining("[unlinked] stage=member_fetch_started"),
+      expect.stringContaining("[unlinked] stage=persisted_unlinked_query_started"),
     );
     expect(infoSpy).toHaveBeenCalledWith(
-      expect.stringContaining("[unlinked] stage=member_fetch_completed"),
+      expect.stringContaining("[unlinked] stage=persisted_unlinked_query_completed"),
     );
     expect(infoSpy).toHaveBeenCalledWith(
       expect.stringContaining("[unlinked] stage=list_render_started"),
@@ -127,7 +128,8 @@ describe("/unlinked command", () => {
   });
 
   it("returns a clear empty-state list when no unresolved players remain", async () => {
-    vi.spyOn(unlinkedMemberAlertService, "listCurrentUnlinkedMembers").mockResolvedValue([]);
+    const liveSpy = vi.spyOn(unlinkedMemberAlertService, "listCurrentUnlinkedMembers");
+    vi.spyOn(unlinkedMemberAlertService, "listPersistedUnlinkedMembers").mockResolvedValue([]);
     const interaction = createInteraction({
       subcommand: "list",
     });
@@ -137,13 +139,15 @@ describe("/unlinked command", () => {
     expect(interaction.editReply).toHaveBeenCalledWith(
       "Current unresolved unlinked players:\n- none",
     );
+    expect(liveSpy).not.toHaveBeenCalled();
   });
 
-  it("surfaces a visible timeout when live member lookup stalls", async () => {
+  it("surfaces a visible timeout when persisted unresolved lookup stalls", async () => {
     const infoSpy = vi.spyOn(console, "info").mockImplementation(() => undefined);
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
-    vi.spyOn(unlinkedMemberAlertService, "listCurrentUnlinkedMembers").mockRejectedValue(
-      new UnlinkedStageTimeoutError("fwa_member_fetch", 15_000, "clan=#2QG2C08UP"),
+    const liveSpy = vi.spyOn(unlinkedMemberAlertService, "listCurrentUnlinkedMembers");
+    vi.spyOn(unlinkedMemberAlertService, "listPersistedUnlinkedMembers").mockRejectedValue(
+      new UnlinkedStageTimeoutError("persisted_unlinked_query", 5_000, "guild=guild-1 clan=#2QG2C08UP"),
     );
     const interaction = createInteraction({
       subcommand: "list",
@@ -154,14 +158,15 @@ describe("/unlinked command", () => {
 
     expect(interaction.deferReply).toHaveBeenCalledWith({ ephemeral: true });
     expect(interaction.editReply).toHaveBeenCalledWith(
-      "Unlinked-player lookup timed out while loading live clan data. Please try again.",
+      "Unlinked-player lookup timed out while loading persisted unresolved data. Please try again.",
     );
     expect(infoSpy).toHaveBeenCalledWith(
-      expect.stringContaining("[unlinked] stage=handler_entered"),
+      expect.stringContaining("[unlinked] stage=persisted_unlinked_query_started"),
     );
     expect(infoSpy).toHaveBeenCalledWith(
       expect.stringContaining("[unlinked] stage=interaction_deferred"),
     );
+    expect(liveSpy).not.toHaveBeenCalled();
     expect(errorSpy).toHaveBeenCalledWith(
       expect.stringContaining("[unlinked] stage=terminal_error status=timeout"),
     );

--- a/tests/unlinkedMemberAlert.service.test.ts
+++ b/tests/unlinkedMemberAlert.service.test.ts
@@ -1,7 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   UNLINKED_DB_STAGE_TIMEOUT_MS,
-  UNLINKED_EXTERNAL_STAGE_TIMEOUT_MS,
   UnlinkedStageTimeoutError,
 } from "../src/services/UnlinkedMemberAlertService";
 
@@ -115,23 +114,32 @@ describe("UnlinkedMemberAlertService", () => {
     ).toBe("An unlinked player, Alpha (`#PYLQ0289`), has joined **Clan One**.");
   });
 
-  it("treats members with no PlayerLink row as unlinked", async () => {
-    prismaMock.trackedClan.findMany.mockResolvedValue([
-      { tag: "#2QG2C08UP", name: "Alpha Clan", logChannelId: "222222222222222222" },
+  it("reads persisted unresolved rows without live clan fetches", async () => {
+    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => undefined);
+    prismaMock.unlinkedPlayer.findMany.mockResolvedValue([
+      {
+        playerTag: "#PYLQ0289",
+        playerName: "One",
+        clanTag: "#2QG2C08UP",
+        clanName: "Alpha Clan",
+      },
     ]);
     const service = new UnlinkedMemberAlertService();
 
-    const result = await service.listCurrentUnlinkedMembers({
+    const result = await service.listPersistedUnlinkedMembers({
       guildId: "guild-1",
-      cocService: {
-        getClan: vi.fn().mockResolvedValue({
-          tag: "#2QG2C08UP",
-          name: "Alpha Clan",
-          members: [{ tag: "#PYLQ0289", name: "One" }],
-        }),
-      } as any,
     });
 
+    expect(prismaMock.unlinkedPlayer.findMany).toHaveBeenCalledWith({
+      where: { guildId: "guild-1" },
+      orderBy: [{ createdAt: "asc" }, { playerTag: "asc" }],
+      select: {
+        playerTag: true,
+        playerName: true,
+        clanTag: true,
+        clanName: true,
+      },
+    });
     expect(result).toEqual([
       {
         playerTag: "#PYLQ0289",
@@ -140,28 +148,48 @@ describe("UnlinkedMemberAlertService", () => {
         clanName: "Alpha Clan",
       },
     ]);
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[unlinked] stage=persisted_unlinked_query status=started"),
+    );
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[unlinked] stage=persisted_unlinked_query status=completed"),
+    );
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[unlinked] stage=persisted_unlinked_query_summary guild=guild-1 clan=all row_count=1"),
+    );
+    expect(prismaMock.trackedClan.findMany).not.toHaveBeenCalled();
+    expect(prismaMock.cwlTrackedClan.findMany).not.toHaveBeenCalled();
   });
 
-  it("logs the read-path stages and avoids unresolved-state writes while listing", async () => {
-    const infoSpy = vi.spyOn(console, "info").mockImplementation(() => undefined);
-    prismaMock.trackedClan.findMany.mockResolvedValue([
-      { tag: "#2QG2C08UP", name: "Alpha Clan", logChannelId: "222222222222222222" },
+  it("filters persisted unresolved rows by clan tag", async () => {
+    prismaMock.unlinkedPlayer.findMany.mockResolvedValue([
+      {
+        playerTag: "#PYLQ0289",
+        playerName: "One",
+        clanTag: "#2QG2C08UP",
+        clanName: "Alpha Clan",
+      },
     ]);
-    prismaMock.cwlTrackedClan.findMany.mockResolvedValue([]);
-    const getClan = vi.fn().mockResolvedValue({
-      tag: "#2QG2C08UP",
-      name: "Alpha Clan",
-      members: [{ tag: "#PYLQ0289", name: "One" }],
-    });
     const service = new UnlinkedMemberAlertService();
 
-    const result = await service.listCurrentUnlinkedMembers({
+    const result = await service.listPersistedUnlinkedMembers({
       guildId: "guild-1",
-      cocService: {
-        getClan,
-      } as any,
+      clanTag: "#2QG2C08UP",
     });
 
+    expect(prismaMock.unlinkedPlayer.findMany).toHaveBeenCalledWith({
+      where: {
+        guildId: "guild-1",
+        clanTag: "#2QG2C08UP",
+      },
+      orderBy: [{ createdAt: "asc" }, { playerTag: "asc" }],
+      select: {
+        playerTag: true,
+        playerName: true,
+        clanTag: true,
+        clanName: true,
+      },
+    });
     expect(result).toEqual([
       {
         playerTag: "#PYLQ0289",
@@ -170,26 +198,6 @@ describe("UnlinkedMemberAlertService", () => {
         clanName: "Alpha Clan",
       },
     ]);
-    expect(getClan).toHaveBeenCalledTimes(1);
-    expect(infoSpy).toHaveBeenCalledWith(
-      expect.stringContaining("[unlinked] stage=tracked_clan_members_query status=completed"),
-    );
-    expect(infoSpy).toHaveBeenCalledWith(
-      expect.stringContaining("[unlinked] stage=tracked_clan_members_summary clan_count=1 live_clan_count=1"),
-    );
-    expect(infoSpy).toHaveBeenCalledWith(
-      expect.stringContaining("[unlinked] stage=cwl_tracked_clan_summary season="),
-    );
-    expect(infoSpy).toHaveBeenCalledWith(
-      expect.stringContaining("[unlinked] stage=player_link_query_summary guild=guild-1 player_count=1 row_count=0"),
-    );
-    expect(infoSpy).toHaveBeenCalledWith(
-      expect.stringContaining("[unlinked] stage=current_unlinked_summary guild=guild-1 current_member_count=1 unresolved_count=1"),
-    );
-    expect(prismaMock.unlinkedPlayer.findMany).not.toHaveBeenCalled();
-    expect(prismaMock.unlinkedPlayer.deleteMany).not.toHaveBeenCalled();
-    expect(prismaMock.unlinkedPlayer.upsert).not.toHaveBeenCalled();
-    expect(prismaMock.unlinkedPlayer.update).not.toHaveBeenCalled();
   });
 
   it("treats PlayerLink rows without a Discord user as unlinked", async () => {
@@ -216,45 +224,39 @@ describe("UnlinkedMemberAlertService", () => {
     expect(result[0]?.playerTag).toBe("#PYLQ0289");
   });
 
-  it("times out a stalled live clan fetch and logs the slow stage", async () => {
+  it("times out a stalled persisted unresolved query and logs the slow stage", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-04-01T00:00:00.000Z"));
     try {
       const infoSpy = vi.spyOn(console, "info").mockImplementation(() => undefined);
       const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
-      prismaMock.trackedClan.findMany.mockResolvedValue([
-        { tag: "#2QG2C08UP", name: "Alpha Clan", logChannelId: "222222222222222222" },
-      ]);
-      prismaMock.cwlTrackedClan.findMany.mockResolvedValue([]);
-      prismaMock.playerLink.findMany.mockResolvedValue([]);
+      prismaMock.unlinkedPlayer.findMany.mockImplementation(
+        () =>
+          new Promise(() => {
+            // intentionally unresolved to exercise the bounded DB timeout
+          }),
+      );
       const service = new UnlinkedMemberAlertService();
 
       const outcomePromise = service
-        .listCurrentUnlinkedMembers({
-        guildId: "guild-1",
-        cocService: {
-          getClan: vi.fn(
-            () =>
-              new Promise(() => {
-                // intentionally unresolved to exercise the bounded stage timeout
-              }),
-          ),
-        } as any,
+        .listPersistedUnlinkedMembers({
+          guildId: "guild-1",
+          clanTag: "#2QG2C08UP",
         })
         .then(
           () => ({ ok: true as const, error: null as null }),
           (error) => ({ ok: false as const, error }),
         );
 
-      await vi.advanceTimersByTimeAsync(UNLINKED_EXTERNAL_STAGE_TIMEOUT_MS + 1);
+      await vi.advanceTimersByTimeAsync(UNLINKED_DB_STAGE_TIMEOUT_MS + 1);
       const outcome = await outcomePromise;
       expect(outcome.ok).toBe(false);
       expect(outcome.error).toBeInstanceOf(UnlinkedStageTimeoutError);
       expect(infoSpy).toHaveBeenCalledWith(
-        expect.stringContaining("[unlinked] stage=tracked_clan_members_query status=started"),
+        expect.stringContaining("[unlinked] stage=persisted_unlinked_query status=started"),
       );
       expect(errorSpy).toHaveBeenCalledWith(
-        expect.stringContaining("[unlinked] stage=fwa_member_fetch status=timeout"),
+        expect.stringContaining("[unlinked] stage=persisted_unlinked_query status=timeout"),
       );
     } finally {
       vi.useRealTimers();


### PR DESCRIPTION
- read persisted unresolved rows instead of live clan membership
- keep reconciliation and alert writes in the background observer