### PR TITLE
fix(accounts): autocomplete player tags from PlayerLink

### DIFF
--- a/src/commands/Accounts.ts
+++ b/src/commands/Accounts.ts
@@ -30,6 +30,17 @@ type ClanGroup = {
   entries: AccountRow[];
 };
 
+type AccountAutocompleteRow = {
+  playerTag: string;
+  playerName: string | null;
+  discordUserId: string | null;
+};
+
+type AccountAutocompleteChoice = {
+  name: string;
+  value: string;
+};
+
 const MAX_ACCOUNTS_PER_PAGE = 18;
 
 function normalizeTag(input: string): string {
@@ -43,6 +54,90 @@ function sanitizeDisplayText(input: unknown): string | null {
     .replace(/\s+/g, " ")
     .trim();
   return normalized.length > 0 ? normalized : null;
+}
+
+function normalizeAutocompleteQuery(input: string): string {
+  return String(input ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/^#+/, "");
+}
+
+function buildAccountsTagAutocompleteChoices(
+  rows: AccountAutocompleteRow[],
+  query: string,
+): AccountAutocompleteChoice[] {
+  const normalizedQuery = normalizeAutocompleteQuery(query);
+  const deduped = new Map<
+    string,
+    { tag: string; linkedName: string | null; hasDiscordUserId: boolean }
+  >();
+
+  for (const row of rows) {
+    const tag = normalizeTag(row.playerTag);
+    if (!tag) continue;
+    const linkedName = sanitizeDisplayText(row.playerName);
+    const hasDiscordUserId = Boolean(String(row.discordUserId ?? "").trim());
+    const existing = deduped.get(tag);
+    if (!existing) {
+      deduped.set(tag, { tag, linkedName, hasDiscordUserId });
+      continue;
+    }
+
+    if (hasDiscordUserId && !existing.hasDiscordUserId) {
+      deduped.set(tag, { tag, linkedName, hasDiscordUserId });
+      continue;
+    }
+    if (hasDiscordUserId === existing.hasDiscordUserId && linkedName && !existing.linkedName) {
+      deduped.set(tag, { tag, linkedName, hasDiscordUserId });
+    }
+  }
+
+  const ranked = [...deduped.values()]
+    .map((row) => {
+      const tagNoHash = row.tag.replace(/^#/, "").toLowerCase();
+      const linkedNameLower = row.linkedName?.toLowerCase() ?? "";
+      const exactTagMatch = normalizedQuery.length > 0 && tagNoHash === normalizedQuery;
+      const prefixTagMatch =
+        normalizedQuery.length > 0 &&
+        tagNoHash.startsWith(normalizedQuery) &&
+        !exactTagMatch;
+      const nameMatch =
+        normalizedQuery.length > 0 &&
+        row.linkedName !== null &&
+        linkedNameLower.includes(normalizedQuery);
+      const matchRank =
+        normalizedQuery.length === 0
+          ? 3
+          : exactTagMatch
+            ? 0
+            : prefixTagMatch
+              ? 1
+              : nameMatch
+                ? 2
+                : 99;
+      return {
+        ...row,
+        matchRank,
+        sortName: row.linkedName?.toLowerCase() ?? "\uffff",
+        sortTag: tagNoHash,
+      };
+    })
+    .filter((row) => row.matchRank !== 99)
+    .sort((a, b) => {
+      if (a.matchRank !== b.matchRank) return a.matchRank - b.matchRank;
+      const byName = a.sortName.localeCompare(b.sortName, undefined, {
+        sensitivity: "base",
+      });
+      if (byName !== 0) return byName;
+      return a.sortTag.localeCompare(b.sortTag, undefined, { sensitivity: "base" });
+    })
+    .slice(0, 25);
+
+  return ranked.map((row) => ({
+    name: (row.linkedName ? `${row.linkedName} (${row.tag})` : row.tag).slice(0, 100),
+    value: row.tag,
+  }));
 }
 
 function buildGroups(rows: AccountRow[]): ClanGroup[] {
@@ -378,23 +473,19 @@ export const Accounts: Command = {
       return;
     }
 
-    const query = normalizeTag(String(focused.value ?? "")).replace(/^#/, "").toLowerCase();
-    const tracked = await prisma.trackedClan.findMany({
-      orderBy: { createdAt: "asc" },
-      select: { name: true, tag: true },
+    const query = String(focused.value ?? "");
+    const rows = await prisma.playerLink.findMany({
+      select: {
+        discordUserId: true,
+        playerName: true,
+        playerTag: true,
+      },
     });
 
-    const choices = tracked
-      .map((clan) => {
-        const tag = normalizeTag(clan.tag).replace(/^#/, "");
-        const name = clan.name?.trim() ? `${clan.name.trim()} (#${tag})` : `#${tag}`;
-        return { name: name.slice(0, 100), value: tag };
-      })
-      .filter(
-        (choice) =>
-          choice.name.toLowerCase().includes(query) || choice.value.toLowerCase().includes(query)
-      )
-      .slice(0, 25);
+    const choices = buildAccountsTagAutocompleteChoices(
+      rows as AccountAutocompleteRow[],
+      query,
+    );
 
     await interaction.respond(choices);
   },

--- a/tests/accounts.command.test.ts
+++ b/tests/accounts.command.test.ts
@@ -44,6 +44,15 @@ function makeInteraction(input?: {
   };
 }
 
+function makeAutocompleteInteraction(value: string) {
+  return {
+    options: {
+      getFocused: vi.fn(() => ({ name: "tag", value })),
+    },
+    respond: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
 function getEmbedDescription(interaction: any): string {
   const payload = interaction.editReply.mock.calls.find(
     (call: unknown[]) => call[0] && typeof call[0] === "object" && Array.isArray(call[0].embeds)
@@ -136,6 +145,87 @@ describe("/accounts command", () => {
 
     expect(getEmbedDescription(interaction)).toContain("- Activity Charlie `#CUV9082`");
     expect(prismaMock.playerLink.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("autocompletes player tags from PlayerLink and ignores tracked clans", async () => {
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      {
+        playerTag: "#ABC123",
+        playerName: "Alpha",
+        discordUserId: null,
+      },
+      {
+        playerTag: "#ABC123",
+        playerName: "Alpha Prime",
+        discordUserId: "111111111111111111",
+      },
+      {
+        playerTag: "#ABC999",
+        playerName: "Beta",
+        discordUserId: "222222222222222222",
+      },
+    ]);
+    const interaction = makeAutocompleteInteraction("abc");
+
+    await Accounts.autocomplete(interaction as any);
+
+    expect(prismaMock.playerLink.findMany).toHaveBeenCalledWith({
+      select: {
+        discordUserId: true,
+        playerName: true,
+        playerTag: true,
+      },
+    });
+    expect(prismaMock.trackedClan.findMany).not.toHaveBeenCalled();
+    expect(interaction.respond).toHaveBeenCalledWith([
+      { name: "Alpha Prime (#ABC123)", value: "#ABC123" },
+      { name: "Beta (#ABC999)", value: "#ABC999" },
+    ]);
+  });
+
+  it("matches by partial linked name and falls back to the bare tag label", async () => {
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      {
+        playerTag: "#QGRJ2222",
+        playerName: "Bravo Player",
+        discordUserId: "111111111111111111",
+      },
+      {
+        playerTag: "#LQ9P8R2",
+        playerName: null,
+        discordUserId: "222222222222222222",
+      },
+    ]);
+    const interaction = makeAutocompleteInteraction("brav");
+
+    await Accounts.autocomplete(interaction as any);
+
+    expect(interaction.respond).toHaveBeenCalledWith([
+      { name: "Bravo Player (#QGRJ2222)", value: "#QGRJ2222" },
+    ]);
+
+    const emptyQueryInteraction = makeAutocompleteInteraction("");
+    await Accounts.autocomplete(emptyQueryInteraction as any);
+
+    expect(emptyQueryInteraction.respond).toHaveBeenCalledWith([
+      { name: "Bravo Player (#QGRJ2222)", value: "#QGRJ2222" },
+      { name: "#LQ9P8R2", value: "#LQ9P8R2" },
+    ]);
+  });
+
+  it("caps autocomplete results at 25", async () => {
+    prismaMock.playerLink.findMany.mockResolvedValue(
+      Array.from({ length: 30 }, (_, index) => ({
+        playerTag: `#PYLQ0${String(index).padStart(3, "0")}`,
+        playerName: `Player ${String(index).padStart(2, "0")}`,
+        discordUserId: "111111111111111111",
+      })),
+    );
+    const interaction = makeAutocompleteInteraction("");
+
+    await Accounts.autocomplete(interaction as any);
+
+    expect((interaction.respond as any).mock.calls[0][0]).toHaveLength(25);
   });
 
   it("falls back to raw tag when no linked/live/activity name exists", async () => {


### PR DESCRIPTION
- query player-link rows instead of tracked clans
- rank and dedupe autocomplete suggestions by tag and linked name