### PR TITLE
docs(deployment): document health endpoint wiring

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -8,6 +8,16 @@
   - Staging: `POLLING_MODE=mirror` with `MIRROR_SOURCE_DATABASE_URL` set to prod DB and `POLLING_ENV=staging`
 - Observability is documented separately in `docs/observability.md` and is intended to stay localhost-only by default on the droplet.
 - Droplet app deploys use the Yarn path (`yarn.lock`) for deterministic installs.
+- Current localhost-only app health port mappings on the droplet:
+  - Production app: `127.0.0.1:8085:8080`
+  - Staging app: `127.0.0.1:8086:8080`
+- The app health server defaults are:
+  - `HEALTHCHECK_ENABLED=true`
+  - `HEALTHCHECK_HOST=0.0.0.0`
+  - `HEALTHCHECK_PORT=8080`
+  - `HEALTHCHECK_LIVE_PATH=/livez`
+  - `HEALTHCHECK_READY_PATH=/healthz`
+- These defaults are currently relied on directly; no extra env overrides are required unless you intentionally want non-default paths or ports.
 
 ## Droplet Dependency Cache
 - The droplet app containers use persistent `node_modules` and Yarn cache volumes so code-only deploys can skip a full reinstall.
@@ -16,6 +26,15 @@
 
 Operator note:
 - The dependency cache is invalidated by changes to `package.json` or `yarn.lock`, by deleting the `node_modules` volume, or by losing `.yarn-integrity` / the stored manifest hash file inside that volume.
+
+## Health Endpoint Validation
+- From the droplet host, use:
+  - `curl http://127.0.0.1:8085/livez`
+  - `curl http://127.0.0.1:8085/healthz`
+  - `curl http://127.0.0.1:8086/livez`
+  - `curl http://127.0.0.1:8086/healthz`
+- `/livez` is liveness only and does not require Discord readiness.
+- `/healthz` should return success only when the Discord client is ready and the database probe succeeds.
 
 ## Install Links
 Prod guild install:

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -65,15 +65,20 @@ Use Docker Container monitors from inside Uptime Kuma:
 
 This works immediately with the localhost-only Uptime Kuma deployment because the Kuma container mounts the Docker socket privately.
 
-### Optional HTTP readiness monitors
+### HTTP readiness monitors to add alongside container monitors
 
-If you also deploy the bot health endpoint and localhost port mappings, use HTTP monitors:
+Keep the Docker Container monitors above, and add HTTP monitors for app readiness:
 
 - Production URL: `http://host.docker.internal:8085/healthz`
 - Staging URL: `http://host.docker.internal:8086/healthz`
 - Expected status: `200`
 
 If `host.docker.internal` is not available in your Docker runtime, use the droplet host gateway IP from inside the Uptime Kuma container instead.
+
+Result:
+
+- container monitors tell you whether the container is up
+- HTTP monitors tell you whether the bot is actually ready
 
 ## Bot Health Endpoint
 


### PR DESCRIPTION
- record localhost-only health port mappings for prod and staging
- clarify Kuma should use both container and HTTP readiness monitors