### PR TITLE
fix(cwl): render only player-name snippets in import preview

### DIFF
--- a/src/commands/Cwl.ts
+++ b/src/commands/Cwl.ts
@@ -377,7 +377,7 @@ function buildCwlRotationImportPreviewPlayerLine(input: {
         : ":black_circle:";
   const playerName = input.row.resolvedPlayerName ?? input.row.parsedPlayerName;
   const playerTag = input.row.resolvedPlayerTag ?? input.row.parsedPlayerTag ?? "unmapped";
-  const rawSnippet = input.includeRawSnippet && input.row.rawText ? ` | ${input.row.rawText}` : "";
+  const rawSnippet = input.includeRawSnippet && input.row.rawPlayerNameSnippet ? ` | ${input.row.rawPlayerNameSnippet}` : "";
   return `${statusEmoji} ${playerName} ${playerTag}${rawSnippet}`;
 }
 

--- a/src/services/CwlRotationSheetService.ts
+++ b/src/services/CwlRotationSheetService.ts
@@ -51,6 +51,7 @@ export type CwlRotationImportRow = {
   clanTag: string;
   clanName: string | null;
   rawText: string;
+  rawPlayerNameSnippet?: string | null;
   parsedPlayerTag: string | null;
   parsedPlayerName: string;
   classification: CwlRotationImportRowClassification;
@@ -951,6 +952,11 @@ function parseCwlRotationImportRow(input: {
   }) || memberCell || firstNonEmptyCell || rawText;
   const parsedIdentity = parseCwlRotationPlayerIdentity(candidateCell);
   const parsedPlayerName = parsedIdentity?.playerName || candidateCell;
+  const rawPlayerNameSnippet = resolveCwlRotationImportRawPlayerNameSnippet({
+    row: input.row,
+    candidateCell,
+    rawText,
+  });
   const explicitTag = normalizePlayerTag(
     input.header.playerTagColumnIndex !== null
       ? String(input.row[input.header.playerTagColumnIndex] ?? "")
@@ -974,6 +980,7 @@ function parseCwlRotationImportRow(input: {
       clanTag: "",
       clanName: null,
       rawText,
+      rawPlayerNameSnippet,
       parsedPlayerTag: parsedIdentity?.playerTag ?? null,
       parsedPlayerName,
       classification: "unresolved_needs_review",
@@ -994,6 +1001,7 @@ function parseCwlRotationImportRow(input: {
       clanTag: "",
       clanName: null,
       rawText,
+      rawPlayerNameSnippet,
       parsedPlayerTag: explicitTag,
       parsedPlayerName,
       classification: "exact_match",
@@ -1015,6 +1023,7 @@ function parseCwlRotationImportRow(input: {
       clanTag: "",
       clanName: null,
       rawText,
+      rawPlayerNameSnippet,
       parsedPlayerTag: exactRosterMatch.playerTag,
       parsedPlayerName: exactRosterMatch.playerName || parsedPlayerName,
       classification: "exact_match",
@@ -1044,6 +1053,7 @@ function parseCwlRotationImportRow(input: {
     clanTag: "",
     clanName: null,
     rawText,
+    rawPlayerNameSnippet,
     parsedPlayerTag: parsedIdentity?.playerTag ?? null,
     parsedPlayerName,
     classification,
@@ -1059,6 +1069,33 @@ function parseCwlRotationImportRow(input: {
     resolvedPlayerName: null,
     ignored: false,
   };
+}
+
+function resolveCwlRotationImportRawPlayerNameSnippet(input: {
+  row: string[];
+  candidateCell: string;
+  rawText: string;
+}): string | null {
+  const candidateCell = sanitizeDisplayText(input.candidateCell);
+  if (!candidateCell || !looksLikeUsefulCwlRotationPlayerNameSnippet(candidateCell)) return null;
+
+  const nonEmptyCellCount = input.row.reduce(
+    (count, cell) => count + (sanitizeDisplayText(cell).length > 0 ? 1 : 0),
+    0,
+  );
+  if (nonEmptyCellCount <= 1) {
+    return candidateCell;
+  }
+
+  return candidateCell === sanitizeDisplayText(input.rawText) ? null : candidateCell;
+}
+
+function looksLikeUsefulCwlRotationPlayerNameSnippet(value: string): boolean {
+  const normalized = sanitizeDisplayText(value).toLowerCase();
+  if (!normalized) return false;
+  if (/^\d+$/.test(normalized)) return false;
+  if (/^(?:in|out|yes|no|y|n|true|false|member|player|name|total)$/i.test(normalized)) return false;
+  return true;
 }
 
 function findExactRosterMatch(

--- a/tests/cwl.command.test.ts
+++ b/tests/cwl.command.test.ts
@@ -475,6 +475,7 @@ describe("/cwl command", () => {
               clanTag: "#2QG2C08UP",
               clanName: "CWL Alpha",
               rawText: "Alpha | #PYLQ0289 | 12 | IN",
+              rawPlayerNameSnippet: "Alpha",
               parsedPlayerTag: "#PYLQ0289",
               parsedPlayerName: "Alpha",
               classification: "exact_match",
@@ -500,6 +501,7 @@ describe("/cwl command", () => {
               clanTag: "#2QG2C08UP",
               clanName: "CWL Alpha",
               rawText: "Bravo | #QGRJ2222 | 8 | ",
+              rawPlayerNameSnippet: "Bravo",
               parsedPlayerTag: "#QGRJ2222",
               parsedPlayerName: "Bravo",
               classification: "exact_match",
@@ -570,8 +572,10 @@ describe("/cwl command", () => {
     expect(getDescription(interaction)).toContain("Importable clans: 1 / 1");
     expect(getDescription(interaction)).toContain("Clan: CWL Alpha (#2QG2C08UP)");
     expect(getDescription(interaction)).toContain("Day: Day 1");
-    expect(getDescription(interaction)).toContain(":black_circle: Alpha #PYLQ0289");
-    expect(getDescription(interaction)).toContain(":x: Bravo #QGRJ2222");
+    expect(getDescription(interaction)).toContain(":black_circle: Alpha #PYLQ0289 | Alpha");
+    expect(getDescription(interaction)).toContain(":x: Bravo #QGRJ2222 | Bravo");
+    expect(getDescription(interaction)).not.toContain("Alpha | #PYLQ0289 | 12 | IN");
+    expect(getDescription(interaction)).not.toContain("Bravo | #QGRJ2222 | 8 |");
 
     expect(new Set(getComponentCustomIds(interaction)).size).toBe(getComponentCustomIds(interaction).length);
     expect(getComponentSelectMenuCustomIds(interaction)).toHaveLength(1);
@@ -696,6 +700,7 @@ describe("/cwl command", () => {
               clanTag: "#9GLGQCCU",
               clanName: "CWL Beta",
               rawText: "Bravo | #QGRJ2222 | OUT",
+              rawPlayerNameSnippet: null,
               parsedPlayerTag: "#QGRJ2222",
               parsedPlayerName: "Bravo",
               classification: "exact_match",
@@ -797,6 +802,7 @@ describe("/cwl command", () => {
     expect(getUpdatedDescription(betaClanInteraction)).toContain("Clan: CWL Beta (#9GLGQCCU)");
     expect(getUpdatedDescription(betaClanInteraction)).toContain("Day: Day 1");
     expect(getUpdatedDescription(betaClanInteraction)).toContain(":x: Bravo #QGRJ2222");
+    expect(getUpdatedDescription(betaClanInteraction)).not.toContain("Bravo | #QGRJ2222 | OUT");
 
     const betaNextDayId = getComponentButtonCustomIds(betaClanInteraction).find((id) => id.includes(":preview-day:next:"));
     expect(betaNextDayId).toBeTruthy();
@@ -1432,6 +1438,7 @@ describe("/cwl command", () => {
       clanTag: "#2QG2C08UP",
       clanName: "CWL Alpha",
       rawText: `${row.playerName} | ${row.playerTag} | IN | THIS RAW SNIPPET SHOULD BE OMITTED ${String(index).padStart(3, "0")}`,
+      rawPlayerNameSnippet: row.playerName,
       parsedPlayerTag: row.playerTag,
       parsedPlayerName: row.playerName,
       classification: "exact_match" as const,

--- a/tests/cwlRotationSheet.service.test.ts
+++ b/tests/cwlRotationSheet.service.test.ts
@@ -251,6 +251,9 @@ describe("CwlRotationSheetService", () => {
     expect(preview.matchedClans[0]?.parsedRows[0]?.parsedPlayerName).toBe(
       "\u{2606}\u{2605}\u{2606}\u{2605}\u{2606}\u{2605}\u{2606}\u{2605}\u{2606}\u{2605}",
     );
+    expect(preview.matchedClans[0]?.parsedRows[0]?.rawPlayerNameSnippet).toBe(
+      "\u{2606}\u{2605}\u{2606}\u{2605}\u{2606}\u{2605}\u{2606}\u{2605}\u{2606}\u{2605}",
+    );
     expect(preview.matchedClans[0]?.parsedRows[0]?.parsedPlayerTag).toBeNull();
     expect(preview.matchedClans[0]?.parsedRows[0]?.classification).toBe("unresolved_needs_review");
     expect(preview.matchedClans[0]?.warnings).toEqual(
@@ -359,6 +362,7 @@ describe("CwlRotationSheetService", () => {
     expect(preview.matchedClans).toHaveLength(1);
     expect(preview.matchedClans[0]?.importable).toBe(false);
     expect(preview.matchedClans[0]?.reviewRequiredRowCount).toBe(1);
+    expect(preview.matchedClans[0]?.parsedRows[0]?.rawPlayerNameSnippet).toBeNull();
     expect(preview.matchedClans[0]?.warnings).toEqual(
       expect.arrayContaining([expect.stringContaining("1 row need review")]),
     );


### PR DESCRIPTION
- store a parsed name fragment on imported CWL rows
- keep preview snippets compact and omit them when no useful fragment exists