### PR TITLE
feat(compo): tighten advice embed and clan switching UX

### DIFF
--- a/src/commands/Compo.ts
+++ b/src/commands/Compo.ts
@@ -11,6 +11,8 @@ import {
   Client,
   ComponentType,
   EmbedBuilder,
+  StringSelectMenuBuilder,
+  StringSelectMenuInteraction,
 } from "discord.js";
 import { Command } from "../Command";
 import {
@@ -146,6 +148,15 @@ type CompoRefreshPayload =
       customBandCount: number;
   }
   | {
+      kind: "advice-clan";
+      userId: string;
+      mode: "war" | "actual";
+      targetTag: string;
+      adviceView?: CompoAdviceView;
+      customBandIndex?: number | null;
+      customBandCount?: number;
+    }
+  | {
       kind: "view";
       userId: string;
       target: "state";
@@ -189,6 +200,13 @@ function buildCompoRefreshCustomId(payload: CompoRefreshPayload): string {
         : `${base}:${Math.trunc(payload.customBandIndex)}`;
     }
     return `${COMPO_REFRESH_PREFIX}:advice:${payload.userId}:war:${payload.targetTag}`;
+  }
+  if (payload.kind === "advice-clan") {
+    if (payload.mode === "actual") {
+      const base = `${COMPO_REFRESH_PREFIX}:advice-clan:${payload.userId}:actual:${payload.targetTag}:${payload.adviceView ?? "auto"}`;
+      return `${base}:${Math.trunc(payload.customBandCount ?? 0)}:${Math.trunc(payload.customBandIndex ?? 0)}`;
+    }
+    return `${COMPO_REFRESH_PREFIX}:advice-clan:${payload.userId}:war:${payload.targetTag}`;
   }
   if (payload.kind === "view") {
     if (payload.target === "advice") {
@@ -288,6 +306,45 @@ function parseCompoRefreshCustomId(
     }
     return null;
   }
+  if (kind === "advice-clan") {
+    const mode = parts[3];
+    if (mode === "war" && parts.length === 5) {
+      const targetTag = normalizeTag(parts[4] ?? "");
+      if (!targetTag) return null;
+      return {
+        kind: "advice-clan",
+        userId,
+        mode,
+        targetTag,
+      };
+    }
+    if (mode === "actual" && parts.length === 8) {
+      const targetTag = normalizeTag(parts[4] ?? "");
+      const adviceView = parts[5];
+      const customBandCount = Number(parts[6]);
+      const customBandIndex = Number(parts[7]);
+      if (
+        !targetTag ||
+        !COMPO_ADVICE_VIEWS.includes(adviceView as CompoAdviceView) ||
+        !Number.isFinite(customBandCount) ||
+        customBandCount < 0 ||
+        !Number.isFinite(customBandIndex) ||
+        customBandIndex < 0
+      ) {
+        return null;
+      }
+      return {
+        kind: "advice-clan",
+        userId,
+        mode,
+        targetTag,
+        adviceView: adviceView as CompoAdviceView,
+        customBandCount: Math.trunc(customBandCount),
+        customBandIndex: Math.trunc(customBandIndex),
+      };
+    }
+    return null;
+  }
   if (kind === "view" && parts.length >= 5) {
     const target = parts[3];
     if (target === "state" && parts.length === 5) {
@@ -381,6 +438,11 @@ export function isCompoRefreshButtonCustomId(customId: string): boolean {
   return String(customId ?? "").startsWith(`${COMPO_REFRESH_PREFIX}:`);
 }
 
+export function isCompoAdviceClanSelectMenuCustomId(customId: string): boolean {
+  const parsed = parseCompoRefreshCustomId(customId);
+  return parsed?.kind === "advice-clan";
+}
+
 function buildCompoRefreshActionRow(
   customId: string,
   options?: { loading?: boolean },
@@ -435,6 +497,111 @@ function buildCompoActualViewActionRow(input: {
       })(),
     ),
   );
+}
+
+type CompoAdviceClanChoice = {
+  tag: string;
+  name: string;
+};
+
+function buildCompoAdviceClanSelectRow(input: {
+  userId: string;
+  mode: "war" | "actual";
+  targetTag: string | null;
+  adviceView?: CompoAdviceView;
+  customBandIndex?: number | null;
+  customBandCount?: number;
+  trackedClanChoices: readonly CompoAdviceClanChoice[];
+  loading?: boolean;
+}): ActionRowBuilder<StringSelectMenuBuilder> | null {
+  const choices = [...input.trackedClanChoices]
+    .map((choice) => ({
+      tag: normalizeTag(choice.tag),
+      name: choice.name?.trim() || choice.tag,
+    }))
+    .filter((choice, index, list) => {
+      if (!choice.tag) return false;
+      return list.findIndex((entry) => entry.tag === choice.tag) === index;
+    })
+    .slice(0, 25);
+  if (choices.length === 0) {
+    return null;
+  }
+
+  const selectedChoice = choices.find(
+    (choice) => choice.tag === normalizeTag(input.targetTag ?? ""),
+  );
+  const menu = new StringSelectMenuBuilder()
+    .setCustomId(
+      buildCompoRefreshCustomId({
+        kind: "advice-clan",
+        userId: input.userId,
+        mode: input.mode,
+        targetTag: normalizeTag(input.targetTag ?? selectedChoice?.tag ?? choices[0]!.tag),
+        adviceView: input.adviceView,
+        customBandIndex: input.customBandIndex,
+        customBandCount: input.customBandCount,
+      }),
+    )
+    .setPlaceholder(
+      selectedChoice
+        ? `Viewing: ${normalizeCompoClanDisplayName(selectedChoice.name)} (#${selectedChoice.tag})`
+        : "Select a tracked clan",
+    )
+    .setMinValues(1)
+    .setMaxValues(1)
+    .setDisabled(input.loading ?? false);
+
+  menu.addOptions(
+    choices.map((choice) => ({
+      label: `${normalizeCompoClanDisplayName(choice.name)} (#${choice.tag})`.slice(0, 100),
+      value: choice.tag,
+      default: choice.tag === selectedChoice?.tag,
+    })),
+  );
+
+  return new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(menu);
+}
+
+function extractCompoAdviceClanChoicesFromMessage(
+  interaction: ButtonInteraction | StringSelectMenuInteraction,
+): CompoAdviceClanChoice[] {
+  const rows = interaction.message.components.map(
+    (row) => row.toJSON() as APIActionRowComponent<APIComponentInMessageActionRow>,
+  );
+  const selectRow = rows.find((row) =>
+    row.components.some(
+      (component) =>
+        component.type === ComponentType.StringSelect &&
+        "custom_id" in component &&
+        typeof component.custom_id === "string" &&
+        component.custom_id.startsWith(`${COMPO_REFRESH_PREFIX}:advice-clan:`),
+    ),
+  );
+  if (!selectRow) {
+    return [];
+  }
+  const select = selectRow.components.find(
+    (component) =>
+      component.type === ComponentType.StringSelect &&
+      "options" in component,
+  );
+  if (!select || !("options" in select) || !Array.isArray(select.options)) {
+    return [];
+  }
+  return select.options
+    .map((option) => ({
+      tag: normalizeTag(String(option.value ?? "")),
+      name: (() => {
+        const tag = normalizeTag(String(option.value ?? ""));
+        const label = String(option.label ?? "").trim();
+        const suffix = tag ? ` (#${tag})` : "";
+        return suffix && label.endsWith(suffix)
+          ? label.slice(0, -suffix.length).trimEnd()
+          : label;
+      })(),
+    }))
+    .filter((choice) => Boolean(choice.tag));
 }
 
 function buildCompoAdviceViewActionRow(input: {
@@ -514,7 +681,7 @@ function buildCompoAdviceBandActionRow(input: {
 }
 
 function extractSupplementalRowsFromMessage(
-  interaction: ButtonInteraction,
+  interaction: ButtonInteraction | StringSelectMenuInteraction,
 ): Array<APIActionRowComponent<APIComponentInMessageActionRow>> {
   return interaction.message.components
     .map(
@@ -529,6 +696,15 @@ function extractSupplementalRowsFromMessage(
             "custom_id" in component &&
             typeof component.custom_id === "string" &&
             isCompoRefreshButtonCustomId(component.custom_id),
+        ),
+    )
+    .filter(
+      (row) =>
+        !row.components.some(
+          (component) =>
+            "custom_id" in component &&
+            typeof component.custom_id === "string" &&
+            component.custom_id.startsWith(`${COMPO_REFRESH_PREFIX}:advice-clan:`),
         ),
     );
 }
@@ -878,8 +1054,6 @@ function buildCompoAdviceEmbed(input: { advice: CompoAdviceReadResult }): EmbedB
         value: [
           `Members: ${summary.currentProjection.memberCount} / 50`,
           `Rushed: ${input.advice.rushedCount}`,
-          `Current Score: ${formatAdviceScore(summary.currentScore)}`,
-          `Current Band: ${summary.currentBandLabel}`,
         ].join("\n"),
         inline: false,
       },
@@ -904,7 +1078,11 @@ function buildCompoAdviceEmbed(input: { advice: CompoAdviceReadResult }): EmbedB
     );
 
     if (input.advice.refreshLine) {
-      embed.setFooter({ text: input.advice.refreshLine });
+      embed.addFields({
+        name: "Snapshot",
+        value: input.advice.refreshLine,
+        inline: false,
+      });
     }
     return embed;
   }
@@ -919,7 +1097,11 @@ function buildCompoAdviceEmbed(input: { advice: CompoAdviceReadResult }): EmbedB
     );
 
   if (input.advice.refreshLine) {
-    embed.setFooter({ text: input.advice.refreshLine });
+    embed.addFields({
+      name: "Snapshot",
+      value: input.advice.refreshLine,
+      inline: false,
+    });
   }
   return embed;
 }
@@ -1161,16 +1343,20 @@ function renderStatePng(
 function buildCompoRefreshComponents(input: {
   refreshPayload: Extract<CompoRefreshPayload, { kind: "state" | "advice" | "place" }>;
   loading: boolean;
+  adviceClanChoices?: readonly CompoAdviceClanChoice[];
+  selectedAdviceClanTag?: string | null;
   supplementalRows?: Array<
     APIActionRowComponent<APIComponentInMessageActionRow>
   >;
 }): Array<
   | ActionRowBuilder<ButtonBuilder>
+  | ActionRowBuilder<StringSelectMenuBuilder>
   | APIActionRowComponent<APIComponentInMessageActionRow>
 > {
   const refreshCustomId = buildCompoRefreshCustomId(input.refreshPayload);
   const components: Array<
     | ActionRowBuilder<ButtonBuilder>
+    | ActionRowBuilder<StringSelectMenuBuilder>
     | APIActionRowComponent<APIComponentInMessageActionRow>
   > = [buildCompoRefreshActionRow(refreshCustomId, { loading: input.loading })];
   if (input.refreshPayload.kind === "state" && input.refreshPayload.mode === "actual") {
@@ -1184,6 +1370,19 @@ function buildCompoRefreshComponents(input: {
     );
   }
   if (input.refreshPayload.kind === "advice" && input.refreshPayload.mode === "actual") {
+    const clanRow = buildCompoAdviceClanSelectRow({
+      userId: input.refreshPayload.userId,
+      mode: input.refreshPayload.mode,
+      targetTag: input.selectedAdviceClanTag ?? input.refreshPayload.targetTag,
+      adviceView: input.refreshPayload.adviceView,
+      customBandIndex: input.refreshPayload.customBandIndex,
+      customBandCount: input.refreshPayload.customBandCount,
+      trackedClanChoices: input.adviceClanChoices ?? [],
+      loading: input.loading,
+    });
+    if (clanRow) {
+      components.push(clanRow);
+    }
     components.push(
       buildCompoAdviceViewActionRow({
         userId: input.refreshPayload.userId,
@@ -1208,6 +1407,18 @@ function buildCompoRefreshComponents(input: {
           loading: input.loading,
         }),
       );
+    }
+  }
+  if (input.refreshPayload.kind === "advice" && input.refreshPayload.mode === "war") {
+    const clanRow = buildCompoAdviceClanSelectRow({
+      userId: input.refreshPayload.userId,
+      mode: input.refreshPayload.mode,
+      targetTag: input.selectedAdviceClanTag ?? input.refreshPayload.targetTag,
+      trackedClanChoices: input.adviceClanChoices ?? [],
+      loading: input.loading,
+    });
+    if (clanRow) {
+      components.push(clanRow);
     }
   }
   if (input.supplementalRows && input.supplementalRows.length > 0) {
@@ -1288,6 +1499,7 @@ export async function handleCompoRefreshButton(
   }
 
   const supplementalRows = extractSupplementalRowsFromMessage(interaction);
+  const adviceClanChoices = extractCompoAdviceClanChoicesFromMessage(interaction);
   let adviceRefreshPayload: Extract<CompoRefreshPayload, { kind: "advice" }> | null = null;
   let loadingRefreshPayload: Extract<
     CompoRefreshPayload,
@@ -1323,6 +1535,25 @@ export async function handleCompoRefreshButton(
   } else if (parsed.kind === "advice") {
     adviceRefreshPayload = parsed;
     loadingRefreshPayload = parsed;
+  } else if (parsed.kind === "advice-clan") {
+    adviceRefreshPayload =
+      parsed.mode === "actual"
+        ? {
+            kind: "advice",
+            userId: parsed.userId,
+            mode: "actual",
+            adviceView: parsed.adviceView ?? "auto",
+            targetTag: parsed.targetTag,
+            customBandIndex: parsed.customBandIndex ?? 0,
+            customBandCount: parsed.customBandCount ?? 0,
+          }
+        : {
+            kind: "advice",
+            userId: parsed.userId,
+            mode: "war",
+            targetTag: parsed.targetTag,
+          };
+    loadingRefreshPayload = adviceRefreshPayload;
   } else if (parsed.kind === "view" && parsed.target === "state") {
     loadingRefreshPayload = {
       kind: "state",
@@ -1337,6 +1568,10 @@ export async function handleCompoRefreshButton(
     components: buildCompoRefreshComponents({
       refreshPayload: loadingRefreshPayload,
       loading: true,
+      adviceClanChoices,
+      selectedAdviceClanTag:
+        adviceRefreshPayload?.targetTag ??
+        (parsed.kind === "advice-clan" ? parsed.targetTag : null),
       supplementalRows,
     }),
   });
@@ -1380,6 +1615,8 @@ export async function handleCompoRefreshButton(
         components: buildCompoRefreshComponents({
           refreshPayload: parsed,
           loading: false,
+          adviceClanChoices,
+          selectedAdviceClanTag: null,
           supplementalRows,
         }),
       });
@@ -1406,6 +1643,8 @@ export async function handleCompoRefreshButton(
         components: buildCompoRefreshComponents({
           refreshPayload: adviceRefreshPayload,
           loading: false,
+          adviceClanChoices: advice.trackedClanChoices,
+          selectedAdviceClanTag: advice.clanTag,
           supplementalRows,
         }),
       });
@@ -1442,6 +1681,8 @@ export async function handleCompoRefreshButton(
               actualView: parsed.actualView,
             },
             loading: false,
+            adviceClanChoices,
+            selectedAdviceClanTag: null,
             supplementalRows,
           }),
         });
@@ -1470,6 +1711,8 @@ export async function handleCompoRefreshButton(
             weight: parsed.weight,
           },
           loading: false,
+          adviceClanChoices,
+          selectedAdviceClanTag: null,
           supplementalRows,
         }),
       });
@@ -1480,12 +1723,111 @@ export async function handleCompoRefreshButton(
       components: buildCompoRefreshComponents({
         refreshPayload: loadingRefreshPayload,
         loading: false,
+        adviceClanChoices,
+        selectedAdviceClanTag: adviceRefreshPayload?.targetTag ?? null,
         supplementalRows,
       }),
     });
     await interaction.followUp({
       ephemeral: true,
       content: getCompoRefreshFailureMessage(parsed),
+    });
+  }
+}
+
+export async function handleCompoAdviceClanSelectMenuInteraction(
+  interaction: StringSelectMenuInteraction,
+): Promise<void> {
+  const parsed = parseCompoRefreshCustomId(interaction.customId);
+  if (!parsed || parsed.kind !== "advice-clan") {
+    if (!interaction.replied && !interaction.deferred) {
+      await interaction.reply({
+        ephemeral: true,
+        content: "Invalid advice clan selection.",
+      });
+    }
+    return;
+  }
+  if (interaction.user.id !== parsed.userId) {
+    await interaction.reply({
+      ephemeral: true,
+      content: "Only the command requester can use this clan selector.",
+    });
+    return;
+  }
+
+  const selectedTargetTag = normalizeTag(interaction.values[0] ?? "");
+  if (!selectedTargetTag) {
+    await interaction.reply({
+      ephemeral: true,
+      content: "Invalid clan selection.",
+    });
+    return;
+  }
+
+  const supplementalRows = extractSupplementalRowsFromMessage(interaction);
+  const adviceClanChoices = extractCompoAdviceClanChoicesFromMessage(interaction);
+  const adviceRefreshPayload: Extract<CompoRefreshPayload, { kind: "advice" }> =
+    parsed.mode === "actual"
+      ? {
+          kind: "advice",
+          userId: parsed.userId,
+          mode: "actual",
+          adviceView: parsed.adviceView ?? "auto",
+          targetTag: selectedTargetTag,
+          customBandIndex: parsed.customBandIndex ?? 0,
+          customBandCount: parsed.customBandCount ?? 0,
+        }
+      : {
+          kind: "advice",
+          userId: parsed.userId,
+          mode: "war",
+          targetTag: selectedTargetTag,
+        };
+
+  await interaction.update({
+    components: buildCompoRefreshComponents({
+      refreshPayload: adviceRefreshPayload,
+      loading: true,
+      adviceClanChoices,
+      selectedAdviceClanTag: selectedTargetTag,
+      supplementalRows,
+    }),
+  });
+
+  try {
+    const advice = await new CompoAdviceService().refreshAdvice({
+      guildId: interaction.guildId ?? null,
+      targetTag: selectedTargetTag,
+      mode: parsed.mode,
+      view: parsed.mode === "actual" ? parsed.adviceView : "raw",
+      customBandIndex:
+        parsed.mode === "actual" ? parsed.customBandIndex ?? 0 : null,
+    });
+    await interaction.editReply({
+      ...buildCompoAdviceResponsePayload({ advice }),
+      components: buildCompoRefreshComponents({
+        refreshPayload: adviceRefreshPayload,
+        loading: false,
+        adviceClanChoices: advice.trackedClanChoices,
+        selectedAdviceClanTag: advice.clanTag ?? selectedTargetTag,
+        supplementalRows,
+      }),
+    });
+  } catch (err) {
+    console.error(`compo advice clan selector failed: ${formatError(err)}`);
+    await interaction.editReply({
+      components: buildCompoRefreshComponents({
+        refreshPayload: adviceRefreshPayload,
+        loading: false,
+        adviceClanChoices,
+        selectedAdviceClanTag: selectedTargetTag,
+        supplementalRows,
+      }),
+    });
+    await interaction.followUp({
+      ephemeral: true,
+      content: getCompoRefreshFailureMessage(adviceRefreshPayload),
     });
   }
 }
@@ -1613,6 +1955,8 @@ export const Compo: Command = {
           components: buildCompoRefreshComponents({
             refreshPayload: adviceRefreshPayload,
             loading: false,
+            adviceClanChoices: advice.trackedClanChoices,
+            selectedAdviceClanTag: advice.clanTag,
           }),
         });
         logCompoStage(interaction, "response_sent", {

--- a/src/listeners/interactionCreate.ts
+++ b/src/listeners/interactionCreate.ts
@@ -73,7 +73,9 @@ import {
 } from "../commands/Notify";
 import {
   handleCompoRefreshButton,
+  handleCompoAdviceClanSelectMenuInteraction,
   isCompoRefreshButtonCustomId,
+  isCompoAdviceClanSelectMenuCustomId,
 } from "../commands/Compo";
 import {
   handleNotifyWarEndedViewButton,
@@ -383,6 +385,22 @@ const handleSelectMenuInteraction = async (
         });
       }
     }
+    return;
+  }
+
+  if (isCompoAdviceClanSelectMenuCustomId(interaction.customId)) {
+    try {
+      await handleCompoAdviceClanSelectMenuInteraction(interaction);
+    } catch (err) {
+      console.error(`Compo advice clan select menu failed: ${formatError(err)}`);
+      if (!interaction.replied && !interaction.deferred) {
+        await interaction.reply({
+          ephemeral: true,
+          content: "Failed to update compo advice clan selection.",
+        });
+      }
+    }
+    return;
   }
 };
 

--- a/src/services/CompoAdviceService.ts
+++ b/src/services/CompoAdviceService.ts
@@ -26,6 +26,7 @@ export type CompoAdviceReadyResult = {
   mode: CompoAdviceMode;
   selectedView: CompoAdviceView;
   trackedClanTags: string[];
+  trackedClanChoices: Array<{ tag: string; name: string }>;
   clanTag: string;
   clanName: string;
   summary: CompoAdviceSummary;
@@ -39,6 +40,7 @@ export type CompoAdviceEmptyResult = {
   mode: CompoAdviceMode;
   selectedView: CompoAdviceView;
   trackedClanTags: string[];
+  trackedClanChoices: Array<{ tag: string; name: string }>;
   clanTag: string | null;
   clanName: string | null;
   message: string;
@@ -52,6 +54,15 @@ function buildPersistedRefreshLine(latestSourceSyncedAt: Date | null): string {
     return "RAW Data last refreshed: (not available)";
   }
   return `RAW Data last refreshed: <t:${Math.floor(latestSourceSyncedAt.getTime() / 1000)}:F>`;
+}
+
+function buildTrackedClanChoices(input: {
+  clans: Array<{ clanTag: string; clanName: string }>;
+}): Array<{ tag: string; name: string }> {
+  return input.clans.map((clan) => ({
+    tag: clan.clanTag,
+    name: clan.clanName,
+  }));
 }
 
 function buildNoTrackedClansMessage(input: {
@@ -131,6 +142,7 @@ function buildReadyResult(input: {
   mode: CompoAdviceMode;
   selectedView: CompoAdviceView;
   trackedClanTags: string[];
+  trackedClanChoices: Array<{ tag: string; name: string }>;
   clanTag: string;
   clanName: string;
   summary: CompoAdviceSummary;
@@ -142,6 +154,7 @@ function buildReadyResult(input: {
     mode: input.mode,
     selectedView: input.selectedView,
     trackedClanTags: input.trackedClanTags,
+    trackedClanChoices: input.trackedClanChoices,
     clanTag: input.clanTag,
     clanName: input.clanName,
     summary: input.summary,
@@ -155,6 +168,7 @@ function buildEmptyResult(input: {
   mode: CompoAdviceMode;
   selectedView: CompoAdviceView;
   trackedClanTags: string[];
+  trackedClanChoices: Array<{ tag: string; name: string }>;
   clanTag: string | null;
   clanName: string | null;
   message: string;
@@ -165,6 +179,7 @@ function buildEmptyResult(input: {
     mode: input.mode,
     selectedView: input.selectedView,
     trackedClanTags: input.trackedClanTags,
+    trackedClanChoices: input.trackedClanChoices,
     clanTag: input.clanTag,
     clanName: input.clanName,
     message: input.message,
@@ -193,6 +208,7 @@ export class CompoAdviceService {
         mode: input.mode,
         selectedView: view,
         trackedClanTags: [],
+        trackedClanChoices: [],
         clanTag: null,
         clanName: null,
         message: buildNoTargetMessage({
@@ -207,11 +223,15 @@ export class CompoAdviceService {
 
     if (input.mode === "actual") {
       const context = await loadCompoActualStateContext(input.guildId ?? null);
+      const trackedClanChoices = buildTrackedClanChoices({
+        clans: context.clans,
+      });
       if (context.trackedClanTags.length === 0) {
         return buildEmptyResult({
           mode: input.mode,
           selectedView: view,
           trackedClanTags: [],
+          trackedClanChoices: [],
           clanTag: null,
           clanName: null,
           message: buildNoTrackedClansMessage({
@@ -228,6 +248,7 @@ export class CompoAdviceService {
           mode: input.mode,
           selectedView: view,
           trackedClanTags: context.trackedClanTags,
+          trackedClanChoices,
           clanTag: null,
           clanName: null,
           message: buildNoTargetMessage({
@@ -256,6 +277,7 @@ export class CompoAdviceService {
         mode: input.mode,
         selectedView: view,
         trackedClanTags: context.trackedClanTags,
+        trackedClanChoices,
         clanTag: clan.clanTag,
         clanName: clan.clanName,
         summary,
@@ -265,11 +287,15 @@ export class CompoAdviceService {
     }
 
     const context = await loadCompoWarStateContext();
+    const trackedClanChoices = buildTrackedClanChoices({
+      clans: context.clans,
+    });
     if (context.trackedClanTags.length === 0) {
       return buildEmptyResult({
         mode: input.mode,
         selectedView: view,
         trackedClanTags: [],
+        trackedClanChoices: [],
         clanTag: null,
         clanName: null,
         message: buildNoTrackedClansMessage({
@@ -286,6 +312,7 @@ export class CompoAdviceService {
         mode: input.mode,
         selectedView: view,
         trackedClanTags: context.trackedClanTags,
+        trackedClanChoices,
         clanTag: null,
         clanName: null,
         message: buildNoTargetMessage({
@@ -311,6 +338,7 @@ export class CompoAdviceService {
       mode: input.mode,
       selectedView: view,
       trackedClanTags: context.trackedClanTags,
+      trackedClanChoices,
       clanTag: clan.clanTag,
       clanName: clan.clanName,
       summary,

--- a/tests/compo.commandSheetRead.test.ts
+++ b/tests/compo.commandSheetRead.test.ts
@@ -70,6 +70,7 @@ describe("/compo advice command", () => {
         mode: "actual",
         selectedView: "auto",
         trackedClanTags: ["#AAA111"],
+        trackedClanChoices: [{ tag: "#AAA111", name: "Alpha Clan-actual" }],
         clanTag: "#AAA111",
         clanName: "Alpha Clan-actual",
         memberCount: 50,
@@ -129,12 +130,28 @@ describe("/compo advice command", () => {
     expect(String(payload?.embeds?.[0]?.data?.description ?? "")).toContain(
       "Advice View: **Auto-Detect Band**",
     );
+    expect(String(payload?.embeds?.[0]?.data?.description ?? "")).toContain(
+      "Target Band: **1,000,000 - 2,000,000**",
+    );
+    expect(String(payload?.embeds?.[0]?.data?.description ?? "")).toContain(
+      "Current Score: **0**",
+    );
     expect(String(payload?.embeds?.[0]?.data?.title ?? "")).toContain(
       "Alpha Clan (#AAA111)",
     );
+    expect(
+      JSON.stringify(payload?.embeds?.[0]?.data?.fields ?? []),
+    ).toContain("Snapshot");
+    expect(
+      JSON.stringify(payload?.embeds?.[0]?.data?.fields ?? []),
+    ).not.toContain("Current Band");
+    expect(
+      JSON.stringify(payload?.embeds?.[0]?.data?.fields ?? []),
+    ).not.toContain("Current Score: 0");
     expect(getComponentCustomIds(payload)).toEqual(
       expect.arrayContaining([
         "compo-refresh:advice:user-1:actual:auto:LQQ99UV8:1:0",
+        "compo-refresh:advice-clan:user-1:actual:AAA111:auto:1:0",
         "compo-refresh:view:user-1:advice:raw:LQQ99UV8:1:0",
         "compo-refresh:view:user-1:advice:auto:LQQ99UV8:1:0",
         "compo-refresh:view:user-1:advice:best:LQQ99UV8:1:0",
@@ -145,13 +162,14 @@ describe("/compo advice command", () => {
 
   it("renders WAR advice with only a refresh button", async () => {
     vi.spyOn(CompoAdviceService.prototype, "readAdvice").mockResolvedValue({
-      kind: "ready",
-      mode: "war",
-      selectedView: "raw",
-      trackedClanTags: ["#AAA111"],
-      clanTag: "#AAA111",
-      clanName: "Alpha Clan-war",
-      memberCount: 50,
+        kind: "ready",
+        mode: "war",
+        selectedView: "raw",
+        trackedClanTags: ["#AAA111"],
+        trackedClanChoices: [{ tag: "#AAA111", name: "Alpha Clan-war" }],
+        clanTag: "#AAA111",
+        clanName: "Alpha Clan-war",
+        memberCount: 50,
       rushedCount: 0,
       refreshLine: "RAW Data last refreshed: <t:1709900000:F>",
       summary: {
@@ -194,6 +212,7 @@ describe("/compo advice command", () => {
     );
     expect(getComponentCustomIds(payload)).toEqual([
       "compo-refresh:advice:user-1:war:LQQ99UV8",
+      "compo-refresh:advice-clan:user-1:war:AAA111",
     ]);
   });
 });

--- a/tests/compoAdvice.service.test.ts
+++ b/tests/compoAdvice.service.test.ts
@@ -196,6 +196,9 @@ describe("CompoAdviceService", () => {
     expect(result.kind).toBe("ready");
     expect(result.selectedView).toBe("auto");
     expect(result.summary.viewLabel).toBe("Auto-Detect Band");
+    expect(result.trackedClanChoices).toEqual([
+      { tag: "#AAA111", name: "Alpha Clan-actual" },
+    ]);
   });
 
   it("keeps ACTUAL custom advice on a manually selected target band", async () => {
@@ -247,6 +250,9 @@ describe("CompoAdviceService", () => {
     expect(result.summary.selectedCustomBandIndex).toBe(1);
     expect(result.summary.currentBandLabel).toContain("1,500,000");
     expect(result.summary.currentScore).toBeGreaterThanOrEqual(0);
+    expect(result.trackedClanChoices).toEqual([
+      { tag: "#AAA111", name: "Alpha Clan-actual" },
+    ]);
   });
 
   it("loads WAR advice from DB-backed tracked war state without sheet reads", async () => {
@@ -297,6 +303,9 @@ describe("CompoAdviceService", () => {
     expect(result.selectedView).toBe("raw");
     expect(result.summary.viewLabel).toBe("Raw Data");
     expect(result.summary.currentScore).toBe(0);
+    expect(result.trackedClanChoices).toEqual([
+      { tag: "#AAA111", name: "Alpha Clan-war" },
+    ]);
   });
 
   it("counts rushed members from the resolved bucket, not the collapsed display label", () => {

--- a/tests/compoAdviceClanSelect.command.test.ts
+++ b/tests/compoAdviceClanSelect.command.test.ts
@@ -1,0 +1,137 @@
+import { ActionRowBuilder, StringSelectMenuBuilder } from "discord.js";
+import { describe, expect, it, vi } from "vitest";
+import {
+  handleCompoAdviceClanSelectMenuInteraction,
+  parseCompoRefreshCustomIdForTest,
+} from "../src/commands/Compo";
+import { CompoAdviceService } from "../src/services/CompoAdviceService";
+
+function makeMessageComponents() {
+  const select = new StringSelectMenuBuilder()
+    .setCustomId("compo-refresh:advice-clan:user-1:actual:AAA111:custom:3:1")
+    .setPlaceholder("Viewing: Alpha Clan (#AAA111)")
+    .addOptions([
+      { label: "Alpha Clan (#AAA111)", value: "AAA111", default: true },
+      { label: "Beta Clan (#BBB222)", value: "BBB222" },
+    ]);
+  return [new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select)];
+}
+
+function makeInteraction(input?: { userId?: string; selected?: string }) {
+  const update = vi.fn().mockResolvedValue(undefined);
+  const editReply = vi.fn().mockResolvedValue(undefined);
+  const followUp = vi.fn().mockResolvedValue(undefined);
+  const reply = vi.fn().mockResolvedValue(undefined);
+  return {
+    customId: "compo-refresh:advice-clan:user-1:actual:AAA111:custom:3:1",
+    user: { id: input?.userId ?? "user-1" },
+    guildId: "guild-1",
+    values: [input?.selected ?? "BBB222"],
+    message: {
+      components: makeMessageComponents(),
+    },
+    update,
+    editReply,
+    followUp,
+    reply,
+    replied: false,
+    deferred: false,
+  } as any;
+}
+
+describe("handleCompoAdviceClanSelectMenuInteraction", () => {
+  it("switches clans while preserving actual custom band state", async () => {
+    const refreshAdviceSpy = vi
+      .spyOn(CompoAdviceService.prototype, "refreshAdvice")
+      .mockResolvedValue({
+        kind: "ready",
+        mode: "actual",
+        selectedView: "custom",
+        trackedClanTags: ["#AAA111", "#BBB222"],
+        trackedClanChoices: [
+          { tag: "#AAA111", name: "Alpha Clan" },
+          { tag: "#BBB222", name: "Beta Clan" },
+        ],
+        clanTag: "#BBB222",
+        clanName: "Beta Clan",
+        memberCount: 50,
+        rushedCount: 0,
+        refreshLine: null,
+        summary: {
+          mode: "actual",
+          view: "custom",
+          viewLabel: "Custom",
+          currentProjection: {
+            memberCount: 50,
+            deltaByBucket: {
+              TH18: 0,
+              TH17: 0,
+              TH16: 0,
+              TH15: 0,
+              TH14: 0,
+              "<=TH13": 0,
+            },
+          } as any,
+          currentScore: 0,
+          currentBandLabel: "1,000,000 - 2,000,000",
+          recommendationText: "Add TH17",
+          resultingScore: 0,
+          resultingBandLabel: "1,000,000 - 2,000,000",
+          alternateTexts: [],
+          statusText: null,
+          selectedCustomBandIndex: 1,
+          customBandCount: 3,
+        } as any,
+      } as never);
+    const interaction = makeInteraction();
+
+    await handleCompoAdviceClanSelectMenuInteraction(interaction);
+
+    expect(refreshAdviceSpy).toHaveBeenCalledWith({
+      guildId: "guild-1",
+      targetTag: "BBB222",
+      mode: "actual",
+      view: "custom",
+      customBandIndex: 1,
+    });
+    expect(interaction.update).toHaveBeenCalled();
+    expect(interaction.editReply).toHaveBeenCalled();
+    const payload = interaction.editReply.mock.calls[0]?.[0];
+    const customIds = JSON.stringify(payload?.components ?? []);
+    expect(customIds).toContain(
+      "compo-refresh:advice-clan:user-1:actual:BBB222:custom:3:1",
+    );
+    expect(customIds).toContain(
+      "compo-refresh:advice-band:user-1:BBB222:3:1:prev",
+    );
+  });
+
+  it("rejects clan switching when the requester does not match", async () => {
+    const interaction = makeInteraction({ userId: "user-2" });
+
+    await handleCompoAdviceClanSelectMenuInteraction(interaction);
+
+    expect(interaction.reply).toHaveBeenCalledWith({
+      ephemeral: true,
+      content: "Only the command requester can use this clan selector.",
+    });
+  });
+});
+
+describe("compo advice clan select custom id", () => {
+  it("parses the clan-switch payload", () => {
+    expect(
+      parseCompoRefreshCustomIdForTest(
+        "compo-refresh:advice-clan:user-1:actual:AAA111:custom:3:1",
+      ),
+    ).toMatchObject({
+      kind: "advice-clan",
+      userId: "user-1",
+      mode: "actual",
+      targetTag: "AAA111",
+      adviceView: "custom",
+      customBandCount: 3,
+      customBandIndex: 1,
+    });
+  });
+});

--- a/tests/compoRefresh.logic.test.ts
+++ b/tests/compoRefresh.logic.test.ts
@@ -244,6 +244,7 @@ describe("compo refresh button behavior", () => {
       mode: "actual",
       selectedView: "best",
       trackedClanTags: ["#AAA111"],
+      trackedClanChoices: [{ tag: "#AAA111", name: "Alpha Clan" }],
       clanTag: "#AAA111",
       clanName: "Alpha Clan-actual",
       memberCount: 49,
@@ -305,6 +306,7 @@ describe("compo refresh button behavior", () => {
     expect(collectButtonCustomIds(viewPayload)).toEqual(
       expect.arrayContaining([
         "compo-refresh:advice:user-1:actual:best:AAA111:1:0",
+        "compo-refresh:advice-clan:user-1:actual:AAA111:best:1:0",
         "compo-refresh:view:user-1:advice:raw:AAA111:1:0",
         "compo-refresh:view:user-1:advice:auto:AAA111:1:0",
         "compo-refresh:view:user-1:advice:best:AAA111:1:0",
@@ -339,6 +341,7 @@ describe("compo refresh button behavior", () => {
       mode: "actual",
       selectedView: "custom",
       trackedClanTags: ["#AAA111"],
+      trackedClanChoices: [{ tag: "#AAA111", name: "Alpha Clan" }],
       clanTag: "#AAA111",
       clanName: "Alpha Clan-actual",
       memberCount: 50,
@@ -399,6 +402,7 @@ describe("compo refresh button behavior", () => {
     expect(collectButtonCustomIds(payload)).toEqual(
       expect.arrayContaining([
         "compo-refresh:advice:user-1:actual:custom:AAA111:2:1",
+        "compo-refresh:advice-clan:user-1:actual:AAA111:custom:2:1",
         "compo-refresh:advice-band:user-1:AAA111:2:1:prev",
         "compo-refresh:advice-band:user-1:AAA111:2:1:next",
       ]),


### PR DESCRIPTION
- remove duplicated advice summary fields and render refresh timestamps in the embed body
- add tracked-clan dropdown selection that preserves advice mode and custom band state