### PR TITLE
feat(recruitment): polish dashboard controls and formatting

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -89,7 +89,7 @@
   - Reddit: subject (`[Recruiting] Name of Clan | #ClanTag | Required TH/Level | Clan Level | FWA | Discord`) auto-prefilled from in-game TH minimum and clan level, body (markdown), optional image URL(s)
 - `/recruitment countdown start platform:discord|reddit|band clan:<tag>` - Start exact cooldown timer for your account on that platform+clan pair.
 - `/recruitment countdown status` - Show your current recruitment cooldown timers.
-- `/recruitment dashboard timezone:<ianaTz>` - Open an interactive alliance/clan dashboard in the selected timezone with timers, scripts, optimize guidance, template tabs, and recruitment reminder scheduling.
+- `/recruitment dashboard [timezone:<ianaTz>]` - Open an interactive alliance/clan dashboard in the selected timezone with timers, scripts, optimize guidance, template tabs, timezone controls, a Start countdown button, and recruitment reminder scheduling. When omitted, the dashboard reuses your stored dashboard timezone from `/sync time post` and falls back to UTC if none is remembered.
 - `/defer add player-tag:<playerTag> weight:<weight>` - Add one deferred weight-input task for a prospective member (accepts `145000`, `145,000`, or `145k`).
 - `/defer list` - Show active open deferred weight-input tasks in oldest-first order for the active scope.
 - `/defer remove player-tag:<playerTag>` - Mark one open deferred task as resolved after FWAStats weight entry is complete.

--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -470,7 +470,7 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
       "`show` renders platform-specific recruitment output for a tracked clan.",
       "`edit` now requires platform and opens a platform-specific modal (discord/band/reddit fields differ).",
       "`countdown start` begins exact platform cooldown timers; `countdown status` shows your timers.",
-      "`dashboard` requires an IANA `timezone` and opens an interactive alliance/clan dashboard with timers, scripts, optimize guidance, and reminder scheduling.",
+      "`dashboard` accepts an optional IANA `timezone`, remembers your last dashboard timezone from `/sync time post`, and opens an interactive alliance/clan dashboard with timers, scripts, optimize guidance, timezone controls, a Start countdown button, and reminder scheduling.",
     ],
     examples: [
       "/recruitment show platform:discord clan:2QG2C08UP",
@@ -478,6 +478,7 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
       "/recruitment countdown start platform:reddit clan:2QG2C08UP",
       "/recruitment countdown status",
       "/recruitment dashboard timezone:America/Los_Angeles",
+      "/recruitment dashboard",
     ],
   },
   defer: {

--- a/src/commands/Recruitment.ts
+++ b/src/commands/Recruitment.ts
@@ -18,6 +18,7 @@ import { truncateDiscordContent } from "../helper/discordContent";
 import { formatError } from "../helper/formatError";
 import { prisma } from "../prisma";
 import { CoCService } from "../services/CoCService";
+import { SettingsService } from "../services/SettingsService";
 import {
   formatClanTag,
   getRecruitmentCooldown,
@@ -37,6 +38,7 @@ import {
   autocompleteRecruitmentTimeZones,
   getDateKeyInTimeZone,
   formatRecruitmentReminderTime,
+  formatRecruitmentReminderBody,
   formatRecruitmentReminderWindowSummaryInTimeZone,
   formatRecruitmentReminderRhythmSummaryInTimeZone,
   getNextRecruitmentReminderSlot,
@@ -44,6 +46,7 @@ import {
   normalizeRecruitmentTimezone,
   recruitmentReminderService,
 } from "../services/RecruitmentReminderService";
+import { getSupportedSyncTimeZones } from "../services/syncTimeZone";
 
 const RECRUITMENT_MODAL_PREFIX = "recruitment-edit";
 const DISCORD_CLAN_TAG_INPUT_ID = "discord-clan-tag";
@@ -78,9 +81,8 @@ function sanitizeBodyForBand(body: string): string {
     .trim();
 }
 
-function codeBlock(content: string, language = ""): string {
-  const safe = content.replaceAll("```", "`\u200b``");
-  return `\`\`\`${language}\n${safe}\n\`\`\``;
+function doubleBacktickBlock(content: string): string {
+  return formatRecruitmentReminderBody(content);
 }
 
 function parseModalCustomId(
@@ -143,7 +145,7 @@ function buildDiscordShowMessage(input: {
     `Clan: **${input.clanName}**`,
     "",
     `Recruitment Contents (${input.body.length}/1024):`,
-    codeBlock(input.body),
+    doubleBacktickBlock(input.body),
   ];
 
   if (input.imageUrls.length > 0) {
@@ -155,6 +157,7 @@ function buildDiscordShowMessage(input: {
     "Instructions:",
     `- Go to ${DISCORD_RECRUITMENT_CHANNEL_URL}`,
     "- Type `/post` in that channel and fill clan tag, recruitment contents, image URL, and language.",
+    "- Copy/paste the body from the double-backtick block below.",
     "",
     input.cooldownLine
   );
@@ -177,14 +180,20 @@ function buildBandShowMessage(input: {
     "⚠️ Do NOT mention alliances, families, or Discord servers.",
     "",
     "Recruitment Contents:",
-    codeBlock(sanitizedBody),
+    doubleBacktickBlock(sanitizedBody),
   ];
 
   if (input.imageUrls.length > 0) {
     lines.push("", "Suggested Image URLs:", ...input.imageUrls.map((url) => `- ${url}`));
   }
 
-  lines.push("", input.cooldownLine);
+  lines.push(
+    "",
+    "Destination:",
+    "- https://www.band.us/band/67130116/post",
+    "",
+    input.cooldownLine,
+  );
   return lines.join("\n");
 }
 
@@ -209,11 +218,14 @@ function buildRedditShowMessage(input: {
     `\`${input.subject}\``,
     "",
     "Recruitment Contents:",
-    codeBlock(noGiveawayBody, "md"),
+    doubleBacktickBlock(noGiveawayBody),
     "",
     "Rules:",
     "- No giveaway mentions.",
     "- Once per 7 days per account.",
+    "",
+    "Destination:",
+    "- https://www.reddit.com/r/ClashOfClansRecruit/",
     "",
     input.cooldownLine,
   ].join("\n");
@@ -294,6 +306,63 @@ function formatClanLabel(tag: string, name: string | null): string {
   return name?.trim() ? `${name.trim()} (${formatClanTag(tag)})` : formatClanTag(tag);
 }
 
+function recruitmentDashboardTimezoneKey(userId: string): string {
+  return `user_timezone:${userId}`;
+}
+
+async function resolveRecruitmentDashboardTimezone(input: {
+  settings: SettingsService;
+  userId: string;
+  timezoneSeedRaw: string | null;
+}): Promise<string> {
+  const provided = input.timezoneSeedRaw ? normalizeRecruitmentTimezone(input.timezoneSeedRaw) : null;
+  if (input.timezoneSeedRaw && !provided) {
+    throw new Error("invalid_timezone");
+  }
+
+  const rememberedRaw = await input.settings.get(recruitmentDashboardTimezoneKey(input.userId));
+  const remembered = normalizeRecruitmentTimezone(rememberedRaw);
+  const resolved = provided ?? remembered ?? "UTC";
+  await input.settings.set(recruitmentDashboardTimezoneKey(input.userId), resolved);
+  return resolved;
+}
+
+async function persistRecruitmentDashboardTimezone(
+  settings: SettingsService,
+  userId: string,
+  timezone: string,
+): Promise<void> {
+  const normalized = normalizeRecruitmentTimezone(timezone) ?? "UTC";
+  await settings.set(recruitmentDashboardTimezoneKey(userId), normalized);
+}
+
+function stepRecruitmentDashboardTimezone(
+  currentTimezone: string,
+  delta: -1 | 1,
+  referenceDate = new Date(),
+): string {
+  const zones = getSupportedSyncTimeZones(referenceDate);
+  const current = normalizeRecruitmentTimezone(currentTimezone) ?? "UTC";
+  const index = zones.indexOf(current);
+  const baseIndex = index >= 0 ? index : zones.indexOf("UTC");
+  if (zones.length === 0 || baseIndex < 0) return "UTC";
+  const nextIndex = (baseIndex + delta + zones.length) % zones.length;
+  return zones[nextIndex] ?? "UTC";
+}
+
+function buildRecruitmentDashboardTimezoneControls(input: { sessionId: string }): ActionRowBuilder<ButtonBuilder> {
+  return new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder()
+      .setCustomId(recruitmentDashboardCustomId(input.sessionId, "timezone:prev"))
+      .setLabel("TZ -")
+      .setStyle(ButtonStyle.Secondary),
+    new ButtonBuilder()
+      .setCustomId(recruitmentDashboardCustomId(input.sessionId, "timezone:next"))
+      .setLabel("TZ +")
+      .setStyle(ButtonStyle.Secondary),
+  );
+}
+
 async function loadRecruitmentDashboardData(guildId: string, userId: string): Promise<{
   trackedClans: RecruitmentDashboardTrackedClan[];
   templates: Map<string, RecruitmentDashboardTemplateRow>;
@@ -372,38 +441,44 @@ function buildRecruitmentDashboardEmbed(input: {
       if (tracked.length <= 0) {
         lines.push("No tracked clans configured.");
       } else {
-        for (const clan of tracked) {
-          const statuses = (["discord", "reddit", "band"] as RecruitmentPlatform[]).map((platform) => {
-            const hasTemplate = input.data.templates.has(`${clan.tag}:${platform}`);
-            return `${formatRecruitmentPlatformChoice(platform)}=${hasTemplate ? "stored" : "missing"}`;
-          });
-          lines.push(`- ${formatClanLabel(clan.tag, clan.name)} | ${statuses.join(" | ")}`);
-        }
+        const tableLines = [
+          "Clan".padEnd(24),
+          "Discord".padEnd(10),
+          "Reddit".padEnd(10),
+          "Band".padEnd(10),
+        ];
+        const rows = tracked.map((clan) => {
+          const discord = input.data.templates.has(`${clan.tag}:discord`) ? ":white_check_mark:" : "";
+          const reddit = input.data.templates.has(`${clan.tag}:reddit`) ? ":white_check_mark:" : "";
+          const band = input.data.templates.has(`${clan.tag}:band`) ? ":white_check_mark:" : "";
+          return [
+            formatClanLabel(clan.tag, clan.name).slice(0, 24).padEnd(24),
+            discord.padEnd(10),
+            reddit.padEnd(10),
+            band.padEnd(10),
+          ].join(" | ");
+        });
+        lines.push("```text", tableLines.join(" | "), ...rows, "```");
       }
     } else {
       lines.push("", "Optimization guide:");
       for (const platform of ["discord", "reddit", "band"] as RecruitmentPlatform[]) {
-        const windows = formatRecruitmentReminderWindowSummaryInTimeZone(
-          platform,
-          state.timezone,
-          new Date(input.nowMs),
-        );
+        const now = new Date(input.nowMs);
+        const windows = formatRecruitmentReminderWindowSummaryInTimeZone(platform, state.timezone, now);
         const nextSlots = getRecruitmentReminderSlotCandidates({
           platform,
           timezone: state.timezone,
-          after: new Date(input.nowMs),
+          after: now,
         })
           .slice(0, 3)
           .map((slot) => `\`${formatRecruitmentReminderTime(slot, state.timezone)}\``)
-          .join(", ");
+          .join("\n    - ");
         lines.push(
-          `- ${formatRecruitmentPlatformChoice(platform)}: ${windows}`,
-          `  Rhythm: ${formatRecruitmentReminderRhythmSummaryInTimeZone(
-            platform,
-            state.timezone,
-            new Date(input.nowMs),
-          )}`,
-          `  Next: ${nextSlots || "no upcoming slots"}`,
+          `- ${formatRecruitmentPlatformChoice(platform)}`,
+          `  - Best windows: ${windows}`,
+          `  - Rhythm: ${formatRecruitmentReminderRhythmSummaryInTimeZone(platform, state.timezone, now)}`,
+          "  - Next recommended slots:",
+          nextSlots ? `    - ${nextSlots}` : "    - no upcoming slots",
         );
       }
     }
@@ -423,6 +498,7 @@ function buildRecruitmentDashboardEmbed(input: {
         imageUrls: template.imageUrls,
         cooldownLine: buildCooldownLine(input.data.cooldowns.get(`${state.clanTag}:${platform}`) ?? null),
       }));
+      lines.push("", "Destination:", `- ${DISCORD_RECRUITMENT_CHANNEL_URL}`);
     } else if (platform === "band") {
       lines.push("", buildBandShowMessage({
         clanName: clan?.name ?? state.clanTag,
@@ -499,7 +575,6 @@ function buildRecruitmentDashboardComponents(input: {
 }): Array<ActionRowBuilder<ButtonBuilder> | ActionRowBuilder<StringSelectMenuBuilder>> {
   const state = input.state;
   const tracked = input.data.trackedClans;
-  const buttons = new ActionRowBuilder<ButtonBuilder>();
   const dropdown = new StringSelectMenuBuilder()
     .setCustomId(recruitmentDashboardCustomId(input.sessionId, "scope"))
     .setMinValues(1)
@@ -521,6 +596,7 @@ function buildRecruitmentDashboardComponents(input: {
     })),
   ];
   dropdown.addOptions(menuOptions);
+  const timezoneControls = buildRecruitmentDashboardTimezoneControls({ sessionId: input.sessionId });
 
   if (state.scope === "schedule") {
     const confirmEnabled = Boolean(
@@ -543,6 +619,7 @@ function buildRecruitmentDashboardComponents(input: {
     const dayOptions = buildRecruitmentDashboardDayOptions(input.state, input.data);
     const timeOptions = buildRecruitmentDashboardTimeOptions(input.state, input.data);
     return [
+      timezoneControls,
       scheduleButtons,
       new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
         new StringSelectMenuBuilder()
@@ -567,7 +644,7 @@ function buildRecruitmentDashboardComponents(input: {
   }
 
   if (state.scope === "overview") {
-    buttons.addComponents(
+    const overviewButtons = new ActionRowBuilder<ButtonBuilder>().addComponents(
       new ButtonBuilder()
         .setCustomId(recruitmentDashboardCustomId(input.sessionId, "overview:timers"))
         .setLabel("Timers")
@@ -582,13 +659,14 @@ function buildRecruitmentDashboardComponents(input: {
         .setStyle(state.overviewTab === "optimize" ? ButtonStyle.Primary : ButtonStyle.Secondary),
     );
     return [
-      buttons,
+      timezoneControls,
+      overviewButtons,
       new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(dropdown),
     ];
   }
 
   const templateExists = input.data.templates.has(`${state.clanTag}:${state.clanTab}`);
-  buttons.addComponents(
+  const clanButtons = new ActionRowBuilder<ButtonBuilder>().addComponents(
     new ButtonBuilder()
       .setCustomId(recruitmentDashboardCustomId(input.sessionId, "clan:discord"))
       .setLabel("Discord")
@@ -606,9 +684,14 @@ function buildRecruitmentDashboardComponents(input: {
       .setLabel("Remind")
       .setStyle(ButtonStyle.Success)
       .setDisabled(!templateExists),
+    new ButtonBuilder()
+      .setCustomId(recruitmentDashboardCustomId(input.sessionId, "clan:start-countdown"))
+      .setLabel("Start countdown")
+      .setStyle(ButtonStyle.Secondary),
   );
   return [
-    buttons,
+    timezoneControls,
+    clanButtons,
     new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(dropdown),
   ];
 }
@@ -950,9 +1033,16 @@ async function handleDashboardSubcommand(interaction: ChatInputCommandInteractio
     return;
   }
   await interaction.deferReply({ ephemeral: true });
-  const timezoneSeedRaw = interaction.options.getString("timezone", true);
-  const normalizedTimezone = normalizeRecruitmentTimezone(timezoneSeedRaw);
-  if (!normalizedTimezone) {
+  const settings = new SettingsService();
+  const timezoneSeedRaw = interaction.options.getString("timezone", false)?.trim() ?? null;
+  let normalizedTimezone: string;
+  try {
+    normalizedTimezone = await resolveRecruitmentDashboardTimezone({
+      settings,
+      userId: interaction.user.id,
+      timezoneSeedRaw,
+    });
+  } catch {
     await interaction.editReply("Invalid timezone. Use a valid IANA timezone.");
     return;
   }
@@ -1002,6 +1092,26 @@ async function handleDashboardSubcommand(interaction: ChatInputCommandInteractio
     }
 
     try {
+      if (component.isButton() && parsed.action === "timezone:prev") {
+        await component.deferUpdate();
+        state.timezone = stepRecruitmentDashboardTimezone(state.timezone, -1, new Date());
+        state.reminderDayKey = null;
+        state.reminderTimeIso = null;
+        await persistRecruitmentDashboardTimezone(settings, interaction.user.id, state.timezone);
+        await render();
+        return;
+      }
+
+      if (component.isButton() && parsed.action === "timezone:next") {
+        await component.deferUpdate();
+        state.timezone = stepRecruitmentDashboardTimezone(state.timezone, 1, new Date());
+        state.reminderDayKey = null;
+        state.reminderTimeIso = null;
+        await persistRecruitmentDashboardTimezone(settings, interaction.user.id, state.timezone);
+        await render();
+        return;
+      }
+
       if (component.isStringSelectMenu() && parsed.action === "scope") {
         await component.deferUpdate();
         const selected = component.values[0] ?? "overview";
@@ -1057,6 +1167,29 @@ async function handleDashboardSubcommand(interaction: ChatInputCommandInteractio
           state.reminderDayKey = null;
           state.reminderTimeIso = null;
           await render();
+          return;
+        }
+        if (next === "start-countdown") {
+          if (!state.clanTag) {
+            await render("Select a clan first.");
+            return;
+          }
+          const startedAt = new Date();
+          const expiresAt = new Date(startedAt.getTime() + getRecruitmentCooldownDurationMs(state.clanTab));
+          await startOrResetRecruitmentCooldown({
+            guildId: interaction.guildId!,
+            userId: interaction.user.id,
+            clanTag: state.clanTag,
+            platform: state.clanTab,
+            startedAt,
+            expiresAt,
+          });
+          await render(
+            `Started ${formatRecruitmentPlatformChoice(state.clanTab)} countdown for ${formatClanLabel(
+              state.clanTag,
+              tracked.find((row) => row.tag === state.clanTag)?.name ?? null,
+            )}.`,
+          );
           return;
         }
       }
@@ -1336,7 +1469,7 @@ export const Recruitment: Command = {
           name: "timezone",
           description: "IANA timezone to use for window display and slot selection",
           type: ApplicationCommandOptionType.String,
-          required: true,
+          required: false,
           autocomplete: true,
         },
       ],

--- a/src/services/RecruitmentReminderService.ts
+++ b/src/services/RecruitmentReminderService.ts
@@ -340,6 +340,11 @@ export function formatRecruitmentReminderTime(date: Date, timeZone: string): str
   return formatDateInTimeZone(date, timeZone);
 }
 
+export function formatRecruitmentReminderBody(body: string): string {
+  const safe = body.replaceAll("``", "`\u200b`");
+  return `\`\`${safe}\`\``;
+}
+
 export function getRecruitmentReminderSlotCandidates(input: {
   platform: RecruitmentReminderPlatform;
   timezone: string;
@@ -425,9 +430,7 @@ export function buildRecruitmentReminderDmContent(input: {
     lines.push(`Subject: \`${input.templateSubject}\``);
   }
   lines.push("Template:");
-  lines.push("```");
-  lines.push(input.templateBody);
-  lines.push("```");
+  lines.push(formatRecruitmentReminderBody(input.templateBody));
   if (input.templateImageUrls.length > 0) {
     lines.push("Images:");
     lines.push(...input.templateImageUrls.map((url) => `- ${url}`));
@@ -629,6 +632,7 @@ export async function processDueRecruitmentReminders(input: {
 export const recruitmentReminderService = {
   autocompleteRecruitmentTimeZones,
   formatRecruitmentReminderTime,
+  formatRecruitmentReminderBody,
   formatRecruitmentReminderWindowSummary,
   formatRecruitmentReminderWindowSummaryInTimeZone,
   formatRecruitmentReminderRhythmSummaryInTimeZone,

--- a/src/services/syncTimeZone.ts
+++ b/src/services/syncTimeZone.ts
@@ -185,3 +185,30 @@ export function normalizeSyncTimeZone(input: string | null | undefined): string 
 export function autocompleteSyncTimeZones(input: string | null | undefined): SyncTimeZoneAutocompleteChoice[] {
   return buildAutocompleteChoices(getSupportedIanaTimeZones(), String(input ?? ""));
 }
+
+function getTimeZoneOffsetMinutes(timeZone: string, referenceDate: Date): number {
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    timeZoneName: "shortOffset",
+  });
+  const token =
+    formatter.formatToParts(referenceDate).find((part) => part.type === "timeZoneName")?.value ??
+    "GMT+00";
+  const normalized = token.replace("UTC", "GMT");
+  const match = normalized.match(/^GMT([+-])(\d{1,2})(?::?(\d{2}))?$/i);
+  if (!match) return 0;
+  const sign = match[1] === "-" ? -1 : 1;
+  const hours = Number(match[2] ?? "0");
+  const minutes = Number(match[3] ?? "0");
+  return sign * (hours * 60 + minutes);
+}
+
+/** Purpose: return supported canonical IANA zones in stable current-offset order for timezone stepping. */
+export function getSupportedSyncTimeZones(referenceDate = new Date()): string[] {
+  const supported = ["UTC", ...getSupportedIanaTimeZones()];
+  return [...new Set(supported)].sort(
+    (left, right) =>
+      getTimeZoneOffsetMinutes(left, referenceDate) - getTimeZoneOffsetMinutes(right, referenceDate) ||
+      left.localeCompare(right)
+  );
+}

--- a/tests/recruitment.command.test.ts
+++ b/tests/recruitment.command.test.ts
@@ -7,6 +7,7 @@ const prismaMock = vi.hoisted(() => ({
 }));
 
 const recruitmentServiceMock = vi.hoisted(() => ({
+  getRecruitmentCooldown: vi.fn(),
   getRecruitmentTemplate: vi.fn(),
   upsertRecruitmentTemplate: vi.fn(),
 }));
@@ -19,6 +20,7 @@ vi.mock("../src/services/RecruitmentService", async () => {
   const actual = await vi.importActual("../src/services/RecruitmentService");
   return {
     ...actual,
+    getRecruitmentCooldown: recruitmentServiceMock.getRecruitmentCooldown,
     getRecruitmentTemplate: recruitmentServiceMock.getRecruitmentTemplate,
     upsertRecruitmentTemplate: recruitmentServiceMock.upsertRecruitmentTemplate,
   };
@@ -44,6 +46,28 @@ function createEditInteraction(input?: { clan?: string; platform?: string }) {
     reply: vi.fn().mockResolvedValue(undefined),
     editReply: vi.fn().mockResolvedValue(undefined),
     showModal: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function createShowInteraction(input: { clan: string; platform: "discord" | "reddit" | "band" }) {
+  return {
+    guildId: "guild-1",
+    user: { id: "user-1" },
+    deferred: false,
+    replied: false,
+    options: {
+      getSubcommandGroup: vi.fn().mockReturnValue(null),
+      getSubcommand: vi.fn().mockReturnValue("show"),
+      getString: vi.fn((name: string) => {
+        if (name === "clan") return input.clan;
+        if (name === "platform") return input.platform;
+        return null;
+      }),
+    },
+    reply: vi.fn().mockResolvedValue(undefined),
+    editReply: vi.fn().mockResolvedValue(undefined),
+    showModal: vi.fn().mockResolvedValue(undefined),
+    deferReply: vi.fn().mockResolvedValue(undefined),
   };
 }
 
@@ -74,6 +98,7 @@ describe("/recruitment command", () => {
       tag: "#PQL0289",
       name: "Clan One",
     });
+    recruitmentServiceMock.getRecruitmentCooldown.mockResolvedValue(null);
     recruitmentServiceMock.getRecruitmentTemplate.mockResolvedValue(null);
     recruitmentServiceMock.upsertRecruitmentTemplate.mockResolvedValue(undefined);
   });
@@ -140,5 +165,41 @@ describe("/recruitment command", () => {
     expect(interaction.editReply).toHaveBeenCalledWith(
       "Saved band recruitment template for Clan One (#PQL0289).",
     );
+  });
+
+  it("renders double-backtick recruitment output and platform links in show output", async () => {
+    recruitmentServiceMock.getRecruitmentTemplate.mockImplementation(async (_guildId: string, _clanTag: string, platform: string) => {
+      if (platform === "reddit") {
+        return {
+          subject: "Alpha Reddit",
+          body: "Alpha reddit body",
+          imageUrls: [],
+        } as any;
+      }
+      if (platform === "band") {
+        return {
+          subject: null,
+          body: "Band body",
+          imageUrls: [],
+        } as any;
+      }
+      return null;
+    });
+
+    const redditInteraction = createShowInteraction({ clan: "PQL0289", platform: "reddit" });
+    await Recruitment.run({} as any, redditInteraction as any, {} as any);
+
+    expect(redditInteraction.editReply).toHaveBeenCalledTimes(1);
+    const redditPayload = redditInteraction.editReply.mock.calls[0]?.[0] as string;
+    expect(redditPayload).toContain("https://www.reddit.com/r/ClashOfClansRecruit/");
+    expect(redditPayload).toContain("``Alpha reddit body``");
+
+    const bandInteraction = createShowInteraction({ clan: "PQL0289", platform: "band" });
+    await Recruitment.run({} as any, bandInteraction as any, {} as any);
+
+    expect(bandInteraction.editReply).toHaveBeenCalledTimes(1);
+    const bandPayload = bandInteraction.editReply.mock.calls[0]?.[0] as string;
+    expect(bandPayload).toContain("https://www.band.us/band/67130116/post");
+    expect(bandPayload).toContain("``Band body``");
   });
 });

--- a/tests/recruitment.dashboard.command.test.ts
+++ b/tests/recruitment.dashboard.command.test.ts
@@ -1,4 +1,11 @@
-import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const settingsStore = new Map<string, string>();
+const cooldownRows: Array<{
+  clanTag: string;
+  platform: "discord" | "reddit" | "band";
+  expiresAt: Date;
+}> = [];
 
 const prismaMock = vi.hoisted(() => ({
   trackedClan: {
@@ -20,6 +27,46 @@ const prismaMock = vi.hoisted(() => ({
 vi.mock("../src/prisma", () => ({
   prisma: prismaMock,
 }));
+
+vi.mock("../src/services/SettingsService", () => ({
+  SettingsService: class {
+    async get(key: string): Promise<string | null> {
+      return settingsStore.get(key) ?? null;
+    }
+
+    async set(key: string, value: string): Promise<void> {
+      settingsStore.set(key, value);
+    }
+
+    async delete(key: string): Promise<void> {
+      settingsStore.delete(key);
+    }
+  },
+}));
+
+vi.mock("../src/services/RecruitmentService", async () => {
+  const actual = await vi.importActual("../src/services/RecruitmentService");
+  return {
+    ...actual,
+    getRecruitmentTemplate: vi.fn(),
+    startOrResetRecruitmentCooldown: vi.fn(async (input: { clanTag: string; platform: string; expiresAt: Date }) => {
+      const normalizedTag = String(input.clanTag).trim().toUpperCase().replace(/^#/, "");
+      const existingIndex = cooldownRows.findIndex(
+        (row) => row.clanTag === normalizedTag && row.platform === input.platform,
+      );
+      const nextRow = {
+        clanTag: normalizedTag,
+        platform: input.platform,
+        expiresAt: input.expiresAt,
+      } as const;
+      if (existingIndex >= 0) {
+        cooldownRows[existingIndex] = nextRow;
+      } else {
+        cooldownRows.push(nextRow);
+      }
+    }),
+  };
+});
 
 import { Recruitment } from "../src/commands/Recruitment";
 import * as recruitmentServiceModule from "../src/services/RecruitmentService";
@@ -43,7 +90,7 @@ function createCollector() {
   };
 }
 
-function createDashboardInteraction(timezone = "America/Los_Angeles") {
+function createDashboardInteraction(timezone: string | null = null) {
   const { handlers, collector } = createCollector();
   const interaction: any = {
     id: "dashboard-1",
@@ -104,14 +151,14 @@ function getLastPayload(interaction: any): any {
   return interaction.editReply.mock.calls.at(-1)?.[0] ?? {};
 }
 
-function getComponentJson(payload: any): Array<any> {
+function getRowComponents(payload: any): Array<any> {
   return Array.isArray(payload?.components)
     ? payload.components.map((row: any) => (typeof row?.toJSON === "function" ? row.toJSON() : row))
     : [];
 }
 
 function getButtonLabels(payload: any): string[] {
-  return getComponentJson(payload).flatMap((row) =>
+  return getRowComponents(payload).flatMap((row) =>
     Array.isArray(row?.components)
       ? row.components
           .map((component: any) => (typeof component?.toJSON === "function" ? component.toJSON() : component))
@@ -122,7 +169,7 @@ function getButtonLabels(payload: any): string[] {
 }
 
 function getSelectMenus(payload: any): Array<any> {
-  return getComponentJson(payload).flatMap((row) =>
+  return getRowComponents(payload).flatMap((row) =>
     Array.isArray(row?.components)
       ? row.components
           .map((component: any) => (typeof component?.toJSON === "function" ? component.toJSON() : component))
@@ -132,15 +179,50 @@ function getSelectMenus(payload: any): Array<any> {
 }
 
 describe("/recruitment dashboard", () => {
+  it("registers an optional timezone argument on the dashboard subcommand", () => {
+    const dashboardOption = Recruitment.options.find((option) => option.name === "dashboard");
+    const timezoneOption = dashboardOption?.options?.find((option) => option.name === "timezone");
+    expect(timezoneOption?.required).toBe(false);
+    expect(timezoneOption?.autocomplete).toBe(true);
+  });
+
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-04-08T17:45:00-07:00"));
     vi.clearAllMocks();
-    vi.spyOn(recruitmentServiceModule, "getRecruitmentTemplate").mockResolvedValue({
-      subject: "Alpha Subject",
-      body: "Alpha body",
-      imageUrls: ["https://img.example/alpha.png"],
-    } as any);
+    settingsStore.clear();
+    cooldownRows.length = 0;
+
+    vi.mocked(recruitmentServiceModule.getRecruitmentTemplate).mockImplementation(
+      async (guildId: string, clanTag: string, platform: string) => {
+        if (guildId !== "guild-1") return null;
+        const normalized = String(clanTag).trim().toUpperCase().replace(/^#/, "");
+        if (normalized !== "AAA111") return null;
+        if (platform === "discord") {
+          return {
+            subject: "Alpha Subject",
+            body: "Alpha body",
+            imageUrls: ["https://img.example/alpha.png"],
+          } as any;
+        }
+        if (platform === "reddit") {
+          return {
+            subject: "Alpha Reddit",
+            body: "Alpha reddit body",
+            imageUrls: [],
+          } as any;
+        }
+        if (platform === "band") {
+          return {
+            subject: null,
+            body: "Alpha band body",
+            imageUrls: [],
+          } as any;
+        }
+        return null;
+      },
+    );
+
     prismaMock.trackedClan.findMany.mockResolvedValue([
       { tag: "#AAA111", name: "Alpha" },
       { tag: "#BBB222", name: "Beta" },
@@ -160,14 +242,15 @@ describe("/recruitment dashboard", () => {
         body: "Alpha reddit body",
         imageUrls: [],
       },
-    ]);
-    prismaMock.recruitmentCooldown.findMany.mockResolvedValue([
       {
         clanTag: "#AAA111",
-        platform: "discord",
-        expiresAt: new Date("2026-04-08T18:30:00-07:00"),
+        platform: "band",
+        subject: null,
+        body: "Alpha band body",
+        imageUrls: [],
       },
     ]);
+    prismaMock.recruitmentCooldown.findMany.mockImplementation(async () => [...cooldownRows]);
     prismaMock.recruitmentReminderRule.findFirst.mockResolvedValue(null);
     prismaMock.recruitmentReminderRule.create.mockResolvedValue({ id: "rule-1" });
     prismaMock.recruitmentReminderRule.update.mockResolvedValue({ id: "rule-1" });
@@ -178,91 +261,130 @@ describe("/recruitment dashboard", () => {
     vi.restoreAllMocks();
   });
 
-  it("wires timezone autocomplete and renders the alliance overview controls", async () => {
-    const autocompleteInteraction: any = {
-      user: { id: "user-1" },
-      options: {
-        getFocused: vi.fn().mockReturnValue({
-          name: "timezone",
-          value: "pac",
-        }),
-      },
-      respond: vi.fn().mockResolvedValue(undefined),
-    };
-
-    await Recruitment.autocomplete?.(autocompleteInteraction);
-
-    expect(autocompleteInteraction.respond).toHaveBeenCalledWith(
-      expect.arrayContaining([
-        expect.objectContaining({ value: "America/Los_Angeles" }),
-      ]),
-    );
-
-    const { interaction, handlers } = createDashboardInteraction();
+  it("uses UTC when timezone is omitted and no remembered timezone exists", async () => {
+    const { interaction } = createDashboardInteraction();
     await Recruitment.run({} as any, interaction as any, {} as any);
 
     const payload = getLastPayload(interaction);
-    expect(String(payload.embeds[0].toJSON().description)).toContain("Alliance Overview");
-    expect(String(payload.embeds[0].toJSON().description)).toContain("Active recruitment timers");
-    expect(getButtonLabels(payload)).toEqual(["Timers", "Scripts", "Optimize"]);
-    const scopeMenu = getSelectMenus(payload)[0];
-    expect(scopeMenu?.options?.[0]?.label).toBe("Alliance Overview");
-    expect(scopeMenu?.options?.some((option: any) => String(option.label).includes("Alpha"))).toBe(true);
-    expect(handlers.collect).toBeTypeOf("function");
+    expect(String(payload.embeds[0].toJSON().description)).toContain("Timezone: `UTC`");
+    expect(settingsStore.get("user_timezone:user-1")).toBe("UTC");
+    expect(getButtonLabels(payload)).toEqual(
+      expect.arrayContaining(["TZ -", "TZ +", "Timers", "Scripts", "Optimize"]),
+    );
   });
 
-  it("switches between alliance overview, clan templates, empty states, and reminder scheduling", async () => {
+  it("falls back to the stored sync timezone when available", async () => {
+    settingsStore.set("user_timezone:user-1", "America/Chicago");
+    const { interaction } = createDashboardInteraction();
+
+    await Recruitment.run({} as any, interaction as any, {} as any);
+
+    const payload = getLastPayload(interaction);
+    expect(String(payload.embeds[0].toJSON().description)).toContain("Timezone: `America/Chicago`");
+    expect(settingsStore.get("user_timezone:user-1")).toBe("America/Chicago");
+  });
+
+  it("timezone buttons update the dashboard timezone and persist it", async () => {
     const { interaction, handlers } = createDashboardInteraction();
+    await Recruitment.run({} as any, interaction as any, {} as any);
+
+    await handlers.collect?.(createButtonComponent("recruitment-dashboard:dashboard-1:timezone:next"));
+    let payload = getLastPayload(interaction);
+    const nextTimezone = settingsStore.get("user_timezone:user-1");
+    expect(nextTimezone).toBeTruthy();
+    expect(nextTimezone).not.toBe("UTC");
+    expect(String(payload.embeds[0].toJSON().description)).toContain(`Timezone: \`${nextTimezone}\``);
+
+    await handlers.collect?.(createButtonComponent("recruitment-dashboard:dashboard-1:timezone:prev"));
+    payload = getLastPayload(interaction);
+    expect(String(payload.embeds[0].toJSON().description)).toContain(
+      `Timezone: \`${settingsStore.get("user_timezone:user-1")}\``,
+    );
+  });
+
+  it("renders scripts as a table and optimize as bullets", async () => {
+    settingsStore.set("user_timezone:user-1", "UTC");
+    const { interaction, handlers } = createDashboardInteraction();
+    await Recruitment.run({} as any, interaction as any, {} as any);
+
+    await handlers.collect?.(createButtonComponent("recruitment-dashboard:dashboard-1:overview:scripts"));
+    let payload = getLastPayload(interaction);
+    const scriptsDescription = String(payload.embeds[0].toJSON().description);
+    expect(scriptsDescription).toMatch(/Discord\s+\|\s+Reddit\s+\|\s+Band/);
+    expect(scriptsDescription).toContain(":white_check_mark:");
+    expect(scriptsDescription).toContain("Alpha (#AAA111)");
+
+    await handlers.collect?.(createButtonComponent("recruitment-dashboard:dashboard-1:overview:optimize"));
+    payload = getLastPayload(interaction);
+    const optimizeDescription = String(payload.embeds[0].toJSON().description);
+    expect(optimizeDescription).toContain("- Discord");
+    expect(optimizeDescription).toContain("  - Best windows:");
+    expect(optimizeDescription).toContain("  - Rhythm:");
+    expect(optimizeDescription).toContain("  - Next recommended slots:");
+  });
+
+  it("shows platform links and double-backtick body wrapping on clan views", async () => {
+    const { interaction, handlers } = createDashboardInteraction("America/Los_Angeles");
+    await Recruitment.run({} as any, interaction as any, {} as any);
+
+    await handlers.collect?.(createSelectComponent("recruitment-dashboard:dashboard-1:scope", ["AAA111"]));
+    await handlers.collect?.(createButtonComponent("recruitment-dashboard:dashboard-1:clan:reddit"));
+    let payload = getLastPayload(interaction);
+    const redditDescription = String(payload.embeds[0].toJSON().description);
+    expect(redditDescription).toContain("https://www.reddit.com/r/ClashOfClansRecruit/");
+    expect(redditDescription).toContain("``Alpha reddit body``");
+
+    await handlers.collect?.(createButtonComponent("recruitment-dashboard:dashboard-1:clan:band"));
+    payload = getLastPayload(interaction);
+    const bandDescription = String(payload.embeds[0].toJSON().description);
+    expect(bandDescription).toContain("https://www.band.us/band/67130116/post");
+    expect(bandDescription).toContain("``Alpha band body``");
+  });
+
+  it("starts cooldowns from the dashboard and reflects them in timers", async () => {
+    const { interaction, handlers } = createDashboardInteraction("UTC");
+    await Recruitment.run({} as any, interaction as any, {} as any);
+
+    await handlers.collect?.(createSelectComponent("recruitment-dashboard:dashboard-1:scope", ["AAA111"]));
+    await handlers.collect?.(createButtonComponent("recruitment-dashboard:dashboard-1:clan:discord"));
+    const clanButtons = getButtonLabels(getLastPayload(interaction));
+    expect(clanButtons).toEqual(
+      expect.arrayContaining(["Discord", "Reddit", "Band", "Remind", "Start countdown"]),
+    );
+    await handlers.collect?.(createButtonComponent("recruitment-dashboard:dashboard-1:clan:start-countdown"));
+
+    const startCall = vi.mocked(recruitmentServiceModule.startOrResetRecruitmentCooldown).mock.calls[0]?.[0];
+    expect(startCall).toEqual(
+      expect.objectContaining({
+        guildId: "guild-1",
+        userId: "user-1",
+        clanTag: "AAA111",
+        platform: "discord",
+      }),
+    );
+    expect(cooldownRows).toHaveLength(1);
+
+    await handlers.collect?.(createButtonComponent("recruitment-dashboard:dashboard-1:scope", ["overview"]));
+    await handlers.collect?.(createButtonComponent("recruitment-dashboard:dashboard-1:overview:timers"));
+    const payload = getLastPayload(interaction);
+    expect(String(payload.embeds[0].toJSON().description)).toContain("Alpha (#AAA111)");
+    expect(String(payload.embeds[0].toJSON().description)).toContain("<t:");
+  });
+
+  it("supports reminder scheduling from the clan view", async () => {
     const reminderUpsertSpy = vi
       .spyOn(recruitmentReminderService, "upsertRecruitmentReminderRule")
       .mockResolvedValue({
         id: "rule-1",
       } as any);
-
+    const { interaction, handlers } = createDashboardInteraction("America/Los_Angeles");
     await Recruitment.run({} as any, interaction as any, {} as any);
 
-    await handlers.collect?.(createButtonComponent("recruitment-dashboard:dashboard-1:overview:scripts"));
-    expect(String(getLastPayload(interaction).embeds[0].toJSON().description)).toContain(
-      "Stored template coverage",
-    );
-    expect(String(getLastPayload(interaction).embeds[0].toJSON().description)).toContain(
-      "Discord=stored",
-    );
-
-    await handlers.collect?.(createButtonComponent("recruitment-dashboard:dashboard-1:overview:optimize"));
-    let payload = getLastPayload(interaction);
-    expect(String(payload.embeds[0].toJSON().description)).toContain("Optimization guide:");
-    expect(String(payload.embeds[0].toJSON().description)).not.toContain("PST");
-    expect(String(payload.embeds[0].toJSON().description)).toContain("Next:");
-
-    await handlers.collect?.(createSelectComponent("recruitment-dashboard:dashboard-1:scope", ["#AAA111"]));
-    payload = getLastPayload(interaction);
-    expect(String(payload.embeds[0].toJSON().description)).toContain("Scope: Alpha (#AAA111)");
-    expect(getButtonLabels(payload)).toEqual(["Discord", "Reddit", "Band", "Remind"]);
-
-    await handlers.collect?.(createButtonComponent("recruitment-dashboard:dashboard-1:clan:band"));
-    payload = getLastPayload(interaction);
-    expect(String(payload.embeds[0].toJSON().description)).toContain(
-      "No stored template for this platform.",
-    );
-    const bandButtons = getButtonLabels(payload);
-    expect(bandButtons).toContain("Remind");
-    const bandButtonRow = getComponentJson(payload)[0];
-    const remindButton = bandButtonRow?.components?.find((component: any) => component.label === "Remind");
-    expect(remindButton?.disabled).toBe(true);
-
+    await handlers.collect?.(createSelectComponent("recruitment-dashboard:dashboard-1:scope", ["AAA111"]));
     await handlers.collect?.(createButtonComponent("recruitment-dashboard:dashboard-1:clan:discord"));
-    payload = getLastPayload(interaction);
-    expect(String(payload.embeds[0].toJSON().description)).toContain("Recruitment Contents");
-    expect(String(payload.embeds[0].toJSON().description)).toContain("Suggested Image URLs");
-    const remindButtonRow = getComponentJson(payload)[0];
-    const discordRemind = remindButtonRow?.components?.find((component: any) => component.label === "Remind");
-    expect(discordRemind?.disabled).toBe(false);
-
     await handlers.collect?.(createButtonComponent("recruitment-dashboard:dashboard-1:clan:remind"));
-    payload = getLastPayload(interaction);
-    expect(String(payload.embeds[0].toJSON().description)).toContain("Scheduling reminder for");
-    expect(String(payload.embeds[0].toJSON().description)).toContain("Recommended:");
+
+    let payload = getLastPayload(interaction);
     expect(String(payload.embeds[0].toJSON().footer?.text)).toContain("Reminder Scheduling");
     expect(getSelectMenus(payload)).toHaveLength(3);
 
@@ -270,9 +392,8 @@ describe("/recruitment dashboard", () => {
     const dayValue = dayMenu?.options?.[0]?.value;
     expect(dayValue).toBeTypeOf("string");
     await handlers.collect?.(createSelectComponent("recruitment-dashboard:dashboard-1:schedule:day", [dayValue]));
+
     payload = getLastPayload(interaction);
-    expect(String(payload.embeds[0].toJSON().description)).toContain("Select a day and time in 30-minute increments");
-    expect(String(payload.embeds[0].toJSON().description)).toContain("Day choice:");
     const timeMenu = getSelectMenus(payload)[1];
     const selectedTimeValue = timeMenu?.options?.[0]?.value;
     expect(selectedTimeValue).toBeTypeOf("string");
@@ -294,6 +415,5 @@ describe("/recruitment dashboard", () => {
         templateImageUrls: ["https://img.example/alpha.png"],
       }),
     );
-    expect(String(getLastPayload(interaction).content)).toContain("Reminder saved for Alpha (#AAA111).");
   });
 });

--- a/tests/recruitmentReminder.service.test.ts
+++ b/tests/recruitmentReminder.service.test.ts
@@ -212,4 +212,19 @@ describe("recruitment reminder service", () => {
       }),
     });
   });
+
+  it("formats recruitment reminder bodies with double backticks", () => {
+    const content = buildRecruitmentReminderDmContent({
+      clanTag: "#PYLQ0289",
+      clanName: "Alpha",
+      platform: "reddit",
+      cooldownExpiresAt: null,
+      templateSubject: "Subject",
+      templateBody: "Line 1\nLine 2",
+      templateImageUrls: [],
+    });
+
+    expect(content).toContain("``Line 1\nLine 2``");
+    expect(content).not.toContain("```");
+  });
 });


### PR DESCRIPTION
- make dashboard timezone optional and remembered from sync-time settings
- add timezone step controls and start-countdown action to clan tabs
- switch recruitment body output to double-backtick copy/paste formatting