### PR TITLE
fix(fwa): preserve war-mail role mention on refresh

### DIFF
--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -4168,17 +4168,40 @@ export const buildWarMailPostedContentForTest = buildWarMailPostedContent;
 export const buildWarMailNextRefreshLabelForTest =
   buildNextRefreshRelativeLabel;
 
+function buildWarMailSendPayload(
+  roleId: string | null | undefined,
+  nowMs: number | undefined,
+  options: {
+    pingRole: boolean;
+    planText: string | null | undefined;
+    includeNextRefresh: boolean;
+  },
+): {
+  content: string;
+  allowedMentions: { roles: string[] } | undefined;
+} {
+  const normalizedRoleId = normalizeDiscordRoleId(roleId);
+  return {
+    content: buildWarMailPostedContent(normalizedRoleId, nowMs, {
+      pingRole: options.pingRole,
+      planText: options.planText ?? undefined,
+      includeNextRefresh: options.includeNextRefresh,
+    }),
+    allowedMentions:
+      options.pingRole && normalizedRoleId
+        ? { roles: [normalizedRoleId] }
+        : undefined,
+  };
+}
+
+export const buildWarMailSendPayloadForTest = buildWarMailSendPayload;
+
 /** Purpose: keep an already-visible role mention on refresh edits without deriving new mention state. */
 function extractPostedWarMailMentionRoleId(
   existingPostedContent: string | null | undefined,
 ): string | null {
-  const lines = String(existingPostedContent ?? "").split(/\r?\n/);
-  for (const line of lines) {
-    const trimmed = line.trim();
-    if (!trimmed) continue;
-    const match = trimmed.match(/^<@&(\d{5,})>$/);
-    if (match?.[1]) return normalizeDiscordRoleId(match[1]);
-  }
+  const match = String(existingPostedContent ?? "").match(/<@&(\d{5,})>/);
+  if (match?.[1]) return normalizeDiscordRoleId(match[1]);
   return null;
 }
 
@@ -4189,14 +4212,15 @@ function buildWarMailRefreshEditPayload(
   nowMs?: number,
   options?: {
     includeNextRefresh?: boolean;
+    mentionRoleId?: string | null;
   },
 ): {
   content: string;
   allowedMentions: { parse: [] };
 } {
-  const persistedMentionRoleId = extractPostedWarMailMentionRoleId(
-    existingPostedContent,
-  );
+  const persistedMentionRoleId =
+    normalizeDiscordRoleId(options?.mentionRoleId ?? null) ??
+    extractPostedWarMailMentionRoleId(existingPostedContent);
   return {
     content: buildWarMailPostedContent(persistedMentionRoleId, nowMs, {
       planText: String(planText ?? ""),
@@ -4597,6 +4621,7 @@ async function refreshWarMailPostByResolvedTarget(params: {
     undefined,
     {
       includeNextRefresh: !rendered.freezeRefresh,
+      mentionRoleId: rendered.clanRoleId,
     },
   );
   await message.edit({
@@ -6912,17 +6937,14 @@ async function handleFwaMailConfirmAction(
     payload.tag,
     renderedWarIdNumber,
   );
-  const mentionRoleId = normalizeDiscordRoleId(rendered.clanRoleId);
+  const sendPayload = buildWarMailSendPayload(rendered.clanRoleId, undefined, {
+    pingRole: options.pingRole,
+    planText: rendered.planText,
+    includeNextRefresh: !rendered.freezeRefresh,
+  });
   const sent = await (channel as any).send({
-    content: buildWarMailPostedContent(mentionRoleId, undefined, {
-      pingRole: options.pingRole,
-      planText: rendered.planText,
-      includeNextRefresh: !rendered.freezeRefresh,
-    }),
-    allowedMentions:
-      options.pingRole && mentionRoleId
-        ? { roles: [mentionRoleId] }
-        : undefined,
+    content: sendPayload.content,
+    allowedMentions: sendPayload.allowedMentions,
     embeds: [rendered.embed],
     components: rendered.freezeRefresh
       ? []

--- a/tests/fwaMailDownstream.logic.test.ts
+++ b/tests/fwaMailDownstream.logic.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildWarMailPostedContentForTest,
+  buildWarMailSendPayloadForTest,
   buildWarMailRefreshEditPayloadForTest,
   hasWarIdentityShiftedForTest,
   resolveWarMailRefreshIdentityDecisionForTest,
@@ -151,6 +152,30 @@ describe("fwa war-mail posted content", () => {
   });
 });
 
+describe("fwa war-mail send payload", () => {
+  it("includes the visible role mention and allows the ping when enabled", () => {
+    const payload = buildWarMailSendPayloadForTest("123456789", 0, {
+      pingRole: true,
+      planText: "Plan body",
+      includeNextRefresh: true,
+    });
+
+    expect(payload.content).toBe("Plan body\n\n<@&123456789>\n\nNext refresh <t:1200:R>");
+    expect(payload.allowedMentions).toEqual({ roles: ["123456789"] });
+  });
+
+  it("omits the visible role mention and allowedMentions when pinging is disabled", () => {
+    const payload = buildWarMailSendPayloadForTest("123456789", 0, {
+      pingRole: false,
+      planText: "Plan body",
+      includeNextRefresh: true,
+    });
+
+    expect(payload.content).toBe("Plan body\n\nNext refresh <t:1200:R>");
+    expect(payload.allowedMentions).toBeUndefined();
+  });
+});
+
 describe("fwa war-mail refresh edit payload", () => {
   it("preserves existing visible role mention in refreshed content", () => {
     const payload = buildWarMailRefreshEditPayloadForTest(
@@ -182,6 +207,17 @@ describe("fwa war-mail refresh edit payload", () => {
     expect(payload.allowedMentions).toEqual({ parse: [] });
   });
 
+  it("prefers durable mention role state over parsing when provided", () => {
+    const payload = buildWarMailRefreshEditPayloadForTest(
+      "Old plan -- <@&999999999> in the middle of text\n\nNext refresh <t:999:R>",
+      "New plan",
+      0,
+      { mentionRoleId: "123456789" },
+    );
+
+    expect(payload.content).toBe("New plan\n\n<@&123456789>\n\nNext refresh <t:1200:R>");
+  });
+
   it("does not add a role mention when existing posted message has none", () => {
     const payload = buildWarMailRefreshEditPayloadForTest(
       "Old plan\n\nNext refresh <t:999:R>",
@@ -194,7 +230,7 @@ describe("fwa war-mail refresh edit payload", () => {
 
   it("removes stale next-refresh text when refresh is frozen", () => {
     const payload = buildWarMailRefreshEditPayloadForTest(
-      "Old plan\n\n<@&123456789>\n\nNext refresh <t:999:R>",
+      "Old plan\n\nMail role: <@&123456789>.\n\nNext refresh <t:999:R>",
       "New plan",
       0,
       { includeNextRefresh: false },


### PR DESCRIPTION
- prefer tracked clan role config when rebuilding refreshed mail content
- keep refresh edits non-pinging while tolerating legacy mention parsing