### PR TITLE
feat(cwl): add clan/day preview controls for rotation import

### DIFF
--- a/src/commands/Cwl.ts
+++ b/src/commands/Cwl.ts
@@ -54,6 +54,7 @@ type CwlRotationImportSession = {
   overwrite: boolean;
   view: "preview" | "review";
   pageIndex: number;
+  previewClanIndex: number;
   activeClanIndex: number;
   clanSessions: CwlRotationImportClanSession[];
 };
@@ -252,6 +253,10 @@ function createCwlRotationImportSession(
   pruneExpiredCwlRotationImportSessions();
   const sessionId = randomUUID().replace(/-/g, "").slice(0, 18);
   const clanSessions = preview.matchedClans.map((clan) => createCwlRotationImportClanSession(clan));
+  const previewClanIndex = Math.max(
+    0,
+    clanSessions.findIndex((clan) => clan.tab.parsedRows.length > 0),
+  );
   cwlRotationImportSessions.set(sessionId, {
     requestedByUserId,
     createdAtMs: Date.now(),
@@ -260,6 +265,7 @@ function createCwlRotationImportSession(
     overwrite,
     view: "preview",
     pageIndex: 0,
+    previewClanIndex,
     activeClanIndex: Math.max(0, clanSessions.findIndex((clan) => !clan.confirmed && clan.reviewRowIds.length > 0)),
     clanSessions,
   });
@@ -286,13 +292,16 @@ export function isCwlRotationImportButtonCustomId(customId: string): boolean {
 }
 
 export function isCwlRotationImportSelectMenuCustomId(customId: string): boolean {
-  return String(customId ?? "").startsWith(`${CWL_ROTATION_IMPORT_SESSION_PREFIX}:resolve:`);
+  return (
+    String(customId ?? "").startsWith(`${CWL_ROTATION_IMPORT_SESSION_PREFIX}:resolve:`) ||
+    String(customId ?? "").startsWith(`${CWL_ROTATION_IMPORT_SESSION_PREFIX}:preview-clan:`)
+  );
 }
 
 function parseCwlRotationImportButtonCustomId(
   customId: string,
 ): {
-  action: "page" | "review" | "review-page" | "preview" | "confirm" | "cancel";
+  action: "page" | "review" | "review-page" | "preview" | "preview-day" | "confirm" | "cancel";
   sessionId: string;
   pageIndex: number | null;
 } | null {
@@ -304,19 +313,20 @@ function parseCwlRotationImportButtonCustomId(
     action !== "review" &&
     action !== "review-page" &&
     action !== "preview" &&
+    action !== "preview-day" &&
     action !== "confirm" &&
     action !== "cancel"
   ) {
     return null;
   }
-  const hasReviewPageDirection = action === "review-page" && (parts[2] === "prev" || parts[2] === "next");
-  const sessionId = String(hasReviewPageDirection ? parts[3] ?? "" : parts[2] ?? "").trim();
+  const hasDirectionalIndex = (action === "review-page" || action === "preview-day") && (parts[2] === "prev" || parts[2] === "next");
+  const sessionId = String(hasDirectionalIndex ? parts[3] ?? "" : parts[2] ?? "").trim();
   if (!sessionId) return null;
   const pageIndex =
-    action === "page" || action === "review-page" || action === "preview"
+    action === "page" || action === "review-page" || action === "preview" || action === "preview-day"
       ? Math.max(
           0,
-          Math.trunc(Number(hasReviewPageDirection ? parts[4] ?? "0" : parts[3] ?? "0") || 0),
+          Math.trunc(Number(hasDirectionalIndex ? parts[4] ?? "0" : parts[3] ?? "0") || 0),
         )
       : null;
   return {
@@ -328,10 +338,19 @@ function parseCwlRotationImportButtonCustomId(
 
 function parseCwlRotationImportSelectMenuCustomId(
   customId: string,
-): { action: "resolve"; sessionId: string; rowId: string } | null {
+): { action: "resolve"; sessionId: string; rowId: string } | { action: "preview-clan"; sessionId: string } | null {
   const parts = String(customId ?? "").split(":");
-  if (parts.length < 4 || parts[0] !== CWL_ROTATION_IMPORT_SESSION_PREFIX) return null;
-  if (parts[1] !== "resolve") return null;
+  if (parts.length < 3 || parts[0] !== CWL_ROTATION_IMPORT_SESSION_PREFIX) return null;
+  const action = parts[1];
+  if (action === "preview-clan") {
+    const sessionId = String(parts[2] ?? "").trim();
+    if (!sessionId) return null;
+    return {
+      action,
+      sessionId,
+    };
+  }
+  if (action !== "resolve" || parts.length < 4) return null;
   const sessionId = String(parts[2] ?? "").trim();
   const rowId = String(parts.slice(3).join(":") ?? "").trim();
   if (!sessionId || !rowId) return null;
@@ -342,17 +361,49 @@ function parseCwlRotationImportSelectMenuCustomId(
   };
 }
 
+function buildCwlRotationImportPreviewPlayerLine(input: {
+  row: CwlRotationImportRow;
+  dayIndex: number;
+  includeRawSnippet: boolean;
+}): string {
+  const dayNumber = Math.max(1, Math.min(7, Math.trunc(input.dayIndex) + 1));
+  const dayRow = input.row.dayRows.find((entry) => entry.roundDay === dayNumber) ?? null;
+  const statusEmoji = input.row.ignored
+    ? ":no_entry:"
+    : isCwlRotationImportRowPendingReview(input.row)
+      ? ":warning:"
+      : dayRow?.subbedOut
+        ? ":x:"
+        : ":black_circle:";
+  const playerName = input.row.resolvedPlayerName ?? input.row.parsedPlayerName;
+  const playerTag = input.row.resolvedPlayerTag ?? input.row.parsedPlayerTag ?? "unmapped";
+  const rawSnippet = input.includeRawSnippet && input.row.rawText ? ` | ${input.row.rawText}` : "";
+  return `${statusEmoji} ${playerName} ${playerTag}${rawSnippet}`;
+}
+
 function buildCwlRotationImportPreviewPageLines(input: {
   preview: CwlRotationSheetImportPreview;
-  pageIndex: number;
+  clanSession: CwlRotationImportClanSession | null;
+  dayIndex: number;
 }): string[] {
-  const roundDay = Math.max(1, Math.min(7, Math.trunc(input.pageIndex) + 1));
+  const dayNumber = Math.max(1, Math.min(7, Math.trunc(input.dayIndex) + 1));
+  const clanLabel = input.clanSession?.clanName
+    ? `${input.clanSession.clanName} (${input.clanSession.clanTag})`
+    : input.clanSession?.clanTag ?? "unknown clan";
+  const totalRows = input.clanSession?.tab.parsedRows.length ?? 0;
+  const mappedRows = input.clanSession
+    ? input.clanSession.tab.parsedRows.filter((row) => !isCwlRotationImportRowPendingReview(row)).length
+    : 0;
+  const reviewRows = input.clanSession
+    ? input.clanSession.tab.parsedRows.filter(isCwlRotationImportRowPendingReview).length
+    : 0;
   const lines: string[] = [
     `Season: ${input.preview.season}`,
     `Source: ${input.preview.sourceSheetTitle || input.preview.sourceSheetId}`,
-    `Page: ${roundDay} / 7`,
     `Importable clans: ${input.preview.matchedClans.filter((clan) => clan.importable).length} / ${input.preview.matchedClans.length}`,
-    "",
+    `Clan: ${clanLabel}`,
+    `Day: Day ${dayNumber}`,
+    `Rows: ${mappedRows} mapped / ${totalRows} total ${reviewRows > 0 ? "⚠️" : "✅"}`,
   ];
 
   if (input.preview.skippedTrackedClans.length > 0) {
@@ -361,7 +412,6 @@ function buildCwlRotationImportPreviewPageLines(input: {
         .map((entry) => `${entry.clanName || entry.clanTag} (${entry.reason})`)
         .join(" | ")}`,
     );
-    lines.push("");
   }
   if (input.preview.skippedTabs.length > 0) {
     lines.push(
@@ -369,57 +419,55 @@ function buildCwlRotationImportPreviewPageLines(input: {
         .map((entry) => `${entry.tabTitle} (${entry.reason})`)
         .join(" | ")}`,
     );
-    lines.push("");
+  }
+  const clanWarnings = input.clanSession?.tab.warnings ?? [];
+  if (clanWarnings.length > 0) {
+    lines.push(`Warnings: ${clanWarnings.join(" | ")}`);
   }
 
-  for (const clan of input.preview.matchedClans) {
-    const day = clan.days.find((entry) => entry.roundDay === roundDay);
-    const clanLabel = clan.clanName || clan.clanTag;
-    const statusLabel = clan.importable
-      ? ""
-      : ` - blocked${clan.importBlockedReason ? ` (${clan.importBlockedReason})` : ""}`;
-    lines.push(`**${clanLabel}**${statusLabel}`);
-    if (clan.warnings.length > 0) {
-      lines.push(`Warnings: ${clan.warnings.join(" | ")}`);
-    }
-    if (!day || day.members.length <= 0) {
-      lines.push("No rows parsed.");
-    } else {
-      lines.push(
-        ...buildCwlRotationMemberLines({
-          members: day.members,
-          emptyMessage: "No rows parsed.",
-        }),
-      );
-    }
-    lines.push("");
+  lines.push("");
+
+  const rows = input.clanSession?.tab.parsedRows ?? [];
+  if (rows.length <= 0) {
+    lines.push("No player rows were parsed for this clan.");
+    return lines;
   }
 
-  if (lines.at(-1) === "") {
-    lines.pop();
+  const renderRows = (includeRawSnippet: boolean): string[] => [
+    ...lines,
+    ...rows.map((row) => buildCwlRotationImportPreviewPlayerLine({ row, dayIndex: input.dayIndex, includeRawSnippet })),
+  ];
+
+  const withRawSnippets = renderRows(true);
+  if (withRawSnippets.join("\n").length <= DISCORD_DESCRIPTION_LIMIT) {
+    return withRawSnippets;
   }
-  return lines;
+
+  return renderRows(false);
 }
 
 function buildCwlRotationImportPreviewEmbed(input: {
   preview: CwlRotationSheetImportPreview;
-  pageIndex: number;
+  clanSession: CwlRotationImportClanSession | null;
+  dayIndex: number;
   sessionId: string;
 }): EmbedBuilder {
-  const roundDay = Math.max(1, Math.min(7, Math.trunc(input.pageIndex) + 1));
+  const dayNumber = Math.max(1, Math.min(7, Math.trunc(input.dayIndex) + 1));
+  const clanLabel = input.clanSession?.clanName || input.clanSession?.clanTag || "unknown clan";
   return new EmbedBuilder()
     .setColor(CWL_EMBED_COLOR)
-    .setTitle(`/cwl rotations import preview - day ${roundDay}`)
+    .setTitle(`/cwl rotations import preview - ${clanLabel} - day ${dayNumber}`)
     .setDescription(
       buildDescription(
         buildCwlRotationImportPreviewPageLines({
           preview: input.preview,
-          pageIndex: input.pageIndex,
+          clanSession: input.clanSession,
+          dayIndex: input.dayIndex,
         }),
       ),
     )
     .setFooter({
-      text: `Session ${input.sessionId.slice(0, 8)} - page ${roundDay}/7`,
+      text: `Session ${input.sessionId.slice(0, 8)} - ${clanLabel} day ${dayNumber}/7`,
     });
 }
 
@@ -539,38 +587,81 @@ function buildCwlRotationImportReviewEmbed(input: {
     });
 }
 
+function buildCwlRotationImportPreviewClanSelectMenu(input: {
+  sessionId: string;
+  session: CwlRotationImportSession;
+  selectedClanIndex: number;
+  dayIndex: number;
+}): ActionRowBuilder<StringSelectMenuBuilder> | null {
+  if (input.session.clanSessions.length <= 0) return null;
+  const selectedDay = Math.max(1, Math.min(7, Math.trunc(input.dayIndex) + 1));
+  const selectedClanIndex = Math.max(0, Math.min(input.session.clanSessions.length - 1, input.selectedClanIndex));
+  const menu = new StringSelectMenuBuilder()
+    .setCustomId(`${CWL_ROTATION_IMPORT_SESSION_PREFIX}:preview-clan:${input.sessionId}`)
+    .setPlaceholder("Select a clan to preview")
+    .setMinValues(1)
+    .setMaxValues(1);
+  const options = input.session.clanSessions.map((clanSession, clanIndex) => {
+    const totalRows = clanSession.tab.parsedRows.length;
+    const mappedRows = clanSession.tab.parsedRows.filter((row) => !isCwlRotationImportRowPendingReview(row)).length;
+    const reviewRows = clanSession.tab.parsedRows.filter(isCwlRotationImportRowPendingReview).length;
+    const hasUsableData = totalRows > 0;
+    return {
+      label: `${(clanSession.clanName || clanSession.clanTag).slice(0, 100)} - ${mappedRows}/${totalRows} ${reviewRows > 0 ? "⚠️" : "✅"}`.slice(0, 100),
+      value: clanSession.clanTag,
+      description: hasUsableData ? `Preview Day ${selectedDay}` : `No usable rows for Day ${selectedDay}`,
+      default: clanIndex === selectedClanIndex,
+      emoji: hasUsableData ? (reviewRows > 0 ? "⚠️" : "✅") : "🚫",
+    };
+  });
+  menu.addOptions(options);
+  return new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(menu);
+}
+
 function buildCwlRotationImportPreviewActionRows(input: {
   sessionId: string;
-  pageIndex: number;
+  session: CwlRotationImportSession;
+  clanSession: CwlRotationImportClanSession | null;
+  dayIndex: number;
   hasImportableClans: boolean;
   hasReviewRows: boolean;
-}): ActionRowBuilder<ButtonBuilder>[] {
+}): ActionRowBuilder<ButtonBuilder | StringSelectMenuBuilder>[] {
+  const dayIndex = Math.max(0, Math.min(6, Math.trunc(input.dayIndex)));
+  const clanSelectMenu = buildCwlRotationImportPreviewClanSelectMenu({
+    sessionId: input.sessionId,
+    session: input.session,
+    selectedClanIndex: input.session.previewClanIndex,
+    dayIndex,
+  });
   const prevButton = new ButtonBuilder()
-    .setCustomId(`${CWL_ROTATION_IMPORT_SESSION_PREFIX}:page:${input.sessionId}:${Math.max(0, input.pageIndex - 1)}`)
-    .setLabel("Prev")
+    .setCustomId(`${CWL_ROTATION_IMPORT_SESSION_PREFIX}:preview-day:prev:${input.sessionId}:${Math.max(0, dayIndex - 1)}`)
+    .setLabel("Prev Day")
     .setStyle(ButtonStyle.Secondary)
-    .setDisabled(input.pageIndex <= 0);
+    .setDisabled(dayIndex <= 0);
   const nextButton = new ButtonBuilder()
-    .setCustomId(`${CWL_ROTATION_IMPORT_SESSION_PREFIX}:page:${input.sessionId}:${Math.min(6, input.pageIndex + 1)}`)
-    .setLabel("Next")
+    .setCustomId(`${CWL_ROTATION_IMPORT_SESSION_PREFIX}:preview-day:next:${input.sessionId}:${Math.min(6, dayIndex + 1)}`)
+    .setLabel("Next Day")
     .setStyle(ButtonStyle.Secondary)
-    .setDisabled(input.pageIndex >= 6);
+    .setDisabled(dayIndex >= 6);
   const reviewButton = new ButtonBuilder()
     .setCustomId(`${CWL_ROTATION_IMPORT_SESSION_PREFIX}:review:${input.sessionId}`)
-    .setLabel(input.hasReviewRows ? "Review Rows" : "Review Complete")
+    .setLabel(input.hasReviewRows ? "Continue to Review" : "Review Complete")
     .setStyle(ButtonStyle.Primary)
     .setDisabled(!input.hasReviewRows);
   const confirmButton = new ButtonBuilder()
     .setCustomId(`${CWL_ROTATION_IMPORT_SESSION_PREFIX}:confirm:${input.sessionId}`)
     .setLabel("Save Import")
     .setStyle(ButtonStyle.Success)
-    .setDisabled(!input.hasImportableClans);
+    .setDisabled(!input.hasImportableClans || input.hasReviewRows);
   const cancelButton = new ButtonBuilder()
     .setCustomId(`${CWL_ROTATION_IMPORT_SESSION_PREFIX}:cancel:${input.sessionId}`)
     .setLabel("Cancel")
     .setStyle(ButtonStyle.Danger);
 
-  return [new ActionRowBuilder<ButtonBuilder>().addComponents(prevButton, nextButton, reviewButton, confirmButton, cancelButton)];
+  return [
+    ...(clanSelectMenu ? [clanSelectMenu] : []),
+    new ActionRowBuilder<ButtonBuilder>().addComponents(prevButton, nextButton, reviewButton, confirmButton, cancelButton),
+  ];
 }
 
 function buildCwlRotationImportReviewActionRows(input: {
@@ -982,6 +1073,13 @@ function getCwlRotationImportActiveClanSession(
   return session.clanSessions[session.activeClanIndex] ?? null;
 }
 
+function getCwlRotationImportPreviewClanSession(
+  session: CwlRotationImportSession,
+): CwlRotationImportClanSession | null {
+  const previewClanIndex = Math.max(0, Math.min(session.clanSessions.length - 1, session.previewClanIndex));
+  return session.clanSessions[previewClanIndex] ?? null;
+}
+
 function getCwlRotationImportClanReviewRows(
   clanSession: CwlRotationImportClanSession,
 ): CwlRotationImportRow[] {
@@ -1146,17 +1244,22 @@ function buildCwlRotationImportSessionMessage(
     };
   }
 
+  const previewClan = getCwlRotationImportPreviewClanSession(session);
+
   return {
     embeds: [
       buildCwlRotationImportPreviewEmbed({
         preview: session.preview,
-        pageIndex: session.pageIndex,
+        clanSession: previewClan,
+        dayIndex: session.pageIndex,
         sessionId,
       }),
     ],
     components: buildCwlRotationImportPreviewActionRows({
       sessionId,
-      pageIndex: session.pageIndex,
+      session,
+      clanSession: previewClan,
+      dayIndex: session.pageIndex,
       hasImportableClans,
       hasReviewRows,
     }),
@@ -1499,7 +1602,7 @@ export async function handleCwlRotationImportButtonInteraction(
     return;
   }
 
-  if (parsed.action === "page") {
+  if (parsed.action === "page" || parsed.action === "preview-day") {
     session.view = "preview";
     session.pageIndex = Math.max(0, Math.min(6, parsed.pageIndex ?? 0));
     rebuildImportPreviewSessionState(session);
@@ -1631,6 +1734,44 @@ export async function handleCwlRotationImportSelectMenuInteraction(
       content: "That CWL rotation import preview has expired or is no longer available.",
       ephemeral: true,
     });
+    return;
+  }
+
+  if (parsed.action === "preview-clan") {
+    if (session.view !== "preview") {
+      await interaction.reply({
+        content: "That CWL rotation import preview has expired. Please restart the import.",
+        ephemeral: true,
+      });
+      return;
+    }
+
+    const selectedClanTag = normalizeClanTag(String(interaction.values[0] ?? ""));
+    const selectedClanIndex = session.clanSessions.findIndex(
+      (clanSession) => normalizeClanTag(clanSession.clanTag) === selectedClanTag,
+    );
+    if (selectedClanIndex < 0) {
+      await interaction.reply({
+        content: "That CWL rotation import clan selection is no longer available. Please restart the import.",
+        ephemeral: true,
+      });
+      return;
+    }
+
+    const selectedClan = session.clanSessions[selectedClanIndex] ?? null;
+    const selectedDay = Math.max(1, Math.min(7, Math.trunc(session.pageIndex) + 1));
+    const hasUsableRows = Boolean(selectedClan?.tab.parsedRows.length > 0);
+    if (!hasUsableRows) {
+      await interaction.reply({
+        content: `That clan has no usable rows for Day ${selectedDay}. Select a different clan or day.`,
+        ephemeral: true,
+      });
+      return;
+    }
+
+    session.previewClanIndex = selectedClanIndex;
+    session.view = "preview";
+    await interaction.update(buildCwlRotationImportSessionMessage(parsed.sessionId, session));
     return;
   }
 

--- a/tests/cwl.command.test.ts
+++ b/tests/cwl.command.test.ts
@@ -106,6 +106,10 @@ function getComponentSelectMenuCustomIds(interaction: any): string[] {
     const rowJson = typeof row?.toJSON === "function" ? row.toJSON() : row;
     for (const menu of Array.isArray(rowJson?.components) ? rowJson.components : []) {
       const menuJson = typeof menu?.toJSON === "function" ? menu.toJSON() : menu;
+      const options = menuJson?.options ?? menuJson?.data?.options ?? [];
+      if (!Array.isArray(options) || options.length <= 0) {
+        continue;
+      }
       const id =
         menuJson?.custom_id ??
         menuJson?.customId ??
@@ -118,6 +122,10 @@ function getComponentSelectMenuCustomIds(interaction: any): string[] {
     }
   }
   return ids;
+}
+
+function getComponentCustomIds(interaction: any): string[] {
+  return [...new Set([...getComponentButtonCustomIds(interaction), ...getComponentSelectMenuCustomIds(interaction)])];
 }
 
 function getComponentSelectMenuOptions(interaction: any): Array<{ label: string; value: string; description?: string }> {
@@ -559,11 +567,34 @@ describe("/cwl command", () => {
       overwrite: false,
     });
     expect(cwlRotationSheetService.confirmImport).not.toHaveBeenCalled();
-    const customIds = getComponentButtonCustomIds(interaction);
-    expect(customIds.some((id) => id.includes(":confirm:"))).toBe(true);
     expect(getDescription(interaction)).toContain("Importable clans: 1 / 1");
-    expect(getDescription(interaction)).toContain("**CWL Alpha**");
-    expect(getDescription(interaction)).toContain(":x: Bravo (#QGRJ2222)");
+    expect(getDescription(interaction)).toContain("Clan: CWL Alpha (#2QG2C08UP)");
+    expect(getDescription(interaction)).toContain("Day: Day 1");
+    expect(getDescription(interaction)).toContain(":black_circle: Alpha #PYLQ0289");
+    expect(getDescription(interaction)).toContain(":x: Bravo #QGRJ2222");
+
+    expect(new Set(getComponentCustomIds(interaction)).size).toBe(getComponentCustomIds(interaction).length);
+    expect(getComponentSelectMenuCustomIds(interaction)).toHaveLength(1);
+    expect(getComponentSelectMenuOptions(interaction).map((option) => option.label)).toEqual(
+      expect.arrayContaining([expect.stringContaining("CWL Alpha - 2/2")]),
+    );
+
+    const nextDayId = getComponentButtonCustomIds(interaction).find((id) => id.includes(":preview-day:next:"));
+    expect(nextDayId).toBeTruthy();
+    const nextDayInteraction = {
+      customId: nextDayId,
+      user: { id: "111111111111111111" },
+      update: vi.fn().mockResolvedValue(undefined),
+      reply: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await handleCwlRotationImportButtonInteraction(nextDayInteraction as any);
+    expect(getUpdatedDescription(nextDayInteraction)).toContain("Day: Day 2");
+    expect(getUpdatedDescription(nextDayInteraction)).toContain(":x: Alpha #PYLQ0289");
+    expect(getUpdatedDescription(nextDayInteraction)).toContain(":black_circle: Bravo #QGRJ2222");
+
+    const customIds = getComponentButtonCustomIds(nextDayInteraction);
+    expect(customIds.some((id) => id.includes(":confirm:"))).toBe(true);
 
     const confirmId = customIds.find((id) => id.includes(":confirm:"));
     expect(confirmId).toBeTruthy();
@@ -581,6 +612,203 @@ describe("/cwl command", () => {
     expect(cwlRotationSheetService.confirmImport).toHaveBeenCalledTimes(1);
     expect(confirmInteraction.deferUpdate).toHaveBeenCalled();
     expect(confirmInteraction.editReply).toHaveBeenCalled();
+  });
+
+  it("switches preview clans directly, preserves the selected day, and surfaces unavailable clans for that day", async () => {
+    const preview: CwlRotationSheetImportPreview = {
+      sourceSheetId: "sheet-1",
+      sourceSheetTitle: "Imported CWL Planner",
+      season: "2026-04",
+      matchedClans: [
+        {
+          clanTag: "#2QG2C08UP",
+          clanName: "CWL Alpha",
+          tabTitle: "CWL Alpha roster",
+          existingVersion: null,
+          importable: true,
+          importBlockedReason: null,
+          warnings: [],
+          structuralRowCount: 1,
+          reviewRequiredRowCount: 0,
+          ignoredRowCount: 0,
+          rosterRows: [{ playerTag: "#PYLQ0289", playerName: "Alpha" }],
+          days: [
+            {
+              roundDay: 1,
+              lineupSize: 1,
+              rows: [{ playerTag: "#PYLQ0289", playerName: "Alpha", subbedOut: false, assignmentOrder: 0 }],
+              members: [{ playerTag: "#PYLQ0289", playerName: "Alpha", subbedOut: false, assignmentOrder: 0 }],
+            },
+          ],
+          parsedRows: [
+            {
+              rowId: "cwl-alpha-roster:3",
+              sheetRowNumber: 3,
+              tabTitle: "CWL Alpha roster",
+              clanTag: "#2QG2C08UP",
+              clanName: "CWL Alpha",
+              rawText: "Alpha | #PYLQ0289 | IN",
+              parsedPlayerTag: "#PYLQ0289",
+              parsedPlayerName: "Alpha",
+              classification: "exact_match",
+              reason: null,
+              suggestions: [],
+              dayRows: [
+                { roundDay: 1, subbedOut: false, assignmentOrder: 0 },
+                { roundDay: 2, subbedOut: true, assignmentOrder: 1 },
+                { roundDay: 3, subbedOut: true, assignmentOrder: 2 },
+                { roundDay: 4, subbedOut: true, assignmentOrder: 3 },
+                { roundDay: 5, subbedOut: true, assignmentOrder: 4 },
+                { roundDay: 6, subbedOut: true, assignmentOrder: 5 },
+                { roundDay: 7, subbedOut: true, assignmentOrder: 6 },
+              ],
+              resolvedPlayerTag: "#PYLQ0289",
+              resolvedPlayerName: "Alpha",
+              ignored: false,
+            },
+          ],
+        },
+        {
+          clanTag: "#9GLGQCCU",
+          clanName: "CWL Beta",
+          tabTitle: "CWL Beta roster",
+          existingVersion: null,
+          importable: true,
+          importBlockedReason: null,
+          warnings: [],
+          structuralRowCount: 1,
+          reviewRequiredRowCount: 0,
+          ignoredRowCount: 0,
+          rosterRows: [{ playerTag: "#QGRJ2222", playerName: "Bravo" }],
+          days: [
+            {
+              roundDay: 1,
+              lineupSize: 1,
+              rows: [{ playerTag: "#QGRJ2222", playerName: "Bravo", subbedOut: true, assignmentOrder: 0 }],
+              members: [{ playerTag: "#QGRJ2222", playerName: "Bravo", subbedOut: true, assignmentOrder: 0 }],
+            },
+          ],
+          parsedRows: [
+            {
+              rowId: "cwl-beta-roster:3",
+              sheetRowNumber: 3,
+              tabTitle: "CWL Beta roster",
+              clanTag: "#9GLGQCCU",
+              clanName: "CWL Beta",
+              rawText: "Bravo | #QGRJ2222 | OUT",
+              parsedPlayerTag: "#QGRJ2222",
+              parsedPlayerName: "Bravo",
+              classification: "exact_match",
+              reason: null,
+              suggestions: [],
+              dayRows: [
+                { roundDay: 1, subbedOut: true, assignmentOrder: 0 },
+                { roundDay: 2, subbedOut: false, assignmentOrder: 1 },
+                { roundDay: 3, subbedOut: true, assignmentOrder: 2 },
+                { roundDay: 4, subbedOut: true, assignmentOrder: 3 },
+                { roundDay: 5, subbedOut: true, assignmentOrder: 4 },
+                { roundDay: 6, subbedOut: true, assignmentOrder: 5 },
+                { roundDay: 7, subbedOut: true, assignmentOrder: 6 },
+              ],
+              resolvedPlayerTag: "#QGRJ2222",
+              resolvedPlayerName: "Bravo",
+              ignored: false,
+            },
+          ],
+        },
+        {
+          clanTag: "#7X7X7X7X",
+          clanName: "CWL Gamma",
+          tabTitle: "CWL Gamma roster",
+          existingVersion: null,
+          importable: false,
+          importBlockedReason: "No parsed rows",
+          warnings: ["No parsed rows."],
+          structuralRowCount: 2,
+          reviewRequiredRowCount: 0,
+          ignoredRowCount: 0,
+          rosterRows: [],
+          days: [],
+          parsedRows: [],
+        },
+      ],
+      skippedTrackedClans: [],
+      skippedTabs: [],
+      warnings: ["No parsed rows."],
+    };
+    vi.mocked(cwlRotationSheetService.buildImportPreview).mockResolvedValue(preview);
+
+    const interaction = makeInteraction({
+      group: "rotations",
+      subcommand: "import",
+    });
+    (interaction.options.getString as any).mockImplementation((name: string) => {
+      if (name === "sheet") return "https://docs.google.com/spreadsheets/d/sheet-1/edit";
+      if (name === "visibility") return null;
+      return null;
+    });
+    (interaction.options.getBoolean as any).mockImplementation((name: string) => {
+      if (name === "overwrite") return false;
+      return null;
+    });
+
+    await Cwl.run({} as any, interaction as any);
+
+    expect(getDescription(interaction)).toContain("Clan: CWL Alpha (#2QG2C08UP)");
+    expect(getDescription(interaction)).toContain("Day: Day 1");
+
+    const clanOptions = getComponentSelectMenuOptions(interaction);
+    expect(clanOptions.map((option) => option.label)).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("CWL Alpha - 1/1"),
+        expect.stringContaining("CWL Beta - 1/1"),
+        expect.stringContaining("CWL Gamma - 0/0"),
+      ]),
+    );
+    expect(clanOptions.find((option) => option.label.includes("CWL Gamma"))?.description).toContain(
+      "No usable rows for Day 1",
+    );
+
+    const clanSelectId = getComponentSelectMenuCustomIds(interaction).find((id) => id.includes(":preview-clan:"));
+    expect(clanSelectId).toBeTruthy();
+    const unavailableClanInteraction = {
+      customId: clanSelectId,
+      values: ["#7X7X7X7X"],
+      user: { id: "111111111111111111" },
+      update: vi.fn().mockResolvedValue(undefined),
+      reply: vi.fn().mockResolvedValue(undefined),
+    };
+    await handleCwlRotationImportSelectMenuInteraction(unavailableClanInteraction as any);
+    expect(unavailableClanInteraction.reply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining("no usable rows for Day 1"),
+        ephemeral: true,
+      }),
+    );
+
+    const betaClanInteraction = {
+      customId: clanSelectId,
+      values: ["#9GLGQCCU"],
+      user: { id: "111111111111111111" },
+      update: vi.fn().mockResolvedValue(undefined),
+      reply: vi.fn().mockResolvedValue(undefined),
+    };
+    await handleCwlRotationImportSelectMenuInteraction(betaClanInteraction as any);
+    expect(getUpdatedDescription(betaClanInteraction)).toContain("Clan: CWL Beta (#9GLGQCCU)");
+    expect(getUpdatedDescription(betaClanInteraction)).toContain("Day: Day 1");
+    expect(getUpdatedDescription(betaClanInteraction)).toContain(":x: Bravo #QGRJ2222");
+
+    const betaNextDayId = getComponentButtonCustomIds(betaClanInteraction).find((id) => id.includes(":preview-day:next:"));
+    expect(betaNextDayId).toBeTruthy();
+    const betaNextDayInteraction = {
+      customId: betaNextDayId,
+      user: { id: "111111111111111111" },
+      update: vi.fn().mockResolvedValue(undefined),
+      reply: vi.fn().mockResolvedValue(undefined),
+    };
+    await handleCwlRotationImportButtonInteraction(betaNextDayInteraction as any);
+    expect(getUpdatedDescription(betaNextDayInteraction)).toContain("Clan: CWL Beta (#9GLGQCCU)");
+    expect(getUpdatedDescription(betaNextDayInteraction)).toContain("Day: Day 2");
   });
 
   it("forces unresolved import rows through review before save and allows inline remap", async () => {
@@ -684,6 +912,7 @@ describe("/cwl command", () => {
         expect.stringContaining(":confirm:"),
       ]),
     );
+    expect(getDescription(interaction)).toContain(":warning: Bravoo");
 
     const reviewId = getComponentButtonCustomIds(interaction).find((id) => id.includes(":review:"));
     expect(reviewId).toBeTruthy();
@@ -747,6 +976,8 @@ describe("/cwl command", () => {
 
     expect(getUpdatedDescription(confirmClanInteraction)).toContain("Importable clans: 1 / 1");
     expect(getUpdatedDescription(confirmClanInteraction)).toContain("CWL Alpha");
+    expect(getUpdatedDescription(confirmClanInteraction)).not.toContain(":warning:");
+    expect(getUpdatedDescription(confirmClanInteraction)).toContain(":black_circle: Bravo #QGRJ2222");
     expect(cwlRotationSheetService.confirmImport).not.toHaveBeenCalled();
 
     const saveId = getComponentButtonCustomIds(confirmClanInteraction).find((id) => id.includes(":confirm:"));
@@ -1186,6 +1417,105 @@ describe("/cwl command", () => {
 
     await handleCwlRotationImportButtonInteraction(legacyPrevInteraction as any);
     expect(getUpdatedDescription(legacyPrevInteraction)).toContain("Sheet row: 5");
+  });
+
+  it("omits raw snippets when the preview would otherwise exceed Discord limits", async () => {
+    const rosterRows = Array.from({ length: 110 }, (_, index) => {
+      const playerTag = `#PX${String(index).padStart(4, "0")}`;
+      const playerName = `Player ${index + 1}`;
+      return { playerTag, playerName };
+    });
+    const parsedRows = rosterRows.map((row, index) => ({
+      rowId: `cwl-alpha-roster:${index + 3}`,
+      sheetRowNumber: index + 3,
+      tabTitle: "CWL Alpha roster",
+      clanTag: "#2QG2C08UP",
+      clanName: "CWL Alpha",
+      rawText: `${row.playerName} | ${row.playerTag} | IN | THIS RAW SNIPPET SHOULD BE OMITTED ${String(index).padStart(3, "0")}`,
+      parsedPlayerTag: row.playerTag,
+      parsedPlayerName: row.playerName,
+      classification: "exact_match" as const,
+      reason: null,
+      suggestions: [],
+      dayRows: [
+        { roundDay: 1, subbedOut: false, assignmentOrder: index },
+        { roundDay: 2, subbedOut: true, assignmentOrder: index },
+        { roundDay: 3, subbedOut: true, assignmentOrder: index },
+        { roundDay: 4, subbedOut: true, assignmentOrder: index },
+        { roundDay: 5, subbedOut: true, assignmentOrder: index },
+        { roundDay: 6, subbedOut: true, assignmentOrder: index },
+        { roundDay: 7, subbedOut: true, assignmentOrder: index },
+      ],
+      resolvedPlayerTag: row.playerTag,
+      resolvedPlayerName: row.playerName,
+      ignored: false,
+    }));
+    const preview: CwlRotationSheetImportPreview = {
+      sourceSheetId: "sheet-1",
+      sourceSheetTitle: "Imported CWL Planner",
+      season: "2026-04",
+      matchedClans: [
+        {
+          clanTag: "#2QG2C08UP",
+          clanName: "CWL Alpha",
+          tabTitle: "CWL Alpha roster",
+          existingVersion: null,
+          importable: true,
+          importBlockedReason: null,
+          warnings: [],
+          structuralRowCount: 1,
+          reviewRequiredRowCount: 0,
+          ignoredRowCount: 0,
+          rosterRows,
+          days: [
+            {
+              roundDay: 1,
+              lineupSize: rosterRows.length,
+              rows: rosterRows.map((row, index) => ({
+                playerTag: row.playerTag,
+                playerName: row.playerName,
+                subbedOut: false,
+                assignmentOrder: index,
+              })),
+              members: rosterRows.map((row, index) => ({
+                playerTag: row.playerTag,
+                playerName: row.playerName,
+                subbedOut: false,
+                assignmentOrder: index,
+              })),
+            },
+          ],
+          parsedRows,
+        },
+      ],
+      skippedTrackedClans: [],
+      skippedTabs: [],
+      warnings: [],
+    };
+    vi.mocked(cwlRotationSheetService.buildImportPreview).mockResolvedValue(preview);
+
+    const interaction = makeInteraction({
+      group: "rotations",
+      subcommand: "import",
+    });
+    (interaction.options.getString as any).mockImplementation((name: string) => {
+      if (name === "sheet") return "https://docs.google.com/spreadsheets/d/sheet-1/edit";
+      if (name === "visibility") return null;
+      return null;
+    });
+    (interaction.options.getBoolean as any).mockImplementation((name: string) => {
+      if (name === "overwrite") return false;
+      return null;
+    });
+
+    await Cwl.run({} as any, interaction as any);
+
+    const description = getDescription(interaction);
+    expect(description.length).toBeLessThanOrEqual(4096);
+    expect(description).toContain("Day: Day 1");
+    expect(description).toContain("Player 1 #PX0000");
+    expect(description).toContain(`Player ${rosterRows.length} #PX${String(rosterRows.length - 1).padStart(4, "0")}`);
+    expect(description).not.toContain("THIS RAW SNIPPET SHOULD BE OMITTED");
   });
 
   it("surfaces a clear message when the import sheet link format is unsupported", async () => {


### PR DESCRIPTION
- add clan switching and day navigation to the import preview
- render one clan/day page with compact rows and raw-snippet fallback