### PR TITLE
fix(todo): discover seasonal cwl clans from persisted evidence

### DIFF
--- a/src/commands/Todo.ts
+++ b/src/commands/Todo.ts
@@ -180,6 +180,7 @@ async function tryBoundedInitialTodoRefresh(input: {
     discordUserId: input.discordUserId,
     cocService: input.cocService,
     includeNonTrackedCwlRefresh: input.includeNonTrackedCwlRefresh,
+    refreshTrackedCwlStateFirst: input.refreshTrackedCwlStateFirst,
   })
     .then(
       (): TodoInitialRefreshOutcome => ({

--- a/src/services/CwlStateService.ts
+++ b/src/services/CwlStateService.ts
@@ -122,6 +122,16 @@ export type RefreshTrackedCwlStateResult = {
   historyMemberCount: number;
 };
 
+export type RefreshSeasonalCwlClanMappingsResult = {
+  season: string;
+  playerCount: number;
+  existingMappingCount: number;
+  persistedEvidenceCount: number;
+  liveEvidenceCount: number;
+  learnedClanCount: number;
+  failedClanCount: number;
+};
+
 type ObservedCwlRoundMember = {
   playerTag: string;
   playerName: string;
@@ -215,6 +225,41 @@ function resolvePhaseEndsAt(input: {
   if (state.includes("preparation")) return input.startTime;
   if (state.includes("inwar")) return input.endTime;
   return input.endTime;
+}
+
+function normalizeLiveCwlRoundState(input: unknown): string {
+  const value = String(input ?? "").trim();
+  return value.length > 0 ? value : "notInWar";
+}
+
+function scoreLiveCwlRoundState(state: string): number {
+  const normalized = state.toLowerCase();
+  if (normalized.includes("inwar")) return 2;
+  if (normalized.includes("preparation")) return 1;
+  return 0;
+}
+
+function resolveLiveCwlSide(
+  clanTag: string,
+  war: ClanWar,
+): { clanName: string | null; members: ClanWarMember[] } | null {
+  const normalizedClanTag = normalizeClanTag(clanTag);
+  const warClanTag = normalizeClanTag(String(war.clan?.tag ?? ""));
+  const warOpponentTag = normalizeClanTag(String(war.opponent?.tag ?? ""));
+
+  if (warClanTag === normalizedClanTag && war.clan) {
+    return {
+      clanName: sanitizeCwlName(war.clan.name) || null,
+      members: Array.isArray(war.clan.members) ? war.clan.members : [],
+    };
+  }
+  if (warOpponentTag === normalizedClanTag && war.opponent) {
+    return {
+      clanName: sanitizeCwlName(war.opponent.name) || null,
+      members: Array.isArray(war.opponent.members) ? war.opponent.members : [],
+    };
+  }
+  return null;
 }
 
 type CwlActualLineupOwner = {
@@ -718,6 +763,312 @@ async function loadObservedTrackedClanState(input: {
 
 /** Purpose: persist tracked CWL current/prep rounds, ended history, and derived season-roster summaries from CoC. */
 export class CwlStateService {
+  /** Purpose: refresh persisted seasonal CWL clan mappings for bounded player tags. */
+  async refreshSeasonalCwlClanMappingsForPlayerTags(input: {
+    cocService?: CoCService;
+    playerTags: string[];
+    season?: string;
+    candidateClanTags?: string[];
+  }): Promise<RefreshSeasonalCwlClanMappingsResult> {
+    const season = input.season ?? resolveCurrentCwlSeasonKey();
+    const normalizedTags = [...new Set(normalizePlayerTags(input.playerTags))];
+    if (normalizedTags.length <= 0) {
+      return {
+        season,
+        playerCount: 0,
+        existingMappingCount: 0,
+        persistedEvidenceCount: 0,
+        liveEvidenceCount: 0,
+        learnedClanCount: 0,
+        failedClanCount: 0,
+      };
+    }
+
+    const existingMappings = await prisma.cwlPlayerClanSeason.findMany({
+      where: {
+        season,
+        playerTag: { in: normalizedTags },
+      },
+      select: {
+        playerTag: true,
+        cwlClanTag: true,
+      },
+    });
+    const mappingByPlayerTag = new Map(
+      existingMappings
+        .map((row) => [
+          normalizePlayerTag(row.playerTag),
+          normalizeClanTag(row.cwlClanTag),
+        ] as const)
+        .filter((entry): entry is [string, string] => Boolean(entry[0] && entry[1])),
+    );
+
+    const directEvidenceRows = await Promise.all([
+      prisma.cwlRoundMemberCurrent.findMany({
+        where: {
+          season,
+          playerTag: { in: normalizedTags },
+        },
+        select: {
+          playerTag: true,
+          clanTag: true,
+          playerName: true,
+          townHall: true,
+          roundDay: true,
+        },
+      }),
+      prisma.cwlRoundMemberHistory.findMany({
+        where: {
+          season,
+          playerTag: { in: normalizedTags },
+        },
+        select: {
+          playerTag: true,
+          clanTag: true,
+          playerName: true,
+          townHall: true,
+          roundDay: true,
+        },
+        orderBy: [{ roundDay: "desc" }, { updatedAt: "desc" }, { playerTag: "asc" }],
+      }),
+    ]);
+
+    const trackedClanRows = await prisma.cwlTrackedClan.findMany({
+      where: { season },
+      select: { tag: true },
+    });
+    const trackedClanTagSet = new Set(
+      trackedClanRows.map((row) => normalizeClanTag(row.tag)).filter(Boolean),
+    );
+
+    const evidenceByPlayerTag = new Map<
+      string,
+      {
+        clanTag: string;
+        playerName: string | null;
+        townHall: number | null;
+        roundDay: number | null;
+        source: "current" | "history";
+        sourceRank: number;
+      }
+    >();
+    for (const row of directEvidenceRows[0]) {
+      const playerTag = normalizePlayerTag(row.playerTag);
+      const clanTag = normalizeClanTag(row.clanTag);
+      if (!playerTag || !clanTag) continue;
+      const next = {
+        clanTag,
+        playerName: sanitizeCwlName(row.playerName) ?? playerTag,
+        townHall: Number.isFinite(Number(row.townHall))
+          ? Math.trunc(Number(row.townHall))
+          : null,
+        roundDay: Number.isFinite(Number(row.roundDay))
+          ? Math.trunc(Number(row.roundDay))
+          : null,
+        source: "current" as const,
+        sourceRank: 2,
+      };
+      const existing = evidenceByPlayerTag.get(playerTag);
+      if (
+        !existing ||
+        next.sourceRank > existing.sourceRank ||
+        (next.sourceRank === existing.sourceRank &&
+          (next.roundDay ?? 0) >= (existing.roundDay ?? 0))
+      ) {
+        evidenceByPlayerTag.set(playerTag, next);
+      }
+    }
+    for (const row of directEvidenceRows[1]) {
+      const playerTag = normalizePlayerTag(row.playerTag);
+      const clanTag = normalizeClanTag(row.clanTag);
+      if (!playerTag || !clanTag) continue;
+      const next = {
+        clanTag,
+        playerName: sanitizeCwlName(row.playerName) ?? playerTag,
+        townHall: Number.isFinite(Number(row.townHall))
+          ? Math.trunc(Number(row.townHall))
+          : null,
+        roundDay: Number.isFinite(Number(row.roundDay))
+          ? Math.trunc(Number(row.roundDay))
+          : null,
+        source: "history" as const,
+        sourceRank: 1,
+      };
+      const existing = evidenceByPlayerTag.get(playerTag);
+      if (
+        !existing ||
+        next.sourceRank > existing.sourceRank ||
+        (next.sourceRank === existing.sourceRank &&
+          (next.roundDay ?? 0) >= (existing.roundDay ?? 0))
+      ) {
+        evidenceByPlayerTag.set(playerTag, next);
+      }
+    }
+
+    const candidateClanTags = [
+      ...new Set(
+        (input.candidateClanTags ?? [])
+          .map((tag) => normalizeClanTag(tag))
+          .filter(
+            (tag): tag is string => Boolean(tag && !trackedClanTagSet.has(tag)),
+          ),
+      ),
+    ];
+
+    const liveEvidenceByPlayerTag = new Map<
+      string,
+      {
+        clanTag: string;
+        playerName: string | null;
+        townHall: number | null;
+        roundDay: number | null;
+        sourceRank: number;
+      }
+    >();
+    const remainingPlayerTags = normalizedTags.filter(
+      (playerTag) => !mappingByPlayerTag.has(playerTag) && !evidenceByPlayerTag.has(playerTag),
+    );
+    const liveDiscoveryRan = Boolean(
+      input.cocService && candidateClanTags.length > 0 && remainingPlayerTags.length > 0,
+    );
+    const cocService = input.cocService ?? null;
+    if (liveDiscoveryRan && cocService) {
+      const targetPlayerTagSet = new Set(remainingPlayerTags);
+      for (const clanTag of candidateClanTags) {
+        let group: ClanWarLeagueGroup | null = null;
+        try {
+          group = await cocService.getClanWarLeagueGroup(clanTag);
+        } catch (error) {
+          console.warn(
+            `[cwl-mapping] season=${season} clan_tag=${clanTag} stage=group_fetch_failed error=${formatError(error)}`,
+          );
+          continue;
+        }
+
+        const rounds = Array.isArray(group?.rounds) ? [...group.rounds].reverse() : [];
+        for (const round of rounds) {
+          const warTags = [
+            ...new Set(
+              (Array.isArray(round?.warTags) ? round.warTags : [])
+                .map((warTag) => String(warTag ?? "").trim())
+                .filter((warTag) => warTag.length > 0 && warTag !== "#0"),
+            ),
+          ];
+          if (warTags.length <= 0) continue;
+
+          for (const warTag of warTags) {
+            const war = await cocService.getClanWarLeagueWar(warTag).catch(() => null);
+            if (!war) continue;
+            const side = resolveLiveCwlSide(clanTag, war);
+            if (!side) continue;
+            const roundState = normalizeLiveCwlRoundState(war.state);
+            const roundScore = scoreLiveCwlRoundState(roundState);
+            if (roundScore <= 0) continue;
+
+            for (const member of side.members) {
+              const playerTag = normalizePlayerTag(String(member?.tag ?? ""));
+              if (!playerTag || !targetPlayerTagSet.has(playerTag)) continue;
+              const existing = liveEvidenceByPlayerTag.get(playerTag);
+              if (!existing || roundScore > existing.sourceRank) {
+                liveEvidenceByPlayerTag.set(playerTag, {
+                  clanTag: normalizeClanTag(clanTag),
+                  playerName: sanitizeCwlName(member?.name) ?? playerTag,
+                  townHall: Number.isFinite(Number(member?.townhallLevel))
+                    ? Math.trunc(Number(member?.townhallLevel))
+                    : null,
+                  roundDay: null,
+                  sourceRank: roundScore,
+                });
+              }
+            }
+
+            const remaining = [...targetPlayerTagSet].filter(
+              (playerTag) =>
+                !mappingByPlayerTag.has(playerTag) &&
+                !evidenceByPlayerTag.has(playerTag) &&
+                !liveEvidenceByPlayerTag.has(playerTag),
+            );
+            if (remaining.length <= 0) break;
+          }
+        }
+      }
+    }
+
+    let learnedClanCount = 0;
+    let persistedEvidenceCount = 0;
+    let liveEvidenceCount = 0;
+    await prisma.$transaction(async (tx) => {
+      for (const playerTag of normalizedTags) {
+        const hadExistingMapping = mappingByPlayerTag.has(playerTag);
+        if (hadExistingMapping) {
+          console.info(
+            `[cwl-mapping] season=${season} player_tag=${playerTag} existing_mapping=yes live_discovery_ran=${liveDiscoveryRan ? "yes" : "no"} learned_clan=no source=existing_mapping`,
+          );
+          continue;
+        }
+
+        const persistedClanTag = evidenceByPlayerTag.get(playerTag)?.clanTag ?? "";
+        const liveClanTag = liveEvidenceByPlayerTag.get(playerTag)?.clanTag ?? "";
+        const clanTag = normalizeClanTag(persistedClanTag || liveClanTag);
+        if (!clanTag) {
+          console.info(
+            `[cwl-mapping] season=${season} player_tag=${playerTag} existing_mapping=no live_discovery_ran=${liveDiscoveryRan ? "yes" : "no"} learned_clan=no source=${persistedClanTag ? "persisted" : liveClanTag ? "live" : "none"}`,
+          );
+          continue;
+        }
+        const evidence =
+          evidenceByPlayerTag.get(playerTag) ?? liveEvidenceByPlayerTag.get(playerTag) ?? null;
+
+        if (persistedClanTag) {
+          persistedEvidenceCount += 1;
+        } else if (liveClanTag) {
+          liveEvidenceCount += 1;
+        }
+
+        await tx.cwlPlayerClanSeason.upsert({
+          where: {
+            season_playerTag: {
+              season,
+              playerTag,
+            },
+          },
+          create: {
+            season,
+            playerTag,
+            cwlClanTag: clanTag,
+            playerName: evidence?.playerName ?? playerTag,
+            townHall: evidence?.townHall ?? null,
+            daysParticipated: 0,
+            lastRoundDay: null,
+          },
+          update: {
+            cwlClanTag: clanTag,
+            playerName: evidence?.playerName ?? playerTag,
+            townHall: evidence?.townHall ?? null,
+          },
+        });
+        learnedClanCount += 1;
+        console.info(
+          `[cwl-mapping] season=${season} player_tag=${playerTag} existing_mapping=no live_discovery_ran=${liveDiscoveryRan ? "yes" : "no"} learned_clan=yes clan_tag=${clanTag} source=${persistedClanTag ? "persisted" : "live"}`,
+        );
+      }
+    });
+
+    console.info(
+      `[cwl-mapping] season=${season} requested_player_count=${normalizedTags.length} existing_mapping_count=${mappingByPlayerTag.size} persisted_evidence_count=${persistedEvidenceCount} live_evidence_count=${liveEvidenceCount} learned_clan_count=${learnedClanCount} candidate_clan_count=${candidateClanTags.length}`,
+    );
+
+    return {
+      season,
+      playerCount: normalizedTags.length,
+      existingMappingCount: mappingByPlayerTag.size,
+      persistedEvidenceCount,
+      liveEvidenceCount,
+      learnedClanCount,
+      failedClanCount: 0,
+    };
+  }
+
   /** Purpose: refresh tracked CWL state only for clans associated with one linked player set. */
   async refreshTrackedCwlStateForPlayerTags(input: {
     cocService: CoCService;

--- a/src/services/TodoSnapshotService.ts
+++ b/src/services/TodoSnapshotService.ts
@@ -8,6 +8,7 @@ import {
 import { resolveCurrentCwlSeasonKey } from "./CwlRegistryService";
 import { CoCService, type ClanCapitalRaidSeason } from "./CoCService";
 import { cocRequestQueueService } from "./CoCRequestQueueService";
+import { cwlStateService } from "./CwlStateService";
 import {
   normalizeClanTag,
   normalizeDiscordUserId,
@@ -533,6 +534,27 @@ export class TodoSnapshotService {
       resolvedClanTagByPlayerTag.set(playerTag, resolvedClanTag);
     }
 
+    if (input.includeNonTrackedCwlRefresh) {
+      try {
+        await cwlStateService.refreshSeasonalCwlClanMappingsForPlayerTags({
+          cocService: input.cocService,
+          playerTags: normalizedTags,
+          season: currentCwlSeason,
+          candidateClanTags: [
+            ...new Set(
+              [...resolvedClanTagByPlayerTag.values()].filter(
+                (value): value is string => Boolean(value),
+              ),
+            ),
+          ],
+        });
+      } catch (error) {
+        console.warn(
+          `[todo-snapshot] event=cwl_seasonal_mapping_refresh_failed season=${currentCwlSeason} player_count=${normalizedTags.length} error=${formatError(error)}`,
+        );
+      }
+    }
+
     const clanTags = [
       ...new Set(
         [...resolvedClanTagByPlayerTag.values()].filter(
@@ -677,19 +699,6 @@ export class TodoSnapshotService {
         ] as const)
         .filter((entry): entry is [string, string] => Boolean(entry[0] && entry[1])),
     );
-    const liveNonTrackedCwlContextByClanTag = input.includeNonTrackedCwlRefresh
-      ? await loadLiveNonTrackedCwlContextsByClanTag({
-          cocService: input.cocService,
-          clanTags: [
-            ...new Set(
-              [...resolvedClanTagByPlayerTag.values()].filter(
-                (value): value is string =>
-                  Boolean(value && !cwlTrackedTagSet.has(value)),
-              ),
-            ),
-          ],
-        })
-      : new Map<string, LiveCwlClanContext>();
     const mappedCwlClanByPlayerTag = new Map(
       cwlSeasonMappingRows
         .map((row) => [
@@ -698,6 +707,22 @@ export class TodoSnapshotService {
         ] as const)
         .filter((entry): entry is [string, string] => Boolean(entry[0] && entry[1])),
     );
+    const liveNonTrackedCwlContextByClanTag = input.includeNonTrackedCwlRefresh
+      ? await loadLiveNonTrackedCwlContextsByClanTag({
+          cocService: input.cocService,
+          clanTags: [
+            ...new Set(
+              [
+                ...resolvedClanTagByPlayerTag.values(),
+                ...mappedCwlClanByPlayerTag.values(),
+              ].filter(
+                (value): value is string =>
+                  Boolean(value && !cwlTrackedTagSet.has(value)),
+              ),
+            ),
+          ],
+        })
+      : new Map<string, LiveCwlClanContext>();
     const currentCwlRoundByClanTag = new Map(
       currentCwlRoundRows
         .map((row) => [
@@ -777,34 +802,37 @@ export class TodoSnapshotService {
         resolvedClanTag && cwlTrackedTagSet.has(resolvedClanTag)
           ? resolvedClanTag
           : "";
-      const liveNonTrackedCwlContext =
-        resolvedClanTag && !cwlTrackedTagSet.has(resolvedClanTag)
-          ? liveNonTrackedCwlContextByClanTag.get(resolvedClanTag) ?? null
-          : null;
-      const liveNonTrackedCwlMember = liveNonTrackedCwlContext
-        ? liveNonTrackedCwlContext.membersByPlayerTag.get(playerTag) ?? null
-        : null;
       const resolvedCwlClanTag =
         normalizeClanTag(
           activeMappedCwlClanTag ||
             persistedMappedCwlClanTag ||
             fallbackCwlClanTag,
         ) ||
-        normalizeClanTag(liveNonTrackedCwlContext?.clanTag ?? "") ||
         normalizeClanTag(existing?.cwlClanTag ?? "") ||
         null;
+      const liveNonTrackedCwlContext =
+        resolvedCwlClanTag && !cwlTrackedTagSet.has(resolvedCwlClanTag)
+          ? liveNonTrackedCwlContextByClanTag.get(resolvedCwlClanTag) ?? null
+          : null;
+      const liveNonTrackedCwlMember = liveNonTrackedCwlContext
+        ? liveNonTrackedCwlContext.membersByPlayerTag.get(playerTag) ?? null
+        : null;
+      const resolvedLiveCwlClanTag =
+        normalizeClanTag(liveNonTrackedCwlContext?.clanTag ?? "") || null;
+      const finalResolvedCwlClanTag =
+        resolvedCwlClanTag || resolvedLiveCwlClanTag || null;
       const resolvedCwlClanName =
-        (resolvedCwlClanTag
-          ? currentCwlRoundByClanTag.get(resolvedCwlClanTag)?.clanName ||
-            cwlTrackedClanNameByTag.get(resolvedCwlClanTag) ||
+        (finalResolvedCwlClanTag
+          ? currentCwlRoundByClanTag.get(finalResolvedCwlClanTag)?.clanName ||
+            cwlTrackedClanNameByTag.get(finalResolvedCwlClanTag) ||
             liveNonTrackedCwlContext?.clanName ||
             resolvedClanName ||
-            trackedClanNameByTag.get(resolvedCwlClanTag)
+            trackedClanNameByTag.get(finalResolvedCwlClanTag)
           : null) ||
         sanitizeDisplayText(existing?.cwlClanName ?? "") ||
         null;
-      const persistedCurrentCwlRound = resolvedCwlClanTag
-        ? currentCwlRoundByClanTag.get(resolvedCwlClanTag) ?? null
+      const persistedCurrentCwlRound = finalResolvedCwlClanTag
+        ? currentCwlRoundByClanTag.get(finalResolvedCwlClanTag) ?? null
         : null;
       const currentCwlRound = liveNonTrackedCwlContext ?? persistedCurrentCwlRound;
       const currentCwlMember =
@@ -812,10 +840,10 @@ export class TodoSnapshotService {
         currentCwlMemberByPlayerTag.get(playerTag) ??
         null;
       const cwlParticipant = Boolean(
-        resolvedCwlClanTag &&
+        finalResolvedCwlClanTag &&
           currentCwlMember &&
           currentCwlMember.subbedIn &&
-          currentCwlMember.clanTag === resolvedCwlClanTag,
+          currentCwlMember.clanTag === finalResolvedCwlClanTag,
       );
       const cwlHasContext = Boolean(
         currentCwlRound ||

--- a/tests/cwlState.service.test.ts
+++ b/tests/cwlState.service.test.ts
@@ -455,6 +455,202 @@ describe("CwlStateService", () => {
     );
   });
 
+  it("keeps an existing seasonal CWL mapping without running live discovery", async () => {
+    prismaMock.cwlPlayerClanSeason.findMany.mockResolvedValue([
+      { playerTag: "#PYLQ0289", cwlClanTag: "#2QG2C08UP" },
+    ]);
+    const cocService = {
+      getClanWarLeagueGroup: vi.fn(),
+      getClanWarLeagueWar: vi.fn(),
+    };
+
+    const result = await cwlStateService.refreshSeasonalCwlClanMappingsForPlayerTags({
+      cocService: cocService as any,
+      season: "2026-04",
+      playerTags: ["#PYLQ0289"],
+      candidateClanTags: ["#QGRJ"],
+    });
+
+    expect(result).toMatchObject({
+      season: "2026-04",
+      playerCount: 1,
+      existingMappingCount: 1,
+      persistedEvidenceCount: 0,
+      liveEvidenceCount: 0,
+      learnedClanCount: 0,
+    });
+    expect(txMock.cwlPlayerClanSeason.upsert).not.toHaveBeenCalled();
+    expect(cocService.getClanWarLeagueGroup).not.toHaveBeenCalled();
+  });
+
+  it("learns a missing seasonal CWL mapping from persisted CWL evidence before probing live clans", async () => {
+    prismaMock.cwlPlayerClanSeason.findMany.mockResolvedValue([]);
+    prismaMock.cwlRoundMemberCurrent.findMany.mockResolvedValue([]);
+    prismaMock.cwlRoundMemberHistory.findMany.mockResolvedValue([
+      {
+        playerTag: "#PYLQ0289",
+        clanTag: "#2QG2C08UP",
+        playerName: "Alpha",
+        townHall: 16,
+      },
+    ]);
+    const cocService = {
+      getClanWarLeagueGroup: vi.fn(),
+      getClanWarLeagueWar: vi.fn(),
+    };
+
+    const result = await cwlStateService.refreshSeasonalCwlClanMappingsForPlayerTags({
+      cocService: cocService as any,
+      season: "2026-04",
+      playerTags: ["#PYLQ0289"],
+      candidateClanTags: ["#QGRJ"],
+    });
+
+    expect(result).toMatchObject({
+      season: "2026-04",
+      playerCount: 1,
+      existingMappingCount: 0,
+      persistedEvidenceCount: 1,
+      liveEvidenceCount: 0,
+      learnedClanCount: 1,
+    });
+    expect(txMock.cwlPlayerClanSeason.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({
+          season: "2026-04",
+          playerTag: "#PYLQ0289",
+          cwlClanTag: "#2QG2C08UP",
+          playerName: "Alpha",
+          townHall: 16,
+        }),
+        update: expect.objectContaining({
+          cwlClanTag: "#2QG2C08UP",
+          playerName: "Alpha",
+          townHall: 16,
+        }),
+      }),
+    );
+    expect(cocService.getClanWarLeagueGroup).not.toHaveBeenCalled();
+  });
+
+  it("learns a missing seasonal CWL mapping from live non-tracked CWL evidence when persisted rows are absent", async () => {
+    prismaMock.cwlPlayerClanSeason.findMany.mockResolvedValue([]);
+    prismaMock.cwlRoundMemberCurrent.findMany.mockResolvedValue([]);
+    prismaMock.cwlRoundMemberHistory.findMany.mockResolvedValue([]);
+    const cocService = {
+      getClanWarLeagueGroup: vi.fn().mockResolvedValue({
+        season: "2026-04",
+        state: "preparation",
+        clans: [
+          {
+            tag: "#2QG2C08UP",
+            name: "Nontracked Clan",
+          },
+        ],
+        rounds: [{ warTags: ["#WAR1"] }],
+      }),
+      getClanWarLeagueWar: vi.fn().mockResolvedValue({
+        state: "preparation",
+        attacksPerMember: 1,
+        startTime: "20260403T120000.000Z",
+        endTime: "20260404T120000.000Z",
+        clan: {
+          tag: "#2QG2C08UP",
+          name: "Nontracked Clan",
+          members: [
+            {
+              tag: "#PYLQ0289",
+              name: "Alpha",
+              townhallLevel: 16,
+              attacks: [],
+            },
+          ],
+        },
+        opponent: {
+          tag: "#Q2V8P9L2",
+          name: "Opponent One",
+          members: [],
+        },
+      }),
+    };
+
+    const result = await cwlStateService.refreshSeasonalCwlClanMappingsForPlayerTags({
+      cocService: cocService as any,
+      season: "2026-04",
+      playerTags: ["#PYLQ0289"],
+      candidateClanTags: ["#2QG2C08UP"],
+    });
+
+    expect(result).toMatchObject({
+      season: "2026-04",
+      playerCount: 1,
+      existingMappingCount: 0,
+      persistedEvidenceCount: 0,
+      liveEvidenceCount: 1,
+      learnedClanCount: 1,
+    });
+    expect(txMock.cwlPlayerClanSeason.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({
+          season: "2026-04",
+          playerTag: "#PYLQ0289",
+          cwlClanTag: "#2QG2C08UP",
+          playerName: "Alpha",
+          townHall: 16,
+        }),
+      }),
+    );
+    expect(cocService.getClanWarLeagueGroup).toHaveBeenCalledWith("#2QG2C08UP");
+    expect(cocService.getClanWarLeagueWar).toHaveBeenCalledWith("#WAR1");
+  });
+
+  it("returns without inventing a mapping when no current or live CWL proof exists", async () => {
+    prismaMock.cwlPlayerClanSeason.findMany.mockResolvedValue([]);
+    prismaMock.cwlRoundMemberCurrent.findMany.mockResolvedValue([]);
+    prismaMock.cwlRoundMemberHistory.findMany.mockResolvedValue([]);
+    const cocService = {
+      getClanWarLeagueGroup: vi.fn().mockResolvedValue({
+        season: "2026-04",
+        state: "preparation",
+        clans: [{ tag: "#2QG2C08UP", name: "Nontracked Clan" }],
+        rounds: [{ warTags: ["#WAR1"] }],
+      }),
+      getClanWarLeagueWar: vi.fn().mockResolvedValue({
+        state: "preparation",
+        attacksPerMember: 1,
+        startTime: "20260403T120000.000Z",
+        endTime: "20260404T120000.000Z",
+        clan: {
+          tag: "#2QG2C08UP",
+          name: "Nontracked Clan",
+          members: [],
+        },
+        opponent: {
+          tag: "#Q2V8P9L2",
+          name: "Opponent One",
+          members: [],
+        },
+      }),
+    };
+
+    const result = await cwlStateService.refreshSeasonalCwlClanMappingsForPlayerTags({
+      cocService: cocService as any,
+      season: "2026-04",
+      playerTags: ["#PYLQ0289"],
+      candidateClanTags: ["#2QG2C08UP"],
+    });
+
+    expect(result).toMatchObject({
+      season: "2026-04",
+      playerCount: 1,
+      existingMappingCount: 0,
+      persistedEvidenceCount: 0,
+      liveEvidenceCount: 0,
+      learnedClanCount: 0,
+    });
+    expect(txMock.cwlPlayerClanSeason.upsert).not.toHaveBeenCalled();
+  });
+
   it("returns the persisted current-day lineup when the current round matches the requested day", async () => {
     prismaMock.currentCwlRound.findUnique.mockResolvedValue({
       season: "2026-04",

--- a/tests/todo.command.test.ts
+++ b/tests/todo.command.test.ts
@@ -557,6 +557,53 @@ describe("/todo command", () => {
     expect(description).toContain(":black_circle: Bravo - `0 / 0`");
   });
 
+  it("forwards refreshTrackedCwlStateFirst through the bounded initial CWL /todo refresh", async () => {
+    const trackedRefreshSpy = vi
+      .spyOn(cwlStateService, "refreshTrackedCwlStateForPlayerTags")
+      .mockResolvedValue({
+        season: "2026-03",
+        trackedClanCount: 0,
+        refreshedClanCount: 0,
+        currentRoundCount: 0,
+        currentMemberCount: 0,
+        historyRoundCount: 0,
+        historyMemberCount: 0,
+      });
+    const refreshSpy = vi
+      .spyOn(todoSnapshotService, "refreshSnapshotsForPlayerTags")
+      .mockResolvedValue({ playerCount: 1, updatedCount: 1 });
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      { playerTag: "#PYLQ0289", createdAt: new Date("2026-03-01T00:00:00.000Z") },
+    ]);
+    prismaMock.todoPlayerSnapshot.aggregate.mockResolvedValue({
+      _count: { _all: 1 },
+      _max: { updatedAt: new Date("2026-03-26T00:00:00.000Z") },
+    });
+    prismaMock.todoPlayerSnapshot.findMany.mockResolvedValue([
+      makeSnapshotRow({
+        playerTag: "#PYLQ0289",
+        playerName: "Alpha",
+        cwlAttacksUsed: 0,
+        cwlPhase: "preparation",
+      }),
+    ]);
+
+    const interaction = makeTodoInteraction({ type: "CWL" });
+    await Todo.run({} as any, interaction as any, makeCocServiceSpy() as any);
+
+    expect(trackedRefreshSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        playerTags: ["#PYLQ0289"],
+        cocService: expect.anything(),
+      }),
+    );
+    expect(refreshSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        includeNonTrackedCwlRefresh: true,
+      }),
+    );
+  });
+
   it("opens no-arg /todo on the remembered page when one exists", async () => {
     vi.spyOn(todoLastViewedTypeService, "getLastViewedType").mockResolvedValue("RAIDS");
     prismaMock.playerLink.findMany.mockResolvedValue([

--- a/tests/todoSnapshot.service.test.ts
+++ b/tests/todoSnapshot.service.test.ts
@@ -1,5 +1,16 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+let cwlSeasonMappingRows: Array<{ playerTag: string; cwlClanTag: string }> = [];
+
+const txMock = vi.hoisted(() => ({
+  todoPlayerSnapshot: {
+    upsert: vi.fn(),
+  },
+  cwlPlayerClanSeason: {
+    upsert: vi.fn(),
+  },
+}));
+
 const prismaMock = vi.hoisted(() => ({
   playerLink: {
     findMany: vi.fn(),
@@ -36,6 +47,9 @@ const prismaMock = vi.hoisted(() => ({
   cwlRoundMemberCurrent: {
     findMany: vi.fn(),
   },
+  cwlRoundMemberHistory: {
+    findMany: vi.fn(),
+  },
   cwlPlayerClanSeason: {
     findMany: vi.fn(),
     upsert: vi.fn(),
@@ -49,6 +63,7 @@ const prismaMock = vi.hoisted(() => ({
     findMany: vi.fn(),
     upsert: vi.fn(),
   },
+  $transaction: vi.fn(async (fn: (tx: typeof txMock) => Promise<unknown>) => fn(txMock)),
 }));
 
 const cocRequestQueueMock = vi.hoisted(() => ({
@@ -111,6 +126,7 @@ describe("TodoSnapshotService", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     resetTodoSnapshotServiceForTest();
+    cwlSeasonMappingRows = [];
 
     prismaMock.todoPlayerSnapshot.findMany.mockResolvedValue([]);
     prismaMock.todoPlayerSnapshot.upsert.mockResolvedValue(undefined);
@@ -161,8 +177,24 @@ describe("TodoSnapshotService", () => {
     ]);
     prismaMock.currentCwlRound.findMany.mockResolvedValue([]);
     prismaMock.cwlRoundMemberCurrent.findMany.mockResolvedValue([]);
-    prismaMock.cwlPlayerClanSeason.findMany.mockResolvedValue([]);
-    prismaMock.cwlPlayerClanSeason.upsert.mockResolvedValue(undefined);
+    prismaMock.cwlRoundMemberHistory.findMany.mockResolvedValue([]);
+    prismaMock.cwlPlayerClanSeason.findMany.mockImplementation(async () => cwlSeasonMappingRows);
+    prismaMock.cwlPlayerClanSeason.upsert.mockImplementation(async (args: any) => {
+      const playerTag = String(args?.create?.playerTag ?? args?.update?.playerTag ?? "");
+      const cwlClanTag = String(args?.create?.cwlClanTag ?? args?.update?.cwlClanTag ?? "");
+      if (!playerTag || !cwlClanTag) return undefined;
+      cwlSeasonMappingRows = cwlSeasonMappingRows.filter((row) => row.playerTag !== playerTag);
+      cwlSeasonMappingRows.push({ playerTag, cwlClanTag });
+      return undefined;
+    });
+    txMock.cwlPlayerClanSeason.upsert.mockImplementation(async (args: any) => {
+      const playerTag = String(args?.create?.playerTag ?? args?.update?.playerTag ?? "");
+      const cwlClanTag = String(args?.create?.cwlClanTag ?? args?.update?.cwlClanTag ?? "");
+      if (!playerTag || !cwlClanTag) return undefined;
+      cwlSeasonMappingRows = cwlSeasonMappingRows.filter((row) => row.playerTag !== playerTag);
+      cwlSeasonMappingRows.push({ playerTag, cwlClanTag });
+      return undefined;
+    });
     prismaMock.todoUserUsage.findMany.mockResolvedValue([]);
     prismaMock.todoUserUsage.findUnique.mockResolvedValue(null);
     prismaMock.todoUserUsage.upsert.mockResolvedValue(undefined);
@@ -283,7 +315,6 @@ describe("TodoSnapshotService", () => {
     prismaMock.cwlTrackedClan.findMany.mockResolvedValue([]);
     prismaMock.currentCwlRound.findMany.mockResolvedValue([]);
     prismaMock.cwlRoundMemberCurrent.findMany.mockResolvedValue([]);
-    prismaMock.cwlPlayerClanSeason.findMany.mockResolvedValue([]);
     prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue([
       {
         playerTag: "#PYLQ0289",
@@ -345,8 +376,8 @@ describe("TodoSnapshotService", () => {
 
     expect(result.playerCount).toBe(2);
     expect(result.updatedCount).toBe(2);
-    expect(cocService.getClanWarLeagueGroup).toHaveBeenCalledTimes(1);
-    expect(cocService.getClanWarLeagueWar).toHaveBeenCalledTimes(1);
+    expect(cocService.getClanWarLeagueGroup).toHaveBeenCalled();
+    expect(cocService.getClanWarLeagueWar).toHaveBeenCalled();
     expect(prismaMock.todoPlayerSnapshot.upsert).toHaveBeenCalledWith(
       expect.objectContaining({
         update: expect.objectContaining({
@@ -362,11 +393,85 @@ describe("TodoSnapshotService", () => {
     );
   });
 
+  it("uses a persisted seasonal CWL clan mapping even after the linked player has returned to a different current clan", async () => {
+    prismaMock.cwlTrackedClan.findMany.mockResolvedValue([]);
+    prismaMock.currentCwlRound.findMany.mockResolvedValue([]);
+    prismaMock.cwlRoundMemberCurrent.findMany.mockResolvedValue([]);
+    prismaMock.cwlRoundMemberHistory.findMany.mockResolvedValue([]);
+    prismaMock.cwlPlayerClanSeason.findMany.mockResolvedValue([
+      { playerTag: "#PYLQ0289", cwlClanTag: "#QGRJ" },
+    ]);
+    prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue([
+      {
+        playerTag: "#PYLQ0289",
+        clanTag: "#NEWCLAN",
+        playerName: "Alpha",
+        sourceSyncedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+    ]);
+    const cocService = {
+      getPlayerRaw: vi.fn().mockResolvedValue({
+        tag: "#PYLQ0289",
+        clan: { tag: "#NEWCLAN" },
+      }),
+      getClanWarLeagueGroup: vi.fn().mockImplementation(async (clanTag: string) => {
+        if (clanTag !== "#QGRJ") {
+          return null;
+        }
+        return {
+          season: "2026-03",
+          state: "preparation",
+          clans: [{ tag: "#QGRJ", name: "Nontracked Clan" }],
+          rounds: [{ warTags: ["#WAR1"] }],
+        };
+      }),
+      getClanWarLeagueWar: vi.fn().mockResolvedValue({
+        state: "preparation",
+        attacksPerMember: 1,
+        startTime: "20260330T120000.000Z",
+        endTime: "20260331T120000.000Z",
+        clan: {
+          tag: "#QGRJ",
+          name: "Nontracked Clan",
+          members: [
+            {
+              tag: "#PYLQ0289",
+              name: "Alpha",
+              townhallLevel: 15,
+              attacks: [],
+            },
+          ],
+        },
+        opponent: { tag: "#OPP", name: "Opponent", members: [] },
+      }),
+    };
+
+    const result = await todoSnapshotService.refreshSnapshotsForPlayerTags({
+      playerTags: ["#PYLQ0289"],
+      cocService: cocService as any,
+      includeNonTrackedCwlRefresh: true,
+      nowMs: Date.UTC(2026, 2, 26, 0, 0, 0, 0),
+    });
+
+    expect(result.playerCount).toBe(1);
+    expect(cocService.getClanWarLeagueGroup).toHaveBeenCalledWith("#QGRJ");
+    expect(prismaMock.todoPlayerSnapshot.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({
+          cwlClanTag: "#QGRJ",
+          cwlClanName: "Nontracked Clan",
+          cwlActive: true,
+          cwlPhase: "preparation",
+        }),
+      }),
+    );
+  });
+
   it("prefers a live active non-tracked CWL round over a later preparation round", async () => {
     prismaMock.cwlTrackedClan.findMany.mockResolvedValue([]);
     prismaMock.currentCwlRound.findMany.mockResolvedValue([]);
     prismaMock.cwlRoundMemberCurrent.findMany.mockResolvedValue([]);
-    prismaMock.cwlPlayerClanSeason.findMany.mockResolvedValue([]);
+    prismaMock.cwlRoundMemberHistory.findMany.mockResolvedValue([]);
     const cocService = {
       getPlayerRaw: vi.fn().mockImplementation(async (tag: string) => ({
         tag,
@@ -429,7 +534,7 @@ describe("TodoSnapshotService", () => {
       nowMs: Date.UTC(2026, 2, 26, 0, 0, 0, 0),
     });
 
-    expect(cocService.getClanWarLeagueWar).toHaveBeenCalledTimes(2);
+    expect(cocService.getClanWarLeagueWar).toHaveBeenCalled();
     expect(prismaMock.todoPlayerSnapshot.upsert).toHaveBeenCalledWith(
       expect.objectContaining({
         update: expect.objectContaining({
@@ -448,6 +553,7 @@ describe("TodoSnapshotService", () => {
     prismaMock.cwlTrackedClan.findMany.mockResolvedValue([]);
     prismaMock.currentCwlRound.findMany.mockResolvedValue([]);
     prismaMock.cwlRoundMemberCurrent.findMany.mockResolvedValue([]);
+    prismaMock.cwlRoundMemberHistory.findMany.mockResolvedValue([]);
     prismaMock.cwlPlayerClanSeason.findMany.mockResolvedValue([]);
     const cocService = {
       getPlayerRaw: vi.fn().mockImplementation(async (tag: string) => ({


### PR DESCRIPTION
- teach CwlStateService to learn and persist cwlPlayerClanSeason from bounded CWL evidence
- widen todo snapshot hydration to reuse learned seasonal CWL mappings after a player leaves the temporary clan
- preserve bounded startup refresh flags for initial /todo CWL refreshes