### PR TITLE
fix(todo): use displayed source freshness for last updated legend

### DIFF
--- a/src/services/ActivitySignalService.ts
+++ b/src/services/ActivitySignalService.ts
@@ -104,6 +104,19 @@ export function extractGamesChampionTotalFromSignalState(raw: string | null | un
   }
 }
 
+/** Purpose: extract one persisted freshness timestamp from a player signal-state JSON blob. */
+export function extractSignalStateFreshnessMsFromState(raw: string | null | undefined): number | null {
+  const parsed = parseState(raw ?? null);
+  if (!parsed) return null;
+  const candidates = [
+    parsed.lastSeenAtMs,
+    parsed.updatedAtMs,
+    ...Object.values(parsed.signalTimes ?? {}),
+  ].filter((value): value is number => Number.isFinite(value));
+  if (candidates.length <= 0) return null;
+  return Math.max(...candidates);
+}
+
 /** Purpose: to finite number. */
 function toFiniteNumber(value: unknown): number {
   const num = Number(value ?? 0);

--- a/src/services/CwlRotationService.ts
+++ b/src/services/CwlRotationService.ts
@@ -53,6 +53,7 @@ export type CwlRotationPlanExport = {
   clanTag: string;
   clanName: string | null;
   version: number;
+  updatedAt: Date;
   rosterSize: number;
   generatedFromRoundDay: number | null;
   excludedPlayerTags: string[];
@@ -898,6 +899,7 @@ export class CwlRotationService {
         clanTag: plan.clanTag,
         clanName,
         version: plan.version,
+        updatedAt: plan.updatedAt,
         rosterSize: plan.rosterSize,
         generatedFromRoundDay: plan.generatedFromRoundDay ?? null,
         excludedPlayerTags: [...plan.excludedPlayerTags],

--- a/src/services/TodoService.ts
+++ b/src/services/TodoService.ts
@@ -1,5 +1,9 @@
 import { CoCService } from "./CoCService";
 import {
+  buildPlayerSignalStateKey,
+  extractSignalStateFreshnessMsFromState,
+} from "./ActivitySignalService";
+import {
   listPlayerLinksForDiscordUser,
   normalizeClanTag,
   normalizePlayerTag,
@@ -50,6 +54,7 @@ type TodoRenderRow = {
   snapshot: TodoSnapshotRecord | null;
   missingSnapshot: boolean;
   staleSnapshot: boolean;
+  displayedFreshnessAtMsByType: Record<TodoType, number | null>;
 };
 
 type TodoEventGroup = {
@@ -101,6 +106,8 @@ type FwaClanMemberTownHallRow = {
 type FwaPlayerCatalogTownHallRow = {
   playerTag: string;
   latestTownHall: number | null;
+  lastSeenAt: Date | null;
+  lastSyncedAt: Date | null;
 };
 
 const DISCORD_DESCRIPTION_LIMIT = 4096;
@@ -223,6 +230,7 @@ export async function buildTodoPagesForUser(input: {
     currentWarRows,
     clanMemberTownHallRows,
     playerCatalogTownHallRows,
+    playerSignalStateRows,
     currentCwlRoundRows,
     currentCwlMemberRows,
     activeCwlPlans,
@@ -265,6 +273,21 @@ export async function buildTodoPagesForUser(input: {
           select: {
             playerTag: true,
             latestTownHall: true,
+            lastSeenAt: true,
+            lastSyncedAt: true,
+          },
+        })
+      : Promise.resolve([]),
+    linkedTags.length > 0
+      ? prisma.botSetting.findMany({
+          where: {
+            key: {
+              in: linkedTags.map((tag) => buildPlayerSignalStateKey(tag)),
+            },
+          },
+          select: {
+            key: true,
+            value: true,
           },
         })
       : Promise.resolve([]),
@@ -279,6 +302,8 @@ export async function buildTodoPagesForUser(input: {
             roundState: true,
             startTime: true,
             endTime: true,
+            sourceUpdatedAt: true,
+            updatedAt: true,
           },
         })
       : Promise.resolve([]),
@@ -291,6 +316,7 @@ export async function buildTodoPagesForUser(input: {
             clanTag: true,
             playerTag: true,
             subbedIn: true,
+            updatedAt: true,
           },
         })
       : Promise.resolve([]),
@@ -340,12 +366,34 @@ export async function buildTodoPagesForUser(input: {
   }
 
   const townHallByPlayerCatalogTag = new Map<string, number>();
+  const latestPlayerCatalogSeenAtByTag = new Map<string, Date>();
   for (const row of playerCatalogTownHallRows as FwaPlayerCatalogTownHallRow[]) {
     const playerTag = normalizePlayerTag(row.playerTag);
     if (!playerTag) continue;
     const townHall = toFiniteIntOrNull(row.latestTownHall);
     if (townHall === null || townHall <= 0) continue;
     townHallByPlayerCatalogTag.set(playerTag, townHall);
+    if (row.lastSeenAt instanceof Date) {
+      const existingSeenAt = latestPlayerCatalogSeenAtByTag.get(playerTag);
+      if (!existingSeenAt || row.lastSeenAt > existingSeenAt) {
+        latestPlayerCatalogSeenAtByTag.set(playerTag, row.lastSeenAt);
+      }
+    }
+  }
+
+  const playerSignalStateList = Array.isArray(playerSignalStateRows)
+    ? playerSignalStateRows
+    : [];
+  const playerSignalStateFreshnessByTag = new Map<string, number>();
+  for (const row of playerSignalStateList as Array<{ key: string; value: string }>) {
+    const playerTag = normalizePlayerTag(String(row.key ?? "").replace(/^player_signal_state:/i, ""));
+    if (!playerTag) continue;
+    const freshnessMs = extractSignalStateFreshnessMsFromState(row.value);
+    if (freshnessMs === null) continue;
+    const existingFreshnessMs = playerSignalStateFreshnessByTag.get(playerTag);
+    if (existingFreshnessMs === undefined || freshnessMs > existingFreshnessMs) {
+      playerSignalStateFreshnessByTag.set(playerTag, freshnessMs);
+    }
   }
 
   const currentCwlRoundByClanTag = new Map<
@@ -358,6 +406,8 @@ export async function buildTodoPagesForUser(input: {
       roundState: string;
       startTime: Date | null;
       endTime: Date | null;
+      sourceUpdatedAt: Date;
+      updatedAt: Date;
     }
   >();
   for (const row of currentCwlRoundList as Array<{
@@ -368,6 +418,8 @@ export async function buildTodoPagesForUser(input: {
     roundState: string;
     startTime: Date | null;
     endTime: Date | null;
+    sourceUpdatedAt: Date;
+    updatedAt: Date;
   }>) {
     const clanTag = normalizeClanTag(row.clanTag);
     if (!clanTag) continue;
@@ -379,6 +431,8 @@ export async function buildTodoPagesForUser(input: {
       roundState: row.roundState,
       startTime: row.startTime ?? null,
       endTime: row.endTime ?? null,
+      sourceUpdatedAt: row.sourceUpdatedAt,
+      updatedAt: row.updatedAt,
     });
   }
 
@@ -388,12 +442,14 @@ export async function buildTodoPagesForUser(input: {
       clanTag: string;
       playerTag: string;
       subbedIn: boolean;
+      updatedAt: Date;
     }
   >();
   for (const row of currentCwlMemberList as Array<{
     clanTag: string;
     playerTag: string;
     subbedIn: boolean;
+    updatedAt: Date;
   }>) {
     const clanTag = normalizeClanTag(row.clanTag);
     const playerTag = normalizePlayerTag(row.playerTag);
@@ -402,6 +458,7 @@ export async function buildTodoPagesForUser(input: {
       clanTag,
       playerTag,
       subbedIn: Boolean(row.subbedIn),
+      updatedAt: row.updatedAt,
     });
   }
 
@@ -410,6 +467,7 @@ export async function buildTodoPagesForUser(input: {
     {
       clanTag: string;
       clanName: string | null;
+      updatedAt: Date;
       days: Array<{
         roundDay: number;
         rows: Array<{
@@ -424,6 +482,7 @@ export async function buildTodoPagesForUser(input: {
   for (const plan of activeCwlPlanList as Array<{
     clanTag: string;
     clanName: string | null;
+    updatedAt: Date;
     days: Array<{
       roundDay: number;
       rows: Array<{
@@ -547,6 +606,38 @@ export async function buildTodoPagesForUser(input: {
       snapshotPlayerName: snapshot?.playerName,
       linkedName: link.linkedName,
     });
+    const warFreshnessCandidates = [
+      resolvedClanTag ? currentWarIdentityByClanTag.get(resolvedClanTag)?.updatedAt.getTime() ?? null : null,
+      trackedWarMember?.attackDetails
+        ? Math.min(
+            ...trackedWarMember.attackDetails
+              .map((detail) => detail.seenAtMs)
+              .filter((value): value is number => Number.isFinite(value)),
+          )
+        : null,
+    ].filter((value): value is number => Number.isFinite(value));
+    const cwlFreshnessCandidates = [
+      resolvedCwlClanTag
+        ? currentCwlRoundByClanTag.get(resolvedCwlClanTag)?.sourceUpdatedAt?.getTime() ?? null
+        : null,
+      resolvedCwlClanTag
+        ? currentCwlRoundByClanTag.get(resolvedCwlClanTag)?.updatedAt?.getTime() ?? null
+        : null,
+      resolvedCwlClanTag && normalizedTag
+        ? currentCwlMemberByClanAndPlayerTag.get(`${resolvedCwlClanTag}:${normalizedTag}`)?.updatedAt?.getTime() ?? null
+        : null,
+      resolvedCwlClanTag ? activeCwlPlanByClanTag.get(resolvedCwlClanTag)?.updatedAt?.getTime() ?? null : null,
+    ].filter((value): value is number => Number.isFinite(value));
+    const raidFreshnessCandidates = [
+      resolvedClanTag
+        ? latestTownHallByClanAndPlayer.get(`${resolvedClanTag}:${normalizedTag}`)?.getTime() ?? null
+        : null,
+      latestTownHallByPlayerTag.get(normalizedTag)?.getTime() ?? null,
+      latestPlayerCatalogSeenAtByTag.get(normalizedTag)?.getTime() ?? null,
+    ].filter((value): value is number => Number.isFinite(value));
+    const gamesFreshnessCandidates = [
+      playerSignalStateFreshnessByTag.get(normalizedTag) ?? null,
+    ].filter((value): value is number => Number.isFinite(value));
     return {
       playerTag: normalizedTag,
       playerName: resolvedPlayerName,
@@ -565,6 +656,12 @@ export async function buildTodoPagesForUser(input: {
       snapshot,
       missingSnapshot,
       staleSnapshot,
+      displayedFreshnessAtMsByType: {
+        WAR: resolveMinimumTimestampMs(warFreshnessCandidates),
+        CWL: resolveMinimumTimestampMs(cwlFreshnessCandidates),
+        RAIDS: resolveMinimumTimestampMs(raidFreshnessCandidates),
+        GAMES: resolveMinimumTimestampMs(gamesFreshnessCandidates),
+      },
     } satisfies TodoRenderRow;
   });
 
@@ -583,33 +680,19 @@ export async function buildTodoPagesForUser(input: {
       .catch(() => undefined);
   }
 
-  const snapshotLastUpdatedAtMs = snapshotVersion.maxUpdatedAtMs;
-  const warView = buildWarPageDescription(
-    renderRows,
-    linkedTags.length,
-    snapshotLastUpdatedAtMs,
-  );
-  const cwlView = buildCwlPageDescription(
-    renderRows,
-    linkedTags.length,
-    snapshotLastUpdatedAtMs,
-  );
+  const warFreshnessAtMs = resolveTodoPageDisplayedDataFreshnessMs(renderRows, "WAR");
+  const cwlFreshnessAtMs = resolveTodoPageDisplayedDataFreshnessMs(renderRows, "CWL");
+  const raidsFreshnessAtMs = resolveTodoPageDisplayedDataFreshnessMs(renderRows, "RAIDS");
+  const gamesFreshnessAtMs = resolveTodoPageDisplayedDataFreshnessMs(renderRows, "GAMES");
+  const warView = buildWarPageDescription(renderRows, linkedTags.length, warFreshnessAtMs);
+  const cwlView = buildCwlPageDescription(renderRows, linkedTags.length, cwlFreshnessAtMs);
   const pages = {
     linkedPlayerCount: linkedTags.length,
     pages: {
       WAR: warView.description,
       CWL: cwlView.description,
-      RAIDS: buildRaidsPageDescription(
-        renderRows,
-        linkedTags.length,
-        snapshotLastUpdatedAtMs,
-      ),
-      GAMES: buildGamesPageDescription(
-        renderRows,
-        linkedTags.length,
-        nowMs,
-        snapshotLastUpdatedAtMs,
-      ),
+      RAIDS: buildRaidsPageDescription(renderRows, linkedTags.length, raidsFreshnessAtMs),
+      GAMES: buildGamesPageDescription(renderRows, linkedTags.length, nowMs, gamesFreshnessAtMs),
     },
     sidebarStateByType: {
       WAR: warView.sidebarState,
@@ -668,7 +751,7 @@ function isSnapshotStale(snapshot: TodoSnapshotRecord, nowMs: number): boolean {
 function buildWarPageDescription(
   rows: TodoRenderRow[],
   linkedPlayerCount: number,
-  snapshotLastUpdatedAtMs: number,
+  displayedFreshnessAtMs: number | null,
 ): { description: string; sidebarState: TodoSidebarState } {
   const activeRows = rows.filter((row) => Boolean(row.snapshot?.warActive));
   const warCompletion = summarizeWarCompletionStatus(activeRows);
@@ -677,7 +760,7 @@ function buildWarPageDescription(
       description: buildTodoPageDescription({
         heading: "WAR",
         linkedPlayerCount,
-        snapshotLastUpdatedAtMs,
+        displayedFreshnessAtMs,
         statusLine: warCompletion.statusLine,
         lines: ["No war active"],
       }),
@@ -705,7 +788,7 @@ function buildWarPageDescription(
     description: buildTodoPageDescription({
       heading: "WAR",
       linkedPlayerCount,
-      snapshotLastUpdatedAtMs,
+      displayedFreshnessAtMs,
       statusLine: warCompletion.statusLine,
       lines,
     }),
@@ -717,7 +800,7 @@ function buildWarPageDescription(
 function buildCwlPageDescription(
   rows: TodoRenderRow[],
   linkedPlayerCount: number,
-  snapshotLastUpdatedAtMs: number,
+  displayedFreshnessAtMs: number | null,
 ): { description: string; sidebarState: TodoSidebarState } {
   const contextRows = rows.filter((row) => hasCwlRenderContext(row));
   if (contextRows.length <= 0) {
@@ -725,7 +808,7 @@ function buildCwlPageDescription(
       description: buildTodoPageDescription({
         heading: "CWL",
         linkedPlayerCount,
-        snapshotLastUpdatedAtMs,
+        displayedFreshnessAtMs,
         statusLine: "CWL Status: 0 / 0 attacks completed",
         lines: ["No CWL active"],
       }),
@@ -751,7 +834,7 @@ function buildCwlPageDescription(
     description: buildTodoPageDescription({
       heading: "CWL",
       linkedPlayerCount,
-      snapshotLastUpdatedAtMs,
+      displayedFreshnessAtMs,
       statusLine: cwlCompletion.statusLine,
       lines,
     }),
@@ -821,14 +904,14 @@ function summarizeCwlCompletionStatus(
 function buildRaidsPageDescription(
   rows: TodoRenderRow[],
   linkedPlayerCount: number,
-  snapshotLastUpdatedAtMs: number,
+  displayedFreshnessAtMs: number | null,
 ): string {
   const hasActive = rows.some((row) => Boolean(row.snapshot?.raidActive));
   if (!hasActive) {
     return buildTodoPageDescription({
       heading: "RAIDS",
       linkedPlayerCount,
-      snapshotLastUpdatedAtMs,
+      displayedFreshnessAtMs,
       lines: ["No raids active"],
     });
   }
@@ -846,7 +929,7 @@ function buildRaidsPageDescription(
   return buildTodoPageDescription({
     heading: "RAIDS",
     linkedPlayerCount,
-    snapshotLastUpdatedAtMs,
+    displayedFreshnessAtMs,
     lines,
   });
 }
@@ -856,7 +939,7 @@ function buildGamesPageDescription(
   rows: TodoRenderRow[],
   linkedPlayerCount: number,
   nowMs: number,
-  snapshotLastUpdatedAtMs: number,
+  displayedFreshnessAtMs: number | null,
 ): string {
   const hasActive = rows.some((row) =>
     isTodoGamesSessionActive(row.snapshot, nowMs),
@@ -878,7 +961,7 @@ function buildGamesPageDescription(
     return buildTodoPageDescription({
       heading: "GAMES",
       linkedPlayerCount,
-      snapshotLastUpdatedAtMs,
+      displayedFreshnessAtMs,
       lines,
     });
   }
@@ -888,7 +971,7 @@ function buildGamesPageDescription(
     return buildTodoPageDescription({
       heading: "GAMES",
       linkedPlayerCount,
-      snapshotLastUpdatedAtMs,
+      displayedFreshnessAtMs,
       lines: buildGamesRewardCollectionLines(rows, rewardCollectionEndsAt),
     });
   }
@@ -897,7 +980,7 @@ function buildGamesPageDescription(
   return buildTodoPageDescription({
     heading: "GAMES",
     linkedPlayerCount,
-    snapshotLastUpdatedAtMs,
+    displayedFreshnessAtMs,
     lines: offCycleLines,
   });
 }
@@ -1101,14 +1184,14 @@ function formatWarPlayerIdentity(row: TodoRenderRow): string {
 function buildTodoPageDescription(input: {
   heading: TodoType;
   linkedPlayerCount: number;
-  snapshotLastUpdatedAtMs: number;
+  displayedFreshnessAtMs: number | null;
   statusLine?: string | null;
   lines: string[];
 }): string {
   const statusLine = sanitizeStatusText(input.statusLine ?? "");
   const lines = [
     `Type: ${input.heading}`,
-    formatTodoSnapshotLegend(input.snapshotLastUpdatedAtMs),
+    formatTodoDisplayedDataLegend(input.displayedFreshnessAtMs),
     statusLine || `Linked players: ${input.linkedPlayerCount}`,
     "",
     ...input.lines,
@@ -1726,11 +1809,32 @@ function formatRelativeTimestamp(input: Date): string {
   return `<t:${Math.floor(input.getTime() / 1000)}:R>`;
 }
 
-/** Purpose: build the shared todo snapshot freshness legend from the authoritative snapshot version timestamp. */
-function formatTodoSnapshotLegend(snapshotLastUpdatedAtMs: number): string {
+/** Purpose: build the shared todo freshness legend from the displayed page data timestamp. */
+function formatTodoDisplayedDataLegend(displayedFreshnessAtMs: number | null): string {
+  if (displayedFreshnessAtMs === null) {
+    return ":hourglass: last updated unknown";
+  }
   return `:hourglass: last updated ${formatRelativeTimestamp(
-    new Date(snapshotLastUpdatedAtMs),
+    new Date(displayedFreshnessAtMs),
   )}`;
+}
+
+/** Purpose: resolve one page-wide freshness timestamp from the per-row displayed-data timestamps. */
+function resolveTodoPageDisplayedDataFreshnessMs(
+  rows: TodoRenderRow[],
+  type: TodoType,
+): number | null {
+  const candidates = rows
+    .map((row) => row.displayedFreshnessAtMsByType[type])
+    .filter((value): value is number => Number.isFinite(value));
+  return resolveMinimumTimestampMs(candidates);
+}
+
+/** Purpose: choose the oldest usable timestamp from one candidate list. */
+function resolveMinimumTimestampMs(values: Array<number | null | undefined>): number | null {
+  const candidates = values.filter((value): value is number => Number.isFinite(value));
+  if (candidates.length <= 0) return null;
+  return candidates.reduce((min, value) => (value < min ? value : min), candidates[0]);
 }
 
 /** Purpose: keep status labels compact and deterministic for embed row rendering. */

--- a/src/services/TodoTrackedWarStateService.ts
+++ b/src/services/TodoTrackedWarStateService.ts
@@ -24,6 +24,7 @@ export type TodoTrackedWarAttackRow = {
 export type TodoTrackedWarAttackDetail = {
   defenderPosition: number | null;
   stars: number | null;
+  seenAtMs: number;
 };
 
 export type TodoTrackedWarMemberState = {
@@ -121,10 +122,11 @@ export function buildTrackedWarMemberStateByClanAndPlayer(input: {
         return a.seenAtMs - b.seenAtMs;
       })
       .slice(0, 2)
-      .map((detail) => ({
-        defenderPosition: detail.defenderPosition,
-        stars: detail.stars,
-      }));
+        .map((detail) => ({
+          defenderPosition: detail.defenderPosition,
+          stars: detail.stars,
+          seenAtMs: detail.seenAtMs,
+        }));
     const attacksUsed = Math.max(
       value.attacksUsed,
       Math.min(2, orderedAttackDetails.length),

--- a/tests/todo.command.test.ts
+++ b/tests/todo.command.test.ts
@@ -264,6 +264,12 @@ function expectTodoLegendWithLastUpdated(description: string): void {
   expect(description).not.toContain(":hourglass: snapshot may be out of date");
 }
 
+function expectTodoLegendUnknown(description: string): void {
+  expect(description).toContain(":hourglass: last updated unknown");
+  expect(description).not.toContain(":hourglass: last updated <t:");
+  expect(description).not.toContain(":hourglass: snapshot may be out of date");
+}
+
 function expectTodoPagesLastUpdatedAt(pages: Record<TodoType, string>, timestamp: Date): void {
   const unix = Math.floor(timestamp.getTime() / 1000);
   const expected = `:hourglass: last updated <t:${unix}:R>`;
@@ -490,6 +496,20 @@ describe("/todo command", () => {
         cwlAttacksUsed: 0,
       }),
     ]);
+    prismaMock.currentCwlRound.findMany.mockResolvedValue([
+      {
+        season: "2026-03",
+        clanTag: "#PQL0289",
+        clanName: "Clan One",
+        roundDay: 1,
+        roundState: "idle",
+        startTime: null,
+        endTime: null,
+        sourceUpdatedAt: new Date("2026-03-26T00:00:00.000Z"),
+        updatedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.cwlRoundMemberCurrent.findMany.mockResolvedValue([]);
 
     const cocService = makeCocServiceSpy();
     const interaction = makeTodoInteraction({ type: "CWL" });
@@ -517,6 +537,39 @@ describe("/todo command", () => {
     expect(cocService.getCurrentWar).not.toHaveBeenCalled();
     expect(cocService.getClanWarLeagueGroup).not.toHaveBeenCalled();
     expect(cocService.getClanWarLeagueWar).not.toHaveBeenCalled();
+  });
+
+  it("shows unknown freshness when the displayed source timestamps are unavailable", async () => {
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      { playerTag: "#PYLQ0289", createdAt: new Date("2026-03-01T00:00:00.000Z") },
+    ]);
+    prismaMock.todoPlayerSnapshot.aggregate.mockResolvedValue({
+      _count: { _all: 1 },
+      _max: { updatedAt: null },
+    });
+    prismaMock.todoPlayerSnapshot.findMany.mockResolvedValue([
+      makeSnapshotRow({
+        playerTag: "#PYLQ0289",
+        playerName: "Alpha",
+      }),
+    ]);
+    prismaMock.currentWar.findMany.mockResolvedValue([]);
+    prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue([]);
+    prismaMock.fwaPlayerCatalog.findMany.mockResolvedValue([]);
+    prismaMock.botSetting.findMany.mockResolvedValue([]);
+    prismaMock.currentCwlRound.findMany.mockResolvedValue([]);
+    prismaMock.cwlRoundMemberCurrent.findMany.mockResolvedValue([]);
+    (cwlRotationService as any).listActivePlanExports = vi.fn().mockResolvedValue([]);
+
+    const pages = await buildTodoPagesForUser({
+      discordUserId: "111111111111111111",
+      cocService: makeCocServiceSpy() as any,
+    });
+
+    expectTodoLegendUnknown(pages.pages.WAR);
+    expectTodoLegendUnknown(pages.pages.CWL);
+    expectTodoLegendUnknown(pages.pages.RAIDS);
+    expectTodoLegendUnknown(pages.pages.GAMES);
   });
 
   it("shows the first-run notice and refreshes non-tracked CWL clans on initial CWL /todo renders", async () => {
@@ -661,6 +714,19 @@ describe("/todo command", () => {
         cwlPhase: "preparation",
         cwlEndsAt: new Date("2026-03-30T12:00:00.000Z"),
       }),
+    ]);
+    prismaMock.currentCwlRound.findMany.mockResolvedValue([
+      {
+        season: "2026-03",
+        clanTag: "#PQL0289",
+        clanName: "Clan One",
+        roundDay: 1,
+        roundState: "idle",
+        startTime: null,
+        endTime: null,
+        sourceUpdatedAt: new Date("2026-03-26T00:00:00.000Z"),
+        updatedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
     ]);
     const interaction = makeTodoInteraction({ type: null });
 
@@ -2201,6 +2267,46 @@ describe("/todo command", () => {
         raidEndsAt: new Date("2026-03-29T07:00:00.000Z"),
       }),
     ]);
+    prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue([
+      {
+        playerTag: "#PYLQ0289",
+        clanTag: "#PQL0289",
+        townHall: 15,
+        sourceSyncedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+      {
+        playerTag: "#QGRJ2222",
+        clanTag: "#PQL0289",
+        townHall: 14,
+        sourceSyncedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+      {
+        playerTag: "#LQ9P8R2",
+        clanTag: "#PQL0289",
+        townHall: 13,
+        sourceSyncedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.fwaPlayerCatalog.findMany.mockResolvedValue([
+      {
+        playerTag: "#PYLQ0289",
+        latestTownHall: 15,
+        lastSeenAt: new Date("2026-03-26T00:00:00.000Z"),
+        lastSyncedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+      {
+        playerTag: "#QGRJ2222",
+        latestTownHall: 14,
+        lastSeenAt: new Date("2026-03-26T00:00:00.000Z"),
+        lastSyncedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+      {
+        playerTag: "#LQ9P8R2",
+        latestTownHall: 13,
+        lastSeenAt: new Date("2026-03-26T00:00:00.000Z"),
+        lastSyncedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+    ]);
 
     const interaction = makeTodoInteraction({ type: "RAIDS" });
     await Todo.run({} as any, interaction as any, makeCocServiceSpy() as any);
@@ -2358,6 +2464,62 @@ describe("/todo command", () => {
         gamesChampionTotal: 5000,
         gamesEndsAt: new Date("2026-03-28T08:00:00.000Z"),
       }),
+    ]);
+    prismaMock.botSetting.findMany.mockResolvedValue([
+      {
+        key: "player_signal_state:#PYLQ0289",
+        value: JSON.stringify({
+          version: 1,
+          lastSeenAtMs: new Date("2026-03-26T00:00:00.000Z").getTime(),
+          updatedAtMs: new Date("2026-03-26T00:00:00.000Z").getTime(),
+          signalTimes: {},
+        }),
+      },
+      {
+        key: "player_signal_state:#QGRJ2222",
+        value: JSON.stringify({
+          version: 1,
+          lastSeenAtMs: new Date("2026-03-26T00:00:00.000Z").getTime(),
+          updatedAtMs: new Date("2026-03-26T00:00:00.000Z").getTime(),
+          signalTimes: {},
+        }),
+      },
+      {
+        key: "player_signal_state:#CUV9082",
+        value: JSON.stringify({
+          version: 1,
+          lastSeenAtMs: new Date("2026-03-26T00:00:00.000Z").getTime(),
+          updatedAtMs: new Date("2026-03-26T00:00:00.000Z").getTime(),
+          signalTimes: {},
+        }),
+      },
+      {
+        key: "player_signal_state:#LQ9P8R2",
+        value: JSON.stringify({
+          version: 1,
+          lastSeenAtMs: new Date("2026-03-26T00:00:00.000Z").getTime(),
+          updatedAtMs: new Date("2026-03-26T00:00:00.000Z").getTime(),
+          signalTimes: {},
+        }),
+      },
+      {
+        key: "player_signal_state:#Q2V8P9L2",
+        value: JSON.stringify({
+          version: 1,
+          lastSeenAtMs: new Date("2026-03-26T00:00:00.000Z").getTime(),
+          updatedAtMs: new Date("2026-03-26T00:00:00.000Z").getTime(),
+          signalTimes: {},
+        }),
+      },
+      {
+        key: "player_signal_state:#9C8VY2L2",
+        value: JSON.stringify({
+          version: 1,
+          lastSeenAtMs: new Date("2026-03-26T00:00:00.000Z").getTime(),
+          updatedAtMs: new Date("2026-03-26T00:00:00.000Z").getTime(),
+          signalTimes: {},
+        }),
+      },
     ]);
 
     const interaction = makeTodoInteraction({ type: "GAMES" });
@@ -2673,6 +2835,7 @@ describe("/todo pagination buttons", () => {
     prismaMock.cwlTrackedClan.findMany.mockReset();
     prismaMock.cwlPlayerClanSeason.findMany.mockReset();
     prismaMock.cwlPlayerClanSeason.upsert.mockReset();
+    prismaMock.botSetting.findMany.mockReset();
 
     prismaMock.playerLink.findMany.mockResolvedValue([
       { playerTag: "#PYLQ0289", createdAt: new Date("2026-03-01T00:00:00.000Z") },
@@ -2711,6 +2874,7 @@ describe("/todo pagination buttons", () => {
     prismaMock.cwlTrackedClan.findMany.mockResolvedValue([]);
     prismaMock.cwlPlayerClanSeason.findMany.mockResolvedValue([]);
     prismaMock.cwlPlayerClanSeason.upsert.mockResolvedValue(undefined);
+    prismaMock.botSetting.findMany.mockResolvedValue([]);
     vi.spyOn(todoLastViewedTypeService, "setLastViewedType").mockResolvedValue(undefined);
   });
 
@@ -2860,6 +3024,87 @@ describe("/todo pagination buttons", () => {
       }),
     ];
 
+    const setDisplayedFreshness = (freshness: Date) => {
+      prismaMock.currentWar.findMany.mockResolvedValue([
+        {
+          clanTag: "#PQL0289",
+          warId: 101,
+          state: "inWar",
+          startTime: new Date("2026-03-25T12:00:00.000Z"),
+          endTime: new Date("2026-03-26T12:00:00.000Z"),
+          matchType: "FWA",
+          outcome: "WIN",
+          updatedAt: freshness,
+        },
+      ]);
+      prismaMock.warAttacks.findMany.mockResolvedValue([]);
+      prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue([
+        {
+          playerTag: "#PYLQ0289",
+          clanTag: "#PQL0289",
+          townHall: 15,
+          sourceSyncedAt: freshness,
+        },
+        {
+          playerTag: "#QGRJ2222",
+          clanTag: "#PQL0289",
+          townHall: 14,
+          sourceSyncedAt: freshness,
+        },
+      ]);
+      prismaMock.fwaPlayerCatalog.findMany.mockResolvedValue([
+        {
+          playerTag: "#PYLQ0289",
+          latestTownHall: 15,
+          lastSeenAt: freshness,
+          lastSyncedAt: freshness,
+        },
+        {
+          playerTag: "#QGRJ2222",
+          latestTownHall: 14,
+          lastSeenAt: freshness,
+          lastSyncedAt: freshness,
+        },
+      ]);
+      prismaMock.botSetting.findMany.mockResolvedValue([
+        {
+          key: "player_signal_state:#PYLQ0289",
+          value: JSON.stringify({
+            version: 1,
+            lastSeenAtMs: freshness.getTime(),
+            updatedAtMs: freshness.getTime(),
+            signalTimes: {},
+          }),
+        },
+        {
+          key: "player_signal_state:#QGRJ2222",
+          value: JSON.stringify({
+            version: 1,
+            lastSeenAtMs: freshness.getTime(),
+            updatedAtMs: freshness.getTime(),
+            signalTimes: {},
+          }),
+        },
+      ]);
+      prismaMock.currentCwlRound.findMany.mockResolvedValue([
+        {
+          season: "2026-03",
+          clanTag: "#PQL0289",
+          clanName: "Clan One",
+          roundDay: 1,
+          roundState: "idle",
+          startTime: null,
+          endTime: null,
+          sourceUpdatedAt: freshness,
+          updatedAt: freshness,
+        },
+      ]);
+      prismaMock.cwlRoundMemberCurrent.findMany.mockResolvedValue([]);
+      (cwlRotationService as any).listActivePlanExports = vi.fn().mockResolvedValue([]);
+    };
+
+    setDisplayedFreshness(firstRefreshAt);
+
     prismaMock.playerLink.findMany.mockResolvedValue([
       { playerTag: "#PYLQ0289", createdAt: new Date("2026-03-01T00:00:00.000Z") },
       { playerTag: "#QGRJ2222", createdAt: new Date("2026-03-02T00:00:00.000Z") },
@@ -2891,6 +3136,7 @@ describe("/todo pagination buttons", () => {
     });
     expectTodoPagesLastUpdatedAt(rerenderedPages.pages, firstRefreshAt);
 
+    setDisplayedFreshness(secondRefreshAt);
     const refreshedPages = await buildTodoPagesForUser({
       discordUserId,
       cocService: makeCocServiceSpy() as any,
@@ -2950,6 +3196,7 @@ describe("/todo refresh button", () => {
     prismaMock.cwlTrackedClan.findMany.mockReset();
     prismaMock.cwlPlayerClanSeason.findMany.mockReset();
     prismaMock.cwlPlayerClanSeason.upsert.mockReset();
+    prismaMock.botSetting.findMany.mockReset();
 
     prismaMock.playerLink.findMany.mockImplementation(async (args: any) => {
       const userId = String(args?.where?.discordUserId ?? "");
@@ -2995,6 +3242,7 @@ describe("/todo refresh button", () => {
     prismaMock.cwlTrackedClan.findMany.mockResolvedValue([]);
     prismaMock.cwlPlayerClanSeason.findMany.mockResolvedValue([]);
     prismaMock.cwlPlayerClanSeason.upsert.mockResolvedValue(undefined);
+    prismaMock.botSetting.findMany.mockResolvedValue([]);
     vi.spyOn(todoLastViewedTypeService, "setLastViewedType").mockResolvedValue(undefined);
   });
 


### PR DESCRIPTION
- derive the legend from the oldest displayed source timestamp per todo page
- show `last updated unknown` when no trustworthy freshness timestamp is available