### PR TITLE
fix(cwl): show actual left-out members in mismatch rows

### DIFF
--- a/src/commands/Cwl.ts
+++ b/src/commands/Cwl.ts
@@ -231,7 +231,7 @@ function buildCwlRotationMergedRosterLines(input: {
   }>;
   actualAvailable: boolean;
 }): string[] {
-  const benchMembers = input.plannedMembers
+  const plannedBenchMembers = input.plannedMembers
     .filter((member) => member.subbedOut)
     .map((member) => ({
       playerTag: member.playerTag,
@@ -245,7 +245,7 @@ function buildCwlRotationMergedRosterLines(input: {
   if (!input.actualAvailable) {
     return [
       "Actual lineup unavailable",
-      ...benchMembers.map(
+      ...plannedBenchMembers.map(
         (member) => `:x: ${member.playerName} (${member.playerTag}) | War count: ${member.warCount}`,
       ),
     ];
@@ -288,7 +288,7 @@ function buildCwlRotationMergedRosterLines(input: {
     if (expected) {
       missingExpectedIndex += 1;
       lines.push(
-        `:warning: ${actual.playerName} (${actual.playerTag}) | Expected ${expected.playerName} (${expected.playerTag}) | War count: ${actual.warCount}`,
+        `:warning: ${actual.playerName} (${actual.playerTag}) | War count: ${actual.warCount} - Expected ${expected.playerName} (${expected.playerTag})`,
       );
       continue;
     }
@@ -296,21 +296,14 @@ function buildCwlRotationMergedRosterLines(input: {
     lines.push(`:warning: ${actual.playerName} (${actual.playerTag}) | War count: ${actual.warCount}`);
   }
 
-  for (; missingExpectedIndex < missingExpectedRows.length; missingExpectedIndex += 1) {
-    const expected = missingExpectedRows[missingExpectedIndex];
-    const expectedWarCount = getCwlRotationWarCount({
-      playerTag: expected.playerTag,
-      warCountByPlayerTag: input.warCountByPlayerTag,
-    });
-    lines.push(
-      `:warning: Missing actual member | Expected ${expected.playerName} (${expected.playerTag}) | War count: ${expectedWarCount}`,
-    );
-  }
-
   lines.push(
-    ...benchMembers.map(
-      (member) => `:x: ${member.playerName} (${member.playerTag}) | War count: ${member.warCount}`,
-    ),
+    ...missingExpectedRows.map((member) => {
+      const expectedWarCount = getCwlRotationWarCount({
+        playerTag: member.playerTag,
+        warCountByPlayerTag: input.warCountByPlayerTag,
+      });
+      return `:x: ${member.playerName} (${member.playerTag}) | War count: ${expectedWarCount}`;
+    }),
   );
 
   if (lines.length <= 0) {

--- a/tests/cwl.command.test.ts
+++ b/tests/cwl.command.test.ts
@@ -362,12 +362,11 @@ describe("/cwl command", () => {
     expect(getDescription(interaction)).toContain("Day 1");
     expect(getDescription(interaction)).toContain(":white_check_mark: Alpha (#PYLQ0289) | War count: 1");
     expect(getDescription(interaction)).toContain(
-      ":warning: Charlie (#VJQ28888) | Expected Bravo (#QGRJ2222) | War count: 0",
+      ":warning: Charlie (#VJQ28888) | War count: 0 - Expected Bravo (#QGRJ2222)",
     );
-    expect(getDescription(interaction)).toContain(
-      ":warning: Missing actual member | Expected Delta (#CUV02898) | War count: 1",
-    );
-    expect(getDescription(interaction)).toContain(":x: Hotel (#JQJQ2222) | War count: 0");
+    expect(getDescription(interaction)).toContain(":x: Bravo (#QGRJ2222) | War count: 1");
+    expect(getDescription(interaction)).toContain(":x: Delta (#CUV02898) | War count: 1");
+    expect(getDescription(interaction)).not.toContain(":x: Hotel (#JQJQ2222)");
     expect(getDescription(interaction)).not.toContain("Actual:");
     expect(getDescription(interaction)).not.toContain("Status:");
     expect(getComponentButtonCustomIds(interaction)).toHaveLength(2);
@@ -584,8 +583,11 @@ describe("/cwl command", () => {
     await Cwl.run({} as any, interaction as any);
 
     expect(getDescription(interaction)).toContain(":white_check_mark: Echo (#PYLQ0289)");
-    expect(getDescription(interaction)).toContain(":warning: Zulu (#VJQ28888) | Expected Foxtrot (#QGRJ2222)");
-    expect(getDescription(interaction)).toContain(":warning: Missing actual member | Expected Golf (#CUV02898)");
+    expect(getDescription(interaction)).toContain(
+      ":warning: Zulu (#VJQ28888) | War count: 0 - Expected Foxtrot (#QGRJ2222)",
+    );
+    expect(getDescription(interaction)).toContain(":x: Foxtrot (#QGRJ2222) | War count: 1");
+    expect(getDescription(interaction)).toContain(":x: Golf (#CUV02898) | War count: 1");
     expect(getDescription(interaction)).not.toContain("Actual:");
     expect(getDescription(interaction)).not.toContain("Status:");
   });
@@ -629,7 +631,7 @@ describe("/cwl command", () => {
     await Cwl.run({} as any, interaction as any);
 
     expect(getDescription(interaction)).toContain(":warning: Visitor (#VJQ28888) | War count: 0");
-    expect(getDescription(interaction)).toContain(":x: Hotel (#JQJQ2222) | War count: 0");
+    expect(getDescription(interaction)).not.toContain(":x: Hotel (#JQJQ2222)");
   });
 
   it("renders an import preview before save and confirms only after a button interaction", async () => {


### PR DESCRIPTION
- render mismatch warnings with the active participant first
- move actual-available benched rows to the missing expected members