### PR TITLE
feat(compo): add embed advice with custom band controls

### DIFF
--- a/src/commands/Compo.ts
+++ b/src/commands/Compo.ts
@@ -14,6 +14,12 @@ import {
 } from "discord.js";
 import { Command } from "../Command";
 import {
+  COMPO_ADVICE_VIEW_LABELS,
+  COMPO_ADVICE_VIEWS,
+  stepCompoAdviceCustomBandIndexByCount,
+  type CompoAdviceView,
+} from "../helper/compoAdviceEngine";
+import {
   COMPO_ACTUAL_STATE_VIEWS,
   getCompoActualStateViewLabel,
   type CompoActualStateView,
@@ -24,7 +30,10 @@ import { normalizeCompoClanDisplayName } from "../helper/compoDisplay";
 import { prisma } from "../prisma";
 import { safeReply } from "../helper/safeReply";
 import { CoCService } from "../services/CoCService";
-import { CompoAdviceService } from "../services/CompoAdviceService";
+import {
+  CompoAdviceService,
+  type CompoAdviceReadResult,
+} from "../services/CompoAdviceService";
 import { CompoActualStateService } from "../services/CompoActualStateService";
 import { CompoPlaceService } from "../services/CompoPlaceService";
 import { CompoWarStateService } from "../services/CompoWarStateService";
@@ -126,14 +135,16 @@ type CompoRefreshPayload =
       userId: string;
       mode: "war";
       targetTag: string;
-    }
+  }
   | {
       kind: "advice";
       userId: string;
       mode: "actual";
-      actualView: CompoActualStateView;
+      adviceView: CompoAdviceView;
       targetTag: string;
-    }
+      customBandIndex: number | null;
+      customBandCount: number;
+  }
   | {
       kind: "view";
       userId: string;
@@ -144,8 +155,18 @@ type CompoRefreshPayload =
       kind: "view";
       userId: string;
       target: "advice";
-      actualView: CompoActualStateView;
+      adviceView: CompoAdviceView;
       targetTag: string;
+      customBandIndex: number | null;
+      customBandCount: number;
+    }
+  | {
+      kind: "advice-band";
+      userId: string;
+      targetTag: string;
+      customBandCount: number;
+      customBandIndex: number;
+      direction: "prev" | "next";
     }
   | {
       kind: "place";
@@ -162,15 +183,24 @@ function buildCompoRefreshCustomId(payload: CompoRefreshPayload): string {
   }
   if (payload.kind === "advice") {
     if (payload.mode === "actual") {
-      return `${COMPO_REFRESH_PREFIX}:advice:${payload.userId}:actual:${payload.actualView}:${payload.targetTag}`;
+      const base = `${COMPO_REFRESH_PREFIX}:advice:${payload.userId}:actual:${payload.adviceView}:${payload.targetTag}:${Math.trunc(payload.customBandCount)}`;
+      return payload.customBandIndex === null || payload.customBandIndex === undefined
+        ? `${base}:0`
+        : `${base}:${Math.trunc(payload.customBandIndex)}`;
     }
     return `${COMPO_REFRESH_PREFIX}:advice:${payload.userId}:war:${payload.targetTag}`;
   }
   if (payload.kind === "view") {
     if (payload.target === "advice") {
-      return `${COMPO_REFRESH_PREFIX}:view:${payload.userId}:advice:${payload.actualView}:${payload.targetTag}`;
+      const base = `${COMPO_REFRESH_PREFIX}:view:${payload.userId}:advice:${payload.adviceView}:${payload.targetTag}:${Math.trunc(payload.customBandCount)}`;
+      return payload.customBandIndex === null || payload.customBandIndex === undefined
+        ? `${base}:0`
+        : `${base}:${Math.trunc(payload.customBandIndex)}`;
     }
     return `${COMPO_REFRESH_PREFIX}:view:${payload.userId}:state:${payload.actualView}`;
+  }
+  if (payload.kind === "advice-band") {
+    return `${COMPO_REFRESH_PREFIX}:advice-band:${payload.userId}:${payload.targetTag}:${Math.trunc(payload.customBandCount)}:${Math.trunc(payload.customBandIndex)}:${payload.direction}`;
   }
   return `${COMPO_REFRESH_PREFIX}:place:${payload.userId}:${Math.trunc(payload.weight)}`;
 }
@@ -221,12 +251,25 @@ function parseCompoRefreshCustomId(
         targetTag,
       };
     }
-    if (mode === "actual" && parts.length === 6) {
-      const actualView = parts[4];
+    if (
+      mode === "actual" &&
+      (parts.length === 6 || parts.length === 7 || parts.length === 8)
+    ) {
+      const adviceView = parts[4];
       const targetTag = normalizeTag(parts[5] ?? "");
+      const customBandCount =
+        parts.length >= 7 ? Number(parts[6]) : 0;
+      const customBandIndexRaw =
+        parts.length === 8 ? Number(parts[7]) : null;
       if (
         !targetTag ||
-        !COMPO_ACTUAL_STATE_VIEWS.includes(actualView as CompoActualStateView)
+        !COMPO_ADVICE_VIEWS.includes(adviceView as CompoAdviceView) ||
+        (parts.length >= 7 &&
+          (!Number.isFinite(customBandCount) || customBandCount < 0)) ||
+        (parts.length === 8 &&
+          (typeof customBandIndexRaw !== "number" ||
+            !Number.isFinite(customBandIndexRaw) ||
+            customBandIndexRaw < 0))
       ) {
         return null;
       }
@@ -234,19 +277,24 @@ function parseCompoRefreshCustomId(
         kind: "advice",
         userId,
         mode,
-        actualView: actualView as CompoActualStateView,
+        adviceView: adviceView as CompoAdviceView,
         targetTag,
+        customBandCount: Math.trunc(customBandCount),
+        customBandIndex:
+          typeof customBandIndexRaw === "number"
+            ? Math.trunc(customBandIndexRaw)
+            : null,
       };
     }
     return null;
   }
   if (kind === "view" && parts.length >= 5) {
     const target = parts[3];
-    const actualView = parts[4];
-    if (!COMPO_ACTUAL_STATE_VIEWS.includes(actualView as CompoActualStateView)) {
-      return null;
-    }
     if (target === "state" && parts.length === 5) {
+      const actualView = parts[4];
+      if (!COMPO_ACTUAL_STATE_VIEWS.includes(actualView as CompoActualStateView)) {
+        return null;
+      }
       return {
         kind: "view",
         userId,
@@ -254,18 +302,66 @@ function parseCompoRefreshCustomId(
         actualView: actualView as CompoActualStateView,
       };
     }
-    if (target === "advice" && parts.length === 6) {
+    if (
+      target === "advice" &&
+      (parts.length === 6 || parts.length === 7 || parts.length === 8)
+    ) {
+      const adviceView = parts[4];
       const targetTag = normalizeTag(parts[5] ?? "");
-      if (!targetTag) return null;
+      const customBandCount =
+        parts.length >= 7 ? Number(parts[6]) : 0;
+      const customBandIndexRaw =
+        parts.length === 8 ? Number(parts[7]) : null;
+      if (
+        !targetTag ||
+        !COMPO_ADVICE_VIEWS.includes(adviceView as CompoAdviceView) ||
+        (parts.length >= 7 &&
+          (!Number.isFinite(customBandCount) || customBandCount < 0)) ||
+        (parts.length === 8 &&
+          (typeof customBandIndexRaw !== "number" ||
+            !Number.isFinite(customBandIndexRaw) ||
+            customBandIndexRaw < 0))
+      ) {
+        return null;
+      }
       return {
         kind: "view",
         userId,
         target,
-        actualView: actualView as CompoActualStateView,
+        adviceView: adviceView as CompoAdviceView,
         targetTag,
+        customBandCount: Math.trunc(customBandCount),
+        customBandIndex:
+          typeof customBandIndexRaw === "number"
+            ? Math.trunc(customBandIndexRaw)
+            : null,
       };
     }
     return null;
+  }
+  if (kind === "advice-band" && parts.length === 7) {
+    const targetTag = normalizeTag(parts[3] ?? "");
+    const customBandCount = Number(parts[4]);
+    const customBandIndex = Number(parts[5]);
+    const direction = parts[6];
+    if (
+      !targetTag ||
+      !Number.isFinite(customBandCount) ||
+      customBandCount < 0 ||
+      !Number.isFinite(customBandIndex) ||
+      customBandIndex < 0 ||
+      (direction !== "prev" && direction !== "next")
+    ) {
+      return null;
+    }
+    return {
+      kind: "advice-band",
+      userId,
+      targetTag,
+      customBandCount: Math.trunc(customBandCount),
+      customBandIndex: Math.trunc(customBandIndex),
+      direction,
+    };
   }
   if (kind === "place" && parts.length === 4) {
     const value = parts[3];
@@ -316,8 +412,10 @@ function buildCompoActualViewActionRow(input: {
                 kind: "view" as const,
                 userId: input.userId,
                 target: "advice" as const,
-                actualView: view,
+                adviceView: view as CompoAdviceView,
                 targetTag: input.targetTag ?? "",
+                customBandIndex: null,
+                customBandCount: 0,
               }
             : {
                 kind: "view" as const,
@@ -336,6 +434,82 @@ function buildCompoActualViewActionRow(input: {
           .setDisabled(loading);
       })(),
     ),
+  );
+}
+
+function buildCompoAdviceViewActionRow(input: {
+  userId: string;
+  targetTag: string;
+  selectedView: CompoAdviceView;
+  customBandIndex: number | null;
+  customBandCount: number;
+  loading?: boolean;
+}): ActionRowBuilder<ButtonBuilder> {
+  const loading = input.loading ?? false;
+  return new ActionRowBuilder<ButtonBuilder>().addComponents(
+    COMPO_ADVICE_VIEWS.map((view) =>
+      new ButtonBuilder()
+        .setCustomId(
+          buildCompoRefreshCustomId({
+            kind: "view",
+            userId: input.userId,
+            target: "advice",
+            adviceView: view,
+            targetTag: input.targetTag,
+            customBandIndex: input.customBandIndex,
+            customBandCount: input.customBandCount,
+          }),
+        )
+        .setLabel(COMPO_ADVICE_VIEW_LABELS[view])
+        .setStyle(
+          input.selectedView === view
+            ? ButtonStyle.Primary
+            : ButtonStyle.Secondary,
+        )
+        .setDisabled(loading),
+    ),
+  );
+}
+
+function buildCompoAdviceBandActionRow(input: {
+  userId: string;
+  targetTag: string;
+  customBandIndex: number;
+  customBandCount: number;
+  loading?: boolean;
+}): ActionRowBuilder<ButtonBuilder> {
+  const loading = input.loading ?? false;
+  const canStepPrev = input.customBandIndex > 0;
+  const canStepNext = input.customBandIndex < input.customBandCount - 1;
+  return new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder()
+      .setCustomId(
+        buildCompoRefreshCustomId({
+          kind: "advice-band",
+          userId: input.userId,
+          targetTag: input.targetTag,
+          customBandCount: input.customBandCount,
+          customBandIndex: input.customBandIndex,
+          direction: "prev",
+        }),
+      )
+      .setLabel("-")
+      .setStyle(ButtonStyle.Secondary)
+      .setDisabled(loading || !canStepPrev),
+    new ButtonBuilder()
+      .setCustomId(
+        buildCompoRefreshCustomId({
+          kind: "advice-band",
+          userId: input.userId,
+          targetTag: input.targetTag,
+          customBandCount: input.customBandCount,
+          customBandIndex: input.customBandIndex,
+          direction: "next",
+        }),
+      )
+      .setLabel("+")
+      .setStyle(ButtonStyle.Secondary)
+      .setDisabled(loading || !canStepNext),
   );
 }
 
@@ -650,6 +824,114 @@ function buildCompoStatePayloadFromRows(input: {
   };
 }
 
+function formatSignedValue(value: number | null): string {
+  if (value === null) {
+    return "n/a";
+  }
+  return value > 0 ? `+${value}` : `${value}`;
+}
+
+function formatAdviceScore(value: number | null): string {
+  if (value === null) {
+    return "n/a";
+  }
+  return Number.isInteger(value) ? `${value}` : value.toFixed(1);
+}
+
+function buildCompoAdviceEmbed(input: { advice: CompoAdviceReadResult }): EmbedBuilder {
+  const title = input.advice.clanTag
+    ? `${normalizeCompoClanDisplayName(input.advice.clanName ?? input.advice.clanTag)} (${input.advice.clanTag}) - ${input.advice.mode.toUpperCase()}`
+    : `Compo Advice - ${input.advice.mode.toUpperCase()}`;
+
+  if (input.advice.kind === "ready") {
+    const summary = input.advice.summary;
+    const embed = new EmbedBuilder()
+      .setTitle(title)
+      .setDescription(
+        [
+          `Advice View: **${summary.viewLabel}**`,
+          `Target Band: **${summary.currentBandLabel}**`,
+          `Current Score: **${formatAdviceScore(summary.currentScore)}**`,
+        ].join("\n"),
+      );
+    const currentDeltas = [
+      `TH18: ${formatSignedValue(summary.currentProjection.deltaByBucket.TH18)}`,
+      `TH17: ${formatSignedValue(summary.currentProjection.deltaByBucket.TH17)}`,
+      `TH16: ${formatSignedValue(summary.currentProjection.deltaByBucket.TH16)}`,
+      `TH15: ${formatSignedValue(summary.currentProjection.deltaByBucket.TH15)}`,
+      `TH14: ${formatSignedValue(summary.currentProjection.deltaByBucket.TH14)}`,
+      `<=TH13: ${formatSignedValue(summary.currentProjection.deltaByBucket["<=TH13"])}`,
+    ].join("\n");
+
+    const recommendationLines = [
+      summary.recommendationText,
+      `Resulting Score: ${formatAdviceScore(summary.resultingScore)}`,
+      `Resulting Band: ${summary.resultingBandLabel}`,
+    ];
+    if (summary.statusText) {
+      recommendationLines.push(summary.statusText);
+    }
+
+    embed.addFields(
+      {
+        name: "Overview",
+        value: [
+          `Members: ${summary.currentProjection.memberCount} / 50`,
+          `Rushed: ${input.advice.rushedCount}`,
+          `Current Score: ${formatAdviceScore(summary.currentScore)}`,
+          `Current Band: ${summary.currentBandLabel}`,
+        ].join("\n"),
+        inline: false,
+      },
+      {
+        name: "Current Deltas",
+        value: currentDeltas,
+        inline: false,
+      },
+      {
+        name: "Best Recommendation",
+        value: recommendationLines.join("\n"),
+        inline: false,
+      },
+      {
+        name: "Alternates",
+        value:
+          summary.alternateTexts.length > 0
+            ? summary.alternateTexts.map((line) => `- ${line}`).join("\n")
+            : "None",
+        inline: false,
+      },
+    );
+
+    if (input.advice.refreshLine) {
+      embed.setFooter({ text: input.advice.refreshLine });
+    }
+    return embed;
+  }
+
+  const embed = new EmbedBuilder()
+    .setTitle(title)
+    .setDescription(
+      [
+        `Advice View: **${COMPO_ADVICE_VIEW_LABELS[input.advice.selectedView]}**`,
+        input.advice.message,
+      ].join("\n"),
+    );
+
+  if (input.advice.refreshLine) {
+    embed.setFooter({ text: input.advice.refreshLine });
+  }
+  return embed;
+}
+
+function buildCompoAdviceResponsePayload(input: {
+  advice: CompoAdviceReadResult;
+}): CompoRenderPayload {
+  return {
+    embeds: [buildCompoAdviceEmbed({ advice: input.advice })],
+  };
+}
+
 /*
   const recommendedRows = params.recommended.map(
     (c) =>
@@ -903,14 +1185,30 @@ function buildCompoRefreshComponents(input: {
   }
   if (input.refreshPayload.kind === "advice" && input.refreshPayload.mode === "actual") {
     components.push(
-      buildCompoActualViewActionRow({
+      buildCompoAdviceViewActionRow({
         userId: input.refreshPayload.userId,
-        target: "advice",
         targetTag: input.refreshPayload.targetTag,
-        selectedView: input.refreshPayload.actualView,
+        selectedView: input.refreshPayload.adviceView,
+        customBandIndex: input.refreshPayload.customBandIndex,
+        customBandCount: input.refreshPayload.customBandCount,
         loading: input.loading,
       }),
     );
+    if (
+      input.refreshPayload.adviceView === "custom" &&
+      input.refreshPayload.customBandIndex !== null &&
+      input.refreshPayload.customBandCount > 0
+    ) {
+      components.push(
+        buildCompoAdviceBandActionRow({
+          userId: input.refreshPayload.userId,
+          targetTag: input.refreshPayload.targetTag,
+          customBandIndex: input.refreshPayload.customBandIndex,
+          customBandCount: input.refreshPayload.customBandCount,
+          loading: input.loading,
+        }),
+      );
+    }
   }
   if (input.supplementalRows && input.supplementalRows.length > 0) {
     components.push(...input.supplementalRows);
@@ -952,6 +1250,9 @@ function getCompoRefreshFailureMessage(payload: CompoRefreshPayload): string {
   if (payload.kind === "advice") {
     return mapCompoAdviceErrorToMessage("refresh");
   }
+  if (payload.kind === "advice-band") {
+    return mapCompoAdviceErrorToMessage("refresh");
+  }
   if (payload.kind === "view" && payload.target === "advice") {
     return mapCompoAdviceErrorToMessage("refresh");
   }
@@ -987,26 +1288,51 @@ export async function handleCompoRefreshButton(
   }
 
   const supplementalRows = extractSupplementalRowsFromMessage(interaction);
-  const loadingRefreshPayload: Extract<
+  let adviceRefreshPayload: Extract<CompoRefreshPayload, { kind: "advice" }> | null = null;
+  let loadingRefreshPayload: Extract<
     CompoRefreshPayload,
     { kind: "state" | "advice" | "place" }
-  > =
-    parsed.kind === "view"
-      ? parsed.target === "advice"
-        ? {
-            kind: "advice",
-            userId: parsed.userId,
-            mode: "actual",
-            actualView: parsed.actualView,
-            targetTag: parsed.targetTag,
-          }
-        : {
-            kind: "state",
-            userId: parsed.userId,
-            mode: "actual",
-            actualView: parsed.actualView,
-          }
-      : parsed;
+  >;
+  if (parsed.kind === "view" && parsed.target === "advice") {
+    adviceRefreshPayload = {
+      kind: "advice",
+      userId: parsed.userId,
+      mode: "actual",
+      adviceView: parsed.adviceView,
+      targetTag: parsed.targetTag,
+      customBandIndex: parsed.customBandIndex ?? 0,
+      customBandCount: parsed.customBandCount,
+    };
+    loadingRefreshPayload = adviceRefreshPayload;
+  } else if (parsed.kind === "advice-band") {
+    const nextBandIndex = stepCompoAdviceCustomBandIndexByCount({
+      currentBandIndex: parsed.customBandIndex,
+      bandCount: parsed.customBandCount,
+      direction: parsed.direction,
+    });
+    adviceRefreshPayload = {
+      kind: "advice",
+      userId: parsed.userId,
+      mode: "actual",
+      adviceView: "custom",
+      targetTag: parsed.targetTag,
+      customBandIndex: nextBandIndex,
+      customBandCount: parsed.customBandCount,
+    };
+    loadingRefreshPayload = adviceRefreshPayload;
+  } else if (parsed.kind === "advice") {
+    adviceRefreshPayload = parsed;
+    loadingRefreshPayload = parsed;
+  } else if (parsed.kind === "view" && parsed.target === "state") {
+    loadingRefreshPayload = {
+      kind: "state",
+      userId: parsed.userId,
+      mode: "actual",
+      actualView: parsed.actualView,
+    };
+  } else {
+    loadingRefreshPayload = parsed;
+  }
   await interaction.update({
     components: buildCompoRefreshComponents({
       refreshPayload: loadingRefreshPayload,
@@ -1060,18 +1386,25 @@ export async function handleCompoRefreshButton(
       return;
     }
 
-    if (parsed.kind === "advice") {
+    if (adviceRefreshPayload) {
       const adviceService = new CompoAdviceService();
       const advice = await adviceService.refreshAdvice({
         guildId: interaction.guildId ?? null,
-        targetTag: parsed.targetTag,
-        mode: parsed.mode,
-        view: parsed.mode === "actual" ? parsed.actualView : "raw",
+        targetTag: adviceRefreshPayload.targetTag,
+        mode: adviceRefreshPayload.mode,
+        view:
+          adviceRefreshPayload.mode === "actual"
+            ? adviceRefreshPayload.adviceView
+            : "raw",
+        customBandIndex:
+          adviceRefreshPayload.mode === "actual"
+            ? adviceRefreshPayload.customBandIndex
+            : null,
       });
       await interaction.editReply({
-        content: advice.content,
+        ...buildCompoAdviceResponsePayload({ advice }),
         components: buildCompoRefreshComponents({
-          refreshPayload: parsed,
+          refreshPayload: adviceRefreshPayload,
           loading: false,
           supplementalRows,
         }),
@@ -1114,52 +1447,33 @@ export async function handleCompoRefreshButton(
         });
         return;
       }
+      return;
+    }
 
-      const advice = await new CompoAdviceService().readAdvice({
-        guildId: interaction.guildId ?? null,
-        targetTag: parsed.targetTag,
-        mode: "actual",
-        view: parsed.actualView,
-      });
+    if (parsed.kind === "place") {
+      const bucket = getCompoWarDisplayBucket(parsed.weight);
+      if (!bucket) {
+        throw new Error("Invalid placement bucket for refresh.");
+      }
+      const placeResult = await new CompoPlaceService().refreshPlace(
+        parsed.weight,
+        bucket,
+        interaction.guildId ?? null,
+      );
       await interaction.editReply({
-        content: advice.content,
+        content: placeResult.content,
+        embeds: placeResult.embeds,
         components: buildCompoRefreshComponents({
           refreshPayload: {
-            kind: "advice",
-            userId: parsed.userId,
-            mode: "actual",
-            actualView: parsed.actualView,
-            targetTag: parsed.targetTag,
+            kind: "place",
+            userId: interaction.user.id,
+            weight: parsed.weight,
           },
           loading: false,
           supplementalRows,
         }),
       });
-      return;
     }
-
-    const bucket = getCompoWarDisplayBucket(parsed.weight);
-    if (!bucket) {
-      throw new Error("Invalid placement bucket for refresh.");
-    }
-    const placeResult = await new CompoPlaceService().refreshPlace(
-      parsed.weight,
-      bucket,
-      interaction.guildId ?? null,
-    );
-    await interaction.editReply({
-      content: placeResult.content,
-      embeds: placeResult.embeds,
-      components: buildCompoRefreshComponents({
-        refreshPayload: {
-          kind: "place",
-          userId: interaction.user.id,
-          weight: parsed.weight,
-        },
-        loading: false,
-        supplementalRows,
-      }),
-    });
   } catch (err) {
     console.error(`compo refresh button failed: ${formatError(err)}`);
     await interaction.editReply({
@@ -1273,24 +1587,31 @@ export const Compo: Command = {
           result: "advice_rendered",
           mode,
         });
+        const adviceRefreshPayload =
+          mode === "actual"
+            ? {
+                kind: "advice" as const,
+                userId: interaction.user.id,
+                mode: "actual" as const,
+                adviceView: advice.selectedView,
+                targetTag,
+                customBandIndex:
+                  advice.kind === "ready"
+                    ? advice.summary.selectedCustomBandIndex
+                    : null,
+                customBandCount:
+                  advice.kind === "ready" ? advice.summary.customBandCount : 0,
+              }
+            : {
+                kind: "advice" as const,
+                userId: interaction.user.id,
+                mode: "war" as const,
+                targetTag,
+              };
         await interaction.editReply({
-          content: advice.content,
+          ...buildCompoAdviceResponsePayload({ advice }),
           components: buildCompoRefreshComponents({
-            refreshPayload:
-              mode === "actual"
-                ? {
-                    kind: "advice",
-                    userId: interaction.user.id,
-                    mode: "actual",
-                    actualView: advice.selectedView,
-                    targetTag,
-                  }
-                : {
-                    kind: "advice",
-                    userId: interaction.user.id,
-                    mode: "war",
-                    targetTag,
-                  },
+            refreshPayload: adviceRefreshPayload,
             loading: false,
           }),
         });

--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -188,7 +188,7 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
     summary: "Composition tools with DB-backed WAR state plus DB-backed ACTUAL state/place flows.",
     details: [
       "`advice`: simulate bucket-level compo moves from DB-backed ACTUAL or WAR state and recommend the best improvement.",
-      "`advice` ACTUAL mode defaults to `Auto-Detect Band` and can be switched between `Raw Data`, `Auto-Detect Band`, and `Best Fit` with inline buttons.",
+      "`advice` renders as an embed. ACTUAL mode defaults to `Auto-Detect Band` and can be switched between `Raw Data`, `Auto-Detect Band`, `Best Fit`, and `Custom` with inline buttons. `Custom` also exposes `-` / `+` band-step controls.",
       "`state`: `mode:war` renders from persisted tracked-clan feed state only, while `mode:actual` now renders from persisted ACTUAL current-member state (`TrackedClan` + `FwaClanMemberCurrent` + `HeatMapRef`) with deferred-weight and WAR-effective-weight fallback when member weight is zero.",
       "`state` refresh: `mode:war` refreshes tracked-clan war-roster feed state only and rerenders from DB; `mode:actual` now refreshes ACTUAL current-member/weight state plus live CoC member counts for all tracked clans, then rerenders from DB.",
       "`place`: suggest placement by war weight from persisted ACTUAL FWAStats current-member state (`TrackedClan` + `FwaClanMemberCurrent` + `HeatMapRef`) with deferred-weight and WAR-effective-weight fallback only for zero-weight member rows.",

--- a/src/helper/compoActualStateView.ts
+++ b/src/helper/compoActualStateView.ts
@@ -119,7 +119,7 @@ function buildTargetCounts(heatMapRef: HeatMapRef): CompoWarDisplayBucketCounts 
   };
 }
 
-function buildDeltaByBucket(
+export function getCompoActualStateDeltaByBucket(
   counts: CompoWarDisplayBucketCounts,
   heatMapRef: HeatMapRef | null,
 ): Record<CompoWarDisplayBucket, number | null> {
@@ -153,7 +153,10 @@ export function calculateCompoDeviationScore(input: {
     return null;
   }
 
-  const deltaByBucket = buildDeltaByBucket(input.displayCounts, input.heatMapRef);
+  const deltaByBucket = getCompoActualStateDeltaByBucket(
+    input.displayCounts,
+    input.heatMapRef,
+  );
   return DISPLAY_BUCKETS_ASC.reduce((sum, bucket) => {
     const delta = deltaByBucket[bucket];
     return sum + Math.abs(delta ?? 0) * DEVIATION_SCORE_WEIGHTS[bucket];
@@ -220,7 +223,10 @@ function buildFillPlan(input: {
     };
   }
 
-  const deltas = buildDeltaByBucket(input.displayCounts, input.heatMapRef);
+  const deltas = getCompoActualStateDeltaByBucket(
+    input.displayCounts,
+    input.heatMapRef,
+  );
   let remaining = input.nMissing;
 
   for (const bucket of DISPLAY_BUCKETS_ASC) {
@@ -293,7 +299,7 @@ function buildEstimatedProjectionForBand(input: {
     input.displayCounts,
     fillPlan.fillCounts,
   );
-  const deltaByBucket = buildDeltaByBucket(
+  const deltaByBucket = getCompoActualStateDeltaByBucket(
     estimatedDisplayCounts,
     input.heatMapRef,
   );
@@ -357,7 +363,7 @@ function buildRawProjection(input: {
       Math.max(0, 50 - input.base.memberCount) + input.base.unresolvedWeightCount,
     displayCounts: input.displayCounts,
     selectedHeatMapRef: heatMapRef,
-    deltaByBucket: buildDeltaByBucket(input.displayCounts, heatMapRef),
+    deltaByBucket: getCompoActualStateDeltaByBucket(input.displayCounts, heatMapRef),
     deviationScore: null,
   };
 }

--- a/src/helper/compoAdviceEngine.ts
+++ b/src/helper/compoAdviceEngine.ts
@@ -1,20 +1,18 @@
 import type { HeatMapRef } from "@prisma/client";
 import {
   calculateCompoDeviationScore,
-  getCompoActualStateViewLabel,
+  getCompoActualStateDeltaByBucket,
   getCompoDisplayBucketRepresentativeWeight,
   projectCompoActualStateView,
   type CompoActualStateBaseMetrics,
   type CompoActualStateProjection,
-  type CompoActualStateView,
 } from "./compoActualStateView";
 import {
   formatHeatMapRefBandLabel,
+  getHeatMapRefBandKey,
   getHeatMapRefBandMidpoint,
 } from "./compoHeatMap";
-import {
-  type CompoWarBucketCounts,
-} from "./compoWarBucketCounts";
+import type { CompoWarBucketCounts } from "./compoWarBucketCounts";
 import type { CompoWarDisplayBucket } from "./compoWarWeightBuckets";
 
 export const COMPO_ADVICE_DISPLAY_BUCKETS: readonly CompoWarDisplayBucket[] = [
@@ -47,7 +45,22 @@ const DISPLAY_BUCKET_TO_GRANULAR_BUCKET: Record<
   "<=TH13": "TH13",
 };
 
+export const COMPO_ADVICE_VIEWS = [
+  "raw",
+  "auto",
+  "best",
+  "custom",
+] as const;
+export type CompoAdviceView = (typeof COMPO_ADVICE_VIEWS)[number];
+
 export type CompoAdviceMode = "actual" | "war";
+
+export const COMPO_ADVICE_VIEW_LABELS: Record<CompoAdviceView, string> = {
+  raw: "Raw Data",
+  auto: "Auto-Detect Band",
+  best: "Best Fit",
+  custom: "Custom",
+};
 
 export type CompoAdviceAction =
   | {
@@ -76,7 +89,7 @@ export type CompoAdviceEvaluation = {
 
 export type CompoAdviceSummary = {
   mode: CompoAdviceMode;
-  view: CompoActualStateView;
+  view: CompoAdviceView;
   viewLabel: string;
   currentProjection: CompoActualStateProjection;
   currentScore: number | null;
@@ -86,6 +99,8 @@ export type CompoAdviceSummary = {
   resultingBandLabel: string;
   alternateTexts: string[];
   statusText: string | null;
+  selectedCustomBandIndex: number | null;
+  customBandCount: number;
 };
 
 function normalizeScore(value: number | null): number {
@@ -118,6 +133,117 @@ function cloneBucketCounts(
   counts: CompoWarBucketCounts,
 ): CompoWarBucketCounts {
   return { ...counts };
+}
+
+function sortHeatMapRefs(refs: readonly HeatMapRef[]): HeatMapRef[] {
+  return [...refs].sort((left, right) => {
+    if (left.weightMinInclusive !== right.weightMinInclusive) {
+      return left.weightMinInclusive - right.weightMinInclusive;
+    }
+    if (left.weightMaxInclusive !== right.weightMaxInclusive) {
+      return left.weightMaxInclusive - right.weightMaxInclusive;
+    }
+    return getHeatMapRefBandKey(left).localeCompare(getHeatMapRefBandKey(right));
+  });
+}
+
+function getHeatMapRefIndex(
+  refs: readonly HeatMapRef[],
+  target: HeatMapRef | null,
+): number | null {
+  if (!target) return null;
+  const targetKey = getHeatMapRefBandKey(target);
+  const index = refs.findIndex(
+    (ref) => getHeatMapRefBandKey(ref) === targetKey,
+  );
+  return index >= 0 ? index : null;
+}
+
+function clampHeatMapRefIndex(index: number, length: number): number {
+  if (length <= 0) {
+    return 0;
+  }
+  return Math.max(0, Math.min(length - 1, Math.trunc(index)));
+}
+
+function resolveCustomHeatMapRef(input: {
+  heatMapRefs: readonly HeatMapRef[];
+  currentProjection: CompoActualStateProjection;
+  customBandIndex?: number | null;
+}): {
+  heatMapRefs: HeatMapRef[];
+  selectedHeatMapRef: HeatMapRef | null;
+  selectedCustomBandIndex: number | null;
+} {
+  const heatMapRefs = sortHeatMapRefs(input.heatMapRefs);
+  if (heatMapRefs.length === 0) {
+    return {
+      heatMapRefs,
+      selectedHeatMapRef: null,
+      selectedCustomBandIndex: null,
+    };
+  }
+
+  const defaultIndex =
+    getHeatMapRefIndex(heatMapRefs, input.currentProjection.selectedHeatMapRef) ??
+    0;
+  const selectedCustomBandIndex = clampHeatMapRefIndex(
+    input.customBandIndex ?? defaultIndex,
+    heatMapRefs.length,
+  );
+  return {
+    heatMapRefs,
+    selectedHeatMapRef: heatMapRefs[selectedCustomBandIndex] ?? null,
+    selectedCustomBandIndex,
+  };
+}
+
+function buildCustomProjection(input: {
+  base: CompoActualStateBaseMetrics;
+  heatMapRefs: readonly HeatMapRef[];
+  customBandIndex?: number | null;
+}): {
+  projection: CompoActualStateProjection;
+  selectedCustomBandIndex: number | null;
+  heatMapRefs: HeatMapRef[];
+} {
+  const rawProjection = projectCompoActualStateView({
+    view: "raw",
+    base: input.base,
+    heatMapRefs: input.heatMapRefs,
+  });
+  const selection = resolveCustomHeatMapRef({
+    heatMapRefs: input.heatMapRefs,
+    currentProjection: rawProjection,
+    customBandIndex: input.customBandIndex,
+  });
+
+  if (!selection.selectedHeatMapRef) {
+    return {
+      projection: rawProjection,
+      selectedCustomBandIndex: null,
+      heatMapRefs: selection.heatMapRefs,
+    };
+  }
+
+  const deltaByBucket = getCompoActualStateDeltaByBucket(
+    rawProjection.displayCounts,
+    selection.selectedHeatMapRef,
+  );
+
+  return {
+    projection: {
+      ...rawProjection,
+      selectedHeatMapRef: selection.selectedHeatMapRef,
+      deltaByBucket,
+      deviationScore: calculateCompoDeviationScore({
+        displayCounts: rawProjection.displayCounts,
+        heatMapRef: selection.selectedHeatMapRef,
+      }),
+    },
+    selectedCustomBandIndex: selection.selectedCustomBandIndex,
+    heatMapRefs: selection.heatMapRefs,
+  };
 }
 
 function applyAdviceActionToBase(input: {
@@ -166,31 +292,57 @@ function applyAdviceActionToBase(input: {
 }
 
 function projectAdviceState(input: {
-  view: CompoActualStateView;
+  view: CompoAdviceView;
   base: CompoActualStateBaseMetrics;
   heatMapRefs: readonly HeatMapRef[];
-}): CompoActualStateProjection {
+  customBandIndex?: number | null;
+}): {
+  projection: CompoActualStateProjection;
+  selectedCustomBandIndex: number | null;
+  heatMapRefs: HeatMapRef[];
+} {
+  if (input.view === "custom") {
+    return buildCustomProjection({
+      base: input.base,
+      heatMapRefs: input.heatMapRefs,
+      customBandIndex: input.customBandIndex,
+    });
+  }
+
   const projection = projectCompoActualStateView({
     view: input.view,
     base: input.base,
     heatMapRefs: input.heatMapRefs,
   });
-
-  if (projection.deviationScore !== null || !projection.selectedHeatMapRef) {
-    return projection;
+  if (projection.deviationScore === null && projection.selectedHeatMapRef) {
+    return {
+      projection: {
+        ...projection,
+        deviationScore: calculateCompoDeviationScore({
+          displayCounts: projection.displayCounts,
+          heatMapRef: projection.selectedHeatMapRef,
+        }),
+      },
+      selectedCustomBandIndex:
+        getHeatMapRefIndex(
+          sortHeatMapRefs(input.heatMapRefs),
+          projection.selectedHeatMapRef,
+        ) ??
+        (input.heatMapRefs.length > 0 ? 0 : null),
+      heatMapRefs: sortHeatMapRefs(input.heatMapRefs),
+    };
   }
-
   return {
-    ...projection,
-    deviationScore: calculateCompoDeviationScore({
-      displayCounts: projection.displayCounts,
-      heatMapRef: projection.selectedHeatMapRef,
-    }),
+    projection,
+    selectedCustomBandIndex:
+      getHeatMapRefIndex(sortHeatMapRefs(input.heatMapRefs), projection.selectedHeatMapRef) ??
+      (input.heatMapRefs.length > 0 ? 0 : null),
+    heatMapRefs: sortHeatMapRefs(input.heatMapRefs),
   };
 }
 
 function evaluateAdviceAction(input: {
-  view: CompoActualStateView;
+  view: CompoAdviceView;
   base: CompoActualStateBaseMetrics;
   heatMapRefs: readonly HeatMapRef[];
   currentProjection: CompoActualStateProjection;
@@ -206,7 +358,7 @@ function evaluateAdviceAction(input: {
     view: input.view,
     base: nextBase,
     heatMapRefs: input.heatMapRefs,
-  });
+  }).projection;
   const resultingScore = afterProjection.deviationScore;
   const scoreImprovement =
     input.currentScore !== null && resultingScore !== null
@@ -305,17 +457,92 @@ function generateAdviceActions(input: {
   return actions;
 }
 
+function resolveCurrentProjectionBandIndex(input: {
+  heatMapRefs: readonly HeatMapRef[];
+  currentProjection: CompoActualStateProjection;
+  customBandIndex?: number | null;
+}): {
+  heatMapRefs: HeatMapRef[];
+  selectedCustomBandIndex: number | null;
+} {
+  const heatMapRefs = sortHeatMapRefs(input.heatMapRefs);
+  if (heatMapRefs.length === 0) {
+    return {
+      heatMapRefs,
+      selectedCustomBandIndex: null,
+    };
+  }
+
+  const defaultIndex =
+    getHeatMapRefIndex(heatMapRefs, input.currentProjection.selectedHeatMapRef) ??
+    0;
+  return {
+    heatMapRefs,
+    selectedCustomBandIndex: clampHeatMapRefIndex(
+      input.customBandIndex ?? defaultIndex,
+      heatMapRefs.length,
+    ),
+  };
+}
+
+export function stepCompoAdviceCustomBandIndex(input: {
+  heatMapRefs: readonly HeatMapRef[];
+  currentBandIndex: number;
+  direction: "prev" | "next";
+}): number {
+  return stepCompoAdviceCustomBandIndexByCount({
+    currentBandIndex: input.currentBandIndex,
+    bandCount: input.heatMapRefs.length,
+    direction: input.direction,
+  });
+}
+
+export function stepCompoAdviceCustomBandIndexByCount(input: {
+  currentBandIndex: number;
+  bandCount: number;
+  direction: "prev" | "next";
+}): number {
+  if (input.bandCount <= 0) {
+    return 0;
+  }
+  const delta = input.direction === "prev" ? -1 : 1;
+  return clampHeatMapRefIndex(input.currentBandIndex + delta, input.bandCount);
+}
+
+export function getCompoAdviceCustomBandSelection(input: {
+  heatMapRefs: readonly HeatMapRef[];
+  currentProjection: CompoActualStateProjection;
+  customBandIndex?: number | null;
+}): {
+  heatMapRefs: HeatMapRef[];
+  selectedHeatMapRef: HeatMapRef | null;
+  selectedCustomBandIndex: number | null;
+} {
+  const resolved = resolveCurrentProjectionBandIndex(input);
+  return {
+    heatMapRefs: resolved.heatMapRefs,
+    selectedHeatMapRef:
+      resolved.selectedCustomBandIndex === null
+        ? null
+        : resolved.heatMapRefs[resolved.selectedCustomBandIndex] ?? null,
+    selectedCustomBandIndex: resolved.selectedCustomBandIndex,
+  };
+}
+
 export function evaluateCompoAdvice(input: {
   mode: CompoAdviceMode;
-  view: CompoActualStateView;
+  view: CompoAdviceView;
   base: CompoActualStateBaseMetrics;
   heatMapRefs: readonly HeatMapRef[];
+  customBandIndex?: number | null;
 }): CompoAdviceSummary {
-  const currentProjection = projectAdviceState({
+  const projectionState = projectAdviceState({
     view: input.view,
     base: input.base,
     heatMapRefs: input.heatMapRefs,
+    customBandIndex: input.customBandIndex,
   });
+  const currentProjection = projectionState.projection;
   const currentScore = currentProjection.deviationScore;
   const currentBandLabel = getBandLabel(currentProjection.selectedHeatMapRef);
   const actions = generateAdviceActions({
@@ -356,7 +583,7 @@ export function evaluateCompoAdvice(input: {
   return {
     mode: input.mode,
     view: input.view,
-    viewLabel: getCompoActualStateViewLabel(input.view),
+    viewLabel: COMPO_ADVICE_VIEW_LABELS[input.view],
     currentProjection,
     currentScore,
     currentBandLabel,
@@ -370,6 +597,8 @@ export function evaluateCompoAdvice(input: {
           ? "No improvement found."
           : null
         : "No improvement found.",
+    selectedCustomBandIndex: projectionState.selectedCustomBandIndex,
+    customBandCount: projectionState.heatMapRefs.length,
   };
 }
 
@@ -416,7 +645,7 @@ export function buildWarAdviceSummary(input: {
 export function buildActualAdviceSummary(input: {
   base: CompoActualStateBaseMetrics;
   heatMapRefs: readonly HeatMapRef[];
-  view: CompoActualStateView;
+  view: Exclude<CompoAdviceView, "custom">;
 }): CompoAdviceSummary {
   return evaluateCompoAdvice({
     mode: "actual",
@@ -426,7 +655,23 @@ export function buildActualAdviceSummary(input: {
   });
 }
 
+export function buildCustomAdviceSummary(input: {
+  base: CompoActualStateBaseMetrics;
+  heatMapRefs: readonly HeatMapRef[];
+  customBandIndex?: number | null;
+}): CompoAdviceSummary {
+  return evaluateCompoAdvice({
+    mode: "actual",
+    view: "custom",
+    base: input.base,
+    heatMapRefs: input.heatMapRefs,
+    customBandIndex: input.customBandIndex,
+  });
+}
+
 export const getCompoAdviceActionLabelForTest = buildAdviceActionDescription;
 export const applyAdviceActionToBaseForTest = applyAdviceActionToBase;
 export const evaluateAdviceActionForTest = evaluateAdviceAction;
 export const compareEvaluationsForTest = compareEvaluations;
+export const sortHeatMapRefsForTest = sortHeatMapRefs;
+export const resolveCustomHeatMapRefForTest = resolveCustomHeatMapRef;

--- a/src/services/CompoActualStateService.ts
+++ b/src/services/CompoActualStateService.ts
@@ -20,7 +20,10 @@ import {
   EMPTY_COMPO_WAR_BUCKET_COUNTS,
   type CompoWarBucketCounts,
 } from "../helper/compoWarBucketCounts";
-import { getCompoWarWeightBucket } from "../helper/compoWarWeightBuckets";
+import {
+  getCompoWarWeightBucket,
+  type CompoWarWeightBucket,
+} from "../helper/compoWarWeightBuckets";
 import { prisma } from "../prisma";
 import {
   listOpenDeferredWeightsByClanAndPlayerTags,
@@ -32,7 +35,7 @@ import { FwaClanMembersSyncService } from "./fwa-feeds/FwaClanMembersSyncService
 type TrackedClanRow = Pick<TrackedClan, "tag" | "name">;
 type CurrentMemberRow = Pick<
   FwaClanMemberCurrent,
-  "clanTag" | "playerTag" | "weight" | "sourceSyncedAt"
+  "clanTag" | "playerTag" | "playerName" | "townHall" | "weight" | "sourceSyncedAt"
 >;
 type WarFallbackRow = Pick<
   FwaTrackedClanWarRosterMemberCurrent,
@@ -43,6 +46,16 @@ export type CompoActualStateClanContext = {
   clanTag: string;
   clanName: string;
   base: CompoActualStateBaseMetrics;
+  members: CompoActualStateMemberContext[];
+};
+
+export type CompoActualStateMemberContext = {
+  clanTag: string;
+  playerTag: string;
+  playerName: string;
+  townHall: number | null;
+  resolvedWeight: number | null;
+  resolvedBucket: CompoWarWeightBucket | null;
 };
 
 export type CompoActualStateContext = {
@@ -184,6 +197,8 @@ export async function loadCompoActualStateContext(
       select: {
         clanTag: true,
         playerTag: true,
+        playerName: true,
+        townHall: true,
         weight: true,
         sourceSyncedAt: true,
       },
@@ -276,6 +291,7 @@ export async function loadCompoActualStateContext(
     };
     let totalResolvedWeight = 0;
     let unresolvedWeightCount = 0;
+    const members: CompoActualStateMemberContext[] = [];
 
     for (const member of clanMembers) {
       const playerTag = normalizePlayerTag(member.playerTag);
@@ -291,6 +307,18 @@ export async function loadCompoActualStateContext(
         anyWarWeight,
       });
       const bucket = getCompoWarWeightBucket(resolvedWeight);
+      const normalizedTownHall =
+        Number.isFinite(Number(member.townHall)) && Number(member.townHall) > 0
+          ? Math.trunc(Number(member.townHall))
+          : null;
+      members.push({
+        clanTag,
+        playerTag,
+        playerName: member.playerName,
+        townHall: normalizedTownHall,
+        resolvedWeight,
+        resolvedBucket: bucket,
+      });
       if (resolvedWeight === null || !bucket) {
         unresolvedWeightCount += 1;
         continue;
@@ -308,6 +336,7 @@ export async function loadCompoActualStateContext(
         memberCount: clanMembers.length,
         bucketCounts,
       },
+      members,
     });
   }
 

--- a/src/services/CompoAdviceService.ts
+++ b/src/services/CompoAdviceService.ts
@@ -1,29 +1,51 @@
 import {
+  COMPO_ADVICE_VIEW_LABELS,
   buildActualAdviceSummary,
-  buildCompoAdviceContentLines,
+  buildCustomAdviceSummary,
   buildWarAdviceSummary,
   type CompoAdviceMode,
+  type CompoAdviceSummary,
+  type CompoAdviceView,
 } from "../helper/compoAdviceEngine";
 import {
-  getCompoActualStateViewLabel,
   type CompoActualStateView,
 } from "../helper/compoActualStateView";
 import { normalizeTag } from "./war-events/core";
 import {
   CompoActualStateService,
   loadCompoActualStateContext,
+  type CompoActualStateMemberContext,
 } from "./CompoActualStateService";
 import {
   CompoWarStateService,
   loadCompoWarStateContext,
 } from "./CompoWarStateService";
 
-export type CompoAdviceReadResult = {
-  content: string;
-  trackedClanTags: string[];
-  selectedView: CompoActualStateView;
+export type CompoAdviceReadyResult = {
+  kind: "ready";
   mode: CompoAdviceMode;
+  selectedView: CompoAdviceView;
+  trackedClanTags: string[];
+  clanTag: string;
+  clanName: string;
+  summary: CompoAdviceSummary;
+  memberCount: number;
+  rushedCount: number;
+  refreshLine: string | null;
 };
+
+export type CompoAdviceEmptyResult = {
+  kind: "empty";
+  mode: CompoAdviceMode;
+  selectedView: CompoAdviceView;
+  trackedClanTags: string[];
+  clanTag: string | null;
+  clanName: string | null;
+  message: string;
+  refreshLine: string | null;
+};
+
+export type CompoAdviceReadResult = CompoAdviceReadyResult | CompoAdviceEmptyResult;
 
 function buildPersistedRefreshLine(latestSourceSyncedAt: Date | null): string {
   if (!latestSourceSyncedAt) {
@@ -32,34 +54,122 @@ function buildPersistedRefreshLine(latestSourceSyncedAt: Date | null): string {
   return `RAW Data last refreshed: <t:${Math.floor(latestSourceSyncedAt.getTime() / 1000)}:F>`;
 }
 
-function buildNoTrackedClansContent(input: {
+function buildNoTrackedClansMessage(input: {
   mode: CompoAdviceMode;
-  view: CompoActualStateView;
+  view: CompoAdviceView;
 }): string {
-  const lines = [
-    buildPersistedRefreshLine(null),
+  return [
     `Mode: **${input.mode.toUpperCase()}**`,
-    `Advice View: **${getCompoActualStateViewLabel(input.view)}**`,
+    `Advice View: **${COMPO_ADVICE_VIEW_LABELS[input.view]}**`,
     `No tracked clans are configured for DB-backed ${input.mode.toUpperCase()} advice.`,
-  ];
-  return lines.join("\n");
+  ].join("\n");
 }
 
-function buildNoTargetContent(input: {
+function buildNoTargetMessage(input: {
   mode: CompoAdviceMode;
-  view: CompoActualStateView;
+  view: CompoAdviceView;
   targetTag: string;
   knownTags: string[];
 }): string {
   const lines = [
     `Mode: **${input.mode.toUpperCase()}**`,
-    `Advice View: **${getCompoActualStateViewLabel(input.view)}**`,
+    `Advice View: **${COMPO_ADVICE_VIEW_LABELS[input.view]}**`,
     `No tracked clan matched tag \`#${input.targetTag}\`.`,
   ];
   if (input.knownTags.length > 0) {
     lines.push(`Known tags in this mode: ${input.knownTags.map((tag) => `#${tag}`).join(", ")}`);
   }
   return lines.join("\n");
+}
+
+const IMPLIES_TOWN_HALL_BY_BUCKET: Record<string, number> = {
+  TH18: 18,
+  TH17: 17,
+  TH16: 16,
+  TH15: 15,
+  TH14: 14,
+  TH13: 13,
+  TH12: 12,
+  TH11: 11,
+  TH10: 10,
+  TH9: 9,
+  TH8_OR_LOWER: 8,
+};
+
+function getActualRefreshView(view: CompoAdviceView): CompoActualStateView {
+  if (view === "best") {
+    return "best";
+  }
+  if (view === "raw" || view === "custom") {
+    return "raw";
+  }
+  return "auto";
+}
+
+/** Purpose: count rushed ACTUAL members from persisted member rows using the resolved bucket implied Town Hall. */
+export function countRushedCompoMembers(
+  members: readonly CompoActualStateMemberContext[],
+): number {
+  let rushed = 0;
+  for (const member of members) {
+    if (member.townHall === null || member.resolvedBucket === null) {
+      continue;
+    }
+    const impliedTownHall =
+      IMPLIES_TOWN_HALL_BY_BUCKET[member.resolvedBucket] ?? null;
+    if (impliedTownHall === null) {
+      continue;
+    }
+    if (member.townHall > impliedTownHall) {
+      rushed += 1;
+    }
+  }
+  return rushed;
+}
+
+function buildReadyResult(input: {
+  mode: CompoAdviceMode;
+  selectedView: CompoAdviceView;
+  trackedClanTags: string[];
+  clanTag: string;
+  clanName: string;
+  summary: CompoAdviceSummary;
+  members: readonly CompoActualStateMemberContext[];
+  refreshLine: string | null;
+}): CompoAdviceReadyResult {
+  return {
+    kind: "ready",
+    mode: input.mode,
+    selectedView: input.selectedView,
+    trackedClanTags: input.trackedClanTags,
+    clanTag: input.clanTag,
+    clanName: input.clanName,
+    summary: input.summary,
+    memberCount: input.summary.currentProjection.memberCount,
+    rushedCount: countRushedCompoMembers(input.members),
+    refreshLine: input.refreshLine,
+  };
+}
+
+function buildEmptyResult(input: {
+  mode: CompoAdviceMode;
+  selectedView: CompoAdviceView;
+  trackedClanTags: string[];
+  clanTag: string | null;
+  clanName: string | null;
+  message: string;
+  refreshLine: string | null;
+}): CompoAdviceEmptyResult {
+  return {
+    kind: "empty",
+    mode: input.mode,
+    selectedView: input.selectedView,
+    trackedClanTags: input.trackedClanTags,
+    clanTag: input.clanTag,
+    clanName: input.clanName,
+    message: input.message,
+    refreshLine: input.refreshLine,
+  };
 }
 
 /** Purpose: build DB-backed composition advice from persisted ACTUAL and WAR state snapshots only. */
@@ -71,99 +181,121 @@ export class CompoAdviceService {
     guildId?: string | null;
     targetTag: string;
     mode: CompoAdviceMode;
-    view?: CompoActualStateView;
+    view?: CompoAdviceView;
+    customBandIndex?: number | null;
   }): Promise<CompoAdviceReadResult> {
     const targetTag = normalizeTag(input.targetTag);
     const view =
       input.mode === "actual" ? input.view ?? "auto" : "raw";
 
     if (!targetTag) {
-      return {
-        content: buildNoTargetContent({
+      return buildEmptyResult({
+        mode: input.mode,
+        selectedView: view,
+        trackedClanTags: [],
+        clanTag: null,
+        clanName: null,
+        message: buildNoTargetMessage({
           mode: input.mode,
           view,
           targetTag: "",
           knownTags: [],
         }),
-        trackedClanTags: [],
-        selectedView: view,
-        mode: input.mode,
-      };
+        refreshLine: buildPersistedRefreshLine(null),
+      });
     }
 
     if (input.mode === "actual") {
       const context = await loadCompoActualStateContext(input.guildId ?? null);
       if (context.trackedClanTags.length === 0) {
-        return {
-          content: buildNoTrackedClansContent({
+        return buildEmptyResult({
+          mode: input.mode,
+          selectedView: view,
+          trackedClanTags: [],
+          clanTag: null,
+          clanName: null,
+          message: buildNoTrackedClansMessage({
             mode: input.mode,
             view,
           }),
-          trackedClanTags: [],
-          selectedView: view,
-          mode: input.mode,
-        };
+          refreshLine: buildPersistedRefreshLine(null),
+        });
       }
 
       const clan = context.clans.find((row) => row.clanTag === targetTag);
       if (!clan) {
-        return {
-          content: buildNoTargetContent({
+        return buildEmptyResult({
+          mode: input.mode,
+          selectedView: view,
+          trackedClanTags: context.trackedClanTags,
+          clanTag: null,
+          clanName: null,
+          message: buildNoTargetMessage({
             mode: input.mode,
             view,
             targetTag,
             knownTags: context.trackedClanTags,
           }),
-          trackedClanTags: context.trackedClanTags,
-          selectedView: view,
-          mode: input.mode,
-        };
+          refreshLine: buildPersistedRefreshLine(context.latestSourceSyncedAt),
+        });
       }
 
-      const summary = buildActualAdviceSummary({
-        base: clan.base,
-        heatMapRefs: context.heatMapRefs,
-        view,
-      });
-      const content = buildCompoAdviceContentLines({
-        summary,
-        modeLabel: input.mode.toUpperCase(),
-        refreshLine: buildPersistedRefreshLine(context.latestSourceSyncedAt),
-      }).join("\n");
-      return {
-        content,
-        trackedClanTags: context.trackedClanTags,
-        selectedView: view,
+      const summary =
+        view === "custom"
+          ? buildCustomAdviceSummary({
+              base: clan.base,
+              heatMapRefs: context.heatMapRefs,
+              customBandIndex: input.customBandIndex,
+            })
+          : buildActualAdviceSummary({
+              base: clan.base,
+              heatMapRefs: context.heatMapRefs,
+              view,
+            });
+      return buildReadyResult({
         mode: input.mode,
-      };
+        selectedView: view,
+        trackedClanTags: context.trackedClanTags,
+        clanTag: clan.clanTag,
+        clanName: clan.clanName,
+        summary,
+        members: clan.members,
+        refreshLine: buildPersistedRefreshLine(context.latestSourceSyncedAt),
+      });
     }
 
     const context = await loadCompoWarStateContext();
     if (context.trackedClanTags.length === 0) {
-      return {
-        content: buildNoTrackedClansContent({
+      return buildEmptyResult({
+        mode: input.mode,
+        selectedView: view,
+        trackedClanTags: [],
+        clanTag: null,
+        clanName: null,
+        message: buildNoTrackedClansMessage({
           mode: input.mode,
           view,
         }),
-        trackedClanTags: [],
-        selectedView: view,
-        mode: input.mode,
-      };
+        refreshLine: buildPersistedRefreshLine(null),
+      });
     }
 
     const clan = context.clans.find((row) => row.clanTag === targetTag);
     if (!clan) {
-      return {
-        content: buildNoTargetContent({
+      return buildEmptyResult({
+        mode: input.mode,
+        selectedView: view,
+        trackedClanTags: context.trackedClanTags,
+        clanTag: null,
+        clanName: null,
+        message: buildNoTargetMessage({
           mode: input.mode,
           view,
           targetTag,
           knownTags: context.trackedClanTags,
         }),
-        trackedClanTags: context.trackedClanTags,
-        selectedView: view,
-        mode: input.mode,
-      };
+        refreshLine: buildPersistedRefreshLine(context.latestRefreshAt),
+      });
     }
 
     const summary = buildWarAdviceSummary({
@@ -175,31 +307,31 @@ export class CompoAdviceService {
       },
       heatMapRefs: context.heatMapRefs,
     });
-    const content = buildCompoAdviceContentLines({
-      summary,
-      modeLabel: input.mode.toUpperCase(),
-      refreshLine: buildPersistedRefreshLine(context.latestRefreshAt),
-    }).join("\n");
-    return {
-      content,
-      trackedClanTags: context.trackedClanTags,
-      selectedView: view,
+    return buildReadyResult({
       mode: input.mode,
-    };
+      selectedView: view,
+      trackedClanTags: context.trackedClanTags,
+      clanTag: clan.clanTag,
+      clanName: clan.clanName,
+      summary,
+      members: [],
+      refreshLine: buildPersistedRefreshLine(context.latestRefreshAt),
+    });
   }
 
   async refreshAdvice(input: {
     guildId?: string | null;
     targetTag: string;
     mode: CompoAdviceMode;
-    view?: CompoActualStateView;
+    view?: CompoAdviceView;
+    customBandIndex?: number | null;
   }): Promise<CompoAdviceReadResult> {
     const view =
       input.mode === "actual" ? input.view ?? "auto" : "raw";
 
     if (input.mode === "actual") {
       await this.actualStateService.refreshState(input.guildId ?? null, {
-        view,
+        view: getActualRefreshView(view),
       });
     } else {
       await this.warStateService.refreshState();
@@ -209,5 +341,5 @@ export class CompoAdviceService {
   }
 }
 
-export const buildNoTrackedClansContentForTest = buildNoTrackedClansContent;
-export const buildNoTargetContentForTest = buildNoTargetContent;
+export const buildNoTrackedClansContentForTest = buildNoTrackedClansMessage;
+export const buildNoTargetContentForTest = buildNoTargetMessage;

--- a/tests/compo.commandSheetRead.test.ts
+++ b/tests/compo.commandSheetRead.test.ts
@@ -62,15 +62,44 @@ describe("/compo advice command", () => {
     vi.restoreAllMocks();
   });
 
-  it("uses the DB-backed advice service and keeps sheet access out of the command layer", async () => {
+  it("uses the DB-backed advice service and renders an embed without sheet access", async () => {
     const readAdviceSpy = vi
       .spyOn(CompoAdviceService.prototype, "readAdvice")
       .mockResolvedValue({
-        content:
-          "RAW Data last refreshed: <t:1709900000:F>\nMode: **ACTUAL**\nAdvice View: **Auto-Detect Band**\nCurrent Score: **4**\nCurrent Band: **0 - 9999999**\nRecommendation: **Add TH17**\nResulting Score: **0**\nResulting Band: **0 - 9999999**",
-        trackedClanTags: ["#AAA111"],
-        selectedView: "auto",
+        kind: "ready",
         mode: "actual",
+        selectedView: "auto",
+        trackedClanTags: ["#AAA111"],
+        clanTag: "#AAA111",
+        clanName: "Alpha Clan-actual",
+        memberCount: 50,
+        rushedCount: 1,
+        refreshLine: "RAW Data last refreshed: <t:1709900000:F>",
+        summary: {
+          mode: "actual",
+          view: "auto",
+          viewLabel: "Auto-Detect Band",
+          currentProjection: {
+            memberCount: 50,
+            deltaByBucket: {
+              TH18: 0,
+              TH17: 0,
+              TH16: 0,
+              TH15: 0,
+              TH14: 0,
+              "<=TH13": 0,
+            },
+          } as any,
+          currentScore: 0,
+          currentBandLabel: "1,000,000 - 2,000,000",
+          recommendationText: "Add TH17",
+          resultingScore: 0,
+          resultingBandLabel: "1,000,000 - 2,000,000",
+          alternateTexts: [],
+          statusText: null,
+          selectedCustomBandIndex: 0,
+          customBandCount: 1,
+        } as any,
       });
     const getCompoLinkedSheetSpy = vi.spyOn(
       GoogleSheetsService.prototype,
@@ -96,24 +125,60 @@ describe("/compo advice command", () => {
     expect(readCompoLinkedValuesSpy).not.toHaveBeenCalled();
 
     const payload = interaction.editReply.mock.calls.at(-1)?.[0];
-    expect(String(payload?.content ?? "")).toContain("Advice View: **Auto-Detect Band**");
+    expect(Array.isArray(payload?.embeds)).toBe(true);
+    expect(String(payload?.embeds?.[0]?.data?.description ?? "")).toContain(
+      "Advice View: **Auto-Detect Band**",
+    );
+    expect(String(payload?.embeds?.[0]?.data?.title ?? "")).toContain(
+      "Alpha Clan (#AAA111)",
+    );
     expect(getComponentCustomIds(payload)).toEqual(
       expect.arrayContaining([
-        "compo-refresh:advice:user-1:actual:auto:LQQ99UV8",
-        "compo-refresh:view:user-1:advice:raw:LQQ99UV8",
-        "compo-refresh:view:user-1:advice:auto:LQQ99UV8",
-        "compo-refresh:view:user-1:advice:best:LQQ99UV8",
+        "compo-refresh:advice:user-1:actual:auto:LQQ99UV8:1:0",
+        "compo-refresh:view:user-1:advice:raw:LQQ99UV8:1:0",
+        "compo-refresh:view:user-1:advice:auto:LQQ99UV8:1:0",
+        "compo-refresh:view:user-1:advice:best:LQQ99UV8:1:0",
+        "compo-refresh:view:user-1:advice:custom:LQQ99UV8:1:0",
       ]),
     );
   });
 
   it("renders WAR advice with only a refresh button", async () => {
     vi.spyOn(CompoAdviceService.prototype, "readAdvice").mockResolvedValue({
-      content:
-        "RAW Data last refreshed: <t:1709900000:F>\nMode: **WAR**\nAdvice View: **Raw Data**\nCurrent Score: **0**\nCurrent Band: **0 - 9999999**\nRecommendation: **No improvement found.**\nResulting Score: **n/a**\nResulting Band: **(no band)**",
-      trackedClanTags: ["#AAA111"],
-      selectedView: "raw",
+      kind: "ready",
       mode: "war",
+      selectedView: "raw",
+      trackedClanTags: ["#AAA111"],
+      clanTag: "#AAA111",
+      clanName: "Alpha Clan-war",
+      memberCount: 50,
+      rushedCount: 0,
+      refreshLine: "RAW Data last refreshed: <t:1709900000:F>",
+      summary: {
+        mode: "war",
+        view: "raw",
+        viewLabel: "Raw Data",
+        currentProjection: {
+          memberCount: 50,
+          deltaByBucket: {
+            TH18: 0,
+            TH17: 0,
+            TH16: 0,
+            TH15: 0,
+            TH14: 0,
+            "<=TH13": 0,
+          },
+        } as any,
+        currentScore: 0,
+        currentBandLabel: "0 - 9999999",
+        recommendationText: "No improvement found.",
+        resultingScore: null,
+        resultingBandLabel: "(no band)",
+        alternateTexts: [],
+        statusText: "No improvement found.",
+        selectedCustomBandIndex: 0,
+        customBandCount: 1,
+      } as any,
     });
 
     const interaction = makeInteraction({
@@ -124,7 +189,9 @@ describe("/compo advice command", () => {
     await Compo.run({} as any, interaction as any, {} as any);
 
     const payload = interaction.editReply.mock.calls.at(-1)?.[0];
-    expect(String(payload?.content ?? "")).toContain("Mode: **WAR**");
+    expect(String(payload?.embeds?.[0]?.data?.description ?? "")).toContain(
+      "Advice View: **Raw Data**",
+    );
     expect(getComponentCustomIds(payload)).toEqual([
       "compo-refresh:advice:user-1:war:LQQ99UV8",
     ]);

--- a/tests/compoAdvice.engine.test.ts
+++ b/tests/compoAdvice.engine.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   compareEvaluationsForTest,
   evaluateCompoAdvice,
+  stepCompoAdviceCustomBandIndexByCount,
   type CompoAdviceEvaluation,
 } from "../src/helper/compoAdviceEngine";
 import type { CompoWarBucketCounts } from "../src/helper/compoWarBucketCounts";
@@ -162,6 +163,75 @@ describe("CompoAdviceEngine", () => {
     expect(best.viewLabel).toBe("Best Fit");
     expect(raw.currentBandLabel).not.toBe(auto.currentBandLabel);
     expect(auto.currentBandLabel).not.toBe(best.currentBandLabel);
+  });
+
+  it("changes Custom advice when the target band changes", () => {
+    const base = {
+      resolvedTotalWeight: 49 * 135000 + 145000,
+      unresolvedWeightCount: 0,
+      memberCount: 50,
+      bucketCounts: makeBucketCounts({
+        TH14: 49,
+        TH15: 1,
+      }),
+    };
+    const heatMapRefs = [
+      makeHeatMapRef({
+        weightMinInclusive: 0,
+        weightMaxInclusive: 299999,
+        th14Count: 50,
+      }),
+      makeHeatMapRef({
+        weightMinInclusive: 300000,
+        weightMaxInclusive: 599999,
+        th15Count: 50,
+      }),
+    ];
+
+    const first = evaluateCompoAdvice({
+      mode: "actual",
+      view: "custom",
+      customBandIndex: 0,
+      base,
+      heatMapRefs,
+    });
+    const second = evaluateCompoAdvice({
+      mode: "actual",
+      view: "custom",
+      customBandIndex: 1,
+      base,
+      heatMapRefs,
+    });
+
+    expect(first.viewLabel).toBe("Custom");
+    expect(second.viewLabel).toBe("Custom");
+    expect(first.currentBandLabel).not.toBe(second.currentBandLabel);
+    expect(first.recommendationText).not.toBe(second.recommendationText);
+    expect(first.currentScore).not.toBe(second.currentScore);
+  });
+
+  it("steps Custom band indices deterministically and respects bounds", () => {
+    expect(
+      stepCompoAdviceCustomBandIndexByCount({
+        currentBandIndex: 0,
+        bandCount: 2,
+        direction: "prev",
+      }),
+    ).toBe(0);
+    expect(
+      stepCompoAdviceCustomBandIndexByCount({
+        currentBandIndex: 0,
+        bandCount: 2,
+        direction: "next",
+      }),
+    ).toBe(1);
+    expect(
+      stepCompoAdviceCustomBandIndexByCount({
+        currentBandIndex: 1,
+        bandCount: 2,
+        direction: "next",
+      }),
+    ).toBe(1);
   });
 
   it("orders equal candidates deterministically by incoming bucket priority", () => {

--- a/tests/compoAdvice.service.test.ts
+++ b/tests/compoAdvice.service.test.ts
@@ -1,6 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GoogleSheetsService } from "../src/services/GoogleSheetsService";
-import { CompoAdviceService } from "../src/services/CompoAdviceService";
+import {
+  CompoAdviceService,
+  countRushedCompoMembers,
+} from "../src/services/CompoAdviceService";
 
 const prismaMock = vi.hoisted(() => ({
   trackedClan: {
@@ -67,12 +70,16 @@ function makeHeatMapRef(input?: Partial<{
 function makeCurrentMember(input: {
   clanTag: string;
   playerTag: string;
+  playerName?: string;
+  townHall?: number | null;
   weight: number;
   sourceSyncedAt?: Date;
 }) {
   return {
     clanTag: input.clanTag,
     playerTag: input.playerTag,
+    playerName: input.playerName ?? `Player ${input.playerTag}`,
+    townHall: input.townHall ?? 18,
     weight: input.weight,
     sourceSyncedAt:
       input.sourceSyncedAt ?? new Date("2026-04-12T00:00:00.000Z"),
@@ -140,7 +147,7 @@ describe("CompoAdviceService", () => {
     prismaMock.weightInputDeferment.findMany.mockReset();
   });
 
-  it("loads ACTUAL advice from DB-backed state and defaults to Auto-Detect Band without sheet reads", async () => {
+  it("loads ACTUAL advice from DB-backed state, defaults to Auto-Detect Band, and computes rushed members without sheet reads", async () => {
     prismaMock.trackedClan.findMany.mockResolvedValue([
       makeTrackedClan("#AAA111", "Alpha Clan-actual"),
     ]);
@@ -148,51 +155,15 @@ describe("CompoAdviceService", () => {
       makeCurrentMember({
         clanTag: "#AAA111",
         playerTag: "#P000001",
+        playerName: "Rusher",
+        townHall: 15,
         weight: 135000,
       }),
       makeCurrentMember({
         clanTag: "#AAA111",
         playerTag: "#P000002",
-        weight: 135000,
-      }),
-      makeCurrentMember({
-        clanTag: "#AAA111",
-        playerTag: "#P000003",
-        weight: 135000,
-      }),
-      makeCurrentMember({
-        clanTag: "#AAA111",
-        playerTag: "#P000004",
-        weight: 135000,
-      }),
-      makeCurrentMember({
-        clanTag: "#AAA111",
-        playerTag: "#P000005",
-        weight: 135000,
-      }),
-      makeCurrentMember({
-        clanTag: "#AAA111",
-        playerTag: "#P000006",
-        weight: 135000,
-      }),
-      makeCurrentMember({
-        clanTag: "#AAA111",
-        playerTag: "#P000007",
-        weight: 135000,
-      }),
-      makeCurrentMember({
-        clanTag: "#AAA111",
-        playerTag: "#P000008",
-        weight: 135000,
-      }),
-      makeCurrentMember({
-        clanTag: "#AAA111",
-        playerTag: "#P000009",
-        weight: 135000,
-      }),
-      makeCurrentMember({
-        clanTag: "#AAA111",
-        playerTag: "#P000010",
+        playerName: "Stable",
+        townHall: 13,
         weight: 135000,
       }),
     ]);
@@ -200,9 +171,9 @@ describe("CompoAdviceService", () => {
     prismaMock.fwaTrackedClanWarRosterMemberCurrent.findMany.mockResolvedValue([]);
     prismaMock.heatMapRef.findMany.mockResolvedValue([
       makeHeatMapRef({
-        weightMinInclusive: 1_300_000,
-        weightMaxInclusive: 2_000_000,
-        th14Count: 10,
+        weightMinInclusive: 200_000,
+        weightMaxInclusive: 300_000,
+        th14Count: 2,
       }),
     ]);
     const getCompoLinkedSheetSpy = vi.spyOn(
@@ -222,10 +193,60 @@ describe("CompoAdviceService", () => {
 
     expect(getCompoLinkedSheetSpy).not.toHaveBeenCalled();
     expect(readCompoLinkedValuesSpy).not.toHaveBeenCalled();
+    expect(result.kind).toBe("ready");
     expect(result.selectedView).toBe("auto");
-    expect(result.content).toContain("Mode: **ACTUAL**");
-    expect(result.content).toContain("Advice View: **Auto-Detect Band**");
-    expect(result.content).toContain("Current Score:");
+    expect(result.summary.viewLabel).toBe("Auto-Detect Band");
+  });
+
+  it("keeps ACTUAL custom advice on a manually selected target band", async () => {
+    prismaMock.trackedClan.findMany.mockResolvedValue([
+      makeTrackedClan("#AAA111", "Alpha Clan-actual"),
+    ]);
+    prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue([
+      makeCurrentMember({
+        clanTag: "#AAA111",
+        playerTag: "#P000001",
+        playerName: "P1",
+        townHall: 15,
+        weight: 135000,
+      }),
+      makeCurrentMember({
+        clanTag: "#AAA111",
+        playerTag: "#P000002",
+        playerName: "P2",
+        townHall: 15,
+        weight: 135000,
+      }),
+    ]);
+    prismaMock.weightInputDeferment.findMany.mockResolvedValue([]);
+    prismaMock.fwaTrackedClanWarRosterMemberCurrent.findMany.mockResolvedValue([]);
+    prismaMock.heatMapRef.findMany.mockResolvedValue([
+      makeHeatMapRef({
+        weightMinInclusive: 1_000_000,
+        weightMaxInclusive: 1_499_999,
+        th14Count: 2,
+      }),
+      makeHeatMapRef({
+        weightMinInclusive: 1_500_000,
+        weightMaxInclusive: 1_999_999,
+        th15Count: 2,
+      }),
+    ]);
+
+    const result = await new CompoAdviceService().readAdvice({
+      guildId: "guild-1",
+      targetTag: "#AAA111",
+      mode: "actual",
+      view: "custom",
+      customBandIndex: 1,
+    });
+
+    expect(result.kind).toBe("ready");
+    expect(result.selectedView).toBe("custom");
+    expect(result.summary.viewLabel).toBe("Custom");
+    expect(result.summary.selectedCustomBandIndex).toBe(1);
+    expect(result.summary.currentBandLabel).toContain("1,500,000");
+    expect(result.summary.currentScore).toBeGreaterThanOrEqual(0);
   });
 
   it("loads WAR advice from DB-backed tracked war state without sheet reads", async () => {
@@ -272,9 +293,40 @@ describe("CompoAdviceService", () => {
 
     expect(getCompoLinkedSheetSpy).not.toHaveBeenCalled();
     expect(readCompoLinkedValuesSpy).not.toHaveBeenCalled();
+    expect(result.kind).toBe("ready");
     expect(result.selectedView).toBe("raw");
-    expect(result.content).toContain("Mode: **WAR**");
-    expect(result.content).toContain("Advice View: **Raw Data**");
-    expect(result.content).toContain("Current Score:");
+    expect(result.summary.viewLabel).toBe("Raw Data");
+    expect(result.summary.currentScore).toBe(0);
+  });
+
+  it("counts rushed members from the resolved bucket, not the collapsed display label", () => {
+    expect(
+      countRushedCompoMembers([
+        {
+          clanTag: "#AAA111",
+          playerTag: "#P1",
+          playerName: "Rusher",
+          townHall: 15,
+          resolvedWeight: 135000,
+          resolvedBucket: "TH14",
+        },
+        {
+          clanTag: "#AAA111",
+          playerTag: "#P2",
+          playerName: "Stable",
+          townHall: 13,
+          resolvedWeight: 135000,
+          resolvedBucket: "TH14",
+        },
+        {
+          clanTag: "#AAA111",
+          playerTag: "#P3",
+          playerName: "Low",
+          townHall: 9,
+          resolvedWeight: 55000,
+          resolvedBucket: "TH8_OR_LOWER",
+        },
+      ] as any),
+    ).toBe(2);
   });
 });

--- a/tests/compoRefresh.logic.test.ts
+++ b/tests/compoRefresh.logic.test.ts
@@ -239,19 +239,41 @@ describe("compo refresh button behavior", () => {
   });
 
   it("keeps the selected ACTUAL advice view across view switches and refreshes", async () => {
-    vi.spyOn(CompoAdviceService.prototype, "readAdvice").mockResolvedValue({
-      content:
-        "RAW Data last refreshed: <t:1709900000:F>\nMode: **ACTUAL**\nAdvice View: **Best Fit**\nCurrent Score: **4**\nCurrent Band: **0 - 9999999**\nRecommendation: **Add TH17**\nResulting Score: **0**\nResulting Band: **0 - 9999999**",
-      trackedClanTags: ["#AAA111"],
-      selectedView: "best",
-      mode: "actual",
-    });
     vi.spyOn(CompoAdviceService.prototype, "refreshAdvice").mockResolvedValue({
-      content:
-        "RAW Data last refreshed: <t:1709900001:F>\nMode: **ACTUAL**\nAdvice View: **Best Fit**\nCurrent Score: **4**\nCurrent Band: **0 - 9999999**\nRecommendation: **Add TH17**\nResulting Score: **0**\nResulting Band: **0 - 9999999**",
-      trackedClanTags: ["#AAA111"],
-      selectedView: "best",
+      kind: "ready",
       mode: "actual",
+      selectedView: "best",
+      trackedClanTags: ["#AAA111"],
+      clanTag: "#AAA111",
+      clanName: "Alpha Clan-actual",
+      memberCount: 49,
+      rushedCount: 0,
+      refreshLine: "RAW Data last refreshed: <t:1709900001:F>",
+      summary: {
+        mode: "actual",
+        view: "best",
+        viewLabel: "Best Fit",
+        currentProjection: {
+          memberCount: 49,
+          deltaByBucket: {
+            TH18: 1,
+            TH17: 0,
+            TH16: -1,
+            TH15: 0,
+            TH14: 0,
+            "<=TH13": 0,
+          },
+        } as any,
+        currentScore: 4,
+        currentBandLabel: "0 - 9999999",
+        recommendationText: "Add TH17",
+        resultingScore: 0,
+        resultingBandLabel: "0 - 9999999",
+        alternateTexts: [],
+        statusText: null,
+        selectedCustomBandIndex: 0,
+        customBandCount: 1,
+      } as any,
     });
 
     const viewInteraction = makeInteraction(
@@ -259,35 +281,39 @@ describe("compo refresh button behavior", () => {
         kind: "view",
         userId: "user-1",
         target: "advice",
-        actualView: "best",
+        adviceView: "best",
         targetTag: "AAA111",
+        customBandIndex: 0,
+        customBandCount: 1,
       }),
     );
     viewInteraction.message.components = [
-      makeMessageRow("compo-refresh:advice:user-1:actual:auto:AAA111", "Refresh Data"),
+      makeMessageRow("compo-refresh:advice:user-1:actual:auto:AAA111:1:0", "Refresh Data"),
       makeMessageRow("post-channel:user-1", "Post to Channel"),
     ];
 
     await handleCompoRefreshButton(viewInteraction as any, {} as any);
 
-    expect(CompoAdviceService.prototype.readAdvice).toHaveBeenCalledWith({
+    expect(CompoAdviceService.prototype.refreshAdvice).toHaveBeenCalledWith({
       guildId: "guild-1",
       targetTag: "AAA111",
       mode: "actual",
       view: "best",
+      customBandIndex: 0,
     });
     const viewPayload = viewInteraction.editReply.mock.calls.at(-1)?.[0];
     expect(collectButtonCustomIds(viewPayload)).toEqual(
       expect.arrayContaining([
-        "compo-refresh:advice:user-1:actual:best:AAA111",
-        "compo-refresh:view:user-1:advice:raw:AAA111",
-        "compo-refresh:view:user-1:advice:auto:AAA111",
-        "compo-refresh:view:user-1:advice:best:AAA111",
+        "compo-refresh:advice:user-1:actual:best:AAA111:1:0",
+        "compo-refresh:view:user-1:advice:raw:AAA111:1:0",
+        "compo-refresh:view:user-1:advice:auto:AAA111:1:0",
+        "compo-refresh:view:user-1:advice:best:AAA111:1:0",
+        "compo-refresh:view:user-1:advice:custom:AAA111:1:0",
       ]),
     );
 
     const refreshInteraction = makeInteraction(
-      "compo-refresh:advice:user-1:actual:best:AAA111",
+      "compo-refresh:advice:user-1:actual:best:AAA111:1:0",
     );
     refreshInteraction.message.components = (viewPayload.components as unknown[]).map(
       (row) =>
@@ -303,6 +329,79 @@ describe("compo refresh button behavior", () => {
       targetTag: "AAA111",
       mode: "actual",
       view: "best",
+      customBandIndex: 0,
     });
+  });
+
+  it("steps the ACTUAL custom band and preserves the new selection through refresh", async () => {
+    vi.spyOn(CompoAdviceService.prototype, "refreshAdvice").mockResolvedValue({
+      kind: "ready",
+      mode: "actual",
+      selectedView: "custom",
+      trackedClanTags: ["#AAA111"],
+      clanTag: "#AAA111",
+      clanName: "Alpha Clan-actual",
+      memberCount: 50,
+      rushedCount: 1,
+      refreshLine: "RAW Data last refreshed: <t:1709900002:F>",
+      summary: {
+        mode: "actual",
+        view: "custom",
+        viewLabel: "Custom",
+        currentProjection: {
+          memberCount: 50,
+          deltaByBucket: {
+            TH18: 0,
+            TH17: -1,
+            TH16: 0,
+            TH15: 0,
+            TH14: 1,
+            "<=TH13": 0,
+          },
+        } as any,
+        currentScore: 3,
+        currentBandLabel: "1,500,000 - 1,999,999",
+        recommendationText: "Replace one TH14 with one TH17",
+        resultingScore: 1,
+        resultingBandLabel: "1,500,000 - 1,999,999",
+        alternateTexts: ["Add TH17"],
+        statusText: null,
+        selectedCustomBandIndex: 1,
+        customBandCount: 2,
+      } as any,
+    });
+
+    const stepInteraction = makeInteraction(
+      buildCompoRefreshCustomIdForTest({
+        kind: "advice-band",
+        userId: "user-1",
+        targetTag: "AAA111",
+        customBandIndex: 0,
+        customBandCount: 2,
+        direction: "next",
+      }),
+    );
+    stepInteraction.message.components = [
+      makeMessageRow("compo-refresh:advice:user-1:actual:custom:AAA111:2:0", "Refresh Data"),
+      makeMessageRow("post-channel:user-1", "Post to Channel"),
+    ];
+
+    await handleCompoRefreshButton(stepInteraction as any, {} as any);
+
+    expect(CompoAdviceService.prototype.refreshAdvice).toHaveBeenCalledWith({
+      guildId: "guild-1",
+      targetTag: "AAA111",
+      mode: "actual",
+      view: "custom",
+      customBandIndex: 1,
+    });
+    const payload = stepInteraction.editReply.mock.calls.at(-1)?.[0];
+    expect(collectButtonCustomIds(payload)).toEqual(
+      expect.arrayContaining([
+        "compo-refresh:advice:user-1:actual:custom:AAA111:2:1",
+        "compo-refresh:advice-band:user-1:AAA111:2:1:prev",
+        "compo-refresh:advice-band:user-1:AAA111:2:1:next",
+      ]),
+    );
   });
 });


### PR DESCRIPTION
- render /compo advice as an embed with diagnostics and current deltas
- add ACTUAL custom target-band stepping plus rushed-member counts
- update DB-backed advice tests, refresh wiring, and help text