### PR TITLE
fix(accounts): make account rendering db-first

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -23,7 +23,7 @@ npm start
 - `CLASHKING_API_TOKEN` - bearer token for private ClashKing API (if required).
 
 Behavior:
-- `/accounts` backfills `PlayerLink` from ClashKing when local links are missing for the target user.
+- `/accounts` resolves linked accounts from persisted `PlayerLink` and local player activity only.
 - Activity observe loop checks unresolved tracked-member links via ClashKing at most once every 6 hours and caches matches in `PlayerLink`.
 
 ## Optional War Event Poll Setting

--- a/src/commands/Accounts.ts
+++ b/src/commands/Accounts.ts
@@ -11,11 +11,7 @@ import {
 } from "discord.js";
 import { Command } from "../Command";
 import { prisma } from "../prisma";
-import { CoCService } from "../services/CoCService";
-import {
-  backfillPlayerLinkNameIfMissing,
-  listPlayerLinksForDiscordUser,
-} from "../services/PlayerLinkService";
+import { listPlayerLinksForDiscordUser } from "../services/PlayerLinkService";
 
 type AccountRow = {
   tag: string;
@@ -266,7 +262,7 @@ export const Accounts: Command = {
   run: async (
     _client: Client,
     interaction: ChatInputCommandInteraction,
-    cocService: CoCService
+    _cocService: unknown
   ) => {
     if (!interaction.guildId) {
       await interaction.reply({ ephemeral: true, content: "This command can only be used in a server." });
@@ -362,71 +358,23 @@ export const Accounts: Command = {
         .map((row) => [normalizeTag(row.tag), sanitizeDisplayText(row.name)] as const)
         .filter((entry): entry is [string, string] => Boolean(entry[0] && entry[1]))
     );
-
-    const tagsNeedingLiveFetch = uniqueTags.filter((tag) => {
-      const hasLinkedName = Boolean(linkedNameByTag.get(tag));
-      const localFallback = activityByTag.get(tag);
-      const hasLocalFallback = Boolean(localFallback);
-      const hasIncompleteLocalClanContext = Boolean(
-        localFallback?.clanTag && !sanitizeDisplayText(localFallback.clanName)
-      );
-      return !hasLinkedName || !hasLocalFallback || hasIncompleteLocalClanContext;
-    });
-    const fetchedPlayersByTag = new Map<string, any>();
-    if (tagsNeedingLiveFetch.length > 0) {
-      const fetched = await Promise.allSettled(
-        tagsNeedingLiveFetch.map((tag) => cocService.getPlayerRaw(tag))
-      );
-      for (let i = 0; i < tagsNeedingLiveFetch.length; i += 1) {
-        const tag = tagsNeedingLiveFetch[i];
-        const result = fetched[i];
-        if (result?.status === "fulfilled") {
-          fetchedPlayersByTag.set(tag, result.value);
-        }
-      }
-    }
-
-    const playerNameBackfillTasks: Promise<void>[] = [];
     const rows: AccountRow[] = uniqueTags.map((tag) => {
       const linkedName = linkedNameByTag.get(tag) ?? null;
       const fallback = activityByTag.get(tag);
-      const livePlayer = fetchedPlayersByTag.get(tag) ?? null;
-      const livePlayerName = sanitizeDisplayText(livePlayer?.name);
       const fallbackClanTag = fallback?.clanTag ? normalizeTag(fallback.clanTag) : null;
-      const clanTag = normalizeTag(livePlayer?.clan?.tag ?? fallbackClanTag ?? "");
+      const clanTag = fallbackClanTag ?? "";
+      const activityName = sanitizeDisplayText(fallback?.name);
       const clanName =
-        sanitizeDisplayText(livePlayer?.clan?.name) ??
         sanitizeDisplayText(fallback?.clanName) ??
         (clanTag ? trackedClanNameByTag.get(clanTag) ?? null : null);
 
-      if (!linkedName && livePlayerName) {
-        playerNameBackfillTasks.push(
-          backfillPlayerLinkNameIfMissing({
-            playerTag: tag,
-            playerName: livePlayerName,
-          })
-            .then(() => undefined)
-            .catch((error) => {
-              console.error(
-                `[accounts] player_name_backfill_failed tag=${tag} user=${targetDiscordUserId} error=${String(
-                  (error as { message?: string } | null | undefined)?.message ?? error
-                )}`
-              );
-            })
-        );
-      }
-
       return {
         tag,
-        name: linkedName ?? livePlayerName ?? sanitizeDisplayText(fallback?.name) ?? tag,
+        name: linkedName ?? activityName ?? tag,
         clanTag: clanTag || null,
         clanName,
       };
     });
-
-    if (playerNameBackfillTasks.length > 0) {
-      void Promise.allSettled(playerNameBackfillTasks);
-    }
 
     const embeds = buildEmbeds(rows);
     for (const embed of embeds) {

--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -270,7 +270,7 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
       "If `tag` is provided, resolves linked Discord ID from local PlayerLink, then lists that user's accounts.",
       "Only one of `tag` or `discord-id` can be provided.",
       "Runtime link resolution is local-only from `PlayerLink`.",
-      "Fetches live player data when available and groups accounts by current clan.",
+      "Account display uses persisted local data only.",
       "Set `visibility:public` to post the response directly in channel.",
     ],
     examples: [

--- a/tests/accounts.command.test.ts
+++ b/tests/accounts.command.test.ts
@@ -71,7 +71,7 @@ describe("/accounts command", () => {
     prismaMock.trackedClan.findMany.mockResolvedValue([]);
   });
 
-  it("uses PlayerLink.playerName first when present and avoids live fetch for that row", async () => {
+  it("uses PlayerLink.playerName first when present and keeps render DB-only", async () => {
     prismaMock.playerLink.findMany.mockResolvedValue([
       {
         playerTag: "#PYLQ0289",
@@ -94,7 +94,7 @@ describe("/accounts command", () => {
     expect(prismaMock.playerLink.updateMany).not.toHaveBeenCalled();
   });
 
-  it("fetches live name and backfills PlayerLink.playerName when missing", async () => {
+  it("falls back to playerActivity.name when playerName is missing", async () => {
     prismaMock.playerLink.findMany.mockResolvedValue([
       {
         playerTag: "#QGRJ2222",
@@ -102,7 +102,14 @@ describe("/accounts command", () => {
         createdAt: new Date("2026-03-01T00:00:00.000Z"),
       },
     ]);
-    prismaMock.playerActivity.findMany.mockResolvedValue([]);
+    prismaMock.playerActivity.findMany.mockResolvedValue([
+      {
+        tag: "#QGRJ2222",
+        name: "Activity Bravo",
+        clanTag: "#PQL0289",
+        clanName: "Clan One",
+      },
+    ]);
     const cocService = {
       getPlayerRaw: vi.fn().mockResolvedValue({
         name: "Live Bravo",
@@ -112,20 +119,13 @@ describe("/accounts command", () => {
     const interaction = makeInteraction();
 
     await Accounts.run({} as any, interaction as any, cocService as any);
-    await Promise.resolve();
 
-    expect(cocService.getPlayerRaw).toHaveBeenCalledWith("#QGRJ2222");
-    expect(getEmbedDescription(interaction)).toContain("- Live Bravo `#QGRJ2222`");
-    expect(prismaMock.playerLink.updateMany).toHaveBeenCalledWith({
-      where: {
-        playerTag: "#QGRJ2222",
-        OR: [{ playerName: null }, { playerName: "" }],
-      },
-      data: { playerName: "Live Bravo" },
-    });
+    expect(cocService.getPlayerRaw).not.toHaveBeenCalled();
+    expect(getEmbedDescription(interaction)).toContain("- Activity Bravo `#QGRJ2222`");
+    expect(prismaMock.playerLink.updateMany).not.toHaveBeenCalled();
   });
 
-  it("uses local fallback name when live fetch fails and does not write backfill", async () => {
+  it("falls back to raw tag when neither local name source exists", async () => {
     prismaMock.playerLink.findMany.mockResolvedValue([
       {
         playerTag: "#CUV9082",
@@ -133,9 +133,7 @@ describe("/accounts command", () => {
         createdAt: new Date("2026-03-01T00:00:00.000Z"),
       },
     ]);
-    prismaMock.playerActivity.findMany.mockResolvedValue([
-      { tag: "#CUV9082", name: "Activity Charlie", clanTag: "#2QG2C08UP" },
-    ]);
+    prismaMock.playerActivity.findMany.mockResolvedValue([]);
     const cocService = {
       getPlayerRaw: vi.fn().mockRejectedValue(new Error("coc unavailable")),
     };
@@ -143,7 +141,8 @@ describe("/accounts command", () => {
 
     await Accounts.run({} as any, interaction as any, cocService as any);
 
-    expect(getEmbedDescription(interaction)).toContain("- Activity Charlie `#CUV9082`");
+    expect(cocService.getPlayerRaw).not.toHaveBeenCalled();
+    expect(getEmbedDescription(interaction)).toContain("- #CUV9082 `#CUV9082`");
     expect(prismaMock.playerLink.updateMany).not.toHaveBeenCalled();
   });
 
@@ -228,27 +227,7 @@ describe("/accounts command", () => {
     expect((interaction.respond as any).mock.calls[0][0]).toHaveLength(25);
   });
 
-  it("falls back to raw tag when no linked/live/activity name exists", async () => {
-    prismaMock.playerLink.findMany.mockResolvedValue([
-      {
-        playerTag: "#LQ9P8R2",
-        playerName: null,
-        createdAt: new Date("2026-03-01T00:00:00.000Z"),
-      },
-    ]);
-    prismaMock.playerActivity.findMany.mockResolvedValue([]);
-    const cocService = {
-      getPlayerRaw: vi.fn().mockRejectedValue(new Error("coc unavailable")),
-    };
-    const interaction = makeInteraction();
-
-    await Accounts.run({} as any, interaction as any, cocService as any);
-
-    expect(getEmbedDescription(interaction)).toContain("- #LQ9P8R2 `#LQ9P8R2`");
-    expect(prismaMock.playerLink.updateMany).not.toHaveBeenCalled();
-  });
-
-  it("uses PlayerActivity clan name in output without live fetch when local clan context is complete", async () => {
+  it("uses PlayerActivity clan name in output when local clan context is complete", async () => {
     prismaMock.playerLink.findMany.mockResolvedValue([
       {
         playerTag: "#PYLQ0289",
@@ -270,7 +249,7 @@ describe("/accounts command", () => {
     expect(getEmbedDescription(interaction)).toContain("**Saved Clan Name (#PQL0289)**");
   });
 
-  it("treats clanTag-only local context as incomplete, live-fetches, then falls back to tracked clan name", async () => {
+  it("uses tracked clan fallback name when playerActivity.clanTag exists but clanName is missing", async () => {
     prismaMock.playerLink.findMany.mockResolvedValue([
       {
         playerTag: "#QGRJ2222",
@@ -291,7 +270,7 @@ describe("/accounts command", () => {
 
     await Accounts.run({} as any, interaction as any, cocService as any);
 
-    expect(cocService.getPlayerRaw).toHaveBeenCalledWith("#QGRJ2222");
+    expect(cocService.getPlayerRaw).not.toHaveBeenCalled();
     expect(getEmbedDescription(interaction)).toContain("**Tracked Clan Name (#2QG2C08UP)**");
   });
 });


### PR DESCRIPTION
- remove live CoC fetches and name backfill from the render path
- source tag autocomplete from PlayerLink instead of tracked clans