### PR TITLE
fix(war-poll): stagger linked-player refreshes

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -46,6 +46,7 @@ Queue observability now includes:
 - queue wait timing telemetry for interactive and background CoC work
 - stale background skip counts and logs
 - degraded-delay and 429 recovery logs from the shared CoC pacing owner
+- war-event producer logs such as `war_event_player_refresh_plan`, `war_event_player_refresh_chunk`, `war_event_player_refresh_stagger`, `war_event_player_refresh_deferred`, and `war_event_player_refresh_complete`
 
 ## External Droplet Observability
 

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -27,7 +27,8 @@ Behavior:
 - Activity observe loop checks unresolved tracked-member links via ClashKing at most once every 6 hours and caches matches in `PlayerLink`.
 
 ## Optional War Event Poll Setting
-- `WAR_EVENT_LOG_POLL_INTERVAL_MINUTES` - interval for war-state event listener polling (default: `5` minutes).
+- `WAR_EVENT_LOG_POLL_INTERVAL_MINUTES` - interval for war-state event listener polling (default: `15` minutes).
+  - A longer cadence reduces repeated full-cycle queue pressure while the war-event producer now staggers linked-player refreshes internally.
 
 ## Polling Ownership Mode (Prod Polls, Staging Mirrors)
 - `POLLING_MODE` - `active` (default) or `mirror`.

--- a/src/listeners/ready.ts
+++ b/src/listeners/ready.ts
@@ -51,12 +51,14 @@ import {
   resolveMirrorSyncIntervalMsFromEnv,
   resolvePollingMode,
 } from "../services/PollingModeService";
+import {
+  resolveWarEventPollIntervalMsFromEnv,
+} from "../services/WarEventPollScheduleService";
 import { MirrorSyncService } from "../services/MirrorSyncService";
 
 const DEFAULT_OBSERVE_INTERVAL_MINUTES = 30;
 const RECRUITMENT_REMINDER_INTERVAL_MS = 60 * 60 * 1000;
 const DEFERMENT_REMINDER_INTERVAL_MS = 60 * 60 * 1000;
-const DEFAULT_WAR_EVENT_POLL_INTERVAL_MINUTES = 5;
 const TRACKED_MESSAGE_SWEEP_INTERVAL_MS = 60 * 1000;
 const OBSERVE_LAST_RUN_AT_KEY = "activity_observe:last_run_at_ms";
 const MIRROR_SYNC_POLL_GUARD_KEY = "mirror_snapshot_sync_cycle";
@@ -640,14 +642,8 @@ export default (client: Client, cocService: CoCService): void => {
     }, TRACKED_MESSAGE_SWEEP_INTERVAL_MS);
     console.log("Tracked message sweep enabled (every 1 minute).");
 
-    const warEventPollMinutesRaw = Number(
-      process.env.WAR_EVENT_LOG_POLL_INTERVAL_MINUTES ?? DEFAULT_WAR_EVENT_POLL_INTERVAL_MINUTES
-    );
-    const warEventPollMinutes =
-      Number.isFinite(warEventPollMinutesRaw) && warEventPollMinutesRaw > 0
-        ? warEventPollMinutesRaw
-        : DEFAULT_WAR_EVENT_POLL_INTERVAL_MINUTES;
-    const warEventPollMs = Math.floor(warEventPollMinutes * 60 * 1000);
+    const warEventPollMs = resolveWarEventPollIntervalMsFromEnv(process.env);
+    const warEventPollMinutes = Math.round(warEventPollMs / 60_000);
 
     const runWarEventPoll = async (scheduledAtMs: number = Date.now()) => {
       await runWithCoCQueueContext(
@@ -658,33 +654,34 @@ export default (client: Client, cocService: CoCService): void => {
           nextScheduledAtMs: scheduledAtMs + warEventPollMs,
         },
         async () => {
-      await pollCycleGuard.run("war_event_poll_cycle", async () => {
-        const queueStatus = cocRequestQueueService.getStatus();
-        if (queueStatus.degraded) {
-          console.warn(
-            `[poll-cycle] event=degraded_mode job=war_event_poll_cycle spacing_ms=${queueStatus.spacingMs} penalty_ms=${queueStatus.penaltyMs} queue_depth=${queueStatus.queueDepth} interactive_depth=${queueStatus.interactiveQueueDepth} background_depth=${queueStatus.backgroundQueueDepth} in_flight=${queueStatus.inFlight}`,
-          );
-        }
-        await runFetchTelemetryBatch("war_event_poll_cycle", async () => {
-          try {
-            await warEventLogService.poll();
-            await warEventLogService.refreshBattleDayPosts();
-            await refreshAllTrackedWarMailPosts(client);
-            await cwlStateService.refreshTrackedCwlState({
-              cocService,
-            });
-            await todoSnapshotService.refreshAllLinkedPlayerSnapshots({
-              cocService,
-            });
-          } catch (err) {
-            if (isCoCQueueSkippedError(err)) {
-              console.warn(`[war-events] poll_skipped reason=${err.message}`);
-              return;
+          await pollCycleGuard.run("war_event_poll_cycle", async () => {
+            const queueStatus = cocRequestQueueService.getStatus();
+            if (queueStatus.degraded) {
+              console.warn(
+                `[poll-cycle] event=degraded_mode job=war_event_poll_cycle spacing_ms=${queueStatus.spacingMs} penalty_ms=${queueStatus.penaltyMs} queue_depth=${queueStatus.queueDepth} interactive_depth=${queueStatus.interactiveQueueDepth} background_depth=${queueStatus.backgroundQueueDepth} in_flight=${queueStatus.inFlight}`,
+              );
             }
-            console.error(`[war-events] poll loop failed: ${formatError(err)}`);
-          }
-        });
-      });
+            await runFetchTelemetryBatch("war_event_poll_cycle", async () => {
+              try {
+                await warEventLogService.poll();
+                await warEventLogService.refreshBattleDayPosts();
+                await refreshAllTrackedWarMailPosts(client);
+                await cwlStateService.refreshTrackedCwlState({
+                  cocService,
+                });
+                await todoSnapshotService.refreshAllLinkedPlayerSnapshots({
+                  cocService,
+                  producerPacingMs: warEventPollMs,
+                });
+              } catch (err) {
+                if (isCoCQueueSkippedError(err)) {
+                  console.warn(`[war-events] poll_skipped reason=${err.message}`);
+                  return;
+                }
+                console.error(`[war-events] poll loop failed: ${formatError(err)}`);
+              }
+            });
+          });
         },
       );
     };

--- a/src/services/TodoSnapshotService.ts
+++ b/src/services/TodoSnapshotService.ts
@@ -7,6 +7,7 @@ import {
 } from "./ActivitySignalService";
 import { resolveCurrentCwlSeasonKey } from "./CwlRegistryService";
 import { CoCService, type ClanCapitalRaidSeason } from "./CoCService";
+import { cocRequestQueueService } from "./CoCRequestQueueService";
 import { normalizeClanTag, normalizePlayerTag } from "./PlayerLinkService";
 import {
   buildTrackedWarMemberStateByClanAndPlayer,
@@ -65,6 +66,12 @@ type TodoWindow = {
   active: boolean;
   startMs: number;
   endMs: number;
+};
+
+type WarEventLinkedPlayerRefreshProducer = {
+  source: string;
+  pacingMs: number | null;
+  backlogThreshold: number;
 };
 
 type TodoClanGamesWindow = {
@@ -207,6 +214,7 @@ export class TodoSnapshotService {
   async refreshAllLinkedPlayerSnapshots(input: {
     cocService?: CoCService;
     nowMs?: number;
+    producerPacingMs?: number | null;
   }): Promise<TodoSnapshotRefreshResult> {
     if (this.refreshAllPromise) {
       return this.refreshAllPromise;
@@ -255,6 +263,7 @@ export class TodoSnapshotService {
   private async refreshAllLinkedPlayerSnapshotsInternal(input: {
     cocService?: CoCService;
     nowMs?: number;
+    producerPacingMs?: number | null;
   }): Promise<TodoSnapshotRefreshResult> {
     const links = await prisma.playerLink.findMany({
       where: { discordUserId: { not: null } },
@@ -262,8 +271,8 @@ export class TodoSnapshotService {
       orderBy: [{ createdAt: "asc" }, { playerTag: "asc" }],
     });
 
-    const playerTags = normalizePlayerTags(links.map((row) => row.playerTag));
-    if (playerTags.length <= 0) {
+    const playerTags = links.map((row) => row.playerTag);
+    if (normalizePlayerTags(playerTags).length <= 0) {
       return { playerCount: 0, updatedCount: 0 };
     }
 
@@ -271,6 +280,15 @@ export class TodoSnapshotService {
       playerTags,
       cocService: input.cocService,
       nowMs: input.nowMs,
+      producer: {
+        source: "war_event_poll_cycle",
+        pacingMs:
+          Number.isFinite(input.producerPacingMs ?? NaN) &&
+          Number(input.producerPacingMs) > 0
+            ? Math.trunc(Number(input.producerPacingMs))
+            : null,
+        backlogThreshold: 250,
+      },
     });
   }
 
@@ -280,6 +298,7 @@ export class TodoSnapshotService {
     cocService?: CoCService;
     nowMs?: number;
     includeNonTrackedCwlRefresh?: boolean;
+    producer?: WarEventLinkedPlayerRefreshProducer | null;
   }): Promise<TodoSnapshotRefreshResult> {
     const normalizedTags = normalizePlayerTags(input.playerTags);
     if (normalizedTags.length <= 0) {
@@ -297,6 +316,7 @@ export class TodoSnapshotService {
     const liveClanTagByPlayerTag = await loadLiveClanTagsByPlayerTag({
       cocService: input.cocService,
       playerTags: normalizedTags,
+      producer: input.producer ?? null,
     });
 
     const signalStateKeyByTag = new Map(
@@ -961,6 +981,11 @@ function resolveGamesCyclePoints(input: {
   return 0;
 }
 
+function sleepMs(ms: number): Promise<void> {
+  if (!Number.isFinite(ms) || ms <= 0) return Promise.resolve();
+  return new Promise((resolve) => setTimeout(resolve, Math.trunc(ms)));
+}
+
 /** Purpose: execute write operations in bounded chunks with parallel writes per chunk. */
 async function runChunkedWrites<T>(
   items: T[],
@@ -986,6 +1011,42 @@ function normalizePlayerTags(input: string[]): string[] {
     normalized.push(playerTag);
   }
   return normalized;
+}
+
+function chunkArray<T>(input: T[], chunkSize: number): T[][] {
+  const safeChunkSize =
+    Number.isFinite(chunkSize) && chunkSize > 0 ? Math.trunc(chunkSize) : 1;
+  const chunks: T[][] = [];
+  for (let index = 0; index < input.length; index += safeChunkSize) {
+    chunks.push(input.slice(index, index + safeChunkSize));
+  }
+  return chunks;
+}
+
+export function resolveWarEventLinkedPlayerRefreshPlanForTest(input: {
+  candidateCount: number;
+  dedupedCount: number;
+  pacingMs?: number | null;
+}): {
+  candidateCount: number;
+  dedupedCount: number;
+  chunkSize: number;
+  chunkCount: number;
+  chunkDelayMs: number;
+} {
+  const candidateCount = Math.max(0, Math.trunc(Number(input.candidateCount) || 0));
+  const dedupedCount = Math.max(0, Math.trunc(Number(input.dedupedCount) || 0));
+  const chunkSize = dedupedCount > 0 ? 25 : 1;
+  const chunkCount = dedupedCount > 0 ? Math.ceil(dedupedCount / chunkSize) : 0;
+  const pacingMs =
+    Number.isFinite(input.pacingMs ?? NaN) && Number(input.pacingMs) > 0
+      ? Math.trunc(Number(input.pacingMs))
+      : 0;
+  const chunkDelayMs =
+    pacingMs > 0 && chunkCount > 1
+      ? Math.max(250, Math.floor(pacingMs / chunkCount))
+      : 0;
+  return { candidateCount, dedupedCount, chunkSize, chunkCount, chunkDelayMs };
 }
 
 /** Purpose: keep only the most recent clan-member row per player tag by source sync time. */
@@ -1381,20 +1442,74 @@ function normalizeRoundState(input: unknown): string {
 async function loadLiveClanTagsByPlayerTag(input: {
   cocService?: CoCService;
   playerTags: string[];
+  producer?: WarEventLinkedPlayerRefreshProducer | null;
 }): Promise<Map<string, string>> {
   if (!input.cocService || typeof input.cocService.getPlayerRaw !== "function") {
     return new Map();
   }
 
-  const entries = await Promise.all(
-    input.playerTags.map(async (playerTag) => {
-      const player = await input.cocService!
-        .getPlayerRaw(playerTag, { suppressTelemetry: true })
-        .catch(() => null);
-      const clanTag = normalizeClanTag(String(player?.clan?.tag ?? ""));
-      return [playerTag, clanTag] as const;
-    }),
-  );
+  const normalizedTags = normalizePlayerTags(input.playerTags);
+  const plan = resolveWarEventLinkedPlayerRefreshPlanForTest({
+    candidateCount: input.playerTags.length,
+    dedupedCount: normalizedTags.length,
+    pacingMs: input.producer?.pacingMs ?? null,
+  });
+  const chunkedTags = chunkArray(normalizedTags, plan.chunkSize);
+  if (input.producer) {
+    console.info(
+      `[todo-snapshot] event=war_event_player_refresh_plan source=${input.producer.source} candidate_count=${plan.candidateCount} deduped_count=${plan.dedupedCount} chunk_size=${plan.chunkSize} chunk_count=${plan.chunkCount} stagger_ms=${plan.chunkDelayMs} backlog_threshold=${input.producer.backlogThreshold}`,
+    );
+  }
+
+  const entries: Array<readonly [string, string]> = [];
+  let enqueuedCount = 0;
+  let deferredCount = 0;
+  for (let chunkIndex = 0; chunkIndex < chunkedTags.length; chunkIndex += 1) {
+    if (input.producer) {
+      const queueStatus = cocRequestQueueService.getStatus();
+      if (queueStatus.backgroundQueueDepth >= input.producer.backlogThreshold) {
+        deferredCount = chunkedTags
+          .slice(chunkIndex)
+          .reduce((sum, chunk) => sum + chunk.length, 0);
+        console.warn(
+          `[todo-snapshot] event=war_event_player_refresh_deferred source=${input.producer.source} reason=background_backlog backlog_depth=${queueStatus.backgroundQueueDepth} threshold=${input.producer.backlogThreshold} deferred_count=${deferredCount}`,
+        );
+        break;
+      }
+      if (chunkIndex > 0 && plan.chunkDelayMs > 0) {
+        console.info(
+          `[todo-snapshot] event=war_event_player_refresh_stagger source=${input.producer.source} chunk_index=${chunkIndex + 1} chunk_count=${chunkedTags.length} delay_ms=${plan.chunkDelayMs}`,
+        );
+        await sleepMs(plan.chunkDelayMs);
+      }
+    }
+
+    const chunk = chunkedTags[chunkIndex];
+    if (input.producer) {
+      const queueStatus = cocRequestQueueService.getStatus();
+      console.info(
+        `[todo-snapshot] event=war_event_player_refresh_chunk source=${input.producer.source} chunk_index=${chunkIndex + 1} chunk_count=${chunkedTags.length} chunk_size=${chunk.length} background_depth=${queueStatus.backgroundQueueDepth}`,
+      );
+    }
+    const chunkEntries = await Promise.all(
+      chunk.map(async (playerTag) => {
+        const player = await input.cocService!
+          .getPlayerRaw(playerTag, { suppressTelemetry: true })
+          .catch(() => null);
+        const clanTag = normalizeClanTag(String(player?.clan?.tag ?? ""));
+        return [playerTag, clanTag] as const;
+      }),
+    );
+    entries.push(...chunkEntries);
+    enqueuedCount += chunk.length;
+  }
+
+  if (input.producer) {
+    console.info(
+      `[todo-snapshot] event=war_event_player_refresh_complete source=${input.producer.source} candidate_count=${plan.candidateCount} deduped_count=${plan.dedupedCount} enqueued_count=${enqueuedCount} deferred_count=${deferredCount}`,
+    );
+  }
+
   return new Map(
     entries.filter((entry): entry is [string, string] => Boolean(entry[0] && entry[1])),
   );

--- a/src/services/WarEventPollScheduleService.ts
+++ b/src/services/WarEventPollScheduleService.ts
@@ -1,0 +1,25 @@
+const DEFAULT_WAR_EVENT_POLL_INTERVAL_MINUTES = 15;
+
+function resolvePositiveMinutes(value: unknown, fallbackMinutes: number): number {
+  const parsed = Math.trunc(Number(value));
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return fallbackMinutes;
+  }
+  return parsed;
+}
+
+/** Purpose: resolve the war-event poll cadence from env with a safer bounded default. */
+export function resolveWarEventPollIntervalMsFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): number {
+  const minutes = resolvePositiveMinutes(
+    env.WAR_EVENT_LOG_POLL_INTERVAL_MINUTES ?? DEFAULT_WAR_EVENT_POLL_INTERVAL_MINUTES,
+    DEFAULT_WAR_EVENT_POLL_INTERVAL_MINUTES,
+  );
+  return minutes * 60_000;
+}
+
+/** Purpose: expose the current default for docs/tests without duplicating the constant. */
+export function getDefaultWarEventPollIntervalMinutes(): number {
+  return DEFAULT_WAR_EVENT_POLL_INTERVAL_MINUTES;
+}

--- a/tests/todoSnapshot.service.test.ts
+++ b/tests/todoSnapshot.service.test.ts
@@ -46,12 +46,21 @@ const prismaMock = vi.hoisted(() => ({
   },
 }));
 
+const cocRequestQueueMock = vi.hoisted(() => ({
+  getStatus: vi.fn(),
+}));
+
 vi.mock("../src/prisma", () => ({
   prisma: prismaMock,
 }));
 
+vi.mock("../src/services/CoCRequestQueueService", () => ({
+  cocRequestQueueService: cocRequestQueueMock,
+}));
+
 import {
   resolveClanGamesWindowForTest,
+  resolveWarEventLinkedPlayerRefreshPlanForTest,
   resetTodoSnapshotServiceForTest,
   todoSnapshotService,
 } from "../src/services/TodoSnapshotService";
@@ -151,6 +160,36 @@ describe("TodoSnapshotService", () => {
     prismaMock.cwlPlayerClanSeason.upsert.mockResolvedValue(undefined);
     prismaMock.botSetting.findMany.mockResolvedValue([]);
     prismaMock.botSetting.upsert.mockResolvedValue(undefined);
+    cocRequestQueueMock.getStatus.mockReturnValue({
+      queueDepth: 0,
+      interactiveQueueDepth: 0,
+      backgroundQueueDepth: 0,
+      inFlight: 0,
+      penaltyMs: 0,
+      spacingMs: 120,
+      degraded: false,
+      lastInteractiveWaitMs: 0,
+      lastBackgroundWaitMs: 0,
+      backgroundSkippedCount: 0,
+      interactiveDispatchedCount: 0,
+      backgroundDispatchedCount: 0,
+    });
+  });
+
+  it("spreads large player refresh sets into bounded chunks over the poll window", () => {
+    expect(
+      resolveWarEventLinkedPlayerRefreshPlanForTest({
+        candidateCount: 60,
+        dedupedCount: 60,
+        pacingMs: 15 * 60 * 1000,
+      }),
+    ).toEqual({
+      candidateCount: 60,
+      dedupedCount: 60,
+      chunkSize: 25,
+      chunkCount: 3,
+      chunkDelayMs: 300_000,
+    });
   });
 
   it("reads persisted CWL round state once per clan when refreshing multiple player tags", async () => {
@@ -313,6 +352,109 @@ describe("TodoSnapshotService", () => {
         }),
       }),
     );
+  });
+
+  it("deduplicates duplicate player tags before chunked live clan refresh", async () => {
+    prismaMock.cwlTrackedClan.findMany.mockResolvedValue([]);
+    prismaMock.currentCwlRound.findMany.mockResolvedValue([]);
+    prismaMock.cwlRoundMemberCurrent.findMany.mockResolvedValue([]);
+    prismaMock.cwlPlayerClanSeason.findMany.mockResolvedValue([]);
+    const cocService = {
+      getPlayerRaw: vi.fn().mockImplementation(async (tag: string) => ({
+        tag,
+        clan: { tag: "#QGRJ" },
+      })),
+      getClanWarLeagueGroup: vi.fn().mockResolvedValue({
+        season: "2026-03",
+        state: "preparation",
+        clans: [{ tag: "#QGRJ", name: "Nontracked Clan" }],
+        rounds: [{ warTags: ["#WAR1"] }],
+      }),
+      getClanWarLeagueWar: vi.fn().mockResolvedValue({
+        state: "preparation",
+        attacksPerMember: 1,
+        startTime: "20260330T120000.000Z",
+        endTime: "20260331T120000.000Z",
+        clan: {
+          tag: "#QGRJ",
+          name: "Nontracked Clan",
+          members: [
+            {
+              tag: "#PYLQ0289",
+              name: "Alpha",
+              townhallLevel: 15,
+              attacks: [],
+            },
+            {
+              tag: "#QGRJ2222",
+              name: "Bravo",
+              townhallLevel: 14,
+              attacks: [],
+            },
+          ],
+        },
+        opponent: { tag: "#OPP", name: "Opponent", members: [] },
+      }),
+    };
+
+    await todoSnapshotService.refreshSnapshotsForPlayerTags({
+      playerTags: ["#PYLQ0289", "#PYLQ0289", "#QGRJ2222"],
+      cocService: cocService as any,
+      includeNonTrackedCwlRefresh: true,
+      nowMs: Date.UTC(2026, 2, 26, 0, 0, 0, 0),
+    });
+
+    expect(cocService.getPlayerRaw).toHaveBeenCalledTimes(2);
+  });
+
+  it("defers remaining live refresh chunks when background backlog is already high", async () => {
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      { playerTag: "#PYLQ0289" },
+      { playerTag: "#QGRJ2222" },
+      { playerTag: "#THIRDDDD" },
+    ]);
+    prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue([]);
+    prismaMock.fwaWarMemberCurrent.findMany.mockResolvedValue([]);
+    prismaMock.currentWar.findMany.mockResolvedValue([]);
+    prismaMock.trackedClan.findMany.mockResolvedValue([]);
+    prismaMock.cwlTrackedClan.findMany.mockResolvedValue([]);
+    prismaMock.cwlPlayerClanSeason.findMany.mockResolvedValue([]);
+    prismaMock.currentCwlRound.findMany.mockResolvedValue([]);
+    prismaMock.cwlRoundMemberCurrent.findMany.mockResolvedValue([]);
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const cocService = {
+      getPlayerRaw: vi.fn().mockResolvedValue({
+        tag: "#PYLQ0289",
+        clan: { tag: "#QGRJ" },
+      }),
+      getClanCapitalRaidSeasons: vi.fn().mockResolvedValue([]),
+    };
+    cocRequestQueueMock.getStatus.mockReturnValue({
+      queueDepth: 500,
+      interactiveQueueDepth: 0,
+      backgroundQueueDepth: 500,
+      inFlight: 1,
+      penaltyMs: 0,
+      spacingMs: 120,
+      degraded: false,
+      lastInteractiveWaitMs: 0,
+      lastBackgroundWaitMs: 0,
+      backgroundSkippedCount: 0,
+      interactiveDispatchedCount: 0,
+      backgroundDispatchedCount: 0,
+    });
+
+    await todoSnapshotService.refreshAllLinkedPlayerSnapshots({
+      cocService: cocService as any,
+      producerPacingMs: 15 * 60 * 1000,
+      nowMs: Date.UTC(2026, 2, 26, 0, 0, 0, 0),
+    });
+
+    expect(cocService.getPlayerRaw).not.toHaveBeenCalled();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("event=war_event_player_refresh_deferred"),
+    );
+    warnSpy.mockRestore();
   });
 
   it("sources active raid attacks from live clan raid members even for untracked clans", async () => {

--- a/tests/warEventPollSchedule.service.test.ts
+++ b/tests/warEventPollSchedule.service.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import {
+  getDefaultWarEventPollIntervalMinutes,
+  resolveWarEventPollIntervalMsFromEnv,
+} from "../src/services/WarEventPollScheduleService";
+
+describe("WarEventPollScheduleService", () => {
+  it("defaults to a safer 15 minute war-event poll cadence", () => {
+    expect(getDefaultWarEventPollIntervalMinutes()).toBe(15);
+    expect(resolveWarEventPollIntervalMsFromEnv({} as NodeJS.ProcessEnv)).toBe(
+      15 * 60 * 1000,
+    );
+  });
+
+  it("respects an explicit poll interval override when provided", () => {
+    expect(
+      resolveWarEventPollIntervalMsFromEnv({
+        WAR_EVENT_LOG_POLL_INTERVAL_MINUTES: "20",
+      } as NodeJS.ProcessEnv),
+    ).toBe(20 * 60 * 1000);
+  });
+
+  it("falls back to the safer default when the env value is invalid", () => {
+    expect(
+      resolveWarEventPollIntervalMsFromEnv({
+        WAR_EVENT_LOG_POLL_INTERVAL_MINUTES: "0",
+      } as NodeJS.ProcessEnv),
+    ).toBe(15 * 60 * 1000);
+  });
+
+  it("does not change ownership based on mirror polling mode", () => {
+    expect(
+      resolveWarEventPollIntervalMsFromEnv({
+        POLLING_MODE: "mirror",
+      } as NodeJS.ProcessEnv),
+    ).toBe(15 * 60 * 1000);
+  });
+});


### PR DESCRIPTION
- raise the default war-event poll cadence to 15 minutes
- chunk, stagger, and backlog-gate linked-player refreshes before enqueueing more background CoC work