### PR TITLE
feat(todo): replace stale snapshot labels with hourglass legend

### DIFF
--- a/src/services/TodoService.ts
+++ b/src/services/TodoService.ts
@@ -114,6 +114,7 @@ const TODO_DEFAULT_GAMES_TARGET = 4000;
 const TODO_GAMES_COMPLETE_POINTS = 4000;
 const TODO_GAMES_MAX_POINTS = 10_000;
 const TODO_LOCALE = "en-US";
+const TODO_STALE_SNAPSHOT_LEGEND = ":hourglass: snapshot may be out of date";
 const todoRenderCacheByKey = new Map<string, CachedTodoRender>();
 const todoRenderGenerationByUser = new Map<string, number>();
 
@@ -1076,6 +1077,7 @@ function buildTodoPageDescription(input: {
   const statusLine = sanitizeStatusText(input.statusLine ?? "");
   const lines = [
     `Type: ${input.heading}`,
+    TODO_STALE_SNAPSHOT_LEGEND,
     statusLine || `Linked players: ${input.linkedPlayerCount}`,
     "",
     ...input.lines,
@@ -1092,7 +1094,7 @@ function getWarRowStatus(row: TodoRenderRow): string {
     return "`0 / 2` - snapshot unavailable";
   }
   const { used, max, complete } = getWarRowProgress(row);
-  const staleSuffix = row.staleSnapshot && !complete ? " - stale snapshot" : "";
+  const staleSuffix = row.staleSnapshot && !complete ? " - :hourglass:" : "";
   return `\`${used} / ${max}\`${staleSuffix}`;
 }
 
@@ -1125,7 +1127,7 @@ function getCwlRowStatus(row: TodoRenderRow): string {
   }
 
   if (!isCwlRowAttackPhaseActive(row)) {
-    const staleSuffix = row.staleSnapshot ? " - stale snapshot" : "";
+    const staleSuffix = row.staleSnapshot ? " - :hourglass:" : "";
     const plannedSuffix = row.cwlPlannedSubInAt
       ? ` - planned sub in ${formatRelativeTimestamp(row.cwlPlannedSubInAt)}`
       : "";
@@ -1133,7 +1135,7 @@ function getCwlRowStatus(row: TodoRenderRow): string {
   }
 
   const { used, max } = getCwlRowProgress(row);
-  const staleSuffix = row.staleSnapshot ? " - stale snapshot" : "";
+  const staleSuffix = row.staleSnapshot ? " - :hourglass:" : "";
   return `\`${used} / ${max}\`${staleSuffix}`;
 }
 
@@ -1226,7 +1228,7 @@ function getRaidRowStatus(row: TodoRenderRow): string {
   }
 
   const { used, max } = getRaidRowProgress(row);
-  const staleSuffix = row.staleSnapshot ? " - stale snapshot" : "";
+  const staleSuffix = row.staleSnapshot ? " - :hourglass:" : "";
 
   if (!row.snapshot.raidActive) {
     return `clan capital raids: ${used}/${max} - not active${staleSuffix}`;
@@ -1273,7 +1275,7 @@ function getGamesRowStatus(row: TodoRenderRow): string {
   const points = Math.max(0, toFiniteIntOrNull(row.snapshot.gamesPoints) ?? 0);
   const target =
     toFiniteIntOrNull(row.snapshot.gamesTarget) ?? TODO_DEFAULT_GAMES_TARGET;
-  const staleSuffix = row.staleSnapshot ? " - stale snapshot" : "";
+  const staleSuffix = row.staleSnapshot ? " - :hourglass:" : "";
 
   if (!row.snapshot.gamesActive) {
     return `clan games points: ${points}/${target} - not active${staleSuffix}`;

--- a/tests/todo.command.test.ts
+++ b/tests/todo.command.test.ts
@@ -483,6 +483,7 @@ describe("/todo command", () => {
     const description = getReplyDescription(interaction);
     const payload = interaction.editReply.mock.calls[0]?.[0] as any;
     expect(getReplyTitle(interaction)).toBe("Todo - CWL");
+    expect(description).toContain(":hourglass: snapshot may be out of date");
     expect(description).toContain("CWL Status: Not in war yet");
     expect(description).toContain(
       "[Clan One](https://link.clashofclans.com/en?action=OpenClanProfile&tag=PQL0289) `#PQL0289` - Next war <t:",
@@ -652,6 +653,7 @@ describe("/todo command", () => {
 
     const description = getReplyDescription(interaction);
     expect(getReplyTitle(interaction)).toBe("Todo - CWL");
+    expect(description).toContain(":hourglass: snapshot may be out of date");
     expect(description).toContain("CWL Status: Not in war yet");
     expect(description).toContain(":black_circle: Alpha - `0 / 0`");
   });
@@ -1407,9 +1409,10 @@ describe("/todo command", () => {
     await Todo.run({} as any, interaction as any, makeCocServiceSpy() as any);
 
     const description = getReplyDescription(interaction);
+    expect(description).toContain(":hourglass: snapshot may be out of date");
     expect(description).toContain(":white_check_mark: #1 Alpha - `2 / 2`");
-    expect(description).not.toContain("`2 / 2` - stale snapshot");
-    expect(description).toContain("- #2 Bravo - `1 / 2` - stale snapshot");
+    expect(description).not.toContain("stale snapshot");
+    expect(description).toContain("- #2 Bravo - `1 / 2` - :hourglass:");
   });
 
   it("keeps WAR rows visible when the linked account's current clan differs from the war clan context", async () => {
@@ -1527,6 +1530,7 @@ describe("/todo command", () => {
     await Todo.run({} as any, interaction as any, makeCocServiceSpy() as any);
 
     const description = getReplyDescription(interaction);
+    expect(description).toContain(":hourglass: snapshot may be out of date");
     expect(description).toContain("Alpha #PYLQ0289 - clan capital raids: 3/6");
   });
 
@@ -2187,6 +2191,7 @@ describe("/todo command", () => {
     await Todo.run({} as any, interaction as any, makeCocServiceSpy() as any);
 
     const description = getReplyDescription(interaction);
+    expect(description).toContain(":hourglass: snapshot may be out of date");
     expect(description).toContain("**Time remaining:** <t:");
     expect(countOccurrences(description, "<t:")).toBe(1);
     expect(description).toContain(":white_check_mark: Alpha #PYLQ0289 - clan capital raids: 6/6");


### PR DESCRIPTION
- render stale todo indicators with :hourglass: instead of text labels
- add one shared hourglass legend to the top of every todo embed