### PR TITLE
fix(recruitment): tighten reminder fire markers and mark Discord windows

### DIFF
--- a/src/commands/Recruitment.ts
+++ b/src/commands/Recruitment.ts
@@ -42,6 +42,7 @@ import {
   formatRecruitmentReminderWindowSummaryInTimeZone,
   formatRecruitmentReminderRhythmSummaryInTimeZone,
   getNextRecruitmentReminderSlot,
+  getRecruitmentReminderPlatformWindows,
   getRecruitmentReminderSlotCandidates,
   normalizeRecruitmentTimezone,
   recruitmentReminderService,
@@ -56,6 +57,7 @@ const IMAGE_URLS_INPUT_ID = "image-urls";
 const DISCORD_RECRUITMENT_CHANNEL_URL =
   "https://discord.com/channels/236523452230533121/1058589765508800644";
 const PANEL_TIMEOUT_MS = 10 * 60 * 1000;
+const PACIFIC_TIME_ZONE = "America/Los_Angeles";
 
 const PLATFORM_CHOICES = [
   { name: "discord", value: "discord" },
@@ -340,15 +342,90 @@ function stripRecruitmentTimeOptionMarkers(label: string): string {
   return label.replace(/\s*🔥+$/u, "").trimEnd();
 }
 
+type RecruitmentReminderWindowSpec = ReturnType<typeof getRecruitmentReminderPlatformWindows>[number];
+
+function getRecruitmentDashboardTimeZoneParts(date: Date, timeZone: string): {
+  hour: number;
+  minute: number;
+  weekday: number;
+} {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    hour: "numeric",
+    minute: "numeric",
+    hour12: false,
+    weekday: "short",
+  }).formatToParts(date);
+  const get = (type: string): string => parts.find((part) => part.type === type)?.value ?? "0";
+  const weekdayMap: Record<string, number> = {
+    Sun: 0,
+    Mon: 1,
+    Tue: 2,
+    Wed: 3,
+    Thu: 4,
+    Fri: 5,
+    Sat: 6,
+  };
+  return {
+    hour: Number(get("hour")),
+    minute: Number(get("minute")),
+    weekday: weekdayMap[get("weekday")] ?? 0,
+  };
+}
+
+function isRecruitmentDashboardSlotInWindow(
+  slot: Date,
+  window: RecruitmentReminderWindowSpec,
+): boolean {
+  const parts = getRecruitmentDashboardTimeZoneParts(slot, PACIFIC_TIME_ZONE);
+  const minutes = parts.hour * 60 + parts.minute;
+  if (minutes < window.startMinutes || minutes >= window.endMinutes) return false;
+  if (window.daysOfWeek && !window.daysOfWeek.includes(parts.weekday)) return false;
+  return true;
+}
+
+function getRecruitmentDashboardPrimaryIndexes(
+  options: RecruitmentDashboardTimeOption[],
+  platform: RecruitmentPlatform,
+): number[] {
+  if (options.length === 0) return [];
+  const windows = getRecruitmentReminderPlatformWindows(platform);
+  if (windows.length === 0) return [];
+
+  const optionSlots = options.map((option) => new Date(option.value));
+  const primaryIndexes = new Set<number>();
+
+  if (platform === "discord") {
+    for (const window of windows) {
+      const index = optionSlots.findIndex((slot) => isRecruitmentDashboardSlotInWindow(slot, window));
+      if (index >= 0) primaryIndexes.add(index);
+    }
+  } else {
+    const index = optionSlots.findIndex((slot) =>
+      windows.some((window) => isRecruitmentDashboardSlotInWindow(slot, window)),
+    );
+    if (index >= 0) primaryIndexes.add(index);
+  }
+
+  return [...primaryIndexes].sort((a, b) => a - b);
+}
+
 export function decorateRecruitmentDashboardTimeOptions(
   options: RecruitmentDashboardTimeOption[],
-  bestIndex: number
+  primaryIndexes: number[],
 ): RecruitmentDashboardTimeOption[] {
   if (options.length === 0) return [];
-  const normalizedBestIndex = bestIndex < 0 ? 0 : Math.min(bestIndex, options.length - 1);
+  const normalizedPrimaryIndexes = new Set(
+    primaryIndexes
+      .filter((index) => Number.isInteger(index))
+      .map((index) => Math.max(0, Math.min(index, options.length - 1))),
+  );
   return options.map((option, index) => {
-    const distance = Math.abs(index - normalizedBestIndex);
-    const fireSuffix = index === normalizedBestIndex ? " 🔥🔥" : distance <= 2 ? " 🔥" : "";
+    const fireSuffix = normalizedPrimaryIndexes.has(index)
+      ? " 🔥🔥"
+      : normalizedPrimaryIndexes.has(index - 1) || normalizedPrimaryIndexes.has(index + 1)
+        ? " 🔥"
+        : "";
     return {
       ...option,
       label: `${stripRecruitmentTimeOptionMarkers(option.label)}${fireSuffix}`.slice(0, 100),
@@ -807,16 +884,8 @@ function buildRecruitmentDashboardTimeOptions(
       default: state.reminderTimeIso === slot.toISOString(),
     };
   });
-  const bestReminderSlot = getNextRecruitmentReminderSlot({
-    platform: state.clanTab,
-    timezone: state.timezone,
-    after: new Date(),
-    cooldownExpiresAt: data.cooldowns.get(`${state.clanTag}:${state.clanTab}`) ?? null,
-  });
-  const bestIndex = bestReminderSlot
-    ? baseOptions.findIndex((option) => option.value === bestReminderSlot.toISOString())
-    : -1;
-  return decorateRecruitmentDashboardTimeOptions(baseOptions, bestIndex);
+  const primaryIndexes = getRecruitmentDashboardPrimaryIndexes(baseOptions, state.clanTab);
+  return decorateRecruitmentDashboardTimeOptions(baseOptions, primaryIndexes);
 }
 
 async function handleShowSubcommand(

--- a/tests/recruitment.dashboard.command.test.ts
+++ b/tests/recruitment.dashboard.command.test.ts
@@ -424,16 +424,18 @@ describe("/recruitment dashboard", () => {
     expect(String(payload.embeds[0].toJSON().description)).toContain("Timezone: `America/Los_Angeles`");
 
     const dayMenu = getSelectMenus(payload)[0];
-    const dayValue = dayMenu?.options?.[0]?.value;
+    expect(dayMenu?.options?.length).toBeGreaterThan(1);
+    const dayValue = dayMenu?.options?.[1]?.value;
     expect(dayValue).toBeTypeOf("string");
     await handlers.collect?.(createSelectComponent("recruitment-dashboard:dashboard-1:schedule:day", [dayValue]));
 
     payload = getLastPayload(interaction);
     const timeMenu = getSelectMenus(payload)[1];
     const timeLabels = (timeMenu?.options ?? []).map((option: any) => String(option.label));
-    expect(timeLabels.some((label: string) => label.endsWith("🔥🔥"))).toBe(true);
-    expect(timeLabels.filter((label: string) => label.endsWith("🔥🔥"))).toHaveLength(1);
-    expect(timeLabels.some((label: string) => label.endsWith("🔥"))).toBe(true);
+    expect(timeLabels.filter((label: string) => label.endsWith("🔥🔥"))).toHaveLength(2);
+    expect(
+      timeLabels.filter((label: string) => label.endsWith("🔥") && !label.endsWith("🔥🔥")),
+    ).toHaveLength(2);
     const selectedTimeValue = timeMenu?.options?.[0]?.value;
     expect(selectedTimeValue).toBeTypeOf("string");
     await handlers.collect?.(createSelectComponent("recruitment-dashboard:dashboard-1:schedule:time", [selectedTimeValue]));
@@ -456,26 +458,30 @@ describe("/recruitment dashboard", () => {
     );
   });
 
-  it("decorates reminder slot labels around the best option without stacking markers", () => {
+  it("decorates reminder slot labels around multiple primary options without stacking markers", () => {
     const options = [
-      { label: "Slot 1", value: "1", description: "" },
+      { label: "Slot 1 🔥", value: "1", description: "" },
       { label: "Slot 2", value: "2", description: "" },
       { label: "Slot 3", value: "3", description: "" },
-      { label: "Slot 4", value: "4", description: "" },
+      { label: "Slot 4 🔥🔥", value: "4", description: "" },
       { label: "Slot 5", value: "5", description: "" },
       { label: "Slot 6", value: "6", description: "" },
+      { label: "Slot 7", value: "7", description: "" },
     ];
 
-    const decorated = decorateRecruitmentDashboardTimeOptions(options as any, 3);
+    const decorated = decorateRecruitmentDashboardTimeOptions(options as any, [1, 4]);
     const labels = decorated.map((option) => option.label);
-    expect(labels[3]).toBe("Slot 4 🔥🔥");
-    expect(labels[1]).toBe("Slot 2 🔥");
-    expect(labels[2]).toBe("Slot 3 🔥");
-    expect(labels[4]).toBe("Slot 5 🔥");
-    expect(labels[5]).toBe("Slot 6 🔥");
-    expect(labels[0]).toBe("Slot 1");
+    expect(labels).toEqual([
+      "Slot 1 🔥",
+      "Slot 2 🔥🔥",
+      "Slot 3 🔥",
+      "Slot 4 🔥",
+      "Slot 5 🔥🔥",
+      "Slot 6 🔥",
+      "Slot 7",
+    ]);
 
-    const rerendered = decorateRecruitmentDashboardTimeOptions(decorated, 3);
+    const rerendered = decorateRecruitmentDashboardTimeOptions(decorated, [1, 4]);
     expect(rerendered.map((option) => option.label)).toEqual(labels);
     expect(rerendered.map((option) => option.value)).toEqual(options.map((option) => option.value));
   });
@@ -487,16 +493,16 @@ describe("/recruitment dashboard", () => {
       { label: "Slot C", value: "C", description: "" },
     ];
 
-    const topDecorated = decorateRecruitmentDashboardTimeOptions(options as any, 0);
+    const topDecorated = decorateRecruitmentDashboardTimeOptions(options as any, [0]);
     expect(topDecorated.map((option) => option.label)).toEqual([
       "Slot A 🔥🔥",
       "Slot B 🔥",
-      "Slot C 🔥",
+      "Slot C",
     ]);
 
-    const bottomDecorated = decorateRecruitmentDashboardTimeOptions(options as any, 2);
+    const bottomDecorated = decorateRecruitmentDashboardTimeOptions(options as any, [2]);
     expect(bottomDecorated.map((option) => option.label)).toEqual([
-      "Slot A 🔥",
+      "Slot A",
       "Slot B 🔥",
       "Slot C 🔥🔥",
     ]);


### PR DESCRIPTION
- mark only immediate neighbors around reminder primaries
- highlight both Discord recommended windows in the dashboard day picker
- keep Reddit and Band limited to a single primary reminder slot