### PR TITLE
feat(cwl): add clan detail refresh button

### DIFF
--- a/src/commands/Cwl.ts
+++ b/src/commands/Cwl.ts
@@ -15,6 +15,7 @@ import { randomUUID } from "crypto";
 import { Command } from "../Command";
 import { formatError } from "../helper/formatError";
 import { prisma } from "../prisma";
+import { CoCService } from "../services/CoCService";
 import { resolveCurrentCwlSeasonKey } from "../services/CwlRegistryService";
 import { cwlRotationService } from "../services/CwlRotationService";
 import { emojiResolverService } from "../services/emoji/EmojiResolverService";
@@ -1040,6 +1041,16 @@ function buildCwlRotationShowBackButtonCustomId(input: {
   return `${CWL_ROTATION_SHOW_SESSION_PREFIX}:back:${input.userId}:${input.season}`;
 }
 
+function buildCwlRotationShowRefreshButtonCustomId(input: {
+  userId: string;
+  clanTag: string;
+  season: string;
+  pageIndex: number;
+  showBackButton: boolean;
+}): string {
+  return `${CWL_ROTATION_SHOW_SESSION_PREFIX}:refresh:${input.userId}:${input.clanTag}:${input.season}:${input.pageIndex}:${input.showBackButton ? "1" : "0"}`;
+}
+
 function buildCwlRotationShowSelectMenuCustomId(input: {
   userId: string;
   season: string;
@@ -1050,6 +1061,14 @@ function buildCwlRotationShowSelectMenuCustomId(input: {
 type CwlRotationShowCustomId =
   | { action: "page"; userId: string; clanTag: string; season: string; pageIndex: number }
   | { action: "back"; userId: string; season: string }
+  | {
+      action: "refresh";
+      userId: string;
+      clanTag: string;
+      season: string;
+      pageIndex: number;
+      showBackButton: boolean;
+    }
   | { action: "select"; userId: string; season: string };
 
 function parseCwlRotationShowCustomId(customId: string): CwlRotationShowCustomId | null {
@@ -1065,6 +1084,15 @@ function parseCwlRotationShowCustomId(customId: string): CwlRotationShowCustomId
     if (!userId || !clanTag || !season) return null;
     return { action, userId, clanTag, season, pageIndex };
   }
+  if (action === "refresh") {
+    if (parts.length < 7) return null;
+    const clanTag = normalizeClanTag(parts[3] ?? "");
+    const season = String(parts[4] ?? "").trim();
+    const pageIndex = Math.max(0, Math.trunc(Number(parts[5] ?? "0") || 0));
+    const showBackButton = String(parts[6] ?? "").trim() === "1";
+    if (!userId || !clanTag || !season) return null;
+    return { action, userId, clanTag, season, pageIndex, showBackButton };
+  }
   if (action === "back" || action === "select") {
     const season = String(parts[3] ?? "").trim();
     if (!userId || !season) return null;
@@ -1075,7 +1103,7 @@ function parseCwlRotationShowCustomId(customId: string): CwlRotationShowCustomId
 
 export function isCwlRotationShowButtonCustomId(customId: string): boolean {
   const parsed = parseCwlRotationShowCustomId(customId);
-  return parsed?.action === "page" || parsed?.action === "back";
+  return parsed?.action === "page" || parsed?.action === "back" || parsed?.action === "refresh";
 }
 
 export function isCwlRotationShowSelectMenuCustomId(customId: string): boolean {
@@ -1089,8 +1117,10 @@ function buildCwlRotationShowActionRows(input: {
   pageIndex: number;
   totalPages: number;
   showBackButton: boolean;
+  loading?: boolean;
 }): ActionRowBuilder<ButtonBuilder>[] {
   const components: ButtonBuilder[] = [];
+  const loading = input.loading ?? false;
   if (input.showBackButton) {
     components.push(
       new ButtonBuilder()
@@ -1116,7 +1146,7 @@ function buildCwlRotationShowActionRows(input: {
       )
       .setLabel("Prev")
       .setStyle(ButtonStyle.Secondary)
-      .setDisabled(input.pageIndex <= 0),
+      .setDisabled(loading || input.pageIndex <= 0),
     new ButtonBuilder()
       .setCustomId(
         buildCwlRotationShowPageCustomId({
@@ -1128,7 +1158,20 @@ function buildCwlRotationShowActionRows(input: {
       )
       .setLabel("Next")
       .setStyle(ButtonStyle.Secondary)
-      .setDisabled(input.pageIndex >= input.totalPages - 1),
+      .setDisabled(loading || input.pageIndex >= input.totalPages - 1),
+    new ButtonBuilder()
+      .setCustomId(
+        buildCwlRotationShowRefreshButtonCustomId({
+          userId: input.userId,
+          clanTag: input.clanTag,
+          season: input.season,
+          pageIndex: input.pageIndex,
+          showBackButton: input.showBackButton,
+        }),
+      )
+      .setLabel(loading ? "Refreshing..." : "Refresh")
+      .setStyle(ButtonStyle.Primary)
+      .setDisabled(loading),
   );
 
   return [new ActionRowBuilder<ButtonBuilder>().addComponents(components)];
@@ -1285,6 +1328,111 @@ async function buildCwlRotationShowOverviewPayload(input: {
   };
 }
 
+async function loadCwlRotationShowClanPayload(input: {
+  userId: string;
+  season: string;
+  clanTag: string;
+  showBackButton: boolean;
+  explicitDay?: number | null;
+  pageIndex?: number | null;
+}): Promise<{
+  payload: {
+    embed: EmbedBuilder;
+    components: ActionRowBuilder<ButtonBuilder>[];
+  };
+  planView: CwlRotationPlanExport;
+  dayEntry: CwlRotationPlanExport["days"][number];
+  pageIndex: number;
+  pageCount: number;
+} | null> {
+  const [planView] = await cwlRotationService.listActivePlanExports({
+    season: input.season,
+    clanTags: [input.clanTag],
+  });
+  if (!planView) {
+    return null;
+  }
+
+  const hasExplicitDay =
+    typeof input.explicitDay === "number" && Number.isFinite(input.explicitDay) && input.explicitDay > 0;
+  const relevantDays = hasExplicitDay
+    ? planView.days.filter((entry) =>
+        entry.roundDay === Math.max(1, Math.trunc(Number(input.explicitDay) || 0)),
+      )
+    : planView.days;
+  if (hasExplicitDay && relevantDays.length <= 0) {
+    return null;
+  }
+
+  const preferredDay = hasExplicitDay
+    ? null
+    : await cwlRotationService.getPreferredDisplayDay({
+        clanTag: input.clanTag,
+        season: input.season,
+      });
+  const pageIndex =
+    typeof input.pageIndex === "number"
+      ? Math.max(0, Math.min(Math.max(0, relevantDays.length - 1), input.pageIndex))
+      : hasExplicitDay
+        ? 0
+        : Math.max(
+            0,
+            preferredDay ? relevantDays.findIndex((entry) => entry.roundDay === preferredDay) : 0,
+          );
+
+  const selectedDay = relevantDays[pageIndex];
+  if (!selectedDay) {
+    return null;
+  }
+
+  const [validation, battleDayStartAt, warCountByPlayerTag] = await Promise.all([
+    cwlRotationService.validatePlanDay({
+      clanTag: planView.clanTag,
+      season: planView.season,
+      roundDay: selectedDay.roundDay,
+    }),
+    cwlStateService.getBattleDayStartForClanDay({
+      clanTag: planView.clanTag,
+      season: planView.season,
+      roundDay: selectedDay.roundDay,
+    }),
+    cwlStateService.getParticipationCountsForClanDay({
+      clanTag: planView.clanTag,
+      season: planView.season,
+      throughRoundDay: selectedDay.roundDay,
+    }),
+  ]);
+
+  return {
+    payload: await buildCwlRotationShowClanPayload({
+      userId: input.userId,
+      showBackButton: input.showBackButton,
+      plan: planView,
+      day: selectedDay,
+      pageIndex,
+      pageCount: relevantDays.length,
+      battleDayStartAt,
+      warCountByPlayerTag,
+      validation: validation
+        ? {
+            actualAvailable: validation.actualAvailable,
+            complete: validation.complete,
+            missingExpectedPlayerTags: validation.missingExpectedPlayerTags,
+            extraActualPlayerTags: validation.extraActualPlayerTags,
+            actualPlayerRows: validation.actualPlayerTags.map((playerTag, index) => ({
+              playerTag,
+              playerName: validation.actualPlayerNames[index] ?? playerTag,
+            })),
+          }
+        : null,
+    }),
+    planView,
+    dayEntry: selectedDay,
+    pageIndex,
+    pageCount: relevantDays.length,
+  };
+}
+
 async function buildCwlRotationShowClanPayload(input: {
   userId: string;
   showBackButton: boolean;
@@ -1315,17 +1463,14 @@ async function buildCwlRotationShowClanPayload(input: {
       warCountByPlayerTag: input.warCountByPlayerTag,
       validation: input.validation,
     }),
-    components:
-      input.showBackButton || input.pageCount > 1
-        ? buildCwlRotationShowActionRows({
-            userId: input.userId,
-            clanTag: input.plan.clanTag,
-            season: input.plan.season,
-            pageIndex: input.pageIndex,
-            totalPages: input.pageCount,
-            showBackButton: input.showBackButton,
-          })
-        : [],
+    components: buildCwlRotationShowActionRows({
+      userId: input.userId,
+      clanTag: input.plan.clanTag,
+      season: input.plan.season,
+      pageIndex: input.pageIndex,
+      totalPages: input.pageCount,
+      showBackButton: input.showBackButton,
+    }),
   };
 }
 
@@ -1780,86 +1925,24 @@ async function handleRotationShowSubcommand(client: Client, interaction: ChatInp
     return;
   }
 
-  const [planView] = await cwlRotationService.listActivePlanExports({
+  const payload = await loadCwlRotationShowClanPayload({
+    userId: interaction.user.id,
     season,
-    clanTags: [clanTag],
+    clanTag,
+    showBackButton: !day,
+    explicitDay: day,
   });
-  if (!planView) {
-    await interaction.editReply(`No active CWL rotation plan exists for ${clanTag} in ${season}.`);
-    return;
-  }
-
-  const relevantDays = day
-    ? planView.days.filter((entry) => entry.roundDay === day)
-    : planView.days;
-  if (day && relevantDays.length <= 0) {
-    await interaction.editReply(`No planned CWL rotation day ${day} exists for ${clanTag}.`);
-    return;
-  }
-
-  const renderPage = async (pageIndex: number) => {
-    const dayEntry = relevantDays[pageIndex];
-    if (!dayEntry) return null;
-    const validation = await cwlRotationService.validatePlanDay({
-      clanTag: planView.clanTag,
-      season: planView.season,
-      roundDay: dayEntry.roundDay,
-    });
-    const battleDayStartAt = await cwlStateService.getBattleDayStartForClanDay({
-      clanTag: planView.clanTag,
-      season: planView.season,
-      roundDay: dayEntry.roundDay,
-    });
-    const warCountByPlayerTag = await cwlStateService.getParticipationCountsForClanDay({
-      clanTag: planView.clanTag,
-      season: planView.season,
-      throughRoundDay: dayEntry.roundDay,
-    });
-    return buildCwlRotationShowClanPayload({
-      userId: interaction.user.id,
-      showBackButton: !day,
-      plan: planView,
-      day: dayEntry,
-      pageIndex,
-      pageCount: relevantDays.length,
-      battleDayStartAt,
-      warCountByPlayerTag,
-      validation: validation
-        ? {
-            actualAvailable: validation.actualAvailable,
-            complete: validation.complete,
-            missingExpectedPlayerTags: validation.missingExpectedPlayerTags,
-            extraActualPlayerTags: validation.extraActualPlayerTags,
-            actualPlayerRows: validation.actualPlayerTags.map((playerTag, index) => ({
-              playerTag,
-              playerName: validation.actualPlayerNames[index] ?? playerTag,
-            })),
-          }
-        : null,
-    });
-  };
-
-  const preferredDay = day
-    ? day
-    : await cwlRotationService.getPreferredDisplayDay({
-        clanTag: planView.clanTag,
-        season: planView.season,
-      });
-  const pageIndex = Math.max(
-    0,
-    preferredDay
-      ? relevantDays.findIndex((entry) => entry.roundDay === preferredDay)
-      : 0,
-  );
-  const payload = await renderPage(pageIndex);
   if (!payload) {
-    await interaction.editReply(`No planned CWL rotation day ${day ?? 1} exists for ${clanTag}.`);
+    const message = day
+      ? `No planned CWL rotation day ${day} exists for ${clanTag}.`
+      : `No active CWL rotation plan exists for ${clanTag} in ${season}.`;
+    await interaction.editReply(message);
     return;
   }
 
   await interaction.editReply({
-    embeds: [payload.embed],
-    components: payload.components,
+    embeds: [payload.payload.embed],
+    components: payload.payload.components,
   });
 }
 
@@ -2194,6 +2277,7 @@ export async function handleCwlRotationImportSelectMenuInteraction(
 
 export async function handleCwlRotationShowButtonInteraction(
   interaction: ButtonInteraction,
+  cocService?: CoCService,
 ): Promise<void> {
   const parsed = parseCwlRotationShowCustomId(interaction.customId);
   if (!parsed) return;
@@ -2220,15 +2304,84 @@ export async function handleCwlRotationShowButtonInteraction(
     return;
   }
 
+  if (parsed.action === "refresh") {
+    const currentView = await loadCwlRotationShowClanPayload({
+      userId: interaction.user.id,
+      season: parsed.season,
+      clanTag: parsed.clanTag,
+      pageIndex: parsed.pageIndex,
+      showBackButton: parsed.showBackButton,
+    });
+    if (!currentView) {
+      await interaction.reply({
+        content: `No active CWL rotation plan exists for ${parsed.clanTag} in ${parsed.season}.`,
+        ephemeral: true,
+      });
+      return;
+    }
+
+    await interaction.update({
+      embeds: [currentView.payload.embed],
+      components: buildCwlRotationShowActionRows({
+        userId: interaction.user.id,
+        clanTag: parsed.clanTag,
+        season: parsed.season,
+        pageIndex: currentView.pageIndex,
+        totalPages: currentView.pageCount,
+        showBackButton: parsed.showBackButton,
+        loading: true,
+      }),
+    });
+
+    try {
+      await cwlStateService.refreshTrackedCwlStateForClan({
+        cocService: cocService ?? new CoCService(),
+        clanTag: parsed.clanTag,
+        season: parsed.season,
+      });
+      const refreshedView = await loadCwlRotationShowClanPayload({
+        userId: interaction.user.id,
+        season: parsed.season,
+        clanTag: parsed.clanTag,
+        pageIndex: parsed.pageIndex,
+        showBackButton: parsed.showBackButton,
+      });
+      if (!refreshedView) {
+        await interaction.editReply({
+          embeds: [currentView.payload.embed],
+          components: currentView.payload.components,
+        });
+        return;
+      }
+      await interaction.editReply({
+        embeds: [refreshedView.payload.embed],
+        components: refreshedView.payload.components,
+      });
+    } catch (err) {
+      await interaction.editReply({
+        embeds: [currentView.payload.embed],
+        components: currentView.payload.components,
+      });
+      await interaction.followUp({
+        ephemeral: true,
+        content: "Failed to refresh the CWL rotation view.",
+      });
+    }
+    return;
+  }
+
   if (parsed.action !== "page") {
     return;
   }
 
-  const [planView] = await cwlRotationService.listActivePlanExports({
+  const payload = await loadCwlRotationShowClanPayload({
+    userId: interaction.user.id,
     season: parsed.season,
-    clanTags: [parsed.clanTag],
+    clanTag: parsed.clanTag,
+    pageIndex: parsed.pageIndex,
+    showBackButton: true,
   });
-  if (!planView) {
+  if (!payload) {
     await interaction.reply({
       content: `No active CWL rotation plan exists for ${parsed.clanTag} in ${parsed.season}.`,
       ephemeral: true,
@@ -2236,59 +2389,9 @@ export async function handleCwlRotationShowButtonInteraction(
     return;
   }
 
-  const relevantDays = planView.days;
-  const pageIndex = Math.max(0, Math.min(relevantDays.length - 1, parsed.pageIndex));
-  const dayEntry = relevantDays[pageIndex];
-  if (!dayEntry) {
-    await interaction.reply({
-      content: `No planned CWL rotation day exists for ${parsed.clanTag}.`,
-      ephemeral: true,
-    });
-    return;
-  }
-
-  const validation = await cwlRotationService.validatePlanDay({
-    clanTag: planView.clanTag,
-    season: planView.season,
-    roundDay: dayEntry.roundDay,
-  });
-  const battleDayStartAt = await cwlStateService.getBattleDayStartForClanDay({
-    clanTag: planView.clanTag,
-    season: planView.season,
-    roundDay: dayEntry.roundDay,
-  });
-  const warCountByPlayerTag = await cwlStateService.getParticipationCountsForClanDay({
-    clanTag: planView.clanTag,
-    season: planView.season,
-    throughRoundDay: dayEntry.roundDay,
-  });
-
-  const payload = await buildCwlRotationShowClanPayload({
-    userId: interaction.user.id,
-    showBackButton: true,
-    plan: planView,
-    day: dayEntry,
-    pageIndex,
-    pageCount: relevantDays.length,
-    battleDayStartAt,
-    warCountByPlayerTag,
-    validation: validation
-      ? {
-          actualAvailable: validation.actualAvailable,
-          complete: validation.complete,
-          missingExpectedPlayerTags: validation.missingExpectedPlayerTags,
-          extraActualPlayerTags: validation.extraActualPlayerTags,
-          actualPlayerRows: validation.actualPlayerTags.map((playerTag, index) => ({
-            playerTag,
-            playerName: validation.actualPlayerNames[index] ?? playerTag,
-          })),
-        }
-      : null,
-  });
-
   await interaction.update({
-    embeds: [payload.embed],
-    components: payload.components,
+    embeds: [payload.payload.embed],
+    components: payload.payload.components,
   });
 }
 
@@ -2315,17 +2418,13 @@ export async function handleCwlRotationShowSelectMenuInteraction(
     return;
   }
 
-  const [planView, preferredDay] = await Promise.all([
-    cwlRotationService.listActivePlanExports({
-      season,
-      clanTags: [clanTag],
-    }).then(([plan]) => plan ?? null),
-    cwlRotationService.getPreferredDisplayDay({
-      clanTag,
-      season,
-    }),
-  ]);
-  if (!planView) {
+  const renderPayload = await loadCwlRotationShowClanPayload({
+    userId: interaction.user.id,
+    season,
+    clanTag,
+    showBackButton: true,
+  });
+  if (!renderPayload) {
     await interaction.reply({
       content: `No active CWL rotation plan exists for ${clanTag} in ${season}.`,
       ephemeral: true,
@@ -2333,66 +2432,9 @@ export async function handleCwlRotationShowSelectMenuInteraction(
     return;
   }
 
-  const relevantDays = planView.days;
-  const pageIndex = Math.max(
-    0,
-    preferredDay
-      ? relevantDays.findIndex((entry) => entry.roundDay === preferredDay)
-      : 0,
-  );
-  const dayEntry = relevantDays[pageIndex];
-  if (!dayEntry) {
-    await interaction.reply({
-      content: `No planned CWL rotation day exists for ${clanTag}.`,
-      ephemeral: true,
-    });
-    return;
-  }
-
-  const [validation, battleDayStartAt, warCountByPlayerTag] = await Promise.all([
-    cwlRotationService.validatePlanDay({
-      clanTag: planView.clanTag,
-      season: planView.season,
-      roundDay: dayEntry.roundDay,
-    }),
-    cwlStateService.getBattleDayStartForClanDay({
-      clanTag: planView.clanTag,
-      season: planView.season,
-      roundDay: dayEntry.roundDay,
-    }),
-    cwlStateService.getParticipationCountsForClanDay({
-      clanTag: planView.clanTag,
-      season: planView.season,
-      throughRoundDay: dayEntry.roundDay,
-    }),
-  ]);
-
-  const renderPayload = await buildCwlRotationShowClanPayload({
-    userId: interaction.user.id,
-    showBackButton: true,
-    plan: planView,
-    day: dayEntry,
-    pageIndex,
-    pageCount: relevantDays.length,
-    battleDayStartAt,
-    warCountByPlayerTag,
-    validation: validation
-      ? {
-          actualAvailable: validation.actualAvailable,
-          complete: validation.complete,
-          missingExpectedPlayerTags: validation.missingExpectedPlayerTags,
-          extraActualPlayerTags: validation.extraActualPlayerTags,
-          actualPlayerRows: validation.actualPlayerTags.map((playerTag, index) => ({
-            playerTag,
-            playerName: validation.actualPlayerNames[index] ?? playerTag,
-          })),
-        }
-      : null,
-  });
-
   await interaction.update({
-    embeds: [renderPayload.embed],
-    components: renderPayload.components,
+    embeds: [renderPayload.payload.embed],
+    components: renderPayload.payload.components,
   });
 }
 

--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -246,7 +246,7 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
     details: [
       "`/cwl members clan:<tag>` shows the observed current-season CWL roster for one tracked CWL clan using persisted round observations only.",
       "`/cwl members clan:<tag> inwar:true` narrows to the persisted current/prep lineup and includes current round status when available.",
-      "`/cwl rotations show` renders an interactive overview of active CWL plans with status, next battle-day timing, leadership summary, and a dropdown to open the detailed clan view; add `clan` and optional `day` for the per-clan page flow.",
+      "`/cwl rotations show` renders an interactive overview of active CWL plans with status, next battle-day timing, leadership summary, and a dropdown to open the detailed clan view; the clan page supports paging and manual refresh of that clan's actual CWL state.",
       "`/cwl rotations create` is admin-only by default and only works during persisted CWL preparation state for the tracked clan.",
       "`/cwl rotations import` is admin-only by default and imports active planner tabs from one public Google Sheet after a confirmation preview and clan-by-clan row-review step. Structural rows may be skipped automatically, but player-like rows are never dropped silently. Public imports do not require Google Sheets credentials; export/write still does.",
       "`/cwl rotations export` is admin-only by default and writes the active planner data to a brand-new public Google Sheet using the canonical re-importable tabular format.",

--- a/src/listeners/interactionCreate.ts
+++ b/src/listeners/interactionCreate.ts
@@ -469,7 +469,7 @@ const handleButtonInteraction = async (
 
   if (isCwlRotationShowButtonCustomId(interaction.customId)) {
     try {
-      await handleCwlRotationShowButtonInteraction(interaction);
+      await handleCwlRotationShowButtonInteraction(interaction, cocService);
     } catch (err) {
       console.error(`CWL rotation show button failed: ${formatError(err)}`);
       if (!interaction.replied && !interaction.deferred) {

--- a/src/services/CwlStateService.ts
+++ b/src/services/CwlStateService.ts
@@ -784,6 +784,34 @@ export class CwlStateService {
     });
   }
 
+  /** Purpose: refresh tracked CWL state for one clan only. */
+  async refreshTrackedCwlStateForClan(input: {
+    cocService: CoCService;
+    clanTag: string;
+    season?: string;
+    nowMs?: number;
+  }): Promise<RefreshTrackedCwlStateResult> {
+    const season = input.season ?? resolveCurrentCwlSeasonKey(input.nowMs);
+    const clanTag = normalizeClanTag(input.clanTag);
+    if (!clanTag) {
+      return {
+        season,
+        trackedClanCount: 0,
+        refreshedClanCount: 0,
+        currentRoundCount: 0,
+        currentMemberCount: 0,
+        historyRoundCount: 0,
+        historyMemberCount: 0,
+      };
+    }
+
+    return this.refreshTrackedCwlStateForClanTags({
+      cocService: input.cocService,
+      season,
+      trackedClanTags: [clanTag],
+    });
+  }
+
   /** Purpose: refresh tracked CWL state for one bounded clan-tag set. */
   private async refreshTrackedCwlStateForClanTags(input: {
     cocService: CoCService;

--- a/tests/cwl.command.test.ts
+++ b/tests/cwl.command.test.ts
@@ -78,6 +78,11 @@ function getUpdatedDescription(interaction: any): string {
   return String(payload?.embeds?.[0]?.toJSON?.().description ?? "");
 }
 
+function getEditedDescription(interaction: any): string {
+  const payload = interaction.editReply?.mock.calls.at(-1)?.[0] as any;
+  return String(payload?.embeds?.[0]?.toJSON?.().description ?? "");
+}
+
 function getComponentButtonCustomIds(interaction: any): string[] {
   const payload = (interaction.editReply?.mock.calls[0]?.[0] ?? interaction.update?.mock.calls[0]?.[0]) as any;
   const rows = Array.isArray(payload?.components) ? payload.components : [];
@@ -436,6 +441,7 @@ describe("/cwl command", () => {
       expect.arrayContaining([
         expect.stringContaining(":back:"),
         expect.stringContaining(":page:"),
+        expect.stringContaining(":refresh:"),
       ]),
     );
 
@@ -468,6 +474,159 @@ describe("/cwl command", () => {
       `<:yes:111> CWL Alpha (\`#2QG2C08UP\`) - day 2 - Next Battle Day <t:${alphaBattleDay}:R>`,
     );
     expect(getComponentSelectMenuCustomIds(backInteraction)).toHaveLength(1);
+
+    const refreshId = getComponentButtonCustomIds(selectInteraction).find((id) => id.includes(":refresh:"));
+    expect(refreshId).toBeTruthy();
+    const wrongUserRefresh = {
+      customId: refreshId,
+      user: { id: "222222222222222222" },
+      update: vi.fn().mockResolvedValue(undefined),
+      reply: vi.fn().mockResolvedValue(undefined),
+      editReply: vi.fn().mockResolvedValue(undefined),
+      followUp: vi.fn().mockResolvedValue(undefined),
+    };
+    await handleCwlRotationShowButtonInteraction(wrongUserRefresh as any, {} as any);
+    expect(wrongUserRefresh.reply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: "Only the command requester can use these buttons.",
+        ephemeral: true,
+      }),
+    );
+    const refreshSpy = vi
+      .spyOn(cwlStateService, "refreshTrackedCwlStateForClan")
+      .mockResolvedValue({
+        season: "2026-04",
+        trackedClanCount: 1,
+        refreshedClanCount: 1,
+        currentRoundCount: 1,
+        currentMemberCount: 2,
+        historyRoundCount: 0,
+        historyMemberCount: 0,
+      } as any);
+    const refreshInteraction = {
+      customId: "cwl-rot-show:refresh:111111111111111111:#2QG2C08UP:2026-04:0:1",
+      user: { id: "111111111111111111" },
+      update: vi.fn().mockResolvedValue(undefined),
+      editReply: vi.fn().mockResolvedValue(undefined),
+      followUp: vi.fn().mockResolvedValue(undefined),
+      reply: vi.fn().mockResolvedValue(undefined),
+    };
+    await handleCwlRotationShowButtonInteraction(refreshInteraction as any, {} as any);
+    expect(refreshSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        clanTag: "#2QG2C08UP",
+        season: "2026-04",
+      }),
+    );
+    expect(refreshInteraction.update).toHaveBeenCalled();
+    expect(getEditedDescription(refreshInteraction)).toContain("Day 2");
+    expect(getEditedDescription(refreshInteraction)).toContain("Battle day start: <t:");
+    expect(getEditedDescription(refreshInteraction)).toContain(":R>");
+  });
+
+  it("restores the current clan page and reports a failure when refresh throws", async () => {
+    vi.mocked(cwlRotationService.listOverview).mockResolvedValue([
+      {
+        season: "2026-04",
+        clanTag: "#2QG2C08UP",
+        clanName: "CWL Alpha",
+        version: 1,
+        roundDay: 2,
+        battleDayStartAt: new Date("2026-04-03T12:00:00.000Z"),
+        leaderNames: ["Alpha"],
+        status: "complete",
+        missingExpectedPlayerTags: [],
+        extraActualPlayerTags: [],
+      },
+    ] as any);
+    vi.mocked(cwlRotationService.listActivePlanExports).mockResolvedValue([
+      {
+        season: "2026-04",
+        clanTag: "#2QG2C08UP",
+        clanName: "CWL Alpha",
+        version: 4,
+        warningSummary: null,
+        excludedPlayerTags: [],
+        days: [
+          {
+            roundDay: 2,
+            lineupSize: 2,
+            rows: [
+              { playerTag: "#VJQ28888", playerName: "Charlie", subbedOut: false, assignmentOrder: 0 },
+              { playerTag: "#CUV02898", playerName: "Delta", subbedOut: false, assignmentOrder: 1 },
+            ],
+            actual: null,
+          },
+        ],
+      } as any,
+    ]);
+    vi.mocked(cwlRotationService.getPreferredDisplayDay).mockResolvedValue(2);
+    vi.mocked(cwlRotationService.validatePlanDay).mockResolvedValue({
+      actualAvailable: true,
+      complete: true,
+      missingExpectedPlayerTags: [],
+      extraActualPlayerTags: [],
+      actualPlayerTags: ["#VJQ28888", "#CUV02898"],
+      actualPlayerNames: ["Charlie", "Delta"],
+    } as any);
+    vi.mocked(cwlStateService.getBattleDayStartForClanDay).mockResolvedValue(
+      new Date("2026-04-03T12:00:00.000Z"),
+    );
+    vi.mocked(cwlStateService.getParticipationCountsForClanDay).mockResolvedValue(
+      makeParticipationCounts([
+        ["#VJQ28888", 1],
+        ["#CUV02898", 1],
+      ]),
+    );
+
+    const overviewInteraction = makeInteraction({
+      group: "rotations",
+      subcommand: "show",
+    });
+    await Cwl.run({} as any, overviewInteraction as any);
+
+    const selectId = getComponentSelectMenuCustomIds(overviewInteraction)[0];
+    expect(selectId).toBeTruthy();
+
+    const selectInteraction = {
+      customId: selectId,
+      values: ["#2QG2C08UP"],
+      user: { id: "111111111111111111" },
+      update: vi.fn().mockResolvedValue(undefined),
+      reply: vi.fn().mockResolvedValue(undefined),
+    };
+    await handleCwlRotationShowSelectMenuInteraction(selectInteraction as any);
+
+    const refreshId = getComponentButtonCustomIds(selectInteraction).find((id) => id.includes(":refresh:"));
+    expect(refreshId).toBeTruthy();
+    const refreshSpy = vi.spyOn(cwlStateService, "refreshTrackedCwlStateForClan").mockRejectedValue(
+      new Error("boom"),
+    );
+    const refreshInteraction = {
+      customId: "cwl-rot-show:refresh:111111111111111111:#2QG2C08UP:2026-04:0:1",
+      user: { id: "111111111111111111" },
+      update: vi.fn().mockResolvedValue(undefined),
+      editReply: vi.fn().mockResolvedValue(undefined),
+      followUp: vi.fn().mockResolvedValue(undefined),
+      reply: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await handleCwlRotationShowButtonInteraction(refreshInteraction as any, {} as any);
+
+    expect(refreshSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        clanTag: "#2QG2C08UP",
+        season: "2026-04",
+      }),
+    );
+    expect(refreshInteraction.update).toHaveBeenCalled();
+    expect(getEditedDescription(refreshInteraction)).toContain("Day 2");
+    expect(refreshInteraction.followUp).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: "Failed to refresh the CWL rotation view.",
+        ephemeral: true,
+      }),
+    );
   });
 
   it("renders one merged CWL day per page for /cwl rotations show", async () => {
@@ -574,7 +733,7 @@ describe("/cwl command", () => {
     expect(getDescription(interaction)).not.toContain(":x: Hotel (#JQJQ2222)");
     expect(getDescription(interaction)).not.toContain("Actual:");
     expect(getDescription(interaction)).not.toContain("Status:");
-    expect(getComponentButtonCustomIds(interaction)).toHaveLength(3);
+    expect(getComponentButtonCustomIds(interaction)).toHaveLength(4);
 
     const nextButtonId = getComponentButtonCustomIds(interaction).find((id) => id.endsWith(":1"));
     expect(nextButtonId).toBeTruthy();
@@ -697,6 +856,7 @@ describe("/cwl command", () => {
       expect.arrayContaining([
         expect.stringContaining(":back:"),
         expect.stringContaining(":page:"),
+        expect.stringContaining(":refresh:"),
       ]),
     );
 
@@ -917,7 +1077,10 @@ describe("/cwl command", () => {
     expect(getDescription(interaction)).not.toContain("Day 1");
     expect(getDescription(interaction)).not.toContain("Actual:");
     expect(getDescription(interaction)).not.toContain("Status:");
-    expect(getComponentButtonCustomIds(interaction)).toHaveLength(0);
+    expect(getComponentButtonCustomIds(interaction)).toHaveLength(3);
+    expect(getComponentButtonCustomIds(interaction)).toEqual(
+      expect.arrayContaining([expect.stringContaining(":refresh:")]),
+    );
   });
 
   it("keeps actual lineup unavailable for far-future /cwl rotations show days", async () => {

--- a/tests/cwlState.service.test.ts
+++ b/tests/cwlState.service.test.ts
@@ -183,6 +183,59 @@ describe("CwlStateService", () => {
     });
   });
 
+  it("refreshes one clan only when asked for a targeted CWL clan refresh", async () => {
+    const cocService = {
+      getClanWarLeagueGroup: vi.fn().mockResolvedValue({
+        season: "2026-04",
+        state: "preparation",
+        clans: [
+          {
+            tag: "#2QG2C08UP",
+            members: [{ tag: "#PYLQ0289", name: "Alpha", townHallLevel: 16 }],
+          },
+        ],
+        rounds: [{ warTags: ["#WAR1"] }],
+      }),
+      getClanWarLeagueWar: vi.fn().mockResolvedValue({
+        state: "preparation",
+        preparationStartTime: "20260402T120000.000Z",
+        startTime: "20260403T120000.000Z",
+        endTime: "20260404T120000.000Z",
+        attacksPerMember: 1,
+        teamSize: 15,
+        clan: {
+          tag: "#2QG2C08UP",
+          name: "CWL Alpha",
+          members: [
+            { tag: "#PYLQ0289", name: "Alpha", mapPosition: 1, townhallLevel: 16, attacks: [] },
+          ],
+        },
+        opponent: {
+          tag: "#Q2V8P9L2",
+          name: "Opponent One",
+          members: [],
+        },
+      }),
+    };
+
+    const result = await cwlStateService.refreshTrackedCwlStateForClan({
+      cocService: cocService as any,
+      clanTag: "#2QG2C08UP",
+      season: "2026-04",
+    });
+
+    expect(result).toMatchObject({
+      season: "2026-04",
+      trackedClanCount: 1,
+      refreshedClanCount: 1,
+      currentRoundCount: 1,
+      currentMemberCount: 1,
+      historyRoundCount: 0,
+      historyMemberCount: 0,
+    });
+    expect(prismaMock.cwlTrackedClan.findMany).not.toHaveBeenCalled();
+  });
+
   it("prefers a live battle-day round over a later preparation round and persists the overlap prep snapshot", async () => {
     prismaMock.cwlTrackedClan.findMany.mockResolvedValue([
       { tag: "#2QG2C08UP" },


### PR DESCRIPTION
- refresh actual CWL state for one clan and rerender the same page
- keep overview untouched and preserve requester restrictions