### PR TITLE
fix(cwl): keep rotations show back navigation persisted

### DIFF
--- a/src/commands/Cwl.ts
+++ b/src/commands/Cwl.ts
@@ -1319,13 +1319,40 @@ async function buildCwlRotationShowOverviewPayload(input: {
             statusIcons,
           }),
         ),
-      ),
+    ),
     components: buildCwlRotationShowOverviewActionRows({
       userId: input.userId,
       season: input.season,
       overview: input.overview,
     }),
   };
+}
+
+async function loadCwlRotationShowOverviewPayload(input: {
+  client: Client;
+  userId: string;
+  season: string;
+  refreshLeadershipMembers?: boolean;
+}): Promise<{
+  embed: EmbedBuilder;
+  components: ActionRowBuilder<StringSelectMenuBuilder>[];
+}> {
+  const overview = await cwlRotationService.listOverview(
+    input.refreshLeadershipMembers
+      ? {
+          season: input.season,
+          refreshLeadershipMembers: true,
+        }
+      : {
+          season: input.season,
+        },
+  );
+  return buildCwlRotationShowOverviewPayload({
+    client: input.client,
+    userId: input.userId,
+    season: input.season,
+    overview,
+  });
 }
 
 async function loadCwlRotationShowClanPayload(input: {
@@ -1911,15 +1938,11 @@ async function handleRotationShowSubcommand(client: Client, interaction: ChatInp
   const day = interaction.options.getInteger("day", false);
 
   if (!clanTag) {
-    const overview = await cwlRotationService.listOverview({
-      season,
-      refreshLeadershipMembers: true,
-    });
-    const { embed, components } = await buildCwlRotationShowOverviewPayload({
+    const { embed, components } = await loadCwlRotationShowOverviewPayload({
       client,
       userId: interaction.user.id,
       season,
-      overview,
+      refreshLeadershipMembers: true,
     });
     await interaction.editReply({
       embeds: [embed],
@@ -2293,21 +2316,29 @@ export async function handleCwlRotationShowButtonInteraction(
   }
 
   if (parsed.action === "back") {
-    await interaction.deferUpdate();
-    const overview = await cwlRotationService.listOverview({
-      season: parsed.season,
-      refreshLeadershipMembers: true,
-    });
-    const { embed, components } = await buildCwlRotationShowOverviewPayload({
-      client: interaction.client,
-      userId: interaction.user.id,
-      season: parsed.season,
-      overview,
-    });
-    await interaction.editReply({
-      embeds: [embed],
-      components,
-    });
+    try {
+      await interaction.deferUpdate();
+      const { embed, components } = await loadCwlRotationShowOverviewPayload({
+        client: interaction.client,
+        userId: interaction.user.id,
+        season: parsed.season,
+      });
+      await interaction.editReply({
+        embeds: [embed],
+        components,
+      });
+    } catch (error) {
+      console.error(`CWL rotation show back failed: ${formatError(error)}`);
+      const failurePayload = {
+        content: "Unable to load the CWL overview right now.",
+        ephemeral: true,
+      };
+      if (interaction.deferred || interaction.replied) {
+        await interaction.followUp(failurePayload);
+      } else {
+        await interaction.reply(failurePayload);
+      }
+    }
     return;
   }
 

--- a/tests/cwl.command.test.ts
+++ b/tests/cwl.command.test.ts
@@ -477,6 +477,9 @@ describe("/cwl command", () => {
     await handleCwlRotationShowButtonInteraction(backInteraction as any);
     expect(backInteraction.deferUpdate).toHaveBeenCalledTimes(1);
     expect(backInteraction.editReply).toHaveBeenCalledTimes(1);
+    expect(cwlRotationService.listOverview).toHaveBeenNthCalledWith(2, {
+      season: "2026-04",
+    });
     expect(getEditedDescription(backInteraction)).toContain(
       `<:yes:111> CWL Alpha (\`#2QG2C08UP\`) - day 2 - Next Battle Day <t:${alphaBattleDay}:R>`,
     );
@@ -1034,6 +1037,9 @@ describe("/cwl command", () => {
 
     expect(backInteraction.deferUpdate).toHaveBeenCalledTimes(1);
     expect(backInteraction.editReply).toHaveBeenCalledTimes(1);
+    expect(cwlRotationService.listOverview).toHaveBeenNthCalledWith(2, {
+      season: "2026-04",
+    });
     const backDescription = getEditedDescription(backInteraction);
     expect(backDescription).toContain(
       `<:yes:111> CWL Alpha (\`#2QG2C08UP\`) - day 2 - Next Battle Day <t:${alphaBattleDay}:R>`,


### PR DESCRIPTION
- reuse the shared overview render path without leadership refresh on Back
- add safe fallback messaging when the overview rebuild fails