### PR TITLE
feat(compo): migrate advice to db-backed simulated recommendations

### DIFF
--- a/src/commands/Compo.ts
+++ b/src/commands/Compo.ts
@@ -24,6 +24,7 @@ import { normalizeCompoClanDisplayName } from "../helper/compoDisplay";
 import { prisma } from "../prisma";
 import { safeReply } from "../helper/safeReply";
 import { CoCService } from "../services/CoCService";
+import { CompoAdviceService } from "../services/CompoAdviceService";
 import { CompoActualStateService } from "../services/CompoActualStateService";
 import { CompoPlaceService } from "../services/CompoPlaceService";
 import { CompoWarStateService } from "../services/CompoWarStateService";
@@ -31,9 +32,7 @@ import {
   GoogleSheetMode,
   GoogleSheetReadError,
   GoogleSheetReadErrorCode,
-  GoogleSheetsService,
 } from "../services/GoogleSheetsService";
-import { SettingsService } from "../services/SettingsService";
 
 function normalize(value: string): string {
   return value.trim().toLowerCase();
@@ -77,14 +76,11 @@ function readMode(interaction: ChatInputCommandInteraction): GoogleSheetMode {
 }
 
 const COL_CLAN_NAME = 0; // A
-const COL_CLAN_TAG = 1; // B
 const COL_TOTAL_WEIGHT = 3; // D
 const COL_MISSING_WEIGHT = 20; // U
 const COL_TOTAL_PLAYERS = 21; // V
 const COL_BUCKET_START = 22; // W (was 21 / V)
 const COL_BUCKET_END = 27; // AB (was 26 / AA)
-const COL_ADJUSTMENT = 54; // BC (was 53 / BB)
-const FIXED_LAYOUT_RANGE = "AllianceDashboard!A6:BE500";
 const FIXED_LAYOUT_RANGE_START_ROW = 6;
 const STATE_HEADERS = [
   "Clan",
@@ -126,9 +122,30 @@ type CompoRefreshPayload =
       actualView: CompoActualStateView;
     }
   | {
+      kind: "advice";
+      userId: string;
+      mode: "war";
+      targetTag: string;
+    }
+  | {
+      kind: "advice";
+      userId: string;
+      mode: "actual";
+      actualView: CompoActualStateView;
+      targetTag: string;
+    }
+  | {
       kind: "view";
       userId: string;
+      target: "state";
       actualView: CompoActualStateView;
+    }
+  | {
+      kind: "view";
+      userId: string;
+      target: "advice";
+      actualView: CompoActualStateView;
+      targetTag: string;
     }
   | {
       kind: "place";
@@ -143,8 +160,17 @@ function buildCompoRefreshCustomId(payload: CompoRefreshPayload): string {
     }
     return `${COMPO_REFRESH_PREFIX}:state:${payload.userId}:war`;
   }
+  if (payload.kind === "advice") {
+    if (payload.mode === "actual") {
+      return `${COMPO_REFRESH_PREFIX}:advice:${payload.userId}:actual:${payload.actualView}:${payload.targetTag}`;
+    }
+    return `${COMPO_REFRESH_PREFIX}:advice:${payload.userId}:war:${payload.targetTag}`;
+  }
   if (payload.kind === "view") {
-    return `${COMPO_REFRESH_PREFIX}:view:${payload.userId}:${payload.actualView}`;
+    if (payload.target === "advice") {
+      return `${COMPO_REFRESH_PREFIX}:view:${payload.userId}:advice:${payload.actualView}:${payload.targetTag}`;
+    }
+    return `${COMPO_REFRESH_PREFIX}:view:${payload.userId}:state:${payload.actualView}`;
   }
   return `${COMPO_REFRESH_PREFIX}:place:${payload.userId}:${Math.trunc(payload.weight)}`;
 }
@@ -183,16 +209,63 @@ function parseCompoRefreshCustomId(
     }
     return null;
   }
-  if (kind === "view" && parts.length === 4) {
-    const actualView = parts[3];
+  if (kind === "advice") {
+    const mode = parts[3];
+    if (mode === "war" && parts.length === 5) {
+      const targetTag = normalizeTag(parts[4] ?? "");
+      if (!targetTag) return null;
+      return {
+        kind: "advice",
+        userId,
+        mode,
+        targetTag,
+      };
+    }
+    if (mode === "actual" && parts.length === 6) {
+      const actualView = parts[4];
+      const targetTag = normalizeTag(parts[5] ?? "");
+      if (
+        !targetTag ||
+        !COMPO_ACTUAL_STATE_VIEWS.includes(actualView as CompoActualStateView)
+      ) {
+        return null;
+      }
+      return {
+        kind: "advice",
+        userId,
+        mode,
+        actualView: actualView as CompoActualStateView,
+        targetTag,
+      };
+    }
+    return null;
+  }
+  if (kind === "view" && parts.length >= 5) {
+    const target = parts[3];
+    const actualView = parts[4];
     if (!COMPO_ACTUAL_STATE_VIEWS.includes(actualView as CompoActualStateView)) {
       return null;
     }
-    return {
-      kind: "view",
-      userId,
-      actualView: actualView as CompoActualStateView,
-    };
+    if (target === "state" && parts.length === 5) {
+      return {
+        kind: "view",
+        userId,
+        target,
+        actualView: actualView as CompoActualStateView,
+      };
+    }
+    if (target === "advice" && parts.length === 6) {
+      const targetTag = normalizeTag(parts[5] ?? "");
+      if (!targetTag) return null;
+      return {
+        kind: "view",
+        userId,
+        target,
+        actualView: actualView as CompoActualStateView,
+        targetTag,
+      };
+    }
+    return null;
   }
   if (kind === "place" && parts.length === 4) {
     const value = parts[3];
@@ -228,25 +301,40 @@ function buildCompoRefreshActionRow(
 
 function buildCompoActualViewActionRow(input: {
   userId: string;
+  target: "state" | "advice";
+  targetTag?: string;
   selectedView: CompoActualStateView;
   loading?: boolean;
 }): ActionRowBuilder<ButtonBuilder> {
   const loading = input.loading ?? false;
   return new ActionRowBuilder<ButtonBuilder>().addComponents(
     COMPO_ACTUAL_STATE_VIEWS.map((view) =>
-      new ButtonBuilder()
-        .setCustomId(
-          buildCompoRefreshCustomId({
-            kind: "view",
-            userId: input.userId,
-            actualView: view,
-          }),
-        )
-        .setLabel(getCompoActualStateViewLabel(view))
-        .setStyle(
-          input.selectedView === view ? ButtonStyle.Primary : ButtonStyle.Secondary,
-        )
-        .setDisabled(loading),
+      (() => {
+        const payload =
+          input.target === "advice"
+            ? {
+                kind: "view" as const,
+                userId: input.userId,
+                target: "advice" as const,
+                actualView: view,
+                targetTag: input.targetTag ?? "",
+              }
+            : {
+                kind: "view" as const,
+                userId: input.userId,
+                target: "state" as const,
+                actualView: view,
+              };
+        return new ButtonBuilder()
+          .setCustomId(buildCompoRefreshCustomId(payload))
+          .setLabel(getCompoActualStateViewLabel(view))
+          .setStyle(
+            input.selectedView === view
+              ? ButtonStyle.Primary
+              : ButtonStyle.Secondary,
+          )
+          .setDisabled(loading);
+      })(),
     ),
   );
 }
@@ -789,7 +877,7 @@ function renderStatePng(
 }
 
 function buildCompoRefreshComponents(input: {
-  refreshPayload: Extract<CompoRefreshPayload, { kind: "state" | "place" }>;
+  refreshPayload: Extract<CompoRefreshPayload, { kind: "state" | "advice" | "place" }>;
   loading: boolean;
   supplementalRows?: Array<
     APIActionRowComponent<APIComponentInMessageActionRow>
@@ -807,6 +895,18 @@ function buildCompoRefreshComponents(input: {
     components.push(
       buildCompoActualViewActionRow({
         userId: input.refreshPayload.userId,
+        target: "state",
+        selectedView: input.refreshPayload.actualView,
+        loading: input.loading,
+      }),
+    );
+  }
+  if (input.refreshPayload.kind === "advice" && input.refreshPayload.mode === "actual") {
+    components.push(
+      buildCompoActualViewActionRow({
+        userId: input.refreshPayload.userId,
+        target: "advice",
+        targetTag: input.refreshPayload.targetTag,
         selectedView: input.refreshPayload.actualView,
         loading: input.loading,
       }),
@@ -836,6 +936,34 @@ function mapCompoPlaceErrorToMessage(action: "load" | "refresh"): string {
     : "Failed to load ACTUAL placement suggestions. Try again in a moment.";
 }
 
+function mapCompoAdviceErrorToMessage(action: "load" | "refresh"): string {
+  return action === "refresh"
+    ? "Failed to refresh DB-backed compo advice. Try again in a moment."
+    : "Failed to load DB-backed compo advice. Try again in a moment.";
+}
+
+function getCompoRefreshFailureMessage(payload: CompoRefreshPayload): string {
+  if (payload.kind === "state" && payload.mode === "war") {
+    return mapCompoWarStateErrorToMessage("refresh");
+  }
+  if (payload.kind === "state") {
+    return mapCompoActualStateErrorToMessage("refresh");
+  }
+  if (payload.kind === "advice") {
+    return mapCompoAdviceErrorToMessage("refresh");
+  }
+  if (payload.kind === "view" && payload.target === "advice") {
+    return mapCompoAdviceErrorToMessage("refresh");
+  }
+  if (payload.kind === "view") {
+    return mapCompoActualStateErrorToMessage("refresh");
+  }
+  if (payload.kind === "place") {
+    return mapCompoPlaceErrorToMessage("refresh");
+  }
+  return "Failed to refresh compo view. Try again in a moment.";
+}
+
 export async function handleCompoRefreshButton(
   interaction: ButtonInteraction,
   _cocService: CoCService,
@@ -859,14 +987,25 @@ export async function handleCompoRefreshButton(
   }
 
   const supplementalRows = extractSupplementalRowsFromMessage(interaction);
-  const loadingRefreshPayload: Extract<CompoRefreshPayload, { kind: "state" | "place" }> =
+  const loadingRefreshPayload: Extract<
+    CompoRefreshPayload,
+    { kind: "state" | "advice" | "place" }
+  > =
     parsed.kind === "view"
-      ? {
-          kind: "state",
-          userId: parsed.userId,
-          mode: "actual",
-          actualView: parsed.actualView,
-        }
+      ? parsed.target === "advice"
+        ? {
+            kind: "advice",
+            userId: parsed.userId,
+            mode: "actual",
+            actualView: parsed.actualView,
+            targetTag: parsed.targetTag,
+          }
+        : {
+            kind: "state",
+            userId: parsed.userId,
+            mode: "actual",
+            actualView: parsed.actualView,
+          }
       : parsed;
   await interaction.update({
     components: buildCompoRefreshComponents({
@@ -921,33 +1060,76 @@ export async function handleCompoRefreshButton(
       return;
     }
 
-    if (parsed.kind === "view") {
-      const actualState = await new CompoActualStateService().readState(
-        interaction.guildId ?? null,
-        {
-          view: parsed.actualView,
-        },
-      );
-      const payload = actualState.stateRows
-        ? buildCompoStatePayloadFromRows({
-            mode: "actual",
-            stateRows: actualState.stateRows,
-            contentLines: actualState.contentLines,
-            titleLabel: getCompoActualStateViewLabel(
-              actualState.view ?? "raw",
-            ).toUpperCase(),
-          })
-        : {
-            content: actualState.contentLines.join("\n"),
-          };
+    if (parsed.kind === "advice") {
+      const adviceService = new CompoAdviceService();
+      const advice = await adviceService.refreshAdvice({
+        guildId: interaction.guildId ?? null,
+        targetTag: parsed.targetTag,
+        mode: parsed.mode,
+        view: parsed.mode === "actual" ? parsed.actualView : "raw",
+      });
       await interaction.editReply({
-        ...payload,
+        content: advice.content,
+        components: buildCompoRefreshComponents({
+          refreshPayload: parsed,
+          loading: false,
+          supplementalRows,
+        }),
+      });
+      return;
+    }
+
+    if (parsed.kind === "view") {
+      if (parsed.target === "state") {
+        const actualState = await new CompoActualStateService().readState(
+          interaction.guildId ?? null,
+          {
+            view: parsed.actualView,
+          },
+        );
+        const payload = actualState.stateRows
+          ? buildCompoStatePayloadFromRows({
+              mode: "actual",
+              stateRows: actualState.stateRows,
+              contentLines: actualState.contentLines,
+              titleLabel: getCompoActualStateViewLabel(
+                actualState.view ?? "raw",
+              ).toUpperCase(),
+            })
+          : {
+              content: actualState.contentLines.join("\n"),
+            };
+        await interaction.editReply({
+          ...payload,
+          components: buildCompoRefreshComponents({
+            refreshPayload: {
+              kind: "state",
+              userId: parsed.userId,
+              mode: "actual",
+              actualView: parsed.actualView,
+            },
+            loading: false,
+            supplementalRows,
+          }),
+        });
+        return;
+      }
+
+      const advice = await new CompoAdviceService().readAdvice({
+        guildId: interaction.guildId ?? null,
+        targetTag: parsed.targetTag,
+        mode: "actual",
+        view: parsed.actualView,
+      });
+      await interaction.editReply({
+        content: advice.content,
         components: buildCompoRefreshComponents({
           refreshPayload: {
-            kind: "state",
+            kind: "advice",
             userId: parsed.userId,
             mode: "actual",
             actualView: parsed.actualView,
+            targetTag: parsed.targetTag,
           },
           loading: false,
           supplementalRows,
@@ -989,14 +1171,7 @@ export async function handleCompoRefreshButton(
     });
     await interaction.followUp({
       ephemeral: true,
-      content:
-        parsed.kind === "state" && parsed.mode === "war"
-          ? mapCompoWarStateErrorToMessage("refresh")
-          : parsed.kind === "state"
-            ? mapCompoActualStateErrorToMessage("refresh")
-          : parsed.kind === "place"
-            ? mapCompoPlaceErrorToMessage("refresh")
-            : "Failed to refresh compo view. Try again in a moment.",
+      content: getCompoRefreshFailureMessage(parsed),
     });
   }
 }
@@ -1083,100 +1258,44 @@ export const Compo: Command = {
         const tagInput = interaction.options.getString("tag", true);
         const targetTag = normalizeTag(tagInput);
         logCompoStage(interaction, "computation_start", { targetTag, mode });
-
-        const settings = new SettingsService();
-        const sheets = new GoogleSheetsService(settings);
-        const linked = await sheets.getCompoLinkedSheet(FIXED_LAYOUT_RANGE);
-        logCompoStage(interaction, "db_fetch", {
-          entity: "sheet_link",
+        const adviceService = new CompoAdviceService();
+        const advice = await adviceService.readAdvice({
+          guildId: interaction.guildId ?? null,
+          targetTag,
           mode,
-          result: linked.sheetId ? "found" : "missing",
-          sheetIdPresent: Boolean(linked.sheetId),
-          resolutionSource: linked.source,
         });
-        logCompoStage(interaction, "read_dispatch", {
-          range: FIXED_LAYOUT_RANGE,
-          resolutionSource: linked.source,
-        });
-        const rows = await sheets.readCompoLinkedValues(
-          FIXED_LAYOUT_RANGE,
-          linked,
-        );
-        const modeRows = getModeRows(rows, mode);
         logCompoStage(interaction, "db_fetch", {
-          entity: "sheet_rows",
+          entity: mode === "war" ? "tracked_war_advice_source" : "actual_compo_advice_source",
           mode,
-          result: rows.length > 0 ? "found" : "missing",
-          totalRows: rows.length,
-          modeRows: modeRows.length,
+          trackedClans: advice.trackedClanTags.length,
         });
-
-        if (modeRows.length === 0) {
-          logCompoStage(interaction, "response_build", {
-            reason: "no_mode_rows",
-          });
-          await safeReply(interaction, {
-            ephemeral: !isPublic,
-            content: `No ${mode.toUpperCase()} rows found in ${FIXED_LAYOUT_RANGE}.`,
-          });
-          logCompoStage(interaction, "response_sent", {
-            reason: "no_mode_rows",
-          });
-          return;
-        }
-
-        for (const modeRow of modeRows) {
-          const row = modeRow.row;
-          const clanName = String(row[COL_CLAN_NAME] ?? "").trim();
-          const displayClanName = normalizeCompoClanDisplayName(clanName);
-          const clanTag = normalizeTag(String(row[COL_CLAN_TAG] ?? ""));
-          const advice = String(row[COL_ADJUSTMENT] ?? "").trim();
-          if (!clanName || !clanTag) continue;
-
-          if (clanTag === targetTag) {
-            logCompoStage(interaction, "computation_complete", {
-              result: "target_found",
-              clanTag,
-            });
-            logCompoStage(interaction, "response_build", {
-              reason: "target_found",
-            });
-            await safeReply(interaction, {
-              ephemeral: !isPublic,
-              content:
-                advice && advice.length > 0
-                  ? `Mode: **${mode.toUpperCase()}**\n**${displayClanName}** (\`#${clanTag}\`) adjustment:\n${advice}`
-                  : `Mode: **${mode.toUpperCase()}**\nFound **${displayClanName}** (\`#${clanTag}\`), but there is no adjustment text in column BC.`,
-            });
-            logCompoStage(interaction, "response_sent", {
-              reason: "target_found",
-            });
-            return;
-          }
-        }
-
-        const knownTags = modeRows
-          .map((modeRow) =>
-            normalizeTag(String(modeRow.row[COL_CLAN_TAG] ?? "")),
-          )
-          .filter((tag): tag is string => Boolean(tag));
         logCompoStage(interaction, "computation_complete", {
-          result: "target_missing",
-          knownTags: knownTags.length,
+          result: "advice_rendered",
+          mode,
         });
-
-        logCompoStage(interaction, "response_build", {
-          reason: "target_missing",
-        });
-        await safeReply(interaction, {
-          ephemeral: !isPublic,
-          content:
-            knownTags.length > 0
-              ? `Mode: **${mode.toUpperCase()}**\nNo adjustment mapping found for tag \`#${targetTag}\`. Known tags in this mode: ${knownTags.map((t) => `#${t}`).join(", ")}`
-              : `Mode: **${mode.toUpperCase()}**\nNo adjustment mapping found for tag \`#${targetTag}\`.`,
+        await interaction.editReply({
+          content: advice.content,
+          components: buildCompoRefreshComponents({
+            refreshPayload:
+              mode === "actual"
+                ? {
+                    kind: "advice",
+                    userId: interaction.user.id,
+                    mode: "actual",
+                    actualView: advice.selectedView,
+                    targetTag,
+                  }
+                : {
+                    kind: "advice",
+                    userId: interaction.user.id,
+                    mode: "war",
+                    targetTag,
+                  },
+            loading: false,
+          }),
         });
         logCompoStage(interaction, "response_sent", {
-          reason: "target_missing",
+          reason: "advice_rendered",
         });
         return;
       }
@@ -1389,9 +1508,11 @@ export const Compo: Command = {
             ? mapCompoWarStateErrorToMessage("load")
             : getSubcommandSafe(interaction) === "state"
               ? mapCompoActualStateErrorToMessage("load")
-            : getSubcommandSafe(interaction) === "place"
-              ? mapCompoPlaceErrorToMessage("load")
-              : mapCompoSheetErrorToMessage(err),
+              : getSubcommandSafe(interaction) === "place"
+                ? mapCompoPlaceErrorToMessage("load")
+                : getSubcommandSafe(interaction) === "advice"
+                  ? mapCompoAdviceErrorToMessage("load")
+                  : mapCompoSheetErrorToMessage(err),
       });
       logCompoStage(interaction, "response_sent", { reason: "run_catch" });
     }

--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -187,7 +187,8 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
   compo: {
     summary: "Composition tools with DB-backed WAR state plus DB-backed ACTUAL state/place flows.",
     details: [
-      "`advice`: fetch clan-specific adjustment notes from the existing sheet-backed flow.",
+      "`advice`: simulate bucket-level compo moves from DB-backed ACTUAL or WAR state and recommend the best improvement.",
+      "`advice` ACTUAL mode defaults to `Auto-Detect Band` and can be switched between `Raw Data`, `Auto-Detect Band`, and `Best Fit` with inline buttons.",
       "`state`: `mode:war` renders from persisted tracked-clan feed state only, while `mode:actual` now renders from persisted ACTUAL current-member state (`TrackedClan` + `FwaClanMemberCurrent` + `HeatMapRef`) with deferred-weight and WAR-effective-weight fallback when member weight is zero.",
       "`state` refresh: `mode:war` refreshes tracked-clan war-roster feed state only and rerenders from DB; `mode:actual` now refreshes ACTUAL current-member/weight state plus live CoC member counts for all tracked clans, then rerenders from DB.",
       "`place`: suggest placement by war weight from persisted ACTUAL FWAStats current-member state (`TrackedClan` + `FwaClanMemberCurrent` + `HeatMapRef`) with deferred-weight and WAR-effective-weight fallback only for zero-weight member rows.",
@@ -195,6 +196,7 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
     ],
     examples: [
       "/compo advice tag:#2QG2C08UP mode:actual",
+      "/compo advice tag:#2QG2C08UP mode:war",
       "/compo state mode:war",
       "/compo place weight:145k",
     ],

--- a/src/helper/compoActualStateView.ts
+++ b/src/helper/compoActualStateView.ts
@@ -144,6 +144,22 @@ function buildDeltaByBucket(
   };
 }
 
+/** Purpose: compute the spreadsheet-style weighted deviation score for one projected ACTUAL or WAR display state. */
+export function calculateCompoDeviationScore(input: {
+  displayCounts: CompoWarDisplayBucketCounts;
+  heatMapRef: HeatMapRef | null;
+}): number | null {
+  if (!input.heatMapRef) {
+    return null;
+  }
+
+  const deltaByBucket = buildDeltaByBucket(input.displayCounts, input.heatMapRef);
+  return DISPLAY_BUCKETS_ASC.reduce((sum, bucket) => {
+    const delta = deltaByBucket[bucket];
+    return sum + Math.abs(delta ?? 0) * DEVIATION_SCORE_WEIGHTS[bucket];
+  }, 0);
+}
+
 function getRepresentativeWeight(
   bucket: CompoWarDisplayBucket,
   heatMapRef: HeatMapRef | null,
@@ -167,6 +183,14 @@ function getRepresentativeWeight(
   return countTotal > 0
     ? Math.round(weightTotal / countTotal)
     : LOW_BUCKET_DEFAULT_REPRESENTATIVE_WEIGHT;
+}
+
+/** Purpose: estimate one representative total-weight delta for a displayed ACTUAL/WAR bucket. */
+export function getCompoDisplayBucketRepresentativeWeight(
+  bucket: CompoWarDisplayBucket,
+  heatMapRef: HeatMapRef | null,
+): number {
+  return getRepresentativeWeight(bucket, heatMapRef);
 }
 
 function addDisplayCounts(
@@ -273,10 +297,10 @@ function buildEstimatedProjectionForBand(input: {
     estimatedDisplayCounts,
     input.heatMapRef,
   );
-  const deviationScore = DISPLAY_BUCKETS_ASC.reduce((sum, bucket) => {
-    const delta = deltaByBucket[bucket];
-    return sum + Math.abs(delta ?? 0) * DEVIATION_SCORE_WEIGHTS[bucket];
-  }, 0);
+  const deviationScore = calculateCompoDeviationScore({
+    displayCounts: estimatedDisplayCounts,
+    heatMapRef: input.heatMapRef,
+  });
 
   return {
     view: input.view,

--- a/src/helper/compoAdviceEngine.ts
+++ b/src/helper/compoAdviceEngine.ts
@@ -1,0 +1,432 @@
+import type { HeatMapRef } from "@prisma/client";
+import {
+  calculateCompoDeviationScore,
+  getCompoActualStateViewLabel,
+  getCompoDisplayBucketRepresentativeWeight,
+  projectCompoActualStateView,
+  type CompoActualStateBaseMetrics,
+  type CompoActualStateProjection,
+  type CompoActualStateView,
+} from "./compoActualStateView";
+import {
+  formatHeatMapRefBandLabel,
+  getHeatMapRefBandMidpoint,
+} from "./compoHeatMap";
+import {
+  type CompoWarBucketCounts,
+} from "./compoWarBucketCounts";
+import type { CompoWarDisplayBucket } from "./compoWarWeightBuckets";
+
+export const COMPO_ADVICE_DISPLAY_BUCKETS: readonly CompoWarDisplayBucket[] = [
+  "TH18",
+  "TH17",
+  "TH16",
+  "TH15",
+  "TH14",
+  "<=TH13",
+];
+
+const COMPO_ADVICE_BUCKET_PRIORITY: Record<CompoWarDisplayBucket, number> = {
+  TH18: 0,
+  TH17: 1,
+  TH16: 2,
+  TH15: 3,
+  TH14: 4,
+  "<=TH13": 5,
+};
+
+const DISPLAY_BUCKET_TO_GRANULAR_BUCKET: Record<
+  CompoWarDisplayBucket,
+  keyof CompoWarBucketCounts
+> = {
+  TH18: "TH18",
+  TH17: "TH17",
+  TH16: "TH16",
+  TH15: "TH15",
+  TH14: "TH14",
+  "<=TH13": "TH13",
+};
+
+export type CompoAdviceMode = "actual" | "war";
+
+export type CompoAdviceAction =
+  | {
+      kind: "add";
+      incomingBucket: CompoWarDisplayBucket;
+    }
+  | {
+      kind: "swap";
+      outgoingBucket: CompoWarDisplayBucket;
+      incomingBucket: CompoWarDisplayBucket;
+    };
+
+export type CompoAdviceEvaluation = {
+  action: CompoAdviceAction;
+  description: string;
+  beforeProjection: CompoActualStateProjection;
+  afterProjection: CompoActualStateProjection;
+  currentScore: number | null;
+  resultingScore: number | null;
+  scoreImprovement: number | null;
+  bandFitDistance: number;
+  totalWeightJump: number;
+  incomingPriority: number;
+  outgoingPriority: number;
+};
+
+export type CompoAdviceSummary = {
+  mode: CompoAdviceMode;
+  view: CompoActualStateView;
+  viewLabel: string;
+  currentProjection: CompoActualStateProjection;
+  currentScore: number | null;
+  currentBandLabel: string;
+  recommendationText: string;
+  resultingScore: number | null;
+  resultingBandLabel: string;
+  alternateTexts: string[];
+  statusText: string | null;
+};
+
+function normalizeScore(value: number | null): number {
+  return value === null ? Number.POSITIVE_INFINITY : value;
+}
+
+function formatScore(value: number | null): string {
+  if (value === null) {
+    return "n/a";
+  }
+  return Number.isInteger(value) ? `${value}` : value.toFixed(1);
+}
+
+function getBandLabel(ref: HeatMapRef | null): string {
+  return ref ? formatHeatMapRefBandLabel(ref) : "(no band)";
+}
+
+function getDisplayBucketPriority(bucket: CompoWarDisplayBucket): number {
+  return COMPO_ADVICE_BUCKET_PRIORITY[bucket];
+}
+
+function buildAdviceActionDescription(action: CompoAdviceAction): string {
+  if (action.kind === "add") {
+    return `Add ${action.incomingBucket}`;
+  }
+  return `Replace one ${action.outgoingBucket} with one ${action.incomingBucket}`;
+}
+
+function cloneBucketCounts(
+  counts: CompoWarBucketCounts,
+): CompoWarBucketCounts {
+  return { ...counts };
+}
+
+function applyAdviceActionToBase(input: {
+  base: CompoActualStateBaseMetrics;
+  action: CompoAdviceAction;
+  referenceHeatMapRef: HeatMapRef | null;
+}): CompoActualStateBaseMetrics {
+  const bucketCounts = cloneBucketCounts(input.base.bucketCounts);
+  let resolvedTotalWeight = input.base.resolvedTotalWeight;
+  let memberCount = input.base.memberCount;
+
+  const incomingGranularBucket =
+    DISPLAY_BUCKET_TO_GRANULAR_BUCKET[input.action.incomingBucket];
+  const outgoingGranularBucket =
+    input.action.kind === "swap"
+      ? DISPLAY_BUCKET_TO_GRANULAR_BUCKET[input.action.outgoingBucket]
+      : null;
+
+  if (input.action.kind === "add") {
+    bucketCounts[incomingGranularBucket] += 1;
+    resolvedTotalWeight += getCompoDisplayBucketRepresentativeWeight(
+      input.action.incomingBucket,
+      input.referenceHeatMapRef,
+    );
+    memberCount += 1;
+  } else {
+    bucketCounts[outgoingGranularBucket!] -= 1;
+    bucketCounts[incomingGranularBucket] += 1;
+    resolvedTotalWeight +=
+      getCompoDisplayBucketRepresentativeWeight(
+        input.action.incomingBucket,
+        input.referenceHeatMapRef,
+      ) -
+      getCompoDisplayBucketRepresentativeWeight(
+        input.action.outgoingBucket,
+        input.referenceHeatMapRef,
+      );
+  }
+
+  return {
+    resolvedTotalWeight,
+    unresolvedWeightCount: input.base.unresolvedWeightCount,
+    memberCount,
+    bucketCounts,
+  };
+}
+
+function projectAdviceState(input: {
+  view: CompoActualStateView;
+  base: CompoActualStateBaseMetrics;
+  heatMapRefs: readonly HeatMapRef[];
+}): CompoActualStateProjection {
+  const projection = projectCompoActualStateView({
+    view: input.view,
+    base: input.base,
+    heatMapRefs: input.heatMapRefs,
+  });
+
+  if (projection.deviationScore !== null || !projection.selectedHeatMapRef) {
+    return projection;
+  }
+
+  return {
+    ...projection,
+    deviationScore: calculateCompoDeviationScore({
+      displayCounts: projection.displayCounts,
+      heatMapRef: projection.selectedHeatMapRef,
+    }),
+  };
+}
+
+function evaluateAdviceAction(input: {
+  view: CompoActualStateView;
+  base: CompoActualStateBaseMetrics;
+  heatMapRefs: readonly HeatMapRef[];
+  currentProjection: CompoActualStateProjection;
+  currentScore: number | null;
+  action: CompoAdviceAction;
+}): CompoAdviceEvaluation {
+  const nextBase = applyAdviceActionToBase({
+    base: input.base,
+    action: input.action,
+    referenceHeatMapRef: input.currentProjection.selectedHeatMapRef,
+  });
+  const afterProjection = projectAdviceState({
+    view: input.view,
+    base: nextBase,
+    heatMapRefs: input.heatMapRefs,
+  });
+  const resultingScore = afterProjection.deviationScore;
+  const scoreImprovement =
+    input.currentScore !== null && resultingScore !== null
+      ? input.currentScore - resultingScore
+      : null;
+  const bandFitDistance = afterProjection.selectedHeatMapRef
+    ? Math.abs(
+        afterProjection.totalWeight -
+          getHeatMapRefBandMidpoint(afterProjection.selectedHeatMapRef),
+      )
+    : Number.POSITIVE_INFINITY;
+
+  return {
+    action: input.action,
+    description: buildAdviceActionDescription(input.action),
+    beforeProjection: input.currentProjection,
+    afterProjection,
+    currentScore: input.currentScore,
+    resultingScore,
+    scoreImprovement,
+    bandFitDistance,
+    totalWeightJump: Math.abs(
+      afterProjection.totalWeight - input.currentProjection.totalWeight,
+    ),
+    incomingPriority: getDisplayBucketPriority(input.action.incomingBucket),
+    outgoingPriority:
+      input.action.kind === "swap"
+        ? getDisplayBucketPriority(input.action.outgoingBucket)
+        : Number.POSITIVE_INFINITY,
+  };
+}
+
+function compareEvaluations(
+  left: CompoAdviceEvaluation,
+  right: CompoAdviceEvaluation,
+): number {
+  const leftImprovement = left.scoreImprovement ?? Number.NEGATIVE_INFINITY;
+  const rightImprovement = right.scoreImprovement ?? Number.NEGATIVE_INFINITY;
+  if (leftImprovement !== rightImprovement) {
+    return rightImprovement - leftImprovement;
+  }
+
+  const leftResultingScore = normalizeScore(left.resultingScore);
+  const rightResultingScore = normalizeScore(right.resultingScore);
+  if (leftResultingScore !== rightResultingScore) {
+    return leftResultingScore - rightResultingScore;
+  }
+
+  if (left.bandFitDistance !== right.bandFitDistance) {
+    return left.bandFitDistance - right.bandFitDistance;
+  }
+
+  if (left.incomingPriority !== right.incomingPriority) {
+    return left.incomingPriority - right.incomingPriority;
+  }
+
+  if (left.totalWeightJump !== right.totalWeightJump) {
+    return left.totalWeightJump - right.totalWeightJump;
+  }
+
+  if (left.outgoingPriority !== right.outgoingPriority) {
+    return left.outgoingPriority - right.outgoingPriority;
+  }
+
+  return left.description.localeCompare(right.description);
+}
+
+function generateAdviceActions(input: {
+  base: CompoActualStateBaseMetrics;
+  currentProjection: CompoActualStateProjection;
+}): CompoAdviceAction[] {
+  if (input.base.memberCount < 50) {
+    return [...COMPO_ADVICE_DISPLAY_BUCKETS].map((incomingBucket) => ({
+      kind: "add" as const,
+      incomingBucket,
+    }));
+  }
+
+  const positiveBuckets = COMPO_ADVICE_DISPLAY_BUCKETS.filter(
+    (bucket) => (input.currentProjection.deltaByBucket[bucket] ?? 0) > 0,
+  );
+  const negativeBuckets = COMPO_ADVICE_DISPLAY_BUCKETS.filter(
+    (bucket) => (input.currentProjection.deltaByBucket[bucket] ?? 0) < 0,
+  );
+
+  const actions: CompoAdviceAction[] = [];
+  for (const outgoingBucket of positiveBuckets) {
+    for (const incomingBucket of negativeBuckets) {
+      actions.push({
+        kind: "swap",
+        outgoingBucket,
+        incomingBucket,
+      });
+    }
+  }
+  return actions;
+}
+
+export function evaluateCompoAdvice(input: {
+  mode: CompoAdviceMode;
+  view: CompoActualStateView;
+  base: CompoActualStateBaseMetrics;
+  heatMapRefs: readonly HeatMapRef[];
+}): CompoAdviceSummary {
+  const currentProjection = projectAdviceState({
+    view: input.view,
+    base: input.base,
+    heatMapRefs: input.heatMapRefs,
+  });
+  const currentScore = currentProjection.deviationScore;
+  const currentBandLabel = getBandLabel(currentProjection.selectedHeatMapRef);
+  const actions = generateAdviceActions({
+    base: input.base,
+    currentProjection,
+  });
+  const evaluations = actions
+    .map((action) =>
+      evaluateAdviceAction({
+        view: input.view,
+        base: input.base,
+        heatMapRefs: input.heatMapRefs,
+        currentProjection,
+        currentScore,
+        action,
+      }),
+    )
+    .sort(compareEvaluations);
+
+  const best = evaluations[0] ?? null;
+  const isImproving = (best?.scoreImprovement ?? Number.NEGATIVE_INFINITY) > 0;
+  const isNeutral = (best?.scoreImprovement ?? Number.NEGATIVE_INFINITY) === 0;
+  const recommendationText =
+    best && (isImproving || isNeutral)
+      ? best.description
+      : "No improvement found.";
+  const resultingScore =
+    best && (isImproving || isNeutral) ? best.resultingScore : null;
+  const resultingBandLabel =
+    best && (isImproving || isNeutral)
+      ? getBandLabel(best.afterProjection.selectedHeatMapRef)
+      : "(no band)";
+  const alternateTexts =
+    best && (isImproving || isNeutral)
+      ? evaluations.slice(1, 3).map((evaluation) => evaluation.description)
+      : [];
+
+  return {
+    mode: input.mode,
+    view: input.view,
+    viewLabel: getCompoActualStateViewLabel(input.view),
+    currentProjection,
+    currentScore,
+    currentBandLabel,
+    recommendationText,
+    resultingScore,
+    resultingBandLabel,
+    alternateTexts,
+    statusText:
+      best && (isImproving || isNeutral)
+        ? isNeutral
+          ? "No improvement found."
+          : null
+        : "No improvement found.",
+  };
+}
+
+export function buildCompoAdviceContentLines(input: {
+  summary: CompoAdviceSummary;
+  modeLabel: string;
+  refreshLine: string | null;
+}): string[] {
+  const lines: string[] = [];
+  if (input.refreshLine) {
+    lines.push(input.refreshLine);
+  }
+  lines.push(`Mode: **${input.modeLabel}**`);
+  lines.push(`Advice View: **${input.summary.viewLabel}**`);
+  lines.push(`Current Score: **${formatScore(input.summary.currentScore)}**`);
+  lines.push(`Current Band: **${input.summary.currentBandLabel}**`);
+  lines.push(`Recommendation: **${input.summary.recommendationText}**`);
+  lines.push(`Resulting Score: **${formatScore(input.summary.resultingScore)}**`);
+  lines.push(`Resulting Band: **${input.summary.resultingBandLabel}**`);
+  if (input.summary.statusText) {
+    lines.push(input.summary.statusText);
+  }
+  if (input.summary.alternateTexts.length > 0) {
+    lines.push("Alternates:");
+    for (const alternate of input.summary.alternateTexts) {
+      lines.push(`- ${alternate}`);
+    }
+  }
+  return lines;
+}
+
+export function buildWarAdviceSummary(input: {
+  base: CompoActualStateBaseMetrics;
+  heatMapRefs: readonly HeatMapRef[];
+}): CompoAdviceSummary {
+  return evaluateCompoAdvice({
+    mode: "war",
+    view: "raw",
+    base: input.base,
+    heatMapRefs: input.heatMapRefs,
+  });
+}
+
+export function buildActualAdviceSummary(input: {
+  base: CompoActualStateBaseMetrics;
+  heatMapRefs: readonly HeatMapRef[];
+  view: CompoActualStateView;
+}): CompoAdviceSummary {
+  return evaluateCompoAdvice({
+    mode: "actual",
+    view: input.view,
+    base: input.base,
+    heatMapRefs: input.heatMapRefs,
+  });
+}
+
+export const getCompoAdviceActionLabelForTest = buildAdviceActionDescription;
+export const applyAdviceActionToBaseForTest = applyAdviceActionToBase;
+export const evaluateAdviceActionForTest = evaluateAdviceAction;
+export const compareEvaluationsForTest = compareEvaluations;

--- a/src/helper/compoHeatMap.ts
+++ b/src/helper/compoHeatMap.ts
@@ -26,6 +26,13 @@ export function getHeatMapRefBandMidpoint(
   return (ref.weightMinInclusive + ref.weightMaxInclusive) / 2;
 }
 
+/** Purpose: render one HeatMapRef band in a compact, user-facing range format. */
+export function formatHeatMapRefBandLabel(
+  ref: Pick<HeatMapRef, "weightMinInclusive" | "weightMaxInclusive">,
+): string {
+  return `${ref.weightMinInclusive.toLocaleString("en-US")} - ${ref.weightMaxInclusive.toLocaleString("en-US")}`;
+}
+
 /** Purpose: bound HeatMapRef candidate scans to bands that intersect one possible total-weight window. */
 export function listHeatMapRefsIntersectingWeightWindow(
   refs: readonly HeatMapRef[],

--- a/src/services/CompoActualStateService.ts
+++ b/src/services/CompoActualStateService.ts
@@ -1,4 +1,5 @@
 import type {
+  HeatMapRef,
   FwaClanMemberCurrent,
   FwaTrackedClanWarRosterMemberCurrent,
   TrackedClan,
@@ -10,6 +11,7 @@ import {
 import {
   getCompoActualStateViewLabel,
   projectCompoActualStateView,
+  type CompoActualStateBaseMetrics,
   type CompoActualStateProjection,
   type CompoActualStateView,
 } from "../helper/compoActualStateView";
@@ -36,6 +38,20 @@ type WarFallbackRow = Pick<
   FwaTrackedClanWarRosterMemberCurrent,
   "clanTag" | "playerTag" | "effectiveWeight" | "updatedAt"
 >;
+
+export type CompoActualStateClanContext = {
+  clanTag: string;
+  clanName: string;
+  base: CompoActualStateBaseMetrics;
+};
+
+export type CompoActualStateContext = {
+  trackedClanTags: string[];
+  renderableClanTags: string[];
+  latestSourceSyncedAt: Date | null;
+  heatMapRefs: HeatMapRef[];
+  clans: CompoActualStateClanContext[];
+};
 
 export type CompoActualStateReadResult = {
   stateRows: string[][] | null;
@@ -140,6 +156,170 @@ function buildActualViewSummaryLines(
   return contentLines;
 }
 
+/** Purpose: load the persisted ACTUAL compo state snapshot used by both state rendering and advice simulation. */
+export async function loadCompoActualStateContext(
+  guildId?: string | null,
+): Promise<CompoActualStateContext> {
+  const tracked = await prisma.trackedClan.findMany({
+    orderBy: { createdAt: "asc" },
+    select: { tag: true, name: true },
+  });
+  const trackedClanTags = tracked
+    .map((clan) => normalizeTag(clan.tag))
+    .filter((tag): tag is string => Boolean(tag));
+
+  if (trackedClanTags.length === 0) {
+    return {
+      trackedClanTags: [],
+      renderableClanTags: [],
+      latestSourceSyncedAt: null,
+      heatMapRefs: [],
+      clans: [],
+    };
+  }
+
+  const [members, heatMapRefs] = await Promise.all([
+    prisma.fwaClanMemberCurrent.findMany({
+      where: { clanTag: { in: trackedClanTags } },
+      select: {
+        clanTag: true,
+        playerTag: true,
+        weight: true,
+        sourceSyncedAt: true,
+      },
+      orderBy: [{ clanTag: "asc" }, { sourceSyncedAt: "desc" }, { playerTag: "asc" }],
+    }),
+    prisma.heatMapRef.findMany({
+      orderBy: [{ weightMinInclusive: "asc" }, { weightMaxInclusive: "asc" }],
+    }),
+  ]);
+
+  const membersByClanTag = new Map<string, CurrentMemberRow[]>();
+  const allPlayerTags = new Set<string>();
+  let latestSourceSyncedAt: Date | null = null;
+  for (const member of members) {
+    const clanTag = normalizeTag(member.clanTag);
+    const playerTag = normalizePlayerTag(member.playerTag);
+    if (!clanTag || !playerTag) continue;
+    allPlayerTags.add(playerTag);
+    const existing = membersByClanTag.get(clanTag) ?? [];
+    existing.push({
+      ...member,
+      clanTag,
+      playerTag,
+    });
+    membersByClanTag.set(clanTag, existing);
+    if (
+      !latestSourceSyncedAt ||
+      member.sourceSyncedAt.getTime() > latestSourceSyncedAt.getTime()
+    ) {
+      latestSourceSyncedAt = member.sourceSyncedAt;
+    }
+  }
+
+  const [warFallbackMembers, deferredByClanTag] = await Promise.all([
+    allPlayerTags.size === 0
+      ? Promise.resolve([] as WarFallbackRow[])
+      : prisma.fwaTrackedClanWarRosterMemberCurrent.findMany({
+          where: {
+            playerTag: { in: [...allPlayerTags] },
+            effectiveWeight: { not: null },
+          },
+          select: {
+            clanTag: true,
+            playerTag: true,
+            effectiveWeight: true,
+            updatedAt: true,
+          },
+          orderBy: [{ updatedAt: "desc" }, { clanTag: "asc" }, { playerTag: "asc" }],
+        }),
+    guildId
+      ? listOpenDeferredWeightsByClanAndPlayerTags({
+          guildId,
+          clanPlayerTags: trackedClanTags.map((clanTag) => ({
+            clanTag,
+            playerTags: (membersByClanTag.get(clanTag) ?? []).map(
+              (member) => member.playerTag,
+            ),
+          })),
+        })
+      : Promise.resolve(new Map<string, Map<string, number>>()),
+  ]);
+
+  const warFallbackByClanAndPlayerTag = new Map<string, number>();
+  const warFallbackByPlayerTag = new Map<string, number>();
+  for (const row of warFallbackMembers) {
+    const clanTag = normalizeTag(row.clanTag);
+    const playerTag = normalizePlayerTag(row.playerTag);
+    const effectiveWeight = toPositiveCompoWeight(row.effectiveWeight);
+    if (!clanTag || !playerTag || effectiveWeight === null) {
+      continue;
+    }
+    const clanAndPlayerTagKey = `${clanTag}|${playerTag}`;
+    if (!warFallbackByClanAndPlayerTag.has(clanAndPlayerTagKey)) {
+      warFallbackByClanAndPlayerTag.set(clanAndPlayerTagKey, effectiveWeight);
+    }
+    if (!warFallbackByPlayerTag.has(playerTag)) {
+      warFallbackByPlayerTag.set(playerTag, effectiveWeight);
+    }
+  }
+
+  const clans: CompoActualStateClanContext[] = [];
+  for (const clan of tracked) {
+    const clanTag = normalizeTag(clan.tag);
+    if (!clanTag) continue;
+
+    const clanMembers = membersByClanTag.get(clanTag) ?? [];
+    const deferredByPlayerTag = deferredByClanTag.get(clanTag) ?? new Map();
+    const bucketCounts: CompoWarBucketCounts = {
+      ...EMPTY_COMPO_WAR_BUCKET_COUNTS,
+    };
+    let totalResolvedWeight = 0;
+    let unresolvedWeightCount = 0;
+
+    for (const member of clanMembers) {
+      const playerTag = normalizePlayerTag(member.playerTag);
+      const sameClanWarWeight = playerTag
+        ? warFallbackByClanAndPlayerTag.get(`${clanTag}|${playerTag}`)
+        : null;
+      const anyWarWeight = playerTag ? warFallbackByPlayerTag.get(playerTag) : null;
+      const deferredWeight = playerTag ? deferredByPlayerTag.get(playerTag) : null;
+      const resolvedWeight = resolveActualCompoWeight({
+        memberWeight: member.weight,
+        deferredWeight,
+        sameClanWarWeight,
+        anyWarWeight,
+      });
+      const bucket = getCompoWarWeightBucket(resolvedWeight);
+      if (resolvedWeight === null || !bucket) {
+        unresolvedWeightCount += 1;
+        continue;
+      }
+      totalResolvedWeight += resolvedWeight;
+      bucketCounts[bucket] += 1;
+    }
+
+    clans.push({
+      clanTag,
+      clanName: clan.name?.trim() || clan.tag,
+      base: {
+        resolvedTotalWeight: totalResolvedWeight,
+        unresolvedWeightCount,
+        memberCount: clanMembers.length,
+        bucketCounts,
+      },
+    });
+  }
+
+  return {
+    trackedClanTags,
+    renderableClanTags: clans.map((clan) => clan.clanTag),
+    latestSourceSyncedAt,
+    heatMapRefs,
+    clans,
+  };
+}
+
 /** Purpose: load and explicitly refresh DB-backed ACTUAL compo state from persisted current-member rows only. */
 export class CompoActualStateService {
   private readonly clanMembersSync = new FwaClanMembersSyncService();
@@ -150,15 +330,9 @@ export class CompoActualStateService {
     options?: { view?: CompoActualStateView },
   ): Promise<CompoActualStateReadResult> {
     const view = options?.view ?? "raw";
-    const tracked = await prisma.trackedClan.findMany({
-      orderBy: { createdAt: "asc" },
-      select: { tag: true, name: true },
-    });
-    const trackedClanTags = tracked
-      .map((clan) => normalizeTag(clan.tag))
-      .filter((tag): tag is string => Boolean(tag));
+    const context = await loadCompoActualStateContext(guildId);
 
-    if (trackedClanTags.length === 0) {
+    if (context.trackedClanTags.length === 0) {
       return {
         stateRows: null,
         trackedClanTags: [],
@@ -172,145 +346,20 @@ export class CompoActualStateService {
       };
     }
 
-    const [members, heatMapRefs] = await Promise.all([
-      prisma.fwaClanMemberCurrent.findMany({
-        where: { clanTag: { in: trackedClanTags } },
-        select: {
-          clanTag: true,
-          playerTag: true,
-          weight: true,
-          sourceSyncedAt: true,
-        },
-        orderBy: [{ clanTag: "asc" }, { sourceSyncedAt: "desc" }, { playerTag: "asc" }],
-      }),
-      prisma.heatMapRef.findMany({
-        orderBy: [{ weightMinInclusive: "asc" }, { weightMaxInclusive: "asc" }],
-      }),
-    ]);
-
-    const membersByClanTag = new Map<string, CurrentMemberRow[]>();
-    const allPlayerTags = new Set<string>();
-    let latestSourceSyncedAt: Date | null = null;
-    for (const member of members) {
-      const clanTag = normalizeTag(member.clanTag);
-      const playerTag = normalizePlayerTag(member.playerTag);
-      if (!clanTag || !playerTag) continue;
-      allPlayerTags.add(playerTag);
-      const existing = membersByClanTag.get(clanTag) ?? [];
-      existing.push({
-        ...member,
-        clanTag,
-        playerTag,
-      });
-      membersByClanTag.set(clanTag, existing);
-      if (
-        !latestSourceSyncedAt ||
-        member.sourceSyncedAt.getTime() > latestSourceSyncedAt.getTime()
-      ) {
-        latestSourceSyncedAt = member.sourceSyncedAt;
-      }
-    }
-
-    const [warFallbackMembers, deferredByClanTag] = await Promise.all([
-      allPlayerTags.size === 0
-        ? Promise.resolve([] as WarFallbackRow[])
-        : prisma.fwaTrackedClanWarRosterMemberCurrent.findMany({
-            where: {
-              playerTag: { in: [...allPlayerTags] },
-              effectiveWeight: { not: null },
-            },
-            select: {
-              clanTag: true,
-              playerTag: true,
-              effectiveWeight: true,
-              updatedAt: true,
-            },
-            orderBy: [{ updatedAt: "desc" }, { clanTag: "asc" }, { playerTag: "asc" }],
-          }),
-      guildId
-        ? listOpenDeferredWeightsByClanAndPlayerTags({
-            guildId,
-            clanPlayerTags: trackedClanTags.map((clanTag) => ({
-              clanTag,
-              playerTags: (membersByClanTag.get(clanTag) ?? []).map(
-                (member) => member.playerTag,
-              ),
-            })),
-          })
-        : Promise.resolve(new Map<string, Map<string, number>>()),
-    ]);
-
-    const warFallbackByClanAndPlayerTag = new Map<string, number>();
-    const warFallbackByPlayerTag = new Map<string, number>();
-    for (const row of warFallbackMembers) {
-      const clanTag = normalizeTag(row.clanTag);
-      const playerTag = normalizePlayerTag(row.playerTag);
-      const effectiveWeight = toPositiveCompoWeight(row.effectiveWeight);
-      if (!clanTag || !playerTag || effectiveWeight === null) {
-        continue;
-      }
-      const clanAndPlayerTagKey = `${clanTag}|${playerTag}`;
-      if (!warFallbackByClanAndPlayerTag.has(clanAndPlayerTagKey)) {
-        warFallbackByClanAndPlayerTag.set(clanAndPlayerTagKey, effectiveWeight);
-      }
-      if (!warFallbackByPlayerTag.has(playerTag)) {
-        warFallbackByPlayerTag.set(playerTag, effectiveWeight);
-      }
-    }
-
     const renderableClanTags: string[] = [];
     const missingHeatMapBands: string[] = [];
     const rows: string[][] = [];
 
-    for (const clan of tracked) {
-      const clanTag = normalizeTag(clan.tag);
-      if (!clanTag) continue;
-
-      const clanMembers = membersByClanTag.get(clanTag) ?? [];
-      const deferredByPlayerTag = deferredByClanTag.get(clanTag) ?? new Map();
-      const bucketCounts: CompoWarBucketCounts = {
-        ...EMPTY_COMPO_WAR_BUCKET_COUNTS,
-      };
-      let totalResolvedWeight = 0;
-      let unresolvedWeightCount = 0;
-
-      for (const member of clanMembers) {
-        const playerTag = normalizePlayerTag(member.playerTag);
-        const sameClanWarWeight = playerTag
-          ? warFallbackByClanAndPlayerTag.get(`${clanTag}|${playerTag}`)
-          : null;
-        const anyWarWeight = playerTag
-          ? warFallbackByPlayerTag.get(playerTag)
-          : null;
-        const deferredWeight = playerTag
-          ? deferredByPlayerTag.get(playerTag)
-          : null;
-        const resolvedWeight = resolveActualCompoWeight({
-          memberWeight: member.weight,
-          deferredWeight,
-          sameClanWarWeight,
-          anyWarWeight,
-        });
-        const bucket = getCompoWarWeightBucket(resolvedWeight);
-        if (resolvedWeight === null || !bucket) {
-          unresolvedWeightCount += 1;
-          continue;
-        }
-        totalResolvedWeight += resolvedWeight;
-        bucketCounts[bucket] += 1;
-      }
-
+    for (const clan of context.clans) {
       const projection = projectCompoActualStateView({
         view,
-        base: {
-          resolvedTotalWeight: totalResolvedWeight,
-          unresolvedWeightCount,
-          memberCount: clanMembers.length,
-          bucketCounts,
-        },
-        heatMapRefs,
+        base: clan.base,
+        heatMapRefs: context.heatMapRefs,
       });
-      const displayName = buildTrackedClanDisplayName(clan);
+      const displayName = buildTrackedClanDisplayName({
+        tag: clan.clanTag,
+        name: clan.clanName,
+      });
       if (!projection.selectedHeatMapRef) {
         missingHeatMapBands.push(
           `${normalizeActualStateClanDisplayName(displayName)} (${projection.totalWeight.toLocaleString("en-US")})`,
@@ -333,7 +382,7 @@ export class CompoActualStateService {
         row.th14Delta,
         row.th13OrLowerDelta,
       ]);
-      renderableClanTags.push(clanTag);
+      renderableClanTags.push(clan.clanTag);
     }
 
     return {
@@ -343,10 +392,10 @@ export class CompoActualStateService {
       ],
       contentLines: buildActualViewSummaryLines(
         view,
-        latestSourceSyncedAt,
+        context.latestSourceSyncedAt,
         missingHeatMapBands,
       ),
-      trackedClanTags,
+      trackedClanTags: context.trackedClanTags,
       renderableClanTags,
       view,
     };
@@ -357,20 +406,14 @@ export class CompoActualStateService {
     guildId?: string | null,
     options?: { view?: CompoActualStateView },
   ): Promise<CompoActualStateReadResult> {
-    const tracked = await prisma.trackedClan.findMany({
-      orderBy: { createdAt: "asc" },
-      select: { tag: true },
-    });
-    const trackedClanTags = tracked
-      .map((clan) => normalizeTag(clan.tag))
-      .filter((tag): tag is string => Boolean(tag));
+    const context = await loadCompoActualStateContext(guildId);
 
-    if (trackedClanTags.length > 0) {
+    if (context.trackedClanTags.length > 0) {
       await this.clanMembersSync.syncAllTrackedClans({
         force: true,
       });
       await this.clanMembersSync.refreshCurrentClanMembersForClanTags(
-        trackedClanTags,
+        context.trackedClanTags,
       );
     }
 

--- a/src/services/CompoAdviceService.ts
+++ b/src/services/CompoAdviceService.ts
@@ -1,0 +1,213 @@
+import {
+  buildActualAdviceSummary,
+  buildCompoAdviceContentLines,
+  buildWarAdviceSummary,
+  type CompoAdviceMode,
+} from "../helper/compoAdviceEngine";
+import {
+  getCompoActualStateViewLabel,
+  type CompoActualStateView,
+} from "../helper/compoActualStateView";
+import { normalizeTag } from "./war-events/core";
+import {
+  CompoActualStateService,
+  loadCompoActualStateContext,
+} from "./CompoActualStateService";
+import {
+  CompoWarStateService,
+  loadCompoWarStateContext,
+} from "./CompoWarStateService";
+
+export type CompoAdviceReadResult = {
+  content: string;
+  trackedClanTags: string[];
+  selectedView: CompoActualStateView;
+  mode: CompoAdviceMode;
+};
+
+function buildPersistedRefreshLine(latestSourceSyncedAt: Date | null): string {
+  if (!latestSourceSyncedAt) {
+    return "RAW Data last refreshed: (not available)";
+  }
+  return `RAW Data last refreshed: <t:${Math.floor(latestSourceSyncedAt.getTime() / 1000)}:F>`;
+}
+
+function buildNoTrackedClansContent(input: {
+  mode: CompoAdviceMode;
+  view: CompoActualStateView;
+}): string {
+  const lines = [
+    buildPersistedRefreshLine(null),
+    `Mode: **${input.mode.toUpperCase()}**`,
+    `Advice View: **${getCompoActualStateViewLabel(input.view)}**`,
+    `No tracked clans are configured for DB-backed ${input.mode.toUpperCase()} advice.`,
+  ];
+  return lines.join("\n");
+}
+
+function buildNoTargetContent(input: {
+  mode: CompoAdviceMode;
+  view: CompoActualStateView;
+  targetTag: string;
+  knownTags: string[];
+}): string {
+  const lines = [
+    `Mode: **${input.mode.toUpperCase()}**`,
+    `Advice View: **${getCompoActualStateViewLabel(input.view)}**`,
+    `No tracked clan matched tag \`#${input.targetTag}\`.`,
+  ];
+  if (input.knownTags.length > 0) {
+    lines.push(`Known tags in this mode: ${input.knownTags.map((tag) => `#${tag}`).join(", ")}`);
+  }
+  return lines.join("\n");
+}
+
+/** Purpose: build DB-backed composition advice from persisted ACTUAL and WAR state snapshots only. */
+export class CompoAdviceService {
+  private readonly actualStateService = new CompoActualStateService();
+  private readonly warStateService = new CompoWarStateService();
+
+  async readAdvice(input: {
+    guildId?: string | null;
+    targetTag: string;
+    mode: CompoAdviceMode;
+    view?: CompoActualStateView;
+  }): Promise<CompoAdviceReadResult> {
+    const targetTag = normalizeTag(input.targetTag);
+    const view =
+      input.mode === "actual" ? input.view ?? "auto" : "raw";
+
+    if (!targetTag) {
+      return {
+        content: buildNoTargetContent({
+          mode: input.mode,
+          view,
+          targetTag: "",
+          knownTags: [],
+        }),
+        trackedClanTags: [],
+        selectedView: view,
+        mode: input.mode,
+      };
+    }
+
+    if (input.mode === "actual") {
+      const context = await loadCompoActualStateContext(input.guildId ?? null);
+      if (context.trackedClanTags.length === 0) {
+        return {
+          content: buildNoTrackedClansContent({
+            mode: input.mode,
+            view,
+          }),
+          trackedClanTags: [],
+          selectedView: view,
+          mode: input.mode,
+        };
+      }
+
+      const clan = context.clans.find((row) => row.clanTag === targetTag);
+      if (!clan) {
+        return {
+          content: buildNoTargetContent({
+            mode: input.mode,
+            view,
+            targetTag,
+            knownTags: context.trackedClanTags,
+          }),
+          trackedClanTags: context.trackedClanTags,
+          selectedView: view,
+          mode: input.mode,
+        };
+      }
+
+      const summary = buildActualAdviceSummary({
+        base: clan.base,
+        heatMapRefs: context.heatMapRefs,
+        view,
+      });
+      const content = buildCompoAdviceContentLines({
+        summary,
+        modeLabel: input.mode.toUpperCase(),
+        refreshLine: buildPersistedRefreshLine(context.latestSourceSyncedAt),
+      }).join("\n");
+      return {
+        content,
+        trackedClanTags: context.trackedClanTags,
+        selectedView: view,
+        mode: input.mode,
+      };
+    }
+
+    const context = await loadCompoWarStateContext();
+    if (context.trackedClanTags.length === 0) {
+      return {
+        content: buildNoTrackedClansContent({
+          mode: input.mode,
+          view,
+        }),
+        trackedClanTags: [],
+        selectedView: view,
+        mode: input.mode,
+      };
+    }
+
+    const clan = context.clans.find((row) => row.clanTag === targetTag);
+    if (!clan) {
+      return {
+        content: buildNoTargetContent({
+          mode: input.mode,
+          view,
+          targetTag,
+          knownTags: context.trackedClanTags,
+        }),
+        trackedClanTags: context.trackedClanTags,
+        selectedView: view,
+        mode: input.mode,
+      };
+    }
+
+    const summary = buildWarAdviceSummary({
+      base: {
+        resolvedTotalWeight: clan.totalEffectiveWeight,
+        unresolvedWeightCount: clan.missingWeights,
+        memberCount: clan.rosterSize,
+        bucketCounts: clan.bucketCounts,
+      },
+      heatMapRefs: context.heatMapRefs,
+    });
+    const content = buildCompoAdviceContentLines({
+      summary,
+      modeLabel: input.mode.toUpperCase(),
+      refreshLine: buildPersistedRefreshLine(context.latestRefreshAt),
+    }).join("\n");
+    return {
+      content,
+      trackedClanTags: context.trackedClanTags,
+      selectedView: view,
+      mode: input.mode,
+    };
+  }
+
+  async refreshAdvice(input: {
+    guildId?: string | null;
+    targetTag: string;
+    mode: CompoAdviceMode;
+    view?: CompoActualStateView;
+  }): Promise<CompoAdviceReadResult> {
+    const view =
+      input.mode === "actual" ? input.view ?? "auto" : "raw";
+
+    if (input.mode === "actual") {
+      await this.actualStateService.refreshState(input.guildId ?? null, {
+        view,
+      });
+    } else {
+      await this.warStateService.refreshState();
+    }
+
+    return this.readAdvice(input);
+  }
+}
+
+export const buildNoTrackedClansContentForTest = buildNoTrackedClansContent;
+export const buildNoTargetContentForTest = buildNoTargetContent;

--- a/src/services/CompoWarStateService.ts
+++ b/src/services/CompoWarStateService.ts
@@ -32,6 +32,26 @@ type GranularBucketKey = CompoWarWeightBucket;
 
 type BucketCounts = Record<GranularBucketKey, number>;
 
+export type CompoWarStateClanContext = {
+  clanTag: string;
+  clanName: string;
+  totalEffectiveWeight: number;
+  rosterSize: number;
+  missingWeights: number;
+  bucketCounts: BucketCounts;
+  heatMapRef: HeatMapRef;
+};
+
+export type CompoWarStateContext = {
+  trackedClanTags: string[];
+  snapshotClanTags: string[];
+  renderableClanTags: string[];
+  latestRefreshAt: Date | null;
+  skipped: string[];
+  clans: CompoWarStateClanContext[];
+  heatMapRefs: HeatMapRef[];
+};
+
 export type CompoWarStateReadResult = {
   stateRows: string[][] | null;
   contentLines: string[];
@@ -119,6 +139,116 @@ function getIneligibleReason(input: {
   return null;
 }
 
+/** Purpose: load the persisted WAR compo state snapshot used by both state rendering and advice simulation. */
+export async function loadCompoWarStateContext(): Promise<CompoWarStateContext> {
+  const tracked = await prisma.trackedClan.findMany({
+    orderBy: { createdAt: "asc" },
+    select: { tag: true, name: true },
+  });
+  const trackedTags = tracked
+    .map((row) => normalizeFwaTag(row.tag))
+    .filter((tag): tag is string => Boolean(tag));
+
+  if (trackedTags.length === 0) {
+    return {
+      trackedClanTags: [],
+      snapshotClanTags: [],
+      renderableClanTags: [],
+      latestRefreshAt: null,
+      skipped: [],
+      clans: [],
+      heatMapRefs: [],
+    };
+  }
+
+  const [parents, members, refs] = await Promise.all([
+    prisma.fwaTrackedClanWarRosterCurrent.findMany({
+      where: { clanTag: { in: trackedTags } },
+    }),
+    prisma.fwaTrackedClanWarRosterMemberCurrent.findMany({
+      where: { clanTag: { in: trackedTags } },
+      orderBy: [{ clanTag: "asc" }, { position: "asc" }],
+    }),
+    prisma.heatMapRef.findMany({
+      orderBy: [{ weightMinInclusive: "asc" }, { weightMaxInclusive: "asc" }],
+    }),
+  ]);
+
+  const trackedByTag = new Map(
+    trackedTags.map((tag, index) => [tag, tracked[index]?.name?.trim() ?? null]),
+  );
+  const parentByTag = new Map(parents.map((row) => [row.clanTag, row]));
+  const membersByTag = new Map<string, FwaTrackedClanWarRosterMemberCurrent[]>();
+  for (const member of members) {
+    const existing = membersByTag.get(member.clanTag) ?? [];
+    existing.push(member);
+    membersByTag.set(member.clanTag, existing);
+  }
+
+  const clans: CompoWarStateClanContext[] = [];
+  const skipped: string[] = [];
+  const renderableClanTags: string[] = [];
+  const snapshotClanTags = parents.map((row) => row.clanTag);
+  let latestRefreshAt: Date | null = null;
+
+  for (const clanTag of trackedTags) {
+    const parent = parentByTag.get(clanTag);
+    if (!parent) {
+      continue;
+    }
+    const clanMembers = membersByTag.get(clanTag) ?? [];
+    const effectiveWeight = parent.totalEffectiveWeight;
+    const heatMapRef =
+      effectiveWeight === null ? null : findHeatMapRefForWeight(refs, effectiveWeight);
+    const ineligibleReason = getIneligibleReason({
+      parent,
+      memberCount: clanMembers.length,
+      heatMapRef,
+    });
+    const displayName =
+      parent.clanName?.trim() ||
+      trackedByTag.get(clanTag) ||
+      parent.clanTag;
+
+    const freshness = parent.sourceUpdatedAt ?? parent.observedAt;
+    if (!latestRefreshAt || freshness.getTime() > latestRefreshAt.getTime()) {
+      latestRefreshAt = freshness;
+    }
+
+    if (ineligibleReason) {
+      skipped.push(`${normalizeWarStateClanDisplayName(displayName)} (${ineligibleReason})`);
+      continue;
+    }
+
+    const bucketCounts = buildCompoWarBucketCounts(clanMembers);
+    if (!bucketCounts) {
+      skipped.push(`${normalizeWarStateClanDisplayName(displayName)} (unresolved effective weights)`);
+      continue;
+    }
+    const missingWeights = clanMembers.filter((row) => row.rawWeight <= 0).length;
+    clans.push({
+      clanTag,
+      clanName: displayName,
+      totalEffectiveWeight: effectiveWeight as number,
+      rosterSize: parent.rosterSize,
+      missingWeights,
+      bucketCounts,
+      heatMapRef: heatMapRef as HeatMapRef,
+    });
+    renderableClanTags.push(clanTag);
+  }
+
+  return {
+    trackedClanTags: trackedTags,
+    snapshotClanTags,
+    renderableClanTags,
+    latestRefreshAt,
+    skipped,
+    clans,
+    heatMapRefs: refs,
+  };
+}
+
 type FeedOpsLike = Pick<FwaFeedOpsService, "runTracked">;
 
 /** Purpose: read and explicitly refresh DB-backed tracked-clan war compo state without touching sheet-backed flows. */
@@ -128,15 +258,9 @@ export class CompoWarStateService {
 
   /** Purpose: load alliance-wide tracked-clan war state rows from persisted feed-owned tables only. */
   async readState(): Promise<CompoWarStateReadResult> {
-    const tracked = await prisma.trackedClan.findMany({
-      orderBy: { createdAt: "asc" },
-      select: { tag: true, name: true },
-    });
-    const trackedTags = tracked
-      .map((row) => normalizeFwaTag(row.tag))
-      .filter((tag): tag is string => Boolean(tag));
+    const context = await loadCompoWarStateContext();
 
-    if (trackedTags.length === 0) {
+    if (context.trackedClanTags.length === 0) {
       return {
         stateRows: null,
         trackedClanTags: [],
@@ -149,79 +273,15 @@ export class CompoWarStateService {
         ],
       };
     }
-
-    const [parents, members, refs] = await Promise.all([
-      prisma.fwaTrackedClanWarRosterCurrent.findMany({
-        where: { clanTag: { in: trackedTags } },
-      }),
-      prisma.fwaTrackedClanWarRosterMemberCurrent.findMany({
-        where: { clanTag: { in: trackedTags } },
-        orderBy: [{ clanTag: "asc" }, { position: "asc" }],
-      }),
-      prisma.heatMapRef.findMany({
-        orderBy: [{ weightMinInclusive: "asc" }, { weightMaxInclusive: "asc" }],
-      }),
-    ]);
-
-    const trackedByTag = new Map(
-      trackedTags.map((tag, index) => [tag, tracked[index]?.name?.trim() ?? null]),
-    );
-    const parentByTag = new Map(parents.map((row) => [row.clanTag, row]));
-    const membersByTag = new Map<string, FwaTrackedClanWarRosterMemberCurrent[]>();
-    for (const member of members) {
-      const existing = membersByTag.get(member.clanTag) ?? [];
-      existing.push(member);
-      membersByTag.set(member.clanTag, existing);
-    }
-
     const renderableRows: string[][] = [];
-    const skipped: string[] = [];
-    const renderableClanTags: string[] = [];
-    const snapshotClanTags = parents.map((row) => row.clanTag);
-    let latestRefreshAt: Date | null = null;
-
-    for (const clanTag of trackedTags) {
-      const parent = parentByTag.get(clanTag);
-      if (!parent) {
-        continue;
-      }
-      const clanMembers = membersByTag.get(clanTag) ?? [];
-      const effectiveWeight = parent.totalEffectiveWeight;
-      const heatMapRef =
-        effectiveWeight === null ? null : findHeatMapRefForWeight(refs, effectiveWeight);
-      const ineligibleReason = getIneligibleReason({
-        parent,
-        memberCount: clanMembers.length,
-        heatMapRef,
-      });
-      const displayName =
-        parent.clanName?.trim() ||
-        trackedByTag.get(clanTag) ||
-        parent.clanTag;
-
-      const freshness = parent.sourceUpdatedAt ?? parent.observedAt;
-      if (!latestRefreshAt || freshness.getTime() > latestRefreshAt.getTime()) {
-        latestRefreshAt = freshness;
-      }
-
-      if (ineligibleReason) {
-        skipped.push(`${normalizeWarStateClanDisplayName(displayName)} (${ineligibleReason})`);
-        continue;
-      }
-
-      const bucketCounts = buildCompoWarBucketCounts(clanMembers);
-      if (!bucketCounts) {
-        skipped.push(`${normalizeWarStateClanDisplayName(displayName)} (unresolved effective weights)`);
-        continue;
-      }
-      const missingWeights = clanMembers.filter((row) => row.rawWeight <= 0).length;
+    for (const clan of context.clans) {
       const collapsed = buildCollapsedStateRow({
-        clanName: displayName,
-        totalEffectiveWeight: effectiveWeight as number,
-        rosterSize: parent.rosterSize,
-        missingWeights,
-        bucketCounts,
-        heatMapRef: heatMapRef as HeatMapRef,
+        clanName: clan.clanName,
+        totalEffectiveWeight: clan.totalEffectiveWeight,
+        rosterSize: clan.rosterSize,
+        missingWeights: clan.missingWeights,
+        bucketCounts: clan.bucketCounts,
+        heatMapRef: clan.heatMapRef,
       });
       renderableRows.push([
         collapsed.clanName,
@@ -235,25 +295,24 @@ export class CompoWarStateService {
         collapsed.th14Delta,
         collapsed.th13OrLowerDelta,
       ]);
-      renderableClanTags.push(clanTag);
     }
 
     const contentLines = [
       "Mode Displayed: **WAR**",
-      toEpochLine("Persisted WAR data last refreshed", latestRefreshAt),
+      toEpochLine("Persisted WAR data last refreshed", context.latestRefreshAt),
     ];
 
-    if (skipped.length > 0) {
-      contentLines.push(`Skipped ineligible clans: ${skipped.join("; ")}`);
+    if (context.skipped.length > 0) {
+      contentLines.push(`Skipped ineligible clans: ${context.skipped.join("; ")}`);
     }
 
     if (renderableRows.length === 0) {
       contentLines.push("No DB-backed WAR roster snapshots are currently renderable.");
       return {
         stateRows: null,
-        trackedClanTags: trackedTags,
-        snapshotClanTags,
-        renderableClanTags,
+        trackedClanTags: context.trackedClanTags,
+        snapshotClanTags: context.snapshotClanTags,
+        renderableClanTags: context.renderableClanTags,
         contentLines,
       };
     }
@@ -263,9 +322,9 @@ export class CompoWarStateService {
         ["Clan", "Total", "Missing", "Players", "TH18", "TH17", "TH16", "TH15", "TH14", "<=TH13"],
         ...renderableRows,
       ],
-      trackedClanTags: trackedTags,
-      snapshotClanTags,
-      renderableClanTags,
+      trackedClanTags: context.trackedClanTags,
+      snapshotClanTags: context.snapshotClanTags,
+      renderableClanTags: context.renderableClanTags,
       contentLines,
     };
   }

--- a/tests/compo.commandSheetRead.test.ts
+++ b/tests/compo.commandSheetRead.test.ts
@@ -1,44 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { Compo, mapCompoSheetErrorToMessageForTest } from "../src/commands/Compo";
-import { CompoActualStateService } from "../src/services/CompoActualStateService";
-import {
-  GoogleSheetReadError,
-  GoogleSheetReadErrorCode,
-  GoogleSheetsService,
-} from "../src/services/GoogleSheetsService";
-
-const FIXED_LAYOUT_RANGE = "AllianceDashboard!A6:BE500";
-const LOOKUP_REFRESH_RANGE = "Lookup!B10:B10";
-
-function makeRows(): string[][] {
-  const rows = Array.from({ length: 8 }, () => Array.from({ length: 57 }, () => ""));
-  const actualRow = rows[1];
-  actualRow[0] = "DARK EMPIRE";
-  actualRow[1] = "#LQQ99UV8";
-  actualRow[3] = "1,470,000";
-  actualRow[20] = "1";
-  actualRow[21] = "0";
-  actualRow[22] = "0";
-  actualRow[23] = "-1";
-  actualRow[24] = "0";
-  actualRow[25] = "0";
-  actualRow[26] = "0";
-  actualRow[49] = "1,500,000";
-  actualRow[54] = "Add 1x TH16";
-  return rows;
-}
-
-function makeRowsWithActualSuffix(): string[][] {
-  const rows = makeRows();
-  rows[1][0] = "DARK EMPIRE-actual";
-  return rows;
-}
+import { Compo } from "../src/commands/Compo";
+import { CompoAdviceService } from "../src/services/CompoAdviceService";
+import { GoogleSheetsService } from "../src/services/GoogleSheetsService";
 
 function makeInteraction(params: {
-  subcommand: "advice" | "state" | "place";
+  subcommand: "advice";
   tag?: string;
   mode?: string | null;
-  weight?: string;
 }) {
   const interaction: any = {
     commandName: "compo",
@@ -56,22 +24,11 @@ function makeInteraction(params: {
       getString: vi.fn((name: string) => {
         if (name === "tag") return params.tag ?? null;
         if (name === "mode") return params.mode ?? null;
-        if (name === "weight") return params.weight ?? null;
         return null;
       }),
     },
   };
   return interaction;
-}
-
-function makeReadError(code: GoogleSheetReadErrorCode): GoogleSheetReadError {
-  return new GoogleSheetReadError(code, code, {
-    action: "readValues",
-    range: FIXED_LAYOUT_RANGE,
-    resolutionSource: "google_sheet_id",
-    source: "proxy",
-    httpStatus: 403,
-  });
 }
 
 function getComponentCustomIds(payload: unknown): string[] {
@@ -93,204 +50,83 @@ function getComponentCustomIds(payload: unknown): string[] {
         String(
           (component as { custom_id?: unknown; customId?: unknown }).custom_id ??
             (component as { custom_id?: unknown; customId?: unknown }).customId ??
-            ""
-        )
+            "",
+        ),
       )
       .filter((value) => value.length > 0);
   });
 }
 
-describe("/compo strict sheet read path", () => {
-  const linkedSheet = {
-    sheetId: "sheet-1",
-    tabName: "AllianceDashboard",
-    source: "google_sheet_id" as const,
-  };
-
+describe("/compo advice command", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
   });
 
-  it.each([
-    {
-      subcommand: "advice" as const,
-      tag: "#LQQ99UV8",
-      expectedRanges: [FIXED_LAYOUT_RANGE],
-    },
-  ])("uses strict canonical resolver for /compo $subcommand", async (testCase) => {
-    const getCompoLinkedSheetSpy = vi
-      .spyOn(GoogleSheetsService.prototype, "getCompoLinkedSheet")
-      .mockResolvedValue(linkedSheet);
-    const readCompoLinkedValuesSpy = vi
-      .spyOn(GoogleSheetsService.prototype, "readCompoLinkedValues")
-      .mockImplementation(async (range: string) => {
-        if (range === LOOKUP_REFRESH_RANGE) return [["1709900000"]];
-        return makeRows();
+  it("uses the DB-backed advice service and keeps sheet access out of the command layer", async () => {
+    const readAdviceSpy = vi
+      .spyOn(CompoAdviceService.prototype, "readAdvice")
+      .mockResolvedValue({
+        content:
+          "RAW Data last refreshed: <t:1709900000:F>\nMode: **ACTUAL**\nAdvice View: **Auto-Detect Band**\nCurrent Score: **4**\nCurrent Band: **0 - 9999999**\nRecommendation: **Add TH17**\nResulting Score: **0**\nResulting Band: **0 - 9999999**",
+        trackedClanTags: ["#AAA111"],
+        selectedView: "auto",
+        mode: "actual",
       });
-
-    const interaction = makeInteraction(testCase);
-    const cocService = {
-      getClan: vi.fn().mockResolvedValue({
-        memberList: Array.from({ length: 49 }, () => ({ tag: "#P" })),
-      }),
-    };
-
-    await Compo.run({} as any, interaction as any, cocService as any);
-
-    expect(getCompoLinkedSheetSpy).toHaveBeenCalledTimes(1);
-    expect(getCompoLinkedSheetSpy).toHaveBeenCalledWith(FIXED_LAYOUT_RANGE);
-    const ranges = readCompoLinkedValuesSpy.mock.calls.map((call) => String(call[0] ?? ""));
-    expect(ranges).toEqual(testCase.expectedRanges);
-    for (const call of readCompoLinkedValuesSpy.mock.calls) {
-      expect(call[1]).toBe(linkedSheet);
-    }
-  });
-
-  it.each([
-    { subcommand: "advice" as const, tag: "#LQQ99UV8" },
-  ])(
-    "maps normalized sheet errors consistently for /compo $subcommand",
-    async (testCase) => {
-      vi.spyOn(GoogleSheetsService.prototype, "getCompoLinkedSheet").mockResolvedValue(
-        linkedSheet
-      );
-      vi.spyOn(GoogleSheetsService.prototype, "readCompoLinkedValues").mockRejectedValue(
-        makeReadError("SHEET_PROXY_UNAUTHORIZED")
-      );
-
-      const interaction = makeInteraction(testCase);
-      const cocService = { getClan: vi.fn() };
-
-      await Compo.run({} as any, interaction as any, cocService as any);
-
-      const payload = interaction.editReply.mock.calls.at(-1)?.[0];
-      expect(String(payload?.content ?? "")).toBe(
-        "The linked compo sheet could not be accessed because the sheet proxy is not authorized."
-      );
-    }
-  );
-
-  it("sanitizes trailing -actual suffix in /compo advice display output", async () => {
-    vi.spyOn(GoogleSheetsService.prototype, "getCompoLinkedSheet").mockResolvedValue(
-      linkedSheet
+    const getCompoLinkedSheetSpy = vi.spyOn(
+      GoogleSheetsService.prototype,
+      "getCompoLinkedSheet",
     );
-    vi.spyOn(GoogleSheetsService.prototype, "readCompoLinkedValues").mockImplementation(
-      async (range: string) => {
-        if (range === LOOKUP_REFRESH_RANGE) return [["1709900000"]];
-        return makeRowsWithActualSuffix();
-      }
+    const readCompoLinkedValuesSpy = vi.spyOn(
+      GoogleSheetsService.prototype,
+      "readCompoLinkedValues",
     );
 
     const interaction = makeInteraction({
       subcommand: "advice",
       tag: "#LQQ99UV8",
     });
-    const cocService = { getClan: vi.fn() };
+    await Compo.run({} as any, interaction as any, {} as any);
 
-    await Compo.run({} as any, interaction as any, cocService as any);
+    expect(readAdviceSpy).toHaveBeenCalledWith({
+      guildId: "guild-1",
+      targetTag: "LQQ99UV8",
+      mode: "actual",
+    });
+    expect(getCompoLinkedSheetSpy).not.toHaveBeenCalled();
+    expect(readCompoLinkedValuesSpy).not.toHaveBeenCalled();
 
     const payload = interaction.editReply.mock.calls.at(-1)?.[0];
-    expect(String(payload?.content ?? "")).toContain("**DARK EMPIRE** (`#LQQ99UV8`)");
-    expect(String(payload?.content ?? "")).not.toContain("-actual");
-  });
-
-  it("adds an inline refresh button for /compo state output", async () => {
-    const readStateSpy = vi
-      .spyOn(CompoActualStateService.prototype, "readState")
-      .mockResolvedValue({
-      stateRows: [
-        ["Clan", "Total", "Missing", "Players", "TH18", "TH17", "TH16", "TH15", "TH14", "<=TH13"],
-        ["DARK EMPIRE", "1,470,000", "1", "0", "0", "-1", "0", "0", "0", "0"],
-      ],
-      contentLines: ["RAW Data last refreshed: <t:1709900000:F>"],
-      trackedClanTags: ["#LQQ99UV8"],
-      renderableClanTags: ["#LQQ99UV8"],
-      view: "raw",
-    });
-
-    const stateInteraction = makeInteraction({ subcommand: "state", mode: "actual" });
-    await Compo.run({} as any, stateInteraction as any, {
-      getClan: vi.fn().mockResolvedValue({
-        memberList: Array.from({ length: 49 }, () => ({ tag: "#P" })),
-      }),
-    } as any);
-    const statePayload = stateInteraction.editReply.mock.calls.at(-1)?.[0];
-    expect(readStateSpy).toHaveBeenCalledWith("guild-1", { view: "raw" });
-    expect(getComponentCustomIds(statePayload).some((id) => id.startsWith("compo-refresh:state:"))).toBe(
-      true
-    );
-    expect(getComponentCustomIds(statePayload)).toEqual(
+    expect(String(payload?.content ?? "")).toContain("Advice View: **Auto-Detect Band**");
+    expect(getComponentCustomIds(payload)).toEqual(
       expect.arrayContaining([
-        "compo-refresh:state:user-1:actual:raw",
-        "compo-refresh:view:user-1:raw",
-        "compo-refresh:view:user-1:auto",
-        "compo-refresh:view:user-1:best",
-      ])
+        "compo-refresh:advice:user-1:actual:auto:LQQ99UV8",
+        "compo-refresh:view:user-1:advice:raw:LQQ99UV8",
+        "compo-refresh:view:user-1:advice:auto:LQQ99UV8",
+        "compo-refresh:view:user-1:advice:best:LQQ99UV8",
+      ]),
     );
   });
 
-  it("does not attempt a second defer when /compo is already acknowledged", async () => {
-    vi.spyOn(CompoActualStateService.prototype, "readState").mockResolvedValue({
-      stateRows: [
-        ["Clan", "Total", "Missing", "Players", "TH18", "TH17", "TH16", "TH15", "TH14", "<=TH13"],
-        ["DARK EMPIRE", "1,470,000", "1", "0", "0", "-1", "0", "0", "0", "0"],
-      ],
-      contentLines: ["RAW Data last refreshed: <t:1709900000:F>"],
-      trackedClanTags: ["#LQQ99UV8"],
-      renderableClanTags: ["#LQQ99UV8"],
-      view: "raw",
+  it("renders WAR advice with only a refresh button", async () => {
+    vi.spyOn(CompoAdviceService.prototype, "readAdvice").mockResolvedValue({
+      content:
+        "RAW Data last refreshed: <t:1709900000:F>\nMode: **WAR**\nAdvice View: **Raw Data**\nCurrent Score: **0**\nCurrent Band: **0 - 9999999**\nRecommendation: **No improvement found.**\nResulting Score: **n/a**\nResulting Band: **(no band)**",
+      trackedClanTags: ["#AAA111"],
+      selectedView: "raw",
+      mode: "war",
     });
 
-    const interaction = makeInteraction({ subcommand: "state" });
-    interaction.deferred = true;
+    const interaction = makeInteraction({
+      subcommand: "advice",
+      tag: "#LQQ99UV8",
+      mode: "war",
+    });
+    await Compo.run({} as any, interaction as any, {} as any);
 
-    await Compo.run({} as any, interaction as any, {
-      getClan: vi.fn().mockResolvedValue({
-        memberList: Array.from({ length: 49 }, () => ({ tag: "#P" })),
-      }),
-    } as any);
-
-    expect(interaction.deferReply).not.toHaveBeenCalled();
-    expect(interaction.editReply).toHaveBeenCalled();
+    const payload = interaction.editReply.mock.calls.at(-1)?.[0];
+    expect(String(payload?.content ?? "")).toContain("Mode: **WAR**");
+    expect(getComponentCustomIds(payload)).toEqual([
+      "compo-refresh:advice:user-1:war:LQQ99UV8",
+    ]);
   });
 });
-
-describe("/compo error message mapping", () => {
-  it("maps all normalized sheet codes to stable user messages", () => {
-    const cases: Array<{ code: GoogleSheetReadErrorCode; message: string }> = [
-      {
-        code: "SHEET_LINK_MISSING",
-        message: "No compo sheet is linked for this server.",
-      },
-      {
-        code: "SHEET_PROXY_UNAUTHORIZED",
-        message:
-          "The linked compo sheet could not be accessed because the sheet proxy is not authorized.",
-      },
-      {
-        code: "SHEET_ACCESS_DENIED",
-        message:
-          "The linked compo sheet exists, but this bot does not currently have access to read it.",
-      },
-      {
-        code: "SHEET_RANGE_INVALID",
-        message:
-          "The linked compo sheet does not contain the expected AllianceDashboard layout.",
-      },
-      {
-        code: "SHEET_READ_FAILURE",
-        message: "The compo sheet could not be read due to a sheet service error.",
-      },
-    ];
-
-    for (const testCase of cases) {
-      const err = makeReadError(testCase.code);
-      expect(mapCompoSheetErrorToMessageForTest(err)).toBe(testCase.message);
-    }
-
-    expect(mapCompoSheetErrorToMessageForTest(new Error("boom"))).toBe(
-      "The compo sheet could not be read due to a sheet service error."
-    );
-  });
-});
-

--- a/tests/compoAdvice.engine.test.ts
+++ b/tests/compoAdvice.engine.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it } from "vitest";
+import {
+  compareEvaluationsForTest,
+  evaluateCompoAdvice,
+  type CompoAdviceEvaluation,
+} from "../src/helper/compoAdviceEngine";
+import type { CompoWarBucketCounts } from "../src/helper/compoWarBucketCounts";
+
+function makeBucketCounts(
+  partial?: Partial<CompoWarBucketCounts>,
+): CompoWarBucketCounts {
+  return {
+    TH18: 0,
+    TH17: 0,
+    TH16: 0,
+    TH15: 0,
+    TH14: 0,
+    TH13: 0,
+    TH12: 0,
+    TH11: 0,
+    TH10: 0,
+    TH9: 0,
+    TH8_OR_LOWER: 0,
+    ...partial,
+  };
+}
+
+function makeHeatMapRef(input: Partial<{
+  weightMinInclusive: number;
+  weightMaxInclusive: number;
+  th18Count: number;
+  th17Count: number;
+  th16Count: number;
+  th15Count: number;
+  th14Count: number;
+  th13Count: number;
+  th12Count: number;
+  th11Count: number;
+  th10OrLowerCount: number;
+}>) {
+  return {
+    weightMinInclusive: input.weightMinInclusive ?? 0,
+    weightMaxInclusive: input.weightMaxInclusive ?? 9999999,
+    th18Count: input.th18Count ?? 0,
+    th17Count: input.th17Count ?? 0,
+    th16Count: input.th16Count ?? 0,
+    th15Count: input.th15Count ?? 0,
+    th14Count: input.th14Count ?? 0,
+    th13Count: input.th13Count ?? 0,
+    th12Count: input.th12Count ?? 0,
+    th11Count: input.th11Count ?? 0,
+    th10OrLowerCount: input.th10OrLowerCount ?? 0,
+    sourceVersion: "test",
+    refreshedAt: new Date("2026-04-12T00:00:00.000Z"),
+  };
+}
+
+describe("CompoAdviceEngine", () => {
+  it("recommends adding the highest-priority negative bucket when the clan is not full", () => {
+    const summary = evaluateCompoAdvice({
+      mode: "actual",
+      view: "raw",
+      base: {
+        resolvedTotalWeight: 135000 * 49,
+        unresolvedWeightCount: 0,
+        memberCount: 49,
+        bucketCounts: makeBucketCounts({
+          TH14: 49,
+        }),
+      },
+      heatMapRefs: [
+        makeHeatMapRef({
+          weightMinInclusive: 6_000_000,
+          weightMaxInclusive: 7_000_000,
+          th17Count: 1,
+          th14Count: 49,
+        }),
+      ],
+    });
+
+    expect(summary.viewLabel).toBe("Raw Data");
+    expect(summary.recommendationText).toBe("Add TH17");
+    expect(summary.currentScore).toBe(4);
+    expect(summary.resultingScore).toBe(0);
+    expect(summary.statusText).toBeNull();
+  });
+
+  it("recommends the best swap when the clan is full", () => {
+    const summary = evaluateCompoAdvice({
+      mode: "actual",
+      view: "raw",
+      base: {
+        resolvedTotalWeight: 48 * 135000 + 2 * 145000,
+        unresolvedWeightCount: 0,
+        memberCount: 50,
+        bucketCounts: makeBucketCounts({
+          TH14: 48,
+          TH15: 2,
+        }),
+      },
+      heatMapRefs: [
+        makeHeatMapRef({
+          weightMinInclusive: 6_000_000,
+          weightMaxInclusive: 7_000_000,
+          th17Count: 1,
+          th16Count: 1,
+          th15Count: 1,
+          th14Count: 47,
+        }),
+      ],
+    });
+
+    expect(summary.recommendationText).toBe("Replace one TH15 with one TH17");
+    expect(summary.currentScore).toBe(10);
+    expect(summary.resultingScore).toBe(4);
+    expect(summary.alternateTexts.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("distinguishes Raw Data, Auto-Detect Band, and Best Fit advice views", () => {
+    const base = {
+      resolvedTotalWeight: 175000,
+      unresolvedWeightCount: 0,
+      memberCount: 49,
+      bucketCounts: makeBucketCounts({
+        TH18: 1,
+      }),
+    };
+    const heatMapRefs = [
+      makeHeatMapRef({
+        weightMinInclusive: 0,
+        weightMaxInclusive: 300000,
+        th18Count: 2,
+      }),
+      makeHeatMapRef({
+        weightMinInclusive: 300001,
+        weightMaxInclusive: 500000,
+        th17Count: 1,
+      }),
+    ];
+
+    const raw = evaluateCompoAdvice({
+      mode: "actual",
+      view: "raw",
+      base,
+      heatMapRefs,
+    });
+    const auto = evaluateCompoAdvice({
+      mode: "actual",
+      view: "auto",
+      base,
+      heatMapRefs,
+    });
+    const best = evaluateCompoAdvice({
+      mode: "actual",
+      view: "best",
+      base,
+      heatMapRefs,
+    });
+
+    expect(raw.viewLabel).toBe("Raw Data");
+    expect(auto.viewLabel).toBe("Auto-Detect Band");
+    expect(best.viewLabel).toBe("Best Fit");
+    expect(raw.currentBandLabel).not.toBe(auto.currentBandLabel);
+    expect(auto.currentBandLabel).not.toBe(best.currentBandLabel);
+  });
+
+  it("orders equal candidates deterministically by incoming bucket priority", () => {
+    const better = {
+      action: { kind: "swap", outgoingBucket: "TH14", incomingBucket: "TH17" },
+      description: "Replace one TH14 with one TH17",
+      beforeProjection: {} as never,
+      afterProjection: {} as never,
+      currentScore: 5,
+      resultingScore: 1,
+      scoreImprovement: 4,
+      bandFitDistance: 100,
+      totalWeightJump: 1000,
+      incomingPriority: 1,
+      outgoingPriority: 4,
+    } as CompoAdviceEvaluation;
+    const worse = {
+      action: { kind: "swap", outgoingBucket: "TH14", incomingBucket: "TH16" },
+      description: "Replace one TH14 with one TH16",
+      beforeProjection: {} as never,
+      afterProjection: {} as never,
+      currentScore: 5,
+      resultingScore: 1,
+      scoreImprovement: 4,
+      bandFitDistance: 100,
+      totalWeightJump: 1000,
+      incomingPriority: 2,
+      outgoingPriority: 4,
+    } as CompoAdviceEvaluation;
+
+    expect(compareEvaluationsForTest(better, worse)).toBeLessThan(0);
+    expect(compareEvaluationsForTest(worse, better)).toBeGreaterThan(0);
+  });
+});

--- a/tests/compoAdvice.service.test.ts
+++ b/tests/compoAdvice.service.test.ts
@@ -1,0 +1,280 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { GoogleSheetsService } from "../src/services/GoogleSheetsService";
+import { CompoAdviceService } from "../src/services/CompoAdviceService";
+
+const prismaMock = vi.hoisted(() => ({
+  trackedClan: {
+    findMany: vi.fn(),
+  },
+  fwaClanMemberCurrent: {
+    findMany: vi.fn(),
+  },
+  fwaTrackedClanWarRosterCurrent: {
+    findMany: vi.fn(),
+  },
+  fwaTrackedClanWarRosterMemberCurrent: {
+    findMany: vi.fn(),
+  },
+  heatMapRef: {
+    findMany: vi.fn(),
+  },
+  weightInputDeferment: {
+    findMany: vi.fn(),
+  },
+}));
+
+vi.mock("../src/prisma", () => ({
+  prisma: prismaMock,
+}));
+
+function makeTrackedClan(tag: string, name: string) {
+  return {
+    tag,
+    name,
+  };
+}
+
+function makeHeatMapRef(input?: Partial<{
+  weightMinInclusive: number;
+  weightMaxInclusive: number;
+  th18Count: number;
+  th17Count: number;
+  th16Count: number;
+  th15Count: number;
+  th14Count: number;
+  th13Count: number;
+  th12Count: number;
+  th11Count: number;
+  th10OrLowerCount: number;
+}>) {
+  return {
+    weightMinInclusive: input?.weightMinInclusive ?? 0,
+    weightMaxInclusive: input?.weightMaxInclusive ?? 9_999_999,
+    th18Count: input?.th18Count ?? 0,
+    th17Count: input?.th17Count ?? 0,
+    th16Count: input?.th16Count ?? 0,
+    th15Count: input?.th15Count ?? 0,
+    th14Count: input?.th14Count ?? 0,
+    th13Count: input?.th13Count ?? 0,
+    th12Count: input?.th12Count ?? 0,
+    th11Count: input?.th11Count ?? 0,
+    th10OrLowerCount: input?.th10OrLowerCount ?? 0,
+    sourceVersion: "test",
+    refreshedAt: new Date("2026-04-12T00:00:00.000Z"),
+  };
+}
+
+function makeCurrentMember(input: {
+  clanTag: string;
+  playerTag: string;
+  weight: number;
+  sourceSyncedAt?: Date;
+}) {
+  return {
+    clanTag: input.clanTag,
+    playerTag: input.playerTag,
+    weight: input.weight,
+    sourceSyncedAt:
+      input.sourceSyncedAt ?? new Date("2026-04-12T00:00:00.000Z"),
+  };
+}
+
+function makeWarParent(input: {
+  clanTag: string;
+  clanName: string;
+  rosterSize?: number;
+  totalEffectiveWeight?: number | null;
+  sourceUpdatedAt?: Date | null;
+  observedAt?: Date;
+}) {
+  return {
+    clanTag: input.clanTag,
+    clanName: input.clanName,
+    opponentTag: null,
+    opponentName: null,
+    rosterSize: input.rosterSize ?? 50,
+    totalRawWeight: input.totalEffectiveWeight ?? 8_100_000,
+    totalEffectiveWeight:
+      input.totalEffectiveWeight === undefined ? 8_100_000 : input.totalEffectiveWeight,
+    hasUnresolvedWeights: false,
+    observedAt: input.observedAt ?? new Date("2026-04-12T00:00:00.000Z"),
+    sourceUpdatedAt:
+      input.sourceUpdatedAt === undefined
+        ? new Date("2026-04-12T00:00:00.000Z")
+        : input.sourceUpdatedAt,
+    createdAt: new Date("2026-04-12T00:00:00.000Z"),
+    updatedAt: new Date("2026-04-12T00:00:00.000Z"),
+  };
+}
+
+function makeWarMember(input: {
+  clanTag: string;
+  position: number;
+  rawWeight: number;
+  effectiveWeight: number;
+}) {
+  return {
+    clanTag: input.clanTag,
+    position: input.position,
+    playerTag: `#P${String(input.position).padStart(6, "0")}`,
+    playerName: `Player ${input.position}`,
+    townHall: 18,
+    rawWeight: input.rawWeight,
+    effectiveWeight: input.effectiveWeight,
+    effectiveWeightStatus: "RAW",
+    opponentTag: null,
+    opponentName: null,
+    createdAt: new Date("2026-04-12T00:00:00.000Z"),
+    updatedAt: new Date("2026-04-12T00:00:00.000Z"),
+  };
+}
+
+describe("CompoAdviceService", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    prismaMock.trackedClan.findMany.mockReset();
+    prismaMock.fwaClanMemberCurrent.findMany.mockReset();
+    prismaMock.fwaTrackedClanWarRosterCurrent.findMany.mockReset();
+    prismaMock.fwaTrackedClanWarRosterMemberCurrent.findMany.mockReset();
+    prismaMock.heatMapRef.findMany.mockReset();
+    prismaMock.weightInputDeferment.findMany.mockReset();
+  });
+
+  it("loads ACTUAL advice from DB-backed state and defaults to Auto-Detect Band without sheet reads", async () => {
+    prismaMock.trackedClan.findMany.mockResolvedValue([
+      makeTrackedClan("#AAA111", "Alpha Clan-actual"),
+    ]);
+    prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue([
+      makeCurrentMember({
+        clanTag: "#AAA111",
+        playerTag: "#P000001",
+        weight: 135000,
+      }),
+      makeCurrentMember({
+        clanTag: "#AAA111",
+        playerTag: "#P000002",
+        weight: 135000,
+      }),
+      makeCurrentMember({
+        clanTag: "#AAA111",
+        playerTag: "#P000003",
+        weight: 135000,
+      }),
+      makeCurrentMember({
+        clanTag: "#AAA111",
+        playerTag: "#P000004",
+        weight: 135000,
+      }),
+      makeCurrentMember({
+        clanTag: "#AAA111",
+        playerTag: "#P000005",
+        weight: 135000,
+      }),
+      makeCurrentMember({
+        clanTag: "#AAA111",
+        playerTag: "#P000006",
+        weight: 135000,
+      }),
+      makeCurrentMember({
+        clanTag: "#AAA111",
+        playerTag: "#P000007",
+        weight: 135000,
+      }),
+      makeCurrentMember({
+        clanTag: "#AAA111",
+        playerTag: "#P000008",
+        weight: 135000,
+      }),
+      makeCurrentMember({
+        clanTag: "#AAA111",
+        playerTag: "#P000009",
+        weight: 135000,
+      }),
+      makeCurrentMember({
+        clanTag: "#AAA111",
+        playerTag: "#P000010",
+        weight: 135000,
+      }),
+    ]);
+    prismaMock.weightInputDeferment.findMany.mockResolvedValue([]);
+    prismaMock.fwaTrackedClanWarRosterMemberCurrent.findMany.mockResolvedValue([]);
+    prismaMock.heatMapRef.findMany.mockResolvedValue([
+      makeHeatMapRef({
+        weightMinInclusive: 1_300_000,
+        weightMaxInclusive: 2_000_000,
+        th14Count: 10,
+      }),
+    ]);
+    const getCompoLinkedSheetSpy = vi.spyOn(
+      GoogleSheetsService.prototype,
+      "getCompoLinkedSheet",
+    );
+    const readCompoLinkedValuesSpy = vi.spyOn(
+      GoogleSheetsService.prototype,
+      "readCompoLinkedValues",
+    );
+
+    const result = await new CompoAdviceService().readAdvice({
+      guildId: "guild-1",
+      targetTag: "#AAA111",
+      mode: "actual",
+    });
+
+    expect(getCompoLinkedSheetSpy).not.toHaveBeenCalled();
+    expect(readCompoLinkedValuesSpy).not.toHaveBeenCalled();
+    expect(result.selectedView).toBe("auto");
+    expect(result.content).toContain("Mode: **ACTUAL**");
+    expect(result.content).toContain("Advice View: **Auto-Detect Band**");
+    expect(result.content).toContain("Current Score:");
+  });
+
+  it("loads WAR advice from DB-backed tracked war state without sheet reads", async () => {
+    prismaMock.trackedClan.findMany.mockResolvedValue([
+      makeTrackedClan("#AAA111", "Alpha Clan-war"),
+    ]);
+    prismaMock.fwaTrackedClanWarRosterCurrent.findMany.mockResolvedValue([
+      makeWarParent({
+        clanTag: "#AAA111",
+        clanName: "Alpha Clan-war",
+        totalEffectiveWeight: 8_100_000,
+      }),
+    ]);
+    prismaMock.fwaTrackedClanWarRosterMemberCurrent.findMany.mockResolvedValue([
+      ...Array.from({ length: 50 }, (_, index) =>
+        makeWarMember({
+          clanTag: "#AAA111",
+          position: index + 1,
+          rawWeight: 145000,
+          effectiveWeight: 145000,
+        }),
+      ),
+    ]);
+    prismaMock.heatMapRef.findMany.mockResolvedValue([
+      makeHeatMapRef({
+        weightMinInclusive: 8_000_001,
+        weightMaxInclusive: 8_100_000,
+        th15Count: 50,
+      }),
+    ]);
+    const getCompoLinkedSheetSpy = vi.spyOn(
+      GoogleSheetsService.prototype,
+      "getCompoLinkedSheet",
+    );
+    const readCompoLinkedValuesSpy = vi.spyOn(
+      GoogleSheetsService.prototype,
+      "readCompoLinkedValues",
+    );
+
+    const result = await new CompoAdviceService().readAdvice({
+      targetTag: "#AAA111",
+      mode: "war",
+    });
+
+    expect(getCompoLinkedSheetSpy).not.toHaveBeenCalled();
+    expect(readCompoLinkedValuesSpy).not.toHaveBeenCalled();
+    expect(result.selectedView).toBe("raw");
+    expect(result.content).toContain("Mode: **WAR**");
+    expect(result.content).toContain("Advice View: **Raw Data**");
+    expect(result.content).toContain("Current Score:");
+  });
+});

--- a/tests/compoRefresh.logic.test.ts
+++ b/tests/compoRefresh.logic.test.ts
@@ -3,6 +3,7 @@ import {
   buildCompoRefreshCustomIdForTest,
   handleCompoRefreshButton,
 } from "../src/commands/Compo";
+import { CompoAdviceService } from "../src/services/CompoAdviceService";
 import { CompoActualStateService } from "../src/services/CompoActualStateService";
 
 function makeMessageRow(customId: string, label: string, disabled = false): { toJSON: () => unknown } {
@@ -215,9 +216,9 @@ describe("compo refresh button behavior", () => {
     expect(collectButtonCustomIds(viewPayload)).toEqual(
       expect.arrayContaining([
         "compo-refresh:state:user-1:actual:auto",
-        "compo-refresh:view:user-1:raw",
-        "compo-refresh:view:user-1:auto",
-        "compo-refresh:view:user-1:best",
+        "compo-refresh:view:user-1:state:raw",
+        "compo-refresh:view:user-1:state:auto",
+        "compo-refresh:view:user-1:state:best",
       ]),
     );
 
@@ -235,5 +236,73 @@ describe("compo refresh button behavior", () => {
       "guild-1",
       { view: "auto" },
     );
+  });
+
+  it("keeps the selected ACTUAL advice view across view switches and refreshes", async () => {
+    vi.spyOn(CompoAdviceService.prototype, "readAdvice").mockResolvedValue({
+      content:
+        "RAW Data last refreshed: <t:1709900000:F>\nMode: **ACTUAL**\nAdvice View: **Best Fit**\nCurrent Score: **4**\nCurrent Band: **0 - 9999999**\nRecommendation: **Add TH17**\nResulting Score: **0**\nResulting Band: **0 - 9999999**",
+      trackedClanTags: ["#AAA111"],
+      selectedView: "best",
+      mode: "actual",
+    });
+    vi.spyOn(CompoAdviceService.prototype, "refreshAdvice").mockResolvedValue({
+      content:
+        "RAW Data last refreshed: <t:1709900001:F>\nMode: **ACTUAL**\nAdvice View: **Best Fit**\nCurrent Score: **4**\nCurrent Band: **0 - 9999999**\nRecommendation: **Add TH17**\nResulting Score: **0**\nResulting Band: **0 - 9999999**",
+      trackedClanTags: ["#AAA111"],
+      selectedView: "best",
+      mode: "actual",
+    });
+
+    const viewInteraction = makeInteraction(
+      buildCompoRefreshCustomIdForTest({
+        kind: "view",
+        userId: "user-1",
+        target: "advice",
+        actualView: "best",
+        targetTag: "AAA111",
+      }),
+    );
+    viewInteraction.message.components = [
+      makeMessageRow("compo-refresh:advice:user-1:actual:auto:AAA111", "Refresh Data"),
+      makeMessageRow("post-channel:user-1", "Post to Channel"),
+    ];
+
+    await handleCompoRefreshButton(viewInteraction as any, {} as any);
+
+    expect(CompoAdviceService.prototype.readAdvice).toHaveBeenCalledWith({
+      guildId: "guild-1",
+      targetTag: "AAA111",
+      mode: "actual",
+      view: "best",
+    });
+    const viewPayload = viewInteraction.editReply.mock.calls.at(-1)?.[0];
+    expect(collectButtonCustomIds(viewPayload)).toEqual(
+      expect.arrayContaining([
+        "compo-refresh:advice:user-1:actual:best:AAA111",
+        "compo-refresh:view:user-1:advice:raw:AAA111",
+        "compo-refresh:view:user-1:advice:auto:AAA111",
+        "compo-refresh:view:user-1:advice:best:AAA111",
+      ]),
+    );
+
+    const refreshInteraction = makeInteraction(
+      "compo-refresh:advice:user-1:actual:best:AAA111",
+    );
+    refreshInteraction.message.components = (viewPayload.components as unknown[]).map(
+      (row) =>
+        row && typeof (row as { toJSON?: () => unknown }).toJSON === "function"
+          ? row
+          : { toJSON: () => row },
+    );
+
+    await handleCompoRefreshButton(refreshInteraction as any, {} as any);
+
+    expect(CompoAdviceService.prototype.refreshAdvice).toHaveBeenCalledWith({
+      guildId: "guild-1",
+      targetTag: "AAA111",
+      mode: "actual",
+      view: "best",
+    });
   });
 });


### PR DESCRIPTION
- load ACTUAL and WAR advice from persisted state snapshots
- simulate add and swap candidates with weighted deviation scoring
- add ACTUAL advice view switching and refresh payload preservation