### PR TITLE
fix(todo): anchor war and raid snapshots to event clan context

### DIFF
--- a/src/services/TodoService.ts
+++ b/src/services/TodoService.ts
@@ -638,9 +638,7 @@ function buildWarPageDescription(
   rows: TodoRenderRow[],
   linkedPlayerCount: number,
 ): { description: string; sidebarState: TodoSidebarState } {
-  const activeRows = rows.filter(
-    (row) => Boolean(row.snapshot?.warActive) && row.inValidatedWarMemberSet,
-  );
+  const activeRows = rows.filter((row) => Boolean(row.snapshot?.warActive));
   const warCompletion = summarizeWarCompletionStatus(activeRows);
   if (activeRows.length <= 0) {
     return {

--- a/src/services/TodoSnapshotService.ts
+++ b/src/services/TodoSnapshotService.ts
@@ -518,11 +518,18 @@ export class TodoSnapshotService {
     );
     const resolvedClanTagByPlayerTag = new Map<string, string | null>();
     for (const playerTag of normalizedTags) {
+      const existing = existingByTag.get(playerTag) ?? null;
       const liveClanTag = liveClanTagByPlayerTag.get(playerTag) ?? "";
       const fromMember = latestClanMemberByTag.get(playerTag)?.clanTag ?? "";
       const fromExisting = existingByTag.get(playerTag)?.clanTag ?? "";
+      const pinnedEventClanTag =
+        existing && (existing.warActive || existing.raidActive)
+          ? normalizeClanTag(existing.clanTag ?? "")
+          : "";
       const resolvedClanTag =
-        normalizeClanTag(liveClanTag || fromMember || fromExisting) || null;
+        normalizeClanTag(
+          pinnedEventClanTag || liveClanTag || fromMember || fromExisting,
+        ) || null;
       resolvedClanTagByPlayerTag.set(playerTag, resolvedClanTag);
     }
 

--- a/tests/todo.command.test.ts
+++ b/tests/todo.command.test.ts
@@ -636,6 +636,7 @@ describe("/todo command", () => {
       makeSnapshotRow({
         playerTag: "#PYLQ0289",
         playerName: "Alpha",
+        warActive: true,
         clanTag: "#PQL0289",
         clanName: "Clan One",
         warAttacksUsed: 0,
@@ -1298,7 +1299,7 @@ describe("/todo command", () => {
     expect(description).toContain("- #2 Bravo - `1 / 2` - stale snapshot");
   });
 
-  it("excludes players not present in the clan's validated current-war member set", async () => {
+  it("keeps WAR rows visible when the linked account's current clan differs from the war clan context", async () => {
     prismaMock.playerLink.findMany.mockResolvedValue([
       { playerTag: "#PYLQ0289", createdAt: new Date("2026-03-01T00:00:00.000Z") },
       { playerTag: "#QGRJ2222", createdAt: new Date("2026-03-02T00:00:00.000Z") },
@@ -1313,16 +1314,19 @@ describe("/todo command", () => {
         playerName: "Alpha",
         clanTag: "#PQL0289",
         clanName: "Clan One",
+        warActive: true,
         warAttacksUsed: 1,
         warPhase: "battle day",
+        warEndsAt: new Date("2026-03-31T12:00:00.000Z"),
       }),
       makeSnapshotRow({
         playerTag: "#QGRJ2222",
         playerName: "Bravo",
         clanTag: "#PQL0289",
         clanName: "Clan One",
+        warActive: false,
         warAttacksUsed: 0,
-        warPhase: "battle day",
+        warPhase: null,
       }),
     ]);
     prismaMock.trackedClan.findMany.mockResolvedValue([
@@ -1339,19 +1343,19 @@ describe("/todo command", () => {
         updatedAt: new Date("2026-03-26T00:00:00.000Z"),
       },
     ]);
-    prismaMock.warAttacks.findMany.mockResolvedValue([
+    prismaMock.warAttacks.findMany.mockResolvedValue([]);
+    prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue([
       {
-        warId: 1001,
-        clanTag: "#PQL0289",
-        warStartTime: new Date("2026-03-25T12:00:00.000Z"),
         playerTag: "#PYLQ0289",
-        playerPosition: 8,
-        attacksUsed: 1,
-        attackOrder: 1,
-        attackNumber: 1,
-        defenderPosition: 7,
-        stars: 2,
-        attackSeenAt: new Date("2026-03-26T00:00:00.000Z"),
+        clanTag: "#NEWCLAN",
+        townHall: 15,
+        sourceSyncedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+      {
+        playerTag: "#QGRJ2222",
+        clanTag: "#NEWCLAN",
+        townHall: 14,
+        sourceSyncedAt: new Date("2026-03-26T00:00:00.000Z"),
       },
     ]);
 
@@ -1359,8 +1363,58 @@ describe("/todo command", () => {
     await Todo.run({} as any, interaction as any, makeCocServiceSpy() as any);
 
     const description = getReplyDescription(interaction);
-    expect(description).toContain("- #8 Alpha - `1 / 2`");
+    expect(description).toContain("#? Alpha - `1 / 2`");
+    expect(description).not.toContain("No war active");
     expect(description).not.toContain("Bravo");
+  });
+
+  it("keeps RAIDS rows visible when the linked account's current clan differs from the raid clan context", async () => {
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      { playerTag: "#PYLQ0289", createdAt: new Date("2026-03-01T00:00:00.000Z") },
+      { playerTag: "#QGRJ2222", createdAt: new Date("2026-03-02T00:00:00.000Z") },
+    ]);
+    prismaMock.todoPlayerSnapshot.aggregate.mockResolvedValue({
+      _count: { _all: 2 },
+      _max: { updatedAt: new Date("2026-03-26T00:00:00.000Z") },
+    });
+    prismaMock.todoPlayerSnapshot.findMany.mockResolvedValue([
+      makeSnapshotRow({
+        playerTag: "#PYLQ0289",
+        playerName: "Alpha",
+        clanTag: "#PQL0289",
+        clanName: "Clan One",
+        raidActive: true,
+        raidAttacksUsed: 3,
+      }),
+      makeSnapshotRow({
+        playerTag: "#QGRJ2222",
+        playerName: "Bravo",
+        clanTag: "#PQL0289",
+        clanName: "Clan One",
+        raidActive: false,
+        raidAttacksUsed: 0,
+      }),
+    ]);
+    prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue([
+      {
+        playerTag: "#PYLQ0289",
+        clanTag: "#NEWCLAN",
+        townHall: 15,
+        sourceSyncedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+      {
+        playerTag: "#QGRJ2222",
+        clanTag: "#NEWCLAN",
+        townHall: 14,
+        sourceSyncedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+    ]);
+
+    const interaction = makeTodoInteraction({ type: "RAIDS" });
+    await Todo.run({} as any, interaction as any, makeCocServiceSpy() as any);
+
+    const description = getReplyDescription(interaction);
+    expect(description).toContain("Alpha #PYLQ0289 - clan capital raids: 3/6");
   });
 
   it("uses safe #? fallback when war lineup position is unavailable", async () => {
@@ -1541,6 +1595,7 @@ describe("/todo command", () => {
         playerName: "Alpha",
         clanTag: "#PQL0289",
         clanName: "Clan One",
+        warActive: false,
         warAttacksUsed: 0,
         warPhase: "battle day",
       }),
@@ -2499,6 +2554,7 @@ describe("/todo pagination buttons", () => {
       makeSnapshotRow({
         playerTag: "#PYLQ0289",
         playerName: "Alpha",
+        warActive: false,
         warAttacksUsed: 1,
         cwlAttacksUsed: 1,
         raidAttacksUsed: 3,
@@ -2507,6 +2563,7 @@ describe("/todo pagination buttons", () => {
       makeSnapshotRow({
         playerTag: "#QGRJ2222",
         playerName: "Bravo",
+        warActive: false,
         warAttacksUsed: 2,
         cwlAttacksUsed: 0,
         raidAttacksUsed: 0,

--- a/tests/todoSnapshot.service.test.ts
+++ b/tests/todoSnapshot.service.test.ts
@@ -502,7 +502,8 @@ describe("TodoSnapshotService", () => {
   it("sources active raid attacks from live clan raid members even for untracked clans", async () => {
     prismaMock.todoPlayerSnapshot.findMany.mockResolvedValue([
       buildSnapshotRow({
-        raidActive: true,
+        warActive: false,
+        raidActive: false,
         raidAttacksUsed: 0,
       }),
     ]);
@@ -537,6 +538,65 @@ describe("TodoSnapshotService", () => {
       expect.objectContaining({
         update: expect.objectContaining({
           clanTag: "#P2YLC8R0",
+          raidActive: true,
+          raidAttacksUsed: 6,
+        }),
+      }),
+    );
+  });
+
+  it("preserves the active raid clan context when a linked account moves clans", async () => {
+    prismaMock.todoPlayerSnapshot.findMany.mockResolvedValue([
+      buildSnapshotRow({
+        playerTag: "#PYLQ0289",
+        playerName: "Alpha",
+        clanTag: "#PQL0289",
+        clanName: "Clan One",
+        raidActive: true,
+        raidAttacksUsed: 4,
+        raidEndsAt: new Date("2026-03-29T07:00:00.000Z"),
+      }),
+    ]);
+    prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue([
+      {
+        playerTag: "#PYLQ0289",
+        clanTag: "#NEWCLAN",
+        playerName: "Alpha",
+        sourceSyncedAt: new Date("2026-03-27T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.fwaWarMemberCurrent.findMany.mockResolvedValue([]);
+    prismaMock.currentWar.findMany.mockResolvedValue([]);
+    prismaMock.trackedClan.findMany.mockResolvedValue([
+      { tag: "#PQL0289", name: "Clan One" },
+    ]);
+    prismaMock.cwlTrackedClan.findMany.mockResolvedValue([]);
+    prismaMock.cwlPlayerClanSeason.findMany.mockResolvedValue([]);
+    const cocService = {
+      getPlayerRaw: vi.fn().mockResolvedValue({
+        tag: "#PYLQ0289",
+        clan: { tag: "#NEWCLAN" },
+      }),
+      getClanCapitalRaidSeasons: vi.fn().mockResolvedValue([
+        {
+          startTime: "20260327T070000.000Z",
+          endTime: "20260330T070000.000Z",
+          members: [{ tag: "#PYLQ0289", attacks: 6 }],
+        },
+      ]),
+    };
+
+    await todoSnapshotService.refreshSnapshotsForPlayerTags({
+      playerTags: ["#PYLQ0289"],
+      cocService: cocService as any,
+      nowMs: Date.UTC(2026, 2, 27, 12, 0, 0, 0),
+    });
+
+    expect(cocService.getClanCapitalRaidSeasons).toHaveBeenCalledWith("#PQL0289", 2);
+    expect(prismaMock.todoPlayerSnapshot.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({
+          clanTag: "#PQL0289",
           raidActive: true,
           raidAttacksUsed: 6,
         }),
@@ -623,6 +683,91 @@ describe("TodoSnapshotService", () => {
         update: expect.objectContaining({
           raidActive: true,
           raidAttacksUsed: 0,
+        }),
+      }),
+    );
+  });
+
+  it("preserves the active war clan context when a linked account moves clans", async () => {
+    prismaMock.todoPlayerSnapshot.findMany.mockResolvedValue([
+      buildSnapshotRow({
+        playerTag: "#PYLQ0289",
+        playerName: "Alpha",
+        clanTag: "#PQL0289",
+        clanName: "Clan One",
+        warActive: true,
+        warAttacksUsed: 1,
+        warPhase: "battle day",
+        warEndsAt: new Date("2026-03-31T12:00:00.000Z"),
+        raidActive: false,
+        raidAttacksUsed: 0,
+      }),
+    ]);
+    prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue([
+      {
+        playerTag: "#PYLQ0289",
+        clanTag: "#NEWCLAN",
+        playerName: "Alpha",
+        sourceSyncedAt: new Date("2026-03-27T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.fwaWarMemberCurrent.findMany.mockResolvedValue([
+      {
+        playerTag: "#PYLQ0289",
+        clanTag: "#PQL0289",
+        attacks: 1,
+        sourceSyncedAt: new Date("2026-03-27T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.currentWar.findMany.mockResolvedValue([
+      {
+        clanTag: "#PQL0289",
+        state: "inWar",
+        startTime: new Date("2026-03-25T12:00:00.000Z"),
+        endTime: new Date("2026-03-26T12:00:00.000Z"),
+        updatedAt: new Date("2026-03-27T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.warAttacks.findMany.mockResolvedValue([
+      {
+        warId: 1001,
+        clanTag: "#PQL0289",
+        warStartTime: new Date("2026-03-25T12:00:00.000Z"),
+        playerTag: "#PYLQ0289",
+        playerPosition: 8,
+        attacksUsed: 1,
+        attackOrder: 1,
+        attackNumber: 1,
+        defenderPosition: 7,
+        stars: 2,
+        attackSeenAt: new Date("2026-03-27T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.trackedClan.findMany.mockResolvedValue([
+      { tag: "#PQL0289", name: "Clan One" },
+    ]);
+    prismaMock.cwlTrackedClan.findMany.mockResolvedValue([]);
+    prismaMock.cwlPlayerClanSeason.findMany.mockResolvedValue([]);
+    const cocService = {
+      getPlayerRaw: vi.fn().mockResolvedValue({
+        tag: "#PYLQ0289",
+        clan: { tag: "#NEWCLAN" },
+      }),
+      getClanCapitalRaidSeasons: vi.fn(),
+    };
+
+    await todoSnapshotService.refreshSnapshotsForPlayerTags({
+      playerTags: ["#PYLQ0289"],
+      cocService: cocService as any,
+      nowMs: Date.UTC(2026, 2, 26, 0, 0, 0, 0),
+    });
+
+    expect(prismaMock.todoPlayerSnapshot.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({
+          clanTag: "#PQL0289",
+          warActive: true,
+          warAttacksUsed: 1,
         }),
       }),
     );


### PR DESCRIPTION
- preserve active war and raid clan identity across clan moves
- keep /todo WAR visible without current-clan validation gating