### PR TITLE
feat(cwl): improve rotation import review mappings

### DIFF
--- a/src/commands/Cwl.ts
+++ b/src/commands/Cwl.ts
@@ -45,6 +45,19 @@ type CwlRotationImportSession = {
   reviewIndex: number;
 };
 
+type CwlRotationImportReviewOption = {
+  playerTag: string;
+  playerName: string;
+  source: "suggested" | "fallback";
+  score?: number;
+};
+
+type CwlRotationImportReviewOptions = {
+  suggested: CwlRotationImportReviewOption[];
+  fallback: CwlRotationImportReviewOption[];
+  options: CwlRotationImportReviewOption[];
+};
+
 const cwlRotationImportSessions = new Map<string, CwlRotationImportSession>();
 
 function formatRelativeTimestamp(value: Date | null): string {
@@ -342,6 +355,12 @@ function buildCwlRotationImportReviewPageLines(input: {
   reviewIndex: number;
   reviewCount: number;
 }): string[] {
+  const reviewOptions = input.reviewRow
+    ? buildCwlRotationImportReviewOptions({
+        preview: input.preview,
+        reviewRow: input.reviewRow,
+      })
+    : null;
   const lines: string[] = [
     `Season: ${input.preview.season}`,
     `Source: ${input.preview.sourceSheetTitle || input.preview.sourceSheetId}`,
@@ -358,17 +377,32 @@ function buildCwlRotationImportReviewPageLines(input: {
   lines.push(`Sheet row: ${input.reviewRow.sheetRowNumber}`);
   lines.push(`Raw: ${input.reviewRow.rawText}`);
   lines.push(`Parsed tag: ${input.reviewRow.parsedPlayerTag || "none"}`);
-  lines.push(`Player: ${input.reviewRow.parsedPlayerName}`);
+  lines.push(`Parsed player: ${input.reviewRow.parsedPlayerName}`);
   lines.push(`Reason: ${input.reviewRow.reason || "Review required."}`);
 
-  if (input.reviewRow.suggestions.length > 0) {
+  if (reviewOptions) {
     lines.push("");
-    lines.push("Suggested matches:");
-    for (const suggestion of input.reviewRow.suggestions.slice(0, 5)) {
-      lines.push(
-        `${suggestion.playerName} (${suggestion.playerTag}) - ${(suggestion.score * 100).toFixed(0)}%`,
-      );
+    if (reviewOptions.suggested.length > 0) {
+      lines.push("Suggested matches:");
+      for (const suggestion of reviewOptions.suggested.slice(0, 5)) {
+        lines.push(
+          `${suggestion.playerName} (${suggestion.playerTag}) - ${((suggestion.score ?? 0) * 100).toFixed(0)}%`,
+        );
+      }
     }
+    if (reviewOptions.fallback.length > 0) {
+      lines.push("");
+      lines.push("Remaining tracked players:");
+      for (const fallback of reviewOptions.fallback.slice(0, 5)) {
+        lines.push(`${fallback.playerName} (${fallback.playerTag})`);
+      }
+    }
+    lines.push("");
+    lines.push(
+      reviewOptions.options.length > 0
+        ? `Selectable mappings: ${reviewOptions.options.length} available.`
+        : "No tracked players remain; ignore is the only available action.",
+    );
   }
 
   return lines;
@@ -471,7 +505,7 @@ function buildCwlRotationImportReviewActionRows(input: {
   ];
 }
 
-function buildCwlRotationImportReviewSelectMenu(input: {
+function _buildCwlRotationImportReviewSelectMenu(input: {
   sessionId: string;
   reviewRow: CwlRotationImportRow;
 }): ActionRowBuilder<StringSelectMenuBuilder> | null {
@@ -492,6 +526,97 @@ function buildCwlRotationImportReviewSelectMenu(input: {
   });
   menu.addOptions(options);
   return new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(menu);
+}
+
+function buildCwlRotationImportReviewSelectMenuV2(input: {
+  sessionId: string;
+  preview: CwlRotationSheetImportPreview;
+  reviewRow: CwlRotationImportRow;
+}): ActionRowBuilder<StringSelectMenuBuilder> | null {
+  if (input.reviewRow.ignored || input.reviewRow.resolvedPlayerTag) return null;
+  const reviewOptions = buildCwlRotationImportReviewOptions({
+    preview: input.preview,
+    reviewRow: input.reviewRow,
+  });
+  const menu = new StringSelectMenuBuilder()
+    .setCustomId(`${CWL_ROTATION_IMPORT_SESSION_PREFIX}:resolve:${input.sessionId}:${input.reviewRow.rowId}`)
+    .setPlaceholder("Choose a suggested or remaining tracked player, or ignore this row");
+
+  const options = reviewOptions.options.slice(0, 24).map((option) => ({
+    label: `${option.playerName}`.slice(0, 100),
+    value: `tag:${option.playerTag}`,
+    description:
+      option.source === "suggested"
+        ? `${option.playerTag} - ${((option.score ?? 0) * 100).toFixed(0)}% suggested`.slice(0, 100)
+        : `${option.playerTag} - remaining tracked player`.slice(0, 100),
+  }));
+  options.push({
+    label: "Ignore this row",
+    value: "ignore",
+    description: "Leave this row out of the imported plan.",
+  });
+  menu.addOptions(options);
+  return new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(menu);
+}
+
+function buildCwlRotationImportReviewOptions(input: {
+  preview: CwlRotationSheetImportPreview;
+  reviewRow: CwlRotationImportRow;
+}): CwlRotationImportReviewOptions {
+  const clan = input.preview.matchedClans.find(
+    (entry) =>
+      normalizeClanTag(entry.clanTag) === normalizeClanTag(input.reviewRow.clanTag) &&
+      entry.tabTitle === input.reviewRow.tabTitle,
+  );
+  const resolvedTags = getCwlRotationImportResolvedPlayerTagSet(input.preview);
+  const seenTags = new Set<string>();
+
+  const suggested = input.reviewRow.suggestions
+    .filter((suggestion) => !resolvedTags.has(normalizePlayerTag(suggestion.playerTag)))
+    .map((suggestion) => ({
+      playerTag: normalizePlayerTag(suggestion.playerTag),
+      playerName: suggestion.playerName,
+      score: suggestion.score,
+      source: "suggested" as const,
+    }))
+    .filter((suggestion) => {
+      if (!suggestion.playerTag || seenTags.has(suggestion.playerTag)) return false;
+      seenTags.add(suggestion.playerTag);
+      return true;
+    });
+
+  const fallback = (clan?.trackedRosterRows ?? [])
+    .map((entry) => ({
+      playerTag: normalizePlayerTag(entry.playerTag),
+      playerName: entry.playerName,
+      source: "fallback" as const,
+    }))
+    .filter((entry) => {
+      if (!entry.playerTag) return false;
+      if (resolvedTags.has(entry.playerTag)) return false;
+      if (seenTags.has(entry.playerTag)) return false;
+      seenTags.add(entry.playerTag);
+      return true;
+    });
+
+  return {
+    suggested,
+    fallback,
+    options: [...suggested, ...fallback],
+  };
+}
+
+function getCwlRotationImportResolvedPlayerTagSet(preview: CwlRotationSheetImportPreview): Set<string> {
+  const resolvedTags = new Set<string>();
+  for (const clan of preview.matchedClans) {
+    for (const row of clan.parsedRows) {
+      const resolvedPlayerTag = normalizePlayerTag(row.resolvedPlayerTag ?? "");
+      if (resolvedPlayerTag && !row.ignored) {
+        resolvedTags.add(resolvedPlayerTag);
+      }
+    }
+  }
+  return resolvedTags;
 }
 
 function getCwlRotationImportPendingRows(preview: CwlRotationSheetImportPreview): CwlRotationImportRow[] {
@@ -784,7 +909,7 @@ function buildCwlRotationImportSessionMessage(
       }),
     ];
     if (reviewRow) {
-      const menu = buildCwlRotationImportReviewSelectMenu({ sessionId, reviewRow });
+      const menu = buildCwlRotationImportReviewSelectMenuV2({ sessionId, preview: session.preview, reviewRow });
       if (menu) components.push(menu);
     }
     return {
@@ -1248,16 +1373,28 @@ export async function handleCwlRotationImportSelectMenuInteraction(
     targetRow.resolvedPlayerName = null;
   } else if (choice.startsWith("tag:")) {
     const playerTag = normalizePlayerTag(choice.slice(4));
-    const suggestion = targetRow.suggestions.find((entry) => normalizePlayerTag(entry.playerTag) === playerTag) ?? null;
-    if (!suggestion) {
+    const availableOptions = buildCwlRotationImportReviewOptions({
+      preview: session.preview,
+      reviewRow: targetRow,
+    });
+    const option = availableOptions.options.find((entry) => normalizePlayerTag(entry.playerTag) === playerTag) ?? null;
+    if (!option) {
       await interaction.reply({
         content: "That tracked-player mapping is no longer available.",
         ephemeral: true,
       });
       return;
     }
-    targetRow.resolvedPlayerTag = suggestion.playerTag;
-    targetRow.resolvedPlayerName = suggestion.playerName;
+    const resolvedTags = getCwlRotationImportResolvedPlayerTagSet(session.preview);
+    if (resolvedTags.has(playerTag)) {
+      await interaction.reply({
+        content: "That tracked player is already mapped to another row in this import session.",
+        ephemeral: true,
+      });
+      return;
+    }
+    targetRow.resolvedPlayerTag = option.playerTag;
+    targetRow.resolvedPlayerName = option.playerName;
     targetRow.ignored = false;
     if (targetRow.classification === "unresolved_needs_review" || targetRow.classification === "ambiguous_match_needs_review" || targetRow.classification === "fuzzy_match_needs_review") {
       targetRow.reason = null;

--- a/src/services/CwlRotationSheetService.ts
+++ b/src/services/CwlRotationSheetService.ts
@@ -96,6 +96,7 @@ export type CwlRotationSheetClanImportTab = {
   ignoredRowCount: number;
   days: CwlRotationImportDayPreview[];
   parsedRows: CwlRotationImportRow[];
+  trackedRosterRows?: Array<{ playerTag: string; playerName: string }>;
   rosterRows: Array<{ playerTag: string; playerName: string }>;
 };
 
@@ -318,6 +319,10 @@ export class CwlRotationSheetService {
             clanTag: match.clanTag,
             clanName: match.clanName,
             tabTitle: match.tabTitle,
+          })),
+          trackedRosterRows: rosterEntries.map((entry) => ({
+            playerTag: entry.playerTag,
+            playerName: entry.playerName,
           })),
           rosterRows: parsed.rosterRows,
         });
@@ -574,6 +579,7 @@ export function rebuildCwlRotationImportTabState(
     reviewRequiredRowCount: pendingReviewCount,
     ignoredRowCount: tab.parsedRows.filter((row) => row.ignored).length,
     structuralRowCount: tab.structuralRowCount,
+    trackedRosterRows: tab.trackedRosterRows ?? [],
   };
 }
 
@@ -940,7 +946,11 @@ function parseCwlRotationImportRow(input: {
 
   const memberCell = sanitizeDisplayText(input.row[input.header.memberColumnIndex] ?? "");
   const firstNonEmptyCell = sanitizeDisplayText(input.row.find((cell) => cell.length > 0) ?? "");
-  const candidateCell = memberCell || firstNonEmptyCell || rawText;
+  const candidateCell = resolveCwlRotationImportIdentityCell({
+    row: input.row,
+    header: input.header,
+    rawText,
+  }) || memberCell || firstNonEmptyCell || rawText;
   const parsedIdentity = parseCwlRotationPlayerIdentity(candidateCell);
   const parsedPlayerName = parsedIdentity?.playerName || candidateCell;
   const explicitTag = normalizePlayerTag(
@@ -970,7 +980,7 @@ function parseCwlRotationImportRow(input: {
       parsedPlayerName,
       classification: "unresolved_needs_review",
       reason: "Could not identify the player name column for this row.",
-      suggestions: buildRosterSuggestions(parsedPlayerName, input.rosterEntries),
+      suggestions: buildRosterSuggestions(parsedPlayerName, input.rosterEntries, []),
       dayRows,
       resolvedPlayerTag: null,
       resolvedPlayerName: null,
@@ -1019,7 +1029,7 @@ function parseCwlRotationImportRow(input: {
     };
   }
 
-  const suggestions = buildRosterSuggestions(parsedPlayerName, input.rosterEntries);
+  const suggestions = buildRosterSuggestions(parsedPlayerName, input.rosterEntries, []);
   const bestScore = suggestions[0]?.score ?? 0;
   const secondScore = suggestions[1]?.score ?? 0;
   const classification =
@@ -1064,9 +1074,11 @@ function findExactRosterMatch(
 function buildRosterSuggestions(
   playerName: string,
   rosterEntries: CwlSeasonRosterEntry[],
+  excludedTags: string[] = [],
 ): CwlRotationImportRowSuggestion[] {
   const normalizedQuery = normalizeMatchKey(playerName);
   if (!normalizedQuery) return [];
+  const excludedTagSet = new Set(excludedTags.map((tag) => normalizePlayerTag(tag)).filter(Boolean));
 
   return rosterEntries
     .map((entry) => {
@@ -1078,7 +1090,7 @@ function buildRosterSuggestions(
         score,
       };
     })
-    .filter((entry) => entry.score >= 0.55)
+    .filter((entry) => entry.score >= 0.55 && !excludedTagSet.has(normalizePlayerTag(entry.playerTag)))
     .sort((a, b) => b.score - a.score || a.playerName.localeCompare(b.playerName) || a.playerTag.localeCompare(b.playerTag))
     .slice(0, 5);
 }
@@ -1117,6 +1129,39 @@ function levenshteinDistance(a: string, b: string): number {
 
 function normalizeRosterNameKey(input: string): string {
   return normalizeMatchKey(input);
+}
+
+function resolveCwlRotationImportIdentityCell(input: {
+  row: string[];
+  header: ParsedCwlRotationTableHeader;
+  rawText: string;
+}): string {
+  const firstCell = sanitizeDisplayText(input.row[0] ?? "");
+  const secondCell = sanitizeDisplayText(input.row[1] ?? "");
+  const explicitIdentityCell = sanitizeDisplayText(input.row[input.header.memberColumnIndex] ?? "");
+
+  if (isRosterIndexCell(firstCell) && secondCell) {
+    return secondCell;
+  }
+
+  if (input.header.canonical && explicitIdentityCell) {
+    return explicitIdentityCell;
+  }
+
+  if (explicitIdentityCell) {
+    return explicitIdentityCell;
+  }
+
+  if (secondCell) {
+    return secondCell;
+  }
+
+  return sanitizeDisplayText(input.rawText);
+}
+
+function isRosterIndexCell(cell: string): boolean {
+  const normalized = sanitizeDisplayText(cell);
+  return /^\d+$/.test(normalized);
 }
 
 function isPlannedInCell(cell: string): boolean {

--- a/tests/cwl.command.test.ts
+++ b/tests/cwl.command.test.ts
@@ -120,6 +120,26 @@ function getComponentSelectMenuCustomIds(interaction: any): string[] {
   return ids;
 }
 
+function getComponentSelectMenuOptions(interaction: any): Array<{ label: string; value: string; description?: string }> {
+  const payload = (interaction.editReply?.mock.calls[0]?.[0] ?? interaction.update?.mock.calls[0]?.[0]) as any;
+  const rows = Array.isArray(payload?.components) ? payload.components : [];
+  for (const row of rows) {
+    const rowJson = typeof row?.toJSON === "function" ? row.toJSON() : row;
+    for (const menu of Array.isArray(rowJson?.components) ? rowJson.components : []) {
+      const menuJson = typeof menu?.toJSON === "function" ? menu.toJSON() : menu;
+      const options = menuJson?.options ?? menuJson?.data?.options ?? [];
+      if (Array.isArray(options) && options.length > 0) {
+        return options.map((option: any) => ({
+          label: String(option?.label ?? ""),
+          value: String(option?.value ?? ""),
+          description: option?.description ? String(option.description) : undefined,
+        }));
+      }
+    }
+  }
+  return [];
+}
+
 describe("/cwl command", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -695,6 +715,158 @@ describe("/cwl command", () => {
     expect(getUpdatedDescription(selectInteraction)).toContain("Importable clans: 1 / 1");
     expect(getUpdatedDescription(selectInteraction)).not.toContain("Review rows: 1");
     expect(cwlRotationSheetService.confirmImport).not.toHaveBeenCalled();
+  });
+
+  it("offers remaining tracked players as fallback mappings and prevents duplicate row mappings", async () => {
+    const preview: CwlRotationSheetImportPreview = {
+      sourceSheetId: "sheet-1",
+      sourceSheetTitle: "Imported CWL Planner",
+      season: "2026-04",
+      matchedClans: [
+        {
+          clanTag: "#2QG2C08UP",
+          clanName: "CWL Alpha",
+          tabTitle: "CWL Alpha roster",
+          existingVersion: null,
+          importable: false,
+          importBlockedReason: "2 rows need review before save.",
+          warnings: ["2 rows need review."],
+          structuralRowCount: 1,
+          reviewRequiredRowCount: 2,
+          ignoredRowCount: 0,
+          rosterRows: [
+            { playerTag: "#PYLQ0289", playerName: "Alpha" },
+            { playerTag: "#QGRJ2222", playerName: "Bravo" },
+          ],
+          trackedRosterRows: [
+            { playerTag: "#PYLQ0289", playerName: "Alpha" },
+            { playerTag: "#QGRJ2222", playerName: "Bravo" },
+          ],
+          days: [
+            {
+              roundDay: 1,
+              lineupSize: 0,
+              rows: [],
+              members: [],
+            },
+          ],
+          parsedRows: [
+            {
+              rowId: "cwl-alpha-roster:4",
+              sheetRowNumber: 4,
+              tabTitle: "CWL Alpha roster",
+              clanTag: "#2QG2C08UP",
+              clanName: "CWL Alpha",
+              rawText: "Alpha-ish | 12 | IN",
+              parsedPlayerTag: null,
+              parsedPlayerName: "Alpha-ish",
+              classification: "fuzzy_match_needs_review",
+              reason: "Player row needs review before it can be saved.",
+              suggestions: [],
+              dayRows: [{ roundDay: 1, subbedOut: false, assignmentOrder: 0 }],
+              resolvedPlayerTag: null,
+              resolvedPlayerName: null,
+              ignored: false,
+            },
+            {
+              rowId: "cwl-alpha-roster:5",
+              sheetRowNumber: 5,
+              tabTitle: "CWL Alpha roster",
+              clanTag: "#2QG2C08UP",
+              clanName: "CWL Alpha",
+              rawText: "Bravo-ish | 12 | IN",
+              parsedPlayerTag: null,
+              parsedPlayerName: "Bravo-ish",
+              classification: "fuzzy_match_needs_review",
+              reason: "Player row needs review before it can be saved.",
+              suggestions: [],
+              dayRows: [{ roundDay: 1, subbedOut: false, assignmentOrder: 0 }],
+              resolvedPlayerTag: null,
+              resolvedPlayerName: null,
+              ignored: false,
+            },
+          ],
+        },
+      ],
+      skippedTrackedClans: [],
+      skippedTabs: [],
+      warnings: ["2 rows need review."],
+    };
+    vi.mocked(cwlRotationSheetService.buildImportPreview).mockResolvedValue(preview);
+    vi.mocked(cwlRotationSheetService.confirmImport).mockResolvedValue({
+      season: "2026-04",
+      saved: [],
+      skippedTrackedClans: [],
+      skippedTabs: [],
+      ignoredRows: [],
+    } as any);
+
+    const interaction = makeInteraction({
+      group: "rotations",
+      subcommand: "import",
+    });
+    (interaction.options.getString as any).mockImplementation((name: string) => {
+      if (name === "sheet") return "https://docs.google.com/spreadsheets/d/sheet-1/edit";
+      if (name === "visibility") return null;
+      return null;
+    });
+    (interaction.options.getBoolean as any).mockImplementation((name: string) => {
+      if (name === "overwrite") return false;
+      return null;
+    });
+
+    await Cwl.run({} as any, interaction as any);
+
+    const reviewId = getComponentButtonCustomIds(interaction).find((id) => id.includes(":review:"));
+    expect(reviewId).toBeTruthy();
+    const reviewInteraction = {
+      customId: reviewId,
+      user: { id: "111111111111111111" },
+      update: vi.fn().mockResolvedValue(undefined),
+      reply: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await handleCwlRotationImportButtonInteraction(reviewInteraction as any);
+
+    const initialOptions = getComponentSelectMenuOptions(reviewInteraction);
+    expect(initialOptions.map((option) => option.label)).toEqual(
+      expect.arrayContaining(["Alpha", "Bravo", "Ignore this row"]),
+    );
+
+    const selectId = getComponentSelectMenuCustomIds(reviewInteraction).find((id) => id.includes(":resolve:"));
+    expect(selectId).toBeTruthy();
+    const firstSelectInteraction = {
+      customId: selectId,
+      values: ["tag:#PYLQ0289"],
+      user: { id: "111111111111111111" },
+      update: vi.fn().mockResolvedValue(undefined),
+      reply: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await handleCwlRotationImportSelectMenuInteraction(firstSelectInteraction as any);
+    const secondOptions = getComponentSelectMenuOptions(firstSelectInteraction);
+    expect(secondOptions.map((option) => option.label)).not.toContain("Alpha");
+    expect(secondOptions.map((option) => option.label)).toEqual(
+      expect.arrayContaining(["Bravo", "Ignore this row"]),
+    );
+
+    const secondSelectId = getComponentSelectMenuCustomIds(firstSelectInteraction).find((id) => id.includes(":resolve:"));
+    expect(secondSelectId).toBeTruthy();
+    const duplicateInteraction = {
+      customId: secondSelectId,
+      values: ["tag:#PYLQ0289"],
+      user: { id: "111111111111111111" },
+      update: vi.fn().mockResolvedValue(undefined),
+      reply: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await handleCwlRotationImportSelectMenuInteraction(duplicateInteraction as any);
+    expect(duplicateInteraction.reply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining("no longer available"),
+        ephemeral: true,
+      }),
+    );
   });
 
   it("surfaces a clear message when the import sheet link format is unsupported", async () => {

--- a/tests/cwlRotationSheet.service.test.ts
+++ b/tests/cwlRotationSheet.service.test.ts
@@ -137,6 +137,53 @@ describe("CwlRotationSheetService", () => {
     expect(String(preview.warnings.join(" "))).not.toContain("could not parse member line");
   });
 
+  it("parses legacy public table rows as roster-index plus player-name columns", async () => {
+    vi.spyOn(PublicGoogleSheetsService.prototype, "readPublishedWorkbook").mockResolvedValue({
+      title: "Imported CWL Planner",
+      tabs: [
+        {
+          title: "CWL Alpha roster",
+          pageUrl: "https://docs.google.com/spreadsheets/d/e/published-id/pubhtml/sheet?headers=false&gid=0",
+          gid: "0",
+        },
+      ],
+    });
+    vi.spyOn(PublicGoogleSheetsService.prototype, "readPublishedSheetValues").mockResolvedValue([
+      ["Season: 2026-04"],
+      ["Clan: CWL Alpha"],
+      ["Member", "Total Wars", "Day 1", "Day 2", "Day 3", "Day 4", "Day 5", "Day 6", "Day 7"],
+      [
+        "8",
+        "\u{2606}\u{2605}\u{2606}\u{2605}\u{2606}\u{2605}\u{2606}\u{2605}\u{2606}\u{2605}",
+        "IN",
+        "IN",
+        "IN",
+        "IN",
+        "IN",
+        "IN",
+        "IN",
+        "7",
+      ],
+      ["", "", "", "", "", "", "", "", "", ""],
+    ]);
+
+    const preview = await cwlRotationSheetService.buildImportPreview({
+      sheetLink: "https://docs.google.com/spreadsheets/d/e/published-id/pubhtml#gid=123456789",
+      overwrite: false,
+    });
+
+    expect(preview.matchedClans).toHaveLength(1);
+    expect(preview.matchedClans[0]?.parsedRows).toHaveLength(1);
+    expect(preview.matchedClans[0]?.parsedRows[0]?.parsedPlayerName).toBe(
+      "\u{2606}\u{2605}\u{2606}\u{2605}\u{2606}\u{2605}\u{2606}\u{2605}\u{2606}\u{2605}",
+    );
+    expect(preview.matchedClans[0]?.parsedRows[0]?.parsedPlayerTag).toBeNull();
+    expect(preview.matchedClans[0]?.parsedRows[0]?.classification).toBe("unresolved_needs_review");
+    expect(preview.matchedClans[0]?.warnings).toEqual(
+      expect.arrayContaining([expect.stringContaining("1 row need review")]),
+    );
+  });
+
   it("still requires credentials for non-public Google Sheets links", async () => {
     const publicWorkbookSpy = vi.spyOn(PublicGoogleSheetsService.prototype, "readPublishedWorkbook");
     const interactionLink = "https://docs.google.com/spreadsheets/d/standard-sheet-id/edit";


### PR DESCRIPTION
- parse legacy roster-index rows from the player-name column
- offer remaining tracked players as fallback review mappings