### PR TITLE
feat(cwl): add war counts to merged show roster

### DIFF
--- a/src/commands/Cwl.ts
+++ b/src/commands/Cwl.ts
@@ -111,6 +111,35 @@ function buildCwlRotationMemberLines(input: {
   });
 }
 
+function buildCwlRotationWarCountMap(input: {
+  days: Array<{
+    rows: Array<{
+      playerTag: string;
+      subbedOut: boolean;
+    }>;
+  }>;
+}): Map<string, number> {
+  const warCountByPlayerTag = new Map<string, number>();
+  for (const day of input.days) {
+    for (const row of day.rows) {
+      if (row.subbedOut) continue;
+      const playerTag = normalizePlayerTag(row.playerTag);
+      if (!playerTag) continue;
+      warCountByPlayerTag.set(playerTag, (warCountByPlayerTag.get(playerTag) ?? 0) + 1);
+    }
+  }
+  return warCountByPlayerTag;
+}
+
+function getCwlRotationWarCount(input: {
+  playerTag: string;
+  warCountByPlayerTag: Map<string, number>;
+}): number {
+  const playerTag = normalizePlayerTag(input.playerTag);
+  if (!playerTag) return 0;
+  return input.warCountByPlayerTag.get(playerTag) ?? 0;
+}
+
 function renderCurrentRoundSummary(input: {
   clanTag: string;
   clanName: string | null;
@@ -187,6 +216,7 @@ function renderValidationSummary(input: {
 }
 
 function buildCwlRotationMergedRosterLines(input: {
+  warCountByPlayerTag: Map<string, number>;
   plannedMembers: Array<{
     playerTag: string;
     playerName: string;
@@ -198,8 +228,24 @@ function buildCwlRotationMergedRosterLines(input: {
   }>;
   actualAvailable: boolean;
 }): string[] {
+  const benchMembers = input.plannedMembers
+    .filter((member) => member.subbedOut)
+    .map((member) => ({
+      playerTag: member.playerTag,
+      playerName: member.playerName,
+      warCount: getCwlRotationWarCount({
+        playerTag: member.playerTag,
+        warCountByPlayerTag: input.warCountByPlayerTag,
+      }),
+    }));
+
   if (!input.actualAvailable) {
-    return ["Actual lineup unavailable"];
+    return [
+      "Actual lineup unavailable",
+      ...benchMembers.map(
+        (member) => `:x: ${member.playerName} (${member.playerTag}) | War count: ${member.warCount}`,
+      ),
+    ];
   }
 
   const expectedMembers = input.plannedMembers.filter((member) => !member.subbedOut);
@@ -216,6 +262,10 @@ function buildCwlRotationMergedRosterLines(input: {
     normalizedTag: normalizePlayerTag(member.playerTag),
     playerTag: member.playerTag,
     playerName: member.playerName,
+    warCount: getCwlRotationWarCount({
+      playerTag: member.playerTag,
+      warCountByPlayerTag: input.warCountByPlayerTag,
+    }),
   }));
   const actualTagSet = new Set(actualRows.map((member) => member.normalizedTag).filter(Boolean));
   const missingExpectedRows = expectedMembers.filter((member) => {
@@ -227,7 +277,7 @@ function buildCwlRotationMergedRosterLines(input: {
   let missingExpectedIndex = 0;
   for (const actual of actualRows) {
     if (actual.normalizedTag && expectedByTag.has(actual.normalizedTag)) {
-      lines.push(`:white_check_mark: ${actual.playerName} (${actual.playerTag})`);
+      lines.push(`:white_check_mark: ${actual.playerName} (${actual.playerTag}) | War count: ${actual.warCount}`);
       continue;
     }
 
@@ -235,18 +285,30 @@ function buildCwlRotationMergedRosterLines(input: {
     if (expected) {
       missingExpectedIndex += 1;
       lines.push(
-        `:warning: ${actual.playerName} (${actual.playerTag}) | Expected ${expected.playerName} (${expected.playerTag})`,
+        `:warning: ${actual.playerName} (${actual.playerTag}) | Expected ${expected.playerName} (${expected.playerTag}) | War count: ${actual.warCount}`,
       );
       continue;
     }
 
-    lines.push(`:warning: ${actual.playerName} (${actual.playerTag})`);
+    lines.push(`:warning: ${actual.playerName} (${actual.playerTag}) | War count: ${actual.warCount}`);
   }
 
   for (; missingExpectedIndex < missingExpectedRows.length; missingExpectedIndex += 1) {
     const expected = missingExpectedRows[missingExpectedIndex];
-    lines.push(`:warning: Missing actual member | Expected ${expected.playerName} (${expected.playerTag})`);
+    const expectedWarCount = getCwlRotationWarCount({
+      playerTag: expected.playerTag,
+      warCountByPlayerTag: input.warCountByPlayerTag,
+    });
+    lines.push(
+      `:warning: Missing actual member | Expected ${expected.playerName} (${expected.playerTag}) | War count: ${expectedWarCount}`,
+    );
   }
+
+  lines.push(
+    ...benchMembers.map(
+      (member) => `:x: ${member.playerName} (${member.playerTag}) | War count: ${member.warCount}`,
+    ),
+  );
 
   if (lines.length <= 0) {
     lines.push("No actual lineup members.");
@@ -999,6 +1061,9 @@ function buildCwlRotationShowPageLines(input: {
     actualPlayerRows: Array<{ playerTag: string; playerName: string }>;
   } | null;
 }): string[] {
+  const warCountByPlayerTag = buildCwlRotationWarCountMap({
+    days: input.plan.days,
+  });
   const lines: string[] = [
     `Season: ${input.plan.season}`,
     `Clan: ${input.plan.clanName || input.plan.clanTag}`,
@@ -1016,9 +1081,18 @@ function buildCwlRotationShowPageLines(input: {
   lines.push("");
   if (!input.validation || !input.validation.actualAvailable) {
     lines.push("Actual lineup unavailable");
+    lines.push(
+      ...buildCwlRotationMergedRosterLines({
+        warCountByPlayerTag,
+        plannedMembers: input.day.rows,
+        actualPlayerRows: [],
+        actualAvailable: false,
+      }).slice(1),
+    );
   } else {
     lines.push(
       ...buildCwlRotationMergedRosterLines({
+        warCountByPlayerTag,
         plannedMembers: input.day.rows,
         actualPlayerRows: input.validation.actualPlayerRows,
         actualAvailable: input.validation.actualAvailable,

--- a/tests/cwl.command.test.ts
+++ b/tests/cwl.command.test.ts
@@ -311,6 +311,7 @@ describe("/cwl command", () => {
               { playerTag: "#PYLQ0289", playerName: "Alpha", subbedOut: false, assignmentOrder: 0 },
               { playerTag: "#QGRJ2222", playerName: "Bravo", subbedOut: false, assignmentOrder: 1 },
               { playerTag: "#CUV02898", playerName: "Delta", subbedOut: false, assignmentOrder: 2 },
+              { playerTag: "#JQJQ2222", playerName: "Hotel", subbedOut: true, assignmentOrder: 3 },
             ],
             actual: null,
           },
@@ -359,9 +360,14 @@ describe("/cwl command", () => {
     expect(getDescription(interaction)).toContain("Warnings: 1 warning");
     expect(getDescription(interaction)).toContain("Excluded: #P9");
     expect(getDescription(interaction)).toContain("Day 1");
-    expect(getDescription(interaction)).toContain(":white_check_mark: Alpha (#PYLQ0289)");
-    expect(getDescription(interaction)).toContain(":warning: Charlie (#VJQ28888) | Expected Bravo (#QGRJ2222)");
-    expect(getDescription(interaction)).toContain(":warning: Missing actual member | Expected Delta (#CUV02898)");
+    expect(getDescription(interaction)).toContain(":white_check_mark: Alpha (#PYLQ0289) | War count: 1");
+    expect(getDescription(interaction)).toContain(
+      ":warning: Charlie (#VJQ28888) | Expected Bravo (#QGRJ2222) | War count: 1",
+    );
+    expect(getDescription(interaction)).toContain(
+      ":warning: Missing actual member | Expected Delta (#CUV02898) | War count: 2",
+    );
+    expect(getDescription(interaction)).toContain(":x: Hotel (#JQJQ2222) | War count: 0");
     expect(getDescription(interaction)).not.toContain("Actual:");
     expect(getDescription(interaction)).not.toContain("Status:");
     expect(getComponentButtonCustomIds(interaction)).toHaveLength(2);
@@ -378,8 +384,12 @@ describe("/cwl command", () => {
     await handleCwlRotationShowButtonInteraction(buttonInteraction as any);
 
     expect(getUpdatedDescription(buttonInteraction)).toContain("Day 2");
-    expect(getUpdatedDescription(buttonInteraction)).toContain(":white_check_mark: Charlie (#VJQ28888)");
-    expect(getUpdatedDescription(buttonInteraction)).toContain(":white_check_mark: Delta (#CUV02898)");
+    expect(getUpdatedDescription(buttonInteraction)).toContain(
+      ":white_check_mark: Charlie (#VJQ28888) | War count: 1",
+    );
+    expect(getUpdatedDescription(buttonInteraction)).toContain(
+      ":white_check_mark: Delta (#CUV02898) | War count: 2",
+    );
     expect(getUpdatedDescription(buttonInteraction)).not.toContain("Actual:");
     expect(getUpdatedDescription(buttonInteraction)).not.toContain("Status:");
   });
@@ -433,8 +443,8 @@ describe("/cwl command", () => {
     await Cwl.run({} as any, interaction as any);
 
     expect(getDescription(interaction)).toContain("Day 4");
-    expect(getDescription(interaction)).toContain(":white_check_mark: Charlie (#VJQ28888)");
-    expect(getDescription(interaction)).toContain(":white_check_mark: Delta (#CUV02898)");
+    expect(getDescription(interaction)).toContain(":white_check_mark: Charlie (#VJQ28888) | War count: 1");
+    expect(getDescription(interaction)).toContain(":white_check_mark: Delta (#CUV02898) | War count: 1");
     expect(getDescription(interaction)).not.toContain("Day 3");
     expect(getDescription(interaction)).not.toContain("Actual:");
     expect(getDescription(interaction)).not.toContain("Status:");
@@ -480,8 +490,8 @@ describe("/cwl command", () => {
     await Cwl.run({} as any, interaction as any);
 
     expect(getDescription(interaction)).toContain("Day 2");
-    expect(getDescription(interaction)).toContain(":white_check_mark: Charlie (#VJQ28888)");
-    expect(getDescription(interaction)).toContain(":white_check_mark: Delta (#CUV02898)");
+    expect(getDescription(interaction)).toContain(":white_check_mark: Charlie (#VJQ28888) | War count: 1");
+    expect(getDescription(interaction)).toContain(":white_check_mark: Delta (#CUV02898) | War count: 1");
     expect(getDescription(interaction)).not.toContain("Day 1");
     expect(getDescription(interaction)).not.toContain("Actual:");
     expect(getDescription(interaction)).not.toContain("Status:");
@@ -502,8 +512,7 @@ describe("/cwl command", () => {
             roundDay: 7,
             lineupSize: 2,
             rows: [
-              { playerTag: "#P7", playerName: "Golf", subbedOut: false, assignmentOrder: 0 },
-              { playerTag: "#P8", playerName: "Hotel", subbedOut: true, assignmentOrder: 1 },
+              { playerTag: "#JQJQ2222", playerName: "Hotel", subbedOut: true, assignmentOrder: 0 },
             ],
             actual: null,
           },
@@ -529,6 +538,7 @@ describe("/cwl command", () => {
 
     expect(getDescription(interaction)).toContain("Day 7");
     expect(getDescription(interaction)).toContain("Actual lineup unavailable");
+    expect(getDescription(interaction)).toContain(":x: Hotel (#JQJQ2222) | War count: 0");
     expect(getDescription(interaction)).not.toContain("Actual:");
     expect(getDescription(interaction)).not.toContain("Status:");
   });
@@ -578,6 +588,48 @@ describe("/cwl command", () => {
     expect(getDescription(interaction)).toContain(":warning: Missing actual member | Expected Golf (#CUV02898)");
     expect(getDescription(interaction)).not.toContain("Actual:");
     expect(getDescription(interaction)).not.toContain("Status:");
+  });
+
+  it("shows unexpected actual members with zero war count when they are absent from the plan", async () => {
+    vi.mocked(cwlRotationService.listActivePlanExports).mockResolvedValue([
+      {
+        season: "2026-04",
+        clanTag: "#2QG2C08UP",
+        clanName: "CWL Alpha",
+        version: 4,
+        warningSummary: null,
+        excludedPlayerTags: [],
+        days: [
+          {
+            roundDay: 5,
+            lineupSize: 1,
+            rows: [
+              { playerTag: "#JQJQ2222", playerName: "Hotel", subbedOut: true, assignmentOrder: 0 },
+            ],
+            actual: null,
+          },
+        ],
+      } as any,
+    ]);
+    vi.mocked(cwlRotationService.validatePlanDay).mockResolvedValue({
+      actualAvailable: true,
+      complete: false,
+      missingExpectedPlayerTags: [],
+      extraActualPlayerTags: ["#VJQ28888"],
+      actualPlayerTags: ["#VJQ28888"],
+      actualPlayerNames: ["Visitor"],
+    } as any);
+    const interaction = makeInteraction({
+      group: "rotations",
+      subcommand: "show",
+      clan: "#2QG2C08UP",
+      day: 5,
+    });
+
+    await Cwl.run({} as any, interaction as any);
+
+    expect(getDescription(interaction)).toContain(":warning: Visitor (#VJQ28888) | War count: 0");
+    expect(getDescription(interaction)).toContain(":x: Hotel (#JQJQ2222) | War count: 0");
   });
 
   it("renders an import preview before save and confirms only after a button interaction", async () => {


### PR DESCRIPTION
- append per-plan war counts to merged CWL day roster lines
- render benched members at the bottom and preserve unavailable-day benches