### PR TITLE
feat(todo): show snapshot last updated legend

### DIFF
--- a/src/services/TodoService.ts
+++ b/src/services/TodoService.ts
@@ -114,7 +114,6 @@ const TODO_DEFAULT_GAMES_TARGET = 4000;
 const TODO_GAMES_COMPLETE_POINTS = 4000;
 const TODO_GAMES_MAX_POINTS = 10_000;
 const TODO_LOCALE = "en-US";
-const TODO_STALE_SNAPSHOT_LEGEND = ":hourglass: snapshot may be out of date";
 const todoRenderCacheByKey = new Map<string, CachedTodoRender>();
 const todoRenderGenerationByUser = new Map<string, number>();
 
@@ -584,15 +583,33 @@ export async function buildTodoPagesForUser(input: {
       .catch(() => undefined);
   }
 
-  const warView = buildWarPageDescription(renderRows, linkedTags.length);
-  const cwlView = buildCwlPageDescription(renderRows, linkedTags.length);
+  const snapshotLastUpdatedAtMs = snapshotVersion.maxUpdatedAtMs;
+  const warView = buildWarPageDescription(
+    renderRows,
+    linkedTags.length,
+    snapshotLastUpdatedAtMs,
+  );
+  const cwlView = buildCwlPageDescription(
+    renderRows,
+    linkedTags.length,
+    snapshotLastUpdatedAtMs,
+  );
   const pages = {
     linkedPlayerCount: linkedTags.length,
     pages: {
       WAR: warView.description,
       CWL: cwlView.description,
-      RAIDS: buildRaidsPageDescription(renderRows, linkedTags.length),
-      GAMES: buildGamesPageDescription(renderRows, linkedTags.length, nowMs),
+      RAIDS: buildRaidsPageDescription(
+        renderRows,
+        linkedTags.length,
+        snapshotLastUpdatedAtMs,
+      ),
+      GAMES: buildGamesPageDescription(
+        renderRows,
+        linkedTags.length,
+        nowMs,
+        snapshotLastUpdatedAtMs,
+      ),
     },
     sidebarStateByType: {
       WAR: warView.sidebarState,
@@ -651,6 +668,7 @@ function isSnapshotStale(snapshot: TodoSnapshotRecord, nowMs: number): boolean {
 function buildWarPageDescription(
   rows: TodoRenderRow[],
   linkedPlayerCount: number,
+  snapshotLastUpdatedAtMs: number,
 ): { description: string; sidebarState: TodoSidebarState } {
   const activeRows = rows.filter((row) => Boolean(row.snapshot?.warActive));
   const warCompletion = summarizeWarCompletionStatus(activeRows);
@@ -659,6 +677,7 @@ function buildWarPageDescription(
       description: buildTodoPageDescription({
         heading: "WAR",
         linkedPlayerCount,
+        snapshotLastUpdatedAtMs,
         statusLine: warCompletion.statusLine,
         lines: ["No war active"],
       }),
@@ -686,6 +705,7 @@ function buildWarPageDescription(
     description: buildTodoPageDescription({
       heading: "WAR",
       linkedPlayerCount,
+      snapshotLastUpdatedAtMs,
       statusLine: warCompletion.statusLine,
       lines,
     }),
@@ -697,6 +717,7 @@ function buildWarPageDescription(
 function buildCwlPageDescription(
   rows: TodoRenderRow[],
   linkedPlayerCount: number,
+  snapshotLastUpdatedAtMs: number,
 ): { description: string; sidebarState: TodoSidebarState } {
   const contextRows = rows.filter((row) => hasCwlRenderContext(row));
   if (contextRows.length <= 0) {
@@ -704,6 +725,7 @@ function buildCwlPageDescription(
       description: buildTodoPageDescription({
         heading: "CWL",
         linkedPlayerCount,
+        snapshotLastUpdatedAtMs,
         statusLine: "CWL Status: 0 / 0 attacks completed",
         lines: ["No CWL active"],
       }),
@@ -729,6 +751,7 @@ function buildCwlPageDescription(
     description: buildTodoPageDescription({
       heading: "CWL",
       linkedPlayerCount,
+      snapshotLastUpdatedAtMs,
       statusLine: cwlCompletion.statusLine,
       lines,
     }),
@@ -798,12 +821,14 @@ function summarizeCwlCompletionStatus(
 function buildRaidsPageDescription(
   rows: TodoRenderRow[],
   linkedPlayerCount: number,
+  snapshotLastUpdatedAtMs: number,
 ): string {
   const hasActive = rows.some((row) => Boolean(row.snapshot?.raidActive));
   if (!hasActive) {
     return buildTodoPageDescription({
       heading: "RAIDS",
       linkedPlayerCount,
+      snapshotLastUpdatedAtMs,
       lines: ["No raids active"],
     });
   }
@@ -821,6 +846,7 @@ function buildRaidsPageDescription(
   return buildTodoPageDescription({
     heading: "RAIDS",
     linkedPlayerCount,
+    snapshotLastUpdatedAtMs,
     lines,
   });
 }
@@ -830,6 +856,7 @@ function buildGamesPageDescription(
   rows: TodoRenderRow[],
   linkedPlayerCount: number,
   nowMs: number,
+  snapshotLastUpdatedAtMs: number,
 ): string {
   const hasActive = rows.some((row) =>
     isTodoGamesSessionActive(row.snapshot, nowMs),
@@ -851,6 +878,7 @@ function buildGamesPageDescription(
     return buildTodoPageDescription({
       heading: "GAMES",
       linkedPlayerCount,
+      snapshotLastUpdatedAtMs,
       lines,
     });
   }
@@ -860,6 +888,7 @@ function buildGamesPageDescription(
     return buildTodoPageDescription({
       heading: "GAMES",
       linkedPlayerCount,
+      snapshotLastUpdatedAtMs,
       lines: buildGamesRewardCollectionLines(rows, rewardCollectionEndsAt),
     });
   }
@@ -868,6 +897,7 @@ function buildGamesPageDescription(
   return buildTodoPageDescription({
     heading: "GAMES",
     linkedPlayerCount,
+    snapshotLastUpdatedAtMs,
     lines: offCycleLines,
   });
 }
@@ -1071,13 +1101,14 @@ function formatWarPlayerIdentity(row: TodoRenderRow): string {
 function buildTodoPageDescription(input: {
   heading: TodoType;
   linkedPlayerCount: number;
+  snapshotLastUpdatedAtMs: number;
   statusLine?: string | null;
   lines: string[];
 }): string {
   const statusLine = sanitizeStatusText(input.statusLine ?? "");
   const lines = [
     `Type: ${input.heading}`,
-    TODO_STALE_SNAPSHOT_LEGEND,
+    formatTodoSnapshotLegend(input.snapshotLastUpdatedAtMs),
     statusLine || `Linked players: ${input.linkedPlayerCount}`,
     "",
     ...input.lines,
@@ -1693,6 +1724,13 @@ function needsGamesLifetimeBackfill(row: TodoRenderRow, nowMs: number): boolean 
 /** Purpose: format one date as a Discord relative timestamp token. */
 function formatRelativeTimestamp(input: Date): string {
   return `<t:${Math.floor(input.getTime() / 1000)}:R>`;
+}
+
+/** Purpose: build the shared todo snapshot freshness legend from the authoritative snapshot version timestamp. */
+function formatTodoSnapshotLegend(snapshotLastUpdatedAtMs: number): string {
+  return `:hourglass: last updated ${formatRelativeTimestamp(
+    new Date(snapshotLastUpdatedAtMs),
+  )}`;
 }
 
 /** Purpose: keep status labels compact and deterministic for embed row rendering. */

--- a/tests/todo.command.test.ts
+++ b/tests/todo.command.test.ts
@@ -258,6 +258,12 @@ function countOccurrences(haystack: string, needle: string): number {
   return count;
 }
 
+function expectTodoLegendWithLastUpdated(description: string): void {
+  expect(description).toContain(":hourglass: last updated <t:");
+  expect(description).toMatch(/:hourglass: last updated <t:\d+:R>/);
+  expect(description).not.toContain(":hourglass: snapshot may be out of date");
+}
+
 describe("/todo command", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -483,7 +489,7 @@ describe("/todo command", () => {
     const description = getReplyDescription(interaction);
     const payload = interaction.editReply.mock.calls[0]?.[0] as any;
     expect(getReplyTitle(interaction)).toBe("Todo - CWL");
-    expect(description).toContain(":hourglass: snapshot may be out of date");
+    expectTodoLegendWithLastUpdated(description);
     expect(description).toContain("CWL Status: Not in war yet");
     expect(description).toContain(
       "[Clan One](https://link.clashofclans.com/en?action=OpenClanProfile&tag=PQL0289) `#PQL0289` - Next war <t:",
@@ -653,7 +659,7 @@ describe("/todo command", () => {
 
     const description = getReplyDescription(interaction);
     expect(getReplyTitle(interaction)).toBe("Todo - CWL");
-    expect(description).toContain(":hourglass: snapshot may be out of date");
+    expectTodoLegendWithLastUpdated(description);
     expect(description).toContain("CWL Status: Not in war yet");
     expect(description).toContain(":black_circle: Alpha - `0 / 0`");
   });
@@ -1409,7 +1415,7 @@ describe("/todo command", () => {
     await Todo.run({} as any, interaction as any, makeCocServiceSpy() as any);
 
     const description = getReplyDescription(interaction);
-    expect(description).toContain(":hourglass: snapshot may be out of date");
+    expectTodoLegendWithLastUpdated(description);
     expect(description).toContain(":white_check_mark: #1 Alpha - `2 / 2`");
     expect(description).not.toContain("stale snapshot");
     expect(description).toContain("- #2 Bravo - `1 / 2` - :hourglass:");
@@ -1530,7 +1536,7 @@ describe("/todo command", () => {
     await Todo.run({} as any, interaction as any, makeCocServiceSpy() as any);
 
     const description = getReplyDescription(interaction);
-    expect(description).toContain(":hourglass: snapshot may be out of date");
+    expectTodoLegendWithLastUpdated(description);
     expect(description).toContain("Alpha #PYLQ0289 - clan capital raids: 3/6");
   });
 
@@ -2191,9 +2197,9 @@ describe("/todo command", () => {
     await Todo.run({} as any, interaction as any, makeCocServiceSpy() as any);
 
     const description = getReplyDescription(interaction);
-    expect(description).toContain(":hourglass: snapshot may be out of date");
+    expectTodoLegendWithLastUpdated(description);
     expect(description).toContain("**Time remaining:** <t:");
-    expect(countOccurrences(description, "<t:")).toBe(1);
+    expect(countOccurrences(description, "<t:")).toBe(2);
     expect(description).toContain(":white_check_mark: Alpha #PYLQ0289 - clan capital raids: 6/6");
     expect(description).toContain(":yellow_circle: Bravo #QGRJ2222 - clan capital raids: 1/6");
     expect(description).toContain(":black_circle: Charlie #LQ9P8R2 - clan capital raids: 0/6");
@@ -2350,7 +2356,7 @@ describe("/todo command", () => {
 
     const description = getReplyDescription(interaction);
     expect(description).toContain("**Time remaining:** <t:");
-    expect(countOccurrences(description, "<t:")).toBe(1);
+    expect(countOccurrences(description, "<t:")).toBe(2);
     expect(description).toContain("Alpha #LQ9P8R2 - clan games points: 10000/4000");
     expect(description).toContain("Bravo #Q2V8P9L2 - clan games points: 4000/4000");
     expect(description).toContain("Charlie #CUV9082 - clan games points: 5200/4000");


### PR DESCRIPTION
- replace the stale hourglass legend with a relative last-updated timestamp
- reuse the existing snapshot version timestamp across all todo views