### PR TITLE
fix(cwl): resolve next-day prep lineup validation

### DIFF
--- a/src/services/CwlStateService.ts
+++ b/src/services/CwlStateService.ts
@@ -194,6 +194,65 @@ function resolvePhaseEndsAt(input: {
   return input.endTime;
 }
 
+type CwlActualLineupOwner = {
+  season: string;
+  clanTag: string;
+  clanName: string | null;
+  roundDay: number;
+  roundState: string;
+  opponentTag: string | null;
+  opponentName: string | null;
+  preparationStartTime: Date | null;
+  startTime: Date | null;
+  endTime: Date | null;
+};
+
+/** Purpose: map one persisted CWL round owner row into a lineup response with sorted members. */
+async function loadPersistedCwlActualLineup(input: {
+  owner: CwlActualLineupOwner;
+  memberSource: "current" | "history";
+}): Promise<CwlActualLineup> {
+  const members =
+    input.memberSource === "current"
+      ? await prisma.cwlRoundMemberCurrent.findMany({
+          where: {
+            season: input.owner.season,
+            clanTag: input.owner.clanTag,
+            roundDay: input.owner.roundDay,
+          },
+          orderBy: [{ mapPosition: "asc" }, { playerName: "asc" }, { playerTag: "asc" }],
+        })
+      : await prisma.cwlRoundMemberHistory.findMany({
+          where: {
+            season: input.owner.season,
+            clanTag: input.owner.clanTag,
+            roundDay: input.owner.roundDay,
+          },
+          orderBy: [{ mapPosition: "asc" }, { playerName: "asc" }, { playerTag: "asc" }],
+        });
+
+  return {
+    season: input.owner.season,
+    clanTag: input.owner.clanTag,
+    clanName: input.owner.clanName,
+    roundDay: input.owner.roundDay,
+    roundState: input.owner.roundState,
+    opponentTag: input.owner.opponentTag,
+    opponentName: input.owner.opponentName,
+    phaseEndsAt: resolvePhaseEndsAt(input.owner),
+    members: members.map((member) => ({
+      playerTag: member.playerTag,
+      playerName: member.playerName,
+      mapPosition: member.mapPosition,
+      townHall: member.townHall,
+      attacksUsed: member.attacksUsed,
+      attacksAvailable: member.attacksAvailable,
+      subbedIn: member.subbedIn,
+      subbedOut: member.subbedOut,
+    })),
+  };
+}
+
 function compareRoundMembers(a: { mapPosition: number | null; playerName: string; playerTag: string }, b: { mapPosition: number | null; playerName: string; playerTag: string }): number {
   const aPos = a.mapPosition ?? Number.MAX_SAFE_INTEGER;
   const bPos = b.mapPosition ?? Number.MAX_SAFE_INTEGER;
@@ -833,7 +892,7 @@ export class CwlStateService {
     };
   }
 
-  /** Purpose: load one persisted actual CWL lineup for a requested round day from current or history owners. */
+  /** Purpose: load one persisted actual CWL lineup for a requested round day from current, history, or next-day prep owners. */
   async getActualLineupForDay(input: {
     clanTag: string;
     season?: string;
@@ -848,30 +907,10 @@ export class CwlStateService {
       where: { season_clanTag: { season, clanTag } },
     });
     if (currentRound && currentRound.roundDay === roundDay) {
-      const members = await prisma.cwlRoundMemberCurrent.findMany({
-        where: { season, clanTag },
-        orderBy: [{ mapPosition: "asc" }, { playerName: "asc" }, { playerTag: "asc" }],
+      return loadPersistedCwlActualLineup({
+        owner: currentRound,
+        memberSource: "current",
       });
-      return {
-        season,
-        clanTag,
-        clanName: currentRound.clanName,
-        roundDay,
-        roundState: currentRound.roundState,
-        opponentTag: currentRound.opponentTag,
-        opponentName: currentRound.opponentName,
-        phaseEndsAt: resolvePhaseEndsAt(currentRound),
-        members: members.map((member) => ({
-          playerTag: member.playerTag,
-          playerName: member.playerName,
-          mapPosition: member.mapPosition,
-          townHall: member.townHall,
-          attacksUsed: member.attacksUsed,
-          attacksAvailable: member.attacksAvailable,
-          subbedIn: member.subbedIn,
-          subbedOut: member.subbedOut,
-        })),
-      };
     }
 
     const historyRound = await prisma.cwlRoundHistory.findUnique({
@@ -879,31 +918,37 @@ export class CwlStateService {
         season_clanTag_roundDay: { season, clanTag, roundDay },
       },
     });
-    if (!historyRound) return null;
-    const members = await prisma.cwlRoundMemberHistory.findMany({
-      where: { season, clanTag, roundDay },
-      orderBy: [{ mapPosition: "asc" }, { playerName: "asc" }, { playerTag: "asc" }],
-    });
-    return {
-      season,
-      clanTag,
-      clanName: historyRound.clanName,
-      roundDay,
-      roundState: historyRound.roundState,
-      opponentTag: historyRound.opponentTag,
-      opponentName: historyRound.opponentName,
-      phaseEndsAt: resolvePhaseEndsAt(historyRound),
-      members: members.map((member) => ({
-        playerTag: member.playerTag,
-        playerName: member.playerName,
-        mapPosition: member.mapPosition,
-        townHall: member.townHall,
-        attacksUsed: member.attacksUsed,
-        attacksAvailable: member.attacksAvailable,
-        subbedIn: member.subbedIn,
-        subbedOut: member.subbedOut,
-      })),
-    };
+    if (historyRound) {
+      return loadPersistedCwlActualLineup({
+        owner: historyRound,
+        memberSource: "history",
+      });
+    }
+
+    if (
+      currentRound &&
+      currentRound.roundState.toLowerCase().includes("inwar") &&
+      currentRound.roundDay + 1 === roundDay
+    ) {
+      const preparationRound = await prisma.currentCwlRound.findFirst({
+        where: {
+          season,
+          clanTag,
+          roundDay,
+        },
+        orderBy: {
+          updatedAt: "desc",
+        },
+      });
+      if (preparationRound && preparationRound.roundState.toLowerCase().includes("preparation")) {
+        return loadPersistedCwlActualLineup({
+          owner: preparationRound,
+          memberSource: "current",
+        });
+      }
+    }
+
+    return null;
   }
 
   /** Purpose: build one DB-first current-season CWL roster view from persisted roster and round owners. */

--- a/tests/cwl.command.test.ts
+++ b/tests/cwl.command.test.ts
@@ -412,6 +412,51 @@ describe("/cwl command", () => {
     expect(getComponentButtonCustomIds(interaction)).toHaveLength(0);
   });
 
+  it("keeps actual lineup unavailable for far-future /cwl rotations show days", async () => {
+    vi.mocked(cwlRotationService.listActivePlanExports).mockResolvedValue([
+      {
+        season: "2026-04",
+        clanTag: "#2QG2C08UP",
+        clanName: "CWL Alpha",
+        version: 4,
+        warningSummary: null,
+        excludedPlayerTags: [],
+        days: [
+          {
+            roundDay: 7,
+            lineupSize: 2,
+            rows: [
+              { playerTag: "#P7", playerName: "Golf", subbedOut: false, assignmentOrder: 0 },
+              { playerTag: "#P8", playerName: "Hotel", subbedOut: true, assignmentOrder: 1 },
+            ],
+            actual: null,
+          },
+        ],
+      } as any,
+    ]);
+    vi.mocked(cwlRotationService.validatePlanDay).mockResolvedValue({
+      actualAvailable: false,
+      complete: false,
+      missingExpectedPlayerTags: [],
+      extraActualPlayerTags: [],
+      actualPlayerTags: [],
+      actualPlayerNames: [],
+    } as any);
+    const interaction = makeInteraction({
+      group: "rotations",
+      subcommand: "show",
+      clan: "#2QG2C08UP",
+      day: 7,
+    });
+
+    await Cwl.run({} as any, interaction as any);
+
+    expect(getDescription(interaction)).toContain("Day 7");
+    expect(getDescription(interaction)).toContain("Actual:");
+    expect(getDescription(interaction)).toContain("unavailable");
+    expect(getDescription(interaction)).toContain("Status: actual lineup unavailable");
+  });
+
   it("renders an import preview before save and confirms only after a button interaction", async () => {
     const preview: CwlRotationSheetImportPreview = {
       sourceSheetId: "sheet-1",

--- a/tests/cwlRotation.service.test.ts
+++ b/tests/cwlRotation.service.test.ts
@@ -302,4 +302,70 @@ describe("CwlRotationService", () => {
       currentState: "inWar",
     });
   });
+
+  it("validates the next-day preparation lineup against the planned roster", async () => {
+    prismaMock.cwlRotationPlan.findFirst.mockResolvedValue({
+      id: "plan-1",
+      clanTag: "#2QG2C08UP",
+      season: "2026-04",
+      version: 2,
+      isActive: true,
+    });
+    prismaMock.cwlRotationPlanDay.findMany.mockResolvedValue([
+      {
+        roundDay: 4,
+        lineupSize: 2,
+        members: [
+          { playerTag: "#PYLQ0289", playerName: "Alpha", assignmentOrder: 0 },
+          { playerTag: "#QGRJ2222", playerName: "Bravo", assignmentOrder: 1 },
+        ],
+      },
+    ]);
+    vi.spyOn(cwlStateService, "getActualLineupForDay").mockResolvedValue({
+      season: "2026-04",
+      clanTag: "#2QG2C08UP",
+      clanName: "CWL Alpha",
+      roundDay: 4,
+      roundState: "preparation",
+      opponentTag: "#OPP2",
+      opponentName: "Opponent Two",
+      phaseEndsAt: new Date("2026-04-04T12:00:00.000Z"),
+      members: [
+        {
+          playerTag: "#PYLQ0289",
+          playerName: "Alpha",
+          mapPosition: 1,
+          townHall: 16,
+          attacksUsed: 0,
+          attacksAvailable: 0,
+          subbedIn: true,
+          subbedOut: false,
+        },
+        {
+          playerTag: "#CUV9082",
+          playerName: "Charlie",
+          mapPosition: 2,
+          townHall: 15,
+          attacksUsed: 0,
+          attacksAvailable: 0,
+          subbedIn: true,
+          subbedOut: false,
+        },
+      ],
+    });
+
+    const result = await cwlRotationService.validatePlanDay({
+      clanTag: "#2QG2C08UP",
+      season: "2026-04",
+      roundDay: 4,
+    });
+
+    expect(result).toMatchObject({
+      complete: false,
+      actualAvailable: true,
+      missingExpectedPlayerTags: ["#QGRJ2222"],
+      extraActualPlayerTags: ["#CUV9082"],
+      currentState: "preparation",
+    });
+  });
 });

--- a/tests/cwlState.service.test.ts
+++ b/tests/cwlState.service.test.ts
@@ -27,6 +27,7 @@ const prismaMock = vi.hoisted(() => ({
   },
   currentCwlRound: {
     findUnique: vi.fn(),
+    findFirst: vi.fn(),
   },
   cwlRoundMemberCurrent: {
     findMany: vi.fn(),
@@ -58,6 +59,7 @@ describe("CwlStateService", () => {
 
     prismaMock.cwlTrackedClan.findMany.mockResolvedValue([]);
     prismaMock.currentCwlRound.findUnique.mockResolvedValue(null);
+    prismaMock.currentCwlRound.findFirst.mockResolvedValue(null);
     prismaMock.cwlRoundMemberCurrent.findMany.mockResolvedValue([]);
     prismaMock.cwlRoundHistory.findUnique.mockResolvedValue(null);
     prismaMock.cwlRoundMemberHistory.findMany.mockResolvedValue([]);
@@ -363,6 +365,283 @@ describe("CwlStateService", () => {
         ]),
       }),
     );
+  });
+
+  it("returns the persisted current-day lineup when the current round matches the requested day", async () => {
+    prismaMock.currentCwlRound.findUnique.mockResolvedValue({
+      season: "2026-04",
+      clanTag: "#2QG2C08UP",
+      clanName: "CWL Alpha",
+      roundDay: 2,
+      roundState: "preparation",
+      opponentTag: "#OPP1",
+      opponentName: "Opponent One",
+      preparationStartTime: new Date("2026-04-02T10:00:00.000Z"),
+      startTime: new Date("2026-04-02T12:00:00.000Z"),
+      endTime: new Date("2026-04-03T12:00:00.000Z"),
+      sourceUpdatedAt: new Date("2026-04-02T00:00:00.000Z"),
+    });
+    prismaMock.cwlRoundMemberCurrent.findMany.mockResolvedValue([
+      {
+        season: "2026-04",
+        clanTag: "#2QG2C08UP",
+        playerTag: "#PYLQ0289",
+        roundDay: 2,
+        playerName: "Alpha",
+        mapPosition: 1,
+        townHall: 16,
+        attacksUsed: 0,
+        attacksAvailable: 0,
+        subbedIn: true,
+        subbedOut: false,
+      },
+      {
+        season: "2026-04",
+        clanTag: "#2QG2C08UP",
+        playerTag: "#QGRJ2222",
+        roundDay: 2,
+        playerName: "Bravo",
+        mapPosition: 2,
+        townHall: 15,
+        attacksUsed: 0,
+        attacksAvailable: 0,
+        subbedIn: true,
+        subbedOut: false,
+      },
+    ]);
+
+    const actual = await cwlStateService.getActualLineupForDay({
+      clanTag: "#2QG2C08UP",
+      season: "2026-04",
+      roundDay: 2,
+    });
+
+    expect(actual).toEqual(
+      expect.objectContaining({
+        season: "2026-04",
+        clanTag: "#2QG2C08UP",
+        clanName: "CWL Alpha",
+        roundDay: 2,
+        roundState: "preparation",
+        opponentTag: "#OPP1",
+        opponentName: "Opponent One",
+        phaseEndsAt: new Date("2026-04-02T12:00:00.000Z"),
+        members: [
+          expect.objectContaining({
+            playerTag: "#PYLQ0289",
+            playerName: "Alpha",
+            mapPosition: 1,
+            subbedIn: true,
+          }),
+          expect.objectContaining({
+            playerTag: "#QGRJ2222",
+            playerName: "Bravo",
+            mapPosition: 2,
+            subbedIn: true,
+          }),
+        ],
+      }),
+    );
+    expect(prismaMock.currentCwlRound.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("returns the persisted history lineup when the requested day is in history", async () => {
+    prismaMock.currentCwlRound.findUnique.mockResolvedValue({
+      season: "2026-04",
+      clanTag: "#2QG2C08UP",
+      clanName: "CWL Alpha",
+      roundDay: 3,
+      roundState: "inWar",
+      opponentTag: "#OPP1",
+      opponentName: "Opponent One",
+      preparationStartTime: new Date("2026-04-03T10:00:00.000Z"),
+      startTime: new Date("2026-04-03T12:00:00.000Z"),
+      endTime: new Date("2026-04-04T12:00:00.000Z"),
+      sourceUpdatedAt: new Date("2026-04-03T00:00:00.000Z"),
+    });
+    prismaMock.cwlRoundHistory.findUnique.mockResolvedValue({
+      season: "2026-04",
+      clanTag: "#2QG2C08UP",
+      roundDay: 1,
+      clanName: "CWL Alpha",
+      roundState: "warEnded",
+      opponentTag: "#OPP2",
+      opponentName: "Opponent Two",
+      preparationStartTime: new Date("2026-04-01T10:00:00.000Z"),
+      startTime: new Date("2026-04-01T12:00:00.000Z"),
+      endTime: new Date("2026-04-02T12:00:00.000Z"),
+      sourceUpdatedAt: new Date("2026-04-01T00:00:00.000Z"),
+    });
+    prismaMock.cwlRoundMemberHistory.findMany.mockResolvedValue([
+      {
+        season: "2026-04",
+        clanTag: "#2QG2C08UP",
+        roundDay: 1,
+        playerTag: "#PYLQ0289",
+        playerName: "Alpha",
+        mapPosition: 1,
+        townHall: 16,
+        attacksUsed: 1,
+        attacksAvailable: 1,
+        subbedIn: true,
+        subbedOut: false,
+      },
+    ]);
+
+    const actual = await cwlStateService.getActualLineupForDay({
+      clanTag: "#2QG2C08UP",
+      season: "2026-04",
+      roundDay: 1,
+    });
+
+    expect(actual).toEqual(
+      expect.objectContaining({
+        season: "2026-04",
+        clanTag: "#2QG2C08UP",
+        clanName: "CWL Alpha",
+        roundDay: 1,
+        roundState: "warEnded",
+        opponentTag: "#OPP2",
+        opponentName: "Opponent Two",
+        phaseEndsAt: new Date("2026-04-02T12:00:00.000Z"),
+        members: [
+          expect.objectContaining({
+            playerTag: "#PYLQ0289",
+            playerName: "Alpha",
+            subbedIn: true,
+          }),
+        ],
+      }),
+    );
+    expect(prismaMock.currentCwlRound.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("returns the persisted next-day preparation lineup when the current round remains in war", async () => {
+    prismaMock.currentCwlRound.findUnique.mockResolvedValue({
+      season: "2026-04",
+      clanTag: "#2QG2C08UP",
+      clanName: "CWL Alpha",
+      roundDay: 1,
+      roundState: "inWar",
+      opponentTag: "#OPP1",
+      opponentName: "Opponent One",
+      preparationStartTime: new Date("2026-04-01T10:00:00.000Z"),
+      startTime: new Date("2026-04-01T12:00:00.000Z"),
+      endTime: new Date("2026-04-02T12:00:00.000Z"),
+      sourceUpdatedAt: new Date("2026-04-01T00:00:00.000Z"),
+    });
+    prismaMock.currentCwlRound.findFirst.mockResolvedValue({
+      season: "2026-04",
+      clanTag: "#2QG2C08UP",
+      clanName: "CWL Alpha",
+      roundDay: 2,
+      roundState: "preparation",
+      opponentTag: "#OPP2",
+      opponentName: "Opponent Two",
+      preparationStartTime: new Date("2026-04-02T10:00:00.000Z"),
+      startTime: new Date("2026-04-02T12:00:00.000Z"),
+      endTime: new Date("2026-04-03T12:00:00.000Z"),
+      sourceUpdatedAt: new Date("2026-04-02T00:00:00.000Z"),
+    });
+    prismaMock.cwlRoundMemberCurrent.findMany.mockImplementation(async (args: any) => {
+      if (args?.where?.roundDay === 2) {
+        return [
+          {
+            season: "2026-04",
+            clanTag: "#2QG2C08UP",
+            playerTag: "#QGRJ2222",
+            roundDay: 2,
+            playerName: "Bravo",
+            mapPosition: 1,
+            townHall: 15,
+            attacksUsed: 0,
+            attacksAvailable: 0,
+            subbedIn: true,
+            subbedOut: false,
+          },
+          {
+            season: "2026-04",
+            clanTag: "#2QG2C08UP",
+            playerTag: "#CUV9082",
+            roundDay: 2,
+            playerName: "Charlie",
+            mapPosition: 2,
+            townHall: 15,
+            attacksUsed: 0,
+            attacksAvailable: 0,
+            subbedIn: true,
+            subbedOut: false,
+          },
+        ];
+      }
+      return [];
+    });
+
+    const actual = await cwlStateService.getActualLineupForDay({
+      clanTag: "#2QG2C08UP",
+      season: "2026-04",
+      roundDay: 2,
+    });
+
+    expect(prismaMock.currentCwlRound.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: {
+          season: "2026-04",
+          clanTag: "#2QG2C08UP",
+          roundDay: 2,
+        },
+      }),
+    );
+    expect(actual).toEqual(
+      expect.objectContaining({
+        season: "2026-04",
+        clanTag: "#2QG2C08UP",
+        clanName: "CWL Alpha",
+        roundDay: 2,
+        roundState: "preparation",
+        opponentTag: "#OPP2",
+        opponentName: "Opponent Two",
+        phaseEndsAt: new Date("2026-04-02T12:00:00.000Z"),
+        members: [
+          expect.objectContaining({
+            playerTag: "#QGRJ2222",
+            playerName: "Bravo",
+            subbedIn: true,
+          }),
+          expect.objectContaining({
+            playerTag: "#CUV9082",
+            playerName: "Charlie",
+            subbedIn: true,
+          }),
+        ],
+      }),
+    );
+  });
+
+  it("returns null for a future day that is not yet in preparation", async () => {
+    prismaMock.currentCwlRound.findUnique.mockResolvedValue({
+      season: "2026-04",
+      clanTag: "#2QG2C08UP",
+      clanName: "CWL Alpha",
+      roundDay: 1,
+      roundState: "inWar",
+      opponentTag: "#OPP1",
+      opponentName: "Opponent One",
+      preparationStartTime: new Date("2026-04-01T10:00:00.000Z"),
+      startTime: new Date("2026-04-01T12:00:00.000Z"),
+      endTime: new Date("2026-04-02T12:00:00.000Z"),
+      sourceUpdatedAt: new Date("2026-04-01T00:00:00.000Z"),
+    });
+    prismaMock.currentCwlRound.findFirst.mockResolvedValue(null);
+
+    const actual = await cwlStateService.getActualLineupForDay({
+      clanTag: "#2QG2C08UP",
+      season: "2026-04",
+      roundDay: 4,
+    });
+
+    expect(actual).toBeNull();
+    expect(prismaMock.currentCwlRound.findFirst).not.toHaveBeenCalled();
   });
 
   it("builds a DB-first season roster view with linked-user and current-round context", async () => {


### PR DESCRIPTION
Teach CWL day resolution to read the persisted preparation lineup for the immediate next day when the active current round is still in war, while preserving exact current/history behavior and the far-future unavailable fallback.