### PR TITLE
fix(tracked-clan): make cwl tag registration db-first

### DIFF
--- a/src/commands/TrackedClan.ts
+++ b/src/commands/TrackedClan.ts
@@ -19,6 +19,7 @@ import { CoCService } from "../services/CoCService";
 import { normalizeClanTag } from "../services/PlayerLinkService";
 import {
   addCwlClanTagsForSeason,
+  hydrateMissingCwlClanNamesForSeason,
   listCwlTrackedClansForSeason,
   removeTrackedClanTagFromRegistries,
   resolveCurrentCwlSeasonKey,
@@ -293,7 +294,13 @@ export const TrackedClan: Command = {
     cocService: CoCService
   ) => {
     try {
+      console.info(
+        `[tracked-clan] stage=command_entered command=tracked-clan guild=${interaction.guildId ?? "none"} user=${interaction.user.id}`,
+      );
       await interaction.deferReply({ ephemeral: true });
+      console.info(
+        `[tracked-clan] stage=interaction_deferred command=tracked-clan guild=${interaction.guildId ?? "none"} user=${interaction.user.id}`,
+      );
       const subcommand = interaction.options.getSubcommand(true);
 
       if (subcommand === "list") {
@@ -459,7 +466,6 @@ export const TrackedClan: Command = {
         const rawCwlTags = interaction.options.getString("cwl-tags", true);
         const result = await addCwlClanTagsForSeason({
           rawTags: rawCwlTags,
-          cocService,
         });
 
         await safeReply(interaction, {
@@ -472,6 +478,21 @@ export const TrackedClan: Command = {
             `duplicates in request: ${formatTagListForSummary(result.duplicateInRequest)}`,
           ].join("\n"),
         });
+        console.info(
+          `[tracked-clan] stage=cwl_tags_final_reply_sent season=${result.season} added_count=${result.added.length} existing_count=${result.alreadyExisting.length}`,
+        );
+
+        if (cocService && typeof cocService.getClan === "function") {
+          void hydrateMissingCwlClanNamesForSeason({
+            rawTags: rawCwlTags,
+            season: result.season,
+            cocService,
+          }).catch((err) => {
+            console.error(
+              `[tracked-clan] stage=cwl_tags_name_hydration_unhandled_error season=${result.season} error=${formatError(err)}`,
+            );
+          });
+        }
         return;
       }
 

--- a/src/services/CwlRegistryService.ts
+++ b/src/services/CwlRegistryService.ts
@@ -1,4 +1,5 @@
 import { prisma } from "../prisma";
+import { formatError } from "../helper/formatError";
 import { normalizeClanTag } from "./PlayerLinkService";
 import { CoCService } from "./CoCService";
 
@@ -36,6 +37,59 @@ export type RemoveTrackedClanResult =
       tag: string;
       season: string;
     };
+
+const CWL_TAG_DB_STAGE_TIMEOUT_MS = 5_000;
+const CWL_TAG_HYDRATION_LOOKUP_TIMEOUT_MS = 5_000;
+
+type CwlTagStageDetailValue = string | number | boolean | null | undefined;
+type CwlTagStageDetails = Record<string, CwlTagStageDetailValue>;
+
+function formatCwlTagStageDetails(details?: CwlTagStageDetails): string {
+  if (!details) return "";
+  const parts = Object.entries(details)
+    .map(([key, value]) => `${key}=${String(value)}`)
+    .filter((value) => !value.endsWith("=undefined"));
+  return parts.length > 0 ? ` ${parts.join(" ")}` : "";
+}
+
+async function runBoundedCwlTagStage<T>(input: {
+  stage: string;
+  timeoutMs: number;
+  details?: CwlTagStageDetails;
+  action: () => Promise<T>;
+}): Promise<T> {
+  const startedAtMs = Date.now();
+  const detailText = formatCwlTagStageDetails(input.details);
+  console.info(
+    `[tracked-clan] stage=${input.stage} status=started timeout_ms=${input.timeoutMs}${detailText}`,
+  );
+
+  let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+  try {
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timeoutHandle = setTimeout(() => {
+        reject(new Error(`tracked-clan stage timed out: ${input.stage} after ${input.timeoutMs}ms`));
+      }, input.timeoutMs);
+    });
+    const result = (await Promise.race([input.action(), timeoutPromise])) as T;
+    console.info(
+      `[tracked-clan] stage=${input.stage} status=completed duration_ms=${
+        Date.now() - startedAtMs
+      }${detailText}`,
+    );
+    return result;
+  } catch (err) {
+    const timedOut = String((err as Error)?.message ?? "").includes("timed out");
+    console.error(
+      `[tracked-clan] stage=${input.stage} status=${timedOut ? "timeout" : "failed"} duration_ms=${
+        Date.now() - startedAtMs
+      } timeout_ms=${input.timeoutMs}${detailText}${timedOut ? "" : ` error=${formatError(err)}`}`,
+    );
+    throw err;
+  } finally {
+    if (timeoutHandle) clearTimeout(timeoutHandle);
+  }
+}
 
 /** Purpose: resolve current CWL month key in stable UTC `YYYY-MM` format. */
 export function resolveCurrentCwlSeasonKey(nowMs?: number): string {
@@ -94,10 +148,12 @@ export function parseCwlClanTagsInput(rawInput: string): ParsedCwlTagInput {
 export async function addCwlClanTagsForSeason(input: {
   rawTags: string;
   season?: string;
-  cocService?: CoCService;
 }): Promise<AddCwlClanTagsResult> {
   const season = input.season ?? resolveCurrentCwlSeasonKey();
   const parsed = parseCwlClanTagsInput(input.rawTags);
+  console.info(
+    `[tracked-clan] stage=cwl_tags_parsed season=${season} raw_count=${String(input.rawTags ?? "").split(/[\s,;]+/g).filter(Boolean).length} valid_count=${parsed.validTags.length} invalid_count=${parsed.invalidTags.length} duplicate_count=${parsed.duplicateTagsInRequest.length}`,
+  );
   if (parsed.validTags.length <= 0) {
     return {
       season,
@@ -108,47 +164,54 @@ export async function addCwlClanTagsForSeason(input: {
     };
   }
 
-  const existing = await prisma.cwlTrackedClan.findMany({
-    where: {
-      season,
-      tag: { in: parsed.validTags },
-    },
-    select: { tag: true },
+  const existing = await runBoundedCwlTagStage({
+    stage: "cwl_tags_existing_rows_query",
+    timeoutMs: CWL_TAG_DB_STAGE_TIMEOUT_MS,
+    details: { season, valid_count: parsed.validTags.length },
+    action: () =>
+      prisma.cwlTrackedClan.findMany({
+        where: {
+          season,
+          tag: { in: parsed.validTags },
+        },
+        select: { tag: true },
+      }),
   });
   const existingSet = new Set(existing.map((row) => normalizeClanTag(row.tag)).filter(Boolean));
   const toCreate = parsed.validTags.filter((tag) => !existingSet.has(tag));
-
-  const namesByTag = new Map<string, string | null>();
-  if (input.cocService && toCreate.length > 0) {
-    const lookups = await Promise.allSettled(
-      toCreate.map(async (tag) => {
-        const clan = await input.cocService!.getClan(tag);
-        return [tag, String(clan.name ?? "").trim() || null] as const;
-      }),
-    );
-    for (const lookup of lookups) {
-      if (lookup.status !== "fulfilled") continue;
-      namesByTag.set(lookup.value[0], lookup.value[1]);
-    }
-  }
+  console.info(
+    `[tracked-clan] stage=cwl_tags_existing_rows_loaded season=${season} existing_count=${existing.length} to_create_count=${toCreate.length}`,
+  );
 
   if (toCreate.length > 0) {
-    await prisma.cwlTrackedClan.createMany({
-      data: toCreate.map((tag) => ({
-        season,
-        tag,
-        name: namesByTag.get(tag) ?? null,
-      })),
-      skipDuplicates: true,
+    await runBoundedCwlTagStage({
+      stage: "cwl_tags_create_many",
+      timeoutMs: CWL_TAG_DB_STAGE_TIMEOUT_MS,
+      details: { season, to_create_count: toCreate.length },
+      action: () =>
+        prisma.cwlTrackedClan.createMany({
+          data: toCreate.map((tag) => ({
+            season,
+            tag,
+            name: null,
+          })),
+          skipDuplicates: true,
+        }),
     });
   }
 
-  const finalRows = await prisma.cwlTrackedClan.findMany({
-    where: {
-      season,
-      tag: { in: parsed.validTags },
-    },
-    select: { tag: true },
+  const finalRows = await runBoundedCwlTagStage({
+    stage: "cwl_tags_final_rows_query",
+    timeoutMs: CWL_TAG_DB_STAGE_TIMEOUT_MS,
+    details: { season, valid_count: parsed.validTags.length },
+    action: () =>
+      prisma.cwlTrackedClan.findMany({
+        where: {
+          season,
+          tag: { in: parsed.validTags },
+        },
+        select: { tag: true },
+      }),
   });
   const finalSet = new Set(finalRows.map((row) => normalizeClanTag(row.tag)).filter(Boolean));
 
@@ -170,6 +233,101 @@ export async function addCwlClanTagsForSeason(input: {
     invalid: parsed.invalidTags,
     duplicateInRequest: parsed.duplicateTagsInRequest,
   };
+}
+
+/** Purpose: hydrate missing CWL clan names as best-effort enrichment after rows exist. */
+export async function hydrateMissingCwlClanNamesForSeason(input: {
+  rawTags: string;
+  season?: string;
+  cocService: CoCService;
+}): Promise<void> {
+  const season = input.season ?? resolveCurrentCwlSeasonKey();
+  const parsed = parseCwlClanTagsInput(input.rawTags);
+  console.info(
+    `[tracked-clan] stage=cwl_tags_name_hydration_started season=${season} valid_count=${parsed.validTags.length}`,
+  );
+  if (parsed.validTags.length <= 0) {
+    console.info(
+      `[tracked-clan] stage=cwl_tags_name_hydration_completed season=${season} hydrated_count=0 skipped_count=0`,
+    );
+    return;
+  }
+
+  const missingRows = await runBoundedCwlTagStage({
+    stage: "cwl_tags_missing_name_rows_query",
+    timeoutMs: CWL_TAG_DB_STAGE_TIMEOUT_MS,
+    details: { season, valid_count: parsed.validTags.length },
+    action: () =>
+      prisma.cwlTrackedClan.findMany({
+        where: {
+          season,
+          tag: { in: parsed.validTags },
+          OR: [{ name: null }, { name: "" }],
+        },
+        select: { tag: true },
+      }),
+  });
+
+  if (missingRows.length <= 0) {
+    console.info(
+      `[tracked-clan] stage=cwl_tags_name_hydration_completed season=${season} hydrated_count=0 skipped_count=0`,
+    );
+    return;
+  }
+
+  let hydratedCount = 0;
+  let skippedCount = 0;
+  await Promise.allSettled(
+    missingRows.map(async (row) => {
+      const tag = normalizeClanTag(row.tag) || row.tag;
+      try {
+        const clan = await runBoundedCwlTagStage({
+          stage: "cwl_tags_name_lookup",
+          timeoutMs: CWL_TAG_HYDRATION_LOOKUP_TIMEOUT_MS,
+          details: { season, tag },
+          action: () => input.cocService.getClan(tag),
+        });
+        const clanName = String(clan?.name ?? "").trim();
+        if (!clanName) {
+          skippedCount += 1;
+          console.info(
+            `[tracked-clan] stage=cwl_tags_name_hydration_skipped season=${season} tag=${tag} reason=empty_name`,
+          );
+          return;
+        }
+        const updated = await runBoundedCwlTagStage({
+          stage: "cwl_tags_name_update",
+          timeoutMs: CWL_TAG_DB_STAGE_TIMEOUT_MS,
+          details: { season, tag },
+          action: () =>
+            prisma.cwlTrackedClan.updateMany({
+              where: {
+                season,
+                tag,
+                OR: [{ name: null }, { name: "" }],
+              },
+              data: {
+                name: clanName,
+              },
+            }),
+        });
+        if (updated.count > 0) {
+          hydratedCount += updated.count;
+        } else {
+          skippedCount += 1;
+        }
+      } catch (err) {
+        skippedCount += 1;
+        console.error(
+          `[tracked-clan] stage=cwl_tags_name_hydration_failed season=${season} tag=${tag} error=${formatError(err)}`,
+        );
+      }
+    }),
+  );
+
+  console.info(
+    `[tracked-clan] stage=cwl_tags_name_hydration_completed season=${season} hydrated_count=${hydratedCount} skipped_count=${skippedCount}`,
+  );
 }
 
 /** Purpose: list one season-scoped CWL tracked-clan registry in deterministic order. */

--- a/tests/cwlRegistry.service.test.ts
+++ b/tests/cwlRegistry.service.test.ts
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const prismaMock = vi.hoisted(() => ({
+  cwlTrackedClan: {
+    findMany: vi.fn(),
+    createMany: vi.fn(),
+    updateMany: vi.fn(),
+  },
+}));
+
+vi.mock("../src/prisma", () => ({
+  prisma: prismaMock,
+}));
+
+import {
+  addCwlClanTagsForSeason,
+  hydrateMissingCwlClanNamesForSeason,
+} from "../src/services/CwlRegistryService";
+
+describe("CwlRegistryService helpers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-03-26T00:00:00.000Z"));
+    vi.spyOn(console, "info").mockImplementation(() => undefined);
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    prismaMock.cwlTrackedClan.findMany.mockResolvedValue([]);
+    prismaMock.cwlTrackedClan.createMany.mockResolvedValue({ count: 0 });
+    prismaMock.cwlTrackedClan.updateMany.mockResolvedValue({ count: 0 });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it("creates new CWL rows with null names when clan lookups are unavailable", async () => {
+    prismaMock.cwlTrackedClan.findMany
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ tag: "#PYLQ0289" }, { tag: "#QGRJ2222" }]);
+
+    const result = await addCwlClanTagsForSeason({
+      rawTags: "[#PYLQ0289,#QGRJ2222]",
+      season: "2026-03",
+    });
+
+    expect(prismaMock.cwlTrackedClan.createMany).toHaveBeenCalledWith({
+      data: [
+        { season: "2026-03", tag: "#PYLQ0289", name: null },
+        { season: "2026-03", tag: "#QGRJ2222", name: null },
+      ],
+      skipDuplicates: true,
+    });
+    expect(result).toEqual({
+      season: "2026-03",
+      added: ["#PYLQ0289", "#QGRJ2222"],
+      alreadyExisting: [],
+      invalid: [],
+      duplicateInRequest: [],
+    });
+  });
+
+  it("keeps result buckets correct for existing, invalid, and duplicate tags", async () => {
+    prismaMock.cwlTrackedClan.findMany
+      .mockResolvedValueOnce([{ tag: "#QGRJ2222" }])
+      .mockResolvedValueOnce([{ tag: "#PYLQ0289" }, { tag: "#QGRJ2222" }]);
+
+    const result = await addCwlClanTagsForSeason({
+      rawTags: "[#PYLQ0289,QGRJ2222,BADTAG,#PYLQ0289]",
+      season: "2026-03",
+    });
+
+    expect(result.added).toEqual(["#PYLQ0289"]);
+    expect(result.alreadyExisting).toEqual(["#QGRJ2222"]);
+    expect(result.invalid).toEqual(["BADTAG"]);
+    expect(result.duplicateInRequest).toEqual(["#PYLQ0289"]);
+  });
+
+  it("hydrates missing clan names only when lookups succeed and skips failures", async () => {
+    prismaMock.cwlTrackedClan.findMany
+      .mockResolvedValueOnce([{ tag: "#PYLQ0289" }, { tag: "#QGRJ2222" }])
+      .mockResolvedValueOnce([{ tag: "#PYLQ0289" }, { tag: "#QGRJ2222" }]);
+    const cocService = {
+      getClan: vi.fn(async (tag: string) => {
+        if (tag === "#PYLQ0289") {
+          return { name: "CWL Alpha" };
+        }
+        throw new Error("boom");
+      }),
+    };
+
+    await hydrateMissingCwlClanNamesForSeason({
+      rawTags: "[#PYLQ0289,#QGRJ2222]",
+      season: "2026-03",
+      cocService: cocService as any,
+    });
+
+    expect(prismaMock.cwlTrackedClan.updateMany).toHaveBeenCalledTimes(1);
+    expect(prismaMock.cwlTrackedClan.updateMany).toHaveBeenCalledWith({
+      where: {
+        season: "2026-03",
+        tag: "#PYLQ0289",
+        OR: [{ name: null }, { name: "" }],
+      },
+      data: {
+        name: "CWL Alpha",
+      },
+    });
+
+    const infoLogs = (console.info as unknown as { mock: { calls: unknown[][] } }).mock.calls.map(
+      (call) => String(call[0] ?? ""),
+    );
+    expect(infoLogs.some((line) => line.includes("stage=cwl_tags_name_hydration_started"))).toBe(
+      true,
+    );
+    expect(
+      infoLogs.some((line) => line.includes("stage=cwl_tags_name_lookup")),
+    ).toBe(true);
+    expect(
+      infoLogs.some((line) => line.includes("stage=cwl_tags_name_hydration_completed")),
+    ).toBe(true);
+  });
+
+  it("does not throw when clan-name hydration lookups fail or time out", async () => {
+    prismaMock.cwlTrackedClan.findMany.mockResolvedValueOnce([{ tag: "#PYLQ0289" }]);
+    const cocService = {
+      getClan: vi.fn().mockImplementation(
+        () => new Promise(() => {
+          /* intentionally unresolved */
+        }),
+      ),
+    };
+
+    const promise = hydrateMissingCwlClanNamesForSeason({
+      rawTags: "[#PYLQ0289]",
+      season: "2026-03",
+      cocService: cocService as any,
+    });
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    await promise;
+
+    expect(prismaMock.cwlTrackedClan.updateMany).not.toHaveBeenCalled();
+    const errorLogs = (console.error as unknown as { mock: { calls: unknown[][] } }).mock.calls.map(
+      (call) => String(call[0] ?? ""),
+    );
+    expect(errorLogs.some((line) => line.includes("stage=cwl_tags_name_lookup"))).toBe(true);
+  });
+});

--- a/tests/trackedClan.command.test.ts
+++ b/tests/trackedClan.command.test.ts
@@ -12,6 +12,7 @@ const prismaMock = vi.hoisted(() => ({
     createMany: vi.fn(),
     findFirst: vi.fn(),
     deleteMany: vi.fn(),
+    updateMany: vi.fn(),
   },
   cwlPlayerClanSeason: {
     findMany: vi.fn(),
@@ -73,6 +74,8 @@ describe("/tracked-clan command behavior", () => {
     vi.clearAllMocks();
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-03-26T00:00:00.000Z"));
+    vi.spyOn(console, "info").mockImplementation(() => undefined);
+    vi.spyOn(console, "error").mockImplementation(() => undefined);
 
     prismaMock.trackedClan.findMany.mockResolvedValue([]);
     prismaMock.trackedClan.findUnique.mockResolvedValue(null);
@@ -81,12 +84,14 @@ describe("/tracked-clan command behavior", () => {
     prismaMock.cwlTrackedClan.createMany.mockResolvedValue({ count: 0 });
     prismaMock.cwlTrackedClan.findFirst.mockResolvedValue(null);
     prismaMock.cwlTrackedClan.deleteMany.mockResolvedValue({ count: 0 });
+    prismaMock.cwlTrackedClan.updateMany.mockResolvedValue({ count: 0 });
     prismaMock.cwlPlayerClanSeason.findMany.mockResolvedValue([]);
     prismaMock.cwlPlayerClanSeason.deleteMany.mockResolvedValue({ count: 0 });
     prismaMock.currentWar.deleteMany.mockResolvedValue({ count: 0 });
   });
 
   afterEach(() => {
+    vi.restoreAllMocks();
     vi.useRealTimers();
   });
 
@@ -101,7 +106,7 @@ describe("/tracked-clan command behavior", () => {
       },
     });
     const cocService = {
-      getClan: vi.fn().mockResolvedValue({ name: "CWL Alpha" }),
+      getClan: vi.fn().mockRejectedValue(new Error("boom")),
     };
 
     await TrackedClan.run({} as any, interaction as any, cocService as any);
@@ -111,7 +116,7 @@ describe("/tracked-clan command behavior", () => {
         {
           season: "2026-03",
           tag: "#PYLQ0289",
-          name: "CWL Alpha",
+          name: null,
         },
       ],
       skipDuplicates: true,
@@ -122,6 +127,18 @@ describe("/tracked-clan command behavior", () => {
     expect(content).toContain("already existed: #QGRJ2222");
     expect(content).toContain("invalid: BADTAG");
     expect(content).toContain("duplicates in request: #PYLQ0289");
+
+    const infoLogs = (console.info as unknown as { mock: { calls: unknown[][] } }).mock.calls.map(
+      (call) => String(call[0] ?? ""),
+    );
+    expect(infoLogs.some((line: string) => line.includes("stage=command_entered"))).toBe(true);
+    expect(infoLogs.some((line: string) => line.includes("stage=interaction_deferred"))).toBe(true);
+    expect(infoLogs.some((line: string) => line.includes("stage=cwl_tags_parsed"))).toBe(true);
+    expect(
+      infoLogs.some((line: string) => line.includes("stage=cwl_tags_existing_rows_loaded")),
+    ).toBe(true);
+    expect(infoLogs.some((line: string) => line.includes("stage=cwl_tags_create_many"))).toBe(true);
+    expect(infoLogs.some((line: string) => line.includes("stage=cwl_tags_final_reply_sent"))).toBe(true);
   });
 
   it("keeps default /tracked-clan list behavior on FWA registry when type is omitted", async () => {


### PR DESCRIPTION
- create CWL tracked-clan rows before any clan-name enrichment
- hydrate missing clan names only as bounded best-effort follow-up work