### PR TITLE
fix(cwl): count actual participation through displayed day

### DIFF
--- a/src/commands/Cwl.ts
+++ b/src/commands/Cwl.ts
@@ -111,29 +111,6 @@ function buildCwlRotationMemberLines(input: {
   });
 }
 
-function buildCwlRotationWarCountMap(input: {
-  days: Array<{
-    roundDay: number;
-    rows: Array<{
-      playerTag: string;
-      subbedOut: boolean;
-    }>;
-  }>;
-  throughRoundDay: number;
-}): Map<string, number> {
-  const warCountByPlayerTag = new Map<string, number>();
-  for (const day of input.days) {
-    if (day.roundDay > input.throughRoundDay) continue;
-    for (const row of day.rows) {
-      if (row.subbedOut) continue;
-      const playerTag = normalizePlayerTag(row.playerTag);
-      if (!playerTag) continue;
-      warCountByPlayerTag.set(playerTag, (warCountByPlayerTag.get(playerTag) ?? 0) + 1);
-    }
-  }
-  return warCountByPlayerTag;
-}
-
 function getCwlRotationWarCount(input: {
   playerTag: string;
   warCountByPlayerTag: Map<string, number>;
@@ -1049,6 +1026,7 @@ function buildCwlRotationShowPageLines(input: {
   day: CwlRotationPlanExport["days"][number];
   pageIndex: number;
   pageCount: number;
+  warCountByPlayerTag: Map<string, number>;
   validation: {
     actualAvailable: boolean;
     complete: boolean;
@@ -1057,10 +1035,6 @@ function buildCwlRotationShowPageLines(input: {
     actualPlayerRows: Array<{ playerTag: string; playerName: string }>;
   } | null;
 }): string[] {
-  const warCountByPlayerTag = buildCwlRotationWarCountMap({
-    days: input.plan.days,
-    throughRoundDay: input.day.roundDay,
-  });
   const lines: string[] = [
     `Season: ${input.plan.season}`,
     `Clan: ${input.plan.clanName || input.plan.clanTag}`,
@@ -1080,7 +1054,7 @@ function buildCwlRotationShowPageLines(input: {
     lines.push("Actual lineup unavailable");
     lines.push(
       ...buildCwlRotationMergedRosterLines({
-        warCountByPlayerTag,
+        warCountByPlayerTag: input.warCountByPlayerTag,
         plannedMembers: input.day.rows,
         actualPlayerRows: [],
         actualAvailable: false,
@@ -1089,7 +1063,7 @@ function buildCwlRotationShowPageLines(input: {
   } else {
     lines.push(
       ...buildCwlRotationMergedRosterLines({
-        warCountByPlayerTag,
+        warCountByPlayerTag: input.warCountByPlayerTag,
         plannedMembers: input.day.rows,
         actualPlayerRows: input.validation.actualPlayerRows,
         actualAvailable: input.validation.actualAvailable,
@@ -1105,6 +1079,7 @@ function buildCwlRotationShowPageEmbed(input: {
   day: CwlRotationPlanExport["days"][number];
   pageIndex: number;
   pageCount: number;
+  warCountByPlayerTag: Map<string, number>;
   validation: {
     actualAvailable: boolean;
     complete: boolean;
@@ -1118,13 +1093,14 @@ function buildCwlRotationShowPageEmbed(input: {
     .setTitle(`/cwl rotations show ${input.plan.clanTag}`)
     .setDescription(
       buildDescription(
-        buildCwlRotationShowPageLines({
-          plan: input.plan,
-          day: input.day,
-          pageIndex: input.pageIndex,
-          pageCount: input.pageCount,
-          validation: input.validation,
-        }),
+          buildCwlRotationShowPageLines({
+            plan: input.plan,
+            day: input.day,
+            pageIndex: input.pageIndex,
+            pageCount: input.pageCount,
+            warCountByPlayerTag: input.warCountByPlayerTag,
+            validation: input.validation,
+          }),
       ),
     )
     .setFooter({
@@ -1626,11 +1602,17 @@ async function handleRotationShowSubcommand(interaction: ChatInputCommandInterac
       season: planView.season,
       roundDay: dayEntry.roundDay,
     });
+    const warCountByPlayerTag = await cwlStateService.getParticipationCountsForClanDay({
+      clanTag: planView.clanTag,
+      season: planView.season,
+      throughRoundDay: dayEntry.roundDay,
+    });
     return buildCwlRotationShowPageEmbed({
       plan: planView,
       day: dayEntry,
       pageIndex,
       pageCount: relevantDays.length,
+      warCountByPlayerTag,
       validation: validation
         ? {
             actualAvailable: validation.actualAvailable,
@@ -2051,6 +2033,11 @@ export async function handleCwlRotationShowButtonInteraction(
     season: planView.season,
     roundDay: dayEntry.roundDay,
   });
+  const warCountByPlayerTag = await cwlStateService.getParticipationCountsForClanDay({
+    clanTag: planView.clanTag,
+    season: planView.season,
+    throughRoundDay: dayEntry.roundDay,
+  });
 
   await interaction.update({
     embeds: [
@@ -2059,6 +2046,7 @@ export async function handleCwlRotationShowButtonInteraction(
         day: dayEntry,
         pageIndex,
         pageCount: relevantDays.length,
+        warCountByPlayerTag,
         validation: validation
           ? {
               actualAvailable: validation.actualAvailable,

--- a/src/services/CwlStateService.ts
+++ b/src/services/CwlStateService.ts
@@ -1109,6 +1109,53 @@ export class CwlStateService {
     };
   }
 
+  /** Purpose: load per-player CWL participation counts through one round day from persisted actual rounds. */
+  async getParticipationCountsForClanDay(input: {
+    clanTag: string;
+    season?: string;
+    throughRoundDay: number;
+  }): Promise<Map<string, number>> {
+    const season = input.season ?? resolveCurrentCwlSeasonKey();
+    const clanTag = normalizeClanTag(input.clanTag);
+    const throughRoundDay = Math.max(1, Math.trunc(Number(input.throughRoundDay) || 0));
+    if (!clanTag || throughRoundDay <= 0) {
+      return new Map();
+    }
+
+    const [historyMembers, currentMembers] = await Promise.all([
+      prisma.cwlRoundMemberHistory.findMany({
+        where: {
+          season,
+          clanTag,
+          roundDay: { lte: throughRoundDay },
+          subbedIn: true,
+        },
+        select: {
+          playerTag: true,
+        },
+      }),
+      prisma.cwlRoundMemberCurrent.findMany({
+        where: {
+          season,
+          clanTag,
+          roundDay: { lte: throughRoundDay },
+          subbedIn: true,
+        },
+        select: {
+          playerTag: true,
+        },
+      }),
+    ]);
+
+    const countsByPlayerTag = new Map<string, number>();
+    for (const row of [...historyMembers, ...currentMembers]) {
+      const playerTag = normalizePlayerTag(row.playerTag);
+      if (!playerTag) continue;
+      countsByPlayerTag.set(playerTag, (countsByPlayerTag.get(playerTag) ?? 0) + 1);
+    }
+    return countsByPlayerTag;
+  }
+
   /** Purpose: load one persisted actual CWL lineup for a requested round day from current, history, or live prep snapshot owners. */
   async getActualLineupForDay(input: {
     clanTag: string;

--- a/tests/cwl.command.test.ts
+++ b/tests/cwl.command.test.ts
@@ -148,6 +148,10 @@ function getComponentSelectMenuOptions(interaction: any): Array<{ label: string;
   return [];
 }
 
+function makeParticipationCounts(entries: Array<[string, number]>): Map<string, number> {
+  return new Map(entries);
+}
+
 describe("/cwl command", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -161,6 +165,7 @@ describe("/cwl command", () => {
     vi.spyOn(cwlRotationService, "listActivePlanExports");
     vi.spyOn(cwlRotationService, "getPreferredDisplayDay").mockResolvedValue(null);
     vi.spyOn(cwlRotationService, "validatePlanDay");
+    vi.spyOn(cwlStateService, "getParticipationCountsForClanDay").mockResolvedValue(new Map());
   });
 
   it("renders the persisted season roster with current round summary for /cwl members", async () => {
@@ -345,6 +350,25 @@ describe("/cwl command", () => {
         actualPlayerTags: ["#VJQ28888", "#CUV02898"],
         actualPlayerNames: ["Charlie", "Delta"],
       } as any);
+    vi.mocked(cwlStateService.getParticipationCountsForClanDay).mockImplementation(async ({ throughRoundDay }) => {
+      if (throughRoundDay === 1) {
+        return makeParticipationCounts([
+          ["#PYLQ0289", 1],
+          ["#VJQ28888", 1],
+          ["#QGRJ2222", 0],
+          ["#CUV02898", 0],
+        ]);
+      }
+      if (throughRoundDay === 2) {
+        return makeParticipationCounts([
+          ["#PYLQ0289", 1],
+          ["#VJQ28888", 2],
+          ["#QGRJ2222", 0],
+          ["#CUV02898", 1],
+        ]);
+      }
+      return new Map();
+    });
     const interaction = makeInteraction({
       group: "rotations",
       subcommand: "show",
@@ -362,10 +386,10 @@ describe("/cwl command", () => {
     expect(getDescription(interaction)).toContain("Day 1");
     expect(getDescription(interaction)).toContain(":white_check_mark: Alpha (#PYLQ0289) | War count: 1");
     expect(getDescription(interaction)).toContain(
-      ":warning: Charlie (#VJQ28888) | War count: 0 - Expected Bravo (#QGRJ2222)",
+      ":warning: Charlie (#VJQ28888) | War count: 1 - Expected Bravo (#QGRJ2222)",
     );
-    expect(getDescription(interaction)).toContain(":x: Bravo (#QGRJ2222) | War count: 1");
-    expect(getDescription(interaction)).toContain(":x: Delta (#CUV02898) | War count: 1");
+    expect(getDescription(interaction)).toContain(":x: Bravo (#QGRJ2222) | War count: 0");
+    expect(getDescription(interaction)).toContain(":x: Delta (#CUV02898) | War count: 0");
     expect(getDescription(interaction)).not.toContain(":x: Hotel (#JQJQ2222)");
     expect(getDescription(interaction)).not.toContain("Actual:");
     expect(getDescription(interaction)).not.toContain("Status:");
@@ -384,10 +408,10 @@ describe("/cwl command", () => {
 
     expect(getUpdatedDescription(buttonInteraction)).toContain("Day 2");
     expect(getUpdatedDescription(buttonInteraction)).toContain(
-      ":white_check_mark: Charlie (#VJQ28888) | War count: 1",
+      ":white_check_mark: Charlie (#VJQ28888) | War count: 2",
     );
     expect(getUpdatedDescription(buttonInteraction)).toContain(
-      ":white_check_mark: Delta (#CUV02898) | War count: 2",
+      ":white_check_mark: Delta (#CUV02898) | War count: 1",
     );
     expect(getUpdatedDescription(buttonInteraction)).not.toContain("Actual:");
     expect(getUpdatedDescription(buttonInteraction)).not.toContain("Status:");
@@ -433,6 +457,12 @@ describe("/cwl command", () => {
       actualPlayerTags: ["#VJQ28888", "#CUV02898"],
       actualPlayerNames: ["Charlie", "Delta"],
     } as any);
+    vi.mocked(cwlStateService.getParticipationCountsForClanDay).mockResolvedValue(
+      makeParticipationCounts([
+        ["#VJQ28888", 1],
+        ["#CUV02898", 1],
+      ]),
+    );
     const interaction = makeInteraction({
       group: "rotations",
       subcommand: "show",
@@ -479,6 +509,12 @@ describe("/cwl command", () => {
       actualPlayerTags: ["#VJQ28888", "#CUV02898"],
       actualPlayerNames: ["Charlie", "Delta"],
     } as any);
+    vi.mocked(cwlStateService.getParticipationCountsForClanDay).mockResolvedValue(
+      makeParticipationCounts([
+        ["#VJQ28888", 1],
+        ["#CUV02898", 1],
+      ]),
+    );
     const interaction = makeInteraction({
       group: "rotations",
       subcommand: "show",
@@ -542,6 +578,57 @@ describe("/cwl command", () => {
     expect(getDescription(interaction)).not.toContain("Status:");
   });
 
+  it("shows zero war count for a day-2 benched member who has not actually participated yet", async () => {
+    vi.mocked(cwlRotationService.listActivePlanExports).mockResolvedValue([
+      {
+        season: "2026-04",
+        clanTag: "#2C0UURLQU",
+        clanName: "Rising Crowns",
+        version: 2,
+        warningSummary: null,
+        excludedPlayerTags: [],
+        days: [
+          {
+            roundDay: 2,
+            lineupSize: 2,
+            rows: [
+              { playerTag: "#2JVRPVGLQ", playerName: "ChipsAreTasty", subbedOut: true, assignmentOrder: 0 },
+              { playerTag: "#PYLQ0289", playerName: "Alpha", subbedOut: false, assignmentOrder: 1 },
+            ],
+            actual: null,
+          },
+        ],
+      } as any,
+    ]);
+    vi.mocked(cwlRotationService.validatePlanDay).mockResolvedValue({
+      actualAvailable: false,
+      complete: false,
+      missingExpectedPlayerTags: [],
+      extraActualPlayerTags: [],
+      actualPlayerTags: [],
+      actualPlayerNames: [],
+    } as any);
+    vi.mocked(cwlStateService.getParticipationCountsForClanDay).mockResolvedValue(
+      makeParticipationCounts([
+        ["#2JVRPVGLQ", 0],
+        ["#PYLQ0289", 1],
+      ]),
+    );
+    const interaction = makeInteraction({
+      group: "rotations",
+      subcommand: "show",
+      clan: "#2C0UURLQU",
+      day: 2,
+    });
+
+    await Cwl.run({} as any, interaction as any);
+
+    expect(getDescription(interaction)).toContain("Day 2");
+    expect(getDescription(interaction)).toContain("Actual lineup unavailable");
+    expect(getDescription(interaction)).toContain(":x: ChipsAreTasty (#2JVRPVGLQ) | War count: 0");
+    expect(getDescription(interaction)).not.toContain("War count: 1");
+  });
+
   it("appends trailing missing expected rows when actual lineup runs short", async () => {
     vi.mocked(cwlRotationService.listActivePlanExports).mockResolvedValue([
       {
@@ -573,6 +660,14 @@ describe("/cwl command", () => {
       actualPlayerTags: ["#PYLQ0289", "#VJQ28888"],
       actualPlayerNames: ["Echo", "Zulu"],
     } as any);
+    vi.mocked(cwlStateService.getParticipationCountsForClanDay).mockResolvedValue(
+      makeParticipationCounts([
+        ["#PYLQ0289", 1],
+        ["#VJQ28888", 0],
+        ["#QGRJ2222", 0],
+        ["#CUV02898", 0],
+      ]),
+    );
     const interaction = makeInteraction({
       group: "rotations",
       subcommand: "show",
@@ -586,8 +681,8 @@ describe("/cwl command", () => {
     expect(getDescription(interaction)).toContain(
       ":warning: Zulu (#VJQ28888) | War count: 0 - Expected Foxtrot (#QGRJ2222)",
     );
-    expect(getDescription(interaction)).toContain(":x: Foxtrot (#QGRJ2222) | War count: 1");
-    expect(getDescription(interaction)).toContain(":x: Golf (#CUV02898) | War count: 1");
+    expect(getDescription(interaction)).toContain(":x: Foxtrot (#QGRJ2222) | War count: 0");
+    expect(getDescription(interaction)).toContain(":x: Golf (#CUV02898) | War count: 0");
     expect(getDescription(interaction)).not.toContain("Actual:");
     expect(getDescription(interaction)).not.toContain("Status:");
   });
@@ -621,6 +716,9 @@ describe("/cwl command", () => {
       actualPlayerTags: ["#VJQ28888"],
       actualPlayerNames: ["Visitor"],
     } as any);
+    vi.mocked(cwlStateService.getParticipationCountsForClanDay).mockResolvedValue(
+      makeParticipationCounts([["#VJQ28888", 0]]),
+    );
     const interaction = makeInteraction({
       group: "rotations",
       subcommand: "show",

--- a/tests/cwlState.service.test.ts
+++ b/tests/cwlState.service.test.ts
@@ -668,6 +668,50 @@ describe("CwlStateService", () => {
     expect(prismaMock.currentCwlPrepSnapshot.findUnique).toHaveBeenCalledTimes(1);
   });
 
+  it("counts persisted participation through the requested day from current and history member rows", async () => {
+    prismaMock.cwlRoundMemberHistory.findMany.mockResolvedValue([
+      { playerTag: "#PYLQ0289" },
+      { playerTag: "#PYLQ0289" },
+      { playerTag: "#QGRJ2222" },
+    ]);
+    prismaMock.cwlRoundMemberCurrent.findMany.mockResolvedValue([
+      { playerTag: "#PYLQ0289" },
+      { playerTag: "#VJQ28888" },
+    ]);
+
+    const counts = await cwlStateService.getParticipationCountsForClanDay({
+      clanTag: "#2QG2C08UP",
+      season: "2026-04",
+      throughRoundDay: 2,
+    });
+
+    expect(prismaMock.cwlRoundMemberHistory.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          season: "2026-04",
+          clanTag: "#2QG2C08UP",
+          roundDay: { lte: 2 },
+          subbedIn: true,
+        }),
+        select: { playerTag: true },
+      }),
+    );
+    expect(prismaMock.cwlRoundMemberCurrent.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          season: "2026-04",
+          clanTag: "#2QG2C08UP",
+          roundDay: { lte: 2 },
+          subbedIn: true,
+        }),
+        select: { playerTag: true },
+      }),
+    );
+    expect(counts.get("#PYLQ0289")).toBe(3);
+    expect(counts.get("#QGRJ2222")).toBe(1);
+    expect(counts.get("#VJQ28888")).toBe(1);
+  });
+
   it("builds a DB-first season roster view with linked-user and current-round context", async () => {
     prismaMock.cwlPlayerClanSeason.findMany.mockResolvedValue([
       {


### PR DESCRIPTION
- source show-page war counts from persisted actual CWL rounds instead of the exported plan
- add day-cutoff participation counting for the show command and regression coverage for day 2