### PR TITLE
fix(cwl): count war totals through displayed day

### DIFF
--- a/src/commands/Cwl.ts
+++ b/src/commands/Cwl.ts
@@ -113,14 +113,17 @@ function buildCwlRotationMemberLines(input: {
 
 function buildCwlRotationWarCountMap(input: {
   days: Array<{
+    roundDay: number;
     rows: Array<{
       playerTag: string;
       subbedOut: boolean;
     }>;
   }>;
+  throughRoundDay: number;
 }): Map<string, number> {
   const warCountByPlayerTag = new Map<string, number>();
   for (const day of input.days) {
+    if (day.roundDay > input.throughRoundDay) continue;
     for (const row of day.rows) {
       if (row.subbedOut) continue;
       const playerTag = normalizePlayerTag(row.playerTag);
@@ -1063,6 +1066,7 @@ function buildCwlRotationShowPageLines(input: {
 }): string[] {
   const warCountByPlayerTag = buildCwlRotationWarCountMap({
     days: input.plan.days,
+    throughRoundDay: input.day.roundDay,
   });
   const lines: string[] = [
     `Season: ${input.plan.season}`,

--- a/tests/cwl.command.test.ts
+++ b/tests/cwl.command.test.ts
@@ -362,10 +362,10 @@ describe("/cwl command", () => {
     expect(getDescription(interaction)).toContain("Day 1");
     expect(getDescription(interaction)).toContain(":white_check_mark: Alpha (#PYLQ0289) | War count: 1");
     expect(getDescription(interaction)).toContain(
-      ":warning: Charlie (#VJQ28888) | Expected Bravo (#QGRJ2222) | War count: 1",
+      ":warning: Charlie (#VJQ28888) | Expected Bravo (#QGRJ2222) | War count: 0",
     );
     expect(getDescription(interaction)).toContain(
-      ":warning: Missing actual member | Expected Delta (#CUV02898) | War count: 2",
+      ":warning: Missing actual member | Expected Delta (#CUV02898) | War count: 1",
     );
     expect(getDescription(interaction)).toContain(":x: Hotel (#JQJQ2222) | War count: 0");
     expect(getDescription(interaction)).not.toContain("Actual:");


### PR DESCRIPTION
- limit CWL show war counts to days up to the current page
- keep the merged roster and benched-row formats unchanged