### PR TITLE
fix(todo): prefer live cwl active round

### DIFF
--- a/src/services/TodoSnapshotService.ts
+++ b/src/services/TodoSnapshotService.ts
@@ -1450,6 +1450,7 @@ async function loadLiveNonTrackedCwlContextsByClanTag(input: {
         : null;
       const baseClanName = sanitizeDisplayText(groupClan?.name) || null;
       const rounds = Array.isArray(group.rounds) ? [...group.rounds].reverse() : [];
+      let fallbackContext: LiveCwlClanContext | null = null;
       for (const round of rounds) {
         const warTags = [
           ...new Set(
@@ -1470,7 +1471,8 @@ async function loadLiveNonTrackedCwlContextsByClanTag(input: {
           if (!side) continue;
 
           const roundState = normalizeRoundState(war.state);
-          if (!(isWarStatePreparation(roundState) || isWarStateActive(roundState))) {
+          const roundScore = scoreLiveCwlRoundState(roundState);
+          if (roundScore <= 0) {
             continue;
           }
 
@@ -1510,22 +1512,25 @@ async function loadLiveNonTrackedCwlContextsByClanTag(input: {
             });
           }
 
-          return [
-            clanTag,
-            {
-              clanTag: normalizedClanTag,
-              clanName: side.clanName || baseClanName,
-              roundState,
-              phaseEndsAt,
-              membersByPlayerTag,
-            },
-          ] as const;
+          const context: LiveCwlClanContext = {
+            clanTag: normalizedClanTag,
+            clanName: side.clanName || baseClanName,
+            roundState,
+            phaseEndsAt,
+            membersByPlayerTag,
+          };
+
+          if (roundScore >= 2) {
+            return [clanTag, context] as const;
+          }
+
+          fallbackContext ??= context;
         }
       }
 
       return [
         clanTag,
-        {
+        fallbackContext ?? {
           clanTag: normalizedClanTag,
           clanName: baseClanName,
           roundState: "notInWar",
@@ -1571,6 +1576,14 @@ function resolveLiveCwlSide(
 function normalizeRoundState(input: unknown): string {
   const value = String(input ?? "").trim();
   return value.length > 0 ? value : "notInWar";
+}
+
+/** Purpose: rank live CWL round states so active wars win over later preparation rounds. */
+function scoreLiveCwlRoundState(state: string): number {
+  const normalized = state.toLowerCase();
+  if (normalized.includes("inwar")) return 2;
+  if (normalized.includes("preparation")) return 1;
+  return 0;
 }
 
 /** Purpose: resolve live current-clan tags for player tags when CoC access is available. */

--- a/tests/todoSnapshot.service.test.ts
+++ b/tests/todoSnapshot.service.test.ts
@@ -362,6 +362,88 @@ describe("TodoSnapshotService", () => {
     );
   });
 
+  it("prefers a live active non-tracked CWL round over a later preparation round", async () => {
+    prismaMock.cwlTrackedClan.findMany.mockResolvedValue([]);
+    prismaMock.currentCwlRound.findMany.mockResolvedValue([]);
+    prismaMock.cwlRoundMemberCurrent.findMany.mockResolvedValue([]);
+    prismaMock.cwlPlayerClanSeason.findMany.mockResolvedValue([]);
+    const cocService = {
+      getPlayerRaw: vi.fn().mockImplementation(async (tag: string) => ({
+        tag,
+        clan: { tag: "#QGRJ" },
+      })),
+      getClanWarLeagueGroup: vi.fn().mockResolvedValue({
+        season: "2026-03",
+        state: "preparation",
+        clans: [{ tag: "#QGRJ", name: "Nontracked Clan" }],
+        rounds: [{ warTags: ["#WAR-ACT"] }, { warTags: ["#WAR-PREP"] }],
+      }),
+      getClanWarLeagueWar: vi.fn().mockImplementation(async (warTag: string) => {
+        if (warTag === "#WAR-PREP") {
+          return {
+            state: "preparation",
+            attacksPerMember: 1,
+            startTime: "20260330T120000.000Z",
+            endTime: "20260331T120000.000Z",
+            clan: {
+              tag: "#QGRJ",
+              name: "Nontracked Clan",
+              members: [
+                {
+                  tag: "#PYLQ0289",
+                  name: "Alpha",
+                  townhallLevel: 15,
+                  attacks: [],
+                },
+              ],
+            },
+            opponent: { tag: "#OPP", name: "Opponent", members: [] },
+          };
+        }
+        return {
+          state: "inWar",
+          attacksPerMember: 1,
+          startTime: "20260329T120000.000Z",
+          endTime: "20260330T120000.000Z",
+          clan: {
+            tag: "#QGRJ",
+            name: "Nontracked Clan",
+            members: [
+              {
+                tag: "#PYLQ0289",
+                name: "Alpha",
+                townhallLevel: 15,
+                attacks: [{ stars: 2, destructionPercentage: 100 }],
+              },
+            ],
+          },
+          opponent: { tag: "#OPP", name: "Opponent", members: [] },
+        };
+      }),
+    };
+
+    await todoSnapshotService.refreshSnapshotsForPlayerTags({
+      playerTags: ["#PYLQ0289"],
+      cocService: cocService as any,
+      includeNonTrackedCwlRefresh: true,
+      nowMs: Date.UTC(2026, 2, 26, 0, 0, 0, 0),
+    });
+
+    expect(cocService.getClanWarLeagueWar).toHaveBeenCalledTimes(2);
+    expect(prismaMock.todoPlayerSnapshot.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({
+          cwlClanTag: "#QGRJ",
+          cwlClanName: "Nontracked Clan",
+          cwlPhase: "battle day",
+          cwlEndsAt: new Date("2026-03-30T12:00:00.000Z"),
+          cwlAttacksUsed: 1,
+          cwlAttacksMax: 1,
+        }),
+      }),
+    );
+  });
+
   it("deduplicates duplicate player tags before chunked live clan refresh", async () => {
     prismaMock.cwlTrackedClan.findMany.mockResolvedValue([]);
     prismaMock.currentCwlRound.findMany.mockResolvedValue([]);


### PR DESCRIPTION
- keep non-tracked cwl refresh from getting stuck on later preparation rounds
- preserve battle-day attack and next-war timestamp updates for /todo cwl