### PR TITLE
fix(compo): bucket war state by effective weight

### DIFF
--- a/src/helper/compoWarWeightBuckets.ts
+++ b/src/helper/compoWarWeightBuckets.ts
@@ -1,0 +1,33 @@
+export type CompoWarWeightBucket =
+  | "TH18"
+  | "TH17"
+  | "TH16"
+  | "TH15"
+  | "TH14"
+  | "TH13"
+  | "TH12"
+  | "TH11"
+  | "TH10"
+  | "TH9"
+  | "TH8_OR_LOWER";
+
+/** Purpose: classify one persisted effective roster weight into the WAR compo bucket ranges used for sheet parity. */
+export function getCompoWarWeightBucket(
+  effectiveWeight: number | null,
+): CompoWarWeightBucket | null {
+  if (effectiveWeight === null || !Number.isFinite(effectiveWeight) || effectiveWeight < 0) {
+    return null;
+  }
+  if (effectiveWeight >= 171000 && effectiveWeight <= 180000) return "TH18";
+  if (effectiveWeight >= 161000 && effectiveWeight <= 170000) return "TH17";
+  if (effectiveWeight >= 151000 && effectiveWeight <= 160000) return "TH16";
+  if (effectiveWeight >= 141000 && effectiveWeight <= 150000) return "TH15";
+  if (effectiveWeight >= 131000 && effectiveWeight <= 140000) return "TH14";
+  if (effectiveWeight >= 121000 && effectiveWeight <= 130000) return "TH13";
+  if (effectiveWeight >= 111000 && effectiveWeight <= 120000) return "TH12";
+  if (effectiveWeight >= 91000 && effectiveWeight <= 110000) return "TH11";
+  if (effectiveWeight >= 71000 && effectiveWeight <= 90000) return "TH10";
+  if (effectiveWeight >= 56000 && effectiveWeight <= 70000) return "TH9";
+  if (effectiveWeight <= 55000) return "TH8_OR_LOWER";
+  return null;
+}

--- a/src/services/CompoWarStateService.ts
+++ b/src/services/CompoWarStateService.ts
@@ -5,6 +5,10 @@ import type {
 } from "@prisma/client";
 import { prisma } from "../prisma";
 import { normalizeCompoClanDisplayName } from "../helper/compoDisplay";
+import {
+  type CompoWarWeightBucket,
+  getCompoWarWeightBucket,
+} from "../helper/compoWarWeightBuckets";
 import { mapWithConcurrency } from "./fwa-feeds/concurrency";
 import { FwaFeedOpsService } from "./fwa-feeds/FwaFeedOpsService";
 import { normalizeFwaTag } from "./fwa-feeds/normalize";
@@ -22,16 +26,7 @@ type CollapsedStateRow = {
   th13OrLowerDelta: string;
 };
 
-type GranularBucketKey =
-  | "TH18"
-  | "TH17"
-  | "TH16"
-  | "TH15"
-  | "TH14"
-  | "TH13"
-  | "TH12"
-  | "TH11"
-  | "TH10_OR_LOWER";
+type GranularBucketKey = CompoWarWeightBucket;
 
 type BucketCounts = Record<GranularBucketKey, number>;
 
@@ -52,7 +47,9 @@ const EMPTY_BUCKET_COUNTS: BucketCounts = {
   TH13: 0,
   TH12: 0,
   TH11: 0,
-  TH10_OR_LOWER: 0,
+  TH10: 0,
+  TH9: 0,
+  TH8_OR_LOWER: 0,
 };
 
 function normalizeWarStateClanDisplayName(value: string): string {
@@ -68,26 +65,15 @@ function toEpochLine(prefix: string, value: Date | null): string {
   return `${prefix}: <t:${Math.floor(value.getTime() / 1000)}:F>`;
 }
 
-/** Purpose: bucket one persisted Town Hall value into the canonical internal compo band set. */
-function bucketTownHall(townHall: number): GranularBucketKey {
-  if (townHall >= 18) return "TH18";
-  if (townHall === 17) return "TH17";
-  if (townHall === 16) return "TH16";
-  if (townHall === 15) return "TH15";
-  if (townHall === 14) return "TH14";
-  if (townHall === 13) return "TH13";
-  if (townHall === 12) return "TH12";
-  if (townHall === 11) return "TH11";
-  return "TH10_OR_LOWER";
-}
-
-/** Purpose: count granular Town Hall buckets from the persisted tracked-clan member rows. */
+/** Purpose: count granular compo weight buckets from persisted effective member weights. */
 function buildBucketCounts(
-  members: readonly Pick<FwaTrackedClanWarRosterMemberCurrent, "townHall">[],
-): BucketCounts {
+  members: readonly Pick<FwaTrackedClanWarRosterMemberCurrent, "effectiveWeight">[],
+): BucketCounts | null {
   const counts: BucketCounts = { ...EMPTY_BUCKET_COUNTS };
   for (const member of members) {
-    counts[bucketTownHall(member.townHall)] += 1;
+    const bucket = getCompoWarWeightBucket(member.effectiveWeight);
+    if (!bucket) return null;
+    counts[bucket] += 1;
   }
   return counts;
 }
@@ -125,7 +111,9 @@ function buildCollapsedStateRow(input: {
       input.bucketCounts.TH13 +
       input.bucketCounts.TH12 +
       input.bucketCounts.TH11 +
-      input.bucketCounts.TH10_OR_LOWER -
+      input.bucketCounts.TH10 +
+      input.bucketCounts.TH9 +
+      input.bucketCounts.TH8_OR_LOWER -
       (input.heatMapRef.th13Count +
         input.heatMapRef.th12Count +
         input.heatMapRef.th11Count +
@@ -261,6 +249,10 @@ export class CompoWarStateService {
       }
 
       const bucketCounts = buildBucketCounts(clanMembers);
+      if (!bucketCounts) {
+        skipped.push(`${normalizeWarStateClanDisplayName(displayName)} (unresolved effective weights)`);
+        continue;
+      }
       const missingWeights = clanMembers.filter((row) => row.rawWeight <= 0).length;
       const collapsed = buildCollapsedStateRow({
         clanName: displayName,
@@ -344,7 +336,7 @@ export class CompoWarStateService {
   }
 }
 
-export const bucketTownHallForTest = bucketTownHall;
+export const getCompoWarWeightBucketForTest = getCompoWarWeightBucket;
 export const buildBucketCountsForTest = buildBucketCounts;
 export const findHeatMapRefForWeightForTest = findHeatMapRefForWeight;
 export const buildCollapsedStateRowForTest = buildCollapsedStateRow;

--- a/tests/compoWarState.service.test.ts
+++ b/tests/compoWarState.service.test.ts
@@ -21,6 +21,7 @@ vi.mock("../src/prisma", () => ({
 
 import {
   CompoWarStateService,
+  getCompoWarWeightBucketForTest,
   findHeatMapRefForWeightForTest,
 } from "../src/services/CompoWarStateService";
 
@@ -58,21 +59,153 @@ function makeMember(input: {
   position: number;
   townHall: number;
   rawWeight?: number;
+  effectiveWeight?: number | null;
 }) {
+  const rawWeight = input.rawWeight ?? 140000;
+  const effectiveWeight =
+    input.effectiveWeight === undefined
+      ? rawWeight === 0
+        ? 145000
+        : rawWeight
+      : input.effectiveWeight;
   return {
     clanTag: input.clanTag,
     position: input.position,
     playerTag: `#P${input.position}`,
     playerName: `Player ${input.position}`,
     townHall: input.townHall,
-    rawWeight: input.rawWeight ?? 140000,
-    effectiveWeight: input.rawWeight === 0 ? 145000 : input.rawWeight ?? 140000,
-    effectiveWeightStatus: input.rawWeight === 0 ? "FILLED_FROM_LOWER_BLOCK" : "RAW",
+    rawWeight,
+    effectiveWeight,
+    effectiveWeightStatus: rawWeight === 0 ? "FILLED_FROM_LOWER_BLOCK" : "RAW",
     opponentTag: null,
     opponentName: null,
     createdAt: new Date("2026-04-10T15:00:00.000Z"),
     updatedAt: new Date("2026-04-10T17:00:00.000Z"),
   };
+}
+
+function makeWeightedMembers(input: {
+  clanTag: string;
+  counts: {
+    th18?: number;
+    th17?: number;
+    th16?: number;
+    th15?: number;
+    th14?: number;
+    th13?: number;
+    th12?: number;
+    th11?: number;
+    th10?: number;
+    th9?: number;
+    th8OrLower?: number;
+  };
+  townHall?: number;
+  startPosition?: number;
+}) {
+  let position = input.startPosition ?? 1;
+  const townHall = input.townHall ?? 18;
+  const members = [
+    ...Array.from({ length: input.counts.th18 ?? 0 }, () =>
+      makeMember({
+        clanTag: input.clanTag,
+        position: position++,
+        townHall,
+        rawWeight: 175000,
+        effectiveWeight: 175000,
+      }),
+    ),
+    ...Array.from({ length: input.counts.th17 ?? 0 }, () =>
+      makeMember({
+        clanTag: input.clanTag,
+        position: position++,
+        townHall,
+        rawWeight: 165000,
+        effectiveWeight: 165000,
+      }),
+    ),
+    ...Array.from({ length: input.counts.th16 ?? 0 }, () =>
+      makeMember({
+        clanTag: input.clanTag,
+        position: position++,
+        townHall,
+        rawWeight: 155000,
+        effectiveWeight: 155000,
+      }),
+    ),
+    ...Array.from({ length: input.counts.th15 ?? 0 }, () =>
+      makeMember({
+        clanTag: input.clanTag,
+        position: position++,
+        townHall,
+        rawWeight: 145000,
+        effectiveWeight: 145000,
+      }),
+    ),
+    ...Array.from({ length: input.counts.th14 ?? 0 }, () =>
+      makeMember({
+        clanTag: input.clanTag,
+        position: position++,
+        townHall,
+        rawWeight: 135000,
+        effectiveWeight: 135000,
+      }),
+    ),
+    ...Array.from({ length: input.counts.th13 ?? 0 }, () =>
+      makeMember({
+        clanTag: input.clanTag,
+        position: position++,
+        townHall,
+        rawWeight: 125000,
+        effectiveWeight: 125000,
+      }),
+    ),
+    ...Array.from({ length: input.counts.th12 ?? 0 }, () =>
+      makeMember({
+        clanTag: input.clanTag,
+        position: position++,
+        townHall,
+        rawWeight: 119000,
+        effectiveWeight: 119000,
+      }),
+    ),
+    ...Array.from({ length: input.counts.th11 ?? 0 }, () =>
+      makeMember({
+        clanTag: input.clanTag,
+        position: position++,
+        townHall,
+        rawWeight: 100000,
+        effectiveWeight: 100000,
+      }),
+    ),
+    ...Array.from({ length: input.counts.th10 ?? 0 }, () =>
+      makeMember({
+        clanTag: input.clanTag,
+        position: position++,
+        townHall,
+        rawWeight: 80000,
+        effectiveWeight: 80000,
+      }),
+    ),
+    ...Array.from({ length: input.counts.th9 ?? 0 }, () =>
+      makeMember({
+        clanTag: input.clanTag,
+        position: position++,
+        townHall,
+        rawWeight: 65000,
+        effectiveWeight: 65000,
+      }),
+    ),
+    ...Array.from({ length: input.counts.th8OrLower ?? 0 }, () =>
+      makeMember({
+        clanTag: input.clanTag,
+        position: position++,
+        townHall,
+        rawWeight: 55000,
+        effectiveWeight: 55000,
+      }),
+    ),
+  ];
+  return members;
 }
 
 function makeHeatMapRef(input?: {
@@ -110,7 +243,32 @@ describe("CompoWarStateService", () => {
     vi.clearAllMocks();
   });
 
-  it("builds DB-backed mode:war rows with corrected HeatMapRef band targets", async () => {
+  it("classifies effective-weight boundaries into the expected WAR compo buckets", () => {
+    expect(getCompoWarWeightBucketForTest(180000)).toBe("TH18");
+    expect(getCompoWarWeightBucketForTest(170000)).toBe("TH17");
+    expect(getCompoWarWeightBucketForTest(160000)).toBe("TH16");
+    expect(getCompoWarWeightBucketForTest(150000)).toBe("TH15");
+    expect(getCompoWarWeightBucketForTest(140000)).toBe("TH14");
+    expect(getCompoWarWeightBucketForTest(130000)).toBe("TH13");
+    expect(getCompoWarWeightBucketForTest(120000)).toBe("TH12");
+    expect(getCompoWarWeightBucketForTest(110000)).toBe("TH11");
+    expect(getCompoWarWeightBucketForTest(90000)).toBe("TH10");
+    expect(getCompoWarWeightBucketForTest(70000)).toBe("TH9");
+    expect(getCompoWarWeightBucketForTest(55000)).toBe("TH8_OR_LOWER");
+  });
+
+  it("classifies representative interior effective weights into the expected WAR compo buckets", () => {
+    expect(getCompoWarWeightBucketForTest(175000)).toBe("TH18");
+    expect(getCompoWarWeightBucketForTest(165000)).toBe("TH17");
+    expect(getCompoWarWeightBucketForTest(145000)).toBe("TH15");
+    expect(getCompoWarWeightBucketForTest(119000)).toBe("TH12");
+    expect(getCompoWarWeightBucketForTest(100000)).toBe("TH11");
+    expect(getCompoWarWeightBucketForTest(80000)).toBe("TH10");
+    expect(getCompoWarWeightBucketForTest(65000)).toBe("TH9");
+    expect(getCompoWarWeightBucketForTest(1000)).toBe("TH8_OR_LOWER");
+  });
+
+  it("builds DB-backed mode:war rows from effective-weight buckets with corrected HeatMapRef band targets", async () => {
     prismaMock.trackedClan.findMany.mockResolvedValue([{ tag: "#AAA111", name: "Alpha Clan-war" }]);
     prismaMock.fwaTrackedClanWarRosterCurrent.findMany.mockResolvedValue([
       makeParent({
@@ -120,25 +278,10 @@ describe("CompoWarStateService", () => {
       }),
     ]);
     prismaMock.fwaTrackedClanWarRosterMemberCurrent.findMany.mockResolvedValue([
-      ...Array.from({ length: 19 }, (_, index) =>
-        makeMember({ clanTag: "#AAA111", position: index + 1, townHall: 18 }),
-      ),
-      ...Array.from({ length: 11 }, (_, index) =>
-        makeMember({ clanTag: "#AAA111", position: 20 + index, townHall: 17 }),
-      ),
-      ...Array.from({ length: 7 }, (_, index) =>
-        makeMember({ clanTag: "#AAA111", position: 31 + index, townHall: 16 }),
-      ),
-      ...Array.from({ length: 6 }, (_, index) =>
-        makeMember({ clanTag: "#AAA111", position: 38 + index, townHall: 15 }),
-      ),
-      ...Array.from({ length: 4 }, (_, index) =>
-        makeMember({ clanTag: "#AAA111", position: 44 + index, townHall: 14 }),
-      ),
-      ...Array.from({ length: 2 }, (_, index) =>
-        makeMember({ clanTag: "#AAA111", position: 48 + index, townHall: 13 }),
-      ),
-      makeMember({ clanTag: "#AAA111", position: 50, townHall: 12 }),
+      ...makeWeightedMembers({
+        clanTag: "#AAA111",
+        counts: { th18: 19, th17: 11, th16: 7, th15: 6, th14: 4, th13: 2, th12: 1 },
+      }),
     ]);
     prismaMock.heatMapRef.findMany.mockResolvedValue([makeHeatMapRef()]);
 
@@ -152,6 +295,32 @@ describe("CompoWarStateService", () => {
     ]);
     expect(result.contentLines[0]).toBe("Mode Displayed: **WAR**");
     expect(result.contentLines[1]).toContain("Persisted WAR data last refreshed");
+  });
+
+  it("derives WAR deltas from effective-weight buckets instead of literal town halls", async () => {
+    prismaMock.trackedClan.findMany.mockResolvedValue([{ tag: "#AAA111", name: "Alpha Clan-war" }]);
+    prismaMock.fwaTrackedClanWarRosterCurrent.findMany.mockResolvedValue([
+      makeParent({
+        clanTag: "#AAA111",
+        clanName: "Alpha Clan-war",
+        totalEffectiveWeight: 8_100_000,
+      }),
+    ]);
+    prismaMock.fwaTrackedClanWarRosterMemberCurrent.findMany.mockResolvedValue([
+      ...makeWeightedMembers({
+        clanTag: "#AAA111",
+        townHall: 18,
+        counts: { th18: 19, th17: 11, th16: 7, th15: 6, th14: 4, th13: 2, th12: 1 },
+      }),
+    ]);
+    prismaMock.heatMapRef.findMany.mockResolvedValue([makeHeatMapRef()]);
+
+    const result = await new CompoWarStateService({ runTracked: vi.fn() } as any).readState();
+
+    expect(result.stateRows).toEqual([
+      ["Clan", "Total", "Missing", "Players", "TH18", "TH17", "TH16", "TH15", "TH14", "<=TH13"],
+      ["Alpha Clan", "8,100,000", "0", "50", "0", "0", "0", "0", "0", "0"],
+    ]);
   });
 
   it("resolves corrected HeatMapRef bands at representative totals and boundaries", () => {
@@ -206,9 +375,10 @@ describe("CompoWarStateService", () => {
       makeParent({ clanTag: "#AAA111", clanName: "Alpha Clan", rosterSize: 45 }),
     ]);
     prismaMock.fwaTrackedClanWarRosterMemberCurrent.findMany.mockResolvedValue(
-      Array.from({ length: 45 }, (_, index) =>
-        makeMember({ clanTag: "#AAA111", position: index + 1, townHall: 14 }),
-      ),
+      makeWeightedMembers({
+        clanTag: "#AAA111",
+        counts: { th14: 45 },
+      }),
     );
     prismaMock.heatMapRef.findMany.mockResolvedValue([makeHeatMapRef()]);
 
@@ -240,12 +410,14 @@ describe("CompoWarStateService", () => {
       }),
     ]);
     prismaMock.fwaTrackedClanWarRosterMemberCurrent.findMany.mockResolvedValue([
-      ...Array.from({ length: 50 }, (_, index) =>
-        makeMember({ clanTag: "#AAA111", position: index + 1, townHall: 14 }),
-      ),
-      ...Array.from({ length: 50 }, (_, index) =>
-        makeMember({ clanTag: "#BBB222", position: index + 1, townHall: 14 }),
-      ),
+      ...makeWeightedMembers({
+        clanTag: "#AAA111",
+        counts: { th14: 50 },
+      }),
+      ...makeWeightedMembers({
+        clanTag: "#BBB222",
+        counts: { th14: 50 },
+      }),
     ]);
     prismaMock.heatMapRef.findMany.mockResolvedValue([makeHeatMapRef()]);
 
@@ -267,16 +439,8 @@ describe("CompoWarStateService", () => {
       .mockResolvedValueOnce([makeParent({ clanTag: "#AAA111", clanName: "Alpha Clan" })])
       .mockResolvedValueOnce([makeParent({ clanTag: "#AAA111", clanName: "Alpha Clan" })]);
     prismaMock.fwaTrackedClanWarRosterMemberCurrent.findMany
-      .mockResolvedValueOnce(
-        Array.from({ length: 50 }, (_, index) =>
-          makeMember({ clanTag: "#AAA111", position: index + 1, townHall: 14 }),
-        ),
-      )
-      .mockResolvedValueOnce(
-        Array.from({ length: 50 }, (_, index) =>
-          makeMember({ clanTag: "#AAA111", position: index + 1, townHall: 14 }),
-        ),
-      );
+      .mockResolvedValueOnce(makeWeightedMembers({ clanTag: "#AAA111", counts: { th14: 50 } }))
+      .mockResolvedValueOnce(makeWeightedMembers({ clanTag: "#AAA111", counts: { th14: 50 } }));
     prismaMock.heatMapRef.findMany.mockResolvedValue([makeHeatMapRef()]);
 
     await new CompoWarStateService({ runTracked } as any).refreshState();
@@ -284,5 +448,30 @@ describe("CompoWarStateService", () => {
     expect(runTracked).toHaveBeenCalledTimes(2);
     expect(runTracked).toHaveBeenCalledWith("war-roster", "#AAA111");
     expect(runTracked).toHaveBeenCalledWith("war-roster", "#BBB222");
+  });
+
+  it("collapses TH13-and-lower display deltas from lower effective-weight buckets", async () => {
+    prismaMock.trackedClan.findMany.mockResolvedValue([{ tag: "#AAA111", name: "Alpha Clan-war" }]);
+    prismaMock.fwaTrackedClanWarRosterCurrent.findMany.mockResolvedValue([
+      makeParent({
+        clanTag: "#AAA111",
+        clanName: "Alpha Clan-war",
+        totalEffectiveWeight: 8_100_000,
+      }),
+    ]);
+    prismaMock.fwaTrackedClanWarRosterMemberCurrent.findMany.mockResolvedValue([
+      ...makeWeightedMembers({
+        clanTag: "#AAA111",
+        counts: { th18: 19, th17: 11, th16: 7, th15: 6, th14: 4, th11: 1, th10: 1, th9: 1 },
+      }),
+    ]);
+    prismaMock.heatMapRef.findMany.mockResolvedValue([makeHeatMapRef()]);
+
+    const result = await new CompoWarStateService({ runTracked: vi.fn() } as any).readState();
+
+    expect(result.stateRows).toEqual([
+      ["Clan", "Total", "Missing", "Players", "TH18", "TH17", "TH16", "TH15", "TH14", "<=TH13"],
+      ["Alpha Clan", "8,100,000", "0", "50", "0", "0", "0", "0", "0", "0"],
+    ]);
   });
 });


### PR DESCRIPTION
- classify war-mode compo buckets from persisted effectiveWeight ranges
- keep lower-hall display collapsed into <=TH13 while preserving DB-backed war reads