### PR TITLE
fix(todo): render upcoming cwl prep context

### DIFF
--- a/src/services/TodoService.ts
+++ b/src/services/TodoService.ts
@@ -516,26 +516,26 @@ function buildCwlPageDescription(
   rows: TodoRenderRow[],
   linkedPlayerCount: number,
 ): { description: string; sidebarState: TodoSidebarState } {
-  const activeRows = rows.filter((row) => Boolean(row.snapshot?.cwlActive));
-  const cwlCompletion = summarizeCwlCompletionStatus(activeRows);
-  if (activeRows.length <= 0) {
+  const contextRows = rows.filter((row) => hasCwlRenderContext(row));
+  if (contextRows.length <= 0) {
     return {
       description: buildTodoPageDescription({
         heading: "CWL",
         linkedPlayerCount,
-        statusLine: cwlCompletion.statusLine,
+        statusLine: "CWL Status: 0 / 0 attacks completed",
         lines: ["No CWL active"],
       }),
-      sidebarState: cwlCompletion.sidebarState,
+      sidebarState: "default",
     };
   }
 
-  const grouped = buildEventGroups(activeRows, "cwl");
+  const cwlCompletion = summarizeCwlCompletionStatus(contextRows);
+  const grouped = buildEventGroups(contextRows, "cwl");
   const lines: string[] = [];
   for (const group of grouped) {
-    lines.push(`**${buildEventGroupHeader(group)}**`);
+    lines.push(buildCwlEventGroupHeader(group));
     for (const row of group.rows) {
-      lines.push(formatTodoRow(row, getCwlRowStatus(row)));
+      lines.push(formatCwlTodoRow(row));
     }
     lines.push("");
   }
@@ -586,24 +586,27 @@ function summarizeWarCompletionStatus(
 
 /** Purpose: compute CWL completion totals and sidebar state from confirmed active battle-day participants. */
 function summarizeCwlCompletionStatus(
-  confirmedRows: TodoRenderRow[],
+  contextRows: TodoRenderRow[],
 ): { statusLine: string; sidebarState: TodoSidebarState } {
-  const battleDayRows = confirmedRows.filter((row) =>
+  const battleDayRows = contextRows.filter((row) =>
     isCwlRowAttackPhaseActive(row),
   );
   const completedAttacks = battleDayRows.reduce(
     (sum, row) => sum + getCwlRowProgress(row).used,
     0,
   );
-  const requiredAttacks = battleDayRows.length;
+  const requiredAttacks = battleDayRows.reduce(
+    (sum, row) => sum + getCwlRowProgress(row).max,
+    0,
+  );
   if (battleDayRows.length <= 0) {
     return {
-      statusLine: `cwl status: ${completedAttacks} / ${requiredAttacks} attacks completed`,
+      statusLine: "CWL Status: Not in war yet",
       sidebarState: "default",
     };
   }
   return {
-    statusLine: `cwl status: ${completedAttacks} / ${requiredAttacks} attacks completed`,
+    statusLine: `CWL Status: ${completedAttacks} / ${requiredAttacks} attacks completed`,
     sidebarState:
       completedAttacks >= requiredAttacks ? "complete" : "incomplete",
   };
@@ -760,6 +763,31 @@ function buildEventGroupHeader(group: TodoEventGroup): string {
   return `${clanWithIndicator} - ${group.phase}${endsAt}`;
 }
 
+/** Purpose: build one CWL clan section header as a clickable clan-profile line with phase timing suffix. */
+function buildCwlEventGroupHeader(group: TodoEventGroup): string {
+  const nextWarSuffix = group.phaseEndsAt
+    ? `Next war ${formatRelativeTimestamp(group.phaseEndsAt)}`
+    : "Next war unknown";
+  const clanLink = buildClanProfileMarkdownLink(group.clanName, group.clanTag);
+  const clanTagText = group.clanTag ? ` \`${group.clanTag}\`` : "";
+  return `${clanLink}${clanTagText} - ${nextWarSuffix}`;
+}
+
+/** Purpose: render one clan-profile markdown alias using the tag-stripped Clash link when possible. */
+function buildClanProfileMarkdownLink(
+  clanName: string | null,
+  clanTag: string | null,
+): string {
+  const normalizedClanTag = normalizeClanTag(clanTag ?? "");
+  const fallbackLabel = normalizedClanTag || "Unknown Clan";
+  const label = sanitizeStatusText(clanName) || fallbackLabel;
+  if (!normalizedClanTag) {
+    return label;
+  }
+  const encodedTag = normalizedClanTag.replace(/^#/, "");
+  return `[${label}](https://link.clashofclans.com/en?action=OpenClanProfile&tag=${encodedTag})`;
+}
+
 /** Purpose: build stable clan identity text for grouped section headings. */
 function buildGroupClanIdentity(group: {
   clanName: string | null;
@@ -794,11 +822,6 @@ function getSharedEndsAt(
   return [...candidates].sort((a, b) => a.getTime() - b.getTime())[0];
 }
 
-/** Purpose: format one todo row with stable identity context (player + tag). */
-function formatTodoRow(row: TodoRenderRow, status: string): string {
-  return `- ${formatPlayerIdentity(row)} - ${status}`;
-}
-
 /** Purpose: format one WAR row with lineup position and compact attack-detail suffixes. */
 function formatWarTodoRow(row: TodoRenderRow, status: string): string {
   const identity = formatWarPlayerIdentity(row);
@@ -815,6 +838,11 @@ function formatWarTodoRow(row: TodoRenderRow, status: string): string {
     detailRows.length > 0 ? ` | ${detailRows.join(" | ")}` : "";
   const bullet = warProgress.complete ? ":white_check_mark:" : "-";
   return `${bullet} ${identity} - ${status}${detailsSuffix}`;
+}
+
+/** Purpose: format one CWL row with WAR-style completion markers and compact attack progress text. */
+function formatCwlTodoRow(row: TodoRenderRow): string {
+  return `${getCwlRowMarker(row)} ${row.playerName} - ${getCwlRowStatus(row)}`;
 }
 
 /** Purpose: format one GAMES row with optional completion marker next to player identity text. */
@@ -912,12 +940,17 @@ function isWarEventGroupComplete(group: TodoEventGroup): boolean {
 /** Purpose: build active CWL row status text without repeating group-level phase timing details. */
 function getCwlRowStatus(row: TodoRenderRow): string {
   if (row.missingSnapshot || !row.snapshot) {
-    return "CWL attacks: 0/1 - snapshot unavailable";
+    return "`0 / 0` - snapshot unavailable";
+  }
+
+  if (!isCwlRowAttackPhaseActive(row)) {
+    const staleSuffix = row.staleSnapshot ? " - stale snapshot" : "";
+    return `\`0 / 0\`${staleSuffix}`;
   }
 
   const { used, max } = getCwlRowProgress(row);
   const staleSuffix = row.staleSnapshot ? " - stale snapshot" : "";
-  return `CWL attacks: ${used}/${max}${staleSuffix}`;
+  return `\`${used} / ${max}\`${staleSuffix}`;
 }
 
 /** Purpose: compute stable CWL used/max progress and completion state for one confirmed participant row. */
@@ -943,6 +976,23 @@ function isCwlRowAttackPhaseActive(row: TodoRenderRow): boolean {
   if (!row.snapshot?.cwlActive) return false;
   const phase = sanitizeStatusText(row.snapshot.cwlPhase).toLowerCase();
   return phase.includes("battle");
+}
+
+/** Purpose: include active or upcoming/persisted CWL-clan context rows in the shared CWL page render. */
+function hasCwlRenderContext(row: TodoRenderRow): boolean {
+  if (!row.snapshot) return false;
+  if (row.snapshot.cwlActive) return true;
+  return Boolean(row.cwlClanTag || row.cwlClanName);
+}
+
+/** Purpose: map one CWL row into prep/battle completion markers that match WAR semantics. */
+function getCwlRowMarker(row: TodoRenderRow): string {
+  if (!isCwlRowAttackPhaseActive(row)) {
+    return ":black_circle:";
+  }
+  return getCwlRowProgress(row).complete
+    ? ":white_check_mark:"
+    : ":black_circle:";
 }
 
 /** Purpose: build RAIDS row status text with usage only and without per-row timer duplication. */

--- a/tests/todo.command.test.ts
+++ b/tests/todo.command.test.ts
@@ -146,13 +146,19 @@ function makeSnapshotRow(input: {
   updatedAt?: Date;
 }) {
   const now = new Date("2026-03-26T00:00:00.000Z");
+  const hasOwn = <K extends string>(key: K) =>
+    Object.prototype.hasOwnProperty.call(input, key);
   return {
     playerTag: input.playerTag,
     playerName: input.playerName,
     clanTag: input.clanTag ?? "#PQL0289",
     clanName: input.clanName ?? "Clan One",
-    cwlClanTag: input.cwlClanTag ?? input.clanTag ?? "#PQL0289",
-    cwlClanName: input.cwlClanName ?? input.clanName ?? "Clan One",
+    cwlClanTag: hasOwn("cwlClanTag")
+      ? input.cwlClanTag ?? null
+      : input.clanTag ?? "#PQL0289",
+    cwlClanName: hasOwn("cwlClanName")
+      ? input.cwlClanName ?? null
+      : input.clanName ?? "Clan One",
     warActive: input.warActive ?? true,
     warAttacksUsed: input.warAttacksUsed ?? 0,
     warAttacksMax: input.warAttacksMax ?? 2,
@@ -161,8 +167,10 @@ function makeSnapshotRow(input: {
     cwlActive: input.cwlActive ?? true,
     cwlAttacksUsed: input.cwlAttacksUsed ?? 0,
     cwlAttacksMax: input.cwlAttacksMax ?? 1,
-    cwlPhase: input.cwlPhase ?? "preparation",
-    cwlEndsAt: input.cwlEndsAt ?? new Date("2026-03-30T12:00:00.000Z"),
+    cwlPhase: hasOwn("cwlPhase") ? input.cwlPhase ?? null : "preparation",
+    cwlEndsAt: hasOwn("cwlEndsAt")
+      ? input.cwlEndsAt ?? null
+      : new Date("2026-03-30T12:00:00.000Z"),
     raidActive: input.raidActive ?? true,
     raidAttacksUsed: input.raidAttacksUsed ?? 0,
     raidAttacksMax: input.raidAttacksMax ?? 6,
@@ -467,8 +475,11 @@ describe("/todo command", () => {
     const description = getReplyDescription(interaction);
     const payload = interaction.editReply.mock.calls[0]?.[0] as any;
     expect(getReplyTitle(interaction)).toBe("Todo - CWL");
-    expect(description).toContain("**Clan One (#PQL0289) - preparation ends <t:");
-    expect(description).toContain("CWL attacks: 1/1");
+    expect(description).toContain("CWL Status: Not in war yet");
+    expect(description).toContain(
+      "[Clan One](https://link.clashofclans.com/en?action=OpenClanProfile&tag=PQL0289) `#PQL0289` - Next war <t:",
+    );
+    expect(description).toContain(":black_circle: Alpha - `0 / 0`");
     expect(payload.components[0].components.map((b: any) => b.toJSON().label)).toEqual([
       "WAR",
       "CWL",
@@ -505,6 +516,33 @@ describe("/todo command", () => {
     await Todo.run({} as any, interaction as any, makeCocServiceSpy() as any);
 
     expect(getReplyTitle(interaction)).toBe("Todo - RAIDS");
+  });
+
+  it("uses the same CWL prep rendering when no-arg /todo opens on the remembered CWL page", async () => {
+    vi.spyOn(todoLastViewedTypeService, "getLastViewedType").mockResolvedValue("CWL");
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      { playerTag: "#PYLQ0289", createdAt: new Date("2026-03-01T00:00:00.000Z") },
+    ]);
+    prismaMock.todoPlayerSnapshot.aggregate.mockResolvedValue({
+      _count: { _all: 1 },
+      _max: { updatedAt: new Date("2026-03-26T00:00:00.000Z") },
+    });
+    prismaMock.todoPlayerSnapshot.findMany.mockResolvedValue([
+      makeSnapshotRow({
+        playerTag: "#PYLQ0289",
+        playerName: "Alpha",
+        cwlPhase: "preparation",
+        cwlEndsAt: new Date("2026-03-30T12:00:00.000Z"),
+      }),
+    ]);
+    const interaction = makeTodoInteraction({ type: null });
+
+    await Todo.run({} as any, interaction as any, makeCocServiceSpy() as any);
+
+    const description = getReplyDescription(interaction);
+    expect(getReplyTitle(interaction)).toBe("Todo - CWL");
+    expect(description).toContain("CWL Status: Not in war yet");
+    expect(description).toContain(":black_circle: Alpha - `0 / 0`");
   });
 
   it("falls back to default WAR page for no-arg /todo when no remembered page exists", async () => {
@@ -1591,6 +1629,10 @@ describe("/todo command", () => {
         clanTag: "#PQL0289",
         clanName: "Clan One",
         cwlActive: false,
+        cwlPhase: null,
+        cwlEndsAt: null,
+        cwlClanTag: null,
+        cwlClanName: null,
         cwlAttacksUsed: 0,
       }),
     ]);
@@ -1601,14 +1643,18 @@ describe("/todo command", () => {
     const description = getReplyDescription(interaction);
     expect(getReplyTitle(interaction)).toBe("Todo - CWL");
     expect(getReplyColor(interaction)).toBe(TODO_INCOMPLETE_EMBED_COLOR);
-    expect(description).toContain("cwl status: 1 / 2 attacks completed");
+    expect(description).toContain("CWL Status: 1 / 2 attacks completed");
     expect(description).not.toContain("Linked players:");
-    expect(description).toContain("**Clan One (#PQL0289) - battle day ends <t:");
-    expect(description).toContain("**Clan Two (#2QG2C08UP) - preparation ends <t:");
-    expect(description).toContain("- Alpha #PYLQ0289 - CWL attacks: 1/1");
-    expect(description).toContain("- Bravo #QGRJ2222 - CWL attacks: 0/1");
-    expect(description).not.toContain("**Not in active CWL**");
-    expect(description).not.toContain("Delta #LQ9P8R2");
+    expect(description).toContain(
+      "[Clan One](https://link.clashofclans.com/en?action=OpenClanProfile&tag=PQL0289) `#PQL0289` - Next war <t:",
+    );
+    expect(description).toContain(
+      "[Clan Two](https://link.clashofclans.com/en?action=OpenClanProfile&tag=2QG2C08UP) `#2QG2C08UP` - Next war <t:",
+    );
+    expect(description).toContain(":white_check_mark: Alpha - `1 / 1`");
+    expect(description).toContain(":black_circle: Bravo - `0 / 1`");
+    expect(description).toContain(":black_circle: Charlie - `0 / 0`");
+    expect(description).not.toContain("Delta");
   });
 
   it("uses green CWL sidebar when all active battle-day participants have attacked", async () => {
@@ -1640,7 +1686,7 @@ describe("/todo command", () => {
 
     expect(getReplyColor(interaction)).toBe(TODO_COMPLETE_EMBED_COLOR);
     expect(getReplyDescription(interaction)).toContain(
-      "cwl status: 2 / 2 attacks completed",
+      "CWL Status: 2 / 2 attacks completed",
     );
   });
 
@@ -1666,8 +1712,10 @@ describe("/todo command", () => {
 
     expect(getReplyColor(interaction)).toBe(TODO_DEFAULT_EMBED_COLOR);
     expect(getReplyDescription(interaction)).toContain(
-      "cwl status: 0 / 0 attacks completed",
+      "CWL Status: Not in war yet",
     );
+    expect(getReplyDescription(interaction)).not.toContain("No CWL active");
+    expect(getReplyDescription(interaction)).toContain(":black_circle: Alpha - `0 / 0`");
   });
 
   it("groups CWL rows by cwlClanTag/cwlClanName when different from home clan", async () => {
@@ -1704,9 +1752,42 @@ describe("/todo command", () => {
     await Todo.run({} as any, interaction as any, makeCocServiceSpy() as any);
 
     const description = getReplyDescription(interaction);
-    expect(description).toContain("**CWL One (#2QG2C08UP) - preparation ends <t:");
-    expect(description).not.toContain("**Home Clan (#PQL0289) - preparation ends <t:");
-    expect(description).toContain("- Alpha #PYLQ0289 - CWL attacks: 1/1");
+    expect(description).toContain(
+      "[CWL One](https://link.clashofclans.com/en?action=OpenClanProfile&tag=2QG2C08UP) `#2QG2C08UP` - Next war <t:",
+    );
+    expect(description).not.toContain("Home Clan");
+    expect(description).toContain(":black_circle: Alpha - `0 / 0`");
+  });
+
+  it("renders upcoming CWL context with unknown timing instead of no-context when a CWL clan is already known", async () => {
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      { playerTag: "#PYLQ0289", createdAt: new Date("2026-03-01T00:00:00.000Z") },
+    ]);
+    prismaMock.todoPlayerSnapshot.aggregate.mockResolvedValue({
+      _count: { _all: 1 },
+      _max: { updatedAt: new Date("2026-03-26T00:00:00.000Z") },
+    });
+    prismaMock.todoPlayerSnapshot.findMany.mockResolvedValue([
+      makeSnapshotRow({
+        playerTag: "#PYLQ0289",
+        playerName: "Alpha",
+        cwlActive: false,
+        cwlPhase: null,
+        cwlEndsAt: null,
+        cwlClanTag: "#2QG2C08UP",
+        cwlClanName: "Clan Two",
+      }),
+    ]);
+
+    const interaction = makeTodoInteraction({ type: "CWL" });
+    await Todo.run({} as any, interaction as any, makeCocServiceSpy() as any);
+
+    const description = getReplyDescription(interaction);
+    expect(description).toContain("CWL Status: Not in war yet");
+    expect(description).not.toContain("No CWL active");
+    expect(description).toContain(
+      "[Clan Two](https://link.clashofclans.com/en?action=OpenClanProfile&tag=2QG2C08UP) `#2QG2C08UP` - Next war unknown",
+    );
   });
 
   it("shows explicit inactive WAR page message when no active war contexts exist", async () => {
@@ -1747,6 +1828,10 @@ describe("/todo command", () => {
         playerTag: "#PYLQ0289",
         playerName: "Alpha",
         cwlActive: false,
+        cwlPhase: null,
+        cwlEndsAt: null,
+        cwlClanTag: null,
+        cwlClanName: null,
       }),
     ]);
 
@@ -1754,7 +1839,7 @@ describe("/todo command", () => {
     await Todo.run({} as any, interaction as any, makeCocServiceSpy() as any);
     expect(getReplyColor(interaction)).toBe(TODO_DEFAULT_EMBED_COLOR);
     expect(getReplyDescription(interaction)).toContain(
-      "cwl status: 0 / 0 attacks completed",
+      "CWL Status: 0 / 0 attacks completed",
     );
     expect(getReplyDescription(interaction)).toContain("No CWL active");
   });
@@ -2362,7 +2447,7 @@ describe("/todo pagination buttons", () => {
   it("paginates across WAR/CWL/RAIDS/GAMES with user-scoped access", async () => {
     const checks: Array<{ type: TodoType; contains: string }> = [
       { type: "WAR", contains: "No war active" },
-      { type: "CWL", contains: "CWL attacks:" },
+      { type: "CWL", contains: "CWL Status:" },
       { type: "RAIDS", contains: "clan capital raids:" },
       { type: "GAMES", contains: "clan games points:" },
     ];


### PR DESCRIPTION
- show prep-day CWL as grouped upcoming clan context instead of no-active
- use linked clan headers and war-style CWL completion markers