### PR TITLE
feat(cwl): add interactive rotations overview

### DIFF
--- a/src/commands/Cwl.ts
+++ b/src/commands/Cwl.ts
@@ -17,6 +17,7 @@ import { formatError } from "../helper/formatError";
 import { prisma } from "../prisma";
 import { resolveCurrentCwlSeasonKey } from "../services/CwlRegistryService";
 import { cwlRotationService } from "../services/CwlRotationService";
+import { emojiResolverService } from "../services/emoji/EmojiResolverService";
 import {
   cwlRotationSheetService,
   rebuildCwlRotationImportTabState,
@@ -32,6 +33,7 @@ const DISCORD_DESCRIPTION_LIMIT = 4096;
 const CWL_ROTATION_IMPORT_SESSION_TTL_MS = 15 * 60 * 1000;
 const CWL_ROTATION_IMPORT_SESSION_PREFIX = "cwl-rot-import";
 const CWL_ROTATION_SHOW_SESSION_PREFIX = "cwl-rot-show";
+const CWL_ROTATION_SHOW_OVERVIEW_MAX_OPTIONS = 25;
 const CWL_ROTATION_SHOW_DAY_CHOICES = [1, 2, 3, 4, 5, 6, 7].map((day) => ({
   name: `Day ${day}`,
   value: day,
@@ -93,6 +95,30 @@ function buildDescription(lines: string[]): string {
   return `${description.slice(0, DISCORD_DESCRIPTION_LIMIT - 13)}\n...truncated`;
 }
 
+function normalizeClanMemberRole(input: unknown): "leader" | "coleader" | null {
+  const normalized = String(input ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z]/g, "");
+  if (normalized === "leader") return "leader";
+  if (normalized === "coleader") return "coleader";
+  return null;
+}
+
+async function resolveCwlRotationOverviewStatusIcons(client: Client): Promise<{ yes: string; no: string }> {
+  const fallback = { yes: ":yes:", no: ":no:" };
+  try {
+    const result = await emojiResolverService.fetchApplicationEmojiInventory(client);
+    if (!result.ok) return fallback;
+    return {
+      yes: result.snapshot.exactByName.get("yes")?.rendered ?? result.snapshot.lowercaseByName.get("yes")?.rendered ?? fallback.yes,
+      no: result.snapshot.exactByName.get("no")?.rendered ?? result.snapshot.lowercaseByName.get("no")?.rendered ?? fallback.no,
+    };
+  } catch {
+    return fallback;
+  }
+}
+
 function buildCwlRotationMemberLines(input: {
   members: Array<{
     playerTag: string;
@@ -109,6 +135,32 @@ function buildCwlRotationMemberLines(input: {
     const prefix = member.subbedOut ? ":x:" : ":black_circle:";
     return `${prefix} ${member.playerName} (${member.playerTag})`;
   });
+}
+
+function buildCwlRotationOverviewLines(input: {
+  overview: Awaited<ReturnType<typeof cwlRotationService.listOverview>>;
+  statusIcons: { yes: string; no: string };
+}): string[] {
+  if (input.overview.length <= 0) {
+    return ["No active CWL rotation plans found."];
+  }
+
+  const lines: string[] = [];
+  for (const entry of input.overview) {
+    const clanName = entry.clanName || entry.clanTag;
+    const clanLabel = `${clanName} (\`${entry.clanTag}\`)`;
+    const statusEmoji = entry.status === "complete" ? input.statusIcons.yes : input.statusIcons.no;
+    const battleDayStart = formatRelativeTimestamp(entry.battleDayStartAt);
+    lines.push(`${statusEmoji} ${clanLabel} - day ${entry.roundDay ?? "unknown"} - Next Battle Day ${battleDayStart}`);
+    lines.push(
+      `- Leaders/Co-leaders: ${entry.leaderNames.length > 0 ? entry.leaderNames.join(", ") : "unknown"}`,
+    );
+    lines.push("");
+  }
+  if (lines.at(-1) === "") {
+    lines.pop();
+  }
+  return lines;
 }
 
 function getCwlRotationWarCount(input: {
@@ -972,7 +1024,7 @@ function stripCwlRotationImportSummaryWarnings(warnings: string[]): string[] {
   );
 }
 
-function buildCwlRotationShowButtonCustomId(input: {
+function buildCwlRotationShowPageCustomId(input: {
   userId: string;
   clanTag: string;
   season: string;
@@ -981,21 +1033,53 @@ function buildCwlRotationShowButtonCustomId(input: {
   return `${CWL_ROTATION_SHOW_SESSION_PREFIX}:page:${input.userId}:${input.clanTag}:${input.season}:${input.pageIndex}`;
 }
 
-function parseCwlRotationShowButtonCustomId(
-  customId: string,
-): { userId: string; clanTag: string; season: string; pageIndex: number } | null {
+function buildCwlRotationShowBackButtonCustomId(input: {
+  userId: string;
+  season: string;
+}): string {
+  return `${CWL_ROTATION_SHOW_SESSION_PREFIX}:back:${input.userId}:${input.season}`;
+}
+
+function buildCwlRotationShowSelectMenuCustomId(input: {
+  userId: string;
+  season: string;
+}): string {
+  return `${CWL_ROTATION_SHOW_SESSION_PREFIX}:select:${input.userId}:${input.season}`;
+}
+
+type CwlRotationShowCustomId =
+  | { action: "page"; userId: string; clanTag: string; season: string; pageIndex: number }
+  | { action: "back"; userId: string; season: string }
+  | { action: "select"; userId: string; season: string };
+
+function parseCwlRotationShowCustomId(customId: string): CwlRotationShowCustomId | null {
   const parts = String(customId ?? "").split(":");
-  if (parts.length < 6 || parts[0] !== CWL_ROTATION_SHOW_SESSION_PREFIX || parts[1] !== "page") return null;
+  if (parts.length < 4 || parts[0] !== CWL_ROTATION_SHOW_SESSION_PREFIX) return null;
+  const action = parts[1];
   const userId = String(parts[2] ?? "").trim();
-  const clanTag = normalizeClanTag(parts[3] ?? "");
-  const season = String(parts[4] ?? "").trim();
-  const pageIndex = Math.max(0, Math.trunc(Number(parts[5] ?? "0") || 0));
-  if (!userId || !clanTag || !season) return null;
-  return { userId, clanTag, season, pageIndex };
+  if (action === "page") {
+    if (parts.length < 6) return null;
+    const clanTag = normalizeClanTag(parts[3] ?? "");
+    const season = String(parts[4] ?? "").trim();
+    const pageIndex = Math.max(0, Math.trunc(Number(parts[5] ?? "0") || 0));
+    if (!userId || !clanTag || !season) return null;
+    return { action, userId, clanTag, season, pageIndex };
+  }
+  if (action === "back" || action === "select") {
+    const season = String(parts[3] ?? "").trim();
+    if (!userId || !season) return null;
+    return { action, userId, season };
+  }
+  return null;
 }
 
 export function isCwlRotationShowButtonCustomId(customId: string): boolean {
-  return String(customId ?? "").startsWith(`${CWL_ROTATION_SHOW_SESSION_PREFIX}:page:`);
+  const parsed = parseCwlRotationShowCustomId(customId);
+  return parsed?.action === "page" || parsed?.action === "back";
+}
+
+export function isCwlRotationShowSelectMenuCustomId(customId: string): boolean {
+  return parseCwlRotationShowCustomId(customId)?.action === "select";
 }
 
 function buildCwlRotationShowActionRows(input: {
@@ -1004,33 +1088,78 @@ function buildCwlRotationShowActionRows(input: {
   season: string;
   pageIndex: number;
   totalPages: number;
+  showBackButton: boolean;
 }): ActionRowBuilder<ButtonBuilder>[] {
-  const prevButton = new ButtonBuilder()
-    .setCustomId(
-      buildCwlRotationShowButtonCustomId({
-        userId: input.userId,
-        clanTag: input.clanTag,
-        season: input.season,
-        pageIndex: Math.max(0, input.pageIndex - 1),
-      }),
-    )
-    .setLabel("Prev")
-    .setStyle(ButtonStyle.Secondary)
-    .setDisabled(input.pageIndex <= 0);
-  const nextButton = new ButtonBuilder()
-    .setCustomId(
-      buildCwlRotationShowButtonCustomId({
-        userId: input.userId,
-        clanTag: input.clanTag,
-        season: input.season,
-        pageIndex: Math.min(Math.max(0, input.totalPages - 1), input.pageIndex + 1),
-      }),
-    )
-    .setLabel("Next")
-    .setStyle(ButtonStyle.Secondary)
-    .setDisabled(input.pageIndex >= input.totalPages - 1);
+  const components: ButtonBuilder[] = [];
+  if (input.showBackButton) {
+    components.push(
+      new ButtonBuilder()
+        .setCustomId(
+          buildCwlRotationShowBackButtonCustomId({
+            userId: input.userId,
+            season: input.season,
+          }),
+        )
+        .setLabel("Back")
+        .setStyle(ButtonStyle.Secondary),
+    );
+  }
+  components.push(
+    new ButtonBuilder()
+      .setCustomId(
+        buildCwlRotationShowPageCustomId({
+          userId: input.userId,
+          clanTag: input.clanTag,
+          season: input.season,
+          pageIndex: Math.max(0, input.pageIndex - 1),
+        }),
+      )
+      .setLabel("Prev")
+      .setStyle(ButtonStyle.Secondary)
+      .setDisabled(input.pageIndex <= 0),
+    new ButtonBuilder()
+      .setCustomId(
+        buildCwlRotationShowPageCustomId({
+          userId: input.userId,
+          clanTag: input.clanTag,
+          season: input.season,
+          pageIndex: Math.min(Math.max(0, input.totalPages - 1), input.pageIndex + 1),
+        }),
+      )
+      .setLabel("Next")
+      .setStyle(ButtonStyle.Secondary)
+      .setDisabled(input.pageIndex >= input.totalPages - 1),
+  );
 
-  return [new ActionRowBuilder<ButtonBuilder>().addComponents(prevButton, nextButton)];
+  return [new ActionRowBuilder<ButtonBuilder>().addComponents(components)];
+}
+
+function buildCwlRotationShowOverviewActionRows(input: {
+  userId: string;
+  season: string;
+  overview: Awaited<ReturnType<typeof cwlRotationService.listOverview>>;
+}): ActionRowBuilder<StringSelectMenuBuilder>[] {
+  if (input.overview.length <= 0) {
+    return [];
+  }
+  const menu = new StringSelectMenuBuilder()
+    .setCustomId(
+      buildCwlRotationShowSelectMenuCustomId({
+        userId: input.userId,
+        season: input.season,
+      }),
+    )
+    .setPlaceholder("Select a clan to open")
+    .setMinValues(1)
+    .setMaxValues(1)
+    .addOptions(
+      input.overview.slice(0, CWL_ROTATION_SHOW_OVERVIEW_MAX_OPTIONS).map((entry) => ({
+        label: (entry.clanName || entry.clanTag).slice(0, 100),
+        value: entry.clanTag,
+        description: `day ${entry.roundDay ?? "unknown"} - ${entry.status.replace(/_/g, " ")}`,
+      })),
+    );
+  return [new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(menu)];
 }
 
 function buildCwlRotationShowPageLines(input: {
@@ -1124,6 +1253,80 @@ function buildCwlRotationShowPageEmbed(input: {
     .setFooter({
       text: `Page ${input.pageIndex + 1}/${input.pageCount}`,
     });
+}
+
+async function buildCwlRotationShowOverviewPayload(input: {
+  client: Client;
+  userId: string;
+  season: string;
+  overview: Awaited<ReturnType<typeof cwlRotationService.listOverview>>;
+}): Promise<{
+  embed: EmbedBuilder;
+  components: ActionRowBuilder<StringSelectMenuBuilder>[];
+}> {
+  const statusIcons = await resolveCwlRotationOverviewStatusIcons(input.client);
+  return {
+    embed: new EmbedBuilder()
+      .setColor(CWL_EMBED_COLOR)
+      .setTitle("/cwl rotations show")
+      .setDescription(
+        buildDescription(
+          buildCwlRotationOverviewLines({
+            overview: input.overview,
+            statusIcons,
+          }),
+        ),
+      ),
+    components: buildCwlRotationShowOverviewActionRows({
+      userId: input.userId,
+      season: input.season,
+      overview: input.overview,
+    }),
+  };
+}
+
+async function buildCwlRotationShowClanPayload(input: {
+  userId: string;
+  showBackButton: boolean;
+  plan: CwlRotationPlanExport;
+  day: CwlRotationPlanExport["days"][number];
+  pageIndex: number;
+  pageCount: number;
+  battleDayStartAt: Date | null;
+  warCountByPlayerTag: Map<string, number>;
+  validation: {
+    actualAvailable: boolean;
+    complete: boolean;
+    missingExpectedPlayerTags: string[];
+    extraActualPlayerTags: string[];
+    actualPlayerRows: Array<{ playerTag: string; playerName: string }>;
+  } | null;
+}): Promise<{
+  embed: EmbedBuilder;
+  components: ActionRowBuilder<ButtonBuilder>[];
+}> {
+  return {
+    embed: buildCwlRotationShowPageEmbed({
+      plan: input.plan,
+      day: input.day,
+      pageIndex: input.pageIndex,
+      pageCount: input.pageCount,
+      battleDayStartAt: input.battleDayStartAt,
+      warCountByPlayerTag: input.warCountByPlayerTag,
+      validation: input.validation,
+    }),
+    components:
+      input.showBackButton || input.pageCount > 1
+        ? buildCwlRotationShowActionRows({
+            userId: input.userId,
+            clanTag: input.plan.clanTag,
+            season: input.plan.season,
+            pageIndex: input.pageIndex,
+            totalPages: input.pageCount,
+            showBackButton: input.showBackButton,
+          })
+        : [],
+  };
 }
 
 function buildCwlRotationImportSummaryEmbed(input: {
@@ -1557,40 +1760,22 @@ async function handleRotationCreateSubcommand(interaction: ChatInputCommandInter
   });
 }
 
-async function handleRotationShowSubcommand(interaction: ChatInputCommandInteraction) {
+async function handleRotationShowSubcommand(client: Client, interaction: ChatInputCommandInteraction) {
   const season = resolveCurrentCwlSeasonKey();
   const clanTag = normalizeClanTag(interaction.options.getString("clan", false) ?? "");
   const day = interaction.options.getInteger("day", false);
 
   if (!clanTag) {
     const overview = await cwlRotationService.listOverview({ season });
-    const lines = [
-      `Season: ${season}`,
-      "",
-      ...overview.map((entry) => {
-        const clanLabel = entry.clanName ? `${entry.clanName} (${entry.clanTag})` : entry.clanTag;
-        if (entry.status === "complete") {
-          return `${clanLabel} - day ${entry.roundDay} complete`;
-        }
-        if (entry.status === "mismatch") {
-          return `${clanLabel} - day ${entry.roundDay} mismatch - missing ${entry.missingExpectedPlayerTags.join(", ") || "none"} - extra ${entry.extraActualPlayerTags.join(", ") || "none"}`;
-        }
-        if (entry.status === "no_plan_day") {
-          return `${clanLabel} - no planned lineup for day ${entry.roundDay}`;
-        }
-        return `${clanLabel} - no active CWL round`;
-      }),
-    ];
-    if (overview.length <= 0) {
-      lines.push("No active CWL rotation plans found.");
-    }
+    const { embed, components } = await buildCwlRotationShowOverviewPayload({
+      client,
+      userId: interaction.user.id,
+      season,
+      overview,
+    });
     await interaction.editReply({
-      embeds: [
-        new EmbedBuilder()
-          .setColor(CWL_EMBED_COLOR)
-          .setTitle("/cwl rotations show")
-          .setDescription(buildDescription(lines)),
-      ],
+      embeds: [embed],
+      components,
     });
     return;
   }
@@ -1630,7 +1815,9 @@ async function handleRotationShowSubcommand(interaction: ChatInputCommandInterac
       season: planView.season,
       throughRoundDay: dayEntry.roundDay,
     });
-    return buildCwlRotationShowPageEmbed({
+    return buildCwlRotationShowClanPayload({
+      userId: interaction.user.id,
+      showBackButton: !day,
       plan: planView,
       day: dayEntry,
       pageIndex,
@@ -1664,26 +1851,15 @@ async function handleRotationShowSubcommand(interaction: ChatInputCommandInterac
       ? relevantDays.findIndex((entry) => entry.roundDay === preferredDay)
       : 0,
   );
-  const embed = await renderPage(pageIndex);
-  if (!embed) {
+  const payload = await renderPage(pageIndex);
+  if (!payload) {
     await interaction.editReply(`No planned CWL rotation day ${day ?? 1} exists for ${clanTag}.`);
     return;
   }
 
-  const components =
-    day || relevantDays.length <= 1
-      ? []
-      : buildCwlRotationShowActionRows({
-          userId: interaction.user.id,
-          clanTag: planView.clanTag,
-          season: planView.season,
-          pageIndex,
-          totalPages: relevantDays.length,
-        });
-
   await interaction.editReply({
-    embeds: [embed],
-    components,
+    embeds: [payload.embed],
+    components: payload.components,
   });
 }
 
@@ -2019,13 +2195,32 @@ export async function handleCwlRotationImportSelectMenuInteraction(
 export async function handleCwlRotationShowButtonInteraction(
   interaction: ButtonInteraction,
 ): Promise<void> {
-  const parsed = parseCwlRotationShowButtonCustomId(interaction.customId);
+  const parsed = parseCwlRotationShowCustomId(interaction.customId);
   if (!parsed) return;
   if (parsed.userId !== interaction.user.id) {
     await interaction.reply({
       content: "Only the command requester can use these buttons.",
       ephemeral: true,
     });
+    return;
+  }
+
+  if (parsed.action === "back") {
+    const overview = await cwlRotationService.listOverview({ season: parsed.season });
+    const { embed, components } = await buildCwlRotationShowOverviewPayload({
+      client: interaction.client,
+      userId: interaction.user.id,
+      season: parsed.season,
+      overview,
+    });
+    await interaction.update({
+      embeds: [embed],
+      components,
+    });
+    return;
+  }
+
+  if (parsed.action !== "page") {
     return;
   }
 
@@ -2068,38 +2263,136 @@ export async function handleCwlRotationShowButtonInteraction(
     throughRoundDay: dayEntry.roundDay,
   });
 
+  const payload = await buildCwlRotationShowClanPayload({
+    userId: interaction.user.id,
+    showBackButton: true,
+    plan: planView,
+    day: dayEntry,
+    pageIndex,
+    pageCount: relevantDays.length,
+    battleDayStartAt,
+    warCountByPlayerTag,
+    validation: validation
+      ? {
+          actualAvailable: validation.actualAvailable,
+          complete: validation.complete,
+          missingExpectedPlayerTags: validation.missingExpectedPlayerTags,
+          extraActualPlayerTags: validation.extraActualPlayerTags,
+          actualPlayerRows: validation.actualPlayerTags.map((playerTag, index) => ({
+            playerTag,
+            playerName: validation.actualPlayerNames[index] ?? playerTag,
+          })),
+        }
+      : null,
+  });
+
   await interaction.update({
-    embeds: [
-      buildCwlRotationShowPageEmbed({
-        plan: planView,
-        day: dayEntry,
-        pageIndex,
-        pageCount: relevantDays.length,
-        battleDayStartAt,
-        warCountByPlayerTag,
-        validation: validation
-          ? {
-              actualAvailable: validation.actualAvailable,
-              complete: validation.complete,
-              missingExpectedPlayerTags: validation.missingExpectedPlayerTags,
-              extraActualPlayerTags: validation.extraActualPlayerTags,
-              actualPlayerRows: validation.actualPlayerTags.map((playerTag, index) => ({
-                playerTag,
-                playerName: validation.actualPlayerNames[index] ?? playerTag,
-              })),
-            }
-          : null,
-      }),
-    ],
-    components: relevantDays.length > 1
-      ? buildCwlRotationShowActionRows({
-          userId: interaction.user.id,
-          clanTag: planView.clanTag,
-          season: planView.season,
-          pageIndex,
-          totalPages: relevantDays.length,
-        })
-      : [],
+    embeds: [payload.embed],
+    components: payload.components,
+  });
+}
+
+export async function handleCwlRotationShowSelectMenuInteraction(
+  interaction: StringSelectMenuInteraction,
+): Promise<void> {
+  const parsed = parseCwlRotationShowCustomId(interaction.customId);
+  if (!parsed || parsed.action !== "select") return;
+  if (parsed.userId !== interaction.user.id) {
+    await interaction.reply({
+      content: "Only the command requester can use these buttons.",
+      ephemeral: true,
+    });
+    return;
+  }
+
+  const season = parsed.season;
+  const clanTag = normalizeClanTag(String(interaction.values[0] ?? ""));
+  if (!clanTag) {
+    await interaction.reply({
+      content: "That CWL clan selection is not valid.",
+      ephemeral: true,
+    });
+    return;
+  }
+
+  const [planView, preferredDay] = await Promise.all([
+    cwlRotationService.listActivePlanExports({
+      season,
+      clanTags: [clanTag],
+    }).then(([plan]) => plan ?? null),
+    cwlRotationService.getPreferredDisplayDay({
+      clanTag,
+      season,
+    }),
+  ]);
+  if (!planView) {
+    await interaction.reply({
+      content: `No active CWL rotation plan exists for ${clanTag} in ${season}.`,
+      ephemeral: true,
+    });
+    return;
+  }
+
+  const relevantDays = planView.days;
+  const pageIndex = Math.max(
+    0,
+    preferredDay
+      ? relevantDays.findIndex((entry) => entry.roundDay === preferredDay)
+      : 0,
+  );
+  const dayEntry = relevantDays[pageIndex];
+  if (!dayEntry) {
+    await interaction.reply({
+      content: `No planned CWL rotation day exists for ${clanTag}.`,
+      ephemeral: true,
+    });
+    return;
+  }
+
+  const [validation, battleDayStartAt, warCountByPlayerTag] = await Promise.all([
+    cwlRotationService.validatePlanDay({
+      clanTag: planView.clanTag,
+      season: planView.season,
+      roundDay: dayEntry.roundDay,
+    }),
+    cwlStateService.getBattleDayStartForClanDay({
+      clanTag: planView.clanTag,
+      season: planView.season,
+      roundDay: dayEntry.roundDay,
+    }),
+    cwlStateService.getParticipationCountsForClanDay({
+      clanTag: planView.clanTag,
+      season: planView.season,
+      throughRoundDay: dayEntry.roundDay,
+    }),
+  ]);
+
+  const renderPayload = await buildCwlRotationShowClanPayload({
+    userId: interaction.user.id,
+    showBackButton: true,
+    plan: planView,
+    day: dayEntry,
+    pageIndex,
+    pageCount: relevantDays.length,
+    battleDayStartAt,
+    warCountByPlayerTag,
+    validation: validation
+      ? {
+          actualAvailable: validation.actualAvailable,
+          complete: validation.complete,
+          missingExpectedPlayerTags: validation.missingExpectedPlayerTags,
+          extraActualPlayerTags: validation.extraActualPlayerTags,
+          actualPlayerRows: validation.actualPlayerTags.map((playerTag, index) => ({
+            playerTag,
+            playerName: validation.actualPlayerNames[index] ?? playerTag,
+          })),
+        }
+      : null,
+  });
+
+  await interaction.update({
+    embeds: [renderPayload.embed],
+    components: renderPayload.components,
   });
 }
 
@@ -2134,7 +2427,7 @@ export const Cwl: Command = {
       options: [
         {
           name: "show",
-          description: "Show active CWL rotation status or one clan plan, one CWL day per page",
+          description: "Show the CWL overview or one clan plan, one CWL day per page",
           type: ApplicationCommandOptionType.Subcommand,
           options: [
             {
@@ -2209,7 +2502,7 @@ export const Cwl: Command = {
     },
   ],
   run: async (
-    _client: Client,
+    client: Client,
     interaction: ChatInputCommandInteraction,
   ) => {
     const visibility = interaction.options.getString("visibility", false) ?? "private";
@@ -2236,7 +2529,7 @@ export const Cwl: Command = {
         return;
       }
       if (group === "rotations" && subcommand === "show") {
-        await handleRotationShowSubcommand(interaction);
+        await handleRotationShowSubcommand(client, interaction);
         return;
       }
       await interaction.editReply("Unsupported CWL subcommand.");

--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -246,7 +246,7 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
     details: [
       "`/cwl members clan:<tag>` shows the observed current-season CWL roster for one tracked CWL clan using persisted round observations only.",
       "`/cwl members clan:<tag> inwar:true` narrows to the persisted current/prep lineup and includes current round status when available.",
-      "`/cwl rotations show` summarizes active plan-vs-actual validation across clans; add `clan` and optional `day` for a one-CWL-day-per-page plan view.",
+      "`/cwl rotations show` renders an interactive overview of active CWL plans with status, next battle-day timing, leadership summary, and a dropdown to open the detailed clan view; add `clan` and optional `day` for the per-clan page flow.",
       "`/cwl rotations create` is admin-only by default and only works during persisted CWL preparation state for the tracked clan.",
       "`/cwl rotations import` is admin-only by default and imports active planner tabs from one public Google Sheet after a confirmation preview and clan-by-clan row-review step. Structural rows may be skipped automatically, but player-like rows are never dropped silently. Public imports do not require Google Sheets credentials; export/write still does.",
       "`/cwl rotations export` is admin-only by default and writes the active planner data to a brand-new public Google Sheet using the canonical re-importable tabular format.",

--- a/src/listeners/interactionCreate.ts
+++ b/src/listeners/interactionCreate.ts
@@ -98,6 +98,8 @@ import {
   isCwlRotationImportSelectMenuCustomId,
   handleCwlRotationShowButtonInteraction,
   isCwlRotationShowButtonCustomId,
+  handleCwlRotationShowSelectMenuInteraction,
+  isCwlRotationShowSelectMenuCustomId,
 } from "../commands/Cwl";
 import {
   handleTodoPageButtonInteraction,
@@ -333,6 +335,21 @@ const handleSelectMenuInteraction = async (
         await interaction.reply({
           ephemeral: true,
           content: "Failed to update the CWL rotation import review.",
+        });
+      }
+    }
+    return;
+  }
+
+  if (isCwlRotationShowSelectMenuCustomId(interaction.customId)) {
+    try {
+      await handleCwlRotationShowSelectMenuInteraction(interaction);
+    } catch (err) {
+      console.error(`CWL rotation show select menu failed: ${formatError(err)}`);
+      if (!interaction.replied && !interaction.deferred) {
+        await interaction.reply({
+          ephemeral: true,
+          content: "Failed to update the CWL rotation show overview.",
         });
       }
     }

--- a/src/services/CwlRotationService.ts
+++ b/src/services/CwlRotationService.ts
@@ -149,10 +149,22 @@ export type CwlRotationOverviewEntry = {
   clanName: string | null;
   version: number;
   roundDay: number | null;
+  battleDayStartAt: Date | null;
+  leaderNames: string[];
   status: "complete" | "mismatch" | "no_active_round" | "no_plan_day";
   missingExpectedPlayerTags: string[];
   extraActualPlayerTags: string[];
 };
+
+function normalizeClanMemberRole(input: unknown): "leader" | "coleader" | null {
+  const normalized = String(input ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z]/g, "");
+  if (normalized === "leader") return "leader";
+  if (normalized === "coleader") return "coleader";
+  return null;
+}
 
 function compareRosterEntries(
   a: CwlSeasonRosterEntry,
@@ -996,11 +1008,64 @@ export class CwlRotationService {
       },
       orderBy: [{ clanTag: "asc" }, { version: "desc" }],
     });
+    const clanTags = [...new Set(activePlans.map((plan) => plan.clanTag).filter(Boolean))];
     const uniquePlans = new Map<string, typeof activePlans[number]>();
     for (const plan of activePlans) {
       if (!uniquePlans.has(plan.clanTag)) {
         uniquePlans.set(plan.clanTag, plan);
       }
+    }
+
+    const leaderRows = clanTags.length > 0
+      ? await prisma.fwaClanMemberCurrent.findMany({
+          where: {
+            clanTag: { in: clanTags },
+            role: { not: null },
+          },
+          select: {
+            clanTag: true,
+            playerTag: true,
+            playerName: true,
+            role: true,
+          },
+          orderBy: [
+            { clanTag: "asc" },
+            { role: "asc" },
+            { playerName: "asc" },
+            { playerTag: "asc" },
+          ],
+        })
+      : [];
+    const leaderNamesByClanTag = new Map<string, string[]>();
+    const leaderRowsByClanTag = new Map<
+      string,
+      Array<{ roleRank: number; playerName: string; playerTag: string }>
+    >();
+    for (const row of leaderRows) {
+      const clanTag = normalizeClanTag(row.clanTag);
+      const role = normalizeClanMemberRole(row.role);
+      if (!clanTag || !role) continue;
+      const roleRank = role === "leader" ? 0 : 1;
+      const entries = leaderRowsByClanTag.get(clanTag) ?? [];
+      entries.push({
+        roleRank,
+        playerName: String(row.playerName ?? "").trim() || row.playerTag,
+        playerTag: String(row.playerTag ?? "").trim() || "",
+      });
+      leaderRowsByClanTag.set(clanTag, entries);
+    }
+    for (const [clanTag, rows] of leaderRowsByClanTag.entries()) {
+      leaderNamesByClanTag.set(
+        clanTag,
+        rows
+          .sort((a, b) => {
+            if (a.roleRank !== b.roleRank) return a.roleRank - b.roleRank;
+            const byName = a.playerName.localeCompare(b.playerName, undefined, { sensitivity: "base" });
+            if (byName !== 0) return byName;
+            return a.playerTag.localeCompare(b.playerTag);
+          })
+          .map((row) => row.playerName),
+      );
     }
 
     const entries: CwlRotationOverviewEntry[] = [];
@@ -1022,6 +1087,8 @@ export class CwlRotationService {
           clanName: null,
           version: plan.version,
           roundDay: null,
+          battleDayStartAt: null,
+          leaderNames: leaderNamesByClanTag.get(plan.clanTag) ?? [],
           status: "no_active_round",
           missingExpectedPlayerTags: [],
           extraActualPlayerTags: [],
@@ -1029,11 +1096,18 @@ export class CwlRotationService {
         continue;
       }
       const targetRoundDay = preferredDay ?? currentRound.roundDay;
-      const validation = await this.validatePlanDay({
-        clanTag: plan.clanTag,
-        season,
-        roundDay: targetRoundDay,
-      });
+      const [validation, battleDayStartAt] = await Promise.all([
+        this.validatePlanDay({
+          clanTag: plan.clanTag,
+          season,
+          roundDay: targetRoundDay,
+        }),
+        cwlStateService.getBattleDayStartForClanDay({
+          clanTag: plan.clanTag,
+          season,
+          roundDay: targetRoundDay,
+        }),
+      ]);
       if (!validation || validation.plannedPlayerTags.length <= 0) {
         entries.push({
           season,
@@ -1041,6 +1115,8 @@ export class CwlRotationService {
           clanName: currentRound.clanName,
           version: plan.version,
           roundDay: targetRoundDay,
+          battleDayStartAt,
+          leaderNames: leaderNamesByClanTag.get(plan.clanTag) ?? [],
           status: "no_plan_day",
           missingExpectedPlayerTags: [],
           extraActualPlayerTags: [],
@@ -1053,6 +1129,8 @@ export class CwlRotationService {
         clanName: currentRound.clanName,
         version: plan.version,
         roundDay: targetRoundDay,
+        battleDayStartAt,
+        leaderNames: leaderNamesByClanTag.get(plan.clanTag) ?? [],
         status: validation.complete ? "complete" : "mismatch",
         missingExpectedPlayerTags: validation.missingExpectedPlayerTags,
         extraActualPlayerTags: validation.extraActualPlayerTags,

--- a/tests/cwl.command.test.ts
+++ b/tests/cwl.command.test.ts
@@ -15,12 +15,14 @@ import { Cwl } from "../src/commands/Cwl";
 import { handleCwlRotationImportButtonInteraction } from "../src/commands/Cwl";
 import { handleCwlRotationImportSelectMenuInteraction } from "../src/commands/Cwl";
 import { handleCwlRotationShowButtonInteraction } from "../src/commands/Cwl";
+import { handleCwlRotationShowSelectMenuInteraction } from "../src/commands/Cwl";
 import {
   cwlRotationSheetService,
   type CwlRotationSheetImportPreview,
 } from "../src/services/CwlRotationSheetService";
 import { cwlRotationService } from "../src/services/CwlRotationService";
 import { cwlStateService } from "../src/services/CwlStateService";
+import { emojiResolverService } from "../src/services/emoji/EmojiResolverService";
 
 function makeInteraction(input: {
   group?: "rotations" | null;
@@ -163,10 +165,33 @@ describe("/cwl command", () => {
     vi.spyOn(cwlRotationSheetService, "confirmImport");
     vi.spyOn(cwlRotationSheetService, "exportActivePlans");
     vi.spyOn(cwlRotationService, "listActivePlanExports");
+    vi.spyOn(cwlRotationService, "listOverview");
     vi.spyOn(cwlRotationService, "getPreferredDisplayDay").mockResolvedValue(null);
     vi.spyOn(cwlRotationService, "validatePlanDay");
     vi.spyOn(cwlStateService, "getBattleDayStartForClanDay").mockResolvedValue(null);
     vi.spyOn(cwlStateService, "getParticipationCountsForClanDay").mockResolvedValue(new Map());
+    vi.spyOn(emojiResolverService, "fetchApplicationEmojiInventory").mockResolvedValue({
+      ok: true,
+      snapshot: {
+        fetchedAtMs: Date.now(),
+        entries: [],
+        exactByName: new Map([
+          ["yes", { rendered: "<:yes:111>", name: "yes", shortcode: ":yes:", id: "111", animated: false }],
+          ["no", { rendered: "<:no:222>", name: "no", shortcode: ":no:", id: "222", animated: false }],
+        ]),
+        lowercaseByName: new Map([
+          ["yes", { rendered: "<:yes:111>", name: "yes", shortcode: ":yes:", id: "111", animated: false }],
+          ["no", { rendered: "<:no:222>", name: "no", shortcode: ":no:", id: "222", animated: false }],
+        ]),
+      },
+      diagnostics: {
+        applicationExistedBeforeFetch: true,
+        applicationFetchAttempted: false,
+        applicationEmojiFetchAvailable: true,
+        emojiFetchSucceeded: true,
+        fetchedEmojiCount: 2,
+      },
+    } as any);
   });
 
   it("renders the persisted season roster with current round summary for /cwl members", async () => {
@@ -267,6 +292,7 @@ describe("/cwl command", () => {
   });
 
   it("renders overview status lines for /cwl rotations show with no clan filter", async () => {
+    const alphaBattleDay = Math.floor(new Date("2026-04-03T12:00:00.000Z").getTime() / 1000);
     vi.spyOn(cwlRotationService, "listOverview").mockResolvedValue([
       {
         season: "2026-04",
@@ -274,6 +300,8 @@ describe("/cwl command", () => {
         clanName: "CWL Alpha",
         version: 1,
         roundDay: 3,
+        battleDayStartAt: new Date("2026-04-03T12:00:00.000Z"),
+        leaderNames: ["Alpha", "Bravo"],
         status: "mismatch",
         missingExpectedPlayerTags: ["#P2"],
         extraActualPlayerTags: ["#P3"],
@@ -284,6 +312,8 @@ describe("/cwl command", () => {
         clanName: "CWL Beta",
         version: 1,
         roundDay: 3,
+        battleDayStartAt: null,
+        leaderNames: [],
         status: "complete",
         missingExpectedPlayerTags: [],
         extraActualPlayerTags: [],
@@ -296,8 +326,148 @@ describe("/cwl command", () => {
 
     await Cwl.run({} as any, interaction as any);
 
-    expect(getDescription(interaction)).toContain("CWL Alpha (#2QG2C08UP) - day 3 mismatch - missing #P2 - extra #P3");
-    expect(getDescription(interaction)).toContain("CWL Beta (#9GLGQCCU) - day 3 complete");
+    expect(getDescription(interaction)).toContain(
+      `<:no:222> CWL Alpha (\`#2QG2C08UP\`) - day 3 - Next Battle Day <t:${alphaBattleDay}:R>`,
+    );
+    expect(getDescription(interaction)).toContain("- Leaders/Co-leaders: Alpha, Bravo");
+    expect(getDescription(interaction)).toContain(
+      "<:yes:111> CWL Beta (`#9GLGQCCU`) - day 3 - Next Battle Day unknown",
+    );
+    expect(getDescription(interaction)).toContain("- Leaders/Co-leaders: unknown");
+    expect(getComponentSelectMenuCustomIds(interaction)).toHaveLength(1);
+    expect(getComponentSelectMenuOptions(interaction).map((option) => option.label)).toEqual(
+      expect.arrayContaining(["CWL Alpha", "CWL Beta"]),
+    );
+  });
+
+  it("navigates from the overview dropdown into clan view and back to overview, enforcing requester-only access", async () => {
+    const alphaBattleDay = Math.floor(new Date("2026-04-03T12:00:00.000Z").getTime() / 1000);
+    vi.mocked(cwlRotationService.listOverview).mockResolvedValue([
+      {
+        season: "2026-04",
+        clanTag: "#2QG2C08UP",
+        clanName: "CWL Alpha",
+        version: 1,
+        roundDay: 2,
+        battleDayStartAt: new Date("2026-04-03T12:00:00.000Z"),
+        leaderNames: ["Alpha"],
+        status: "complete",
+        missingExpectedPlayerTags: [],
+        extraActualPlayerTags: [],
+      },
+    ] as any);
+    vi.mocked(cwlRotationService.listActivePlanExports).mockResolvedValue([
+      {
+        season: "2026-04",
+        clanTag: "#2QG2C08UP",
+        clanName: "CWL Alpha",
+        version: 4,
+        warningSummary: null,
+        excludedPlayerTags: [],
+        days: [
+          {
+            roundDay: 2,
+            lineupSize: 2,
+            rows: [
+              { playerTag: "#VJQ28888", playerName: "Charlie", subbedOut: false, assignmentOrder: 0 },
+              { playerTag: "#CUV02898", playerName: "Delta", subbedOut: false, assignmentOrder: 1 },
+            ],
+            actual: null,
+          },
+        ],
+      } as any,
+    ]);
+    vi.mocked(cwlRotationService.getPreferredDisplayDay).mockResolvedValue(2);
+    vi.mocked(cwlRotationService.validatePlanDay).mockResolvedValue({
+      actualAvailable: true,
+      complete: true,
+      missingExpectedPlayerTags: [],
+      extraActualPlayerTags: [],
+      actualPlayerTags: ["#VJQ28888", "#CUV02898"],
+      actualPlayerNames: ["Charlie", "Delta"],
+    } as any);
+    vi.mocked(cwlStateService.getBattleDayStartForClanDay).mockResolvedValue(
+      new Date("2026-04-03T12:00:00.000Z"),
+    );
+    vi.mocked(cwlStateService.getParticipationCountsForClanDay).mockResolvedValue(
+      makeParticipationCounts([
+        ["#VJQ28888", 1],
+        ["#CUV02898", 1],
+      ]),
+    );
+
+    const overviewInteraction = makeInteraction({
+      group: "rotations",
+      subcommand: "show",
+    });
+    await Cwl.run({} as any, overviewInteraction as any);
+
+    const selectId = getComponentSelectMenuCustomIds(overviewInteraction)[0];
+    expect(selectId).toBeTruthy();
+
+    const wrongUserSelect = {
+      customId: selectId,
+      values: ["#2QG2C08UP"],
+      user: { id: "222222222222222222" },
+      reply: vi.fn().mockResolvedValue(undefined),
+      update: vi.fn().mockResolvedValue(undefined),
+    };
+    await handleCwlRotationShowSelectMenuInteraction(wrongUserSelect as any);
+    expect(wrongUserSelect.reply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: "Only the command requester can use these buttons.",
+        ephemeral: true,
+      }),
+    );
+
+    const selectInteraction = {
+      customId: selectId,
+      values: ["#2QG2C08UP"],
+      user: { id: "111111111111111111" },
+      update: vi.fn().mockResolvedValue(undefined),
+      reply: vi.fn().mockResolvedValue(undefined),
+    };
+    await handleCwlRotationShowSelectMenuInteraction(selectInteraction as any);
+    expect(getUpdatedDescription(selectInteraction)).toContain("Day 2");
+    expect(getUpdatedDescription(selectInteraction)).toContain(":white_check_mark: Charlie (#VJQ28888) | War count: 1");
+    expect(getUpdatedDescription(selectInteraction)).toContain("Battle day start: <t:");
+    expect(getUpdatedDescription(selectInteraction)).toContain(":R>");
+    expect(getComponentButtonCustomIds(selectInteraction)).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining(":back:"),
+        expect.stringContaining(":page:"),
+      ]),
+    );
+
+    const wrongUserBack = {
+      customId: getComponentButtonCustomIds(selectInteraction).find((id) => id.includes(":back:")),
+      user: { id: "222222222222222222" },
+      client: {} as any,
+      update: vi.fn().mockResolvedValue(undefined),
+      reply: vi.fn().mockResolvedValue(undefined),
+    };
+    await handleCwlRotationShowButtonInteraction(wrongUserBack as any);
+    expect(wrongUserBack.reply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: "Only the command requester can use these buttons.",
+        ephemeral: true,
+      }),
+    );
+
+    const backId = getComponentButtonCustomIds(selectInteraction).find((id) => id.includes(":back:"));
+    expect(backId).toBeTruthy();
+    const backInteraction = {
+      customId: backId,
+      user: { id: "111111111111111111" },
+      client: {} as any,
+      update: vi.fn().mockResolvedValue(undefined),
+      reply: vi.fn().mockResolvedValue(undefined),
+    };
+    await handleCwlRotationShowButtonInteraction(backInteraction as any);
+    expect(getUpdatedDescription(backInteraction)).toContain(
+      `<:yes:111> CWL Alpha (\`#2QG2C08UP\`) - day 2 - Next Battle Day <t:${alphaBattleDay}:R>`,
+    );
+    expect(getComponentSelectMenuCustomIds(backInteraction)).toHaveLength(1);
   });
 
   it("renders one merged CWL day per page for /cwl rotations show", async () => {
@@ -404,7 +574,7 @@ describe("/cwl command", () => {
     expect(getDescription(interaction)).not.toContain(":x: Hotel (#JQJQ2222)");
     expect(getDescription(interaction)).not.toContain("Actual:");
     expect(getDescription(interaction)).not.toContain("Status:");
-    expect(getComponentButtonCustomIds(interaction)).toHaveLength(2);
+    expect(getComponentButtonCustomIds(interaction)).toHaveLength(3);
 
     const nextButtonId = getComponentButtonCustomIds(interaction).find((id) => id.endsWith(":1"));
     expect(nextButtonId).toBeTruthy();
@@ -429,6 +599,136 @@ describe("/cwl command", () => {
     expect(getUpdatedDescription(buttonInteraction)).not.toContain(":x: Bravo (#QGRJ2222)");
     expect(getUpdatedDescription(buttonInteraction)).not.toContain("Actual:");
     expect(getUpdatedDescription(buttonInteraction)).not.toContain("Status:");
+  });
+
+  it("navigates from the overview dropdown into clan view and back to overview, enforcing requester-only access", async () => {
+    const alphaBattleDay = Math.floor(new Date("2026-04-03T12:00:00.000Z").getTime() / 1000);
+    vi.mocked(cwlRotationService.listOverview).mockResolvedValue([
+      {
+        season: "2026-04",
+        clanTag: "#2QG2C08UP",
+        clanName: "CWL Alpha",
+        version: 1,
+        roundDay: 2,
+        battleDayStartAt: new Date("2026-04-03T12:00:00.000Z"),
+        leaderNames: ["Alpha"],
+        status: "complete",
+        missingExpectedPlayerTags: [],
+        extraActualPlayerTags: [],
+      },
+    ] as any);
+    vi.mocked(cwlRotationService.listActivePlanExports).mockResolvedValue([
+      {
+        season: "2026-04",
+        clanTag: "#2QG2C08UP",
+        clanName: "CWL Alpha",
+        version: 4,
+        warningSummary: null,
+        excludedPlayerTags: [],
+        days: [
+          {
+            roundDay: 2,
+            lineupSize: 2,
+            rows: [
+              { playerTag: "#VJQ28888", playerName: "Charlie", subbedOut: false, assignmentOrder: 0 },
+              { playerTag: "#CUV02898", playerName: "Delta", subbedOut: false, assignmentOrder: 1 },
+            ],
+            actual: null,
+          },
+        ],
+      } as any,
+    ]);
+    vi.mocked(cwlRotationService.getPreferredDisplayDay).mockResolvedValue(2);
+    vi.mocked(cwlRotationService.validatePlanDay).mockResolvedValue({
+      actualAvailable: true,
+      complete: true,
+      missingExpectedPlayerTags: [],
+      extraActualPlayerTags: [],
+      actualPlayerTags: ["#VJQ28888", "#CUV02898"],
+      actualPlayerNames: ["Charlie", "Delta"],
+    } as any);
+    vi.mocked(cwlStateService.getBattleDayStartForClanDay).mockResolvedValue(
+      new Date("2026-04-03T12:00:00.000Z"),
+    );
+    vi.mocked(cwlStateService.getParticipationCountsForClanDay).mockResolvedValue(
+      makeParticipationCounts([
+        ["#VJQ28888", 1],
+        ["#CUV02898", 1],
+      ]),
+    );
+
+    const overviewInteraction = makeInteraction({
+      group: "rotations",
+      subcommand: "show",
+    });
+    await Cwl.run({} as any, overviewInteraction as any);
+
+    const selectId = getComponentSelectMenuCustomIds(overviewInteraction)[0];
+    expect(selectId).toBeTruthy();
+
+    const wrongUserSelect = {
+      customId: selectId,
+      values: ["#2QG2C08UP"],
+      user: { id: "222222222222222222" },
+      reply: vi.fn().mockResolvedValue(undefined),
+      update: vi.fn().mockResolvedValue(undefined),
+    };
+    await handleCwlRotationShowSelectMenuInteraction(wrongUserSelect as any);
+    expect(wrongUserSelect.reply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: "Only the command requester can use these buttons.",
+        ephemeral: true,
+      }),
+    );
+
+    const selectInteraction = {
+      customId: selectId,
+      values: ["#2QG2C08UP"],
+      user: { id: "111111111111111111" },
+      update: vi.fn().mockResolvedValue(undefined),
+      reply: vi.fn().mockResolvedValue(undefined),
+    };
+    await handleCwlRotationShowSelectMenuInteraction(selectInteraction as any);
+    expect(getUpdatedDescription(selectInteraction)).toContain("Day 2");
+    expect(getUpdatedDescription(selectInteraction)).toContain(":white_check_mark: Charlie (#VJQ28888) | War count: 1");
+    expect(getUpdatedDescription(selectInteraction)).toContain("Battle day start: <t:");
+    expect(getUpdatedDescription(selectInteraction)).toContain(":R>");
+    expect(getComponentButtonCustomIds(selectInteraction)).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining(":back:"),
+        expect.stringContaining(":page:"),
+      ]),
+    );
+
+    const wrongUserBack = {
+      customId: getComponentButtonCustomIds(selectInteraction).find((id) => id.includes(":back:")),
+      user: { id: "222222222222222222" },
+      client: {} as any,
+      update: vi.fn().mockResolvedValue(undefined),
+      reply: vi.fn().mockResolvedValue(undefined),
+    };
+    await handleCwlRotationShowButtonInteraction(wrongUserBack as any);
+    expect(wrongUserBack.reply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: "Only the command requester can use these buttons.",
+        ephemeral: true,
+      }),
+    );
+
+    const backId = getComponentButtonCustomIds(selectInteraction).find((id) => id.includes(":back:"));
+    expect(backId).toBeTruthy();
+    const backInteraction = {
+      customId: backId,
+      user: { id: "111111111111111111" },
+      client: {} as any,
+      update: vi.fn().mockResolvedValue(undefined),
+      reply: vi.fn().mockResolvedValue(undefined),
+    };
+    await handleCwlRotationShowButtonInteraction(backInteraction as any);
+    expect(getUpdatedDescription(backInteraction)).toContain(
+      `<:yes:111> CWL Alpha (\`#2QG2C08UP\`) - day 2 - Next Battle Day <t:${alphaBattleDay}:R>`,
+    );
+    expect(getComponentSelectMenuCustomIds(backInteraction)).toHaveLength(1);
   });
 
   it("does not render a duplicate bench line when a visible subbed-out member appears in the actual lineup", async () => {

--- a/tests/cwlRotation.service.test.ts
+++ b/tests/cwlRotation.service.test.ts
@@ -17,8 +17,20 @@ const prismaMock = vi.hoisted(() => ({
   cwlTrackedClan: {
     findFirst: vi.fn(),
   },
+  currentCwlRound: {
+    findUnique: vi.fn(),
+  },
+  cwlRoundHistory: {
+    findUnique: vi.fn(),
+  },
+  currentCwlPrepSnapshot: {
+    findUnique: vi.fn(),
+  },
   cwlRotationPlan: {
     findFirst: vi.fn(),
+    findMany: vi.fn(),
+  },
+  fwaClanMemberCurrent: {
     findMany: vi.fn(),
   },
   cwlRotationPlanDay: {
@@ -40,8 +52,12 @@ describe("CwlRotationService", () => {
     vi.clearAllMocks();
 
     prismaMock.cwlTrackedClan.findFirst.mockResolvedValue({ tag: "#2QG2C08UP" });
+    prismaMock.currentCwlRound.findUnique.mockResolvedValue(null);
+    prismaMock.cwlRoundHistory.findUnique.mockResolvedValue(null);
+    prismaMock.currentCwlPrepSnapshot.findUnique.mockResolvedValue(null);
     prismaMock.cwlRotationPlan.findFirst.mockResolvedValue(null);
     prismaMock.cwlRotationPlan.findMany.mockResolvedValue([]);
+    prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue([]);
     prismaMock.cwlRotationPlanDay.findMany.mockResolvedValue([]);
     txMock.cwlRotationPlan.updateMany.mockResolvedValue({ count: 0 });
     txMock.cwlRotationPlan.create.mockResolvedValue({ id: "plan-1" });
@@ -367,6 +383,78 @@ describe("CwlRotationService", () => {
       extraActualPlayerTags: ["#CUV9082"],
       currentState: "preparation",
     });
+  });
+
+  it("includes leadership names and battle-day timestamps in overview entries", async () => {
+    prismaMock.cwlRotationPlan.findMany.mockResolvedValue([
+      {
+        id: "plan-1",
+        clanTag: "#2QG2C08UP",
+        season: "2026-04",
+        version: 2,
+        isActive: true,
+      },
+    ]);
+    prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue([
+      {
+        clanTag: "#2QG2C08UP",
+        playerTag: "#AAA",
+        playerName: "Alpha",
+        role: "leader",
+      },
+      {
+        clanTag: "#2QG2C08UP",
+        playerTag: "#BBB",
+        playerName: "Bravo",
+        role: "coLeader",
+      },
+    ]);
+    vi.spyOn(cwlStateService, "getCurrentRoundForClan").mockResolvedValue({
+      season: "2026-04",
+      clanTag: "#2QG2C08UP",
+      clanName: "CWL Alpha",
+      roundDay: 2,
+      roundState: "preparation",
+      opponentTag: "#OPP1",
+      opponentName: "Opponent One",
+      teamSize: 15,
+      attacksPerMember: 1,
+      preparationStartTime: new Date("2026-04-03T12:00:00.000Z"),
+      startTime: new Date("2026-04-03T12:00:00.000Z"),
+      endTime: new Date("2026-04-04T12:00:00.000Z"),
+      sourceUpdatedAt: new Date("2026-04-03T00:00:00.000Z"),
+      members: [],
+    });
+    vi.spyOn(cwlRotationService, "getPreferredDisplayDay").mockResolvedValue(2);
+    vi.spyOn(cwlStateService, "getBattleDayStartForClanDay").mockResolvedValue(
+      new Date("2026-04-03T12:00:00.000Z"),
+    );
+    vi.spyOn(cwlRotationService, "validatePlanDay").mockResolvedValue({
+      season: "2026-04",
+      clanTag: "#2QG2C08UP",
+      roundDay: 2,
+      plannedPlayerTags: ["#AAA"],
+      plannedPlayerNames: ["Alpha"],
+      actualPlayerTags: ["#AAA"],
+      actualPlayerNames: ["Alpha"],
+      missingExpectedPlayerTags: [],
+      extraActualPlayerTags: [],
+      complete: true,
+      actualAvailable: true,
+      currentState: "preparation",
+    });
+
+    const overview = await cwlRotationService.listOverview({ season: "2026-04" });
+    expect(overview).toEqual([
+      expect.objectContaining({
+        clanTag: "#2QG2C08UP",
+        clanName: "CWL Alpha",
+        roundDay: 2,
+        battleDayStartAt: new Date("2026-04-03T12:00:00.000Z"),
+        leaderNames: ["Alpha", "Bravo"],
+        status: "complete",
+      }),
+    ]);
   });
 
   it("allows create during overlap, uses the battle lineup as the seed, and locks the battle day", async () => {


### PR DESCRIPTION
- render no-arg show as a two-line per-clan overview with emoji status, timing, and leadership
- add dropdown navigation into clan pages plus back navigation to overview