### PR TITLE
fix(remindme): anchor WAR reminders to battle-day end

### DIFF
--- a/src/services/remindme/UserActivityReminderSchedulerService.ts
+++ b/src/services/remindme/UserActivityReminderSchedulerService.ts
@@ -340,17 +340,18 @@ function resolveReminderEventContext(input: {
   nowMs: number;
 }): ResolvedReminderEventContext | null {
   if (input.ruleType === UserActivityReminderType.WAR) {
-    if (!input.snapshot.warActive || !input.snapshot.warEndsAt) return null;
-    if (input.snapshot.warEndsAt.getTime() <= input.nowMs) return null;
     const clanTag = normalizeClanTag(input.snapshot.clanTag ?? "");
     if (!clanTag) return null;
     const war = input.currentWarByClanTag.get(clanTag) ?? null;
+    const eventEndsAt = war?.endTime ?? input.snapshot.warEndsAt ?? null;
+    if (!input.snapshot.warActive || !eventEndsAt) return null;
+    if (eventEndsAt.getTime() <= input.nowMs) return null;
     const eventInstanceKey = war
       ? buildWarEventInstanceKey(clanTag, war)
-      : `WAR:${clanTag}:${input.snapshot.warEndsAt.getTime()}`;
+      : `WAR:${clanTag}:${eventEndsAt.getTime()}`;
     return {
       eventInstanceKey,
-      eventEndsAt: input.snapshot.warEndsAt,
+      eventEndsAt,
       playerTag: input.snapshot.playerTag,
       playerName: sanitizeDisplayText(input.snapshot.playerName),
       clanName: sanitizeDisplayText(input.snapshot.clanName),

--- a/tests/remindme.scheduler.service.test.ts
+++ b/tests/remindme.scheduler.service.test.ts
@@ -249,6 +249,188 @@ describe("UserActivityReminderSchedulerService", () => {
     });
   });
 
+  it("uses CurrentWar.endTime for prep-day WAR reminders instead of the prep end snapshot", async () => {
+    const nowMs = Date.parse("2026-03-27T11:30:00.000Z");
+    const prepStart = new Date("2026-03-27T12:00:00.000Z");
+    const battleEnd = new Date("2026-03-28T12:00:00.000Z");
+    prismaMock.userActivityReminderRule.findMany.mockResolvedValue([
+      {
+        id: "rule-war",
+        discordUserId: "111111111111111111",
+        type: UserActivityReminderType.WAR,
+        playerTag: "#P1111111",
+        method: UserActivityReminderMethod.DM,
+        offsetMinutes: 60,
+        isActive: true,
+        surfaceChannelId: null,
+      },
+    ]);
+    prismaMock.currentWar.findMany.mockResolvedValue([
+      {
+        clanTag: "#PYLQ0289",
+        warId: 991,
+        startTime: prepStart,
+        endTime: battleEnd,
+        state: "preparation",
+        updatedAt: new Date(nowMs),
+      },
+    ]);
+    todoSnapshotServiceMock.listSnapshotsByPlayerTags.mockResolvedValue([
+      snapshotRow({
+        playerTag: "#P1111111",
+        clanTag: "#PYLQ0289",
+        clanName: "War Clan",
+        warActive: true,
+        warEndsAt: prepStart,
+      }),
+    ]);
+    const dispatch = {
+      dispatchReminder: vi.fn(),
+    };
+
+    const counts = await runUserActivityReminderSchedulerCycle({
+      client: {} as any,
+      cocService: {} as any,
+      dispatch: dispatch as any,
+      nowMs,
+      intervalMs: 60_000,
+    });
+
+    expect(counts).toEqual({
+      evaluated: 1,
+      fired: 0,
+      deduped: 0,
+      failed: 0,
+    });
+    expect(dispatch.dispatchReminder).not.toHaveBeenCalled();
+    expect(prismaMock.userActivityReminderDelivery.create).not.toHaveBeenCalled();
+  });
+
+  it("uses CurrentWar.endTime for battle-day WAR reminders", async () => {
+    const nowMs = Date.parse("2026-03-28T11:30:00.000Z");
+    const warEnd = new Date("2026-03-28T12:00:00.000Z");
+    prismaMock.userActivityReminderRule.findMany.mockResolvedValue([
+      {
+        id: "rule-war",
+        discordUserId: "111111111111111111",
+        type: UserActivityReminderType.WAR,
+        playerTag: "#P1111111",
+        method: UserActivityReminderMethod.DM,
+        offsetMinutes: 60,
+        isActive: true,
+        surfaceChannelId: null,
+      },
+    ]);
+    prismaMock.currentWar.findMany.mockResolvedValue([
+      {
+        clanTag: "#PYLQ0289",
+        warId: 992,
+        startTime: new Date("2026-03-27T12:00:00.000Z"),
+        endTime: warEnd,
+        state: "inWar",
+        updatedAt: new Date(nowMs),
+      },
+    ]);
+    todoSnapshotServiceMock.listSnapshotsByPlayerTags.mockResolvedValue([
+      snapshotRow({
+        playerTag: "#P1111111",
+        clanTag: "#PYLQ0289",
+        clanName: "War Clan",
+        warActive: true,
+        warEndsAt: warEnd,
+      }),
+    ]);
+    prismaMock.userActivityReminderDelivery.create.mockResolvedValue({ id: "delivery-war" });
+    const dispatch = {
+      dispatchReminder: vi.fn().mockResolvedValue({
+        status: "sent",
+        messageId: "msg-war",
+        deliverySurface: "DM:123",
+      }),
+    };
+
+    const counts = await runUserActivityReminderSchedulerCycle({
+      client: {} as any,
+      cocService: {} as any,
+      dispatch: dispatch as any,
+      nowMs,
+      intervalMs: 60_000,
+    });
+
+    expect(counts).toEqual({
+      evaluated: 1,
+      fired: 1,
+      deduped: 0,
+      failed: 0,
+    });
+    expect(dispatch.dispatchReminder).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({
+        reminderType: UserActivityReminderType.WAR,
+        eventEndsAt: warEnd,
+        eventInstanceKey: "WAR:#PYLQ0289:war-id:992",
+      }),
+    );
+  });
+
+  it("falls back to snapshot warEndsAt when CurrentWar is unavailable", async () => {
+    const nowMs = Date.parse("2026-03-28T11:30:00.000Z");
+    const snapshotWarEndsAt = new Date("2026-03-28T12:00:00.000Z");
+    prismaMock.userActivityReminderRule.findMany.mockResolvedValue([
+      {
+        id: "rule-war",
+        discordUserId: "111111111111111111",
+        type: UserActivityReminderType.WAR,
+        playerTag: "#P1111111",
+        method: UserActivityReminderMethod.DM,
+        offsetMinutes: 60,
+        isActive: true,
+        surfaceChannelId: null,
+      },
+    ]);
+    prismaMock.currentWar.findMany.mockResolvedValue([]);
+    todoSnapshotServiceMock.listSnapshotsByPlayerTags.mockResolvedValue([
+      snapshotRow({
+        playerTag: "#P1111111",
+        clanTag: "#PYLQ0289",
+        clanName: "War Clan",
+        warActive: true,
+        warEndsAt: snapshotWarEndsAt,
+      }),
+    ]);
+    prismaMock.userActivityReminderDelivery.create.mockResolvedValue({ id: "delivery-war" });
+    const dispatch = {
+      dispatchReminder: vi.fn().mockResolvedValue({
+        status: "sent",
+        messageId: "msg-war",
+        deliverySurface: "DM:123",
+      }),
+    };
+
+    const counts = await runUserActivityReminderSchedulerCycle({
+      client: {} as any,
+      cocService: {} as any,
+      dispatch: dispatch as any,
+      nowMs,
+      intervalMs: 60_000,
+    });
+
+    expect(counts).toEqual({
+      evaluated: 1,
+      fired: 1,
+      deduped: 0,
+      failed: 0,
+    });
+    expect(dispatch.dispatchReminder).toHaveBeenCalledWith(
+      {},
+      expect.objectContaining({
+        reminderType: UserActivityReminderType.WAR,
+        eventEndsAt: snapshotWarEndsAt,
+        eventInstanceKey: `WAR:#PYLQ0289:${snapshotWarEndsAt.getTime()}`,
+      }),
+    );
+  });
+
   it("dedupes already-sent rule/event identities before dispatch", async () => {
     const nowMs = Date.parse("2026-03-27T12:00:00.000Z");
     prismaMock.userActivityReminderRule.findMany.mockResolvedValue([


### PR DESCRIPTION
- use CurrentWar.endTime when scheduling WAR reminder offsets
- preserve snapshot warEndsAt for /todo rendering fallback only