### PR TITLE
feat(heatmapref): source rebuild from all persisted fwa clans

### DIFF
--- a/src/listeners/ready.ts
+++ b/src/listeners/ready.ts
@@ -685,7 +685,7 @@ export default (client: Client, cocService: CoCService): void => {
           });
           if (result.status !== "skipped") {
             console.log(
-              `[heatmapref] status=${result.status} cycle=${result.cycleKey ?? "none"} tracked=${result.trackedClanCount} rosters=${result.sourceRosterCount} qualifying=${result.qualifyingRosterCount} excluded=${result.excludedRosterCount} rows=${result.rowCount} alerted=${result.alertSent}`,
+              `[heatmapref] status=${result.status} cycle=${result.cycleKey ?? "none"} fwa_clans=${result.trackedClanCount} rosters=${result.sourceRosterCount} qualifying=${result.qualifyingRosterCount} excluded=${result.excludedRosterCount} rows=${result.rowCount} alerted=${result.alertSent}`,
             );
           }
         });

--- a/src/services/HeatMapRefRebuildService.ts
+++ b/src/services/HeatMapRefRebuildService.ts
@@ -180,6 +180,14 @@ function buildSeedCountsByBandKey(): ReadonlyMap<string, HeatMapRefBucketCounts>
   );
 }
 
+async function loadAllFwaClanTags(): Promise<string[]> {
+  const rows = await prisma.fwaClanCatalog.findMany({
+    orderBy: { clanTag: "asc" },
+    select: { clanTag: true },
+  });
+  return [...new Set(rows.map((row) => normalizeFwaTag(row.clanTag)).filter(Boolean))];
+}
+
 function buildSourceRosters(
   members: Array<{
     clanTag: string;
@@ -221,7 +229,7 @@ function buildSummaryLines(input: {
   reason: string | null;
 }): string[] {
   const lines = [
-    `tracked clans: ${input.trackedClanCount}`,
+    `fwa clans: ${input.trackedClanCount}`,
     `source rosters: ${input.sourceRosterCount}`,
     `qualifying rosters: ${input.qualifyingRosters.length}`,
     `excluded rosters: ${input.excludedRosters.length}`,
@@ -258,15 +266,11 @@ export class HeatMapRefRebuildService {
 
   /** Purpose: rebuild HeatMapRef directly from persisted source tables without any scheduling or alert side-effects. */
   async rebuildHeatMapRef(now: Date = new Date()): Promise<HeatMapRefRebuildRunResult> {
-    const trackedClans = await prisma.trackedClan.findMany({
-      orderBy: { createdAt: "asc" },
-      select: { tag: true },
-    });
-    const trackedClanTags = [...new Set(trackedClans.map((row) => normalizeFwaTag(row.tag)).filter(Boolean))];
-    if (trackedClanTags.length === 0) {
+    const fwaClanTags = await loadAllFwaClanTags();
+    if (fwaClanTags.length === 0) {
       return {
         status: "skipped",
-        reason: "no tracked FWA clans are configured",
+        reason: "no persisted FWA clans are configured",
         cycleKey: null,
         dueAt: null,
         trackedClanCount: 0,
@@ -277,12 +281,12 @@ export class HeatMapRefRebuildService {
         changedRowCount: 0,
         contentHash: null,
         alertSent: false,
-        summaryLines: ["No tracked FWA clans are configured."],
+        summaryLines: ["No persisted FWA clans are configured."],
       };
     }
 
     const members = await prisma.fwaWarMemberCurrent.findMany({
-      where: { clanTag: { in: trackedClanTags } },
+      where: { clanTag: { in: fwaClanTags } },
       orderBy: [{ clanTag: "asc" }, { position: "asc" }, { playerTag: "asc" }],
       select: {
         clanTag: true,
@@ -329,7 +333,7 @@ export class HeatMapRefRebuildService {
         reason: "rebuilt content matched the stored HeatMapRef rows",
         cycleKey: null,
         dueAt: null,
-        trackedClanCount: trackedClanTags.length,
+        trackedClanCount: fwaClanTags.length,
         sourceRosterCount: sourceRosters.length,
         qualifyingRosterCount: rebuiltResult.qualifyingRosters.length,
         excludedRosterCount: rebuiltResult.excludedRosters.length,
@@ -338,15 +342,15 @@ export class HeatMapRefRebuildService {
         contentHash: nextHash,
         alertSent: false,
         summaryLines: buildSummaryLines({
-          trackedClanCount: trackedClanTags.length,
+          trackedClanCount: fwaClanTags.length,
           sourceRosterCount: sourceRosters.length,
           qualifyingRosters: rebuiltResult.qualifyingRosters,
           excludedRosters: rebuiltResult.excludedRosters,
-          rows: rebuilt,
-          status: "noop",
-          reason: "rebuilt content matched the stored HeatMapRef rows",
-        }),
-      };
+        rows: rebuilt,
+        status: "noop",
+        reason: "rebuilt content matched the stored HeatMapRef rows",
+      }),
+    };
     }
 
     await prisma.$transaction(async (tx) => {
@@ -374,7 +378,7 @@ export class HeatMapRefRebuildService {
     });
 
     const result = buildSummaryLines({
-      trackedClanCount: trackedClanTags.length,
+      trackedClanCount: fwaClanTags.length,
       sourceRosterCount: sourceRosters.length,
       qualifyingRosters: rebuiltResult.qualifyingRosters,
       excludedRosters: rebuiltResult.excludedRosters,
@@ -387,7 +391,7 @@ export class HeatMapRefRebuildService {
       reason: null,
       cycleKey: null,
       dueAt: null,
-      trackedClanCount: trackedClanTags.length,
+      trackedClanCount: fwaClanTags.length,
       sourceRosterCount: sourceRosters.length,
       qualifyingRosterCount: rebuiltResult.qualifyingRosters.length,
       excludedRosterCount: rebuiltResult.excludedRosters.length,

--- a/tests/heatMapRefRebuild.service.test.ts
+++ b/tests/heatMapRefRebuild.service.test.ts
@@ -10,10 +10,13 @@ import {
 } from "../src/helper/heatMapRefRebuild";
 
 const prismaMock = vi.hoisted(() => ({
-  trackedClan: {
+  fwaClanCatalog: {
     findMany: vi.fn(),
   },
   fwaWarMemberCurrent: {
+    findMany: vi.fn(),
+  },
+  trackedClan: {
     findMany: vi.fn(),
   },
   heatMapRef: {
@@ -160,7 +163,10 @@ describe("HeatMapRefRebuildService", () => {
     vi.clearAllMocks();
     settingsStore.clear();
     prismaMock.$transaction.mockImplementation(async (fn: any) => fn(prismaMock));
-    prismaMock.trackedClan.findMany.mockResolvedValue([{ tag: "#AAA111" }]);
+    prismaMock.fwaClanCatalog.findMany.mockResolvedValue([{ clanTag: "#AAA111" }]);
+    prismaMock.trackedClan.findMany.mockResolvedValue([
+      { tag: "#AAA111", logChannelId: "log-1" },
+    ]);
     prismaMock.fwaWarMemberCurrent.findMany.mockResolvedValue([]);
     prismaMock.heatMapRef.findMany.mockResolvedValue(makeCurrentHeatMapRows());
     prismaMock.heatMapRef.deleteMany.mockResolvedValue({ count: 11 });
@@ -185,6 +191,52 @@ describe("HeatMapRefRebuildService", () => {
     expect(result.status).toBe("noop");
     expect(prismaMock.heatMapRef.createMany).not.toHaveBeenCalled();
     expect(result.summaryLines.join(" ")).toContain("rebuilt content matched");
+  });
+
+  it("includes qualifying untracked FWA clans from the persisted catalog", async () => {
+    const service = new HeatMapRefRebuildService({
+      settings: settings as never,
+      botLogChannels: botLogChannels as never,
+      permissions: permissions as never,
+    });
+    const now = new Date("2026-04-13T00:00:00.000Z");
+    prismaMock.fwaClanCatalog.findMany.mockResolvedValue([
+      { clanTag: "#TRACKED" },
+      { clanTag: "#UNTRACKED" },
+    ]);
+    prismaMock.fwaWarMemberCurrent.findMany.mockResolvedValue(
+      [
+        ...Array.from({ length: 50 }, (_, index) => ({
+          clanTag: "#TRACKED",
+          playerTag: `#T${String(index + 1).padStart(3, "0")}`,
+          position: index + 1,
+          townHall: 18,
+          weight: 175_000,
+          sourceSyncedAt: now,
+        })),
+        ...Array.from({ length: 50 }, (_, index) => ({
+          clanTag: "#UNTRACKED",
+          playerTag: `#U${String(index + 1).padStart(3, "0")}`,
+          position: index + 1,
+          townHall: 17,
+          weight: 145_000,
+          sourceSyncedAt: now,
+        })),
+      ] as never,
+    );
+
+    const result = await service.rebuildHeatMapRef(now);
+
+    expect(result.status).toBe("success");
+    expect(prismaMock.fwaWarMemberCurrent.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { clanTag: { in: ["#TRACKED", "#UNTRACKED"] } },
+      }),
+    );
+    expect(result.qualifyingRosterCount).toBe(2);
+    expect(result.trackedClanCount).toBe(2);
+    expect(result.rowCount).toBeGreaterThan(0);
+    expect(prismaMock.heatMapRef.createMany).toHaveBeenCalledTimes(1);
   });
 
   it("skips the scheduled rebuild in mirror mode", async () => {


### PR DESCRIPTION
- replace tracked-clan source loading with the global FWA clan catalog
- keep scheduled rebuild and /force refresh heatmapref on the same persisted source scope