### PR TITLE
feat(compo): cut war state over to persisted roster data

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -25,7 +25,7 @@
 - `/sheet unlink [mode:actual|war]` - Remove one mode link or all links.
 - `/sheet refresh mode:actual|war` - Trigger mode-specific Apps Script raw feed refresh. Disabled when `POLLING_MODE=mirror`.
 - `/compo advice clan:<tracked-clan> [mode:actual|war]` - Pull advice using mode-specific sheet link.
-- `/compo state [mode:actual|war]` - Render AllianceDashboard state as an attached PNG image with mode label. Includes an inline `Refresh Data` button that triggers the shared sheet-refresh flow and rerenders in place.
+- `/compo state [mode:actual|war]` - Render AllianceDashboard state as an attached PNG image. `mode:war` now reads persisted feed-backed tracked-clan roster state from `FwaTrackedClanWarRosterCurrent` + `FwaTrackedClanWarRosterMemberCurrent` + `HeatMapRef` and its inline `Refresh Data` button refreshes tracked-clan war-roster feed state only before rerendering from DB. `mode:actual` remains sheet-backed and still uses the shared sheet-refresh flow.
 - `/compo place weight:<value>` - Suggest placement options from ACTUAL state (vacancy + composition fit). Accepts formats like `145000`, `145,000`, or `145k` and maps to TH weight buckets. Includes an inline `Refresh Data` button that triggers the shared sheet-refresh flow and rerenders in place.
 - `/cc player tag:<tag>` - Build `https://cc.fwafarm.com/cc_n/member.php?tag=<tag>`.
 - `/cc clan tag:<tag>` - Build `https://cc.fwafarm.com/cc_n/clan.php?tag=<tag>`.

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -133,7 +133,7 @@ Operational notes:
 - Members polling uses tracked clans only.
 - Global WarMembers / optional global Wars use cursor-based distributed sweeps from `FwaClanCatalog`.
 - `HeatMapRef` is an explicit seed/import owner and is not refreshed by per-clan watch jobs.
-- `/compo` remains sheet-backed in this phase.
+- `/compo state mode:war` now reads persisted feed-backed tracked-clan roster state only; `/compo state mode:actual` and `/compo place` remain sheet-backed in this phase.
 
 Manual/dev feed operations:
 ```bash

--- a/src/commands/Compo.ts
+++ b/src/commands/Compo.ts
@@ -18,6 +18,7 @@ import { normalizeCompoClanDisplayName } from "../helper/compoDisplay";
 import { prisma } from "../prisma";
 import { safeReply } from "../helper/safeReply";
 import { CoCService } from "../services/CoCService";
+import { CompoWarStateService } from "../services/CompoWarStateService";
 import {
   getSheetRefreshErrorHint,
   mapSheetRefreshFlowErrorToMessage,
@@ -524,15 +525,23 @@ function buildCompoStatePayload(input: {
   modeRows: SheetIndexedRow[];
   refreshLine: string;
 }): CompoRenderPayload {
-  const stateRows = buildCompoStateRows(input.modeRows);
+  return buildCompoStatePayloadFromRows({
+    mode: input.mode,
+    stateRows: buildCompoStateRows(input.modeRows),
+    contentLines: [input.refreshLine],
+  });
+}
+
+function buildCompoStatePayloadFromRows(input: {
+  mode: GoogleSheetMode;
+  stateRows: string[][];
+  contentLines: string[];
+}): CompoRenderPayload {
   return {
-    content: [
-      `Mode Displayed: **${input.mode.toUpperCase()}**`,
-      input.refreshLine,
-    ].join("\n"),
+    content: input.contentLines.join("\n"),
     files: [
       {
-        attachment: renderStatePng(input.mode, stateRows),
+        attachment: renderStatePng(input.mode, input.stateRows),
         name: `compo-state-${input.mode}.png`,
       },
     ],
@@ -989,6 +998,12 @@ function mapCompoRefreshErrorToMessage(err: unknown): string {
   return `Failed to refresh compo view. ${refreshHint}`;
 }
 
+function mapCompoWarStateErrorToMessage(action: "load" | "refresh"): string {
+  return action === "refresh"
+    ? "Failed to refresh DB-backed WAR state. Try again in a moment."
+    : "Failed to load DB-backed WAR state. Try again in a moment.";
+}
+
 export async function handleCompoRefreshButton(
   interaction: ButtonInteraction,
   cocService: CoCService,
@@ -1021,19 +1036,31 @@ export async function handleCompoRefreshButton(
   });
 
   try {
-    const refreshMode = parsed.kind === "state" ? parsed.mode : "actual";
-    await triggerSharedSheetRefresh({
-      guildId: interaction.guildId ?? null,
-      mode: refreshMode,
-    });
-
     if (parsed.kind === "state") {
-      const snapshot = await readCompoSheetSnapshot(parsed.mode);
-      const payload = buildCompoStatePayload({
-        mode: parsed.mode,
-        modeRows: snapshot.modeRows,
-        refreshLine: snapshot.refreshLine,
-      });
+      let payload: CompoRenderPayload;
+      if (parsed.mode === "war") {
+        const warState = await new CompoWarStateService().refreshState();
+        payload = warState.stateRows
+          ? buildCompoStatePayloadFromRows({
+              mode: "war",
+              stateRows: warState.stateRows,
+              contentLines: warState.contentLines,
+            })
+          : {
+              content: warState.contentLines.join("\n"),
+            };
+      } else {
+        await triggerSharedSheetRefresh({
+          guildId: interaction.guildId ?? null,
+          mode: parsed.mode,
+        });
+        const snapshot = await readCompoSheetSnapshot(parsed.mode);
+        payload = buildCompoStatePayload({
+          mode: parsed.mode,
+          modeRows: snapshot.modeRows,
+          refreshLine: snapshot.refreshLine,
+        });
+      }
       await interaction.editReply({
         ...payload,
         components: buildCompoRefreshComponents({
@@ -1049,6 +1076,10 @@ export async function handleCompoRefreshButton(
     if (!bucket) {
       throw new Error("Invalid placement bucket for refresh.");
     }
+    await triggerSharedSheetRefresh({
+      guildId: interaction.guildId ?? null,
+      mode: "actual",
+    });
     const snapshot = await readCompoSheetSnapshot("actual");
     const placeResult = await buildCompoPlacePayload({
       inputWeight: parsed.weight,
@@ -1076,7 +1107,10 @@ export async function handleCompoRefreshButton(
     });
     await interaction.followUp({
       ephemeral: true,
-      content: mapCompoRefreshErrorToMessage(err),
+      content:
+        parsed.kind === "state" && parsed.mode === "war"
+          ? mapCompoWarStateErrorToMessage("refresh")
+          : mapCompoRefreshErrorToMessage(err),
     });
   }
 }
@@ -1263,34 +1297,61 @@ export const Compo: Command = {
 
       if (subcommand === "state") {
         logCompoStage(interaction, "computation_start", { mode });
-        const snapshot = await readCompoSheetSnapshot(mode);
-        logCompoStage(interaction, "db_fetch", {
-          entity: "sheet_link",
-          mode,
-          result: snapshot.linked.sheetId ? "found" : "missing",
-          sheetIdPresent: Boolean(snapshot.linked.sheetId),
-          resolutionSource: snapshot.linked.source,
-        });
-        logCompoStage(interaction, "read_dispatch", {
-          range: FIXED_LAYOUT_RANGE,
-          resolutionSource: snapshot.linked.source,
-        });
-        logCompoStage(interaction, "read_dispatch", {
-          range: LOOKUP_REFRESH_RANGE,
-          resolutionSource: snapshot.linked.source,
-        });
-        logCompoStage(interaction, "db_fetch", {
-          entity: "sheet_rows",
-          mode,
-          result: snapshot.rows.length > 0 ? "found" : "missing",
-          totalRows: snapshot.rows.length,
-          modeRows: snapshot.modeRows.length,
-        });
-        const payload = buildCompoStatePayload({
-          mode,
-          modeRows: snapshot.modeRows,
-          refreshLine: snapshot.refreshLine,
-        });
+        const payload =
+          mode === "war"
+            ? await (async () => {
+                const warState = await new CompoWarStateService().readState();
+                logCompoStage(interaction, "db_fetch", {
+                  entity: "tracked_war_roster_current",
+                  mode,
+                  renderableRows: warState.renderableClanTags.length,
+                  snapshotRows: warState.snapshotClanTags.length,
+                });
+                logCompoStage(interaction, "db_fetch", {
+                  entity: "heat_map_ref",
+                  mode,
+                  result: warState.stateRows ? "found" : "partial_or_missing",
+                });
+                return warState.stateRows
+                  ? buildCompoStatePayloadFromRows({
+                      mode: "war",
+                      stateRows: warState.stateRows,
+                      contentLines: warState.contentLines,
+                    })
+                  : {
+                      content: warState.contentLines.join("\n"),
+                    };
+              })()
+            : await (async () => {
+                const snapshot = await readCompoSheetSnapshot(mode);
+                logCompoStage(interaction, "db_fetch", {
+                  entity: "sheet_link",
+                  mode,
+                  result: snapshot.linked.sheetId ? "found" : "missing",
+                  sheetIdPresent: Boolean(snapshot.linked.sheetId),
+                  resolutionSource: snapshot.linked.source,
+                });
+                logCompoStage(interaction, "read_dispatch", {
+                  range: FIXED_LAYOUT_RANGE,
+                  resolutionSource: snapshot.linked.source,
+                });
+                logCompoStage(interaction, "read_dispatch", {
+                  range: LOOKUP_REFRESH_RANGE,
+                  resolutionSource: snapshot.linked.source,
+                });
+                logCompoStage(interaction, "db_fetch", {
+                  entity: "sheet_rows",
+                  mode,
+                  result: snapshot.rows.length > 0 ? "found" : "missing",
+                  totalRows: snapshot.rows.length,
+                  modeRows: snapshot.modeRows.length,
+                });
+                return buildCompoStatePayload({
+                  mode,
+                  modeRows: snapshot.modeRows,
+                  refreshLine: snapshot.refreshLine,
+                });
+              })();
         const refreshCustomId = buildCompoRefreshCustomId({
           kind: "state",
           userId: interaction.user.id,
@@ -1299,7 +1360,7 @@ export const Compo: Command = {
 
         logCompoStage(interaction, "computation_complete", {
           result: "state_rendered",
-          modeRows: snapshot.modeRows.length,
+          mode,
         });
         logCompoStage(interaction, "response_build", { reason: "state_png" });
         await interaction.editReply({
@@ -1451,7 +1512,10 @@ export const Compo: Command = {
       });
       await safeReply(interaction, {
         ephemeral: !isPublic,
-        content: mapCompoSheetErrorToMessage(err),
+        content:
+          getSubcommandSafe(interaction) === "state" && readMode(interaction) === "war"
+            ? mapCompoWarStateErrorToMessage("load")
+            : mapCompoSheetErrorToMessage(err),
       });
       logCompoStage(interaction, "response_sent", { reason: "run_catch" });
     }

--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -185,11 +185,12 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
     ],
   },
   compo: {
-    summary: "Composition tools backed by the AllianceDashboard sheet.",
+    summary: "Composition tools with DB-backed WAR state and sheet-backed ACTUAL flows.",
     details: [
-      "`advice`: fetch clan-specific adjustment notes.",
-      "`state`: render state table as an image (with inline refresh button).",
-      "`place`: suggest placement by war weight (with inline refresh button).",
+      "`advice`: fetch clan-specific adjustment notes from the existing sheet-backed flow.",
+      "`state`: `mode:war` renders from persisted tracked-clan feed state only, while `mode:actual` remains on the AllianceDashboard sheet path.",
+      "`state` refresh: `mode:war` refreshes tracked-clan war-roster feed state only and rerenders from DB; `mode:actual` still uses the shared sheet-refresh flow.",
+      "`place`: suggest placement by war weight from the ACTUAL sheet-backed path (with inline refresh button).",
     ],
     examples: [
       "/compo advice tag:#2QG2C08UP mode:actual",

--- a/src/listeners/interactionCreate.ts
+++ b/src/listeners/interactionCreate.ts
@@ -120,7 +120,7 @@ const COMMANDS_WITH_CUSTOM_VISIBILITY = new Set([
   "say",
 ]);
 
-let isRegistered = false;
+const registeredClients = new WeakSet<Client>();
 const telemetryIngest = TelemetryIngestService.getInstance();
 
 function isMissingBotPermissionsError(err: unknown): boolean {
@@ -237,12 +237,12 @@ async function runWithInteractiveQueueContext<T>(
 }
 
 export default (client: Client, cocService: CoCService): void => {
-  if (isRegistered) {
+  if (registeredClients.has(client)) {
     console.warn("interactionCreate already registered, skipping");
     return;
   }
 
-  isRegistered = true;
+  registeredClients.add(client);
 
   client.on("interactionCreate", async (interaction: Interaction) => {
     if (interaction.isAutocomplete()) {

--- a/src/services/CompoWarStateService.ts
+++ b/src/services/CompoWarStateService.ts
@@ -1,0 +1,351 @@
+import type {
+  HeatMapRef,
+  FwaTrackedClanWarRosterCurrent,
+  FwaTrackedClanWarRosterMemberCurrent,
+} from "@prisma/client";
+import { prisma } from "../prisma";
+import { normalizeCompoClanDisplayName } from "../helper/compoDisplay";
+import { mapWithConcurrency } from "./fwa-feeds/concurrency";
+import { FwaFeedOpsService } from "./fwa-feeds/FwaFeedOpsService";
+import { normalizeFwaTag } from "./fwa-feeds/normalize";
+
+type CollapsedStateRow = {
+  clanName: string;
+  totalWeight: string;
+  missingWeights: string;
+  players: string;
+  th18Delta: string;
+  th17Delta: string;
+  th16Delta: string;
+  th15Delta: string;
+  th14Delta: string;
+  th13OrLowerDelta: string;
+};
+
+type GranularBucketKey =
+  | "TH18"
+  | "TH17"
+  | "TH16"
+  | "TH15"
+  | "TH14"
+  | "TH13"
+  | "TH12"
+  | "TH11"
+  | "TH10_OR_LOWER";
+
+type BucketCounts = Record<GranularBucketKey, number>;
+
+export type CompoWarStateReadResult = {
+  stateRows: string[][] | null;
+  contentLines: string[];
+  trackedClanTags: string[];
+  snapshotClanTags: string[];
+  renderableClanTags: string[];
+};
+
+const EMPTY_BUCKET_COUNTS: BucketCounts = {
+  TH18: 0,
+  TH17: 0,
+  TH16: 0,
+  TH15: 0,
+  TH14: 0,
+  TH13: 0,
+  TH12: 0,
+  TH11: 0,
+  TH10_OR_LOWER: 0,
+};
+
+function normalizeWarStateClanDisplayName(value: string): string {
+  const normalized = normalizeCompoClanDisplayName(value);
+  const trimmedRight = normalized.trimEnd();
+  return trimmedRight.endsWith("-war")
+    ? trimmedRight.slice(0, -"-war".length).trimEnd()
+    : trimmedRight;
+}
+
+function toEpochLine(prefix: string, value: Date | null): string {
+  if (!value) return `${prefix}: (not available)`;
+  return `${prefix}: <t:${Math.floor(value.getTime() / 1000)}:F>`;
+}
+
+/** Purpose: bucket one persisted Town Hall value into the canonical internal compo band set. */
+function bucketTownHall(townHall: number): GranularBucketKey {
+  if (townHall >= 18) return "TH18";
+  if (townHall === 17) return "TH17";
+  if (townHall === 16) return "TH16";
+  if (townHall === 15) return "TH15";
+  if (townHall === 14) return "TH14";
+  if (townHall === 13) return "TH13";
+  if (townHall === 12) return "TH12";
+  if (townHall === 11) return "TH11";
+  return "TH10_OR_LOWER";
+}
+
+/** Purpose: count granular Town Hall buckets from the persisted tracked-clan member rows. */
+function buildBucketCounts(
+  members: readonly Pick<FwaTrackedClanWarRosterMemberCurrent, "townHall">[],
+): BucketCounts {
+  const counts: BucketCounts = { ...EMPTY_BUCKET_COUNTS };
+  for (const member of members) {
+    counts[bucketTownHall(member.townHall)] += 1;
+  }
+  return counts;
+}
+
+/** Purpose: resolve the matching persisted HeatMapRef band for one total effective roster weight. */
+function findHeatMapRefForWeight(
+  refs: readonly HeatMapRef[],
+  totalEffectiveWeight: number,
+): HeatMapRef | null {
+  return (
+    refs.find(
+      (row) =>
+        totalEffectiveWeight >= row.weightMinInclusive &&
+        totalEffectiveWeight <= row.weightMaxInclusive,
+    ) ?? null
+  );
+}
+
+/** Purpose: derive the legacy display delta columns while preserving granular internal TH counts. */
+function buildCollapsedStateRow(input: {
+  clanName: string;
+  totalEffectiveWeight: number;
+  rosterSize: number;
+  missingWeights: number;
+  bucketCounts: BucketCounts;
+  heatMapRef: HeatMapRef;
+}): CollapsedStateRow {
+  const deltas = {
+    TH18: input.bucketCounts.TH18 - input.heatMapRef.th18Count,
+    TH17: input.bucketCounts.TH17 - input.heatMapRef.th17Count,
+    TH16: input.bucketCounts.TH16 - input.heatMapRef.th16Count,
+    TH15: input.bucketCounts.TH15 - input.heatMapRef.th15Count,
+    TH14: input.bucketCounts.TH14 - input.heatMapRef.th14Count,
+    TH13_OR_LOWER:
+      input.bucketCounts.TH13 +
+      input.bucketCounts.TH12 +
+      input.bucketCounts.TH11 +
+      input.bucketCounts.TH10_OR_LOWER -
+      (input.heatMapRef.th13Count +
+        input.heatMapRef.th12Count +
+        input.heatMapRef.th11Count +
+        input.heatMapRef.th10OrLowerCount),
+  };
+
+  return {
+    clanName: normalizeWarStateClanDisplayName(input.clanName),
+    totalWeight: input.totalEffectiveWeight.toLocaleString("en-US"),
+    missingWeights: `${input.missingWeights}`,
+    players: `${input.rosterSize}`,
+    th18Delta: `${deltas.TH18}`,
+    th17Delta: `${deltas.TH17}`,
+    th16Delta: `${deltas.TH16}`,
+    th15Delta: `${deltas.TH15}`,
+    th14Delta: `${deltas.TH14}`,
+    th13OrLowerDelta: `${deltas.TH13_OR_LOWER}`,
+  };
+}
+
+/** Purpose: explain why one persisted tracked-clan roster snapshot cannot be safely rendered. */
+function getIneligibleReason(input: {
+  parent: FwaTrackedClanWarRosterCurrent;
+  memberCount: number;
+  heatMapRef: HeatMapRef | null;
+}): string | null {
+  if (input.parent.rosterSize !== 50) {
+    return `roster size ${input.parent.rosterSize}/50`;
+  }
+  if (input.parent.hasUnresolvedWeights) {
+    return "unresolved effective weights";
+  }
+  if (input.parent.totalEffectiveWeight === null) {
+    return "missing total effective weight";
+  }
+  if (input.memberCount !== input.parent.rosterSize) {
+    return `persisted member rows ${input.memberCount}/${input.parent.rosterSize}`;
+  }
+  if (!input.heatMapRef) {
+    return "missing HeatMapRef band";
+  }
+  return null;
+}
+
+type FeedOpsLike = Pick<FwaFeedOpsService, "runTracked">;
+
+/** Purpose: read and explicitly refresh DB-backed tracked-clan war compo state without touching sheet-backed flows. */
+export class CompoWarStateService {
+  /** Purpose: allow feed-ops injection for deterministic refresh tests. */
+  constructor(private readonly feedOps: FeedOpsLike = new FwaFeedOpsService()) {}
+
+  /** Purpose: load alliance-wide tracked-clan war state rows from persisted feed-owned tables only. */
+  async readState(): Promise<CompoWarStateReadResult> {
+    const tracked = await prisma.trackedClan.findMany({
+      orderBy: { createdAt: "asc" },
+      select: { tag: true, name: true },
+    });
+    const trackedTags = tracked
+      .map((row) => normalizeFwaTag(row.tag))
+      .filter((tag): tag is string => Boolean(tag));
+
+    if (trackedTags.length === 0) {
+      return {
+        stateRows: null,
+        trackedClanTags: [],
+        snapshotClanTags: [],
+        renderableClanTags: [],
+        contentLines: [
+          "Mode Displayed: **WAR**",
+          toEpochLine("Persisted WAR data last refreshed", null),
+          "No tracked clans are configured for DB-backed WAR state.",
+        ],
+      };
+    }
+
+    const [parents, members, refs] = await Promise.all([
+      prisma.fwaTrackedClanWarRosterCurrent.findMany({
+        where: { clanTag: { in: trackedTags } },
+      }),
+      prisma.fwaTrackedClanWarRosterMemberCurrent.findMany({
+        where: { clanTag: { in: trackedTags } },
+        orderBy: [{ clanTag: "asc" }, { position: "asc" }],
+      }),
+      prisma.heatMapRef.findMany({
+        orderBy: [{ weightMinInclusive: "asc" }, { weightMaxInclusive: "asc" }],
+      }),
+    ]);
+
+    const trackedByTag = new Map(
+      trackedTags.map((tag, index) => [tag, tracked[index]?.name?.trim() ?? null]),
+    );
+    const parentByTag = new Map(parents.map((row) => [row.clanTag, row]));
+    const membersByTag = new Map<string, FwaTrackedClanWarRosterMemberCurrent[]>();
+    for (const member of members) {
+      const existing = membersByTag.get(member.clanTag) ?? [];
+      existing.push(member);
+      membersByTag.set(member.clanTag, existing);
+    }
+
+    const renderableRows: string[][] = [];
+    const skipped: string[] = [];
+    const renderableClanTags: string[] = [];
+    const snapshotClanTags = parents.map((row) => row.clanTag);
+    let latestRefreshAt: Date | null = null;
+
+    for (const clanTag of trackedTags) {
+      const parent = parentByTag.get(clanTag);
+      if (!parent) {
+        continue;
+      }
+      const clanMembers = membersByTag.get(clanTag) ?? [];
+      const effectiveWeight = parent.totalEffectiveWeight;
+      const heatMapRef =
+        effectiveWeight === null ? null : findHeatMapRefForWeight(refs, effectiveWeight);
+      const ineligibleReason = getIneligibleReason({
+        parent,
+        memberCount: clanMembers.length,
+        heatMapRef,
+      });
+      const displayName =
+        parent.clanName?.trim() ||
+        trackedByTag.get(clanTag) ||
+        parent.clanTag;
+
+      const freshness = parent.sourceUpdatedAt ?? parent.observedAt;
+      if (!latestRefreshAt || freshness.getTime() > latestRefreshAt.getTime()) {
+        latestRefreshAt = freshness;
+      }
+
+      if (ineligibleReason) {
+        skipped.push(`${normalizeWarStateClanDisplayName(displayName)} (${ineligibleReason})`);
+        continue;
+      }
+
+      const bucketCounts = buildBucketCounts(clanMembers);
+      const missingWeights = clanMembers.filter((row) => row.rawWeight <= 0).length;
+      const collapsed = buildCollapsedStateRow({
+        clanName: displayName,
+        totalEffectiveWeight: effectiveWeight as number,
+        rosterSize: parent.rosterSize,
+        missingWeights,
+        bucketCounts,
+        heatMapRef: heatMapRef as HeatMapRef,
+      });
+      renderableRows.push([
+        collapsed.clanName,
+        collapsed.totalWeight,
+        collapsed.missingWeights,
+        collapsed.players,
+        collapsed.th18Delta,
+        collapsed.th17Delta,
+        collapsed.th16Delta,
+        collapsed.th15Delta,
+        collapsed.th14Delta,
+        collapsed.th13OrLowerDelta,
+      ]);
+      renderableClanTags.push(clanTag);
+    }
+
+    const contentLines = [
+      "Mode Displayed: **WAR**",
+      toEpochLine("Persisted WAR data last refreshed", latestRefreshAt),
+    ];
+
+    if (skipped.length > 0) {
+      contentLines.push(`Skipped ineligible clans: ${skipped.join("; ")}`);
+    }
+
+    if (renderableRows.length === 0) {
+      contentLines.push("No DB-backed WAR roster snapshots are currently renderable.");
+      return {
+        stateRows: null,
+        trackedClanTags: trackedTags,
+        snapshotClanTags,
+        renderableClanTags,
+        contentLines,
+      };
+    }
+
+    return {
+      stateRows: [
+        ["Clan", "Total", "Missing", "Players", "TH18", "TH17", "TH16", "TH15", "TH14", "<=TH13"],
+        ...renderableRows,
+      ],
+      trackedClanTags: trackedTags,
+      snapshotClanTags,
+      renderableClanTags,
+      contentLines,
+    };
+  }
+
+  /** Purpose: explicitly refresh the currently persisted tracked-clan war roster scopes and rerender from DB. */
+  async refreshState(): Promise<CompoWarStateReadResult> {
+    const current = await this.readState();
+    if (current.trackedClanTags.length === 0) {
+      return current;
+    }
+
+    const failures: string[] = [];
+    await mapWithConcurrency(current.trackedClanTags, 3, async (clanTag) => {
+      try {
+        await this.feedOps.runTracked("war-roster", clanTag);
+      } catch {
+        failures.push(clanTag);
+      }
+    });
+
+    const next = await this.readState();
+    if (failures.length > 0) {
+      next.contentLines = [
+        ...next.contentLines,
+        `Refresh warnings: ${failures.map((tag) => `#${tag.replace(/^#/, "")}`).join(", ")}`,
+      ];
+    }
+    return next;
+  }
+}
+
+export const bucketTownHallForTest = bucketTownHall;
+export const buildBucketCountsForTest = buildBucketCounts;
+export const findHeatMapRefForWeightForTest = findHeatMapRefForWeight;
+export const buildCollapsedStateRowForTest = buildCollapsedStateRow;
+export const getIneligibleReasonForTest = getIneligibleReason;

--- a/tests/compo.commandSheetRead.test.ts
+++ b/tests/compo.commandSheetRead.test.ts
@@ -213,7 +213,7 @@ describe("/compo strict sheet read path", () => {
       }
     );
 
-    const stateInteraction = makeInteraction({ subcommand: "state", mode: "war" });
+    const stateInteraction = makeInteraction({ subcommand: "state", mode: "actual" });
     await Compo.run({} as any, stateInteraction as any, {
       getClan: vi.fn().mockResolvedValue({
         memberList: Array.from({ length: 49 }, () => ({ tag: "#P" })),

--- a/tests/compoRefresh.logic.test.ts
+++ b/tests/compoRefresh.logic.test.ts
@@ -76,7 +76,7 @@ describe("compo refresh button behavior", () => {
 
   it("shows loading state, routes through shared sheet refresh, and rerenders state output", async () => {
     vi.spyOn(SheetRefreshService, "triggerSharedSheetRefresh").mockResolvedValue({
-      mode: "war",
+      mode: "actual",
       resultText: "ok",
       durationSeconds: "0.10",
     });
@@ -105,7 +105,7 @@ describe("compo refresh button behavior", () => {
     const customId = buildCompoRefreshCustomIdForTest({
       kind: "state",
       userId: "user-1",
-      mode: "war",
+      mode: "actual",
     });
     const interaction = makeInteraction(customId);
 
@@ -113,7 +113,7 @@ describe("compo refresh button behavior", () => {
 
     expect(SheetRefreshService.triggerSharedSheetRefresh).toHaveBeenCalledWith({
       guildId: "guild-1",
-      mode: "war",
+      mode: "actual",
     });
     const loadingPayload = interaction.update.mock.calls[0]?.[0];
     expect(readFirstButton(loadingPayload)).toEqual({

--- a/tests/compoWarRefresh.logic.test.ts
+++ b/tests/compoWarRefresh.logic.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  buildCompoRefreshCustomIdForTest,
+  handleCompoRefreshButton,
+} from "../src/commands/Compo";
+import { CompoWarStateService } from "../src/services/CompoWarStateService";
+import * as SheetRefreshService from "../src/services/SheetRefreshService";
+
+function makeMessageRow(customId: string, label: string, disabled = false): { toJSON: () => unknown } {
+  return {
+    toJSON: () => ({
+      type: 1,
+      components: [
+        {
+          type: 2,
+          style: 2,
+          label,
+          custom_id: customId,
+          disabled,
+        },
+      ],
+    }),
+  };
+}
+
+function makeInteraction(customId: string) {
+  const interaction: any = {
+    customId,
+    guildId: "guild-1",
+    channelId: "channel-1",
+    user: { id: "user-1" },
+    message: {
+      id: "message-1",
+      components: [makeMessageRow(customId, "Refresh Data")],
+    },
+    replied: false,
+    deferred: false,
+    update: vi.fn(async () => {
+      interaction.deferred = true;
+    }),
+    editReply: vi.fn().mockResolvedValue(undefined),
+    followUp: vi.fn().mockResolvedValue(undefined),
+    reply: vi.fn().mockResolvedValue(undefined),
+  };
+  return interaction;
+}
+
+describe("compo war refresh button behavior", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("refreshes DB-backed war mode without calling the shared sheet refresh flow", async () => {
+    const refreshStateSpy = vi
+      .spyOn(CompoWarStateService.prototype, "refreshState")
+      .mockResolvedValue({
+        stateRows: [
+          ["Clan", "Total", "Missing", "Players", "TH18", "TH17", "TH16", "TH15", "TH14", "<=TH13"],
+          ["Alpha Clan", "7,000,000", "0", "50", "0", "0", "0", "0", "0", "0"],
+        ],
+        contentLines: [
+          "Mode Displayed: **WAR**",
+          "Persisted WAR data last refreshed: <t:1775817600:F>",
+        ],
+        trackedClanTags: ["#AAA111"],
+        snapshotClanTags: ["#AAA111"],
+        renderableClanTags: ["#AAA111"],
+      });
+    const sheetRefreshSpy = vi.spyOn(SheetRefreshService, "triggerSharedSheetRefresh");
+    const customId = buildCompoRefreshCustomIdForTest({
+      kind: "state",
+      userId: "user-1",
+      mode: "war",
+    });
+    const interaction = makeInteraction(customId);
+
+    await handleCompoRefreshButton(interaction as any, {} as any);
+
+    expect(refreshStateSpy).toHaveBeenCalledTimes(1);
+    expect(sheetRefreshSpy).not.toHaveBeenCalled();
+    const payload = interaction.editReply.mock.calls.at(-1)?.[0];
+    expect(String(payload?.content ?? "")).toContain("Mode Displayed: **WAR**");
+    expect(Array.isArray(payload?.files)).toBe(true);
+    expect(interaction.followUp).not.toHaveBeenCalled();
+  });
+});

--- a/tests/compoWarState.command.test.ts
+++ b/tests/compoWarState.command.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Compo } from "../src/commands/Compo";
+import { CompoWarStateService } from "../src/services/CompoWarStateService";
+import { GoogleSheetsService } from "../src/services/GoogleSheetsService";
+
+function makeInteraction(params: {
+  subcommand: "state";
+  mode?: string | null;
+}) {
+  const interaction: any = {
+    commandName: "compo",
+    guildId: "guild-1",
+    user: { id: "user-1" },
+    deferred: false,
+    replied: false,
+    deferReply: vi.fn(async () => {
+      interaction.deferred = true;
+    }),
+    editReply: vi.fn().mockResolvedValue(undefined),
+    reply: vi.fn().mockResolvedValue(undefined),
+    options: {
+      getSubcommand: vi.fn(() => params.subcommand),
+      getString: vi.fn((name: string) => {
+        if (name === "mode") return params.mode ?? null;
+        return null;
+      }),
+    },
+  };
+  return interaction;
+}
+
+describe("/compo state mode:war DB cutover", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders mode:war from the DB-backed war state service without sheet reads", async () => {
+    const readStateSpy = vi
+      .spyOn(CompoWarStateService.prototype, "readState")
+      .mockResolvedValue({
+        stateRows: [
+          ["Clan", "Total", "Missing", "Players", "TH18", "TH17", "TH16", "TH15", "TH14", "<=TH13"],
+          ["Alpha Clan", "7,000,000", "0", "50", "0", "1", "0", "-1", "0", "0"],
+        ],
+        contentLines: [
+          "Mode Displayed: **WAR**",
+          "Persisted WAR data last refreshed: <t:1775817600:F>",
+        ],
+        trackedClanTags: ["#AAA111"],
+        snapshotClanTags: ["#AAA111"],
+        renderableClanTags: ["#AAA111"],
+      });
+    const getSheetSpy = vi.spyOn(GoogleSheetsService.prototype, "getCompoLinkedSheet");
+    const readSheetSpy = vi.spyOn(GoogleSheetsService.prototype, "readCompoLinkedValues");
+
+    const interaction = makeInteraction({ subcommand: "state", mode: "war" });
+    await Compo.run({} as any, interaction as any, {} as any);
+
+    expect(readStateSpy).toHaveBeenCalledTimes(1);
+    expect(getSheetSpy).not.toHaveBeenCalled();
+    expect(readSheetSpy).not.toHaveBeenCalled();
+    const payload = interaction.editReply.mock.calls.at(-1)?.[0];
+    expect(String(payload?.content ?? "")).toContain("Mode Displayed: **WAR**");
+    expect(Array.isArray(payload?.files)).toBe(true);
+    expect(payload?.files?.[0]?.name).toBe("compo-state-war.png");
+  });
+
+  it("returns an honest text response when no DB-backed war snapshots are renderable", async () => {
+    vi.spyOn(CompoWarStateService.prototype, "readState").mockResolvedValue({
+      stateRows: null,
+      contentLines: [
+        "Mode Displayed: **WAR**",
+        "Persisted WAR data last refreshed: (not available)",
+        "Skipped ineligible clans: Alpha Clan (roster size 45/50)",
+        "No DB-backed WAR roster snapshots are currently renderable.",
+      ],
+      trackedClanTags: ["#AAA111"],
+      snapshotClanTags: ["#AAA111"],
+      renderableClanTags: [],
+    });
+
+    const interaction = makeInteraction({ subcommand: "state", mode: "war" });
+    await Compo.run({} as any, interaction as any, {} as any);
+
+    const payload = interaction.editReply.mock.calls.at(-1)?.[0];
+    expect(String(payload?.content ?? "")).toContain("No DB-backed WAR roster snapshots are currently renderable.");
+    expect(Object.prototype.hasOwnProperty.call(payload, "files")).toBe(false);
+  });
+
+  it("keeps mode:actual on the sheet-backed path", async () => {
+    const linkedSheet = {
+      sheetId: "sheet-1",
+      tabName: "AllianceDashboard",
+      source: "google_sheet_id" as const,
+    };
+    const readStateSpy = vi.spyOn(CompoWarStateService.prototype, "readState");
+    vi.spyOn(GoogleSheetsService.prototype, "getCompoLinkedSheet").mockResolvedValue(linkedSheet);
+    vi.spyOn(GoogleSheetsService.prototype, "readCompoLinkedValues").mockImplementation(
+      async (range: string) => {
+        if (range === "Lookup!B10:B10") return [["1709900000"]];
+        const rows = Array.from({ length: 8 }, () => Array.from({ length: 57 }, () => ""));
+        rows[1][0] = "Alpha Clan";
+        rows[1][3] = "1,500,000";
+        rows[1][20] = "0";
+        rows[1][21] = "50";
+        rows[1][22] = "0";
+        rows[1][23] = "0";
+        rows[1][24] = "0";
+        rows[1][25] = "0";
+        rows[1][26] = "0";
+        rows[1][27] = "0";
+        return rows;
+      },
+    );
+
+    const interaction = makeInteraction({ subcommand: "state", mode: "actual" });
+    await Compo.run({} as any, interaction as any, {} as any);
+
+    expect(readStateSpy).not.toHaveBeenCalled();
+    const payload = interaction.editReply.mock.calls.at(-1)?.[0];
+    expect(String(payload?.content ?? "")).toContain("RAW Data last refreshed:");
+    expect(Array.isArray(payload?.files)).toBe(true);
+  });
+});

--- a/tests/compoWarState.service.test.ts
+++ b/tests/compoWarState.service.test.ts
@@ -1,0 +1,244 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const prismaMock = vi.hoisted(() => ({
+  trackedClan: {
+    findMany: vi.fn(),
+  },
+  fwaTrackedClanWarRosterCurrent: {
+    findMany: vi.fn(),
+  },
+  fwaTrackedClanWarRosterMemberCurrent: {
+    findMany: vi.fn(),
+  },
+  heatMapRef: {
+    findMany: vi.fn(),
+  },
+}));
+
+vi.mock("../src/prisma", () => ({
+  prisma: prismaMock,
+}));
+
+import { CompoWarStateService } from "../src/services/CompoWarStateService";
+
+function makeParent(input: {
+  clanTag: string;
+  clanName: string;
+  rosterSize?: number;
+  totalEffectiveWeight?: number | null;
+  hasUnresolvedWeights?: boolean;
+  sourceUpdatedAt?: Date | null;
+  observedAt?: Date;
+}) {
+  return {
+    clanTag: input.clanTag,
+    clanName: input.clanName,
+    opponentTag: null,
+    opponentName: null,
+    rosterSize: input.rosterSize ?? 50,
+    totalRawWeight: 7_000_000,
+    totalEffectiveWeight:
+      input.totalEffectiveWeight === undefined ? 7_000_000 : input.totalEffectiveWeight,
+    hasUnresolvedWeights: input.hasUnresolvedWeights ?? false,
+    observedAt: input.observedAt ?? new Date("2026-04-10T17:00:00.000Z"),
+    sourceUpdatedAt:
+      input.sourceUpdatedAt === undefined
+        ? new Date("2026-04-10T16:00:00.000Z")
+        : input.sourceUpdatedAt,
+    createdAt: new Date("2026-04-10T15:00:00.000Z"),
+    updatedAt: new Date("2026-04-10T17:00:00.000Z"),
+  };
+}
+
+function makeMember(input: {
+  clanTag: string;
+  position: number;
+  townHall: number;
+  rawWeight?: number;
+}) {
+  return {
+    clanTag: input.clanTag,
+    position: input.position,
+    playerTag: `#P${input.position}`,
+    playerName: `Player ${input.position}`,
+    townHall: input.townHall,
+    rawWeight: input.rawWeight ?? 140000,
+    effectiveWeight: input.rawWeight === 0 ? 145000 : input.rawWeight ?? 140000,
+    effectiveWeightStatus: input.rawWeight === 0 ? "FILLED_FROM_LOWER_BLOCK" : "RAW",
+    opponentTag: null,
+    opponentName: null,
+    createdAt: new Date("2026-04-10T15:00:00.000Z"),
+    updatedAt: new Date("2026-04-10T17:00:00.000Z"),
+  };
+}
+
+function makeHeatMapRef() {
+  return {
+    weightMinInclusive: 6_900_000,
+    weightMaxInclusive: 7_100_000,
+    th18Count: 1,
+    th17Count: 2,
+    th16Count: 3,
+    th15Count: 4,
+    th14Count: 5,
+    th13Count: 6,
+    th12Count: 7,
+    th11Count: 8,
+    th10OrLowerCount: 14,
+    sourceVersion: "seed",
+    refreshedAt: new Date("2026-04-10T00:00:00.000Z"),
+  };
+}
+
+describe("CompoWarStateService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("builds DB-backed mode:war rows with TH deltas from persisted roster + HeatMapRef", async () => {
+    prismaMock.trackedClan.findMany.mockResolvedValue([
+      { tag: "#AAA111", name: "Alpha Clan-war" },
+    ]);
+    prismaMock.fwaTrackedClanWarRosterCurrent.findMany.mockResolvedValue([
+      makeParent({ clanTag: "#AAA111", clanName: "Alpha Clan-war" }),
+    ]);
+    prismaMock.fwaTrackedClanWarRosterMemberCurrent.findMany.mockResolvedValue([
+      makeMember({ clanTag: "#AAA111", position: 1, townHall: 18 }),
+      makeMember({ clanTag: "#AAA111", position: 2, townHall: 17 }),
+      makeMember({ clanTag: "#AAA111", position: 3, townHall: 17 }),
+      makeMember({ clanTag: "#AAA111", position: 4, townHall: 16 }),
+      makeMember({ clanTag: "#AAA111", position: 5, townHall: 16 }),
+      makeMember({ clanTag: "#AAA111", position: 6, townHall: 16 }),
+      makeMember({ clanTag: "#AAA111", position: 7, townHall: 15 }),
+      makeMember({ clanTag: "#AAA111", position: 8, townHall: 15 }),
+      makeMember({ clanTag: "#AAA111", position: 9, townHall: 15 }),
+      makeMember({ clanTag: "#AAA111", position: 10, townHall: 15 }),
+      makeMember({ clanTag: "#AAA111", position: 11, townHall: 14 }),
+      makeMember({ clanTag: "#AAA111", position: 12, townHall: 14 }),
+      makeMember({ clanTag: "#AAA111", position: 13, townHall: 14 }),
+      makeMember({ clanTag: "#AAA111", position: 14, townHall: 14 }),
+      makeMember({ clanTag: "#AAA111", position: 15, townHall: 14 }),
+      ...Array.from({ length: 6 }, (_, index) =>
+        makeMember({ clanTag: "#AAA111", position: 16 + index, townHall: 13 }),
+      ),
+      ...Array.from({ length: 7 }, (_, index) =>
+        makeMember({ clanTag: "#AAA111", position: 22 + index, townHall: 12 }),
+      ),
+      ...Array.from({ length: 8 }, (_, index) =>
+        makeMember({ clanTag: "#AAA111", position: 29 + index, townHall: 11 }),
+      ),
+      ...Array.from({ length: 14 }, (_, index) =>
+        makeMember({
+          clanTag: "#AAA111",
+          position: 37 + index,
+          townHall: 10,
+          rawWeight: index === 0 ? 0 : 135000,
+        }),
+      ),
+    ]);
+    prismaMock.heatMapRef.findMany.mockResolvedValue([makeHeatMapRef()]);
+
+    const result = await new CompoWarStateService({ runTracked: vi.fn() } as any).readState();
+
+    expect(result.renderableClanTags).toEqual(["#AAA111"]);
+    expect(result.trackedClanTags).toEqual(["#AAA111"]);
+    expect(result.stateRows).toEqual([
+      ["Clan", "Total", "Missing", "Players", "TH18", "TH17", "TH16", "TH15", "TH14", "<=TH13"],
+      ["Alpha Clan", "7,000,000", "1", "50", "0", "0", "0", "0", "0", "0"],
+    ]);
+    expect(result.contentLines[0]).toBe("Mode Displayed: **WAR**");
+    expect(result.contentLines[1]).toContain("Persisted WAR data last refreshed");
+  });
+
+  it("returns honest no-renderable output when roster size is below 50", async () => {
+    prismaMock.trackedClan.findMany.mockResolvedValue([
+      { tag: "#AAA111", name: "Alpha Clan" },
+    ]);
+    prismaMock.fwaTrackedClanWarRosterCurrent.findMany.mockResolvedValue([
+      makeParent({ clanTag: "#AAA111", clanName: "Alpha Clan", rosterSize: 45 }),
+    ]);
+    prismaMock.fwaTrackedClanWarRosterMemberCurrent.findMany.mockResolvedValue(
+      Array.from({ length: 45 }, (_, index) =>
+        makeMember({ clanTag: "#AAA111", position: index + 1, townHall: 14 }),
+      ),
+    );
+    prismaMock.heatMapRef.findMany.mockResolvedValue([makeHeatMapRef()]);
+
+    const result = await new CompoWarStateService({ runTracked: vi.fn() } as any).readState();
+
+    expect(result.stateRows).toBeNull();
+    expect(result.trackedClanTags).toEqual(["#AAA111"]);
+    expect(result.contentLines.join("\n")).toContain("roster size 45/50");
+    expect(result.contentLines.join("\n")).toContain(
+      "No DB-backed WAR roster snapshots are currently renderable.",
+    );
+  });
+
+  it("rejects unresolved or missing-band snapshots instead of rendering bad data", async () => {
+    prismaMock.trackedClan.findMany.mockResolvedValue([
+      { tag: "#AAA111", name: "Alpha Clan" },
+      { tag: "#BBB222", name: "Bravo Clan" },
+    ]);
+    prismaMock.fwaTrackedClanWarRosterCurrent.findMany.mockResolvedValue([
+      makeParent({
+        clanTag: "#AAA111",
+        clanName: "Alpha Clan",
+        hasUnresolvedWeights: true,
+      }),
+      makeParent({
+        clanTag: "#BBB222",
+        clanName: "Bravo Clan",
+        totalEffectiveWeight: 8_500_001,
+      }),
+    ]);
+    prismaMock.fwaTrackedClanWarRosterMemberCurrent.findMany.mockResolvedValue([
+      ...Array.from({ length: 50 }, (_, index) =>
+        makeMember({ clanTag: "#AAA111", position: index + 1, townHall: 14 }),
+      ),
+      ...Array.from({ length: 50 }, (_, index) =>
+        makeMember({ clanTag: "#BBB222", position: index + 1, townHall: 14 }),
+      ),
+    ]);
+    prismaMock.heatMapRef.findMany.mockResolvedValue([makeHeatMapRef()]);
+
+    const result = await new CompoWarStateService({ runTracked: vi.fn() } as any).readState();
+
+    expect(result.stateRows).toBeNull();
+    expect(result.trackedClanTags).toEqual(["#AAA111", "#BBB222"]);
+    expect(result.contentLines.join("\n")).toContain("Alpha Clan (unresolved effective weights)");
+    expect(result.contentLines.join("\n")).toContain("Bravo Clan (missing HeatMapRef band)");
+  });
+
+  it("refreshes only tracked-clan war-roster scopes through the feed-backed path", async () => {
+    const runTracked = vi.fn().mockResolvedValue({});
+    prismaMock.trackedClan.findMany.mockResolvedValue([
+      { tag: "#AAA111", name: "Alpha Clan" },
+      { tag: "#BBB222", name: "Bravo Clan" },
+    ]);
+    prismaMock.fwaTrackedClanWarRosterCurrent.findMany
+      .mockResolvedValueOnce([
+        makeParent({ clanTag: "#AAA111", clanName: "Alpha Clan" }),
+      ])
+      .mockResolvedValueOnce([
+        makeParent({ clanTag: "#AAA111", clanName: "Alpha Clan" }),
+      ]);
+    prismaMock.fwaTrackedClanWarRosterMemberCurrent.findMany
+      .mockResolvedValueOnce(
+        Array.from({ length: 50 }, (_, index) =>
+          makeMember({ clanTag: "#AAA111", position: index + 1, townHall: 14 }),
+        ),
+      )
+      .mockResolvedValueOnce(
+        Array.from({ length: 50 }, (_, index) =>
+          makeMember({ clanTag: "#AAA111", position: index + 1, townHall: 14 }),
+        ),
+      );
+    prismaMock.heatMapRef.findMany.mockResolvedValue([makeHeatMapRef()]);
+
+    await new CompoWarStateService({ runTracked } as any).refreshState();
+
+    expect(runTracked).toHaveBeenCalledTimes(2);
+    expect(runTracked).toHaveBeenCalledWith("war-roster", "#AAA111");
+    expect(runTracked).toHaveBeenCalledWith("war-roster", "#BBB222");
+  });
+});


### PR DESCRIPTION
- read `/compo state mode:war` from tracked-clan roster current-state tables and HeatMapRef
- refresh war mode through tracked-clan feed sync only while leaving actual/place sheet-backed