### PR TITLE
fix(sync): unify active-war sync resolution

### DIFF
--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -83,6 +83,14 @@ import {
 } from "./fwa/mailConfig";
 import { PostedMessageService } from "../services/PostedMessageService";
 import {
+  ActiveWarSyncResolutionService,
+  buildActiveWarSyncIdentity,
+  logActiveWarSyncResolution,
+  resolveActiveWarSyncNumber,
+  resolveCurrentWarSyncIdentity,
+  type ActiveWarSyncIdentity,
+} from "../services/ActiveWarSyncResolutionService";
+import {
   WarMailLifecycleService,
   type WarMailLifecycleReconciliationOutcome,
   type WarMailLifecycleNormalizedStatus,
@@ -231,6 +239,9 @@ const MAILBOX_NOT_SENT_EMOJI = "📭";
 const postedMessageService = new PostedMessageService();
 const warMailLifecycleService = new WarMailLifecycleService();
 const pointsSyncService = new PointsSyncService();
+const activeWarSyncResolutionService = new ActiveWarSyncResolutionService(
+  pointsSyncService,
+);
 const warComplianceService = new WarComplianceService();
 const fwaStatsWeightService = new FwaStatsWeightService();
 const fwaStatsWeightCookieService = new FwaStatsWeightCookieService();
@@ -2892,11 +2903,12 @@ async function buildWarMailEmbedForTag(
       warStartTime: warStartTimeForSync,
     })
     .catch(() => null);
-  const { resolvedCurrentSyncNum } = resolveCurrentSyncNumberForMatch({
-    warState,
-    previousSyncNum: sourceSync,
-    currentWarSyncNum: syncRow?.syncNum ?? null,
+  const syncResolution = resolveActiveWarSyncNumber({
+    identity: syncIdentity,
+    latestPersistedSyncNumber: sourceSync,
+    sameWarPersistedSyncNumber: syncRow?.syncNum ?? null,
   });
+  const resolvedCurrentSyncNum = syncResolution.syncNumber;
   const lifecycle =
     syncRow === null
       ? null
@@ -2942,6 +2954,15 @@ async function buildWarMailEmbedForTag(
     options?.fetchReason ??
     routineDecision.fetchReason ??
     (options?.routine ? "mail_refresh" : "mail_preview");
+  logActiveWarSyncResolution({
+    stage: "fwa_match_mail_embed",
+    guildId,
+    clanTag: normalizedTag,
+    pointsLockPreventedLiveValidation: options?.routine
+      ? !routineDecision.allowed
+      : null,
+    resolution: syncResolution,
+  });
   if (options?.routine && !routineDecision.allowed) {
     const line = `[fwa-mail] points fetch skipped guild=${guildId} clan=#${normalizedTag} outcome=${routineDecision.outcome} code=${routineDecision.decisionCode} reason=${routineDecision.reason}`;
     const logLevel = resolveRoutineBlockedPointsFetchSkipLogLevel({
@@ -7582,34 +7603,10 @@ async function getSourceOfTruthSync(
   _settings: SettingsService,
   _guildId?: string | null,
 ): Promise<number | null> {
-  const latestSync = await pointsSyncService.findLatestSyncNum({
+  void _settings;
+  return activeWarSyncResolutionService.getLatestPersistedSyncBaseline({
     guildId: _guildId ?? null,
   });
-  if (latestSync !== null) {
-    return Math.max(0, latestSync - 1);
-  }
-
-  const tracked = await prisma.trackedClan.findMany({
-    select: { tag: true },
-  });
-  const trackedTags = new Set(tracked.map((row) => normalizeTag(row.tag)));
-  const trackedForHistory = [...trackedTags];
-  const latestHistory = await prisma.clanWarHistory.findFirst({
-    where: {
-      syncNumber: { not: null },
-      ...(trackedForHistory.length > 0
-        ? { clanTag: { in: trackedForHistory } }
-        : {}),
-    },
-    orderBy: { warStartTime: "desc" },
-    select: { syncNumber: true },
-  });
-  const latestHistorySync = Number(latestHistory?.syncNumber ?? NaN);
-  if (Number.isFinite(latestHistorySync)) {
-    return Math.max(0, Math.trunc(latestHistorySync));
-  }
-
-  return null;
 }
 
 function getWarStartDateForSync(
@@ -7620,67 +7617,6 @@ function getWarStartDateForSync(
   const startMs = parseCocApiTime(war?.startTime);
   if (startMs === null || !Number.isFinite(startMs)) return null;
   return new Date(startMs);
-}
-
-type CurrentWarSyncIdentity = {
-  warId: string | null;
-  warStartTime: Date | null;
-  opponentTag: string | null;
-};
-
-/** Purpose: scope active-war sync identity to the live war and drop stale current-war ids on rollover. */
-function resolveCurrentWarSyncIdentity(input: {
-  warState: WarStateForSync;
-  liveWarStartTime: string | null | undefined;
-  liveOpponentTag: string | null | undefined;
-  currentWarId: number | string | null | undefined;
-  currentWarStartTime: Date | null | undefined;
-  currentWarOpponentTag: string | null | undefined;
-}): CurrentWarSyncIdentity {
-  if (input.warState === "notInWar") {
-    return {
-      warId: null,
-      warStartTime: null,
-      opponentTag: null,
-    };
-  }
-
-  const liveWarStartMs = parseCocApiTime(input.liveWarStartTime ?? null);
-  const liveWarStartTime =
-    liveWarStartMs !== null && Number.isFinite(liveWarStartMs)
-      ? new Date(Math.trunc(liveWarStartMs))
-      : null;
-  const currentWarStartTime =
-    input.currentWarStartTime instanceof Date &&
-    Number.isFinite(input.currentWarStartTime.getTime())
-      ? input.currentWarStartTime
-      : null;
-  const liveOpponentTag = normalizeTag(String(input.liveOpponentTag ?? "")) || null;
-  const currentWarOpponentTag =
-    normalizeTag(String(input.currentWarOpponentTag ?? "")) || null;
-  const currentWarId = normalizeWarIdText(input.currentWarId ?? null);
-
-  const startAligned =
-    liveWarStartTime && currentWarStartTime
-      ? liveWarStartTime.getTime() === currentWarStartTime.getTime()
-      : null;
-  const opponentAligned =
-    liveOpponentTag && currentWarOpponentTag
-      ? liveOpponentTag === currentWarOpponentTag
-      : null;
-  const identityMismatch = startAligned === false || opponentAligned === false;
-  const identityConfirmed = startAligned === true || opponentAligned === true;
-  const canUseCurrentWarId =
-    currentWarId !== null &&
-    !identityMismatch &&
-    (identityConfirmed ||
-      (liveWarStartTime === null && liveOpponentTag === null));
-
-  return {
-    warId: canUseCurrentWarId ? currentWarId : null,
-    warStartTime: liveWarStartTime ?? currentWarStartTime,
-    opponentTag: liveOpponentTag ?? currentWarOpponentTag,
-  };
 }
 
 /** Purpose: choose the best war-scoped ClanPointsSync row for the active-war identity. */
@@ -7714,34 +7650,6 @@ function resolveCurrentWarScopedSyncRow(input: {
     }
   }
   return null;
-}
-
-/** Purpose: resolve authoritative current sync using same-war persisted sync first, then previous+1 for active wars. */
-function resolveCurrentSyncNumberForMatch(input: {
-  warState: WarStateForSync;
-  previousSyncNum: number | null;
-  currentWarSyncNum: number | null | undefined;
-}): {
-  resolvedCurrentSyncNum: number | null;
-  derivedCurrentSyncNum: number | null;
-  confirmedCurrentSyncNum: number | null;
-} {
-  const isActiveWar =
-    input.warState === "preparation" || input.warState === "inWar";
-  const confirmedCurrentSyncNum = isActiveWar
-    ? toComparableSyncNumber(input.currentWarSyncNum)
-    : null;
-  const derivedCurrentSyncNum =
-    isActiveWar &&
-    input.previousSyncNum !== null &&
-    Number.isFinite(input.previousSyncNum)
-      ? Math.max(0, Math.trunc(input.previousSyncNum) + 1)
-      : null;
-  return {
-    resolvedCurrentSyncNum: confirmedCurrentSyncNum ?? derivedCurrentSyncNum,
-    derivedCurrentSyncNum,
-    confirmedCurrentSyncNum,
-  };
 }
 
 function normalizeFwaOutcomeForValidation(
@@ -7968,6 +7876,20 @@ function buildStoredSyncSummary(input: {
     differenceCount: input.validationState.differences.length,
   });
   return { syncLine, updatedLine, stateLine };
+}
+
+/** Purpose: render one resolved sync number with parity label for user-facing FWA match displays. */
+function formatResolvedSyncDisplay(syncNumber: number | null): string {
+  const comparableSyncNumber = toComparableSyncNumber(syncNumber);
+  if (comparableSyncNumber === null) return "unknown";
+  const syncMode = getSyncMode(comparableSyncNumber);
+  if (syncMode === "high") {
+    return `#${comparableSyncNumber} (High Sync)`;
+  }
+  if (syncMode === "low") {
+    return `#${comparableSyncNumber} (Low Sync)`;
+  }
+  return `#${comparableSyncNumber}`;
 }
 
 /** Purpose: normalize optional sync values into comparable integers. */
@@ -8354,8 +8276,6 @@ export const isPointsValidationCurrentForMatchupForTest =
 export const shouldHydrateAlliancePayloadForTest = shouldHydrateAlliancePayload;
 export const resolveCurrentWarSyncIdentityForTest =
   resolveCurrentWarSyncIdentity;
-export const resolveCurrentSyncNumberForMatchForTest =
-  resolveCurrentSyncNumberForMatch;
 export const deriveProjectedOutcomeForTest = deriveProjectedOutcome;
 
 export const resolveMatchTypeFromStoredSyncRowForTest =
@@ -9551,7 +9471,7 @@ async function buildTrackedMatchOverview(
   const warByClanTag = new Map<string, CurrentWarResult | null>();
   const warStateByClanTag = new Map<string, WarStateForSync>();
   const warStartMsByClanTag = new Map<string, number | null>();
-  const syncIdentityByClanTag = new Map<string, CurrentWarSyncIdentity>();
+  const syncIdentityByClanTag = new Map<string, ActiveWarSyncIdentity>();
   const activeWarStarts: number[] = [];
 
   await Promise.all(
@@ -9679,11 +9599,9 @@ async function buildTrackedMatchOverview(
   const singleViews: Record<string, MatchView> = {};
   let hasAnyInferredMatchType = false;
   let syncActionAvailableCount = 0;
-  const sourceOfTruthSyncLine = `Sync#: ${
-    sourceSync !== null && Number.isFinite(sourceSync)
-      ? `#${Math.trunc(sourceSync) + 1}`
-      : "unknown"
-  }`;
+  const sourceOfTruthSyncLine = `Latest persisted sync: ${formatResolvedSyncDisplay(
+    sourceSync,
+  )}`;
 
   for (const clan of scopedTracked) {
     const clanTag = normalizeTag(clan.tag);
@@ -9692,9 +9610,12 @@ async function buildTrackedMatchOverview(
     const war = warByClanTag.get(clanTag) ?? null;
     const warState =
       warStateByClanTag.get(clanTag) ?? deriveWarState(war?.state);
-    const clanSyncLine = withSyncModeLabel(
-      getSyncDisplay(sourceSync, warState),
-      sourceSync,
+    let clanSyncLine = formatResolvedSyncDisplay(
+      resolveActiveWarSyncNumber({
+        identity: buildActiveWarSyncIdentity({ warState }),
+        latestPersistedSyncNumber: sourceSync,
+        sameWarPersistedSyncNumber: null,
+      }).syncNumber,
     );
     const clanWarStateLine = formatWarStateLabel(warState);
     const clanTimeRemainingLine = getWarStateRemaining(war, warState);
@@ -9893,11 +9814,9 @@ async function buildTrackedMatchOverview(
       continue;
     }
 
-    const syncIdentity = syncIdentityByClanTag.get(clanTag) ?? {
-      warId: null,
-      warStartTime: null,
-      opponentTag: null,
-    };
+    const syncIdentity =
+      syncIdentityByClanTag.get(clanTag) ??
+      buildActiveWarSyncIdentity({ warState });
     const warIdForReuse = syncIdentity.warId;
     const warStartTimeForReuse = syncIdentity.warStartTime;
     const confirmedCurrentWarSyncRow = resolveCurrentWarScopedSyncRow({
@@ -9906,10 +9825,19 @@ async function buildTrackedMatchOverview(
       warStartTime: warStartTimeForReuse,
       opponentTag: opponentTag || syncIdentity.opponentTag,
     });
-    const { resolvedCurrentSyncNum } = resolveCurrentSyncNumberForMatch({
-      warState,
-      previousSyncNum: sourceSync,
-      currentWarSyncNum: confirmedCurrentWarSyncRow?.syncNum ?? null,
+    const syncResolution = resolveActiveWarSyncNumber({
+      identity: syncIdentity,
+      latestPersistedSyncNumber: sourceSync,
+      sameWarPersistedSyncNumber: confirmedCurrentWarSyncRow?.syncNum ?? null,
+    });
+    const resolvedCurrentSyncNum = syncResolution.syncNumber;
+    clanSyncLine = formatResolvedSyncDisplay(resolvedCurrentSyncNum);
+    logActiveWarSyncResolution({
+      stage: "fwa_match_alliance_view",
+      guildId,
+      clanTag,
+      pointsLockPreventedLiveValidation: false,
+      resolution: syncResolution,
     });
     const warIdForReuseNumber =
       warIdForReuse !== null && Number.isFinite(Number(warIdForReuse))
@@ -13552,10 +13480,18 @@ export const Fwa: Command = {
           warStartTime: warStartTimeForReuse,
           opponentTag: opponentTag || syncIdentity.opponentTag,
         });
-        const { resolvedCurrentSyncNum } = resolveCurrentSyncNumberForMatch({
-          warState,
-          previousSyncNum: sourceSync,
-          currentWarSyncNum: confirmedCurrentWarSyncRow?.syncNum ?? null,
+        const syncResolution = resolveActiveWarSyncNumber({
+          identity: syncIdentity,
+          latestPersistedSyncNumber: sourceSync,
+          sameWarPersistedSyncNumber: confirmedCurrentWarSyncRow?.syncNum ?? null,
+        });
+        const resolvedCurrentSyncNum = syncResolution.syncNumber;
+        logActiveWarSyncResolution({
+          stage: "fwa_match_single_view",
+          guildId: interaction.guildId ?? null,
+          clanTag: tag,
+          pointsLockPreventedLiveValidation: false,
+          resolution: syncResolution,
         });
         if (
           warState === "notInWar" ||
@@ -13590,7 +13526,7 @@ export const Fwa: Command = {
                     "No active war opponent",
                     `War State: **${formatWarStateLabel(warState)}**`,
                     `Time Remaining: **${warRemaining}**`,
-                    `Sync: **${withSyncModeLabel(getSyncDisplay(sourceSync, warState), sourceSync)}**`,
+                    `Sync: **${formatResolvedSyncDisplay(resolvedCurrentSyncNum)}**`,
                     nonActiveMailProjection.mailStatusLine,
                     ...nonActiveMailDebugLines,
                   ].join("\n"),
@@ -13615,7 +13551,7 @@ export const Fwa: Command = {
                   "No active war opponent",
                   `War State: ${formatWarStateLabel(warState)}`,
                   `Time Remaining: ${warRemaining}`,
-                  `Sync: ${withSyncModeLabel(getSyncDisplay(sourceSync, warState), sourceSync)}`,
+                  `Sync: ${formatResolvedSyncDisplay(resolvedCurrentSyncNum)}`,
                   nonActiveMailProjection.mailStatusLine.replace(/\*\*/g, ""),
                   ...nonActiveMailDebugLines,
                 ].join("\n"),
@@ -13680,7 +13616,7 @@ export const Fwa: Command = {
               `Compo advice (ACTUAL): ${actual?.compoAdvice ?? "none"}`,
               `War State: **${formatWarStateLabel(warState)}**`,
               `Time Remaining: **${warRemaining}**`,
-              `Sync: **${withSyncModeLabel(getSyncDisplay(sourceSync, warState), sourceSync)}**`,
+              `Sync: **${formatResolvedSyncDisplay(resolvedCurrentSyncNum)}**`,
               nonActiveMailProjection.mailStatusLine,
               ...nonActiveMailDebugLines,
             ];

--- a/src/services/ActiveWarSyncResolutionService.ts
+++ b/src/services/ActiveWarSyncResolutionService.ts
@@ -1,0 +1,269 @@
+import { PointsSyncService } from "./PointsSyncService";
+
+export type ActiveWarSyncState = "preparation" | "inWar" | "notInWar";
+
+export type ActiveWarSyncResolutionSource =
+  | "same_war_persisted"
+  | "refresh_posted_sync"
+  | "derived_latest_plus_one"
+  | "historical_latest_persisted"
+  | "none";
+
+export type ActiveWarSyncIdentity = {
+  warState: ActiveWarSyncState;
+  warId: string | null;
+  warStartTime: Date | null;
+  opponentTag: string | null;
+  positivelyResolved: boolean;
+};
+
+export type ActiveWarSyncResolutionResult = {
+  syncNumber: number | null;
+  source: ActiveWarSyncResolutionSource;
+  isDerived: boolean;
+  identity: ActiveWarSyncIdentity;
+  latestPersistedSyncNumber: number | null;
+  sameWarPersistedSyncNumber: number | null;
+  postedSyncNumber: number | null;
+};
+
+function normalizeTag(input: string | null | undefined): string | null {
+  const normalized = String(input ?? "")
+    .trim()
+    .toUpperCase()
+    .replace(/^#/, "");
+  return normalized ? normalized : null;
+}
+
+function normalizeWarId(input: string | number | null | undefined): string | null {
+  const raw = String(input ?? "").trim();
+  return raw ? raw : null;
+}
+
+function normalizeSyncNumber(value: number | null | undefined): number | null {
+  if (value === null || value === undefined || !Number.isFinite(value)) {
+    return null;
+  }
+  return Math.trunc(value);
+}
+
+function normalizeDate(value: Date | null | undefined): Date | null {
+  if (!(value instanceof Date)) return null;
+  return Number.isFinite(value.getTime()) ? value : null;
+}
+
+function parseCocApiTime(input: string | null | undefined): Date | null {
+  if (!input) return null;
+  const match = String(input).match(
+    /^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})\.\d{3}Z$/,
+  );
+  if (!match) return null;
+  const [, y, m, d, hh, mm, ss] = match;
+  return new Date(
+    Date.UTC(
+      Number(y),
+      Number(m) - 1,
+      Number(d),
+      Number(hh),
+      Number(mm),
+      Number(ss),
+    ),
+  );
+}
+
+/** Purpose: describe an already-resolved war identity with the minimum fields needed for safe sync fallback. */
+export function buildActiveWarSyncIdentity(input: {
+  warState: ActiveWarSyncState;
+  warId?: string | number | null;
+  warStartTime?: Date | null;
+  opponentTag?: string | null;
+}): ActiveWarSyncIdentity {
+  const warId = normalizeWarId(input.warId ?? null);
+  const warStartTime = normalizeDate(input.warStartTime ?? null);
+  const opponentTag = normalizeTag(input.opponentTag ?? null);
+  const isActiveWar =
+    input.warState === "preparation" || input.warState === "inWar";
+  const positivelyResolved =
+    isActiveWar && (warId !== null || (warStartTime !== null && opponentTag !== null));
+  return {
+    warState: input.warState,
+    warId,
+    warStartTime,
+    opponentTag,
+    positivelyResolved,
+  };
+}
+
+/** Purpose: scope active-war sync identity to the live war and drop stale CurrentWar ids on rollover. */
+export function resolveCurrentWarSyncIdentity(input: {
+  warState: ActiveWarSyncState;
+  liveWarStartTime: string | null | undefined;
+  liveOpponentTag: string | null | undefined;
+  currentWarId: number | string | null | undefined;
+  currentWarStartTime: Date | null | undefined;
+  currentWarOpponentTag: string | null | undefined;
+}): ActiveWarSyncIdentity {
+  if (input.warState === "notInWar") {
+    return buildActiveWarSyncIdentity({ warState: "notInWar" });
+  }
+
+  const liveWarStartTime = parseCocApiTime(input.liveWarStartTime ?? null);
+  const currentWarStartTime = normalizeDate(input.currentWarStartTime ?? null);
+  const liveOpponentTag = normalizeTag(input.liveOpponentTag ?? null);
+  const currentWarOpponentTag = normalizeTag(input.currentWarOpponentTag ?? null);
+  const currentWarId = normalizeWarId(input.currentWarId ?? null);
+
+  const startAligned =
+    liveWarStartTime && currentWarStartTime
+      ? liveWarStartTime.getTime() === currentWarStartTime.getTime()
+      : null;
+  const opponentAligned =
+    liveOpponentTag && currentWarOpponentTag
+      ? liveOpponentTag === currentWarOpponentTag
+      : null;
+  const identityMismatch = startAligned === false || opponentAligned === false;
+  const identityConfirmed = startAligned === true || opponentAligned === true;
+  const canUseCurrentWarId =
+    currentWarId !== null &&
+    !identityMismatch &&
+    (identityConfirmed || (liveWarStartTime === null && liveOpponentTag === null));
+
+  return buildActiveWarSyncIdentity({
+    warState: input.warState,
+    warId: canUseCurrentWarId ? currentWarId : null,
+    warStartTime: liveWarStartTime ?? currentWarStartTime,
+    opponentTag: liveOpponentTag ?? currentWarOpponentTag,
+  });
+}
+
+/** Purpose: resolve active-war sync with one shared precedence stack for commands and notify flows. */
+export function resolveActiveWarSyncNumber(input: {
+  identity: ActiveWarSyncIdentity;
+  latestPersistedSyncNumber: number | null;
+  sameWarPersistedSyncNumber: number | null | undefined;
+  postedSyncNumber?: number | null;
+  allowPostedSyncReuse?: boolean;
+}): ActiveWarSyncResolutionResult {
+  const latestPersistedSyncNumber = normalizeSyncNumber(
+    input.latestPersistedSyncNumber,
+  );
+  const sameWarPersistedSyncNumber = normalizeSyncNumber(
+    input.sameWarPersistedSyncNumber,
+  );
+  const postedSyncNumber = normalizeSyncNumber(input.postedSyncNumber ?? null);
+  if (sameWarPersistedSyncNumber !== null) {
+    return {
+      syncNumber: sameWarPersistedSyncNumber,
+      source: "same_war_persisted",
+      isDerived: false,
+      identity: input.identity,
+      latestPersistedSyncNumber,
+      sameWarPersistedSyncNumber,
+      postedSyncNumber,
+    };
+  }
+
+  if (input.allowPostedSyncReuse && postedSyncNumber !== null) {
+    return {
+      syncNumber: postedSyncNumber,
+      source: "refresh_posted_sync",
+      isDerived: false,
+      identity: input.identity,
+      latestPersistedSyncNumber,
+      sameWarPersistedSyncNumber,
+      postedSyncNumber,
+    };
+  }
+
+  const isActiveWar =
+    input.identity.warState === "preparation" || input.identity.warState === "inWar";
+  if (isActiveWar) {
+    if (input.identity.positivelyResolved && latestPersistedSyncNumber !== null) {
+      return {
+        syncNumber: latestPersistedSyncNumber + 1,
+        source: "derived_latest_plus_one",
+        isDerived: true,
+        identity: input.identity,
+        latestPersistedSyncNumber,
+        sameWarPersistedSyncNumber,
+        postedSyncNumber,
+      };
+    }
+    return {
+      syncNumber: null,
+      source: "none",
+      isDerived: false,
+      identity: input.identity,
+      latestPersistedSyncNumber,
+      sameWarPersistedSyncNumber,
+      postedSyncNumber,
+    };
+  }
+
+  if (latestPersistedSyncNumber !== null) {
+    return {
+      syncNumber: latestPersistedSyncNumber,
+      source: "historical_latest_persisted",
+      isDerived: false,
+      identity: input.identity,
+      latestPersistedSyncNumber,
+      sameWarPersistedSyncNumber,
+      postedSyncNumber,
+    };
+  }
+
+  return {
+    syncNumber: null,
+    source: "none",
+    isDerived: false,
+    identity: input.identity,
+    latestPersistedSyncNumber,
+    sameWarPersistedSyncNumber,
+    postedSyncNumber,
+  };
+}
+
+/** Purpose: log shared sync resolution decisions in one structured format. */
+export function logActiveWarSyncResolution(input: {
+  stage: string;
+  guildId?: string | null;
+  clanTag: string;
+  pointsLockPreventedLiveValidation?: boolean | null;
+  resolution: ActiveWarSyncResolutionResult;
+}): void {
+  const line =
+    `[sync-resolution] stage=${input.stage} guild=${String(input.guildId ?? "none")}` +
+    ` clan=#${normalizeTag(input.clanTag) ?? "unknown"}` +
+    ` sync_resolution_source=${input.resolution.source}` +
+    ` war_state=${input.resolution.identity.warState}` +
+    ` war_id=${input.resolution.identity.warId ?? "none"}` +
+    ` war_start=${input.resolution.identity.warStartTime?.toISOString() ?? "none"}` +
+    ` opponent=${input.resolution.identity.opponentTag ? `#${input.resolution.identity.opponentTag}` : "none"}` +
+    ` identity_positive=${input.resolution.identity.positivelyResolved ? "1" : "0"}` +
+    ` latest_persisted_sync=${input.resolution.latestPersistedSyncNumber ?? "none"}` +
+    ` same_war_persisted_sync=${input.resolution.sameWarPersistedSyncNumber ?? "none"}` +
+    ` posted_sync=${input.resolution.postedSyncNumber ?? "none"}` +
+    ` resolved_sync=${input.resolution.syncNumber ?? "none"}` +
+    ` derived=${input.resolution.isDerived ? "1" : "0"}` +
+    ` points_lock_prevented_live_validation=${input.pointsLockPreventedLiveValidation ? "1" : "0"}`;
+  if (input.resolution.source === "derived_latest_plus_one" || input.resolution.source === "none") {
+    console.info(line);
+    return;
+  }
+  console.debug(line);
+}
+
+/** Purpose: read the latest persisted sync baseline directly from ClanPointsSync. */
+export class ActiveWarSyncResolutionService {
+  /** Purpose: initialize shared sync-resolution dependencies. */
+  constructor(private readonly pointsSync = new PointsSyncService()) {}
+
+  /** Purpose: load the latest persisted sync baseline without pre-decrementing it. */
+  async getLatestPersistedSyncBaseline(input?: {
+    guildId?: string | null;
+  }): Promise<number | null> {
+    return this.pointsSync.findLatestSyncNum({
+      guildId: input?.guildId ?? null,
+    });
+  }
+}

--- a/src/services/WarEventLogService.ts
+++ b/src/services/WarEventLogService.ts
@@ -12,6 +12,12 @@ import { hashMessageConfig } from "../helper/hashConfig";
 import { formatError } from "../helper/formatError";
 import { prisma } from "../prisma";
 import { CoCService } from "./CoCService";
+import {
+  ActiveWarSyncResolutionService,
+  buildActiveWarSyncIdentity,
+  logActiveWarSyncResolution,
+  resolveActiveWarSyncNumber,
+} from "./ActiveWarSyncResolutionService";
 import { PointsProjectionService } from "./PointsProjectionService";
 import { PointsDirectFetchGateService } from "./PointsDirectFetchGateService";
 import { PostedMessageService } from "./PostedMessageService";
@@ -891,24 +897,19 @@ function hasSameWarConfirmedMailBaseline(input: {
 }
 
 function resolveEventRenderSyncNumber(input: {
+  identity: ReturnType<typeof buildActiveWarSyncIdentity>;
   sameWarSyncNumber: number | null;
   postedSyncNumber: number | null;
-  previousSyncNumber: number | null;
-  currentState: WarState;
+  latestPersistedSyncNumber: number | null;
+  allowPostedSyncReuse?: boolean;
 }): number | null {
-  const sameWarSyncNumber = toValidSyncNumber(input.sameWarSyncNumber);
-  if (sameWarSyncNumber !== null) return sameWarSyncNumber;
-
-  const postedSyncNumber = toValidSyncNumber(input.postedSyncNumber);
-  if (postedSyncNumber !== null) return postedSyncNumber;
-
-  const previousSyncNumber = toValidSyncNumber(input.previousSyncNumber);
-  if (previousSyncNumber === null) return null;
-
-  if (input.currentState === "preparation" || input.currentState === "inWar") {
-    return previousSyncNumber + 1;
-  }
-  return previousSyncNumber;
+  return resolveActiveWarSyncNumber({
+    identity: input.identity,
+    latestPersistedSyncNumber: input.latestPersistedSyncNumber,
+    sameWarPersistedSyncNumber: input.sameWarSyncNumber,
+    postedSyncNumber: input.postedSyncNumber,
+    allowPostedSyncReuse: input.allowPostedSyncReuse,
+  }).syncNumber;
 }
 
 export const resolveEventRenderSyncNumberForTest = resolveEventRenderSyncNumber;
@@ -1193,6 +1194,7 @@ export class WarEventLogService {
   private readonly pointsGate: PointsDirectFetchGateService;
   private readonly pointsSync: WarStartPointsSyncService;
   private readonly currentSyncs: PointsSyncService;
+  private readonly syncResolution: ActiveWarSyncResolutionService;
   private readonly commandPermissions: CommandPermissionService;
   private readonly history: WarEventHistoryService;
   private readonly warCompliance: WarComplianceService;
@@ -1212,6 +1214,7 @@ export class WarEventLogService {
       new SettingsService(),
     );
     this.currentSyncs = new PointsSyncService();
+    this.syncResolution = new ActiveWarSyncResolutionService(this.currentSyncs);
     this.commandPermissions = new CommandPermissionService();
     this.history = new WarEventHistoryService(coc);
     this.warCompliance = new WarComplianceService();
@@ -1221,7 +1224,7 @@ export class WarEventLogService {
 
   /** Purpose: poll. */
   async poll(): Promise<void> {
-    const previousSync = await this.pointsSync.getPreviousSyncNum();
+    const previousSync = await this.syncResolution.getLatestPersistedSyncBaseline();
     const syncContext: PollSyncContext = {
       previousSync,
       activeSync: previousSync === null ? null : previousSync + 1,
@@ -1482,7 +1485,7 @@ export class WarEventLogService {
     sub: SubscriptionRow,
     params: { eventType: EventType; source: TestSource },
   ): Promise<EventEmitPayload> {
-    const previousSync = await this.pointsSync.getPreviousSyncNum();
+    const previousSync = await this.syncResolution.getLatestPersistedSyncBaseline();
     const activeSync = previousSync === null ? null : previousSync + 1;
 
     const currentWar =
@@ -3035,6 +3038,7 @@ export class WarEventLogService {
       clanTag: sub.clanTag,
       warId: resolvedWarIdText,
       warStartTime: nextWarStartTime,
+      opponentTag: nextOpponentTag || normalizeTag(sub.opponentTag ?? ""),
       currentState,
       postedSyncNumber: null,
       previousSyncNumber: syncContext.previousSync,
@@ -4285,8 +4289,10 @@ export class WarEventLogService {
       clanTag,
       warId: warIdText,
       warStartTime,
+      opponentTag: nextOpponentTag,
       currentState: state,
       postedSyncNumber: toValidSyncNumber(existingMessage.syncNum),
+      allowPostedSyncReuse: true,
     });
 
     const basePayload = {
@@ -4511,8 +4517,10 @@ export class WarEventLogService {
       clanTag,
       warId: resolvedWarIdText,
       warStartTime,
+      opponentTag: nextOpponentTag || refreshedSub.opponentTag,
       currentState: "inWar",
       postedSyncNumber,
+      allowPostedSyncReuse: true,
     });
 
     const payload = {
@@ -4608,9 +4616,11 @@ export class WarEventLogService {
     clanTag: string;
     warId: string | null;
     warStartTime: Date | null;
+    opponentTag?: string | null;
     currentState: WarState;
     postedSyncNumber: number | null;
     previousSyncNumber?: number | null;
+    allowPostedSyncReuse?: boolean;
   }): Promise<number | null> {
     const sameWarSync = await this.currentSyncs
       .getCurrentSyncForClan({
@@ -4620,25 +4630,42 @@ export class WarEventLogService {
         warStartTime: input.warStartTime,
       })
       .catch(() => null);
-    const sameWarSyncNumber = toValidSyncNumber(sameWarSync?.syncNum ?? null);
-    if (sameWarSyncNumber !== null) {
-      return sameWarSyncNumber;
-    }
-
+    const sameWarPersistedSyncNumber = toValidSyncNumber(sameWarSync?.syncNum ?? null);
     const postedSyncNumber = toValidSyncNumber(input.postedSyncNumber);
-    if (postedSyncNumber !== null) {
-      return postedSyncNumber;
-    }
-
-    const previousSyncNumber = toValidSyncNumber(
-      input.previousSyncNumber ?? (await this.pointsSync.getPreviousSyncNum()),
-    );
-    return resolveEventRenderSyncNumber({
-      sameWarSyncNumber: null,
-      postedSyncNumber: null,
-      previousSyncNumber,
-      currentState: input.currentState,
+    const preferredBaseline = toValidSyncNumber(input.previousSyncNumber ?? null);
+    const needsLatestPersistedBaseline =
+      sameWarPersistedSyncNumber === null &&
+      !(input.allowPostedSyncReuse && postedSyncNumber !== null) &&
+      preferredBaseline === null;
+    const latestPersistedSyncNumber = needsLatestPersistedBaseline
+      ? toValidSyncNumber(
+          await this.syncResolution.getLatestPersistedSyncBaseline({
+            guildId: input.guildId,
+          }),
+        )
+      : preferredBaseline;
+    const identity = buildActiveWarSyncIdentity({
+      warState: input.currentState,
+      warId: input.warId,
+      warStartTime: input.warStartTime,
+      opponentTag: input.opponentTag ?? null,
     });
+    const resolution = resolveActiveWarSyncNumber({
+      identity,
+      latestPersistedSyncNumber,
+      sameWarPersistedSyncNumber,
+      postedSyncNumber,
+      allowPostedSyncReuse: input.allowPostedSyncReuse,
+    });
+    logActiveWarSyncResolution({
+      stage: input.allowPostedSyncReuse
+        ? "notify_refresh_sync"
+        : "notify_event_sync",
+      guildId: input.guildId,
+      clanTag: input.clanTag,
+      resolution,
+    });
+    return resolution.syncNumber;
   }
 
   private async buildBattleDayRefreshEmbed(

--- a/tests/activeWarSyncResolution.service.test.ts
+++ b/tests/activeWarSyncResolution.service.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildActiveWarSyncIdentity,
+  resolveActiveWarSyncNumber,
+} from "../src/services/ActiveWarSyncResolutionService";
+
+describe("ActiveWarSyncResolutionService resolver", () => {
+  it("derives latest persisted + 1 for positively resolved preparation wars", () => {
+    const resolution = resolveActiveWarSyncNumber({
+      identity: buildActiveWarSyncIdentity({
+        warState: "preparation",
+        warId: "4001",
+      }),
+      latestPersistedSyncNumber: 500,
+      sameWarPersistedSyncNumber: null,
+    });
+
+    expect(resolution).toMatchObject({
+      syncNumber: 501,
+      source: "derived_latest_plus_one",
+      isDerived: true,
+    });
+  });
+
+  it("derives latest persisted + 1 for positively resolved in-war identities", () => {
+    const resolution = resolveActiveWarSyncNumber({
+      identity: buildActiveWarSyncIdentity({
+        warState: "inWar",
+        warStartTime: new Date("2026-04-13T08:00:00.000Z"),
+        opponentTag: "#OPP123",
+      }),
+      latestPersistedSyncNumber: 500,
+      sameWarPersistedSyncNumber: null,
+    });
+
+    expect(resolution).toMatchObject({
+      syncNumber: 501,
+      source: "derived_latest_plus_one",
+      isDerived: true,
+    });
+  });
+
+  it("uses latest persisted sync without +1 for not-in-war paths", () => {
+    const resolution = resolveActiveWarSyncNumber({
+      identity: buildActiveWarSyncIdentity({
+        warState: "notInWar",
+      }),
+      latestPersistedSyncNumber: 500,
+      sameWarPersistedSyncNumber: null,
+    });
+
+    expect(resolution).toMatchObject({
+      syncNumber: 500,
+      source: "historical_latest_persisted",
+      isDerived: false,
+    });
+  });
+
+  it("prefers same-war persisted sync over every fallback", () => {
+    const resolution = resolveActiveWarSyncNumber({
+      identity: buildActiveWarSyncIdentity({
+        warState: "inWar",
+        warId: "4002",
+      }),
+      latestPersistedSyncNumber: 500,
+      sameWarPersistedSyncNumber: 503,
+      postedSyncNumber: 502,
+      allowPostedSyncReuse: true,
+    });
+
+    expect(resolution).toMatchObject({
+      syncNumber: 503,
+      source: "same_war_persisted",
+      isDerived: false,
+    });
+  });
+
+  it("reuses posted sync only for refresh continuity when allowed", () => {
+    const refreshResolution = resolveActiveWarSyncNumber({
+      identity: buildActiveWarSyncIdentity({
+        warState: "inWar",
+        warId: "4003",
+      }),
+      latestPersistedSyncNumber: 500,
+      sameWarPersistedSyncNumber: null,
+      postedSyncNumber: 501,
+      allowPostedSyncReuse: true,
+    });
+    const freshResolution = resolveActiveWarSyncNumber({
+      identity: buildActiveWarSyncIdentity({
+        warState: "inWar",
+        warId: "4003",
+      }),
+      latestPersistedSyncNumber: 500,
+      sameWarPersistedSyncNumber: null,
+      postedSyncNumber: 501,
+      allowPostedSyncReuse: false,
+    });
+
+    expect(refreshResolution).toMatchObject({
+      syncNumber: 501,
+      source: "refresh_posted_sync",
+      isDerived: false,
+    });
+    expect(freshResolution).toMatchObject({
+      syncNumber: 501,
+      source: "derived_latest_plus_one",
+      isDerived: true,
+    });
+  });
+
+  it("returns unknown instead of reusing a stale sync when active identity is ambiguous", () => {
+    const resolution = resolveActiveWarSyncNumber({
+      identity: buildActiveWarSyncIdentity({
+        warState: "preparation",
+      }),
+      latestPersistedSyncNumber: 500,
+      sameWarPersistedSyncNumber: null,
+    });
+
+    expect(resolution).toMatchObject({
+      syncNumber: null,
+      source: "none",
+      isDerived: false,
+    });
+  });
+
+  it("switches from derived to same-war persisted once points persistence catches up", () => {
+    const derivedResolution = resolveActiveWarSyncNumber({
+      identity: buildActiveWarSyncIdentity({
+        warState: "inWar",
+        warId: "4004",
+      }),
+      latestPersistedSyncNumber: 500,
+      sameWarPersistedSyncNumber: null,
+    });
+    const persistedResolution = resolveActiveWarSyncNumber({
+      identity: buildActiveWarSyncIdentity({
+        warState: "inWar",
+        warId: "4004",
+      }),
+      latestPersistedSyncNumber: 500,
+      sameWarPersistedSyncNumber: 501,
+    });
+
+    expect(derivedResolution.syncNumber).toBe(501);
+    expect(derivedResolution.source).toBe("derived_latest_plus_one");
+    expect(persistedResolution.syncNumber).toBe(501);
+    expect(persistedResolution.source).toBe("same_war_persisted");
+  });
+
+  it("returns none when no persisted baseline exists", () => {
+    const resolution = resolveActiveWarSyncNumber({
+      identity: buildActiveWarSyncIdentity({
+        warState: "inWar",
+        warId: "4005",
+      }),
+      latestPersistedSyncNumber: null,
+      sameWarPersistedSyncNumber: null,
+    });
+
+    expect(resolution).toMatchObject({
+      syncNumber: null,
+      source: "none",
+      isDerived: false,
+    });
+  });
+});

--- a/tests/fwaMatchResolvedSync.logic.test.ts
+++ b/tests/fwaMatchResolvedSync.logic.test.ts
@@ -1,42 +1,51 @@
 import { describe, expect, it } from "vitest";
 import {
   deriveProjectedOutcomeForTest,
-  resolveCurrentSyncNumberForMatchForTest,
-  resolveCurrentWarSyncIdentityForTest,
   resolveRenderedSyncNumberForStoredSummaryForTest,
 } from "../src/commands/Fwa";
+import {
+  buildActiveWarSyncIdentity,
+  resolveActiveWarSyncNumber,
+  resolveCurrentWarSyncIdentity,
+} from "../src/services/ActiveWarSyncResolutionService";
 
 describe("fwa match resolved current sync", () => {
-  it("derives current sync as previous + 1 for active wars when same-war sync is not persisted", () => {
-    const resolved = resolveCurrentSyncNumberForMatchForTest({
-      warState: "inWar",
-      previousSyncNum: 475,
-      currentWarSyncNum: null,
+  it("derives current sync as latest persisted + 1 for active wars when same-war sync is not persisted", () => {
+    const resolved = resolveActiveWarSyncNumber({
+      identity: buildActiveWarSyncIdentity({
+        warState: "inWar",
+        warId: "2001",
+      }),
+      latestPersistedSyncNumber: 475,
+      sameWarPersistedSyncNumber: null,
     });
 
-    expect(resolved).toEqual({
-      resolvedCurrentSyncNum: 476,
-      derivedCurrentSyncNum: 476,
-      confirmedCurrentSyncNum: null,
+    expect(resolved).toMatchObject({
+      syncNumber: 476,
+      source: "derived_latest_plus_one",
+      isDerived: true,
     });
   });
 
-  it("prefers same-war persisted sync over derived previous + 1", () => {
-    const resolved = resolveCurrentSyncNumberForMatchForTest({
-      warState: "preparation",
-      previousSyncNum: 475,
-      currentWarSyncNum: 478,
+  it("prefers same-war persisted sync over derived latest + 1", () => {
+    const resolved = resolveActiveWarSyncNumber({
+      identity: buildActiveWarSyncIdentity({
+        warState: "preparation",
+        warId: "2002",
+      }),
+      latestPersistedSyncNumber: 475,
+      sameWarPersistedSyncNumber: 478,
     });
 
-    expect(resolved).toEqual({
-      resolvedCurrentSyncNum: 478,
-      derivedCurrentSyncNum: 476,
-      confirmedCurrentSyncNum: 478,
+    expect(resolved).toMatchObject({
+      syncNumber: 478,
+      source: "same_war_persisted",
+      isDerived: false,
     });
   });
 
   it("drops stale CurrentWar warId when live war identity indicates rollover", () => {
-    const identity = resolveCurrentWarSyncIdentityForTest({
+    const identity = resolveCurrentWarSyncIdentity({
       warState: "inWar",
       liveWarStartTime: "20260312T090000.000Z",
       liveOpponentTag: "#2NEW",
@@ -48,13 +57,17 @@ describe("fwa match resolved current sync", () => {
     expect(identity.warId).toBeNull();
     expect(identity.warStartTime?.toISOString()).toBe("2026-03-12T09:00:00.000Z");
     expect(identity.opponentTag).toBe("2NEW");
+    expect(identity.positivelyResolved).toBe(true);
   });
 
-  it("uses resolved current sync parity for tie-break projections instead of stale previous sync", () => {
-    const resolved = resolveCurrentSyncNumberForMatchForTest({
-      warState: "inWar",
-      previousSyncNum: 475,
-      currentWarSyncNum: null,
+  it("uses resolved current sync parity for tie-break projections instead of stale persisted sync", () => {
+    const resolved = resolveActiveWarSyncNumber({
+      identity: buildActiveWarSyncIdentity({
+        warState: "inWar",
+        warId: "2003",
+      }),
+      latestPersistedSyncNumber: 475,
+      sameWarPersistedSyncNumber: null,
     });
 
     const resolvedOutcome = deriveProjectedOutcomeForTest(
@@ -62,7 +75,7 @@ describe("fwa match resolved current sync", () => {
       "A000",
       1000,
       1000,
-      resolved.resolvedCurrentSyncNum,
+      resolved.syncNumber,
     );
     const staleOutcome = deriveProjectedOutcomeForTest(
       "B000",
@@ -77,9 +90,17 @@ describe("fwa match resolved current sync", () => {
   });
 
   it("renders resolved fallback sync for active war when no same-war persisted row exists", () => {
+    const resolution = resolveActiveWarSyncNumber({
+      identity: buildActiveWarSyncIdentity({
+        warState: "inWar",
+        warId: "2002",
+      }),
+      latestPersistedSyncNumber: 475,
+      sameWarPersistedSyncNumber: null,
+    });
     const renderedSync = resolveRenderedSyncNumberForStoredSummaryForTest({
       syncRow: null,
-      fallbackSyncNum: 476,
+      fallbackSyncNum: resolution.syncNumber,
       warId: "2002",
       warStartTime: new Date("2026-03-12T09:00:00.000Z"),
       opponentNotFound: false,
@@ -95,14 +116,17 @@ describe("fwa match resolved current sync", () => {
   });
 
   it("uses the same derived sync value for display and tie-break parity when same-war sync is missing", () => {
-    const resolved = resolveCurrentSyncNumberForMatchForTest({
-      warState: "preparation",
-      previousSyncNum: 481,
-      currentWarSyncNum: null,
+    const resolution = resolveActiveWarSyncNumber({
+      identity: buildActiveWarSyncIdentity({
+        warState: "preparation",
+        warId: "3001",
+      }),
+      latestPersistedSyncNumber: 481,
+      sameWarPersistedSyncNumber: null,
     });
     const renderedSync = resolveRenderedSyncNumberForStoredSummaryForTest({
       syncRow: null,
-      fallbackSyncNum: resolved.resolvedCurrentSyncNum,
+      fallbackSyncNum: resolution.syncNumber,
       warId: "3001",
       warStartTime: new Date("2026-03-25T04:20:57.000Z"),
       opponentNotFound: false,
@@ -115,14 +139,14 @@ describe("fwa match resolved current sync", () => {
     });
 
     expect(renderedSync).toBe(482);
-    expect(renderedSync).toBe(resolved.resolvedCurrentSyncNum);
+    expect(renderedSync).toBe(resolution.syncNumber);
 
     const outcomeFromResolved = deriveProjectedOutcomeForTest(
       "B000",
       "A000",
       1000,
       1000,
-      resolved.resolvedCurrentSyncNum,
+      resolution.syncNumber,
     );
     const outcomeFromRendered = deriveProjectedOutcomeForTest(
       "B000",
@@ -137,10 +161,13 @@ describe("fwa match resolved current sync", () => {
   });
 
   it("uses the same confirmed same-war sync value for display and tie-break parity", () => {
-    const resolved = resolveCurrentSyncNumberForMatchForTest({
-      warState: "inWar",
-      previousSyncNum: 481,
-      currentWarSyncNum: 482,
+    const resolution = resolveActiveWarSyncNumber({
+      identity: buildActiveWarSyncIdentity({
+        warState: "inWar",
+        warId: "3002",
+      }),
+      latestPersistedSyncNumber: 481,
+      sameWarPersistedSyncNumber: 482,
     });
     const renderedSync = resolveRenderedSyncNumberForStoredSummaryForTest({
       syncRow: {
@@ -149,7 +176,7 @@ describe("fwa match resolved current sync", () => {
         warId: "3002",
         warStartTime: new Date("2026-03-25T04:21:07.000Z"),
       },
-      fallbackSyncNum: resolved.resolvedCurrentSyncNum,
+      fallbackSyncNum: resolution.syncNumber,
       warId: "3002",
       warStartTime: new Date("2026-03-25T04:21:07.000Z"),
       opponentNotFound: false,
@@ -162,14 +189,14 @@ describe("fwa match resolved current sync", () => {
     });
 
     expect(renderedSync).toBe(482);
-    expect(renderedSync).toBe(resolved.resolvedCurrentSyncNum);
+    expect(renderedSync).toBe(resolution.syncNumber);
 
     const outcomeFromResolved = deriveProjectedOutcomeForTest(
       "B000",
       "A000",
       1000,
       1000,
-      resolved.resolvedCurrentSyncNum,
+      resolution.syncNumber,
     );
     const outcomeFromRendered = deriveProjectedOutcomeForTest(
       "B000",

--- a/tests/warEventLog.logic.test.ts
+++ b/tests/warEventLog.logic.test.ts
@@ -22,6 +22,7 @@ import {
   resolveParticipationGuildId,
   WarEventHistoryService,
 } from "../src/services/war-events/history";
+import { buildActiveWarSyncIdentity } from "../src/services/ActiveWarSyncResolutionService";
 
 function dateAt(hour: number): Date {
   return new Date(Date.UTC(2026, 0, 1, hour, 0, 0));
@@ -101,53 +102,93 @@ describe("WarEventLogService resolved notify sync fallback", () => {
   it("prefers same-war sync over posted and derived values", () => {
     expect(
       resolveEventRenderSyncNumberForTest({
+        identity: buildActiveWarSyncIdentity({
+          warState: "inWar",
+          warId: "1001",
+        }),
         sameWarSyncNumber: 482,
         postedSyncNumber: 481,
-        previousSyncNumber: 480,
-        currentState: "inWar",
+        latestPersistedSyncNumber: 480,
+        allowPostedSyncReuse: true,
       })
     ).toBe(482);
   });
 
-  it("falls back to posted sync when same-war sync is unavailable", () => {
+  it("falls back to posted sync only for refresh continuity", () => {
     expect(
       resolveEventRenderSyncNumberForTest({
+        identity: buildActiveWarSyncIdentity({
+          warState: "inWar",
+          warId: "1001",
+        }),
         sameWarSyncNumber: null,
         postedSyncNumber: 482,
-        previousSyncNumber: 480,
-        currentState: "inWar",
+        latestPersistedSyncNumber: 480,
+        allowPostedSyncReuse: true,
+      })
+    ).toBe(482);
+    expect(
+      resolveEventRenderSyncNumberForTest({
+        identity: buildActiveWarSyncIdentity({
+          warState: "inWar",
+          warId: "1001",
+        }),
+        sameWarSyncNumber: null,
+        postedSyncNumber: 482,
+        latestPersistedSyncNumber: 480,
+      }),
+    ).toBe(481);
+  });
+
+  it("derives active-war sync as latest persisted + 1 for preparation/inWar", () => {
+    expect(
+      resolveEventRenderSyncNumberForTest({
+        identity: buildActiveWarSyncIdentity({
+          warState: "preparation",
+          warId: "1002",
+        }),
+        sameWarSyncNumber: null,
+        postedSyncNumber: null,
+        latestPersistedSyncNumber: 481,
+      })
+    ).toBe(482);
+    expect(
+      resolveEventRenderSyncNumberForTest({
+        identity: buildActiveWarSyncIdentity({
+          warState: "inWar",
+          warId: "1003",
+        }),
+        sameWarSyncNumber: null,
+        postedSyncNumber: null,
+        latestPersistedSyncNumber: 481,
       })
     ).toBe(482);
   });
 
-  it("derives active-war sync as previous + 1 for preparation/inWar", () => {
+  it("falls back to latest persisted sync when war is not active", () => {
     expect(
       resolveEventRenderSyncNumberForTest({
+        identity: buildActiveWarSyncIdentity({
+          warState: "notInWar",
+        }),
         sameWarSyncNumber: null,
         postedSyncNumber: null,
-        previousSyncNumber: 481,
-        currentState: "preparation",
-      })
-    ).toBe(482);
-    expect(
-      resolveEventRenderSyncNumberForTest({
-        sameWarSyncNumber: null,
-        postedSyncNumber: null,
-        previousSyncNumber: 481,
-        currentState: "inWar",
-      })
-    ).toBe(482);
-  });
-
-  it("falls back to previous sync when war is not active", () => {
-    expect(
-      resolveEventRenderSyncNumberForTest({
-        sameWarSyncNumber: null,
-        postedSyncNumber: null,
-        previousSyncNumber: 481,
-        currentState: "notInWar",
+        latestPersistedSyncNumber: 481,
       })
     ).toBe(481);
+  });
+
+  it("returns unknown when active-looking sync fallback is not positively resolved", () => {
+    expect(
+      resolveEventRenderSyncNumberForTest({
+        identity: buildActiveWarSyncIdentity({
+          warState: "preparation",
+        }),
+        sameWarSyncNumber: null,
+        postedSyncNumber: null,
+        latestPersistedSyncNumber: 481,
+      }),
+    ).toBeNull();
   });
 });
 

--- a/tests/warEventLog.warEndPointsReconcile.test.ts
+++ b/tests/warEventLog.warEndPointsReconcile.test.ts
@@ -1703,7 +1703,7 @@ describe("War-start notify refresh sync fallback", () => {
   }): Promise<{
     ok: boolean;
     payloadSyncNumber: number | null;
-    getPreviousSyncNumSpy: ReturnType<typeof vi.fn>;
+    getLatestPersistedSyncBaselineSpy: ReturnType<typeof vi.fn>;
   }> {
     vi.restoreAllMocks();
     const messageEdit = vi.fn().mockResolvedValue(undefined);
@@ -1750,9 +1750,11 @@ describe("War-start notify refresh sync fallback", () => {
         .fn()
         .mockResolvedValue(input.sameWarSync === null ? null : { syncNum: input.sameWarSync }),
     };
-    const getPreviousSyncNumSpy = vi.fn().mockResolvedValue(input.previousSync);
-    (service as any).pointsSync = {
-      getPreviousSyncNum: getPreviousSyncNumSpy,
+    const getLatestPersistedSyncBaselineSpy = vi
+      .fn()
+      .mockResolvedValue(input.previousSync);
+    (service as any).syncResolution = {
+      getLatestPersistedSyncBaseline: getLatestPersistedSyncBaselineSpy,
     };
 
     const buildSpy = vi
@@ -1764,7 +1766,7 @@ describe("War-start notify refresh sync fallback", () => {
     return {
       ok,
       payloadSyncNumber,
-      getPreviousSyncNumSpy,
+      getLatestPersistedSyncBaselineSpy,
     };
   }
 
@@ -1777,7 +1779,7 @@ describe("War-start notify refresh sync fallback", () => {
 
     expect(result.ok).toBe(true);
     expect(result.payloadSyncNumber).toBe(482);
-    expect(result.getPreviousSyncNumSpy).not.toHaveBeenCalled();
+    expect(result.getLatestPersistedSyncBaselineSpy).not.toHaveBeenCalled();
   });
 
   it("falls back to posted sync when same-war sync is unavailable", async () => {
@@ -1789,7 +1791,7 @@ describe("War-start notify refresh sync fallback", () => {
 
     expect(result.ok).toBe(true);
     expect(result.payloadSyncNumber).toBe(482);
-    expect(result.getPreviousSyncNumSpy).not.toHaveBeenCalled();
+    expect(result.getLatestPersistedSyncBaselineSpy).not.toHaveBeenCalled();
   });
 
   it("derives active-war sync as previous+1 when same-war and posted sync are unavailable", async () => {
@@ -1801,7 +1803,7 @@ describe("War-start notify refresh sync fallback", () => {
 
     expect(result.ok).toBe(true);
     expect(result.payloadSyncNumber).toBe(482);
-    expect(result.getPreviousSyncNumSpy).toHaveBeenCalledTimes(1);
+    expect(result.getLatestPersistedSyncBaselineSpy).toHaveBeenCalledTimes(1);
   });
 
   it("keeps initial notify and refresh sync aligned when same-war sync exists", async () => {


### PR DESCRIPTION
- share active-war sync precedence between /fwa match and war-event notify flows
- remove pre-decrement baseline handling and add targeted sync resolution tests/logging