### PR TITLE
feat(cwl): keep visible subbed-out members in show output

### DIFF
--- a/src/commands/Cwl.ts
+++ b/src/commands/Cwl.ts
@@ -283,6 +283,12 @@ function buildCwlRotationMergedRosterLines(input: {
     }),
   );
 
+  lines.push(
+    ...plannedBenchMembers.map(
+      (member) => `:x: ${member.playerName} (${member.playerTag}) | War count: ${member.warCount}`,
+    ),
+  );
+
   if (lines.length <= 0) {
     lines.push("No actual lineup members.");
   }
@@ -1035,6 +1041,11 @@ function buildCwlRotationShowPageLines(input: {
     actualPlayerRows: Array<{ playerTag: string; playerName: string }>;
   } | null;
 }): string[] {
+  const visibleDayRows = cwlRotationService.getVisibleRotationShowDayRows({
+    excludedPlayerTags: input.plan.excludedPlayerTags,
+    days: input.plan.days,
+    day: input.day,
+  });
   const lines: string[] = [
     `Season: ${input.plan.season}`,
     `Clan: ${input.plan.clanName || input.plan.clanTag}`,
@@ -1055,7 +1066,7 @@ function buildCwlRotationShowPageLines(input: {
     lines.push(
       ...buildCwlRotationMergedRosterLines({
         warCountByPlayerTag: input.warCountByPlayerTag,
-        plannedMembers: input.day.rows,
+        plannedMembers: visibleDayRows,
         actualPlayerRows: [],
         actualAvailable: false,
       }).slice(1),
@@ -1064,7 +1075,7 @@ function buildCwlRotationShowPageLines(input: {
     lines.push(
       ...buildCwlRotationMergedRosterLines({
         warCountByPlayerTag: input.warCountByPlayerTag,
-        plannedMembers: input.day.rows,
+        plannedMembers: visibleDayRows,
         actualPlayerRows: input.validation.actualPlayerRows,
         actualAvailable: input.validation.actualAvailable,
       }),

--- a/src/services/CwlRotationService.ts
+++ b/src/services/CwlRotationService.ts
@@ -327,6 +327,40 @@ function buildRosterRowsForMetadata(roster: CwlSeasonRosterEntry[]): Array<{
   }));
 }
 
+function shouldShowRotationSubbedOutMember(input: {
+  playerTag: string;
+  excludedPlayerTags: string[];
+  scheduledInTagSet: Set<string>;
+}): boolean {
+  const playerTag = normalizePlayerTag(input.playerTag);
+  if (!playerTag) return false;
+  const excludedTagSet = new Set(
+    input.excludedPlayerTags.map((tag) => normalizePlayerTag(tag)).filter(Boolean),
+  );
+  if (excludedTagSet.has(playerTag)) return false;
+  return input.scheduledInTagSet.has(playerTag);
+}
+
+function buildRotationShowScheduledInTagSet(input: {
+  days: Array<{
+    rows: Array<{
+      playerTag: string;
+      subbedOut: boolean;
+    }>;
+  }>;
+}): Set<string> {
+  const scheduledInTagSet = new Set<string>();
+  for (const day of input.days) {
+    for (const row of day.rows) {
+      if (row.subbedOut) continue;
+      const playerTag = normalizePlayerTag(row.playerTag);
+      if (!playerTag) continue;
+      scheduledInTagSet.add(playerTag);
+    }
+  }
+  return scheduledInTagSet;
+}
+
 function sanitizeDisplayText(input: unknown): string {
   return String(input ?? "")
     .replace(/\s+/g, " ")
@@ -487,6 +521,44 @@ async function persistRotationPlanVersion(
 
 /** Purpose: own CWL rotation-plan generation and validation using persisted CWL state only. */
 export class CwlRotationService {
+  /** Purpose: determine which planned day rows should be rendered for CWL show pages. */
+  getVisibleRotationShowDayRows(input: {
+    excludedPlayerTags: string[];
+    days: Array<{
+      rows: Array<{
+        playerTag: string;
+        playerName: string;
+        subbedOut: boolean;
+        assignmentOrder: number;
+      }>;
+    }>;
+    day: {
+      rows: Array<{
+        playerTag: string;
+        playerName: string;
+        subbedOut: boolean;
+        assignmentOrder: number;
+      }>;
+    };
+  }): Array<{
+    playerTag: string;
+    playerName: string;
+    subbedOut: boolean;
+    assignmentOrder: number;
+  }> {
+    const scheduledInTagSet = buildRotationShowScheduledInTagSet({
+      days: input.days,
+    });
+    return input.day.rows.filter((row) => {
+      if (!row.subbedOut) return true;
+      return shouldShowRotationSubbedOutMember({
+        playerTag: row.playerTag,
+        excludedPlayerTags: input.excludedPlayerTags,
+        scheduledInTagSet,
+      });
+    });
+  }
+
   async getPreferredDisplayDay(input: {
     clanTag: string;
     season?: string;

--- a/tests/cwl.command.test.ts
+++ b/tests/cwl.command.test.ts
@@ -324,7 +324,7 @@ describe("/cwl command", () => {
             roundDay: 2,
             lineupSize: 2,
             rows: [
-              { playerTag: "#VJQ28888", playerName: "Charlie", subbedOut: false, assignmentOrder: 0 },
+              { playerTag: "#JQJQ2222", playerName: "Hotel", subbedOut: false, assignmentOrder: 0 },
               { playerTag: "#CUV02898", playerName: "Delta", subbedOut: false, assignmentOrder: 1 },
             ],
             actual: null,
@@ -347,8 +347,8 @@ describe("/cwl command", () => {
         complete: true,
         missingExpectedPlayerTags: [],
         extraActualPlayerTags: [],
-        actualPlayerTags: ["#VJQ28888", "#CUV02898"],
-        actualPlayerNames: ["Charlie", "Delta"],
+        actualPlayerTags: ["#JQJQ2222", "#CUV02898"],
+        actualPlayerNames: ["Hotel", "Delta"],
       } as any);
     vi.mocked(cwlStateService.getParticipationCountsForClanDay).mockImplementation(async ({ throughRoundDay }) => {
       if (throughRoundDay === 1) {
@@ -362,7 +362,7 @@ describe("/cwl command", () => {
       if (throughRoundDay === 2) {
         return makeParticipationCounts([
           ["#PYLQ0289", 1],
-          ["#VJQ28888", 2],
+          ["#JQJQ2222", 1],
           ["#QGRJ2222", 0],
           ["#CUV02898", 1],
         ]);
@@ -390,7 +390,7 @@ describe("/cwl command", () => {
     );
     expect(getDescription(interaction)).toContain(":x: Bravo (#QGRJ2222) | War count: 0");
     expect(getDescription(interaction)).toContain(":x: Delta (#CUV02898) | War count: 0");
-    expect(getDescription(interaction)).not.toContain(":x: Hotel (#JQJQ2222)");
+    expect(getDescription(interaction)).toContain(":x: Hotel (#JQJQ2222) | War count: 0");
     expect(getDescription(interaction)).not.toContain("Actual:");
     expect(getDescription(interaction)).not.toContain("Status:");
     expect(getComponentButtonCustomIds(interaction)).toHaveLength(2);
@@ -408,7 +408,7 @@ describe("/cwl command", () => {
 
     expect(getUpdatedDescription(buttonInteraction)).toContain("Day 2");
     expect(getUpdatedDescription(buttonInteraction)).toContain(
-      ":white_check_mark: Charlie (#VJQ28888) | War count: 2",
+      ":white_check_mark: Hotel (#JQJQ2222) | War count: 1",
     );
     expect(getUpdatedDescription(buttonInteraction)).toContain(
       ":white_check_mark: Delta (#CUV02898) | War count: 1",
@@ -573,7 +573,7 @@ describe("/cwl command", () => {
 
     expect(getDescription(interaction)).toContain("Day 7");
     expect(getDescription(interaction)).toContain("Actual lineup unavailable");
-    expect(getDescription(interaction)).toContain(":x: Hotel (#JQJQ2222) | War count: 0");
+    expect(getDescription(interaction)).not.toContain(":x: Hotel (#JQJQ2222)");
     expect(getDescription(interaction)).not.toContain("Actual:");
     expect(getDescription(interaction)).not.toContain("Status:");
   });
@@ -594,6 +594,15 @@ describe("/cwl command", () => {
             rows: [
               { playerTag: "#2JVRPVGLQ", playerName: "ChipsAreTasty", subbedOut: true, assignmentOrder: 0 },
               { playerTag: "#PYLQ0289", playerName: "Alpha", subbedOut: false, assignmentOrder: 1 },
+            ],
+            actual: null,
+          },
+          {
+            roundDay: 3,
+            lineupSize: 2,
+            rows: [
+              { playerTag: "#2JVRPVGLQ", playerName: "ChipsAreTasty", subbedOut: false, assignmentOrder: 0 },
+              { playerTag: "#QGRJ2222", playerName: "Bravo", subbedOut: false, assignmentOrder: 1 },
             ],
             actual: null,
           },

--- a/tests/cwlRotation.service.test.ts
+++ b/tests/cwlRotation.service.test.ts
@@ -566,4 +566,71 @@ describe("CwlRotationService", () => {
       roundDay: 4,
     });
   });
+
+  it("shows subbed-out members when a create-backed schedule includes them elsewhere and they were not excluded", () => {
+    const visibleRows = cwlRotationService.getVisibleRotationShowDayRows({
+      excludedPlayerTags: ["#CUV02898"],
+      days: [
+        {
+          rows: [
+            { playerTag: "#PYLQ0289", playerName: "Active One", subbedOut: false, assignmentOrder: 0 },
+            { playerTag: "#QGRJ2222", playerName: "Bench Later", subbedOut: true, assignmentOrder: 1 },
+            { playerTag: "#CUV02898", playerName: "Excluded", subbedOut: true, assignmentOrder: 2 },
+            { playerTag: "#JQJQ2222", playerName: "Never", subbedOut: true, assignmentOrder: 3 },
+          ],
+        },
+        {
+          rows: [
+            { playerTag: "#QGRJ2222", playerName: "Bench Later", subbedOut: false, assignmentOrder: 0 },
+            { playerTag: "#PYLQ0289", playerName: "Active One", subbedOut: false, assignmentOrder: 1 },
+          ],
+        },
+      ],
+      day: {
+        rows: [
+          { playerTag: "#PYLQ0289", playerName: "Active One", subbedOut: false, assignmentOrder: 0 },
+          { playerTag: "#QGRJ2222", playerName: "Bench Later", subbedOut: true, assignmentOrder: 1 },
+          { playerTag: "#CUV02898", playerName: "Excluded", subbedOut: true, assignmentOrder: 2 },
+          { playerTag: "#JQJQ2222", playerName: "Never", subbedOut: true, assignmentOrder: 3 },
+        ],
+      },
+    });
+
+    expect(visibleRows).toEqual([
+      { playerTag: "#PYLQ0289", playerName: "Active One", subbedOut: false, assignmentOrder: 0 },
+      { playerTag: "#QGRJ2222", playerName: "Bench Later", subbedOut: true, assignmentOrder: 1 },
+    ]);
+  });
+
+  it("shows imported subbed-out members only when they are scheduled in somewhere in the effective plan", () => {
+    const visibleRows = cwlRotationService.getVisibleRotationShowDayRows({
+      excludedPlayerTags: [],
+      days: [
+        {
+          rows: [
+            { playerTag: "#PYLQ0289", playerName: "Active One", subbedOut: false, assignmentOrder: 0 },
+            { playerTag: "#QGRJ2222", playerName: "Bench Later", subbedOut: true, assignmentOrder: 1 },
+            { playerTag: "#JQJQ2222", playerName: "Never", subbedOut: true, assignmentOrder: 2 },
+          ],
+        },
+        {
+          rows: [
+            { playerTag: "#QGRJ2222", playerName: "Bench Later", subbedOut: false, assignmentOrder: 0 },
+          ],
+        },
+      ],
+      day: {
+        rows: [
+          { playerTag: "#PYLQ0289", playerName: "Active One", subbedOut: false, assignmentOrder: 0 },
+          { playerTag: "#QGRJ2222", playerName: "Bench Later", subbedOut: true, assignmentOrder: 1 },
+          { playerTag: "#JQJQ2222", playerName: "Never", subbedOut: true, assignmentOrder: 2 },
+        ],
+      },
+    });
+
+    expect(visibleRows).toEqual([
+      { playerTag: "#PYLQ0289", playerName: "Active One", subbedOut: false, assignmentOrder: 0 },
+      { playerTag: "#QGRJ2222", playerName: "Bench Later", subbedOut: true, assignmentOrder: 1 },
+    ]);
+  });
 });


### PR DESCRIPTION
- show subbed-out members when they are scheduled in anywhere in the full CWL plan
- keep exclusions authoritative and preserve existing render order
- cover create-backed and import-backed visibility rules in tests