### PR TITLE
fix(compo): support heatmapref glyphs in PNG output

### DIFF
--- a/src/commands/Compo.ts
+++ b/src/commands/Compo.ts
@@ -1220,12 +1220,14 @@ const GLYPHS: Record<string, string[]> = {
   " ": ["00000", "00000", "00000", "00000", "00000", "00000", "00000"],
   "'": ["00100", "00100", "00100", "00000", "00000", "00000", "00000"],
   '"': ["01010", "01010", "01010", "00000", "00000", "00000", "00000"],
+  "+": ["00000", "00100", "00100", "11111", "00100", "00100", "00000"],
   "-": ["00000", "00000", "00000", "01110", "00000", "00000", "00000"],
   ",": ["00000", "00000", "00000", "00000", "00110", "00110", "00100"],
   ".": ["00000", "00000", "00000", "00000", "00000", "00110", "00110"],
   ":": ["00000", "00110", "00110", "00000", "00110", "00110", "00000"],
   "<": ["00010", "00100", "01000", "10000", "01000", "00100", "00010"],
   "=": ["00000", "11111", "00000", "11111", "00000", "00000", "00000"],
+  "%": ["11001", "11010", "00100", "01000", "10011", "10011", "00000"],
   "/": ["00001", "00010", "00100", "01000", "10000", "00000", "00000"],
   "(": ["00010", "00100", "01000", "01000", "01000", "00100", "00010"],
   ")": ["01000", "00100", "00010", "00010", "00010", "00100", "01000"],
@@ -2362,6 +2364,7 @@ export const buildCompoHeatMapRefRowsForTest = buildCompoHeatMapRefRows;
 export const buildCompoHeatMapRefCopyTextForTest = buildCompoHeatMapRefCopyText;
 export const buildCompoHeatMapRefCopyCustomIdForTest = buildCompoHeatMapRefCopyCustomId;
 export const isCompoHeatMapRefCopyButtonCustomIdForTest = isCompoHeatMapRefCopyButtonCustomId;
+export const toGlyphSafeTextForTest = toGlyphSafeText;
 export const getModeRowsForTest = getModeRows;
 export const getAbsoluteSheetRowNumberForTest = getAbsoluteSheetRowNumber;
 export const mapCompoSheetErrorToMessageForTest = mapCompoSheetErrorToMessage;

--- a/tests/compoHeatMapRef.command.test.ts
+++ b/tests/compoHeatMapRef.command.test.ts
@@ -4,6 +4,7 @@ import {
   Compo,
   buildCompoHeatMapRefCopyCustomIdForTest,
   buildCompoHeatMapRefRowsForTest,
+  toGlyphSafeTextForTest,
 } from "../src/commands/Compo";
 import { GoogleSheetsService } from "../src/services/GoogleSheetsService";
 import { HeatMapRefDisplayService } from "../src/services/HeatMapRefDisplayService";
@@ -159,5 +160,12 @@ describe("/compo heatmapref command", () => {
       "83.42%",
       "11",
     ]);
+  });
+
+  it("keeps glyph-safe renderer text literal for plus and percent characters", () => {
+    expect(toGlyphSafeTextForTest("TH11+")).toBe("TH11+");
+    expect(toGlyphSafeTextForTest("Match%")).toBe("MATCH%");
+    expect(toGlyphSafeTextForTest("0%")).toBe("0%");
+    expect(toGlyphSafeTextForTest("83.42%")).toBe("83.42%");
   });
 });


### PR DESCRIPTION
- add + and % to the custom bitmap glyph map
- keep heatmapref rendering read-only and cover the copy/export text path in tests