### PR TITLE
fix(link): sync ClashPerk player names

### DIFF
--- a/src/services/PlayerLinkSyncService.ts
+++ b/src/services/PlayerLinkSyncService.ts
@@ -4,7 +4,10 @@ import { formatError } from "../helper/formatError";
 import { ClashKingService } from "./ClashKingService";
 import { SettingsService } from "./SettingsService";
 import axios from "axios";
-import { normalizePersistedDiscordUsername } from "./PlayerLinkService";
+import {
+  normalizePersistedDiscordUsername,
+  normalizePersistedPlayerName,
+} from "./PlayerLinkService";
 
 const UNRESOLVED_SYNC_INTERVAL_MS = 6 * 60 * 60 * 1000;
 const UNRESOLVED_LAST_SYNC_KEY = "clashking:unresolved_last_sync_ms";
@@ -43,6 +46,7 @@ export type PublicGoogleSheetPlayerLinkSyncResult = {
 };
 
 type ClashPerkColumnIndexes = {
+  name: number;
   username: number;
   id: number;
   tag: number;
@@ -100,6 +104,7 @@ function resolveClashPerkColumnIndexes(
 ): ClashPerkColumnIndexes {
   const normalized = headerRow.map((cell) => cell.trim().toLowerCase());
 
+  const name = normalized.indexOf("name");
   const username = normalized.indexOf("username");
   const id = normalized.indexOf("id");
   const tag = normalized.indexOf("tag");
@@ -109,11 +114,15 @@ function resolveClashPerkColumnIndexes(
   if (id === -1) throw new Error("Missing required ClashPerk column: ID");
   if (tag === -1) throw new Error("Missing required ClashPerk column: Tag");
 
-  return { username, id, tag };
+  return { name, username, id, tag };
 }
 
 function getCell(row: string[], index: number): string {
   return String(row[index] ?? "").trim();
+}
+
+function normalizeClashPerkPlayerName(input: unknown): string | null {
+  return normalizePersistedPlayerName(input);
 }
 
 export class PlayerLinkSyncService {
@@ -190,15 +199,18 @@ export class PlayerLinkSyncService {
         playerTag: string;
         discordUserId: string;
         discordUsername: string | null;
+        playerName: string | null;
       }
     >();
 
     for (const row of dataRows) {
+      const rawName = indexes.name === -1 ? "" : getCell(row, indexes.name);
       const rawTag = getCell(row, indexes.tag);
       const rawDiscordUserId = getCell(row, indexes.id);
       const discordUsername = normalizePersistedDiscordUsername(
         getCell(row, indexes.username),
       );
+      const playerName = normalizeClashPerkPlayerName(rawName);
 
       if (!rawTag || !rawDiscordUserId || !discordUsername) {
         missingRequiredCount += 1;
@@ -226,6 +238,7 @@ export class PlayerLinkSyncService {
         playerTag,
         discordUserId,
         discordUsername,
+        playerName,
       });
     }
 
@@ -258,6 +271,7 @@ export class PlayerLinkSyncService {
         playerTag: true,
         discordUserId: true,
         discordUsername: true,
+        playerName: true,
       },
     });
 
@@ -274,6 +288,7 @@ export class PlayerLinkSyncService {
             playerTag: row.playerTag,
             discordUserId: row.discordUserId,
             discordUsername: row.discordUsername,
+            playerName: row.playerName,
           },
         });
         insertedCount += 1;
@@ -284,22 +299,36 @@ export class PlayerLinkSyncService {
       const existingDiscordUsername = normalizePersistedDiscordUsername(
         existing.discordUsername,
       );
+      const existingPlayerName = normalizeClashPerkPlayerName(
+        existing.playerName,
+      );
 
       const isSameDiscordUserId = existingDiscordUserId === row.discordUserId;
       const isSameDiscordUsername =
         existingDiscordUsername === row.discordUsername;
+      const isSamePlayerName =
+        row.playerName === null || existingPlayerName === row.playerName;
 
-      if (isSameDiscordUserId && isSameDiscordUsername) {
+      if (isSameDiscordUserId && isSameDiscordUsername && isSamePlayerName) {
         unchangedCount += 1;
         continue;
       }
 
+      const updateData: {
+        discordUserId: string;
+        discordUsername: string | null;
+        playerName?: string | null;
+      } = {
+        discordUserId: row.discordUserId,
+        discordUsername: row.discordUsername,
+      };
+      if (row.playerName !== null && row.playerName !== existingPlayerName) {
+        updateData.playerName = row.playerName;
+      }
+
       await prisma.playerLink.update({
         where: { playerTag: row.playerTag },
-        data: {
-          discordUserId: row.discordUserId,
-          discordUsername: row.discordUsername,
-        },
+        data: updateData,
       });
       updatedCount += 1;
     }

--- a/tests/playerLinkSync.service.test.ts
+++ b/tests/playerLinkSync.service.test.ts
@@ -1,0 +1,187 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import axios from "axios";
+import { PlayerLinkSyncService } from "../src/services/PlayerLinkSyncService";
+
+vi.mock("axios");
+
+const mockedAxios = vi.mocked(axios, true);
+
+const prismaMock = vi.hoisted(() => ({
+  playerLink: {
+    findMany: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+  },
+}));
+
+vi.mock("../src/prisma", () => ({
+  prisma: prismaMock,
+}));
+
+function makeTsv(rows: string[]): string {
+  return rows.join("\n");
+}
+
+describe("PlayerLinkSyncService ClashPerk sync", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prismaMock.playerLink.findMany.mockReset();
+    prismaMock.playerLink.create.mockReset();
+    prismaMock.playerLink.update.mockReset();
+  });
+
+  it("creates a new row with playerName from Name", async () => {
+    mockedAxios.get.mockResolvedValueOnce({
+      data: makeTsv([
+        "Name\tUsername\tID\tTag",
+        "  Player One  \t  discord-user  \t111111111111111111\tpyl0289",
+      ]),
+    } as never);
+    prismaMock.playerLink.findMany.mockResolvedValueOnce([]);
+
+    const service = new PlayerLinkSyncService();
+    const result = await service.syncFromPublicGoogleSheet(
+      "https://docs.google.com/spreadsheets/d/test-sheet/edit#gid=0",
+    );
+
+    expect(prismaMock.playerLink.create).toHaveBeenCalledWith({
+      data: {
+        playerTag: "#PYL0289",
+        discordUserId: "111111111111111111",
+        discordUsername: "discord-user",
+        playerName: "Player One",
+      },
+    });
+    expect(result).toMatchObject({
+      totalRowCount: 1,
+      eligibleRowCount: 1,
+      insertedCount: 1,
+      updatedCount: 0,
+      unchangedCount: 0,
+      duplicateTagCount: 0,
+      missingRequiredCount: 0,
+      invalidTagCount: 0,
+      invalidDiscordUserIdCount: 0,
+    });
+  });
+
+  it("updates an existing row when only playerName differs", async () => {
+    mockedAxios.get.mockResolvedValueOnce({
+      data: makeTsv([
+        "Name\tUsername\tID\tTag",
+        "  New Name  \t discord-user \t111111111111111111\tpyl0289",
+      ]),
+    } as never);
+    prismaMock.playerLink.findMany.mockResolvedValueOnce([
+      {
+        playerTag: "#PYL0289",
+        discordUserId: "111111111111111111",
+        discordUsername: "discord-user",
+        playerName: "Old Name",
+      },
+    ]);
+    prismaMock.playerLink.update.mockResolvedValueOnce(undefined);
+
+    const service = new PlayerLinkSyncService();
+    const result = await service.syncFromPublicGoogleSheet(
+      "https://docs.google.com/spreadsheets/d/test-sheet/edit#gid=0",
+    );
+
+    expect(prismaMock.playerLink.update).toHaveBeenCalledWith({
+      where: { playerTag: "#PYL0289" },
+      data: {
+        discordUserId: "111111111111111111",
+        discordUsername: "discord-user",
+        playerName: "New Name",
+      },
+    });
+    expect(result.updatedCount).toBe(1);
+    expect(result.unchangedCount).toBe(0);
+  });
+
+  it("does not clear an existing playerName when sheet Name is blank", async () => {
+    mockedAxios.get.mockResolvedValueOnce({
+      data: makeTsv([
+        "Name\tUsername\tID\tTag",
+        "   \t discord-user \t111111111111111111\tpyl0289",
+      ]),
+    } as never);
+    prismaMock.playerLink.findMany.mockResolvedValueOnce([
+      {
+        playerTag: "#PYL0289",
+        discordUserId: "111111111111111111",
+        discordUsername: "discord-user",
+        playerName: "Old Name",
+      },
+    ]);
+
+    const service = new PlayerLinkSyncService();
+    const result = await service.syncFromPublicGoogleSheet(
+      "https://docs.google.com/spreadsheets/d/test-sheet/edit#gid=0",
+    );
+
+    expect(prismaMock.playerLink.update).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      insertedCount: 0,
+      updatedCount: 0,
+      unchangedCount: 1,
+    });
+  });
+
+  it("still skips rows missing Tag, ID, or Username", async () => {
+    mockedAxios.get.mockResolvedValueOnce({
+      data: makeTsv([
+        "Name\tUsername\tID\tTag",
+        "Player One\tdiscord-user\t111111111111111111\tpyl0289",
+        "Player Two\t\t111111111111111112\tqgrj2222",
+        "Player Three\tdiscord-user\t\tqgrj3333",
+        "Player Four\tdiscord-user\t111111111111111114\t",
+      ]),
+    } as never);
+    prismaMock.playerLink.findMany.mockResolvedValueOnce([]);
+
+    const service = new PlayerLinkSyncService();
+    const result = await service.syncFromPublicGoogleSheet(
+      "https://docs.google.com/spreadsheets/d/test-sheet/edit#gid=0",
+    );
+
+    expect(prismaMock.playerLink.create).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({
+      totalRowCount: 4,
+      eligibleRowCount: 1,
+      insertedCount: 1,
+      updatedCount: 0,
+      unchangedCount: 0,
+      duplicateTagCount: 0,
+      missingRequiredCount: 3,
+      invalidTagCount: 0,
+      invalidDiscordUserIdCount: 0,
+    });
+  });
+
+  it("keeps duplicate tag handling unchanged", async () => {
+    mockedAxios.get.mockResolvedValueOnce({
+      data: makeTsv([
+        "Name\tUsername\tID\tTag",
+        "Player One\tdiscord-user\t111111111111111111\tpyl0289",
+        "Player Two\tdiscord-user\t111111111111111112\tpyl0289",
+      ]),
+    } as never);
+    prismaMock.playerLink.findMany.mockResolvedValueOnce([]);
+
+    const service = new PlayerLinkSyncService();
+    const result = await service.syncFromPublicGoogleSheet(
+      "https://docs.google.com/spreadsheets/d/test-sheet/edit#gid=0",
+    );
+
+    expect(prismaMock.playerLink.create).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({
+      totalRowCount: 2,
+      eligibleRowCount: 1,
+      duplicateTagCount: 1,
+      insertedCount: 1,
+      updatedCount: 0,
+      unchangedCount: 0,
+    });
+  });
+});


### PR DESCRIPTION
- read optional ClashPerk Name column into PlayerLink.playerName
- preserve existing names when sheet values are blank