### PR TITLE
feat(fwa-feeds): add derived clan match stats snapshot

### DIFF
--- a/docs/architecture-contract.md
+++ b/docs/architecture-contract.md
@@ -41,6 +41,7 @@ FwaWarMemberCurrent
 FwaTrackedClanWarRosterCurrent
 FwaTrackedClanWarRosterMemberCurrent
 FwaClanWarLogCurrent
+FwaClanMatchStatsCurrent
 HeatMapRef
 FwaFeedSyncState
 FwaClanWarsWatchState
@@ -131,7 +132,7 @@ Each domain concept must have exactly one authoritative owner.
 | Guild reminder config and dedupe | Reminder, ReminderTimeOffset, ReminderTargetClan, ReminderFireLog |
 | Personal reminder config and dedupe | UserActivityReminderRule, UserActivityReminderDelivery |
 | Tracked reusable posts and claims | TrackedMessage, TrackedMessageClaim |
-| FWA feed current state | FwaClanCatalog, FwaPlayerCatalog, FwaClanMemberCurrent, FwaWarMemberCurrent, FwaTrackedClanWarRosterCurrent, FwaTrackedClanWarRosterMemberCurrent, FwaClanWarLogCurrent |
+| FWA feed current state | FwaClanCatalog, FwaPlayerCatalog, FwaClanMemberCurrent, FwaWarMemberCurrent, FwaTrackedClanWarRosterCurrent, FwaTrackedClanWarRosterMemberCurrent, FwaClanWarLogCurrent, FwaClanMatchStatsCurrent |
 | FWA compo reference bands | HeatMapRef |
 | FWA feed scheduler metadata | FwaFeedSyncState, FwaClanWarsWatchState, FwaFeedCursor |
 | Unlinked alert routing and unresolved members | UnlinkedAlertConfig, UnlinkedPlayer |
@@ -176,6 +177,7 @@ Rules:
 
 - FWAStats JSON feed reads flow into feed-backed current-state tables, not directly into command rendering.
 - `FwaFeedSyncState`, `FwaClanWarsWatchState`, and `FwaFeedCursor` own feed scheduler metadata.
+- `FwaClanMatchStatsCurrent` is a recreatable derived snapshot owned by the clan-wars feed domain and rebuilt from `FwaClanWarLogCurrent`; it is not a source of raw truth.
 - Commands should prefer persisted feed rows over live feed calls on hot paths.
 
 ## 6) Snapshot and reminder ownership

--- a/docs/project-brain.md
+++ b/docs/project-brain.md
@@ -43,7 +43,7 @@ Core subsystems:
 
 - War state: `TrackedClan -> WarEventLogService/poll loops -> CurrentWar -> ClanWarHistory / ClanWarParticipation / WarAttacks / WarLookup / WarEvent / WarMailLifecycle / ClanPostedMessage`
 - Points sync: `points.fwafarm -> PointsSyncService -> ClanPointsSync`
-- Feed-backed current state: `FWAStats JSON feeds -> FwaFeedSchedulerService -> FwaClanCatalog / FwaPlayerCatalog / FwaClanMemberCurrent / FwaWarMemberCurrent / FwaTrackedClanWarRosterCurrent / FwaTrackedClanWarRosterMemberCurrent / FwaClanWarLogCurrent / HeatMapRef`
+- Feed-backed current state: `FWAStats JSON feeds -> FwaFeedSchedulerService -> FwaClanCatalog / FwaPlayerCatalog / FwaClanMemberCurrent / FwaWarMemberCurrent / FwaTrackedClanWarRosterCurrent / FwaTrackedClanWarRosterMemberCurrent / FwaClanWarLogCurrent / FwaClanMatchStatsCurrent / HeatMapRef`
 - Snapshot-backed todo: `PlayerLink + TodoUserUsage + CurrentWar + CurrentCwlRound/CwlRoundMemberCurrent + activity signals -> TodoSnapshotService -> TodoPlayerSnapshot`
 - Persisted CWL state: `CwlTrackedClan -> CwlStateService -> CurrentCwlRound / CwlRoundMemberCurrent / CurrentCwlPrepSnapshot / CwlRoundHistory / CwlRoundMemberHistory / CwlPlayerClanSeason`
 - CWL planner state: `CurrentCwlRound + CwlRoundMemberCurrent + CurrentCwlPrepSnapshot + CwlPlayerClanSeason -> CwlRotationService -> CwlRotationPlan / CwlRotationPlanDay / CwlRotationPlanMember`, with sheet import/export orchestration layered on top for admin-only planner exchange flows.
@@ -81,7 +81,7 @@ Important owners:
 | Guild reminders | Reminder* tables |
 | Personal reminders | UserActivityReminder* tables |
 | Tracked long-lived posts | TrackedMessage* tables |
-| FWA feed current-state tables | Fwa* current-state tables |
+| FWA feed current-state tables | Fwa* current-state tables, including derived recreatable snapshots like `FwaClanMatchStatsCurrent` |
 | FWA compo reference bands | HeatMapRef |
 | Telemetry rollups and report schedules | Telemetry* tables |
 

--- a/prisma/migrations/20260414190000_add_fwa_clan_match_stats_current/migration.sql
+++ b/prisma/migrations/20260414190000_add_fwa_clan_match_stats_current/migration.sql
@@ -1,0 +1,17 @@
+-- CreateTable
+CREATE TABLE "FwaClanMatchStatsCurrent" (
+    "clanTag" TEXT NOT NULL,
+    "fwaWarCount" INTEGER NOT NULL,
+    "blacklistedWarCount" INTEGER NOT NULL,
+    "friendlyWarCount" INTEGER NOT NULL,
+    "unknownWarCount" INTEGER NOT NULL,
+    "successWarCount" INTEGER NOT NULL,
+    "evaluatedWarCount" INTEGER NOT NULL,
+    "matchRate" DOUBLE PRECISION NOT NULL,
+    "lastComputedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "FwaClanMatchStatsCurrent_pkey" PRIMARY KEY ("clanTag")
+);
+
+-- CreateIndex
+CREATE INDEX "FwaClanMatchStatsCurrent_lastComputedAt_idx" ON "FwaClanMatchStatsCurrent"("lastComputedAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1176,6 +1176,20 @@ model FwaClanWarLogCurrent {
   @@index([sourceSyncedAt])
 }
 
+model FwaClanMatchStatsCurrent {
+  clanTag              String   @id
+  fwaWarCount          Int
+  blacklistedWarCount  Int
+  friendlyWarCount     Int
+  unknownWarCount      Int
+  successWarCount      Int
+  evaluatedWarCount    Int
+  matchRate            Float
+  lastComputedAt       DateTime
+
+  @@index([lastComputedAt])
+}
+
 model FwaFeedSyncState {
   id                  String            @id @default(cuid())
   feedType            FwaFeedType

--- a/src/services/fwa-feeds/FwaClanMatchStatsCurrentSyncService.ts
+++ b/src/services/fwa-feeds/FwaClanMatchStatsCurrentSyncService.ts
@@ -1,0 +1,154 @@
+import { prisma } from "../../prisma";
+import { formatError } from "../../helper/formatError";
+import { normalizeFwaTag, normalizeText } from "./normalize";
+
+type SourceWarLogRow = {
+  clanTag: string;
+  opponentInfo: string | null;
+};
+
+type ClanMatchStatsRow = {
+  clanTag: string;
+  fwaWarCount: number;
+  blacklistedWarCount: number;
+  friendlyWarCount: number;
+  unknownWarCount: number;
+  successWarCount: number;
+  evaluatedWarCount: number;
+  matchRate: number;
+  lastComputedAt: Date;
+};
+
+type OpponentInfoClassification = "FWA" | "BLACKLISTED" | "FRIENDLY" | "UNKNOWN" | "IGNORED";
+
+type ClanMatchStatsAccumulator = {
+  clanTag: string;
+  fwaWarCount: number;
+  blacklistedWarCount: number;
+  friendlyWarCount: number;
+  unknownWarCount: number;
+  evaluatedWarCount: number;
+  lastComputedAt: Date;
+};
+
+function classifyOpponentInfo(input: string | null | undefined): OpponentInfoClassification {
+  const normalized = normalizeText(input)?.toLowerCase();
+  if (!normalized) return "IGNORED";
+  if (normalized === "fwa") return "FWA";
+  if (normalized === "blacklisted") return "BLACKLISTED";
+  if (normalized === "friendly") return "FRIENDLY";
+  if (normalized === "unknown") return "UNKNOWN";
+  return "IGNORED";
+}
+
+function createAccumulator(clanTag: string, now: Date): ClanMatchStatsAccumulator {
+  return {
+    clanTag,
+    fwaWarCount: 0,
+    blacklistedWarCount: 0,
+    friendlyWarCount: 0,
+    unknownWarCount: 0,
+    evaluatedWarCount: 0,
+    lastComputedAt: now,
+  };
+}
+
+function finalizeAccumulator(input: ClanMatchStatsAccumulator): ClanMatchStatsRow {
+  const successWarCount =
+    input.fwaWarCount + input.blacklistedWarCount + input.friendlyWarCount;
+  const evaluatedWarCount = input.evaluatedWarCount;
+  return {
+    clanTag: input.clanTag,
+    fwaWarCount: input.fwaWarCount,
+    blacklistedWarCount: input.blacklistedWarCount,
+    friendlyWarCount: input.friendlyWarCount,
+    unknownWarCount: input.unknownWarCount,
+    successWarCount,
+    evaluatedWarCount,
+    matchRate: evaluatedWarCount === 0 ? 0 : successWarCount / evaluatedWarCount,
+    lastComputedAt: input.lastComputedAt,
+  };
+}
+
+/** Purpose: derive one deterministic clan-match snapshot from the current clan-war log rows. */
+export function buildFwaClanMatchStatsCurrentRowsForTest(
+  rows: readonly SourceWarLogRow[],
+  now: Date = new Date(),
+): ClanMatchStatsRow[] {
+  const byClanTag = new Map<string, ClanMatchStatsAccumulator>();
+  for (const row of rows) {
+    const clanTag = normalizeFwaTag(row.clanTag);
+    if (!clanTag) continue;
+    const existing = byClanTag.get(clanTag);
+    const accumulator = existing ?? createAccumulator(clanTag, now);
+    if (!existing) {
+      byClanTag.set(clanTag, accumulator);
+    }
+    const classification = classifyOpponentInfo(row.opponentInfo);
+    if (classification === "IGNORED") continue;
+    accumulator.evaluatedWarCount += 1;
+    if (classification === "FWA") {
+      accumulator.fwaWarCount += 1;
+    } else if (classification === "BLACKLISTED") {
+      accumulator.blacklistedWarCount += 1;
+    } else if (classification === "FRIENDLY") {
+      accumulator.friendlyWarCount += 1;
+    } else if (classification === "UNKNOWN") {
+      accumulator.unknownWarCount += 1;
+    }
+  }
+
+  return [...byClanTag.values()]
+    .sort((a, b) => a.clanTag.localeCompare(b.clanTag))
+    .map((row) => finalizeAccumulator(row));
+}
+
+/** Purpose: rebuild the derived clan-match analytics snapshot from persisted clan-war log rows. */
+export class FwaClanMatchStatsCurrentSyncService {
+  /** Purpose: recompute all clan-match stats as a recreatable current-state snapshot. */
+  async rebuildCurrentStats(options?: { now?: Date }): Promise<{
+    clanCount: number;
+    sourceRowCount: number;
+    evaluatedWarCount: number;
+  }> {
+    const now = options?.now ?? new Date();
+    const startedAt = Date.now();
+    try {
+      const sourceRows = await prisma.fwaClanWarLogCurrent.findMany({
+        orderBy: [{ clanTag: "asc" }, { endTime: "asc" }, { opponentTag: "asc" }],
+        select: {
+          clanTag: true,
+          opponentInfo: true,
+        },
+      });
+      const derivedRows = buildFwaClanMatchStatsCurrentRowsForTest(sourceRows, now);
+      const evaluatedWarCount = derivedRows.reduce(
+        (sum, row) => sum + row.evaluatedWarCount,
+        0,
+      );
+
+      await prisma.$transaction(async (tx) => {
+        await tx.fwaClanMatchStatsCurrent.deleteMany({});
+        if (derivedRows.length > 0) {
+          await tx.fwaClanMatchStatsCurrent.createMany({
+            data: derivedRows,
+          });
+        }
+      });
+
+      console.info(
+        `[fwa-feed] job=clan_match_stats_current clans=${derivedRows.length} source_rows=${sourceRows.length} evaluated=${evaluatedWarCount} duration_ms=${Date.now() - startedAt}`,
+      );
+      return {
+        clanCount: derivedRows.length,
+        sourceRowCount: sourceRows.length,
+        evaluatedWarCount,
+      };
+    } catch (error) {
+      console.error(
+        `[fwa-feed] job=clan_match_stats_current failed error=${formatError(error)}`,
+      );
+      throw error;
+    }
+  }
+}

--- a/src/services/fwa-feeds/FwaClanWarsSyncService.ts
+++ b/src/services/fwa-feeds/FwaClanWarsSyncService.ts
@@ -3,6 +3,7 @@ import { prisma } from "../../prisma";
 import { computeFeedContentHash } from "./hash";
 import { normalizeFwaTag } from "./normalize";
 import { FwaStatsClient } from "./FwaStatsClient";
+import { FwaClanMatchStatsCurrentSyncService } from "./FwaClanMatchStatsCurrentSyncService";
 import { FwaFeedCursorService } from "./FwaFeedCursorService";
 import { FwaFeedSyncStateService } from "./FwaFeedSyncStateService";
 import { mapWithConcurrency } from "./concurrency";
@@ -23,6 +24,7 @@ function buildWarRowKey(input: { endTime: Date; opponentTag: string; teamSize: n
 export class FwaClanWarsSyncService {
   private static readonly FEED_TYPE: FwaFeedType = "CLAN_WARS";
   private readonly syncState = new FwaFeedSyncStateService();
+  private readonly matchStatsSync = new FwaClanMatchStatsCurrentSyncService();
   private readonly cursor = new FwaFeedCursorService();
 
   /** Purpose: initialize clan-wars sync dependencies. */
@@ -258,6 +260,14 @@ export class FwaClanWarsSyncService {
       lastScopeKey: nextCursor,
       lastRunAt: now,
     });
+
+    if (summary.changedRowCount > 0) {
+      try {
+        await this.matchStatsSync.rebuildCurrentStats({ now });
+      } catch {
+        // The source war-log sync succeeded; keep the derived snapshot rebuild best-effort.
+      }
+    }
 
     return {
       ...summary,

--- a/src/services/fwa-feeds/FwaClanWarsWatchService.ts
+++ b/src/services/fwa-feeds/FwaClanWarsWatchService.ts
@@ -7,6 +7,7 @@ import {
 import { normalizeFwaTag } from "./normalize";
 import { FwaClanWarsSyncService } from "./FwaClanWarsSyncService";
 import { FwaWarMembersSyncService } from "./FwaWarMembersSyncService";
+import { FwaClanMatchStatsCurrentSyncService } from "./FwaClanMatchStatsCurrentSyncService";
 import { FwaTrackedClanWarRosterSyncService } from "./FwaTrackedClanWarRosterSyncService";
 import { mapWithConcurrency } from "./concurrency";
 
@@ -42,6 +43,7 @@ export class FwaClanWarsWatchService {
     private readonly clanWarsSync = new FwaClanWarsSyncService(),
     private readonly warMembersSync = new FwaWarMembersSyncService(),
     private readonly trackedRosterSync = new FwaTrackedClanWarRosterSyncService(),
+    private readonly matchStatsSync = new FwaClanMatchStatsCurrentSyncService(),
   ) {}
 
   /** Purpose: execute one watch tick, activating/deactivating per-clan windows and polling active clans. */
@@ -187,6 +189,14 @@ export class FwaClanWarsWatchService {
         updateAcquired,
       };
     });
+
+    if (pollOutcomes.some((row) => row.updateAcquired)) {
+      try {
+        await this.matchStatsSync.rebuildCurrentStats({ now });
+      } catch {
+        // Keep tracked-wars watch best-effort; the source war-log update already completed.
+      }
+    }
 
     return {
       trackedClanCount: trackedTags.length,

--- a/src/services/fwa-feeds/FwaFeedOpsService.ts
+++ b/src/services/fwa-feeds/FwaFeedOpsService.ts
@@ -5,6 +5,7 @@ import { FwaClanMembersSyncService } from "./FwaClanMembersSyncService";
 import { FwaWarMembersSyncService } from "./FwaWarMembersSyncService";
 import { FwaClanWarsSyncService } from "./FwaClanWarsSyncService";
 import { FwaClanWarsWatchService } from "./FwaClanWarsWatchService";
+import { FwaClanMatchStatsCurrentSyncService } from "./FwaClanMatchStatsCurrentSyncService";
 import { FwaFeedSchedulerService } from "./FwaFeedSchedulerService";
 import { FwaTrackedClanWarRosterSyncService } from "./FwaTrackedClanWarRosterSyncService";
 
@@ -14,6 +15,7 @@ export class FwaFeedOpsService {
   private readonly clanMembersSync = new FwaClanMembersSyncService();
   private readonly warMembersSync = new FwaWarMembersSyncService();
   private readonly clanWarsSync = new FwaClanWarsSyncService();
+  private readonly matchStatsSync = new FwaClanMatchStatsCurrentSyncService();
   private readonly trackedRosterSync = new FwaTrackedClanWarRosterSyncService();
   private readonly watchService = new FwaClanWarsWatchService(
     this.clanWarsSync,
@@ -60,7 +62,15 @@ export class FwaFeedOpsService {
         rosterResult,
       };
     }
-    return this.clanWarsSync.syncClan(normalized, { force: true });
+    const result = await this.clanWarsSync.syncClan(normalized, { force: true });
+    if (result.changedRowCount > 0) {
+      try {
+        await this.matchStatsSync.rebuildCurrentStats();
+      } catch {
+        // Best-effort derived rebuild; the raw clan-war-log sync already completed.
+      }
+    }
+    return result;
   }
 
   /** Purpose: run one global one-off sync tick for configured feed families. */

--- a/tests/fwaClanMatchStatsCurrent.service.test.ts
+++ b/tests/fwaClanMatchStatsCurrent.service.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  buildFwaClanMatchStatsCurrentRowsForTest,
+  FwaClanMatchStatsCurrentSyncService,
+} from "../src/services/fwa-feeds/FwaClanMatchStatsCurrentSyncService";
+
+const txMock = vi.hoisted(() => ({
+  fwaClanMatchStatsCurrent: {
+    deleteMany: vi.fn(),
+    createMany: vi.fn(),
+  },
+}));
+
+const prismaMock = vi.hoisted(() => ({
+  fwaClanWarLogCurrent: {
+    findMany: vi.fn(),
+  },
+  $transaction: vi.fn(async (callback: (tx: typeof txMock) => Promise<unknown>) =>
+    callback(txMock),
+  ),
+}));
+
+vi.mock("../src/prisma", () => ({
+  prisma: prismaMock,
+}));
+
+describe("buildFwaClanMatchStatsCurrentRowsForTest", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("aggregates mixed classifications and ignores unexpected rows", () => {
+    const now = new Date("2026-04-14T18:00:00.000Z");
+    const rows = [
+      { clanTag: "#AAA111", opponentInfo: "FWA" },
+      { clanTag: "#AAA111", opponentInfo: "Blacklisted" },
+      { clanTag: "#AAA111", opponentInfo: "Friendly" },
+      { clanTag: "#AAA111", opponentInfo: "Unknown" },
+      { clanTag: "#AAA111", opponentInfo: null },
+      { clanTag: "#AAA111", opponentInfo: "" },
+      { clanTag: "#AAA111", opponentInfo: "unexpected" },
+      { clanTag: "#BBB222", opponentInfo: "Unknown" },
+      { clanTag: "#BBB222", opponentInfo: "ignored" },
+    ];
+
+    const out = buildFwaClanMatchStatsCurrentRowsForTest(rows, now);
+
+    expect(out).toEqual([
+      {
+        clanTag: "#AAA111",
+        fwaWarCount: 1,
+        blacklistedWarCount: 1,
+        friendlyWarCount: 1,
+        unknownWarCount: 1,
+        successWarCount: 3,
+        evaluatedWarCount: 4,
+        matchRate: 0.75,
+        lastComputedAt: now,
+      },
+      {
+        clanTag: "#BBB222",
+        fwaWarCount: 0,
+        blacklistedWarCount: 0,
+        friendlyWarCount: 0,
+        unknownWarCount: 1,
+        successWarCount: 0,
+        evaluatedWarCount: 1,
+        matchRate: 0,
+        lastComputedAt: now,
+      },
+    ]);
+  });
+
+  it("returns deterministic zero matchRate when a clan has no evaluated rows", () => {
+    const now = new Date("2026-04-14T18:00:00.000Z");
+    const rows = [
+      { clanTag: "#AAA111", opponentInfo: null },
+      { clanTag: "#AAA111", opponentInfo: "" },
+      { clanTag: "#AAA111", opponentInfo: "unexpected" },
+    ];
+
+    const out = buildFwaClanMatchStatsCurrentRowsForTest(rows, now);
+
+    expect(out).toEqual([
+      {
+        clanTag: "#AAA111",
+        fwaWarCount: 0,
+        blacklistedWarCount: 0,
+        friendlyWarCount: 0,
+        unknownWarCount: 0,
+        successWarCount: 0,
+        evaluatedWarCount: 0,
+        matchRate: 0,
+        lastComputedAt: now,
+      },
+    ]);
+  });
+});
+
+describe("FwaClanMatchStatsCurrentSyncService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rebuilds the snapshot from all persisted clan-war log rows", async () => {
+    const now = new Date("2026-04-14T18:00:00.000Z");
+    prismaMock.fwaClanWarLogCurrent.findMany.mockResolvedValue([
+      { clanTag: "#AAA111", opponentInfo: "FWA" },
+      { clanTag: "#AAA111", opponentInfo: "Unknown" },
+      { clanTag: "#BBB222", opponentInfo: "Blacklisted" },
+      { clanTag: "#BBB222", opponentInfo: "Friendly" },
+    ]);
+    txMock.fwaClanMatchStatsCurrent.deleteMany.mockResolvedValue({ count: 2 });
+    txMock.fwaClanMatchStatsCurrent.createMany.mockResolvedValue({ count: 2 });
+
+    const service = new FwaClanMatchStatsCurrentSyncService();
+    const result = await service.rebuildCurrentStats({ now });
+
+    expect(txMock.fwaClanMatchStatsCurrent.deleteMany).toHaveBeenCalledWith({});
+    expect(txMock.fwaClanMatchStatsCurrent.createMany).toHaveBeenCalledWith({
+      data: [
+        {
+          clanTag: "#AAA111",
+          fwaWarCount: 1,
+          blacklistedWarCount: 0,
+          friendlyWarCount: 0,
+          unknownWarCount: 1,
+          successWarCount: 1,
+          evaluatedWarCount: 2,
+          matchRate: 0.5,
+          lastComputedAt: now,
+        },
+        {
+          clanTag: "#BBB222",
+          fwaWarCount: 0,
+          blacklistedWarCount: 1,
+          friendlyWarCount: 1,
+          unknownWarCount: 0,
+          successWarCount: 2,
+          evaluatedWarCount: 2,
+          matchRate: 1,
+          lastComputedAt: now,
+        },
+      ],
+    });
+    expect(result).toEqual({
+      clanCount: 2,
+      sourceRowCount: 4,
+      evaluatedWarCount: 4,
+    });
+  });
+});

--- a/tests/fwaFeed.clanWarsSync.test.ts
+++ b/tests/fwaFeed.clanWarsSync.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FwaClanMatchStatsCurrentSyncService } from "../src/services/fwa-feeds/FwaClanMatchStatsCurrentSyncService";
+import { FwaClanWarsSyncService } from "../src/services/fwa-feeds/FwaClanWarsSyncService";
+
+const txMock = vi.hoisted(() => ({
+  fwaClanWarLogCurrent: {
+    findMany: vi.fn(),
+    deleteMany: vi.fn(),
+    upsert: vi.fn(),
+  },
+}));
+
+const prismaMock = vi.hoisted(() => ({
+  fwaClanCatalog: {
+    findMany: vi.fn(),
+  },
+  fwaFeedCursor: {
+    findUnique: vi.fn(),
+    upsert: vi.fn(),
+  },
+  fwaFeedSyncState: {
+    findUnique: vi.fn(),
+    upsert: vi.fn(),
+  },
+  $transaction: vi.fn(async (callback: (tx: typeof txMock) => Promise<unknown>) =>
+    callback(txMock),
+  ),
+}));
+
+vi.mock("../src/prisma", () => ({
+  prisma: prismaMock,
+}));
+
+describe("FwaClanWarsSyncService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("triggers the derived clan-match rebuild after a global clan-wars sweep changes source rows", async () => {
+    const now = new Date("2026-04-14T18:00:00.000Z");
+    const client = {
+      fetchClanWars: vi.fn().mockResolvedValue([
+        {
+          clanTag: "#AAA111",
+          endTime: new Date("2026-04-14T17:00:00.000Z"),
+          searchTime: null,
+          result: "WIN",
+          teamSize: 50,
+          clanName: "Clan A",
+          clanLevel: 30,
+          clanStars: 95,
+          clanDestructionPercentage: 98.5,
+          clanAttacks: 100,
+          clanExpEarned: 300,
+          opponentTag: "#BBB222",
+          opponentName: "Enemy",
+          opponentLevel: 25,
+          opponentStars: 80,
+          opponentDestructionPercentage: 88.1,
+          opponentInfo: "FWA",
+          synced: true,
+          matched: true,
+        },
+      ]),
+    } as any;
+    prismaMock.fwaClanCatalog.findMany.mockResolvedValue([{ clanTag: "#AAA111" }]);
+    prismaMock.fwaFeedCursor.findUnique.mockResolvedValue({ lastScopeKey: null });
+    prismaMock.fwaFeedSyncState.findUnique.mockResolvedValue(null);
+    txMock.fwaClanWarLogCurrent.findMany.mockResolvedValue([]);
+    txMock.fwaClanWarLogCurrent.deleteMany.mockResolvedValue({ count: 0 });
+    txMock.fwaClanWarLogCurrent.upsert.mockResolvedValue({});
+    prismaMock.fwaFeedCursor.upsert.mockResolvedValue({});
+
+    const rebuildSpy = vi
+      .spyOn(FwaClanMatchStatsCurrentSyncService.prototype, "rebuildCurrentStats")
+      .mockResolvedValue({ clanCount: 1, sourceRowCount: 1, evaluatedWarCount: 1 } as any);
+
+    const service = new FwaClanWarsSyncService(client);
+    const result = await service.runDistributedSweep({
+      chunkSize: 1,
+      concurrency: 1,
+      force: true,
+      now,
+    });
+
+    expect(result.changedRowCount).toBe(1);
+    expect(rebuildSpy).toHaveBeenCalledTimes(1);
+    expect(rebuildSpy).toHaveBeenCalledWith({ now });
+  });
+});

--- a/tests/fwaFeed.watchService.test.ts
+++ b/tests/fwaFeed.watchService.test.ts
@@ -22,6 +22,7 @@ vi.mock("../src/prisma", () => ({
 }));
 
 import { FwaClanWarsWatchService } from "../src/services/fwa-feeds/FwaClanWarsWatchService";
+import { FwaClanMatchStatsCurrentSyncService } from "../src/services/fwa-feeds/FwaClanMatchStatsCurrentSyncService";
 
 function buildSyncMetadata(params: {
   syncEpochSeconds: number;
@@ -174,6 +175,9 @@ describe("FwaClanWarsWatchService", () => {
         totalEffectiveWeight: 7600000,
       }),
     } as any;
+    const rebuildSpy = vi
+      .spyOn(FwaClanMatchStatsCurrentSyncService.prototype, "rebuildCurrentStats")
+      .mockResolvedValue({ clanCount: 1, sourceRowCount: 1, evaluatedWarCount: 1 } as any);
     const service = new FwaClanWarsWatchService(clanWarsSync, warMembersSync, trackedRosterSync);
 
     const result = await service.runWatchTick({ now, concurrency: 1 });
@@ -181,6 +185,8 @@ describe("FwaClanWarsWatchService", () => {
     expect(result.updateAcquiredCount).toBe(1);
     expect(warMembersSync.syncClan).toHaveBeenCalledWith("#AAA111", expect.any(Object));
     expect(trackedRosterSync.syncClan).toHaveBeenCalledWith("#AAA111", { now });
+    expect(rebuildSpy).toHaveBeenCalledTimes(1);
+    expect(rebuildSpy).toHaveBeenCalledWith({ now });
     expect(prismaMock.fwaClanWarsWatchState.update).toHaveBeenCalledWith(
       expect.objectContaining({
         where: { clanTag: "#AAA111" },

--- a/tests/fwaFeedOps.service.test.ts
+++ b/tests/fwaFeedOps.service.test.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { FwaClanMatchStatsCurrentSyncService } from "../src/services/fwa-feeds/FwaClanMatchStatsCurrentSyncService";
+import { FwaClanWarsSyncService } from "../src/services/fwa-feeds/FwaClanWarsSyncService";
+import { FwaFeedOpsService } from "../src/services/fwa-feeds/FwaFeedOpsService";
+
+describe("FwaFeedOpsService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rebuilds clan-match stats after a direct clan-wars sync changes source rows", async () => {
+    const syncSpy = vi
+      .spyOn(FwaClanWarsSyncService.prototype, "syncClan")
+      .mockResolvedValue({
+        rowCount: 2,
+        changedRowCount: 2,
+        contentHash: "abc123",
+        status: "SUCCESS",
+      });
+    const rebuildSpy = vi
+      .spyOn(FwaClanMatchStatsCurrentSyncService.prototype, "rebuildCurrentStats")
+      .mockResolvedValue({ clanCount: 1, sourceRowCount: 2, evaluatedWarCount: 2 } as any);
+
+    const ops = new FwaFeedOpsService();
+    const result = await ops.runTracked("clan-wars", "#aaa111");
+
+    expect(syncSpy).toHaveBeenCalledWith("#AAA111", { force: true });
+    expect(rebuildSpy).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      rowCount: 2,
+      changedRowCount: 2,
+      contentHash: "abc123",
+      status: "SUCCESS",
+    });
+  });
+});


### PR DESCRIPTION
- derive per-clan matchup counts from FwaClanWarLogCurrent
- rebuild the snapshot from tracked watch and global clan-wars sync paths
- document the new recreatable feed-owned analytics table