### PR TITLE
fix(war-events): remove FWA leader ping from mismatch alerts

### DIFF
--- a/src/services/WarEventLogService.ts
+++ b/src/services/WarEventLogService.ts
@@ -242,10 +242,9 @@ function buildWarEndDiscrepancyContent(params: {
   opponentName: string | null | undefined;
   expectedPoints: number;
   actualPoints: number;
-  fwaLeaderRoleId: string | null;
 }): {
   content: string;
-  allowedMentions: { parse: []; roles?: string[] };
+  allowedMentions: { parse: [] };
 } {
   const existingMentionRoleId = extractPostedNotifyMentionRoleId(
     params.existingPostedContent,
@@ -261,14 +260,9 @@ function buildWarEndDiscrepancyContent(params: {
     `Expected points: ${Math.trunc(params.expectedPoints)}`,
     `Actual points: ${Math.trunc(params.actualPoints)}`,
   ];
-  if (params.fwaLeaderRoleId) {
-    warningLines.push(`<@&${params.fwaLeaderRoleId}>`);
-  }
   return {
     content: [baseContent, ...warningLines].join("\n"),
-    allowedMentions: params.fwaLeaderRoleId
-      ? { parse: [], roles: [params.fwaLeaderRoleId] }
-      : { parse: [] },
+    allowedMentions: { parse: [] },
   };
 }
 
@@ -3513,18 +3507,11 @@ export class WarEventLogService {
     );
     if (previousFingerprint === fingerprint) return;
 
-    const fwaLeaderRoleId = await this.commandPermissions
-      .getFwaLeaderRoleId(params.guildId)
-      .catch(() => null);
-    const allowedMentions = fwaLeaderRoleId
-      ? ({ parse: [], roles: [fwaLeaderRoleId] } as const)
-      : ({ parse: [] } as const);
     const warningContent =
       `${buildWarEndMismatchWarningHeadline(clanTag)}\n` +
       `${historyRow?.clanName ?? clanTag} (War ID: ${Math.trunc(warId)}).\n` +
       `Expected points: ${expectedPoints}\n` +
-      `Actual points: ${actualPoints}` +
-      (fwaLeaderRoleId ? `\n<@&${fwaLeaderRoleId}>` : "");
+      `Actual points: ${actualPoints}`;
 
     let alerted = false;
     const channel = await this.client.channels
@@ -3541,7 +3528,6 @@ export class WarEventLogService {
           opponentName: historyRow?.opponentName ?? params.fallbackOpponentName,
           expectedPoints,
           actualPoints,
-          fwaLeaderRoleId,
         });
         const editedOk = await message
           .edit({
@@ -3558,7 +3544,7 @@ export class WarEventLogService {
       const sent = await (channel as any)
         .send({
           content: warningContent,
-          allowedMentions,
+          allowedMentions: { parse: [] },
         })
         .catch(() => null);
       alerted = Boolean(sent);

--- a/tests/warEventLog.logic.test.ts
+++ b/tests/warEventLog.logic.test.ts
@@ -6,6 +6,7 @@ import {
   buildBattleDayRefreshEditPayloadForTest,
   buildWarEndedMetadataValueForTest,
   buildNotifyEventPostedContentForTest,
+  buildWarEndDiscrepancyContentForTest,
   computeWarSnapshotAttackRowsForTest,
   computeWarComplianceForTest,
   computeWarPointsDeltaForTest,
@@ -844,6 +845,26 @@ describe("WarEventLogService battle-day refresh content", () => {
     );
     expect(payload.content).toContain("War started against Enemy Clan\nNext refresh <t:");
     expect(payload.content).not.toContain("<@&123456789>");
+  });
+});
+
+describe("WarEventLogService war-end discrepancy content", () => {
+  it("builds the visible mismatch warning without adding a leader mention", () => {
+    const payload = buildWarEndDiscrepancyContentForTest({
+      existingPostedContent: "War ended against Enemy Clan",
+      clanTag: "#AAA111",
+      opponentName: "Enemy Clan",
+      expectedPoints: 100,
+      actualPoints: 99,
+    });
+
+    expect(payload.content).toContain(
+      "⚠️ War-end points mismatch detected. [points.fwafarm](<https://points.fwafarm.com/clan?tag=AAA111>)",
+    );
+    expect(payload.content).toContain("Expected points: 100");
+    expect(payload.content).toContain("Actual points: 99");
+    expect(payload.content).not.toContain("<@&");
+    expect(payload.allowedMentions).toEqual({ parse: [] });
   });
 });
 

--- a/tests/warEventLog.warEndPointsReconcile.test.ts
+++ b/tests/warEventLog.warEndPointsReconcile.test.ts
@@ -1165,13 +1165,13 @@ describe("War-end points reconciliation", () => {
     expect(updateSpy).not.toHaveBeenCalled();
   });
 
-  it("mismatch edits original message with visible warning and fwa leader role ping", async () => {
+  it("mismatch edits original message with visible warning and no leader ping", async () => {
     const edit = vi.fn().mockResolvedValue({});
     const channel = {
       isTextBased: () => true,
       messages: {
         fetch: vi.fn().mockResolvedValue({
-          content: "War ended against Enemy\n<@&555>",
+          content: "War ended against Enemy\n<@&55555>",
           edit,
         }),
       },
@@ -1218,7 +1218,9 @@ describe("War-end points reconciliation", () => {
     );
     expect(editPayload.content).toContain("Expected points: 100");
     expect(editPayload.content).toContain("Actual points: 99");
-    expect(editPayload.content).toContain("<@&777>");
+    expect(editPayload.content).toContain("<@&55555>");
+    expect(editPayload.content).not.toContain("<@&777>");
+    expect(editPayload.allowedMentions).toEqual({ parse: [] });
     expect(editPayload.content).not.toContain("clan?tag=OPP123");
     expect(updateSpy).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
- stop looking up the FWA leader role during war-end discrepancy reconciliation
- keep mismatch warnings visible while forcing non-pinging allowedMentions on edit and send paths
- update tests to cover the no-ping alert contract