### PR TITLE
fix(todo): bust render cache after snapshot refresh

### DIFF
--- a/src/commands/Todo.ts
+++ b/src/commands/Todo.ts
@@ -15,6 +15,7 @@ import { CoCService } from "../services/CoCService";
 import { cocRequestQueueService } from "../services/CoCRequestQueueService";
 import { cwlStateService } from "../services/CwlStateService";
 import {
+  bumpTodoRenderCacheGenerationForUser,
   buildTodoPagesForUser,
   invalidateTodoRenderCacheForUser,
   normalizeTodoType,
@@ -137,6 +138,7 @@ async function refreshTodoSnapshotsForDiscordUser(input: {
       });
     }
     await todoSnapshotService.refreshSnapshotsForPlayerTags(refreshInput);
+    bumpTodoRenderCacheGenerationForUser(input.discordUserId);
   }
   invalidateTodoRenderCacheForUser(input.discordUserId);
 }

--- a/src/services/TodoService.ts
+++ b/src/services/TodoService.ts
@@ -115,6 +115,7 @@ const TODO_GAMES_COMPLETE_POINTS = 4000;
 const TODO_GAMES_MAX_POINTS = 10_000;
 const TODO_LOCALE = "en-US";
 const todoRenderCacheByKey = new Map<string, CachedTodoRender>();
+const todoRenderGenerationByUser = new Map<string, number>();
 
 /** Purpose: normalize `/todo type` input into one safe enum value. */
 export function normalizeTodoType(input: string | null | undefined): TodoType {
@@ -133,6 +134,15 @@ export function normalizeTodoType(input: string | null | undefined): TodoType {
 /** Purpose: clear in-memory todo render cache between isolated tests. */
 export function resetTodoRenderCacheForTest(): void {
   todoRenderCacheByKey.clear();
+  todoRenderGenerationByUser.clear();
+}
+
+/** Purpose: bump the render cache generation for one user after snapshot refreshes. */
+export function bumpTodoRenderCacheGenerationForUser(discordUserId: string): void {
+  const key = String(discordUserId ?? "").trim();
+  if (!key) return;
+  const current = todoRenderGenerationByUser.get(key) ?? 0;
+  todoRenderGenerationByUser.set(key, current + 1);
 }
 
 /** Purpose: invalidate cached todo render entries for one Discord user after snapshot rebuilds. */
@@ -604,8 +614,11 @@ function buildTodoRenderCacheKey(input: {
   linkedTags: string[];
   snapshotVersion: { snapshotCount: number; maxUpdatedAtMs: number };
 }): string {
+  const discordUserId = String(input.discordUserId ?? "").trim();
+  const generation = todoRenderGenerationByUser.get(discordUserId) ?? 0;
   return [
-    input.discordUserId,
+    discordUserId,
+    String(generation),
     input.linkedTags.join(","),
     String(input.snapshotVersion.snapshotCount),
     String(input.snapshotVersion.maxUpdatedAtMs),

--- a/tests/todo.command.test.ts
+++ b/tests/todo.command.test.ts
@@ -81,7 +81,12 @@ import {
   handleTodoRefreshButtonInteraction,
   Todo,
 } from "../src/commands/Todo";
-import { resetTodoRenderCacheForTest } from "../src/services/TodoService";
+import * as TodoServiceModule from "../src/services/TodoService";
+import {
+  bumpTodoRenderCacheGenerationForUser,
+  buildTodoPagesForUser,
+  resetTodoRenderCacheForTest,
+} from "../src/services/TodoService";
 import {
   resetTodoSnapshotServiceForTest,
   todoSnapshotService,
@@ -2755,6 +2760,63 @@ describe("/todo pagination buttons", () => {
     expect(prismaMock.todoPlayerSnapshot.findMany).toHaveBeenCalledTimes(2);
   });
 
+  it("busts cached todo pages after refresh so later page switches see refreshed CWL data", async () => {
+    const discordUserId = "111111111111111111";
+    let snapshotRows = [
+      makeSnapshotRow({
+        playerTag: "#PYLQ0289",
+        playerName: "Alpha",
+        cwlClanTag: "#PQL0289",
+        cwlClanName: "Clan One",
+        cwlActive: true,
+        cwlPhase: "battle day",
+        cwlAttacksUsed: 0,
+        cwlAttacksMax: 1,
+      }),
+    ];
+
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      { playerTag: "#PYLQ0289", createdAt: new Date("2026-03-01T00:00:00.000Z") },
+    ]);
+    prismaMock.todoPlayerSnapshot.aggregate.mockImplementation(async () => ({
+      _count: { _all: snapshotRows.length },
+      _max: { updatedAt: new Date("2026-03-26T00:00:00.000Z") },
+    }));
+    prismaMock.todoPlayerSnapshot.findMany.mockImplementation(async () => snapshotRows);
+
+    const initialPages = await buildTodoPagesForUser({
+      discordUserId,
+      cocService: makeCocServiceSpy() as any,
+    });
+    expect(initialPages.pages.CWL).toContain("CWL Status: 0 / 1 attacks completed");
+
+    snapshotRows = [
+      makeSnapshotRow({
+        playerTag: "#PYLQ0289",
+        playerName: "Alpha",
+        cwlClanTag: "#PQL0289",
+        cwlClanName: "Clan One",
+        cwlActive: true,
+        cwlPhase: "battle day",
+        cwlAttacksUsed: 1,
+        cwlAttacksMax: 1,
+      }),
+    ];
+
+    const cachedPages = await buildTodoPagesForUser({
+      discordUserId,
+      cocService: makeCocServiceSpy() as any,
+    });
+    expect(cachedPages.pages.CWL).toContain("CWL Status: 0 / 1 attacks completed");
+
+    bumpTodoRenderCacheGenerationForUser(discordUserId);
+    const refreshedPages = await buildTodoPagesForUser({
+      discordUserId,
+      cocService: makeCocServiceSpy() as any,
+    });
+    expect(refreshedPages.pages.CWL).toContain("CWL Status: 1 / 1 attacks completed");
+  });
+
   it("rejects button interactions from non-requesting users", async () => {
     const interaction = makeTodoButtonInteraction({
       customId: buildTodoPageButtonCustomId("111111111111111111", "WAR"),
@@ -2861,6 +2923,7 @@ describe("/todo refresh button", () => {
   });
 
   it("refreshes the target user snapshots and updates the existing message on the same page", async () => {
+    const bumpSpy = vi.spyOn(TodoServiceModule, "bumpTodoRenderCacheGenerationForUser");
     const cwlRefreshSpy = vi
       .spyOn(cwlStateService, "refreshTrackedCwlStateForPlayerTags")
       .mockResolvedValue({
@@ -2898,6 +2961,7 @@ describe("/todo refresh button", () => {
       cocService: expect.anything(),
       includeNonTrackedCwlRefresh: true,
     });
+    expect(bumpSpy).toHaveBeenCalledWith("222222222222222222");
     expect(cwlRefreshSpy.mock.invocationCallOrder[0]).toBeLessThan(
       refreshSpy.mock.invocationCallOrder[0],
     );


### PR DESCRIPTION
- bump todo page bundle generation after successful refresh
- keep post-refresh WAR/CWL tab switches reading fresh snapshot data