### PR TITLE
fix(compo): fill trailing war zero blocks from resolved weight

### DIFF
--- a/src/services/fwa-feeds/FwaTrackedClanWarRosterSyncService.ts
+++ b/src/services/fwa-feeds/FwaTrackedClanWarRosterSyncService.ts
@@ -106,7 +106,19 @@ function applyEffectiveWeightRules(
       zeroBlockEndExclusive += 1;
     }
     const fillSource = rows[zeroBlockEndExclusive];
-    const fillWeight = fillSource?.rawWeight && fillSource.rawWeight > 0 ? fillSource.rawWeight : null;
+    const lowestResolvedWeightAbove = derived.reduce<number | null>((lowest, row) => {
+      if (row.effectiveWeight === null || row.effectiveWeight <= 0) {
+        return lowest;
+      }
+      if (lowest === null || row.effectiveWeight < lowest) {
+        return row.effectiveWeight;
+      }
+      return lowest;
+    }, null);
+    const fillWeight =
+      fillSource?.rawWeight && fillSource.rawWeight > 0
+        ? fillSource.rawWeight
+        : lowestResolvedWeightAbove;
     for (let zeroIndex = index; zeroIndex < zeroBlockEndExclusive; zeroIndex += 1) {
       const row = rows[zeroIndex];
       derived.push({

--- a/tests/fwaTrackedClanWarRosterSync.test.ts
+++ b/tests/fwaTrackedClanWarRosterSync.test.ts
@@ -87,7 +87,7 @@ describe("FwaTrackedClanWarRosterSyncService", () => {
     ]);
   });
 
-  it("marks unresolved trailing zero blocks explicitly", () => {
+  it("fills a trailing zero block from the lowest resolved non-zero weight above it", () => {
     const snapshot = deriveTrackedClanWarRosterSnapshotForTest({
       clanTag: "#AAA111",
       clanName: "Tracked Clan",
@@ -95,16 +95,93 @@ describe("FwaTrackedClanWarRosterSyncService", () => {
       rows: [
         makeSourceRow({ playerTag: "#P1", playerName: "One", position: 1, weight: 151000 }),
         makeSourceRow({ playerTag: "#P2", playerName: "Two", position: 2, weight: 0 }),
+        makeSourceRow({ playerTag: "#P3", playerName: "Three", position: 3, weight: 145000 }),
+        makeSourceRow({ playerTag: "#P4", playerName: "Four", position: 4, weight: 0 }),
+        makeSourceRow({ playerTag: "#P5", playerName: "Five", position: 5, weight: 0 }),
+      ],
+    });
+
+    expect(snapshot?.hasUnresolvedWeights).toBe(false);
+    expect(snapshot?.totalEffectiveWeight).toBeNull();
+    expect(snapshot?.members.map((row) => [row.position, row.effectiveWeight, row.effectiveWeightStatus])).toEqual([
+      [1, 151000, "RAW"],
+      [2, 145000, "FILLED_FROM_LOWER_BLOCK"],
+      [3, 145000, "RAW"],
+      [4, 145000, "FILLED_FROM_LOWER_BLOCK"],
+      [5, 145000, "FILLED_FROM_LOWER_BLOCK"],
+    ]);
+  });
+
+  it("copies the same lowest resolved non-zero weight through multiple trailing zero rows", () => {
+    const derived = applyEffectiveWeightRulesForTest([
+      {
+        playerTag: "#P1",
+        playerName: "One",
+        position: 1,
+        townHall: 16,
+        rawWeight: 170000,
+        opponentTag: "#OPP",
+        opponentName: "Opponent",
+        sourceSyncedAt: new Date("2026-04-10T12:00:00.000Z"),
+      },
+      {
+        playerTag: "#P2",
+        playerName: "Two",
+        position: 2,
+        townHall: 16,
+        rawWeight: 155000,
+        opponentTag: "#OPP",
+        opponentName: "Opponent",
+        sourceSyncedAt: new Date("2026-04-10T12:00:00.000Z"),
+      },
+      {
+        playerTag: "#P3",
+        playerName: "Three",
+        position: 3,
+        townHall: 16,
+        rawWeight: 0,
+        opponentTag: "#OPP",
+        opponentName: "Opponent",
+        sourceSyncedAt: new Date("2026-04-10T12:00:00.000Z"),
+      },
+      {
+        playerTag: "#P4",
+        playerName: "Four",
+        position: 4,
+        townHall: 16,
+        rawWeight: 0,
+        opponentTag: "#OPP",
+        opponentName: "Opponent",
+        sourceSyncedAt: new Date("2026-04-10T12:00:00.000Z"),
+      },
+    ]);
+
+    expect(derived.map((row) => [row.position, row.effectiveWeight, row.effectiveWeightStatus])).toEqual([
+      [1, 170000, "RAW"],
+      [2, 155000, "RAW"],
+      [3, 155000, "FILLED_FROM_LOWER_BLOCK"],
+      [4, 155000, "FILLED_FROM_LOWER_BLOCK"],
+    ]);
+  });
+
+  it("keeps pathological all-zero rosters explicitly unresolved", () => {
+    const snapshot = deriveTrackedClanWarRosterSnapshotForTest({
+      clanTag: "#AAA111",
+      clanName: "Tracked Clan",
+      observedAt: new Date("2026-04-10T15:00:00.000Z"),
+      rows: [
+        makeSourceRow({ playerTag: "#P1", playerName: "One", position: 1, weight: 0 }),
+        makeSourceRow({ playerTag: "#P2", playerName: "Two", position: 2, weight: 0 }),
         makeSourceRow({ playerTag: "#P3", playerName: "Three", position: 3, weight: 0 }),
       ],
     });
 
     expect(snapshot?.hasUnresolvedWeights).toBe(true);
     expect(snapshot?.totalEffectiveWeight).toBeNull();
-    expect(snapshot?.members.map((row) => row.effectiveWeightStatus)).toEqual([
-      "RAW",
-      "UNRESOLVED_TRAILING_ZERO",
-      "UNRESOLVED_TRAILING_ZERO",
+    expect(snapshot?.members.map((row) => [row.position, row.effectiveWeight, row.effectiveWeightStatus])).toEqual([
+      [1, null, "UNRESOLVED_TRAILING_ZERO"],
+      [2, null, "UNRESOLVED_TRAILING_ZERO"],
+      [3, null, "UNRESOLVED_TRAILING_ZERO"],
     ]);
   });
 


### PR DESCRIPTION
- reuse the lowest resolved non-zero weight for bottom trailing zero rows
- keep pathological all-zero rosters explicitly unresolved