### PR TITLE
fix(cwl): show battle day start and suppress duplicate benches

### DIFF
--- a/src/commands/Cwl.ts
+++ b/src/commands/Cwl.ts
@@ -208,8 +208,15 @@ function buildCwlRotationMergedRosterLines(input: {
   }>;
   actualAvailable: boolean;
 }): string[] {
+  const actualTagSet = new Set(
+    input.actualPlayerRows.map((member) => normalizePlayerTag(member.playerTag)).filter(Boolean),
+  );
   const plannedBenchMembers = input.plannedMembers
     .filter((member) => member.subbedOut)
+    .filter((member) => {
+      const normalizedTag = normalizePlayerTag(member.playerTag);
+      return !normalizedTag || !actualTagSet.has(normalizedTag);
+    })
     .map((member) => ({
       playerTag: member.playerTag,
       playerName: member.playerName,
@@ -247,7 +254,6 @@ function buildCwlRotationMergedRosterLines(input: {
       warCountByPlayerTag: input.warCountByPlayerTag,
     }),
   }));
-  const actualTagSet = new Set(actualRows.map((member) => member.normalizedTag).filter(Boolean));
   const missingExpectedRows = expectedMembers.filter((member) => {
     const normalizedTag = normalizePlayerTag(member.playerTag);
     return !normalizedTag || !actualTagSet.has(normalizedTag);
@@ -1032,6 +1038,7 @@ function buildCwlRotationShowPageLines(input: {
   day: CwlRotationPlanExport["days"][number];
   pageIndex: number;
   pageCount: number;
+  battleDayStartAt: Date | null;
   warCountByPlayerTag: Map<string, number>;
   validation: {
     actualAvailable: boolean;
@@ -1051,9 +1058,7 @@ function buildCwlRotationShowPageLines(input: {
     `Clan: ${input.plan.clanName || input.plan.clanTag}`,
     `Version: ${input.plan.version}`,
   ];
-  if (input.plan.warningSummary) {
-    lines.push(`Warnings: ${input.plan.warningSummary}`);
-  }
+  lines.push(`Battle day start: ${formatRelativeTimestamp(input.battleDayStartAt)}`);
   if (input.plan.excludedPlayerTags.length > 0) {
     lines.push(`Excluded: ${input.plan.excludedPlayerTags.join(", ")}`);
   }
@@ -1090,6 +1095,7 @@ function buildCwlRotationShowPageEmbed(input: {
   day: CwlRotationPlanExport["days"][number];
   pageIndex: number;
   pageCount: number;
+  battleDayStartAt: Date | null;
   warCountByPlayerTag: Map<string, number>;
   validation: {
     actualAvailable: boolean;
@@ -1109,6 +1115,7 @@ function buildCwlRotationShowPageEmbed(input: {
             day: input.day,
             pageIndex: input.pageIndex,
             pageCount: input.pageCount,
+            battleDayStartAt: input.battleDayStartAt,
             warCountByPlayerTag: input.warCountByPlayerTag,
             validation: input.validation,
           }),
@@ -1613,6 +1620,11 @@ async function handleRotationShowSubcommand(interaction: ChatInputCommandInterac
       season: planView.season,
       roundDay: dayEntry.roundDay,
     });
+    const battleDayStartAt = await cwlStateService.getBattleDayStartForClanDay({
+      clanTag: planView.clanTag,
+      season: planView.season,
+      roundDay: dayEntry.roundDay,
+    });
     const warCountByPlayerTag = await cwlStateService.getParticipationCountsForClanDay({
       clanTag: planView.clanTag,
       season: planView.season,
@@ -1623,6 +1635,7 @@ async function handleRotationShowSubcommand(interaction: ChatInputCommandInterac
       day: dayEntry,
       pageIndex,
       pageCount: relevantDays.length,
+      battleDayStartAt,
       warCountByPlayerTag,
       validation: validation
         ? {
@@ -2044,6 +2057,11 @@ export async function handleCwlRotationShowButtonInteraction(
     season: planView.season,
     roundDay: dayEntry.roundDay,
   });
+  const battleDayStartAt = await cwlStateService.getBattleDayStartForClanDay({
+    clanTag: planView.clanTag,
+    season: planView.season,
+    roundDay: dayEntry.roundDay,
+  });
   const warCountByPlayerTag = await cwlStateService.getParticipationCountsForClanDay({
     clanTag: planView.clanTag,
     season: planView.season,
@@ -2057,6 +2075,7 @@ export async function handleCwlRotationShowButtonInteraction(
         day: dayEntry,
         pageIndex,
         pageCount: relevantDays.length,
+        battleDayStartAt,
         warCountByPlayerTag,
         validation: validation
           ? {

--- a/src/services/CwlStateService.ts
+++ b/src/services/CwlStateService.ts
@@ -235,6 +235,16 @@ type CwlPrepSnapshotOwner = CwlActualLineupOwner & {
   sourceUpdatedAt: Date;
 };
 
+type CwlDayOwnerResolution =
+  | {
+      owner: CwlActualLineupOwner;
+      source: "current" | "history";
+    }
+  | {
+      owner: CwlPrepSnapshotOwner;
+      source: "prep";
+    };
+
 function toRecordValue(value: unknown): Record<string, unknown> | null {
   if (!value || typeof value !== "object" || Array.isArray(value)) return null;
   return value as Record<string, unknown>;
@@ -371,6 +381,39 @@ function mapPreparationSnapshotToActualLineup(
       subbedOut: member.subbedOut,
     })),
   };
+}
+
+async function loadPersistedCwlDayOwner(input: {
+  clanTag: string;
+  season: string;
+  roundDay: number;
+}): Promise<CwlDayOwnerResolution | null> {
+  const currentRound = await prisma.currentCwlRound.findUnique({
+    where: { season_clanTag: { season: input.season, clanTag: input.clanTag } },
+  });
+  if (currentRound && currentRound.roundDay === input.roundDay) {
+    return { owner: currentRound, source: "current" };
+  }
+
+  const historyRound = await prisma.cwlRoundHistory.findUnique({
+    where: {
+      season_clanTag_roundDay: { season: input.season, clanTag: input.clanTag, roundDay: input.roundDay },
+    },
+  });
+  if (historyRound) {
+    return { owner: historyRound, source: "history" };
+  }
+
+  const preparationSnapshot = await prisma.currentCwlPrepSnapshot.findUnique({
+    where: {
+      season_clanTag: { season: input.season, clanTag: input.clanTag },
+    },
+  });
+  if (preparationSnapshot && preparationSnapshot.roundDay === input.roundDay) {
+    return { owner: preparationSnapshot, source: "prep" };
+  }
+
+  return null;
 }
 
 function compareRoundMembers(a: { mapPosition: number | null; playerName: string; playerTag: string }, b: { mapPosition: number | null; playerName: string; playerTag: string }): number {
@@ -1167,38 +1210,33 @@ export class CwlStateService {
     const roundDay = Math.max(1, Math.trunc(Number(input.roundDay) || 0));
     if (!clanTag || roundDay <= 0) return null;
 
-    const currentRound = await prisma.currentCwlRound.findUnique({
-      where: { season_clanTag: { season, clanTag } },
-    });
-    if (currentRound && currentRound.roundDay === roundDay) {
-      return loadPersistedCwlActualLineup({
-        owner: currentRound,
-        memberSource: "current",
-      });
+    const resolvedOwner = await loadPersistedCwlDayOwner({ clanTag, season, roundDay });
+    if (!resolvedOwner) {
+      return null;
     }
 
-    const historyRound = await prisma.cwlRoundHistory.findUnique({
-      where: {
-        season_clanTag_roundDay: { season, clanTag, roundDay },
-      },
-    });
-    if (historyRound) {
-      return loadPersistedCwlActualLineup({
-        owner: historyRound,
-        memberSource: "history",
-      });
+    if (resolvedOwner.source === "prep") {
+      return mapPreparationSnapshotToActualLineup(resolvedOwner.owner);
     }
-
-    const preparationSnapshot = await prisma.currentCwlPrepSnapshot.findUnique({
-      where: {
-        season_clanTag: { season, clanTag },
-      },
+    return loadPersistedCwlActualLineup({
+      owner: resolvedOwner.owner,
+      memberSource: resolvedOwner.source,
     });
-    if (preparationSnapshot && preparationSnapshot.roundDay === roundDay) {
-      return mapPreparationSnapshotToActualLineup(preparationSnapshot);
-    }
+  }
 
-    return null;
+  /** Purpose: load the persisted battle-day start timestamp for one requested CWL day. */
+  async getBattleDayStartForClanDay(input: {
+    clanTag: string;
+    season?: string;
+    roundDay: number;
+  }): Promise<Date | null> {
+    const season = input.season ?? resolveCurrentCwlSeasonKey();
+    const clanTag = normalizeClanTag(input.clanTag);
+    const roundDay = Math.max(1, Math.trunc(Number(input.roundDay) || 0));
+    if (!clanTag || roundDay <= 0) return null;
+
+    const resolvedOwner = await loadPersistedCwlDayOwner({ clanTag, season, roundDay });
+    return resolvedOwner?.owner.startTime ?? null;
   }
 
   /** Purpose: build one DB-first current-season CWL roster view from persisted roster and round owners. */

--- a/tests/cwl.command.test.ts
+++ b/tests/cwl.command.test.ts
@@ -165,6 +165,7 @@ describe("/cwl command", () => {
     vi.spyOn(cwlRotationService, "listActivePlanExports");
     vi.spyOn(cwlRotationService, "getPreferredDisplayDay").mockResolvedValue(null);
     vi.spyOn(cwlRotationService, "validatePlanDay");
+    vi.spyOn(cwlStateService, "getBattleDayStartForClanDay").mockResolvedValue(null);
     vi.spyOn(cwlStateService, "getParticipationCountsForClanDay").mockResolvedValue(new Map());
   });
 
@@ -324,7 +325,7 @@ describe("/cwl command", () => {
             roundDay: 2,
             lineupSize: 2,
             rows: [
-              { playerTag: "#JQJQ2222", playerName: "Hotel", subbedOut: false, assignmentOrder: 0 },
+              { playerTag: "#QGRJ2222", playerName: "Bravo", subbedOut: true, assignmentOrder: 0 },
               { playerTag: "#CUV02898", playerName: "Delta", subbedOut: false, assignmentOrder: 1 },
             ],
             actual: null,
@@ -344,11 +345,11 @@ describe("/cwl command", () => {
       } as any)
       .mockResolvedValueOnce({
         actualAvailable: true,
-        complete: true,
+        complete: false,
         missingExpectedPlayerTags: [],
-        extraActualPlayerTags: [],
-        actualPlayerTags: ["#JQJQ2222", "#CUV02898"],
-        actualPlayerNames: ["Hotel", "Delta"],
+        extraActualPlayerTags: ["#QGRJ2222"],
+        actualPlayerTags: ["#QGRJ2222", "#CUV02898"],
+        actualPlayerNames: ["Bravo", "Delta"],
       } as any);
     vi.mocked(cwlStateService.getParticipationCountsForClanDay).mockImplementation(async ({ throughRoundDay }) => {
       if (throughRoundDay === 1) {
@@ -362,12 +363,20 @@ describe("/cwl command", () => {
       if (throughRoundDay === 2) {
         return makeParticipationCounts([
           ["#PYLQ0289", 1],
-          ["#JQJQ2222", 1],
-          ["#QGRJ2222", 0],
+          ["#QGRJ2222", 1],
           ["#CUV02898", 1],
         ]);
       }
       return new Map();
+    });
+    vi.mocked(cwlStateService.getBattleDayStartForClanDay).mockImplementation(async ({ roundDay }) => {
+      if (roundDay === 1) {
+        return new Date("2026-04-03T12:00:00.000Z");
+      }
+      if (roundDay === 2) {
+        return new Date("2026-04-04T12:00:00.000Z");
+      }
+      return null;
     });
     const interaction = makeInteraction({
       group: "rotations",
@@ -381,16 +390,18 @@ describe("/cwl command", () => {
       season: "2026-04",
       clanTags: ["#2QG2C08UP"],
     });
-    expect(getDescription(interaction)).toContain("Warnings: 1 warning");
+    expect(getDescription(interaction)).toContain("Battle day start: <t:");
+    expect(getDescription(interaction)).toContain(":R>");
     expect(getDescription(interaction)).toContain("Excluded: #P9");
     expect(getDescription(interaction)).toContain("Day 1");
+    expect(getDescription(interaction)).not.toContain("Warnings:");
     expect(getDescription(interaction)).toContain(":white_check_mark: Alpha (#PYLQ0289) | War count: 1");
     expect(getDescription(interaction)).toContain(
       ":warning: Charlie (#VJQ28888) | War count: 1 - Expected Bravo (#QGRJ2222)",
     );
     expect(getDescription(interaction)).toContain(":x: Bravo (#QGRJ2222) | War count: 0");
     expect(getDescription(interaction)).toContain(":x: Delta (#CUV02898) | War count: 0");
-    expect(getDescription(interaction)).toContain(":x: Hotel (#JQJQ2222) | War count: 0");
+    expect(getDescription(interaction)).not.toContain(":x: Hotel (#JQJQ2222)");
     expect(getDescription(interaction)).not.toContain("Actual:");
     expect(getDescription(interaction)).not.toContain("Status:");
     expect(getComponentButtonCustomIds(interaction)).toHaveLength(2);
@@ -407,14 +418,90 @@ describe("/cwl command", () => {
     await handleCwlRotationShowButtonInteraction(buttonInteraction as any);
 
     expect(getUpdatedDescription(buttonInteraction)).toContain("Day 2");
+    expect(getUpdatedDescription(buttonInteraction)).toContain("Battle day start: <t:");
+    expect(getUpdatedDescription(buttonInteraction)).toContain(":R>");
     expect(getUpdatedDescription(buttonInteraction)).toContain(
-      ":white_check_mark: Hotel (#JQJQ2222) | War count: 1",
+      ":warning: Bravo (#QGRJ2222) | War count: 1",
     );
     expect(getUpdatedDescription(buttonInteraction)).toContain(
       ":white_check_mark: Delta (#CUV02898) | War count: 1",
     );
+    expect(getUpdatedDescription(buttonInteraction)).not.toContain(":x: Bravo (#QGRJ2222)");
     expect(getUpdatedDescription(buttonInteraction)).not.toContain("Actual:");
     expect(getUpdatedDescription(buttonInteraction)).not.toContain("Status:");
+  });
+
+  it("does not render a duplicate bench line when a visible subbed-out member appears in the actual lineup", async () => {
+    vi.mocked(cwlRotationService.listActivePlanExports).mockResolvedValue([
+      {
+        season: "2026-04",
+        clanTag: "#2QG2C08UP",
+        clanName: "CWL Alpha",
+        version: 5,
+        warningSummary: null,
+        excludedPlayerTags: [],
+        days: [
+          {
+            roundDay: 1,
+            lineupSize: 3,
+            rows: [
+              { playerTag: "#PYLQ0289", playerName: "Alpha", subbedOut: false, assignmentOrder: 0 },
+              { playerTag: "#QGRJ2222", playerName: "Bench Later", subbedOut: true, assignmentOrder: 1 },
+              { playerTag: "#CUV02898", playerName: "Delta", subbedOut: false, assignmentOrder: 2 },
+            ],
+            actual: null,
+          },
+          {
+            roundDay: 2,
+            lineupSize: 3,
+            rows: [
+              { playerTag: "#QGRJ2222", playerName: "Bench Later", subbedOut: false, assignmentOrder: 0 },
+              { playerTag: "#PYLQ0289", playerName: "Alpha", subbedOut: false, assignmentOrder: 1 },
+              { playerTag: "#CUV02898", playerName: "Delta", subbedOut: false, assignmentOrder: 2 },
+            ],
+            actual: null,
+          },
+        ],
+      } as any,
+    ]);
+    vi.mocked(cwlRotationService.getPreferredDisplayDay).mockResolvedValue(1);
+    vi.mocked(cwlRotationService.validatePlanDay).mockResolvedValue({
+      actualAvailable: true,
+      complete: false,
+      missingExpectedPlayerTags: [],
+      extraActualPlayerTags: ["#QGRJ2222"],
+      actualPlayerTags: ["#PYLQ0289", "#QGRJ2222", "#CUV02898"],
+      actualPlayerNames: ["Alpha", "Bench Later", "Delta"],
+    } as any);
+    vi.mocked(cwlStateService.getBattleDayStartForClanDay).mockResolvedValue(
+      new Date("2026-04-03T12:00:00.000Z"),
+    );
+    vi.mocked(cwlStateService.getParticipationCountsForClanDay).mockResolvedValue(
+      makeParticipationCounts([
+        ["#PYLQ0289", 1],
+        ["#QGRJ2222", 1],
+        ["#CUV02898", 1],
+      ]),
+    );
+    const interaction = makeInteraction({
+      group: "rotations",
+      subcommand: "show",
+      clan: "#2QG2C08UP",
+    });
+
+    await Cwl.run({} as any, interaction as any);
+
+    expect(getDescription(interaction)).toContain("Day 1");
+    expect(getDescription(interaction)).toContain("Battle day start: <t:");
+    expect(getDescription(interaction)).toContain(":white_check_mark: Alpha (#PYLQ0289) | War count: 1");
+    expect(getDescription(interaction)).toContain(
+      ":warning: Bench Later (#QGRJ2222) | War count: 1",
+    );
+    expect(getDescription(interaction)).toContain(":white_check_mark: Delta (#CUV02898) | War count: 1");
+    expect(getDescription(interaction)).not.toContain(":x: Bench Later (#QGRJ2222)");
+    expect(getDescription(interaction)).not.toContain("Warnings:");
+    expect(getDescription(interaction)).not.toContain("Actual:");
+    expect(getDescription(interaction)).not.toContain("Status:");
   });
 
   it("renders the prep-day page with merged check marks during overlap", async () => {
@@ -572,8 +659,10 @@ describe("/cwl command", () => {
     await Cwl.run({} as any, interaction as any);
 
     expect(getDescription(interaction)).toContain("Day 7");
+    expect(getDescription(interaction)).toContain("Battle day start: unknown");
     expect(getDescription(interaction)).toContain("Actual lineup unavailable");
     expect(getDescription(interaction)).not.toContain(":x: Hotel (#JQJQ2222)");
+    expect(getDescription(interaction)).not.toContain("Warnings:");
     expect(getDescription(interaction)).not.toContain("Actual:");
     expect(getDescription(interaction)).not.toContain("Status:");
   });

--- a/tests/cwlState.service.test.ts
+++ b/tests/cwlState.service.test.ts
@@ -668,6 +668,87 @@ describe("CwlStateService", () => {
     expect(prismaMock.currentCwlPrepSnapshot.findUnique).toHaveBeenCalledTimes(1);
   });
 
+  it("loads the persisted battle-day start timestamp from current, history, and prep owners", async () => {
+    prismaMock.currentCwlRound.findUnique.mockResolvedValue({
+      season: "2026-04",
+      clanTag: "#2QG2C08UP",
+      clanName: "CWL Alpha",
+      roundDay: 2,
+      roundState: "inWar",
+      opponentTag: "#OPP1",
+      opponentName: "Opponent One",
+      preparationStartTime: new Date("2026-04-02T10:00:00.000Z"),
+      startTime: new Date("2026-04-02T12:00:00.000Z"),
+      endTime: new Date("2026-04-03T12:00:00.000Z"),
+      sourceUpdatedAt: new Date("2026-04-02T00:00:00.000Z"),
+    });
+    prismaMock.cwlRoundHistory.findUnique.mockImplementation(async ({ where }: any) => {
+      if (where.season_clanTag_roundDay.roundDay === 1) {
+        return {
+          season: "2026-04",
+          clanTag: "#2QG2C08UP",
+          clanName: "CWL Alpha",
+          roundDay: 1,
+          roundState: "warEnded",
+          opponentTag: "#OPP0",
+          opponentName: "Opponent Zero",
+          preparationStartTime: new Date("2026-04-01T10:00:00.000Z"),
+          startTime: new Date("2026-04-01T12:00:00.000Z"),
+          endTime: new Date("2026-04-02T12:00:00.000Z"),
+        };
+      }
+      return null;
+    });
+    prismaMock.currentCwlPrepSnapshot.findUnique.mockImplementation(async ({ where }: any) => {
+      if (where.season_clanTag.clanTag === "#2QG2C08UP") {
+        return {
+          season: "2026-04",
+          clanTag: "#2QG2C08UP",
+          clanName: "CWL Alpha",
+          roundDay: 3,
+          roundState: "preparation",
+          opponentTag: "#OPP2",
+          opponentName: "Opponent Two",
+          preparationStartTime: new Date("2026-04-03T10:00:00.000Z"),
+          startTime: new Date("2026-04-03T12:00:00.000Z"),
+          endTime: new Date("2026-04-04T12:00:00.000Z"),
+          sourceUpdatedAt: new Date("2026-04-03T00:00:00.000Z"),
+          lineupJson: [],
+        };
+      }
+      return null;
+    });
+
+    await expect(
+      cwlStateService.getBattleDayStartForClanDay({
+        clanTag: "#2QG2C08UP",
+        season: "2026-04",
+        roundDay: 2,
+      }),
+    ).resolves.toEqual(new Date("2026-04-02T12:00:00.000Z"));
+    await expect(
+      cwlStateService.getBattleDayStartForClanDay({
+        clanTag: "#2QG2C08UP",
+        season: "2026-04",
+        roundDay: 1,
+      }),
+    ).resolves.toEqual(new Date("2026-04-01T12:00:00.000Z"));
+    await expect(
+      cwlStateService.getBattleDayStartForClanDay({
+        clanTag: "#2QG2C08UP",
+        season: "2026-04",
+        roundDay: 3,
+      }),
+    ).resolves.toEqual(new Date("2026-04-03T12:00:00.000Z"));
+    await expect(
+      cwlStateService.getBattleDayStartForClanDay({
+        clanTag: "#2QG2C08UP",
+        season: "2026-04",
+        roundDay: 4,
+      }),
+    ).resolves.toBeNull();
+  });
+
   it("counts persisted participation through the requested day from current and history member rows", async () => {
     prismaMock.cwlRoundMemberHistory.findMany.mockResolvedValue([
       { playerTag: "#PYLQ0289" },


### PR DESCRIPTION
- replace the show-page warnings header with persisted battle-day start timing
- stop rendering a bench line for players already shown in the actual lineup
- keep the subbed-out visibility rule for qualifying players who are absent