### PR TITLE
feat(recruitment): add interactive dashboard and recruitment reminders

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -46,8 +46,8 @@
 - `/cwl rotations export` - Export the active CWL planner data to a brand-new public Google Sheet using the canonical re-importable tabular format.
 - `/accounts [visibility:private|public] [tag:<playerTag>] [discord-id:<snowflake>]` - List linked player accounts grouped by current clan. Default is your own account; provide exactly one of `tag` or `discord-id` to inspect a different linked user.
 - `/remindme set type:<WAR|CWL|RAIDS|GAMES> player_tags:<comma-separated-linked-tags> time_left:<HhMm[,HhMm...]> [method:DM|ping-me-here]` - Create durable personal recurring reminder rules for linked player tags only. `time_left` accepts one or more offsets like `12h,2h,30m`; `method` defaults to `DM`. Outbound reminder deliveries are plain-text, and `ping-me-here` includes the inline user mention in the message content so Discord notifies correctly.
-- `/remindme list` - Show your active personal activity reminders in a grouped scan-friendly embed (type, player, method, offsets).
-- `/remindme remove` - Open an owner-scoped reminder removal panel with multi-select plus confirm/cancel controls.
+- `/remindme list` - Show your active personal activity reminders plus recruitment reminders in separate grouped scan-friendly sections.
+- `/remindme remove` - Open an owner-scoped reminder removal panel with multi-select plus confirm/cancel controls for both activity and recruitment reminders.
 - `/reminders create [type:{WAR_CWL|RAIDS|GAMES}] [time_left:<HhMm[,HhMm...]>] [channel:<discordChannel>] [clan:<tag>]` - Open a preview-first reminder panel. With no args, starts as a blank interactive setup; supplied args seed initial panel state. `clan` preselects that clan in create-state and prefills channel from tracked-clan `logChannelId` when channel is unset. Clan multi-select combines FWA tracked clans plus current-season CWL tracked clans. Outbound reminder deliveries are posted as plain text with inline user mentions, and overflow continues by whole lines across up to 3 messages.
 - `/reminders list` - List guild reminder configs in an admin-scannable view (type, channel, offsets, target-count, enabled state) with pagination when needed.
 - `/reminders edit clan:<tag>` - Resolve reminder configs targeting the normalized clan tag (with or without `#`) and open an edit panel for offsets, channel, type, clan targets, and enabled state.
@@ -89,7 +89,7 @@
   - Reddit: subject (`[Recruiting] Name of Clan | #ClanTag | Required TH/Level | Clan Level | FWA | Discord`) auto-prefilled from in-game TH minimum and clan level, body (markdown), optional image URL(s)
 - `/recruitment countdown start platform:discord|reddit|band clan:<tag>` - Start exact cooldown timer for your account on that platform+clan pair.
 - `/recruitment countdown status` - Show your current recruitment cooldown timers.
-- `/recruitment dashboard` - Show readiness across all tracked clans/platforms for your account.
+- `/recruitment dashboard timezone:<ianaTz>` - Open an interactive alliance/clan dashboard in the selected timezone with timers, scripts, optimize guidance, template tabs, and recruitment reminder scheduling.
 - `/defer add player-tag:<playerTag> weight:<weight>` - Add one deferred weight-input task for a prospective member (accepts `145000`, `145,000`, or `145k`).
 - `/defer list` - Show active open deferred weight-input tasks in oldest-first order for the active scope.
 - `/defer remove player-tag:<playerTag>` - Mark one open deferred task as resolved after FWAStats weight entry is complete.

--- a/prisma/migrations/20260408120000_add_recruitment_reminders/migration.sql
+++ b/prisma/migrations/20260408120000_add_recruitment_reminders/migration.sql
@@ -1,0 +1,54 @@
+CREATE TABLE "RecruitmentReminderRule" (
+    "id" TEXT NOT NULL,
+    "guildId" TEXT NOT NULL,
+    "discordUserId" TEXT NOT NULL,
+    "clanTag" TEXT NOT NULL,
+    "platform" TEXT NOT NULL,
+    "timezone" TEXT NOT NULL,
+    "nextReminderAt" TIMESTAMP(3) NOT NULL,
+    "isActive" BOOLEAN NOT NULL DEFAULT true,
+    "lastSentAt" TIMESTAMP(3),
+    "clanNameSnapshot" TEXT,
+    "templateSubject" TEXT,
+    "templateBody" TEXT NOT NULL,
+    "templateImageUrls" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "RecruitmentReminderRule_pkey" PRIMARY KEY ("id")
+);
+
+CREATE TABLE "RecruitmentReminderDelivery" (
+    "id" TEXT NOT NULL,
+    "reminderRuleId" TEXT NOT NULL,
+    "scheduledFor" TIMESTAMP(3) NOT NULL,
+    "sentAt" TIMESTAMP(3),
+    "status" TEXT NOT NULL,
+    "errorDetails" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "RecruitmentReminderDelivery_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "RecruitmentReminderRule_guildId_discordUserId_clanTag_platform_key"
+ON "RecruitmentReminderRule"("guildId", "discordUserId", "clanTag", "platform");
+
+CREATE INDEX "RecruitmentReminderRule_guildId_discordUserId_isActive_idx"
+ON "RecruitmentReminderRule"("guildId", "discordUserId", "isActive");
+
+CREATE INDEX "RecruitmentReminderRule_guildId_nextReminderAt_isActive_idx"
+ON "RecruitmentReminderRule"("guildId", "nextReminderAt", "isActive");
+
+CREATE INDEX "RecruitmentReminderRule_guildId_clanTag_platform_idx"
+ON "RecruitmentReminderRule"("guildId", "clanTag", "platform");
+
+CREATE UNIQUE INDEX "RecruitmentReminderDelivery_reminderRuleId_scheduledFor_key"
+ON "RecruitmentReminderDelivery"("reminderRuleId", "scheduledFor");
+
+CREATE INDEX "RecruitmentReminderDelivery_status_createdAt_idx"
+ON "RecruitmentReminderDelivery"("status", "createdAt");
+
+CREATE INDEX "RecruitmentReminderDelivery_reminderRuleId_createdAt_idx"
+ON "RecruitmentReminderDelivery"("reminderRuleId", "createdAt");
+
+ALTER TABLE "RecruitmentReminderDelivery"
+ADD CONSTRAINT "RecruitmentReminderDelivery_reminderRuleId_fkey"
+FOREIGN KEY ("reminderRuleId") REFERENCES "RecruitmentReminderRule"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -659,6 +659,45 @@ model RecruitmentCooldown {
   @@index([guildId, expiresAt, reminded])
 }
 
+model RecruitmentReminderRule {
+  id               String                    @id @default(cuid())
+  guildId          String
+  discordUserId    String
+  clanTag          String
+  platform         String
+  timezone         String
+  nextReminderAt   DateTime
+  isActive         Boolean                   @default(true)
+  lastSentAt       DateTime?
+  clanNameSnapshot String?
+  templateSubject  String?
+  templateBody     String
+  templateImageUrls String[]
+  createdAt        DateTime                  @default(now())
+  updatedAt        DateTime                  @updatedAt
+  deliveries       RecruitmentReminderDelivery[]
+
+  @@unique([guildId, discordUserId, clanTag, platform])
+  @@index([guildId, discordUserId, isActive])
+  @@index([guildId, nextReminderAt, isActive])
+  @@index([guildId, clanTag, platform])
+}
+
+model RecruitmentReminderDelivery {
+  id               String                    @id @default(cuid())
+  reminderRuleId   String
+  scheduledFor     DateTime
+  sentAt           DateTime?
+  status           String
+  errorDetails     String?
+  createdAt        DateTime                  @default(now())
+  reminderRule     RecruitmentReminderRule   @relation(fields: [reminderRuleId], references: [id], onDelete: Cascade)
+
+  @@unique([reminderRuleId, scheduledFor])
+  @@index([status, createdAt])
+  @@index([reminderRuleId, createdAt])
+}
+
 model WeightInputDeferment {
   id                    String   @id @default(cuid())
   guildId               String

--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -357,14 +357,14 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
   },
   remindme: {
     summary:
-      "Configure recurring personal activity reminders for linked WAR/CWL/RAIDS/GAMES players.",
+      "Configure recurring personal activity reminders and manage recruitment reminders.",
     details: [
       "`set` creates one rule per `(type, linked player tag, method, offset)` and stores reminders durably for future event cycles.",
       "`player_tags` only accepts tags linked to your Discord account (autocomplete + server-side validation).",
       "`time_left` accepts one or more `HhMm` offsets (comma-separated), for example `12h,2h,30m`.",
       "`method` defaults to `DM`; `ping-me-here` stores the invoking channel as routing surface.",
-      "`list` shows active reminders grouped by type/player/method with normalized offsets.",
-      "`remove` opens an owner-scoped multi-select panel with confirm/cancel controls.",
+      "`list` shows activity reminders plus recruitment reminders in separate scan-friendly sections.",
+      "`remove` opens an owner-scoped multi-select panel with confirm/cancel controls for both activity and recruitment reminders.",
     ],
     examples: [
       "/remindme set type:WAR player_tags:#PYLQ0289 time_left:12h,2h",
@@ -470,14 +470,14 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
       "`show` renders platform-specific recruitment output for a tracked clan.",
       "`edit` now requires platform and opens a platform-specific modal (discord/band/reddit fields differ).",
       "`countdown start` begins exact platform cooldown timers; `countdown status` shows your timers.",
-      "`dashboard` summarizes readiness across all tracked clans and platforms for your account.",
+      "`dashboard` requires an IANA `timezone` and opens an interactive alliance/clan dashboard with timers, scripts, optimize guidance, and reminder scheduling.",
     ],
     examples: [
       "/recruitment show platform:discord clan:2QG2C08UP",
       "/recruitment edit platform:reddit clan:2QG2C08UP",
       "/recruitment countdown start platform:reddit clan:2QG2C08UP",
       "/recruitment countdown status",
-      "/recruitment dashboard",
+      "/recruitment dashboard timezone:America/Los_Angeles",
     ],
   },
   defer: {

--- a/src/commands/Recruitment.ts
+++ b/src/commands/Recruitment.ts
@@ -4,6 +4,10 @@ import {
   AutocompleteInteraction,
   ChatInputCommandInteraction,
   Client,
+  ButtonBuilder,
+  ButtonStyle,
+  EmbedBuilder,
+  StringSelectMenuBuilder,
   ModalBuilder,
   ModalSubmitInteraction,
   TextInputBuilder,
@@ -21,7 +25,6 @@ import {
   getRecruitmentTemplate,
   getTrackedClanNameMapByTags,
   listRecruitmentCooldownsForUser,
-  listRecruitmentCooldownsForUserByClanTags,
   normalizeClanTag,
   parseImageUrlsCsv,
   parseRecruitmentPlatform,
@@ -30,6 +33,17 @@ import {
   toImageUrlsCsv,
   upsertRecruitmentTemplate,
 } from "../services/RecruitmentService";
+import {
+  autocompleteRecruitmentTimeZones,
+  getDateKeyInTimeZone,
+  formatRecruitmentReminderTime,
+  formatRecruitmentReminderWindowSummaryInTimeZone,
+  formatRecruitmentReminderRhythmSummaryInTimeZone,
+  getNextRecruitmentReminderSlot,
+  getRecruitmentReminderSlotCandidates,
+  normalizeRecruitmentTimezone,
+  recruitmentReminderService,
+} from "../services/RecruitmentReminderService";
 
 const RECRUITMENT_MODAL_PREFIX = "recruitment-edit";
 const DISCORD_CLAN_TAG_INPUT_ID = "discord-clan-tag";
@@ -38,6 +52,7 @@ const BODY_INPUT_ID = "body";
 const IMAGE_URLS_INPUT_ID = "image-urls";
 const DISCORD_RECRUITMENT_CHANNEL_URL =
   "https://discord.com/channels/236523452230533121/1058589765508800644";
+const PANEL_TIMEOUT_MS = 10 * 60 * 1000;
 
 const PLATFORM_CHOICES = [
   { name: "discord", value: "discord" },
@@ -214,6 +229,442 @@ function buildCooldownLine(cooldownExpiresAt: Date | null): string {
   }
   const unix = toUnixSeconds(cooldownExpiresAt);
   return `Cooldown: Active until <t:${unix}:F> (<t:${unix}:R>).`;
+}
+
+const RECRUITMENT_DASHBOARD_PREFIX = "recruitment-dashboard";
+
+type RecruitmentDashboardScope = "overview" | "clan" | "schedule";
+type RecruitmentDashboardOverviewTab = "timers" | "scripts" | "optimize";
+type RecruitmentDashboardClanTab = "discord" | "reddit" | "band";
+
+type RecruitmentDashboardState = {
+  scope: RecruitmentDashboardScope;
+  overviewTab: RecruitmentDashboardOverviewTab;
+  clanTag: string | null;
+  clanTab: RecruitmentDashboardClanTab;
+  timezone: string;
+  reminderDayKey: string | null;
+  reminderTimeIso: string | null;
+};
+
+type RecruitmentDashboardTrackedClan = {
+  tag: string;
+  name: string | null;
+};
+
+type RecruitmentDashboardTemplateRow = {
+  clanTag: string;
+  platform: RecruitmentPlatform;
+  subject: string | null;
+  body: string;
+  imageUrls: string[];
+};
+
+function makeRecruitmentDashboardState(input?: Partial<RecruitmentDashboardState>): RecruitmentDashboardState {
+  return {
+    scope: input?.scope ?? "overview",
+    overviewTab: input?.overviewTab ?? "timers",
+    clanTag: input?.clanTag ?? null,
+    clanTab: input?.clanTab ?? "discord",
+    timezone: input?.timezone ?? "America/Los_Angeles",
+    reminderDayKey: input?.reminderDayKey ?? null,
+    reminderTimeIso: input?.reminderTimeIso ?? null,
+  };
+}
+
+function recruitmentDashboardCustomId(sessionId: string, action: string): string {
+  return `${RECRUITMENT_DASHBOARD_PREFIX}:${sessionId}:${action}`;
+}
+
+function parseRecruitmentDashboardCustomId(customId: string): { sessionId: string; action: string } | null {
+  const parts = String(customId ?? "").split(":");
+  if (parts.length < 3) return null;
+  if (parts[0] !== RECRUITMENT_DASHBOARD_PREFIX) return null;
+  const sessionId = parts[1]?.trim() ?? "";
+  const action = parts.slice(2).join(":").trim();
+  if (!sessionId || !action) return null;
+  return { sessionId, action };
+}
+
+function formatRecruitmentPlatformChoice(platform: RecruitmentPlatform): string {
+  return platform.charAt(0).toUpperCase() + platform.slice(1);
+}
+
+function formatClanLabel(tag: string, name: string | null): string {
+  return name?.trim() ? `${name.trim()} (${formatClanTag(tag)})` : formatClanTag(tag);
+}
+
+async function loadRecruitmentDashboardData(guildId: string, userId: string): Promise<{
+  trackedClans: RecruitmentDashboardTrackedClan[];
+  templates: Map<string, RecruitmentDashboardTemplateRow>;
+  cooldowns: Map<string, Date>;
+}> {
+  const [trackedClans, templates, cooldowns] = await Promise.all([
+    prisma.trackedClan.findMany({
+      orderBy: { createdAt: "asc" },
+      select: { tag: true, name: true },
+    }),
+    prisma.recruitmentTemplate.findMany({
+      where: { guildId },
+      select: { clanTag: true, platform: true, subject: true, body: true, imageUrls: true },
+    }),
+    prisma.recruitmentCooldown.findMany({
+      where: { guildId, userId },
+      select: { clanTag: true, platform: true, expiresAt: true },
+    }),
+  ]);
+
+  return {
+    trackedClans: trackedClans.map((row) => ({
+      tag: normalizeClanTag(row.tag),
+      name: row.name?.trim() || null,
+    })),
+    templates: new Map(
+      templates.map((row) => [
+        `${normalizeClanTag(row.clanTag)}:${String(row.platform)}`,
+        {
+          clanTag: normalizeClanTag(row.clanTag),
+          platform: row.platform as RecruitmentPlatform,
+          subject: row.subject ?? null,
+          body: row.body,
+          imageUrls: row.imageUrls ?? [],
+        },
+      ]),
+    ),
+    cooldowns: new Map(
+      cooldowns.map((row) => [`${normalizeClanTag(row.clanTag)}:${row.platform}`, row.expiresAt]),
+    ),
+  };
+}
+
+function buildRecruitmentDashboardEmbed(input: {
+  state: RecruitmentDashboardState;
+  data: Awaited<ReturnType<typeof loadRecruitmentDashboardData>>;
+  nowMs: number;
+}): EmbedBuilder {
+  const state = input.state;
+  const tracked = input.data.trackedClans;
+  const lines: string[] = [];
+
+  lines.push(`Timezone: \`${state.timezone}\``);
+  if (state.scope === "overview") {
+    lines.push("Scope: Alliance Overview");
+    if (state.overviewTab === "timers") {
+      lines.push("", "Active recruitment timers:");
+      const now = input.nowMs;
+      const timerLines = tracked.flatMap((clan) => {
+        const rowLines: string[] = [];
+        for (const platform of ["discord", "reddit", "band"] as RecruitmentPlatform[]) {
+          const key = `${clan.tag}:${platform}`;
+          const expiresAt = input.data.cooldowns.get(key) ?? null;
+          if (!expiresAt || expiresAt.getTime() <= now) continue;
+          rowLines.push(
+            `- ${formatClanLabel(clan.tag, clan.name)} | ${formatRecruitmentPlatformChoice(platform)} | <t:${toUnixSeconds(
+              expiresAt,
+            )}:R>`,
+          );
+        }
+        return rowLines;
+      });
+      lines.push(...(timerLines.length > 0 ? timerLines : ["No active recruitment timers."]));
+    } else if (state.overviewTab === "scripts") {
+      lines.push("", "Stored template coverage:");
+      if (tracked.length <= 0) {
+        lines.push("No tracked clans configured.");
+      } else {
+        for (const clan of tracked) {
+          const statuses = (["discord", "reddit", "band"] as RecruitmentPlatform[]).map((platform) => {
+            const hasTemplate = input.data.templates.has(`${clan.tag}:${platform}`);
+            return `${formatRecruitmentPlatformChoice(platform)}=${hasTemplate ? "stored" : "missing"}`;
+          });
+          lines.push(`- ${formatClanLabel(clan.tag, clan.name)} | ${statuses.join(" | ")}`);
+        }
+      }
+    } else {
+      lines.push("", "Optimization guide:");
+      for (const platform of ["discord", "reddit", "band"] as RecruitmentPlatform[]) {
+        const windows = formatRecruitmentReminderWindowSummaryInTimeZone(
+          platform,
+          state.timezone,
+          new Date(input.nowMs),
+        );
+        const nextSlots = getRecruitmentReminderSlotCandidates({
+          platform,
+          timezone: state.timezone,
+          after: new Date(input.nowMs),
+        })
+          .slice(0, 3)
+          .map((slot) => `\`${formatRecruitmentReminderTime(slot, state.timezone)}\``)
+          .join(", ");
+        lines.push(
+          `- ${formatRecruitmentPlatformChoice(platform)}: ${windows}`,
+          `  Rhythm: ${formatRecruitmentReminderRhythmSummaryInTimeZone(
+            platform,
+            state.timezone,
+            new Date(input.nowMs),
+          )}`,
+          `  Next: ${nextSlots || "no upcoming slots"}`,
+        );
+      }
+    }
+  } else if (state.scope === "clan" && state.clanTag) {
+    const clan = tracked.find((row) => row.tag === state.clanTag) ?? null;
+    const platform = state.clanTab;
+    const template = input.data.templates.get(`${state.clanTag}:${platform}`) ?? null;
+    lines.push(`Scope: ${formatClanLabel(state.clanTag, clan?.name ?? null)}`);
+    lines.push(`Platform: ${formatRecruitmentPlatformChoice(platform)}`);
+    if (!template) {
+      lines.push("", "No stored template for this platform.");
+    } else if (platform === "discord") {
+      lines.push("", buildDiscordShowMessage({
+        clanName: clan?.name ?? state.clanTag,
+        clanTag: state.clanTag,
+        body: template.body,
+        imageUrls: template.imageUrls,
+        cooldownLine: buildCooldownLine(input.data.cooldowns.get(`${state.clanTag}:${platform}`) ?? null),
+      }));
+    } else if (platform === "band") {
+      lines.push("", buildBandShowMessage({
+        clanName: clan?.name ?? state.clanTag,
+        clanTag: state.clanTag,
+        body: template.body,
+        imageUrls: template.imageUrls,
+        cooldownLine: buildCooldownLine(input.data.cooldowns.get(`${state.clanTag}:${platform}`) ?? null),
+      }));
+    } else {
+      lines.push("", buildRedditShowMessage({
+        clanName: clan?.name ?? state.clanTag,
+        clanTag: state.clanTag,
+        subject: template.subject ?? "",
+        body: template.body,
+        imageUrls: template.imageUrls,
+        cooldownLine: buildCooldownLine(input.data.cooldowns.get(`${state.clanTag}:${platform}`) ?? null),
+      }));
+    }
+  } else if (state.scope === "schedule" && state.clanTag) {
+    const clan = tracked.find((row) => row.tag === state.clanTag) ?? null;
+    const platform = state.clanTab;
+    const template = input.data.templates.get(`${state.clanTag}:${platform}`) ?? null;
+    const cooldown = input.data.cooldowns.get(`${state.clanTag}:${platform}`) ?? null;
+    const now = new Date(input.nowMs);
+    const slots = getRecruitmentReminderSlotCandidates({
+      platform,
+      timezone: state.timezone,
+      after: now,
+      cooldownExpiresAt: cooldown ?? null,
+    });
+    const selectedDayKey = state.reminderDayKey;
+    const dayOptions = [
+      ...new Map(
+        slots.map((slot) => {
+          const key = getDateKeyInTimeZone(slot, state.timezone);
+          return [key, key] as const;
+        }),
+      ).values(),
+    ].slice(0, 25);
+    const dayLabel = selectedDayKey ?? dayOptions[0] ?? "none";
+    lines.push(`Scheduling reminder for ${formatClanLabel(state.clanTag, clan?.name ?? null)}`);
+    lines.push(`Platform: ${formatRecruitmentPlatformChoice(platform)}`);
+    lines.push(`Timezone: \`${state.timezone}\``);
+    lines.push("");
+    lines.push(
+      template
+        ? "Select a day and time in 30-minute increments within the optimized posting windows."
+        : "No stored template exists for this platform. Remind creation is unavailable.",
+    );
+    lines.push(
+      template ? `Recommended: ${formatRecruitmentReminderRhythmSummaryInTimeZone(platform, state.timezone, now)}` : "",
+    );
+    if (cooldown) {
+      lines.push(`Cooldown: active until <t:${toUnixSeconds(cooldown)}:R>`);
+    } else {
+      lines.push("Cooldown: ready now");
+    }
+    lines.push(`Day choice: ${dayLabel}`);
+  }
+
+  return new EmbedBuilder()
+    .setColor(0x5865f2)
+    .setTitle("Recruitment Dashboard")
+    .setDescription(truncateDiscordContent(lines.join("\n")))
+    .setFooter({
+      text: state.scope === "overview" ? "Alliance Overview" : state.scope === "schedule" ? "Reminder Scheduling" : "Clan View",
+    });
+}
+
+function buildRecruitmentDashboardComponents(input: {
+  state: RecruitmentDashboardState;
+  data: Awaited<ReturnType<typeof loadRecruitmentDashboardData>>;
+  sessionId: string;
+}): Array<ActionRowBuilder<ButtonBuilder> | ActionRowBuilder<StringSelectMenuBuilder>> {
+  const state = input.state;
+  const tracked = input.data.trackedClans;
+  const buttons = new ActionRowBuilder<ButtonBuilder>();
+  const dropdown = new StringSelectMenuBuilder()
+    .setCustomId(recruitmentDashboardCustomId(input.sessionId, "scope"))
+    .setMinValues(1)
+    .setMaxValues(1)
+    .setPlaceholder("Select alliance overview or a clan");
+
+  const menuOptions = [
+    {
+      label: "Alliance Overview",
+      value: "overview",
+      description: "Alliance-wide timers, scripts, and optimize guidance",
+      default: state.scope === "overview",
+    },
+    ...tracked.slice(0, 24).map((clan) => ({
+      label: formatClanLabel(clan.tag, clan.name).slice(0, 100),
+      value: clan.tag,
+      description: `Clan view for ${clan.tag}`.slice(0, 100),
+      default: state.scope === "clan" && state.clanTag === clan.tag,
+    })),
+  ];
+  dropdown.addOptions(menuOptions);
+
+  if (state.scope === "schedule") {
+    const confirmEnabled = Boolean(
+      state.clanTag &&
+        state.reminderDayKey &&
+        state.reminderTimeIso &&
+        input.data.templates.has(`${state.clanTag}:${state.clanTab}`),
+    );
+    const scheduleButtons = new ActionRowBuilder<ButtonBuilder>().addComponents(
+      new ButtonBuilder()
+        .setCustomId(recruitmentDashboardCustomId(input.sessionId, "schedule:back"))
+        .setLabel("Back")
+        .setStyle(ButtonStyle.Secondary),
+      new ButtonBuilder()
+        .setCustomId(recruitmentDashboardCustomId(input.sessionId, "schedule:confirm"))
+        .setLabel("Confirm")
+        .setStyle(ButtonStyle.Success)
+        .setDisabled(!confirmEnabled),
+    );
+    const dayOptions = buildRecruitmentDashboardDayOptions(input.state, input.data);
+    const timeOptions = buildRecruitmentDashboardTimeOptions(input.state, input.data);
+    return [
+      scheduleButtons,
+      new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
+        new StringSelectMenuBuilder()
+          .setCustomId(recruitmentDashboardCustomId(input.sessionId, "schedule:day"))
+          .setMinValues(1)
+          .setMaxValues(1)
+          .setPlaceholder(dayOptions.length > 0 ? "Select a day" : "No valid days")
+          .setDisabled(dayOptions.length <= 0)
+          .addOptions(dayOptions.length > 0 ? dayOptions : [{ label: "No valid days", value: "none", description: "No available reminder days" }]),
+      ),
+      new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
+        new StringSelectMenuBuilder()
+          .setCustomId(recruitmentDashboardCustomId(input.sessionId, "schedule:time"))
+          .setMinValues(1)
+          .setMaxValues(1)
+          .setPlaceholder(timeOptions.length > 0 ? "Select a time" : "No valid times")
+          .setDisabled(timeOptions.length <= 0)
+          .addOptions(timeOptions.length > 0 ? timeOptions : [{ label: "No valid times", value: "none", description: "No available reminder slots" }]),
+      ),
+      new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(dropdown),
+    ];
+  }
+
+  if (state.scope === "overview") {
+    buttons.addComponents(
+      new ButtonBuilder()
+        .setCustomId(recruitmentDashboardCustomId(input.sessionId, "overview:timers"))
+        .setLabel("Timers")
+        .setStyle(state.overviewTab === "timers" ? ButtonStyle.Primary : ButtonStyle.Secondary),
+      new ButtonBuilder()
+        .setCustomId(recruitmentDashboardCustomId(input.sessionId, "overview:scripts"))
+        .setLabel("Scripts")
+        .setStyle(state.overviewTab === "scripts" ? ButtonStyle.Primary : ButtonStyle.Secondary),
+      new ButtonBuilder()
+        .setCustomId(recruitmentDashboardCustomId(input.sessionId, "overview:optimize"))
+        .setLabel("Optimize")
+        .setStyle(state.overviewTab === "optimize" ? ButtonStyle.Primary : ButtonStyle.Secondary),
+    );
+    return [
+      buttons,
+      new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(dropdown),
+    ];
+  }
+
+  const templateExists = input.data.templates.has(`${state.clanTag}:${state.clanTab}`);
+  buttons.addComponents(
+    new ButtonBuilder()
+      .setCustomId(recruitmentDashboardCustomId(input.sessionId, "clan:discord"))
+      .setLabel("Discord")
+      .setStyle(state.clanTab === "discord" ? ButtonStyle.Primary : ButtonStyle.Secondary),
+    new ButtonBuilder()
+      .setCustomId(recruitmentDashboardCustomId(input.sessionId, "clan:reddit"))
+      .setLabel("Reddit")
+      .setStyle(state.clanTab === "reddit" ? ButtonStyle.Primary : ButtonStyle.Secondary),
+    new ButtonBuilder()
+      .setCustomId(recruitmentDashboardCustomId(input.sessionId, "clan:band"))
+      .setLabel("Band")
+      .setStyle(state.clanTab === "band" ? ButtonStyle.Primary : ButtonStyle.Secondary),
+    new ButtonBuilder()
+      .setCustomId(recruitmentDashboardCustomId(input.sessionId, "clan:remind"))
+      .setLabel("Remind")
+      .setStyle(ButtonStyle.Success)
+      .setDisabled(!templateExists),
+  );
+  return [
+    buttons,
+    new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(dropdown),
+  ];
+}
+
+function buildRecruitmentDashboardDayOptions(
+  state: RecruitmentDashboardState,
+  data: Awaited<ReturnType<typeof loadRecruitmentDashboardData>>,
+): Array<{ label: string; value: string; description: string; default?: boolean }> {
+  if (!state.clanTag) return [];
+  const slots = getRecruitmentReminderSlotCandidates({
+    platform: state.clanTab,
+    timezone: state.timezone,
+    after: new Date(),
+    cooldownExpiresAt: data.cooldowns.get(`${state.clanTag}:${state.clanTab}`) ?? null,
+  });
+  const days = new Map<string, { label: string; value: string; description: string }>();
+  for (const slot of slots) {
+    const dateLabel = getDateKeyInTimeZone(slot, state.timezone);
+    if (!days.has(dateLabel)) {
+      days.set(dateLabel, {
+        label: dateLabel.slice(0, 100),
+        value: dateLabel,
+        description: `Slots for ${dateLabel}`.slice(0, 100),
+      });
+    }
+  }
+  return [...days.values()].slice(0, 25).map((option) => ({
+    ...option,
+    default: option.value === state.reminderDayKey,
+  }));
+}
+
+function buildRecruitmentDashboardTimeOptions(
+  state: RecruitmentDashboardState,
+  data: Awaited<ReturnType<typeof loadRecruitmentDashboardData>>,
+): Array<{ label: string; value: string; description: string; default?: boolean }> {
+  if (!state.clanTag || !state.reminderDayKey) return [];
+  const slots = getRecruitmentReminderSlotCandidates({
+    platform: state.clanTab,
+    timezone: state.timezone,
+    after: new Date(),
+    cooldownExpiresAt: data.cooldowns.get(`${state.clanTag}:${state.clanTab}`) ?? null,
+  });
+  const matches = slots.filter((slot) => {
+    const dateLabel = getDateKeyInTimeZone(slot, state.timezone);
+    return dateLabel === state.reminderDayKey;
+  });
+  return matches.slice(0, 25).map((slot) => {
+    const display = formatRecruitmentReminderTime(slot, state.timezone);
+    return {
+      label: display.slice(0, 100),
+      value: slot.toISOString(),
+      description: "30-minute slot".slice(0, 100),
+      default: state.reminderTimeIso === slot.toISOString(),
+    };
+  });
 }
 
 async function handleShowSubcommand(
@@ -499,6 +950,12 @@ async function handleDashboardSubcommand(interaction: ChatInputCommandInteractio
     return;
   }
   await interaction.deferReply({ ephemeral: true });
+  const timezoneSeedRaw = interaction.options.getString("timezone", true);
+  const normalizedTimezone = normalizeRecruitmentTimezone(timezoneSeedRaw);
+  if (!normalizedTimezone) {
+    await interaction.editReply("Invalid timezone. Use a valid IANA timezone.");
+    return;
+  }
 
   const tracked = await prisma.trackedClan.findMany({
     orderBy: { createdAt: "asc" },
@@ -509,35 +966,199 @@ async function handleDashboardSubcommand(interaction: ChatInputCommandInteractio
     return;
   }
 
-  const tags = tracked.map((row) => normalizeClanTag(row.tag));
-  const cooldowns = await listRecruitmentCooldownsForUserByClanTags(
-    interaction.guildId,
-    interaction.user.id,
-    tags
-  );
-  const cooldownMap = new Map<string, Date>();
-  for (const row of cooldowns) {
-    cooldownMap.set(`${normalizeClanTag(row.clanTag)}:${row.platform}`, row.expiresAt);
-  }
+  const state = makeRecruitmentDashboardState({
+    scope: "overview",
+    overviewTab: "timers",
+    timezone: normalizedTimezone,
+  });
+  const sessionId = interaction.id;
 
-  const now = Date.now();
-  const platforms: RecruitmentPlatform[] = ["discord", "band", "reddit"];
-  const lines: string[] = [];
-  for (const clan of tracked) {
-    const tag = normalizeClanTag(clan.tag);
-    lines.push(`**${mapTrackedLabel(clan.name, tag)}**`);
-    for (const platform of platforms) {
-      const expiresAt = cooldownMap.get(`${tag}:${platform}`);
-      if (!expiresAt || expiresAt.getTime() <= now) {
-        lines.push(`- ${formatPlatform(platform)}: Ready now`);
-      } else {
-        lines.push(`- ${formatPlatform(platform)}: <t:${toUnixSeconds(expiresAt)}:R>`);
+  const render = async (note: string | null = null): Promise<void> => {
+    const data = await loadRecruitmentDashboardData(interaction.guildId!, interaction.user.id);
+    await interaction.editReply({
+      content: note ?? undefined,
+      embeds: [buildRecruitmentDashboardEmbed({ state, data, nowMs: Date.now() })],
+      components: buildRecruitmentDashboardComponents({
+        state,
+        data,
+        sessionId,
+      }),
+    });
+  };
+
+  await render();
+  const message = await interaction.fetchReply();
+  const collector = message.createMessageComponentCollector({ time: PANEL_TIMEOUT_MS });
+
+  collector.on("collect", async (component) => {
+    const parsed = parseRecruitmentDashboardCustomId(component.customId);
+    if (!parsed || parsed.sessionId !== sessionId) return;
+    if (component.user.id !== interaction.user.id) {
+      await component.reply({
+        ephemeral: true,
+        content: "Only the dashboard requester can use this panel.",
+      });
+      return;
+    }
+
+    try {
+      if (component.isStringSelectMenu() && parsed.action === "scope") {
+        await component.deferUpdate();
+        const selected = component.values[0] ?? "overview";
+        if (selected === "overview") {
+          state.scope = "overview";
+          state.clanTag = null;
+          state.overviewTab = "timers";
+        } else {
+          state.scope = "clan";
+          state.clanTag = normalizeClanTag(selected);
+          state.clanTab = "discord";
+          state.reminderDayKey = null;
+          state.reminderTimeIso = null;
+        }
+        await render();
+        return;
+      }
+
+      if (component.isButton() && parsed.action.startsWith("overview:")) {
+        await component.deferUpdate();
+        const nextTab = parsed.action.split(":")[1] as RecruitmentDashboardOverviewTab | undefined;
+        if (nextTab === "timers" || nextTab === "scripts" || nextTab === "optimize") {
+          state.scope = "overview";
+          state.clanTag = null;
+          state.overviewTab = nextTab;
+          await render();
+        }
+        return;
+      }
+
+      if (component.isButton() && parsed.action.startsWith("clan:")) {
+        await component.deferUpdate();
+        const next = parsed.action.split(":")[1] as RecruitmentDashboardClanTab | "remind" | undefined;
+        if (next === "discord" || next === "reddit" || next === "band") {
+          state.scope = "clan";
+          state.clanTab = next;
+          state.reminderDayKey = null;
+          state.reminderTimeIso = null;
+          await render();
+          return;
+        }
+        if (next === "remind") {
+          if (!state.clanTag) {
+            await render("Select a clan first.");
+            return;
+          }
+          const data = await loadRecruitmentDashboardData(interaction.guildId!, interaction.user.id);
+          if (!data.templates.has(`${state.clanTag}:${state.clanTab}`)) {
+            await render("This clan/platform has no stored template yet.");
+            return;
+          }
+          state.scope = "schedule";
+          state.reminderDayKey = null;
+          state.reminderTimeIso = null;
+          await render();
+          return;
+        }
+      }
+
+      if (component.isButton() && parsed.action === "schedule:back") {
+        await component.deferUpdate();
+        state.scope = "clan";
+        await render();
+        return;
+      }
+
+      if (component.isStringSelectMenu() && parsed.action === "schedule:day") {
+        await component.deferUpdate();
+        state.reminderDayKey = component.values[0] ?? null;
+        const data = await loadRecruitmentDashboardData(interaction.guildId!, interaction.user.id);
+        const slots = getRecruitmentReminderSlotCandidates({
+          platform: state.clanTab,
+          timezone: state.timezone,
+          after: new Date(),
+          cooldownExpiresAt:
+            state.clanTag ? data.cooldowns.get(`${state.clanTag}:${state.clanTab}`) ?? null : null,
+        });
+        const selectedSlot =
+          slots.find((slot) => {
+            const dayLabel = getDateKeyInTimeZone(slot, state.timezone);
+            return dayLabel === state.reminderDayKey;
+          }) ?? null;
+        state.reminderTimeIso = selectedSlot?.toISOString() ?? null;
+        await render();
+        return;
+      }
+
+      if (component.isStringSelectMenu() && parsed.action === "schedule:time") {
+        await component.deferUpdate();
+        state.reminderTimeIso = component.values[0] ?? null;
+        await render();
+        return;
+      }
+
+      if (component.isButton() && parsed.action === "schedule:confirm") {
+        await component.deferUpdate();
+        if (!state.clanTag || !state.reminderTimeIso || !state.reminderDayKey) {
+          await render("Select a day and time before confirming.");
+          return;
+        }
+        const selectedAt = new Date(state.reminderTimeIso);
+        const data = await loadRecruitmentDashboardData(interaction.guildId!, interaction.user.id);
+        const template = await getRecruitmentTemplate(
+          interaction.guildId!,
+          state.clanTag,
+          state.clanTab,
+        );
+        if (!template) {
+          await render("No stored template exists for that clan/platform.");
+          return;
+        }
+        const clan = data.trackedClans.find((row) => row.tag === state.clanTag) ?? null;
+        const next = getNextRecruitmentReminderSlot({
+          platform: state.clanTab,
+          timezone: state.timezone,
+          after: selectedAt,
+          cooldownExpiresAt: state.clanTag
+            ? data.cooldowns.get(`${state.clanTag}:${state.clanTab}`) ?? null
+            : null,
+        });
+        const nextReminderAt = next ?? selectedAt;
+        await recruitmentReminderService.upsertRecruitmentReminderRule({
+          guildId: interaction.guildId!,
+          discordUserId: interaction.user.id,
+          clanTag: state.clanTag,
+          platform: state.clanTab,
+          timezone: state.timezone,
+          nextReminderAt,
+          isActive: true,
+          clanNameSnapshot: clan?.name ?? null,
+          templateSubject: template.subject ?? null,
+          templateBody: template.body,
+          templateImageUrls: template.imageUrls,
+        });
+        await render(`Reminder saved for ${formatClanLabel(state.clanTag, clan?.name ?? null)}.`);
+        return;
+      }
+    } catch (error) {
+      console.error(`[recruitment] dashboard interaction failed error=${formatError(error)}`);
+      if (!component.replied && !component.deferred) {
+        await component.reply({
+          ephemeral: true,
+          content: "Failed to update the recruitment dashboard.",
+        });
       }
     }
-    lines.push("");
-  }
+  });
 
-  await interaction.editReply(truncateDiscordContent(lines.join("\n").trim()));
+  collector.on("end", async () => {
+    try {
+      await interaction.editReply({
+        components: [],
+      });
+    } catch {
+      // no-op
+    }
+  });
 }
 
 export function isRecruitmentModalCustomId(customId: string): boolean {
@@ -710,6 +1331,15 @@ export const Recruitment: Command = {
       name: "dashboard",
       description: "Show readiness across all tracked clans and platforms",
       type: ApplicationCommandOptionType.Subcommand,
+      options: [
+        {
+          name: "timezone",
+          description: "IANA timezone to use for window display and slot selection",
+          type: ApplicationCommandOptionType.String,
+          required: true,
+          autocomplete: true,
+        },
+      ],
     },
   ],
   run: async (
@@ -750,6 +1380,14 @@ export const Recruitment: Command = {
   },
   autocomplete: async (interaction: AutocompleteInteraction) => {
     const focused = interaction.options.getFocused(true);
+    if (focused.name === "timezone") {
+      try {
+        await interaction.respond(autocompleteRecruitmentTimeZones(String(focused.value ?? "")));
+      } catch {
+        await interaction.respond([]);
+      }
+      return;
+    }
     if (focused.name !== "clan") {
       await interaction.respond([]);
       return;

--- a/src/commands/RemindMe.ts
+++ b/src/commands/RemindMe.ts
@@ -24,6 +24,10 @@ import {
   removeUserActivityReminderRulesByIds,
   type UserActivityReminderRuleGroup,
 } from "../services/remindme/UserActivityReminderService";
+import {
+  listRecruitmentReminderRulesForUser,
+  removeRecruitmentReminderRulesByIds,
+} from "../services/RecruitmentReminderService";
 
 const REMINDME_PANEL_TIMEOUT_MS = 10 * 60 * 1000;
 
@@ -123,6 +127,135 @@ function buildRemoveComponents(input: {
   );
 
   return [new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select), actions];
+}
+
+type RecruitmentReminderListRow = Awaited<
+  ReturnType<typeof listRecruitmentReminderRulesForUser>
+>[number];
+
+function formatRecruitmentReminderLine(row: RecruitmentReminderListRow): string {
+  const unix = Math.floor(row.nextReminderAt.getTime() / 1000);
+  const clanLabel = row.clanNameSnapshot
+    ? `${row.clanNameSnapshot} ${row.clanTag}`
+    : row.clanTag;
+  return `- **Recruitment** | ${clanLabel} | ${row.platform} | ${row.timezone} | <t:${unix}:R>`;
+}
+
+function buildRecruitmentReminderListSection(rows: RecruitmentReminderListRow[]): string[] {
+  if (rows.length <= 0) return ["No active recruitment reminders."];
+  return rows.map((row) => formatRecruitmentReminderLine(row));
+}
+
+function buildCombinedReminderRemovalOptions(input: {
+  activityGroups: UserActivityReminderRuleGroup[];
+  recruitmentRows: RecruitmentReminderListRow[];
+}): Array<{
+  label: string;
+  value: string;
+  description: string;
+}> {
+  const activityOptions = input.activityGroups.map((group) => {
+    const playerLabel = group.playerName ?? group.playerTag;
+    const offsets = group.offsetMinutes.map((offset) => formatOffsetMinutes(offset)).join(", ");
+    return {
+      label: `Activity ${group.type} ${playerLabel}`.slice(0, 100),
+      value: `activity|${group.key}`,
+      description: `${group.playerTag} | ${formatReminderMethodLabel(group.method)} | ${offsets}`.slice(
+        0,
+        100,
+      ),
+    };
+  });
+
+  const recruitmentOptions = input.recruitmentRows.map((row) => {
+    const clanLabel = row.clanNameSnapshot ? `${row.clanNameSnapshot} (${row.clanTag})` : row.clanTag;
+    return {
+      label: `Recruitment ${clanLabel}`.slice(0, 100),
+      value: `recruitment|${row.id}`,
+      description: `${row.platform} | ${row.timezone} | <t:${Math.floor(row.nextReminderAt.getTime() / 1000)}:R>`.slice(
+        0,
+        100,
+      ),
+    };
+  });
+
+  return [...activityOptions, ...recruitmentOptions].slice(0, 25);
+}
+
+function buildCombinedRemoveComponents(input: {
+  activityGroups: UserActivityReminderRuleGroup[];
+  recruitmentRows: RecruitmentReminderListRow[];
+  selectedGroupKeys: Set<string>;
+  interactionId: string;
+}) {
+  const options = buildCombinedReminderRemovalOptions({
+    activityGroups: input.activityGroups,
+    recruitmentRows: input.recruitmentRows,
+  });
+  const select = new StringSelectMenuBuilder()
+    .setCustomId(`remindme:remove:select:${input.interactionId}`)
+    .setPlaceholder(options.length > 0 ? "Select reminders to remove" : "No reminders available")
+    .setMinValues(0)
+    .setMaxValues(Math.max(1, options.length))
+    .setDisabled(options.length <= 0)
+    .addOptions(
+        options.length > 0
+          ? options.map((option) => ({
+              ...option,
+              default: input.selectedGroupKeys.has(option.value),
+            }))
+        : [
+            {
+              label: "No reminders",
+              value: "none",
+              description: "Nothing to remove",
+            },
+          ],
+    );
+
+  const actions = new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder()
+      .setCustomId(`remindme:remove:confirm:${input.interactionId}`)
+      .setLabel("Confirm Remove")
+      .setStyle(ButtonStyle.Danger)
+      .setDisabled(options.length <= 0),
+    new ButtonBuilder()
+      .setCustomId(`remindme:remove:cancel:${input.interactionId}`)
+      .setLabel("Cancel")
+      .setStyle(ButtonStyle.Secondary),
+  );
+
+  return [new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select), actions];
+}
+
+function buildCombinedReminderListEmbed(input: {
+  discordUserId: string;
+  activityGroups: UserActivityReminderRuleGroup[];
+  recruitmentRows: RecruitmentReminderListRow[];
+  title: string;
+}): EmbedBuilder {
+  const activityLines =
+    input.activityGroups.length > 0
+      ? input.activityGroups.map((group) => formatReminderGroupLine(group))
+      : ["No active activity reminders."];
+  const recruitmentLines = buildRecruitmentReminderListSection(input.recruitmentRows);
+  const lines = [
+    "Activity reminders:",
+    ...activityLines,
+    "",
+    "Recruitment reminders:",
+    ...recruitmentLines,
+  ];
+  return new EmbedBuilder()
+    .setTitle(input.title)
+    .setDescription(lines.join("\n"))
+    .setColor(0x5865f2)
+    .setFooter({
+      text: `User: ${input.discordUserId} | Activity Rules: ${input.activityGroups.reduce(
+        (sum, group) => sum + group.ruleIds.length,
+        0,
+      )} | Recruitment Rules: ${input.recruitmentRows.length}`,
+    });
 }
 
 /** Purpose: compose and register `/remindme` user-scoped reminder command flows. */
@@ -283,10 +416,22 @@ export const RemindMe: Command = {
     }
 
     if (subcommand === "list") {
-      const groups = await listUserActivityReminderRuleGroups({
+      const guildId = interaction.guildId;
+      if (!guildId) {
+        await safeReply(interaction, {
+          ephemeral: true,
+          content: "This command can only be used in a server.",
+        });
+        return;
+      }
+      const activityGroups = await listUserActivityReminderRuleGroups({
         discordUserId: interaction.user.id,
       });
-      if (groups.length <= 0) {
+      const recruitmentRows = await listRecruitmentReminderRulesForUser({
+        guildId,
+        discordUserId: interaction.user.id,
+      });
+      if (activityGroups.length <= 0 && recruitmentRows.length <= 0) {
         await safeReply(interaction, {
           ephemeral: true,
           content: "You do not have any active reminders yet.",
@@ -296,9 +441,10 @@ export const RemindMe: Command = {
 
       await interaction.editReply({
         embeds: [
-          buildReminderListEmbed({
+          buildCombinedReminderListEmbed({
             discordUserId: interaction.user.id,
-            groups,
+            activityGroups,
+            recruitmentRows,
             title: "Your Reminders",
           }),
         ],
@@ -306,10 +452,23 @@ export const RemindMe: Command = {
       return;
     }
 
-    let groups = await listUserActivityReminderRuleGroups({
+    const guildId = interaction.guildId;
+    if (!guildId) {
+      await safeReply(interaction, {
+        ephemeral: true,
+        content: "This command can only be used in a server.",
+      });
+      return;
+    }
+
+    let activityGroups = await listUserActivityReminderRuleGroups({
       discordUserId: interaction.user.id,
     });
-    if (groups.length <= 0) {
+    let recruitmentRows = await listRecruitmentReminderRulesForUser({
+      guildId,
+      discordUserId: interaction.user.id,
+    });
+    if (activityGroups.length <= 0 && recruitmentRows.length <= 0) {
       await safeReply(interaction, {
         ephemeral: true,
         content: "You do not have any active reminders to remove.",
@@ -320,18 +479,20 @@ export const RemindMe: Command = {
     const selectedGroupKeys = new Set<string>();
     await interaction.editReply({
       content:
-        groups.length > 25
+        activityGroups.length + recruitmentRows.length > 25
           ? "Only the first 25 grouped reminders are selectable in one remove action."
           : null,
       embeds: [
-        buildReminderListEmbed({
+        buildCombinedReminderListEmbed({
           discordUserId: interaction.user.id,
-          groups,
+          activityGroups,
+          recruitmentRows,
           title: "Remove Reminders",
         }),
       ],
-      components: buildRemoveComponents({
-        groups,
+      components: buildCombinedRemoveComponents({
+        activityGroups,
+        recruitmentRows,
         selectedGroupKeys,
         interactionId: interaction.id,
       }),
@@ -364,14 +525,16 @@ export const RemindMe: Command = {
         }
         await component.update({
           embeds: [
-            buildReminderListEmbed({
+            buildCombinedReminderListEmbed({
               discordUserId: interaction.user.id,
-              groups,
+              activityGroups,
+              recruitmentRows,
               title: `Remove Reminders (selected ${selectedGroupKeys.size})`,
             }),
           ],
-          components: buildRemoveComponents({
-            groups,
+          components: buildCombinedRemoveComponents({
+            activityGroups,
+            recruitmentRows,
             selectedGroupKeys,
             interactionId: interaction.id,
           }),
@@ -398,45 +561,59 @@ export const RemindMe: Command = {
           return;
         }
 
-        const selectedRuleIds = groups
-          .filter((group) => selectedGroupKeys.has(group.key))
+        const selectedActivityRuleIds = activityGroups
+          .filter((group) => selectedGroupKeys.has(`activity|${group.key}`))
           .flatMap((group) => group.ruleIds);
-        const removedCount = await removeUserActivityReminderRulesByIds({
+        const selectedRecruitmentRuleIds = recruitmentRows
+          .filter((row) => selectedGroupKeys.has(`recruitment|${row.id}`))
+          .map((row) => row.id);
+        const removedActivityCount = await removeUserActivityReminderRulesByIds({
           discordUserId: interaction.user.id,
-          ruleIds: selectedRuleIds,
+          ruleIds: selectedActivityRuleIds,
+        });
+        const removedRecruitmentCount = await removeRecruitmentReminderRulesByIds({
+          guildId,
+          discordUserId: interaction.user.id,
+          ruleIds: selectedRecruitmentRuleIds,
         });
 
-        groups = await listUserActivityReminderRuleGroups({
+        activityGroups = await listUserActivityReminderRuleGroups({
+          discordUserId: interaction.user.id,
+        });
+        recruitmentRows = await listRecruitmentReminderRulesForUser({
+          guildId,
           discordUserId: interaction.user.id,
         });
         selectedGroupKeys.clear();
 
         await component.update({
           content:
-            groups.length > 0
-              ? `Removed **${removedCount}** reminder rule(s).`
-              : `Removed **${removedCount}** reminder rule(s). No reminders remain.`,
+            activityGroups.length + recruitmentRows.length > 0
+              ? `Removed **${removedActivityCount + removedRecruitmentCount}** reminder rule(s).`
+              : `Removed **${removedActivityCount + removedRecruitmentCount}** reminder rule(s). No reminders remain.`,
           embeds:
-            groups.length > 0
+            activityGroups.length + recruitmentRows.length > 0
               ? [
-                  buildReminderListEmbed({
+                  buildCombinedReminderListEmbed({
                     discordUserId: interaction.user.id,
-                    groups,
+                    activityGroups,
+                    recruitmentRows,
                     title: "Remove Reminders",
                   }),
                 ]
               : [],
           components:
-            groups.length > 0
-              ? buildRemoveComponents({
-                  groups,
+            activityGroups.length + recruitmentRows.length > 0
+              ? buildCombinedRemoveComponents({
+                  activityGroups,
+                  recruitmentRows,
                   selectedGroupKeys,
                   interactionId: interaction.id,
                 })
               : [],
         });
 
-        if (groups.length <= 0) {
+        if (activityGroups.length + recruitmentRows.length <= 0) {
           collector.stop("completed_empty");
         }
       }

--- a/src/listeners/ready.ts
+++ b/src/listeners/ready.ts
@@ -11,6 +11,7 @@ import { formatError } from "../helper/formatError";
 import { runFetchTelemetryBatch } from "../helper/fetchTelemetry";
 import { prisma } from "../prisma";
 import { processRecruitmentCooldownReminders } from "../services/RecruitmentService";
+import { processDueRecruitmentReminders } from "../services/RecruitmentReminderService";
 import { processWeightInputDefermentStages } from "../services/WeightInputDefermentService";
 import { SettingsService } from "../services/SettingsService";
 import { WarEventLogService } from "../services/WarEventLogService";
@@ -58,6 +59,7 @@ import { MirrorSyncService } from "../services/MirrorSyncService";
 
 const DEFAULT_OBSERVE_INTERVAL_MINUTES = 30;
 const RECRUITMENT_REMINDER_INTERVAL_MS = 60 * 60 * 1000;
+const RECRUITMENT_RULE_REMINDER_INTERVAL_MS = 60 * 1000;
 const DEFERMENT_REMINDER_INTERVAL_MS = 60 * 60 * 1000;
 const TRACKED_MESSAGE_SWEEP_INTERVAL_MS = 60 * 1000;
 const OBSERVE_LAST_RUN_AT_KEY = "activity_observe:last_run_at_ms";
@@ -625,6 +627,30 @@ export default (client: Client, cocService: CoCService): void => {
       });
     }, RECRUITMENT_REMINDER_INTERVAL_MS);
     console.log("Recruitment reminder loop enabled (every 60 minute(s)).");
+
+    const runRecruitmentRuleReminders = async () => {
+      await runFetchTelemetryBatch("recruitment_rule_reminder_cycle", async () => {
+        try {
+          const counts = await processDueRecruitmentReminders({
+            client,
+            now: new Date(),
+          });
+          console.log(
+            `[recruitment-reminder] evaluated=${counts.evaluated} sent=${counts.sent} failed=${counts.failed}`,
+          );
+        } catch (err) {
+          console.error(`[recruitment-reminder] loop failed: ${formatError(err)}`);
+        }
+      });
+    };
+
+    await runRecruitmentRuleReminders();
+    setInterval(() => {
+      runRecruitmentRuleReminders().catch((err) => {
+        console.error(`[recruitment-reminder] interval failed: ${formatError(err)}`);
+      });
+    }, RECRUITMENT_RULE_REMINDER_INTERVAL_MS);
+    console.log("Recruitment rule reminder loop enabled (every 1 minute).");
 
     const runDefermentReminders = async () => {
       await runFetchTelemetryBatch("deferment_reminder_cycle", async () => {

--- a/src/services/RecruitmentReminderService.ts
+++ b/src/services/RecruitmentReminderService.ts
@@ -1,0 +1,649 @@
+import { Client } from "discord.js";
+import { prisma } from "../prisma";
+import { autocompleteSyncTimeZones, normalizeSyncTimeZone } from "./syncTimeZone";
+import { formatError } from "../helper/formatError";
+import { getRecruitmentCooldown, getRecruitmentTemplate } from "./RecruitmentService";
+import { normalizeClanTag } from "./PlayerLinkService";
+
+export type RecruitmentReminderPlatform = "discord" | "reddit" | "band";
+export type RecruitmentReminderDeliveryStatus = "SENT" | "FAILED" | "SKIPPED";
+
+export type RecruitmentReminderRuleRecord = {
+  id: string;
+  guildId: string;
+  discordUserId: string;
+  clanTag: string;
+  platform: RecruitmentReminderPlatform;
+  timezone: string;
+  nextReminderAt: Date;
+  isActive: boolean;
+  lastSentAt: Date | null;
+  clanNameSnapshot: string | null;
+  templateSubject: string | null;
+  templateBody: string;
+  templateImageUrls: string[];
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export type RecruitmentReminderDeliveryRecord = {
+  id: string;
+  reminderRuleId: string;
+  scheduledFor: Date;
+  sentAt: Date | null;
+  status: RecruitmentReminderDeliveryStatus;
+  errorDetails: string | null;
+  createdAt: Date;
+};
+
+export type RecruitmentReminderSnapshot = {
+  guildId: string;
+  clanTag: string;
+  clanName: string | null;
+  platform: RecruitmentReminderPlatform;
+  timezone: string;
+  templateSubject: string | null;
+  templateBody: string;
+  templateImageUrls: string[];
+};
+
+const PACIFIC_TIME_ZONE = "America/Los_Angeles";
+const SLOT_STEP_MINUTES = 30;
+const DEFAULT_SLOT_LOOKAHEAD_DAYS = 14;
+
+type WindowSpec = {
+  startMinutes: number;
+  endMinutes: number;
+  daysOfWeek: number[] | null;
+  rhythmLabel: string;
+};
+
+const WINDOW_SPECS: Record<RecruitmentReminderPlatform, WindowSpec[]> = {
+  discord: [
+    {
+      startMinutes: 12 * 60,
+      endMinutes: 13 * 60,
+      daysOfWeek: null,
+      rhythmLabel: "Daily around 12:00 PM PST",
+    },
+    {
+      startMinutes: 18 * 60,
+      endMinutes: 21 * 60,
+      daysOfWeek: null,
+      rhythmLabel: "Daily around 7:00 PM PST",
+    },
+  ],
+  reddit: [
+    {
+      startMinutes: 8 * 60,
+      endMinutes: 11 * 60,
+      daysOfWeek: [0, 6],
+      rhythmLabel: "Sunday around 9:00 AM PST",
+    },
+  ],
+  band: [
+    {
+      startMinutes: 8 * 60,
+      endMinutes: 8 * 60 + 30,
+      daysOfWeek: null,
+      rhythmLabel: "Daily at 8:00 AM PST",
+    },
+    {
+      startMinutes: 19 * 60,
+      endMinutes: 19 * 60 + 30,
+      daysOfWeek: null,
+      rhythmLabel: "Daily at 7:00 PM PST",
+    },
+  ],
+};
+
+function getOffsetMinutes(date: Date, timeZone: string): number {
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    timeZoneName: "shortOffset",
+  });
+  const token =
+    formatter.formatToParts(date).find((part) => part.type === "timeZoneName")?.value ?? "GMT+00";
+  const normalized = token.replace("UTC", "GMT");
+  const match = normalized.match(/^GMT([+-])(\d{1,2})(?::?(\d{2}))?$/i);
+  if (!match) return 0;
+  const sign = match[1] === "-" ? -1 : 1;
+  const hours = Number(match[2] ?? "0");
+  const minutes = Number(match[3] ?? "0");
+  return sign * (hours * 60 + minutes);
+}
+
+function getTimeZoneParts(date: Date, timeZone: string): {
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+  weekday: number;
+} {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    year: "numeric",
+    month: "numeric",
+    day: "numeric",
+    hour: "numeric",
+    minute: "numeric",
+    hour12: false,
+    weekday: "short",
+  }).formatToParts(date);
+  const get = (type: string): string => parts.find((part) => part.type === type)?.value ?? "0";
+  const weekdayText = get("weekday");
+  const weekdayMap: Record<string, number> = {
+    Sun: 0,
+    Mon: 1,
+    Tue: 2,
+    Wed: 3,
+    Thu: 4,
+    Fri: 5,
+    Sat: 6,
+  };
+  return {
+    year: Number(get("year")),
+    month: Number(get("month")),
+    day: Number(get("day")),
+    hour: Number(get("hour")),
+    minute: Number(get("minute")),
+    weekday: weekdayMap[weekdayText] ?? 0,
+  };
+}
+
+export function getDateKeyInTimeZone(date: Date, timeZone: string): string {
+  const parts = getTimeZoneParts(date, timeZone);
+  return `${String(parts.year).padStart(4, "0")}-${String(parts.month).padStart(2, "0")}-${String(
+    parts.day,
+  ).padStart(2, "0")}`;
+}
+
+function zonedLocalToUtc(input: {
+  year: number;
+  month: number;
+  day: number;
+  hour: number;
+  minute: number;
+  timeZone: string;
+}): Date {
+  const localMs = Date.UTC(input.year, input.month - 1, input.day, input.hour, input.minute, 0, 0);
+  let utcMs = localMs;
+  for (let i = 0; i < 2; i += 1) {
+    const offsetMinutes = getOffsetMinutes(new Date(utcMs), input.timeZone);
+    utcMs = localMs - offsetMinutes * 60 * 1000;
+  }
+  return new Date(utcMs);
+}
+
+function addDaysToLocalDateParts(parts: { year: number; month: number; day: number }, days: number) {
+  const anchor = new Date(Date.UTC(parts.year, parts.month - 1, parts.day + days, 12, 0, 0, 0));
+  const localized = getTimeZoneParts(anchor, PACIFIC_TIME_ZONE);
+  return {
+    year: localized.year,
+    month: localized.month,
+    day: localized.day,
+  };
+}
+
+function formatDateInTimeZone(date: Date, timeZone: string): string {
+  return new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    year: "numeric",
+    month: "short",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: true,
+  }).format(date);
+}
+
+function formatTimeInTimeZone(date: Date, timeZone: string): string {
+  return new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    hour: "numeric",
+    minute: "2-digit",
+    hour12: true,
+  }).format(date);
+}
+
+function platformLabel(platform: RecruitmentReminderPlatform): string {
+  return platform.charAt(0).toUpperCase() + platform.slice(1);
+}
+
+function normalizeRecruitmentPlatform(input: string): RecruitmentReminderPlatform | null {
+  const value = String(input ?? "").trim().toLowerCase();
+  if (value === "discord" || value === "reddit" || value === "band") {
+    return value;
+  }
+  return null;
+}
+
+export function normalizeRecruitmentTimezone(input: string | null | undefined): string | null {
+  return normalizeSyncTimeZone(input);
+}
+
+export function autocompleteRecruitmentTimeZones(input: string | null | undefined) {
+  return autocompleteSyncTimeZones(input);
+}
+
+export function getRecruitmentReminderPlatformLabel(platform: RecruitmentReminderPlatform): string {
+  return platformLabel(platform);
+}
+
+export function getRecruitmentReminderPlatformWindows(platform: RecruitmentReminderPlatform): WindowSpec[] {
+  return [...WINDOW_SPECS[platform]];
+}
+
+export function formatRecruitmentReminderWindowSummary(
+  platform: RecruitmentReminderPlatform,
+): string {
+  const windows = WINDOW_SPECS[platform];
+  return windows
+    .map((window) => {
+      const startHour = Math.floor(window.startMinutes / 60);
+      const startMinute = window.startMinutes % 60;
+      const endHour = Math.floor(window.endMinutes / 60);
+      const endMinute = window.endMinutes % 60;
+      return `${String(startHour).padStart(2, "0")}:${String(startMinute).padStart(2, "0")} - ${String(
+        endHour,
+      ).padStart(2, "0")}:${String(endMinute).padStart(2, "0")} PST`;
+    })
+    .join(", ");
+}
+
+export function formatRecruitmentReminderWindowSummaryInTimeZone(
+  platform: RecruitmentReminderPlatform,
+  timeZone: string,
+  referenceDate = new Date(),
+): string {
+  const basePacific = getTimeZoneParts(referenceDate, PACIFIC_TIME_ZONE);
+  return WINDOW_SPECS[platform]
+    .map((window) => {
+      const start = zonedLocalToUtc({
+        year: basePacific.year,
+        month: basePacific.month,
+        day: basePacific.day,
+        hour: Math.floor(window.startMinutes / 60),
+        minute: window.startMinutes % 60,
+        timeZone: PACIFIC_TIME_ZONE,
+      });
+      const end = zonedLocalToUtc({
+        year: basePacific.year,
+        month: basePacific.month,
+        day: basePacific.day,
+        hour: Math.floor(window.endMinutes / 60),
+        minute: window.endMinutes % 60,
+        timeZone: PACIFIC_TIME_ZONE,
+      });
+      const scope = window.daysOfWeek ? "Weekend" : "Daily";
+      return `${scope} ${formatTimeInTimeZone(start, timeZone)} - ${formatTimeInTimeZone(end, timeZone)}`;
+    })
+    .join(", ");
+}
+
+export function formatRecruitmentReminderRhythmSummaryInTimeZone(
+  platform: RecruitmentReminderPlatform,
+  timeZone: string,
+  referenceDate = new Date(),
+): string {
+  const basePacific = getTimeZoneParts(referenceDate, PACIFIC_TIME_ZONE);
+  if (platform === "discord") {
+    const rhythm = zonedLocalToUtc({
+      year: basePacific.year,
+      month: basePacific.month,
+      day: basePacific.day,
+      hour: 19,
+      minute: 0,
+      timeZone: PACIFIC_TIME_ZONE,
+    });
+    return `Daily around ${formatTimeInTimeZone(rhythm, timeZone)}`;
+  }
+  if (platform === "reddit") {
+    const rhythm = zonedLocalToUtc({
+      year: basePacific.year,
+      month: basePacific.month,
+      day: basePacific.day,
+      hour: 9,
+      minute: 0,
+      timeZone: PACIFIC_TIME_ZONE,
+    });
+    return `Sunday around ${formatTimeInTimeZone(rhythm, timeZone)}`;
+  }
+  const eightAm = zonedLocalToUtc({
+    year: basePacific.year,
+    month: basePacific.month,
+    day: basePacific.day,
+    hour: 8,
+    minute: 0,
+    timeZone: PACIFIC_TIME_ZONE,
+  });
+  const sevenPm = zonedLocalToUtc({
+    year: basePacific.year,
+    month: basePacific.month,
+    day: basePacific.day,
+    hour: 19,
+    minute: 0,
+    timeZone: PACIFIC_TIME_ZONE,
+  });
+  return `Daily at ${formatTimeInTimeZone(eightAm, timeZone)} and ${formatTimeInTimeZone(
+    sevenPm,
+    timeZone,
+  )}`;
+}
+
+export function getRecruitmentReminderRhythmLabel(platform: RecruitmentReminderPlatform): string {
+  return WINDOW_SPECS[platform][0]?.rhythmLabel ?? "Daily";
+}
+
+export function formatRecruitmentReminderTime(date: Date, timeZone: string): string {
+  return formatDateInTimeZone(date, timeZone);
+}
+
+export function getRecruitmentReminderSlotCandidates(input: {
+  platform: RecruitmentReminderPlatform;
+  timezone: string;
+  after: Date;
+  cooldownExpiresAt?: Date | null;
+  lookaheadDays?: number;
+}): Date[] {
+  const normalizedZone = normalizeRecruitmentTimezone(input.timezone) ?? "UTC";
+  const afterMs = Math.max(
+    input.after.getTime(),
+    input.cooldownExpiresAt?.getTime() ?? input.after.getTime(),
+  );
+  const basePacific = getTimeZoneParts(input.after, PACIFIC_TIME_ZONE);
+  const lookaheadDays = Math.max(1, Math.trunc(Number(input.lookaheadDays) || DEFAULT_SLOT_LOOKAHEAD_DAYS));
+  const windows = WINDOW_SPECS[input.platform];
+  const candidates: Date[] = [];
+
+  for (let dayOffset = 0; dayOffset <= lookaheadDays; dayOffset += 1) {
+    const localDay = addDaysToLocalDateParts(basePacific, dayOffset);
+    for (const window of windows) {
+      const candidateDayAnchor = zonedLocalToUtc({
+        year: localDay.year,
+        month: localDay.month,
+        day: localDay.day,
+        hour: Math.floor(window.startMinutes / 60),
+        minute: window.startMinutes % 60,
+        timeZone: PACIFIC_TIME_ZONE,
+      });
+      const weekday = getTimeZoneParts(candidateDayAnchor, PACIFIC_TIME_ZONE).weekday;
+      if (window.daysOfWeek && !window.daysOfWeek.includes(weekday)) {
+        continue;
+      }
+
+      for (let minute = window.startMinutes; minute < window.endMinutes; minute += SLOT_STEP_MINUTES) {
+        const slot = zonedLocalToUtc({
+          year: localDay.year,
+          month: localDay.month,
+          day: localDay.day,
+          hour: Math.floor(minute / 60),
+          minute: minute % 60,
+          timeZone: PACIFIC_TIME_ZONE,
+        });
+        if (slot.getTime() <= afterMs) continue;
+        candidates.push(slot);
+      }
+    }
+  }
+
+  const uniqueSorted = [...new Map(candidates.map((slot) => [slot.getTime(), slot])).values()]
+    .sort((a, b) => a.getTime() - b.getTime());
+  return uniqueSorted;
+}
+
+export function getNextRecruitmentReminderSlot(input: {
+  platform: RecruitmentReminderPlatform;
+  timezone: string;
+  after: Date;
+  cooldownExpiresAt?: Date | null;
+}): Date | null {
+  return getRecruitmentReminderSlotCandidates(input)[0] ?? null;
+}
+
+export function buildRecruitmentReminderDmContent(input: {
+  clanTag: string;
+  clanName: string | null;
+  platform: RecruitmentReminderPlatform;
+  cooldownExpiresAt: Date | null;
+  templateSubject: string | null;
+  templateBody: string;
+  templateImageUrls: string[];
+}): string {
+  const lines = [
+    `Recruitment reminder for ${input.clanName ? `${input.clanName} ` : ""}${input.clanTag}`,
+    `Platform: ${platformLabel(input.platform)}`,
+  ];
+  if (input.cooldownExpiresAt) {
+    const unix = Math.floor(input.cooldownExpiresAt.getTime() / 1000);
+    lines.push(`Cooldown: active until <t:${unix}:R>`);
+  } else {
+    lines.push("Cooldown: ready now");
+  }
+  if (input.templateSubject) {
+    lines.push(`Subject: \`${input.templateSubject}\``);
+  }
+  lines.push("Template:");
+  lines.push("```");
+  lines.push(input.templateBody);
+  lines.push("```");
+  if (input.templateImageUrls.length > 0) {
+    lines.push("Images:");
+    lines.push(...input.templateImageUrls.map((url) => `- ${url}`));
+  }
+  return lines.join("\n");
+}
+
+export async function upsertRecruitmentReminderRule(input: {
+  guildId: string;
+  discordUserId: string;
+  clanTag: string;
+  platform: RecruitmentReminderPlatform;
+  timezone: string;
+  nextReminderAt: Date;
+  isActive: boolean;
+  lastSentAt?: Date | null;
+  clanNameSnapshot?: string | null;
+  templateSubject?: string | null;
+  templateBody: string;
+  templateImageUrls: string[];
+}): Promise<RecruitmentReminderRuleRecord> {
+  const clanTag = normalizeClanTag(input.clanTag);
+  const existing = await prisma.recruitmentReminderRule.findFirst({
+    where: {
+      guildId: input.guildId,
+      discordUserId: input.discordUserId,
+      clanTag,
+      platform: input.platform,
+    },
+  });
+  const data = {
+    guildId: input.guildId,
+    discordUserId: input.discordUserId,
+    clanTag,
+    platform: input.platform,
+    timezone: normalizeRecruitmentTimezone(input.timezone) ?? input.timezone,
+    nextReminderAt: input.nextReminderAt,
+    isActive: input.isActive,
+    lastSentAt: input.lastSentAt ?? null,
+    clanNameSnapshot: input.clanNameSnapshot ?? null,
+    templateSubject: input.templateSubject ?? null,
+    templateBody: input.templateBody,
+    templateImageUrls: input.templateImageUrls,
+  };
+  const row = existing
+    ? await prisma.recruitmentReminderRule.update({
+        where: { id: existing.id },
+        data,
+      })
+    : await prisma.recruitmentReminderRule.create({ data });
+  return row as RecruitmentReminderRuleRecord;
+}
+
+export async function listRecruitmentReminderRulesForUser(input: {
+  guildId: string;
+  discordUserId: string;
+}): Promise<RecruitmentReminderRuleRecord[]> {
+  return prisma.recruitmentReminderRule.findMany({
+    where: {
+      guildId: input.guildId,
+      discordUserId: input.discordUserId,
+      isActive: true,
+    },
+    orderBy: [{ nextReminderAt: "asc" }, { clanTag: "asc" }, { platform: "asc" }],
+  }) as Promise<RecruitmentReminderRuleRecord[]>;
+}
+
+export async function listRecruitmentReminderRulesByClanTags(input: {
+  guildId: string;
+  clanTags: string[];
+}): Promise<RecruitmentReminderRuleRecord[]> {
+  const clanTags = [...new Set(input.clanTags.map(normalizeClanTag).filter(Boolean))];
+  if (clanTags.length <= 0) return [];
+  return prisma.recruitmentReminderRule.findMany({
+    where: {
+      guildId: input.guildId,
+      clanTag: { in: clanTags },
+      isActive: true,
+    },
+    orderBy: [{ clanTag: "asc" }, { platform: "asc" }],
+  }) as Promise<RecruitmentReminderRuleRecord[]>;
+}
+
+export async function removeRecruitmentReminderRulesByIds(input: {
+  guildId: string;
+  discordUserId: string;
+  ruleIds: string[];
+}): Promise<number> {
+  const uniqueIds = [...new Set(input.ruleIds.map((id) => String(id ?? "").trim()).filter(Boolean))];
+  if (uniqueIds.length <= 0) return 0;
+  const deleted = await prisma.recruitmentReminderRule.deleteMany({
+    where: {
+      guildId: input.guildId,
+      discordUserId: input.discordUserId,
+      id: { in: uniqueIds },
+    },
+  });
+  return deleted.count;
+}
+
+export async function listDueRecruitmentReminderRules(input: {
+  now: Date;
+}): Promise<RecruitmentReminderRuleRecord[]> {
+  return prisma.recruitmentReminderRule.findMany({
+    where: {
+      isActive: true,
+      nextReminderAt: { lte: input.now },
+    },
+    orderBy: [{ nextReminderAt: "asc" }, { guildId: "asc" }, { clanTag: "asc" }],
+  }) as Promise<RecruitmentReminderRuleRecord[]>;
+}
+
+export async function createRecruitmentReminderDelivery(input: {
+  reminderRuleId: string;
+  scheduledFor: Date;
+  status: RecruitmentReminderDeliveryStatus;
+  sentAt?: Date | null;
+  errorDetails?: string | null;
+}): Promise<RecruitmentReminderDeliveryRecord> {
+  const row = await prisma.recruitmentReminderDelivery.create({
+    data: {
+      reminderRuleId: input.reminderRuleId,
+      scheduledFor: input.scheduledFor,
+      status: input.status,
+      sentAt: input.sentAt ?? null,
+      errorDetails: input.errorDetails ?? null,
+    },
+  });
+  return row as RecruitmentReminderDeliveryRecord;
+}
+
+export async function processDueRecruitmentReminders(input: {
+  client: Client;
+  now?: Date;
+}): Promise<{ evaluated: number; sent: number; failed: number }> {
+  const now = input.now ?? new Date();
+  const dueRules = await listDueRecruitmentReminderRules({ now });
+  let evaluated = 0;
+  let sent = 0;
+  let failed = 0;
+
+  for (const rule of dueRules) {
+    evaluated += 1;
+    const cooldown = await getRecruitmentCooldown(rule.guildId, rule.discordUserId, rule.clanTag, rule.platform as any);
+    const template = await getRecruitmentTemplate(rule.guildId, rule.clanTag, rule.platform as any);
+    const content = buildRecruitmentReminderDmContent({
+      clanTag: rule.clanTag,
+      clanName: rule.clanNameSnapshot,
+      platform: rule.platform,
+      cooldownExpiresAt: cooldown?.expiresAt ?? null,
+      templateSubject: rule.templateSubject ?? template?.subject ?? null,
+      templateBody: rule.templateBody || template?.body || "",
+      templateImageUrls: rule.templateImageUrls.length > 0 ? rule.templateImageUrls : template?.imageUrls ?? [],
+    });
+
+    try {
+      const user = await input.client.users.fetch(rule.discordUserId);
+      await user.send({ content });
+      const nextReminderAt =
+        getNextRecruitmentReminderSlot({
+          platform: rule.platform,
+          timezone: rule.timezone,
+          after: now,
+          cooldownExpiresAt: cooldown?.expiresAt ?? null,
+        }) ?? new Date(now.getTime() + 24 * 60 * 60 * 1000);
+      await prisma.recruitmentReminderRule.update({
+        where: { id: rule.id },
+        data: {
+          lastSentAt: now,
+          nextReminderAt,
+        },
+      });
+      await createRecruitmentReminderDelivery({
+        reminderRuleId: rule.id,
+        scheduledFor: rule.nextReminderAt,
+        status: "SENT",
+        sentAt: now,
+      });
+      sent += 1;
+    } catch (error) {
+      failed += 1;
+      console.error(
+        `[recruitment-reminder] send_failed guild=${rule.guildId} user=${rule.discordUserId} clan=${rule.clanTag} platform=${rule.platform} error=${formatError(
+          error,
+        )}`,
+      );
+      await createRecruitmentReminderDelivery({
+        reminderRuleId: rule.id,
+        scheduledFor: rule.nextReminderAt,
+        status: "FAILED",
+        errorDetails: formatError(error).slice(0, 500),
+      }).catch(() => undefined);
+    }
+  }
+
+  return { evaluated, sent, failed };
+}
+
+export const recruitmentReminderService = {
+  autocompleteRecruitmentTimeZones,
+  formatRecruitmentReminderTime,
+  formatRecruitmentReminderWindowSummary,
+  formatRecruitmentReminderWindowSummaryInTimeZone,
+  formatRecruitmentReminderRhythmSummaryInTimeZone,
+  getNextRecruitmentReminderSlot,
+  getRecruitmentReminderPlatformLabel,
+  getRecruitmentReminderPlatformWindows,
+  getRecruitmentReminderRhythmLabel,
+  getRecruitmentReminderSlotCandidates,
+  listDueRecruitmentReminderRules,
+  listRecruitmentReminderRulesByClanTags,
+  listRecruitmentReminderRulesForUser,
+  normalizeRecruitmentPlatform,
+  normalizeRecruitmentTimezone,
+  processDueRecruitmentReminders,
+  removeRecruitmentReminderRulesByIds,
+  upsertRecruitmentReminderRule,
+  buildRecruitmentReminderDmContent,
+};

--- a/tests/recruitment.dashboard.command.test.ts
+++ b/tests/recruitment.dashboard.command.test.ts
@@ -1,0 +1,299 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+
+const prismaMock = vi.hoisted(() => ({
+  trackedClan: {
+    findMany: vi.fn(),
+  },
+  recruitmentTemplate: {
+    findMany: vi.fn(),
+  },
+  recruitmentCooldown: {
+    findMany: vi.fn(),
+  },
+  recruitmentReminderRule: {
+    findFirst: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+  },
+}));
+
+vi.mock("../src/prisma", () => ({
+  prisma: prismaMock,
+}));
+
+import { Recruitment } from "../src/commands/Recruitment";
+import * as recruitmentServiceModule from "../src/services/RecruitmentService";
+import { recruitmentReminderService } from "../src/services/RecruitmentReminderService";
+
+type CollectorHandlers = {
+  collect?: (component: any) => Promise<void>;
+  end?: () => Promise<void>;
+};
+
+function createCollector() {
+  const handlers: CollectorHandlers = {};
+  return {
+    handlers,
+    collector: {
+      on: vi.fn((event: "collect" | "end", callback: any) => {
+        handlers[event] = callback;
+      }),
+      stop: vi.fn(),
+    },
+  };
+}
+
+function createDashboardInteraction(timezone = "America/Los_Angeles") {
+  const { handlers, collector } = createCollector();
+  const interaction: any = {
+    id: "dashboard-1",
+    guildId: "guild-1",
+    channelId: "channel-1",
+    user: { id: "user-1" },
+    deferred: false,
+    replied: false,
+    options: {
+      getSubcommandGroup: vi.fn().mockReturnValue(null),
+      getSubcommand: vi.fn().mockReturnValue("dashboard"),
+      getString: vi.fn((name: string) => {
+        if (name === "timezone") return timezone;
+        return null;
+      }),
+    },
+    deferReply: vi.fn().mockImplementation(async () => {
+      interaction.deferred = true;
+    }),
+    editReply: vi.fn().mockImplementation(async () => {
+      interaction.replied = true;
+    }),
+    fetchReply: vi.fn().mockResolvedValue({
+      createMessageComponentCollector: vi.fn().mockReturnValue(collector),
+    }),
+    reply: vi.fn().mockImplementation(async () => {
+      interaction.replied = true;
+    }),
+  };
+
+  return { interaction, handlers };
+}
+
+function createButtonComponent(customId: string, userId = "user-1") {
+  return {
+    customId,
+    user: { id: userId },
+    isButton: () => true,
+    isStringSelectMenu: () => false,
+    deferUpdate: vi.fn().mockResolvedValue(undefined),
+    reply: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function createSelectComponent(customId: string, values: string[], userId = "user-1") {
+  return {
+    customId,
+    user: { id: userId },
+    values,
+    isButton: () => false,
+    isStringSelectMenu: () => true,
+    deferUpdate: vi.fn().mockResolvedValue(undefined),
+    reply: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function getLastPayload(interaction: any): any {
+  return interaction.editReply.mock.calls.at(-1)?.[0] ?? {};
+}
+
+function getComponentJson(payload: any): Array<any> {
+  return Array.isArray(payload?.components)
+    ? payload.components.map((row: any) => (typeof row?.toJSON === "function" ? row.toJSON() : row))
+    : [];
+}
+
+function getButtonLabels(payload: any): string[] {
+  return getComponentJson(payload).flatMap((row) =>
+    Array.isArray(row?.components)
+      ? row.components
+          .map((component: any) => (typeof component?.toJSON === "function" ? component.toJSON() : component))
+          .filter((component: any) => typeof component?.label === "string")
+          .map((component: any) => String(component.label))
+      : [],
+  );
+}
+
+function getSelectMenus(payload: any): Array<any> {
+  return getComponentJson(payload).flatMap((row) =>
+    Array.isArray(row?.components)
+      ? row.components
+          .map((component: any) => (typeof component?.toJSON === "function" ? component.toJSON() : component))
+          .filter((component: any) => Array.isArray(component?.options))
+      : [],
+  );
+}
+
+describe("/recruitment dashboard", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-08T17:45:00-07:00"));
+    vi.clearAllMocks();
+    vi.spyOn(recruitmentServiceModule, "getRecruitmentTemplate").mockResolvedValue({
+      subject: "Alpha Subject",
+      body: "Alpha body",
+      imageUrls: ["https://img.example/alpha.png"],
+    } as any);
+    prismaMock.trackedClan.findMany.mockResolvedValue([
+      { tag: "#AAA111", name: "Alpha" },
+      { tag: "#BBB222", name: "Beta" },
+    ]);
+    prismaMock.recruitmentTemplate.findMany.mockResolvedValue([
+      {
+        clanTag: "#AAA111",
+        platform: "discord",
+        subject: "Alpha Subject",
+        body: "Alpha body",
+        imageUrls: ["https://img.example/alpha.png"],
+      },
+      {
+        clanTag: "#AAA111",
+        platform: "reddit",
+        subject: "Alpha Reddit",
+        body: "Alpha reddit body",
+        imageUrls: [],
+      },
+    ]);
+    prismaMock.recruitmentCooldown.findMany.mockResolvedValue([
+      {
+        clanTag: "#AAA111",
+        platform: "discord",
+        expiresAt: new Date("2026-04-08T18:30:00-07:00"),
+      },
+    ]);
+    prismaMock.recruitmentReminderRule.findFirst.mockResolvedValue(null);
+    prismaMock.recruitmentReminderRule.create.mockResolvedValue({ id: "rule-1" });
+    prismaMock.recruitmentReminderRule.update.mockResolvedValue({ id: "rule-1" });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("wires timezone autocomplete and renders the alliance overview controls", async () => {
+    const autocompleteInteraction: any = {
+      user: { id: "user-1" },
+      options: {
+        getFocused: vi.fn().mockReturnValue({
+          name: "timezone",
+          value: "pac",
+        }),
+      },
+      respond: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await Recruitment.autocomplete?.(autocompleteInteraction);
+
+    expect(autocompleteInteraction.respond).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ value: "America/Los_Angeles" }),
+      ]),
+    );
+
+    const { interaction, handlers } = createDashboardInteraction();
+    await Recruitment.run({} as any, interaction as any, {} as any);
+
+    const payload = getLastPayload(interaction);
+    expect(String(payload.embeds[0].toJSON().description)).toContain("Alliance Overview");
+    expect(String(payload.embeds[0].toJSON().description)).toContain("Active recruitment timers");
+    expect(getButtonLabels(payload)).toEqual(["Timers", "Scripts", "Optimize"]);
+    const scopeMenu = getSelectMenus(payload)[0];
+    expect(scopeMenu?.options?.[0]?.label).toBe("Alliance Overview");
+    expect(scopeMenu?.options?.some((option: any) => String(option.label).includes("Alpha"))).toBe(true);
+    expect(handlers.collect).toBeTypeOf("function");
+  });
+
+  it("switches between alliance overview, clan templates, empty states, and reminder scheduling", async () => {
+    const { interaction, handlers } = createDashboardInteraction();
+    const reminderUpsertSpy = vi
+      .spyOn(recruitmentReminderService, "upsertRecruitmentReminderRule")
+      .mockResolvedValue({
+        id: "rule-1",
+      } as any);
+
+    await Recruitment.run({} as any, interaction as any, {} as any);
+
+    await handlers.collect?.(createButtonComponent("recruitment-dashboard:dashboard-1:overview:scripts"));
+    expect(String(getLastPayload(interaction).embeds[0].toJSON().description)).toContain(
+      "Stored template coverage",
+    );
+    expect(String(getLastPayload(interaction).embeds[0].toJSON().description)).toContain(
+      "Discord=stored",
+    );
+
+    await handlers.collect?.(createButtonComponent("recruitment-dashboard:dashboard-1:overview:optimize"));
+    let payload = getLastPayload(interaction);
+    expect(String(payload.embeds[0].toJSON().description)).toContain("Optimization guide:");
+    expect(String(payload.embeds[0].toJSON().description)).not.toContain("PST");
+    expect(String(payload.embeds[0].toJSON().description)).toContain("Next:");
+
+    await handlers.collect?.(createSelectComponent("recruitment-dashboard:dashboard-1:scope", ["#AAA111"]));
+    payload = getLastPayload(interaction);
+    expect(String(payload.embeds[0].toJSON().description)).toContain("Scope: Alpha (#AAA111)");
+    expect(getButtonLabels(payload)).toEqual(["Discord", "Reddit", "Band", "Remind"]);
+
+    await handlers.collect?.(createButtonComponent("recruitment-dashboard:dashboard-1:clan:band"));
+    payload = getLastPayload(interaction);
+    expect(String(payload.embeds[0].toJSON().description)).toContain(
+      "No stored template for this platform.",
+    );
+    const bandButtons = getButtonLabels(payload);
+    expect(bandButtons).toContain("Remind");
+    const bandButtonRow = getComponentJson(payload)[0];
+    const remindButton = bandButtonRow?.components?.find((component: any) => component.label === "Remind");
+    expect(remindButton?.disabled).toBe(true);
+
+    await handlers.collect?.(createButtonComponent("recruitment-dashboard:dashboard-1:clan:discord"));
+    payload = getLastPayload(interaction);
+    expect(String(payload.embeds[0].toJSON().description)).toContain("Recruitment Contents");
+    expect(String(payload.embeds[0].toJSON().description)).toContain("Suggested Image URLs");
+    const remindButtonRow = getComponentJson(payload)[0];
+    const discordRemind = remindButtonRow?.components?.find((component: any) => component.label === "Remind");
+    expect(discordRemind?.disabled).toBe(false);
+
+    await handlers.collect?.(createButtonComponent("recruitment-dashboard:dashboard-1:clan:remind"));
+    payload = getLastPayload(interaction);
+    expect(String(payload.embeds[0].toJSON().description)).toContain("Scheduling reminder for");
+    expect(String(payload.embeds[0].toJSON().description)).toContain("Recommended:");
+    expect(String(payload.embeds[0].toJSON().footer?.text)).toContain("Reminder Scheduling");
+    expect(getSelectMenus(payload)).toHaveLength(3);
+
+    const dayMenu = getSelectMenus(payload)[0];
+    const dayValue = dayMenu?.options?.[0]?.value;
+    expect(dayValue).toBeTypeOf("string");
+    await handlers.collect?.(createSelectComponent("recruitment-dashboard:dashboard-1:schedule:day", [dayValue]));
+    payload = getLastPayload(interaction);
+    expect(String(payload.embeds[0].toJSON().description)).toContain("Select a day and time in 30-minute increments");
+    expect(String(payload.embeds[0].toJSON().description)).toContain("Day choice:");
+    const timeMenu = getSelectMenus(payload)[1];
+    const selectedTimeValue = timeMenu?.options?.[0]?.value;
+    expect(selectedTimeValue).toBeTypeOf("string");
+    await handlers.collect?.(createSelectComponent("recruitment-dashboard:dashboard-1:schedule:time", [selectedTimeValue]));
+    await handlers.collect?.(createButtonComponent("recruitment-dashboard:dashboard-1:schedule:confirm"));
+
+    expect(reminderUpsertSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        guildId: "guild-1",
+        discordUserId: "user-1",
+        clanTag: "AAA111",
+        platform: "discord",
+        timezone: "America/Los_Angeles",
+        isActive: true,
+        nextReminderAt: expect.any(Date),
+        clanNameSnapshot: "Alpha",
+        templateSubject: "Alpha Subject",
+        templateBody: "Alpha body",
+        templateImageUrls: ["https://img.example/alpha.png"],
+      }),
+    );
+    expect(String(getLastPayload(interaction).content)).toContain("Reminder saved for Alpha (#AAA111).");
+  });
+});

--- a/tests/recruitmentReminder.service.test.ts
+++ b/tests/recruitmentReminder.service.test.ts
@@ -1,0 +1,215 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const prismaMock = vi.hoisted(() => ({
+  recruitmentReminderRule: {
+    findFirst: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    findMany: vi.fn(),
+    deleteMany: vi.fn(),
+  },
+  recruitmentReminderDelivery: {
+    create: vi.fn(),
+  },
+}));
+
+const recruitmentServiceMock = vi.hoisted(() => ({
+  getRecruitmentCooldown: vi.fn(),
+  getRecruitmentTemplate: vi.fn(),
+}));
+
+vi.mock("../src/prisma", () => ({
+  prisma: prismaMock,
+}));
+
+vi.mock("../src/services/RecruitmentService", async () => {
+  const actual = await vi.importActual("../src/services/RecruitmentService");
+  return {
+    ...actual,
+    getRecruitmentCooldown: recruitmentServiceMock.getRecruitmentCooldown,
+    getRecruitmentTemplate: recruitmentServiceMock.getRecruitmentTemplate,
+  };
+});
+
+import {
+  autocompleteRecruitmentTimeZones,
+  buildRecruitmentReminderDmContent,
+  getNextRecruitmentReminderSlot,
+  getRecruitmentReminderSlotCandidates,
+  processDueRecruitmentReminders,
+  upsertRecruitmentReminderRule,
+} from "../src/services/RecruitmentReminderService";
+
+describe("recruitment reminder service", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    recruitmentServiceMock.getRecruitmentCooldown.mockResolvedValue(null);
+    recruitmentServiceMock.getRecruitmentTemplate.mockResolvedValue(null);
+    prismaMock.recruitmentReminderRule.findFirst.mockResolvedValue(null);
+    prismaMock.recruitmentReminderRule.create.mockResolvedValue({
+      id: "rule-1",
+    });
+    prismaMock.recruitmentReminderRule.update.mockResolvedValue({
+      id: "rule-1",
+    });
+    prismaMock.recruitmentReminderRule.findMany.mockResolvedValue([]);
+    prismaMock.recruitmentReminderDelivery.create.mockResolvedValue({
+      id: "delivery-1",
+    });
+  });
+
+  it("autocompletes IANA timezones with curated Pacific zones first", () => {
+    const choices = autocompleteRecruitmentTimeZones("pac");
+
+    expect(choices.length).toBeGreaterThan(0);
+    expect(choices[0]?.value).toBe("America/Los_Angeles");
+    expect(choices.every((choice) => choice.value.includes("/"))).toBe(true);
+  });
+
+  it("generates cooldown-aware 30-minute slot options in optimized windows", () => {
+    const after = new Date("2026-04-08T17:17:00-07:00");
+    const cooldownExpiresAt = new Date("2026-04-08T17:17:00-07:00");
+
+    const slots = getRecruitmentReminderSlotCandidates({
+      platform: "band",
+      timezone: "America/Los_Angeles",
+      after,
+      cooldownExpiresAt,
+    });
+
+    expect(slots.length).toBeGreaterThan(0);
+    expect(slots[0]?.toISOString()).toBe("2026-04-09T02:00:00.000Z");
+    expect(slots.every((slot) => slot.getUTCMinutes() % 30 === 0)).toBe(true);
+    expect(slots.every((slot) => slot.getTime() > cooldownExpiresAt.getTime())).toBe(true);
+  });
+
+  it("selects the next optimized slot per platform", () => {
+    expect(
+      getNextRecruitmentReminderSlot({
+        platform: "discord",
+        timezone: "America/Los_Angeles",
+        after: new Date("2026-04-08T17:45:00-07:00"),
+        cooldownExpiresAt: new Date("2026-04-08T18:10:00-07:00"),
+      })?.toISOString(),
+    ).toBe("2026-04-09T01:30:00.000Z");
+
+    expect(
+      getNextRecruitmentReminderSlot({
+        platform: "band",
+        timezone: "America/Los_Angeles",
+        after: new Date("2026-04-08T18:45:00-07:00"),
+        cooldownExpiresAt: null,
+      })?.toISOString(),
+    ).toBe("2026-04-09T02:00:00.000Z");
+
+    expect(
+      getNextRecruitmentReminderSlot({
+        platform: "reddit",
+        timezone: "America/Los_Angeles",
+        after: new Date("2026-04-10T12:00:00-07:00"),
+        cooldownExpiresAt: null,
+      })?.toISOString(),
+    ).toBe("2026-04-11T15:00:00.000Z");
+  });
+
+  it("creates then updates the active reminder rule for the same clan/platform", async () => {
+    prismaMock.recruitmentReminderRule.findFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ id: "rule-1" });
+    prismaMock.recruitmentReminderRule.create.mockResolvedValueOnce({ id: "rule-1" });
+    prismaMock.recruitmentReminderRule.update.mockResolvedValueOnce({ id: "rule-1" });
+
+    const created = await upsertRecruitmentReminderRule({
+      guildId: "guild-1",
+      discordUserId: "user-1",
+      clanTag: "#PYLQ0289",
+      platform: "discord",
+      timezone: "America/Los_Angeles",
+      nextReminderAt: new Date("2026-04-08T18:30:00.000Z"),
+      isActive: true,
+      clanNameSnapshot: "Alpha",
+      templateSubject: "Subject A",
+      templateBody: "Body A",
+      templateImageUrls: ["https://img.example/a.png"],
+    });
+
+    const updated = await upsertRecruitmentReminderRule({
+      guildId: "guild-1",
+      discordUserId: "user-1",
+      clanTag: "#PYLQ0289",
+      platform: "discord",
+      timezone: "America/Los_Angeles",
+      nextReminderAt: new Date("2026-04-08T19:00:00.000Z"),
+      isActive: true,
+      clanNameSnapshot: "Alpha",
+      templateSubject: "Subject B",
+      templateBody: "Body B",
+      templateImageUrls: ["https://img.example/b.png"],
+    });
+
+    expect(prismaMock.recruitmentReminderRule.create).toHaveBeenCalledTimes(1);
+    expect(prismaMock.recruitmentReminderRule.update).toHaveBeenCalledTimes(1);
+    expect(created.id).toBe("rule-1");
+    expect(updated.id).toBe("rule-1");
+  });
+
+  it("sends snapshot content and schedules the next optimized reminder after delivery", async () => {
+    prismaMock.recruitmentReminderRule.findMany.mockResolvedValue([
+      {
+        id: "rule-1",
+        guildId: "guild-1",
+        discordUserId: "user-1",
+        clanTag: "#PYLQ0289",
+        platform: "discord",
+        timezone: "America/Los_Angeles",
+        nextReminderAt: new Date("2026-04-08T17:45:00-07:00"),
+        isActive: true,
+        lastSentAt: null,
+        clanNameSnapshot: "Alpha",
+        templateSubject: "Snapshot Subject",
+        templateBody: "Snapshot Body",
+        templateImageUrls: ["https://img.example/snapshot.png"],
+        createdAt: new Date("2026-04-01T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-01T00:00:00.000Z"),
+      },
+    ]);
+    recruitmentServiceMock.getRecruitmentCooldown.mockResolvedValue({
+      expiresAt: new Date("2026-04-08T18:10:00-07:00"),
+    });
+    recruitmentServiceMock.getRecruitmentTemplate.mockResolvedValue({
+      subject: "Live Subject",
+      body: "Live Body",
+      imageUrls: ["https://img.example/live.png"],
+    });
+    const send = vi.fn().mockResolvedValue(undefined);
+    const fetchUser = vi.fn().mockResolvedValue({ send });
+    const client = { users: { fetch: fetchUser } } as any;
+
+    const counts = await processDueRecruitmentReminders({
+      client,
+      now: new Date("2026-04-08T17:45:00-07:00"),
+    });
+
+    expect(counts).toEqual({ evaluated: 1, sent: 1, failed: 0 });
+    expect(fetchUser).toHaveBeenCalledWith("user-1");
+    expect(send).toHaveBeenCalledWith({
+      content: expect.stringContaining("Snapshot Body"),
+    });
+    expect(send.mock.calls[0]?.[0]?.content).not.toContain("Live Body");
+    expect(prismaMock.recruitmentReminderRule.update).toHaveBeenCalledWith({
+      where: { id: "rule-1" },
+      data: expect.objectContaining({
+        lastSentAt: new Date("2026-04-08T17:45:00-07:00"),
+        nextReminderAt: new Date("2026-04-08T18:30:00-07:00"),
+      }),
+    });
+    expect(prismaMock.recruitmentReminderDelivery.create).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        reminderRuleId: "rule-1",
+        scheduledFor: new Date("2026-04-08T17:45:00-07:00"),
+        status: "SENT",
+        sentAt: new Date("2026-04-08T17:45:00-07:00"),
+      }),
+    });
+  });
+});

--- a/tests/remindme.command.test.ts
+++ b/tests/remindme.command.test.ts
@@ -11,6 +11,11 @@ const remindMeServiceMock = vi.hoisted(() => ({
   removeUserActivityReminderRulesByIds: vi.fn(),
 }));
 
+const recruitmentReminderServiceMock = vi.hoisted(() => ({
+  listRecruitmentReminderRulesForUser: vi.fn(),
+  removeRecruitmentReminderRulesByIds: vi.fn(),
+}));
+
 vi.mock("../src/services/remindme/UserActivityReminderService", async () => {
   const actual = await vi.importActual(
     "../src/services/remindme/UserActivityReminderService",
@@ -27,6 +32,17 @@ vi.mock("../src/services/remindme/UserActivityReminderService", async () => {
   };
 });
 
+vi.mock("../src/services/RecruitmentReminderService", async () => {
+  const actual = await vi.importActual("../src/services/RecruitmentReminderService");
+  return {
+    ...actual,
+    listRecruitmentReminderRulesForUser:
+      recruitmentReminderServiceMock.listRecruitmentReminderRulesForUser,
+    removeRecruitmentReminderRulesByIds:
+      recruitmentReminderServiceMock.removeRecruitmentReminderRulesByIds,
+  };
+});
+
 import { RemindMe } from "../src/commands/RemindMe";
 
 function createInteraction(input: {
@@ -36,6 +52,7 @@ function createInteraction(input: {
   timeLeft?: string;
   method?: UserActivityReminderMethod | null;
 }) {
+  const handlers: Record<string, any> = {};
   const interaction: any = {
     id: "itx-1",
     commandName: "remindme",
@@ -53,7 +70,9 @@ function createInteraction(input: {
     editReply: vi.fn().mockResolvedValue(undefined),
     fetchReply: vi.fn().mockResolvedValue({
       createMessageComponentCollector: vi.fn().mockReturnValue({
-        on: vi.fn(),
+        on: vi.fn((event: string, callback: any) => {
+          handlers[event] = callback;
+        }),
         stop: vi.fn(),
       }),
     }),
@@ -68,6 +87,7 @@ function createInteraction(input: {
       }),
     },
   };
+  interaction.__collectorHandlers = handlers;
   return interaction;
 }
 
@@ -77,6 +97,8 @@ describe("/remindme command", () => {
     remindMeServiceMock.listLinkedPlayerTagOptionsForRemindme.mockResolvedValue([]);
     remindMeServiceMock.listUserActivityReminderRuleGroups.mockResolvedValue([]);
     remindMeServiceMock.removeUserActivityReminderRulesByIds.mockResolvedValue(0);
+    recruitmentReminderServiceMock.listRecruitmentReminderRulesForUser.mockResolvedValue([]);
+    recruitmentReminderServiceMock.removeRecruitmentReminderRulesByIds.mockResolvedValue(0);
   });
 
   it("defaults set method to DM when omitted", async () => {
@@ -188,6 +210,54 @@ describe("/remindme command", () => {
     expect(String(embed.description)).toContain("**WAR** | Alpha #PYLQ0289 | DM | 2h, 12h");
   });
 
+  it("includes recruitment reminders in the combined list output", async () => {
+    remindMeServiceMock.listUserActivityReminderRuleGroups.mockResolvedValue([
+      {
+        key: "WAR|#PYLQ0289|DM",
+        type: UserActivityReminderType.WAR,
+        playerTag: "#PYLQ0289",
+        playerName: "Alpha",
+        method: UserActivityReminderMethod.DM,
+        offsetMinutes: [120],
+        ruleIds: ["rule-1"],
+        surfaceGuildId: null,
+        surfaceChannelId: null,
+      },
+    ]);
+    recruitmentReminderServiceMock.listRecruitmentReminderRulesForUser.mockResolvedValue([
+      {
+        id: "recruitment-1",
+        guildId: "guild-1",
+        discordUserId: "111111111111111111",
+        clanTag: "#AAA111",
+        platform: "discord",
+        timezone: "America/Los_Angeles",
+        nextReminderAt: new Date("2026-04-08T18:30:00.000Z"),
+        isActive: true,
+        lastSentAt: null,
+        clanNameSnapshot: "Alpha",
+        templateSubject: "Subject",
+        templateBody: "Body",
+        templateImageUrls: [],
+        createdAt: new Date("2026-04-01T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-01T00:00:00.000Z"),
+      },
+    ]);
+
+    const interaction = createInteraction({
+      subcommand: "list",
+    });
+
+    await RemindMe.run({} as any, interaction as any, {} as any);
+
+    const payload = interaction.editReply.mock.calls[0]?.[0] as any;
+    const embed = payload.embeds[0].toJSON();
+    expect(String(embed.description)).toContain("Activity reminders:");
+    expect(String(embed.description)).toContain("Recruitment reminders:");
+    expect(String(embed.description)).toContain("Recruitment");
+    expect(String(embed.description)).toContain("#AAA111");
+  });
+
   it("returns clear remove empty-state when user has no reminders", async () => {
     remindMeServiceMock.listUserActivityReminderRuleGroups.mockResolvedValue([]);
     const interaction = createInteraction({
@@ -198,9 +268,85 @@ describe("/remindme command", () => {
 
     expect(interaction.editReply).toHaveBeenCalledWith(
       expect.objectContaining({
-        content: "You do not have any active reminders to remove.",
-      }),
+      content: "You do not have any active reminders to remove.",
+    }),
     );
+  });
+
+  it("shows recruitment reminders in remove options and removes them when selected", async () => {
+    remindMeServiceMock.listUserActivityReminderRuleGroups.mockResolvedValue([
+      {
+        key: "WAR|#PYLQ0289|DM",
+        type: UserActivityReminderType.WAR,
+        playerTag: "#PYLQ0289",
+        playerName: "Alpha",
+        method: UserActivityReminderMethod.DM,
+        offsetMinutes: [120],
+        ruleIds: ["activity-rule-1"],
+        surfaceGuildId: null,
+        surfaceChannelId: null,
+      },
+    ]);
+    recruitmentReminderServiceMock.listRecruitmentReminderRulesForUser.mockResolvedValue([
+      {
+        id: "recruitment-1",
+        guildId: "guild-1",
+        discordUserId: "111111111111111111",
+        clanTag: "#AAA111",
+        platform: "discord",
+        timezone: "America/Los_Angeles",
+        nextReminderAt: new Date("2026-04-08T18:30:00.000Z"),
+        isActive: true,
+        lastSentAt: null,
+        clanNameSnapshot: "Alpha",
+        templateSubject: "Subject",
+        templateBody: "Body",
+        templateImageUrls: [],
+        createdAt: new Date("2026-04-01T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-01T00:00:00.000Z"),
+      },
+    ]);
+    recruitmentReminderServiceMock.removeRecruitmentReminderRulesByIds.mockResolvedValue(1);
+
+    const interaction = createInteraction({
+      subcommand: "remove",
+    });
+
+    await RemindMe.run({} as any, interaction as any, {} as any);
+
+    const payload = interaction.editReply.mock.calls[0]?.[0] as any;
+    const options =
+      payload.components[0].toJSON().components[0].options.map((option: any) => option.value);
+    expect(options).toContain("activity|WAR|#PYLQ0289|DM");
+    expect(options).toContain("recruitment|recruitment-1");
+
+    await interaction.__collectorHandlers.collect({
+      customId: "remindme:remove:select:itx-1",
+      user: { id: "111111111111111111" },
+      values: ["recruitment|recruitment-1"],
+      isStringSelectMenu: () => true,
+      isButton: () => false,
+      reply: vi.fn().mockResolvedValue(undefined),
+      update: vi.fn().mockResolvedValue(undefined),
+      deferUpdate: vi.fn().mockResolvedValue(undefined),
+    });
+
+    await interaction.__collectorHandlers.collect({
+      customId: "remindme:remove:confirm:itx-1",
+      user: { id: "111111111111111111" },
+      values: [],
+      isStringSelectMenu: () => false,
+      isButton: () => true,
+      reply: vi.fn().mockResolvedValue(undefined),
+      update: vi.fn().mockResolvedValue(undefined),
+      deferUpdate: vi.fn().mockResolvedValue(undefined),
+    });
+
+    expect(recruitmentReminderServiceMock.removeRecruitmentReminderRulesByIds).toHaveBeenCalledWith({
+      guildId: "guild-1",
+      discordUserId: "111111111111111111",
+      ruleIds: ["recruitment-1"],
+    });
   });
 
   it("autocomplete suggests only linked tags and preserves comma-prefix input", async () => {


### PR DESCRIPTION
- add timezone-aware recruitment dashboard with overview, clan tabs, and reminder scheduling
- introduce dedicated recruitment reminder persistence, service, and remindme integration
- update help/docs plus tests for dashboard, optimize, reminder scheduling, and list/remove flows