### PR TITLE
fix(cwl): parse published google sheets import links

### DIFF
--- a/src/commands/Cwl.ts
+++ b/src/commands/Cwl.ts
@@ -618,10 +618,17 @@ async function handleRotationShowSubcommand(interaction: ChatInputCommandInterac
 async function handleRotationImportSubcommand(interaction: ChatInputCommandInteraction) {
   const sheetLink = interaction.options.getString("sheet", true);
   const overwrite = interaction.options.getBoolean("overwrite", false) ?? false;
-  const preview = await cwlRotationSheetService.buildImportPreview({
-    sheetLink,
-    overwrite,
-  });
+  let preview;
+  try {
+    preview = await cwlRotationSheetService.buildImportPreview({
+      sheetLink,
+      overwrite,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "Failed to parse the Google Sheets link.";
+    await interaction.editReply(message);
+    return;
+  }
   const sessionId = createCwlRotationImportSession(
     preview,
     overwrite,

--- a/src/services/CwlRotationSheetService.ts
+++ b/src/services/CwlRotationSheetService.ts
@@ -133,10 +133,18 @@ export class CwlRotationSheetService {
     season?: string;
   }): Promise<CwlRotationSheetImportPreview> {
     const season = input.season ?? resolveCurrentCwlSeasonKey();
-    const sheetId = extractSpreadsheetId(input.sheetLink);
-    if (!sheetId) {
-      throw new Error("Unable to parse a Google Sheet ID from the provided link.");
+    const sheetIdResult = extractSpreadsheetId(input.sheetLink);
+    if (!sheetIdResult.sheetId) {
+      if (sheetIdResult.error === "unsupported_format") {
+        throw new Error(
+          "Unsupported Google Sheets link format. Use a standard /spreadsheets/d/<id> link or a published /spreadsheets/d/e/<published-id>/pubhtml link.",
+        );
+      }
+      throw new Error(
+        "No spreadsheet ID could be extracted from the provided Google Sheets link.",
+      );
     }
+    const sheetId = sheetIdResult.sheetId;
 
     const [metadata, trackedClans] = await Promise.all([
       this.sheets.getSpreadsheetMetadata(sheetId),
@@ -565,21 +573,35 @@ function escapeSheetTabName(tabName: string): string {
   return `'${String(tabName ?? "").trim().replace(/'/g, "''")}'`;
 }
 
-function extractSpreadsheetId(input: string): string | null {
+function extractSpreadsheetId(input: string): {
+  sheetId: string | null;
+  error: "unsupported_format" | "missing_id" | null;
+} {
   const trimmed = String(input ?? "").trim();
-  if (!trimmed) return null;
+  if (!trimmed) {
+    return { sheetId: null, error: "missing_id" };
+  }
 
   const directMatch = trimmed.match(/^[a-zA-Z0-9-_]{20,}$/);
   if (directMatch) {
-    return trimmed;
+    return { sheetId: trimmed, error: null };
   }
 
   try {
     const parsed = new URL(trimmed);
-    const match = parsed.pathname.match(/\/spreadsheets\/d\/([a-zA-Z0-9-_]+)/);
-    return match?.[1] ?? null;
+    const publishedMatch = parsed.pathname.match(
+      /\/spreadsheets\/d\/e\/([a-zA-Z0-9-_]+)/,
+    );
+    if (publishedMatch?.[1]) {
+      return { sheetId: publishedMatch[1], error: null };
+    }
+    const standardMatch = parsed.pathname.match(/\/spreadsheets\/d\/([a-zA-Z0-9-_]+)/);
+    if (standardMatch?.[1]) {
+      return { sheetId: standardMatch[1], error: null };
+    }
+    return { sheetId: null, error: "missing_id" };
   } catch {
-    return null;
+    return { sheetId: null, error: "unsupported_format" };
   }
 }
 

--- a/tests/cwl.command.test.ts
+++ b/tests/cwl.command.test.ts
@@ -357,6 +357,33 @@ describe("/cwl command", () => {
     expect(confirmInteraction.editReply).toHaveBeenCalled();
   });
 
+  it("surfaces a clear message when the import sheet link format is unsupported", async () => {
+    vi.mocked(cwlRotationSheetService.buildImportPreview).mockRejectedValueOnce(
+      new Error(
+        "Unsupported Google Sheets link format. Use a standard /spreadsheets/d/<id> link or a published /spreadsheets/d/e/<published-id>/pubhtml link.",
+      ),
+    );
+    const interaction = makeInteraction({
+      group: "rotations",
+      subcommand: "import",
+    });
+    (interaction.options.getString as any).mockImplementation((name: string) => {
+      if (name === "sheet") return "not-a-valid-link";
+      if (name === "visibility") return null;
+      return null;
+    });
+    (interaction.options.getBoolean as any).mockImplementation((name: string) => {
+      if (name === "overwrite") return false;
+      return null;
+    });
+
+    await Cwl.run({} as any, interaction as any);
+
+    expect(String(interaction.editReply.mock.calls[0]?.[0] ?? "")).toContain(
+      "Unsupported Google Sheets link format",
+    );
+  });
+
   it("exports active CWL planner data to a new public sheet", async () => {
     vi.mocked(cwlRotationSheetService.exportActivePlans).mockResolvedValue({
       spreadsheetId: "sheet-new",

--- a/tests/cwlRotationSheet.service.test.ts
+++ b/tests/cwlRotationSheet.service.test.ts
@@ -83,6 +83,42 @@ describe("CwlRotationSheetService", () => {
     );
   });
 
+  it("extracts the real ID from a published Google Sheets pubhtml URL", async () => {
+    vi.spyOn(GoogleSheetsService.prototype, "getSpreadsheetMetadata").mockResolvedValue({
+      spreadsheetId: "published-id",
+      title: "Imported CWL Planner",
+      sheets: [{ sheetId: 1, title: "CWL Alpha roster", index: 0, hidden: false }],
+    });
+    vi.spyOn(GoogleSheetsService.prototype, "readValues").mockResolvedValue([["Day 1"]]);
+
+    const preview = await cwlRotationSheetService.buildImportPreview({
+      sheetLink:
+        "https://docs.google.com/spreadsheets/d/e/published-id/pubhtml#gid=123456789",
+      overwrite: false,
+    });
+
+    expect(preview.sourceSheetId).toBe("published-id");
+    expect(GoogleSheetsService.prototype.getSpreadsheetMetadata).toHaveBeenCalledWith(
+      "published-id",
+    );
+  });
+
+  it("rejects malformed or incomplete Google Sheets links with a clear error", async () => {
+    await expect(
+      cwlRotationSheetService.buildImportPreview({
+        sheetLink: "not-a-valid-link",
+        overwrite: false,
+      }),
+    ).rejects.toThrow("Unsupported Google Sheets link format");
+
+    await expect(
+      cwlRotationSheetService.buildImportPreview({
+        sheetLink: "https://docs.google.com/spreadsheets/d/",
+        overwrite: false,
+      }),
+    ).rejects.toThrow("No spreadsheet ID could be extracted");
+  });
+
   it("blocks clans that already have an active plan unless overwrite is requested", async () => {
     prismaMock.cwlRotationPlan.findFirst.mockResolvedValue({
       id: "plan-1",


### PR DESCRIPTION
- extract the real published sheet id from /spreadsheets/d/e/... links
- surface clear invalid-link errors through the import command