### PR TITLE
fix(fwa): preserve same-war confirmed mail baseline

### DIFF
--- a/src/services/PointsSyncService.ts
+++ b/src/services/PointsSyncService.ts
@@ -43,6 +43,35 @@ function normalizeOptionalInt(input: number | null | undefined): number | null {
     : null;
 }
 
+/** Purpose: preserve explicit same-war mail confirmation fields during routine sync refreshes. */
+function resolveLastKnownMatchBaseline(input: {
+  existing: {
+    confirmedByClanMail: boolean;
+    lastKnownMatchType: string | null;
+    lastKnownOutcome: string | null;
+  } | null;
+  incomingMatchType: string | null;
+  incomingOutcome: string | null;
+  incomingConfirmedByClanMail?: boolean;
+}): {
+  lastKnownMatchType: string | null;
+  lastKnownOutcome: string | null;
+} {
+  const preserveConfirmedBaseline =
+    input.existing?.confirmedByClanMail === true &&
+    input.incomingConfirmedByClanMail !== true;
+  if (!preserveConfirmedBaseline) {
+    return {
+      lastKnownMatchType: input.incomingMatchType,
+      lastKnownOutcome: input.incomingOutcome,
+    };
+  }
+  return {
+    lastKnownMatchType: input.existing?.lastKnownMatchType ?? null,
+    lastKnownOutcome: input.existing?.lastKnownOutcome ?? null,
+  };
+}
+
 export class PointsSyncService {
   /** Purpose: upsert current-war points sync state and lifecycle metadata. */
   async upsertPointsSync(input: UpsertPointsSyncInput) {
@@ -50,6 +79,27 @@ export class PointsSyncService {
     const opponentTag = normalizeTag(input.opponentTag);
     const fetchedAt = normalizeDate(input.fetchedAt) ?? new Date();
     const matchType = (input.matchType ?? "").trim().toUpperCase() || null;
+    const where = {
+      guildId_clanTag_warStartTime: {
+        guildId: input.guildId,
+        clanTag,
+        warStartTime: input.warStartTime,
+      },
+    } as const;
+    const existing = await prisma.clanPointsSync.findUnique({
+      where,
+      select: {
+        confirmedByClanMail: true,
+        lastKnownMatchType: true,
+        lastKnownOutcome: true,
+      },
+    });
+    const lastKnownMatchBaseline = resolveLastKnownMatchBaseline({
+      existing,
+      incomingMatchType: matchType,
+      incomingOutcome: input.outcome ?? null,
+      incomingConfirmedByClanMail: input.confirmedByClanMail,
+    });
     const data = {
       warId: input.warId ?? null,
       syncNum: Math.trunc(input.syncNum),
@@ -62,8 +112,8 @@ export class PointsSyncService {
       lastSuccessfulPointsApiFetchAt: fetchedAt,
       lastFetchReason: input.fetchReason ?? null,
       lastKnownPoints: Math.trunc(input.clanPoints),
-      lastKnownMatchType: matchType,
-      lastKnownOutcome: input.outcome ?? null,
+      lastKnownMatchType: lastKnownMatchBaseline.lastKnownMatchType,
+      lastKnownOutcome: lastKnownMatchBaseline.lastKnownOutcome,
       lastKnownSyncNumber: Math.trunc(input.syncNum),
       needsValidation: input.needsValidation ?? false,
       ...(input.confirmedByClanMail !== undefined
@@ -71,13 +121,7 @@ export class PointsSyncService {
         : {}),
     };
     return prisma.clanPointsSync.upsert({
-      where: {
-        guildId_clanTag_warStartTime: {
-          guildId: input.guildId,
-          clanTag,
-          warStartTime: input.warStartTime,
-        },
-      },
+      where,
       update: data,
       create: {
         guildId: input.guildId,

--- a/src/services/WarEventLogService.ts
+++ b/src/services/WarEventLogService.ts
@@ -846,6 +846,46 @@ function toValidSyncNumber(input: unknown): number | null {
   return normalized > 0 ? normalized : null;
 }
 
+/** Purpose: normalize optional war identifiers for same-war confirmation checks. */
+function toValidWarIdText(input: unknown): string | null {
+  const raw = String(input ?? "").trim();
+  if (!raw) return null;
+  const value = Number(raw);
+  if (!Number.isFinite(value)) return null;
+  const normalized = Math.trunc(value);
+  return normalized > 0 ? String(normalized) : null;
+}
+
+/** Purpose: keep confirmed clan-mail protection scoped to the exact same current-war identity. */
+function hasSameWarConfirmedMailBaseline(input: {
+  sub: SubscriptionRow;
+  effectiveWarIdentityChanged: boolean;
+}): boolean {
+  if (input.effectiveWarIdentityChanged) return false;
+  if (!input.sub.pointsConfirmedByClanMail) return false;
+  if (!input.sub.startTime || !input.sub.pointsWarStartTime) return false;
+  if (
+    input.sub.startTime.getTime() !== input.sub.pointsWarStartTime.getTime()
+  ) {
+    return false;
+  }
+  const currentWarId = toValidWarIdText(input.sub.warId);
+  const pointsWarId = toValidWarIdText(input.sub.pointsWarId);
+  if (currentWarId && pointsWarId && currentWarId !== pointsWarId) {
+    return false;
+  }
+  const currentOpponentTag = normalizeTag(input.sub.opponentTag ?? "");
+  const pointsOpponentTag = normalizeTag(input.sub.pointsOpponentTag ?? "");
+  if (
+    currentOpponentTag &&
+    pointsOpponentTag &&
+    currentOpponentTag !== pointsOpponentTag
+  ) {
+    return false;
+  }
+  return true;
+}
+
 function resolveEventRenderSyncNumber(input: {
   sameWarSyncNumber: number | null;
   postedSyncNumber: number | null;
@@ -2798,6 +2838,10 @@ export class WarEventLogService {
       matchType: currentMatchTypeForResolution,
       inferredMatchType: currentInferredMatchTypeForResolution,
     });
+    const preserveConfirmedCurrentWarRevision = hasSameWarConfirmedMailBaseline({
+      sub,
+      effectiveWarIdentityChanged,
+    });
     let liveOpponentResolution: MatchTypeResolution | null = null;
 
     let nextFwaPoints = sub.fwaPoints;
@@ -2993,6 +3037,10 @@ export class WarEventLogService {
         outcomeComputationInput.opponentPoints,
         syncNumberForEvent,
       );
+    }
+    if (preserveConfirmedCurrentWarRevision) {
+      nextMatchType = sub.matchType;
+      nextOutcome = normalizeOutcome(sub.outcome);
     }
     if (eventType === "war_ended") {
       const finalResult = await this.history.getWarEndResultSnapshot({

--- a/tests/fwaMatchRevisionDraft.logic.test.ts
+++ b/tests/fwaMatchRevisionDraft.logic.test.ts
@@ -67,6 +67,59 @@ describe("fwa match revision baseline resolution", () => {
     });
   });
 
+  it("keeps same-war posted refreshes anchored to the confirmed outcome baseline", () => {
+    const confirmedState = buildCurrentWarConfirmedStateForTest({
+      warId: 777,
+      warStartMs: Date.parse("2026-03-12T00:00:00.000Z"),
+      opponentTag: "2Q80R9PYU",
+      matchType: "FWA",
+      expectedOutcome: "LOSE",
+    });
+    const liveFields = {
+      warId: String(confirmedState?.warId ?? ""),
+      opponentTag: "2Q80R9PYU",
+      matchType: "FWA" as const,
+      expectedOutcome: "WIN" as const,
+    };
+    const baseline = resolveConfirmedRevisionBaselineForTest({
+      syncRow: {
+        warId: String(confirmedState?.warId ?? ""),
+        opponentTag: confirmedState?.opponentTag ?? "#2Q80R9PYU",
+        lastKnownMatchType: confirmedState?.matchType ?? null,
+        lastKnownOutcome: confirmedState?.outcome ?? null,
+        isFwa: true,
+        confirmedByClanMail: true,
+      },
+      mailConfig: {
+        lastWarId: String(confirmedState?.warId ?? ""),
+        lastOpponentTag: confirmedState?.opponentTag ?? "#2Q80R9PYU",
+        lastMatchType: confirmedState?.matchType ?? null,
+        lastExpectedOutcome: confirmedState?.outcome ?? null,
+      },
+      liveFields,
+      lifecycleStatus: "posted",
+    });
+    const resolved = resolveEffectiveRevisionStateForTest({
+      liveFields,
+      confirmedBaseline: baseline,
+      draft: null,
+    });
+
+    expect(baseline).toEqual({
+      warId: "777",
+      opponentTag: "2Q80R9PYU",
+      matchType: "FWA",
+      expectedOutcome: "LOSE",
+    });
+    expect(resolved.effective).toEqual({
+      warId: "777",
+      opponentTag: "2Q80R9PYU",
+      matchType: "FWA",
+      expectedOutcome: "LOSE",
+    });
+    expect(resolved.draftDiffersFromBaseline).toBe(false);
+  });
+
   it("returns null for posted state when confirmed baseline is unavailable", () => {
     const baseline = resolveConfirmedRevisionBaselineForTest({
       syncRow: {

--- a/tests/pointsSync.service.test.ts
+++ b/tests/pointsSync.service.test.ts
@@ -4,6 +4,7 @@ const prismaMock = vi.hoisted(() => ({
   clanPointsSync: {
     findFirst: vi.fn(),
     findUnique: vi.fn(),
+    upsert: vi.fn(),
     updateMany: vi.fn(),
   },
 }));
@@ -136,5 +137,95 @@ describe("PointsSyncService.checkpointCurrentWarSync", () => {
 
     expect(updated).toBe(false);
     expect(prismaMock.clanPointsSync.updateMany).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("PointsSyncService.upsertPointsSync", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("preserves confirmed same-war match baseline while refreshing routine sync fields", async () => {
+    prismaMock.clanPointsSync.findUnique.mockResolvedValue({
+      confirmedByClanMail: true,
+      lastKnownMatchType: "FWA",
+      lastKnownOutcome: "LOSE",
+    });
+    prismaMock.clanPointsSync.upsert.mockResolvedValue({
+      id: 1,
+    });
+    const service = new PointsSyncService();
+    const warStartTime = new Date("2026-03-12T00:00:00.000Z");
+    const fetchedAt = new Date("2026-03-12T00:15:00.000Z");
+
+    await service.upsertPointsSync({
+      guildId: "guild-1",
+      clanTag: "#AAA111",
+      warId: "1001",
+      warStartTime,
+      syncNum: 482,
+      opponentTag: "#OPP123",
+      clanPoints: 1300,
+      opponentPoints: 1200,
+      outcome: "WIN",
+      isFwa: true,
+      fetchedAt,
+      fetchReason: "post_war_reconciliation",
+      matchType: "FWA",
+      needsValidation: false,
+    });
+
+    expect(prismaMock.clanPointsSync.findUnique).toHaveBeenCalledTimes(1);
+    expect(prismaMock.clanPointsSync.upsert).toHaveBeenCalledTimes(1);
+    expect(prismaMock.clanPointsSync.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({
+          syncFetchedAt: fetchedAt,
+          lastSuccessfulPointsApiFetchAt: fetchedAt,
+          lastKnownPoints: 1300,
+          lastKnownSyncNumber: 482,
+          lastKnownMatchType: "FWA",
+          lastKnownOutcome: "LOSE",
+          opponentPoints: 1200,
+        }),
+      }),
+    );
+  });
+
+  it("stores the incoming baseline for a fresh same-war row", async () => {
+    prismaMock.clanPointsSync.findUnique.mockResolvedValue(null);
+    prismaMock.clanPointsSync.upsert.mockResolvedValue({
+      id: 2,
+    });
+    const service = new PointsSyncService();
+
+    await service.upsertPointsSync({
+      guildId: "guild-1",
+      clanTag: "#AAA111",
+      warId: "1002",
+      warStartTime: new Date("2026-03-14T00:00:00.000Z"),
+      syncNum: 483,
+      opponentTag: "#OPP456",
+      clanPoints: 1200,
+      opponentPoints: 1300,
+      outcome: "LOSE",
+      isFwa: true,
+      fetchReason: "post_war_reconciliation",
+      matchType: "FWA",
+      needsValidation: false,
+    });
+
+    expect(prismaMock.clanPointsSync.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({
+          lastKnownMatchType: "FWA",
+          lastKnownOutcome: "LOSE",
+        }),
+        create: expect.objectContaining({
+          lastKnownMatchType: "FWA",
+          lastKnownOutcome: "LOSE",
+        }),
+      }),
+    );
   });
 });

--- a/tests/warEventLog.warEndPointsReconcile.test.ts
+++ b/tests/warEventLog.warEndPointsReconcile.test.ts
@@ -603,6 +603,104 @@ describe("Match-type confirmation rollover via processSubscription", () => {
     expect(updateData?.matchType).toBe("FWA");
     expect(updateData?.inferredMatchType).toBe(true);
   });
+
+  it("preserves same-war confirmed outcome while still refreshing live points fields", async () => {
+    const service = new WarEventLogService({ channels: { fetch: vi.fn() } } as unknown as Client, {} as any);
+    const sub = makeSubscription({
+      matchType: "FWA",
+      inferredMatchType: false,
+      outcome: "LOSE",
+      state: "inWar",
+      startTime: new Date("2026-03-12T00:00:00.000Z"),
+      opponentTag: "#OPP999",
+      pointsConfirmedByClanMail: true,
+      pointsNeedsValidation: false,
+      pointsLastKnownMatchType: "FWA",
+      pointsLastKnownOutcome: "LOSE",
+      pointsWarId: "1001",
+      pointsOpponentTag: "#OPP999",
+      pointsWarStartTime: new Date("2026-03-12T00:00:00.000Z"),
+    });
+    const nowMs = Date.parse("2026-03-12T00:20:00.000Z");
+
+    vi.spyOn(prisma, "$queryRaw").mockResolvedValue([sub] as any);
+    const updateSpy = vi.spyOn(prisma.currentWar, "update").mockResolvedValue({} as any);
+
+    (service as any).getCurrentWarSnapshot = vi.fn().mockResolvedValue({
+      war: buildObservedWarSnapshot({
+        state: "inWar",
+        startTime: "20260312T000000.000Z",
+        opponentTag: "#OPP999",
+      }),
+      observation: { kind: "success" },
+    });
+    (service as any).hasWarEndRecorded = vi.fn().mockResolvedValue(false);
+    (service as any).ensureCurrentWarId = vi.fn().mockResolvedValue(1001);
+    (service as any).syncWarAttacksFromWarSnapshot = vi.fn().mockResolvedValue(undefined);
+    (service as any).dispatchDetectedEvent = vi.fn().mockResolvedValue(undefined);
+    (service as any).reconcileWarEndedPointsDiscrepancy = vi.fn().mockResolvedValue(undefined);
+    (service as any).pointsGate = {
+      evaluatePollerFetch: vi.fn().mockReturnValue({
+        allowed: true,
+        fetchReason: "post_war_reconciliation",
+      }),
+    };
+    (service as any).pointsSync = {
+      resetWarStartPointsJob: vi.fn().mockResolvedValue(undefined),
+      maybeRunWarStartPointsCheck: vi.fn().mockResolvedValue(undefined),
+      getPreviousSyncNum: vi.fn().mockResolvedValue(10),
+    };
+    const upsertPointsSync = vi.fn().mockResolvedValue(undefined);
+    (service as any).currentSyncs = {
+      markNeedsValidation: vi.fn().mockResolvedValue(undefined),
+      getCurrentSyncForClan: vi.fn().mockResolvedValue(null),
+      upsertPointsSync,
+    };
+    (service as any).points = {
+      fetchSnapshot: vi
+        .fn()
+        .mockResolvedValueOnce({
+          balance: 1300,
+          winnerBoxTags: ["#OPP999"],
+          winnerBoxText: "",
+          effectiveSync: 44,
+          fetchedAtMs: nowMs,
+        })
+        .mockResolvedValueOnce({
+          balance: 1200,
+          activeFwa: true,
+          notFound: false,
+          fetchedAtMs: nowMs,
+        }),
+    };
+    (service as any).history = {
+      getWarEndResultSnapshot: vi.fn().mockResolvedValue({
+        clanStars: 100,
+        opponentStars: 99,
+        clanDestruction: 70,
+        opponentDestruction: 69,
+        warEndTime: null,
+        resultLabel: "WIN",
+      }),
+    };
+
+    await (service as any).processSubscription("guild-1", "#AAA111", {
+      previousSync: 10,
+      activeSync: 11,
+    });
+
+    expect(upsertPointsSync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        outcome: "WIN",
+      }),
+    );
+    expect(updateSpy).toHaveBeenCalledTimes(1);
+    const updateData = updateSpy.mock.calls[0]?.[0]?.data;
+    expect(updateData?.matchType).toBe("FWA");
+    expect(updateData?.outcome).toBe("LOSE");
+    expect(updateData?.fwaPoints).toBe(1300);
+    expect(updateData?.opponentFwaPoints).toBe(1200);
+  });
 });
 
 describe("War outage recovery reconciliation", () => {


### PR DESCRIPTION
- keep confirmed ClanPointsSync matchType/outcome stable on same-war refresh upserts
- preserve CurrentWar match baseline during same-war poll updates and cover the regression with tests