### PR TITLE
fix(reminders): refresh WAR reminder rendering

### DIFF
--- a/src/services/reminders/ReminderDispatchService.ts
+++ b/src/services/reminders/ReminderDispatchService.ts
@@ -4,6 +4,7 @@ import type { ClanWar } from "../../generated/coc-api";
 import { formatError } from "../../helper/formatError";
 import { splitDiscordLineMessages } from "../../helper/discordLineMessageSplit";
 import { prisma } from "../../prisma";
+import { resolveCurrentWarMatchTypeSignal } from "../MatchTypeResolutionService";
 import { CoCService, type ClanCapitalRaidSeason } from "../CoCService";
 import { normalizeClanTag, normalizePlayerTag } from "../PlayerLinkService";
 import { parseCocTime } from "../war-events/core";
@@ -55,6 +56,11 @@ type ReminderRosterEntry = {
 type ReminderRosterResolveResult = {
   windowActive: boolean;
   lines: string[];
+};
+
+type ConfirmedWarHeadline = {
+  label: "BL" | "MM" | "FWA-WIN" | "FWA-LOSE";
+  emoji: "⚫" | "⚪" | "🟢" | "🔴";
 };
 
 const MAX_REMINDER_MESSAGES = 3;
@@ -146,26 +152,35 @@ async function buildReminderDispatchContents(input: {
   cocService: ReminderDispatchCoCClient | null;
 }): Promise<string[]> {
   const payload = input.input;
-  const headerLines = buildReminderDispatchHeaderLines({
-    input: payload,
-    nowMs: input.nowMs,
-  });
   const semantic = resolveReminderRosterSemantic({
     reminderType: payload.type,
     eventIdentity: payload.eventIdentity,
   });
-  const roster = await resolveReminderRosterLines({
-    input: payload,
-    semantic,
-    cocService: input.cocService,
-    nowMs: input.nowMs,
-  });
+  const [warHeadline, roster] = await Promise.all([
+    semantic === "WAR"
+      ? resolveConfirmedWarHeadline({
+          clanTag: payload.clanTag,
+        })
+      : Promise.resolve<ConfirmedWarHeadline | null>(null),
+    resolveReminderRosterLines({
+      input: payload,
+      semantic,
+      cocService: input.cocService,
+      nowMs: input.nowMs,
+    }),
+  ]);
   if (semantic !== "OTHER" && !roster.windowActive) {
     return [];
   }
+  const headerLines = buildReminderDispatchHeaderLines({
+    input: payload,
+    nowMs: input.nowMs,
+    warHeadline,
+  });
   return buildReminderContentsWithRosterOverflow({
     headerLines,
     rosterLines: roster.lines,
+    includeRosterHeading: semantic !== "WAR",
   });
 }
 
@@ -173,6 +188,7 @@ async function buildReminderDispatchContents(input: {
 function buildReminderDispatchHeaderLines(input: {
   input: ReminderDispatchInput;
   nowMs: number;
+  warHeadline: ConfirmedWarHeadline | null;
 }): string[] {
   const payload = input.input;
   const clanLabel = payload.clanName
@@ -184,9 +200,13 @@ function buildReminderDispatchHeaderLines(input: {
     Math.floor((payload.eventEndsAt.getTime() - input.nowMs) / 1000),
   );
   const endUnix = Math.floor(payload.eventEndsAt.getTime() / 1000);
+  const headlineLabel = input.warHeadline
+    ? `${input.warHeadline.label} war ends`
+    : getReminderHeadingLabel(payload.type);
+  const headlineEmoji = input.warHeadline ? ` ${input.warHeadline.emoji}` : "";
 
   return [
-    `### ${getReminderHeadingLabel(payload.type)} in ${offsetLabel}`,
+    `### ${headlineLabel} in ${offsetLabel}${headlineEmoji}`,
     `Clan: ${clanLabel}`,
     `Time remaining: <t:${endUnix}:R> (${remainingSeconds}s)`,
     `Ends at: <t:${endUnix}:F> (<t:${endUnix}:R>)`,
@@ -274,22 +294,12 @@ async function resolveReminderRosterLines(input: {
 
   return {
     windowActive,
-    lines: sortedRoster.map((entry) => {
-      const mention = entry.discordUserId;
-      if (input.semantic === "RAIDS") {
-        if (mention) {
-          return `${entry.playerName} - <@${mention}> - ${entry.attacksRemaining} / ${entry.attacksMax}`;
-        }
-        return `:no: ${entry.playerName} - ${entry.attacksRemaining} / ${entry.attacksMax}`;
-      }
-
-      const positionLabel =
-        entry.position !== null && entry.position > 0 ? `#${entry.position}` : "#?";
-      if (mention) {
-        return `${positionLabel} - ${entry.playerName} - <@${mention}> - ${entry.attacksRemaining} / ${entry.attacksMax}`;
-      }
-      return `${positionLabel} - :no: ${entry.playerName} - ${entry.attacksRemaining} / ${entry.attacksMax}`;
-    }),
+    lines: sortedRoster.map((entry) =>
+      formatReminderRosterLine({
+        entry,
+        semantic: input.semantic,
+      }),
+    ),
   };
 }
 
@@ -467,6 +477,83 @@ async function resolveRaidsReminderRoster(input: {
   };
 }
 
+/** Purpose: resolve one confirmed WAR headline variant from the persisted current-war row when the war is leader-confirmed. */
+async function resolveConfirmedWarHeadline(input: {
+  clanTag: string;
+}): Promise<ConfirmedWarHeadline | null> {
+  const clanTag = normalizeClanTag(input.clanTag);
+  if (!clanTag) return null;
+
+  const currentWar = await prisma.currentWar.findFirst({
+    where: { clanTag },
+    orderBy: { updatedAt: "desc" },
+    select: {
+      matchType: true,
+      inferredMatchType: true,
+      outcome: true,
+    },
+  });
+  const confirmed = resolveCurrentWarMatchTypeSignal({
+    matchType: currentWar?.matchType ?? null,
+    inferredMatchType: currentWar?.inferredMatchType ?? null,
+  }).confirmed;
+  if (!confirmed) return null;
+
+  if (confirmed.matchType === "BL") {
+    return {
+      label: "BL",
+      emoji: "⚫",
+    };
+  }
+  if (confirmed.matchType === "MM") {
+    return {
+      label: "MM",
+      emoji: "⚪",
+    };
+  }
+  if (confirmed.matchType === "FWA") {
+    const outcome = String(currentWar?.outcome ?? "").trim().toUpperCase();
+    if (outcome === "WIN") {
+      return {
+        label: "FWA-WIN",
+        emoji: "🟢",
+      };
+    }
+    if (outcome === "LOSE") {
+      return {
+        label: "FWA-LOSE",
+        emoji: "🔴",
+      };
+    }
+  }
+  return null;
+}
+
+/** Purpose: render one roster line with semantic-specific WAR/CWL/RAIDS unlinked formatting. */
+function formatReminderRosterLine(input: {
+  entry: ReminderRosterEntry;
+  semantic: ReminderRosterSemantic;
+}): string {
+  const entry = input.entry;
+  const mention = entry.discordUserId;
+  if (input.semantic === "RAIDS") {
+    if (mention) {
+      return `${entry.playerName} - <@${mention}> - ${entry.attacksRemaining} / ${entry.attacksMax}`;
+    }
+    return `:no: ${entry.playerName} - ${entry.attacksRemaining} / ${entry.attacksMax}`;
+  }
+
+  const positionLabel =
+    entry.position !== null && entry.position > 0 ? `#${entry.position}` : "#?";
+  if (mention) {
+    return `${positionLabel} - ${entry.playerName} - <@${mention}> - ${entry.attacksRemaining} / ${entry.attacksMax}`;
+  }
+  if (input.semantic === "WAR") {
+    return `${positionLabel} - ❌ ${entry.playerName} \`${entry.playerTag}\` - ${entry.attacksRemaining} / ${entry.attacksMax}`;
+  }
+  return `${positionLabel} - :no: ${entry.playerName} - ${entry.attacksRemaining} / ${entry.attacksMax}`;
+}
+
 /** Purpose: select one raid season aligned to active-window or event-end timing so send-time roster resolution stays deterministic. */
 function selectActiveRaidSeasonForReminder(input: {
   seasons: ClanCapitalRaidSeason[];
@@ -558,10 +645,13 @@ async function resolveActiveCwlBattleWarForClan(input: {
 function buildReminderContentsWithRosterOverflow(input: {
   headerLines: string[];
   rosterLines: string[];
+  includeRosterHeading: boolean;
 }): string[] {
   const lines =
     input.rosterLines.length > 0
-      ? [...input.headerLines, "", "Players With Attacks Remaining:", ...input.rosterLines]
+      ? input.includeRosterHeading
+        ? [...input.headerLines, "", "Players With Attacks Remaining:", ...input.rosterLines]
+        : [...input.headerLines, "", ...input.rosterLines]
       : [...input.headerLines];
   return splitDiscordLineMessages({
     lines,

--- a/tests/reminderDispatch.service.test.ts
+++ b/tests/reminderDispatch.service.test.ts
@@ -56,6 +56,13 @@ describe("ReminderDispatchService roster rendering", () => {
       { playerTag: "#PYLQ", discordUserId: "111" },
       { playerTag: "#PYLR", discordUserId: "333" },
     ]);
+    prismaMock.currentWar.findFirst.mockResolvedValue({
+      state: "inWar",
+      warId: 9,
+      matchType: "BL",
+      inferredMatchType: false,
+      outcome: null,
+    });
 
     const contents = await buildReminderDispatchContentsForTest({
       input: {
@@ -76,7 +83,7 @@ describe("ReminderDispatchService roster rendering", () => {
 
     expect(contents).toHaveLength(1);
     const lines = contents[0].split("\n");
-    expect(lines[0]).toBe("### War ends in 1h");
+    expect(lines[0]).toBe("### BL war ends in 1h ⚫");
     expect(lines[1]).toBe("Clan: Alpha Clan #PYLQ");
     expect(lines[2]).toBe("Time remaining: <t:1775782800:R> (1800s)");
     expect(lines[3]).toBe("Ends at: <t:1775782800:F> (<t:1775782800:R>)");
@@ -84,14 +91,129 @@ describe("ReminderDispatchService roster rendering", () => {
     expect(contents[0]).not.toContain("CWL reminder");
     expect(contents[0]).not.toContain("Configured offset");
     expect(contents[0]).not.toContain("Event timing");
+    expect(contents[0]).not.toContain("Players With Attacks Remaining:");
 
     const rosterLines = lines.filter((line) => /^#\d+ /.test(line));
     expect(rosterLines).toEqual([
       "#1 - Alpha - <@111> - 2 / 2",
-      "#2 - :no: Bravo - 1 / 2",
+      "#2 - ❌ Bravo `#PYLG` - 1 / 2",
       "#3 - Charlie - <@333> - 2 / 2",
     ]);
     expect(contents[0]).not.toContain("Done");
+  });
+
+  it("renders unlinked WAR reminder rows with a cross and backticked player tag", async () => {
+    prismaMock.warAttacks.findMany.mockResolvedValue([
+      { playerTag: "#PYLQ0289", playerName: "PlayerName", playerPosition: 12, attacksUsed: 1 },
+    ]);
+    prismaMock.currentWar.findFirst.mockResolvedValue({
+      state: "inWar",
+      warId: 9,
+      matchType: "BL",
+      inferredMatchType: false,
+      outcome: null,
+    });
+
+    const contents = await buildReminderDispatchContentsForTest({
+      input: {
+        guildId: "guild-1",
+        channelId: "channel-1",
+        reminderId: "rem-1",
+        type: ReminderType.WAR_CWL,
+        clanTag: "#PYLQ",
+        clanName: "Alpha Clan",
+        offsetSeconds: 3600,
+        eventIdentity: "WAR:war-id:9",
+        eventEndsAt: new Date("2026-04-10T01:00:00.000Z"),
+        eventLabel: "war end",
+      },
+      nowMs: Date.parse("2026-04-10T00:30:00.000Z"),
+      cocService: null,
+    });
+
+    expect(contents[0]).toContain("#12 - ❌ PlayerName `#PYLQ0289` - 1 / 2");
+    expect(contents[0]).not.toContain("Players With Attacks Remaining:");
+  });
+
+  it.each([
+    {
+      title: "confirmed BL",
+      currentWar: {
+        state: "inWar",
+        warId: 9,
+        matchType: "BL",
+        inferredMatchType: false,
+        outcome: null,
+      },
+      expected: "### BL war ends in 1h ⚫",
+    },
+    {
+      title: "confirmed MM",
+      currentWar: {
+        state: "inWar",
+        warId: 9,
+        matchType: "MM",
+        inferredMatchType: false,
+        outcome: null,
+      },
+      expected: "### MM war ends in 1h ⚪",
+    },
+    {
+      title: "confirmed FWA-WIN",
+      currentWar: {
+        state: "inWar",
+        warId: 9,
+        matchType: "FWA",
+        inferredMatchType: false,
+        outcome: "WIN",
+      },
+      expected: "### FWA-WIN war ends in 1h 🟢",
+    },
+    {
+      title: "confirmed FWA-LOSE",
+      currentWar: {
+        state: "inWar",
+        warId: 9,
+        matchType: "FWA",
+        inferredMatchType: false,
+        outcome: "LOSE",
+      },
+      expected: "### FWA-LOSE war ends in 1h 🔴",
+    },
+    {
+      title: "unconfirmed war",
+      currentWar: {
+        state: "inWar",
+        warId: 9,
+        matchType: "BL",
+        inferredMatchType: true,
+        outcome: null,
+      },
+      expected: "### War ends in 1h",
+    },
+  ])("renders the $title header variant", async ({ currentWar, expected }) => {
+    prismaMock.currentWar.findFirst.mockResolvedValue(currentWar);
+    prismaMock.warAttacks.findMany.mockResolvedValue([]);
+
+    const contents = await buildReminderDispatchContentsForTest({
+      input: {
+        guildId: "guild-1",
+        channelId: "channel-1",
+        reminderId: "rem-1",
+        type: ReminderType.WAR_CWL,
+        clanTag: "#PYLQ",
+        clanName: "Header Clan",
+        offsetSeconds: 3600,
+        eventIdentity: "WAR:war-id:9",
+        eventEndsAt: new Date("2026-04-10T01:00:00.000Z"),
+        eventLabel: "war end",
+      },
+      nowMs: Date.parse("2026-04-10T00:30:00.000Z"),
+      cocService: null,
+    });
+
+    expect(contents).toHaveLength(1);
+    expect(contents[0].split("\n")[0]).toBe(expected);
   });
 
   it("ignores stale FwaWarMemberCurrent data when WarAttacks already has the authoritative counts", async () => {
@@ -163,7 +285,7 @@ describe("ReminderDispatchService roster rendering", () => {
     expect(contents[0].split("\n").filter((line) => /^#\d+ /.test(line))).toEqual([
       "#1 - First - <@111> - 2 / 2",
       "#3 - Second - <@111> - 2 / 2",
-      "#2 - :no: Middle - 2 / 2",
+      "#2 - ❌ Middle `#PYLG` - 2 / 2",
     ]);
   });
 
@@ -320,7 +442,7 @@ describe("ReminderDispatchService roster rendering", () => {
     expect(combinedRosterLines).toHaveLength(30);
     expect(
       combinedRosterLines.every((line) =>
-        /^#\d+ - :no: Player_\d{2}_X+ - 2 \/ 2$/.test(line),
+        /^#\d+ - ❌ Player_\d{2}_X+ `#.+` - 2 \/ 2$/.test(line),
       ),
     ).toBe(true);
   });


### PR DESCRIPTION
- use ❌ and backticked tags for unlinked WAR rows
- add confirmed BL/MM/FWA reminder headlines and remove the redundant roster section label