### PR TITLE
fix(accounts): prefer raw discord ids in autocomplete labels

### DIFF
--- a/src/commands/Accounts.ts
+++ b/src/commands/Accounts.ts
@@ -71,17 +71,15 @@ function normalizeDiscordIdAutocompleteQuery(input: string): string {
     .replace(/^@+/, "");
 }
 
-function resolveDiscordIdAutocompleteLabel(
-  interaction: AutocompleteInteraction,
+export function resolveDiscordIdAutocompleteLabel(
   discordUserId: string,
   persistedUsername: string | null,
 ): string {
-  const cachedUsername = String(
-    interaction.client.users.cache.get(discordUserId)?.username ?? "",
-  ).trim();
-  const resolvedUsername =
-    sanitizeDisplayText(cachedUsername) ?? sanitizeDisplayText(persistedUsername);
-  return resolvedUsername ? `@${resolvedUsername}` : discordUserId;
+  const rawDiscordId = sanitizeDisplayText(discordUserId);
+  if (rawDiscordId) return rawDiscordId;
+
+  const resolvedUsername = sanitizeDisplayText(persistedUsername);
+  return resolvedUsername ? `@${resolvedUsername}` : "";
 }
 
 function buildAccountsTagAutocompleteChoices(
@@ -164,7 +162,6 @@ function buildAccountsTagAutocompleteChoices(
 function buildAccountsDiscordIdAutocompleteChoices(
   rows: DiscordIdAutocompleteRow[],
   query: string,
-  interaction: AutocompleteInteraction,
 ): AccountAutocompleteChoice[] {
   const normalizedQuery = normalizeDiscordIdAutocompleteQuery(query);
   const deduped = new Map<
@@ -230,11 +227,7 @@ function buildAccountsDiscordIdAutocompleteChoices(
     .slice(0, 25);
 
   return ranked.map((row) => ({
-    name: resolveDiscordIdAutocompleteLabel(
-      interaction,
-      row.discordUserId,
-      row.discordUsername,
-    ).slice(0, 100),
+    name: resolveDiscordIdAutocompleteLabel(row.discordUserId, row.discordUsername).slice(0, 100),
     value: row.discordUserId,
   }));
 }
@@ -554,7 +547,6 @@ export const Accounts: Command = {
     const choices = buildAccountsDiscordIdAutocompleteChoices(
       rows as DiscordIdAutocompleteRow[],
       query,
-      interaction,
     );
 
     await interaction.respond(choices);

--- a/tests/accounts.command.test.ts
+++ b/tests/accounts.command.test.ts
@@ -18,7 +18,7 @@ vi.mock("../src/prisma", () => ({
   prisma: prismaMock,
 }));
 
-import { Accounts } from "../src/commands/Accounts";
+import { Accounts, resolveDiscordIdAutocompleteLabel } from "../src/commands/Accounts";
 
 function makeInteraction(input?: {
   visibility?: string | null;
@@ -47,20 +47,8 @@ function makeInteraction(input?: {
 function makeAutocompleteInteraction(
   value: string,
   focusedName = "tag",
-  cachedUsernames: Record<string, string> = {},
 ) {
-  const cache = new Map(
-    Object.entries(cachedUsernames).map(([id, username]) => [
-      id,
-      { username },
-    ]),
-  );
   return {
-    client: {
-      users: {
-        cache,
-      },
-    },
     options: {
       getFocused: vi.fn(() => ({ name: focusedName, value })),
     },
@@ -242,7 +230,7 @@ describe("/accounts command", () => {
     expect((interaction.respond as any).mock.calls[0][0]).toHaveLength(25);
   });
 
-  it("autocompletes discord IDs with @username labels and raw values", async () => {
+  it("autocompletes discord IDs with raw labels and raw values", async () => {
     prismaMock.playerLink.findMany.mockResolvedValue([
       {
         discordUserId: "111111111111111111",
@@ -253,13 +241,7 @@ describe("/accounts command", () => {
         discordUsername: null,
       },
     ]);
-    const interaction = makeAutocompleteInteraction(
-      "",
-      "discord-id",
-      {
-        "111111111111111111": "AlphaUser",
-      },
-    );
+    const interaction = makeAutocompleteInteraction("", "discord-id");
 
     await Accounts.autocomplete(interaction as any);
 
@@ -270,32 +252,17 @@ describe("/accounts command", () => {
       },
     });
     expect(interaction.respond).toHaveBeenCalledWith([
-      { name: "@AlphaUser", value: "111111111111111111" },
+      { name: "111111111111111111", value: "111111111111111111" },
       { name: "222222222222222222", value: "222222222222222222" },
     ]);
   });
 
-  it("matches discord-id autocomplete by username and falls back to raw ID when unavailable", async () => {
-    prismaMock.playerLink.findMany.mockResolvedValue([
-      {
-        discordUserId: "333333333333333333",
-        discordUsername: "BravoUser",
-      },
-      {
-        discordUserId: "444444444444444444",
-        discordUsername: null,
-      },
-    ]);
-    const interaction = makeAutocompleteInteraction(
-      "brav",
-      "discord-id",
+  it("falls back to @username only when the snowflake label cannot be rendered", () => {
+    expect(resolveDiscordIdAutocompleteLabel("111111111111111111", "AlphaUser")).toBe(
+      "111111111111111111",
     );
-
-    await Accounts.autocomplete(interaction as any);
-
-    expect(interaction.respond).toHaveBeenCalledWith([
-      { name: "@BravoUser", value: "333333333333333333" },
-    ]);
+    expect(resolveDiscordIdAutocompleteLabel("", "AlphaUser")).toBe("@AlphaUser");
+    expect(resolveDiscordIdAutocompleteLabel("", null)).toBe("");
   });
 
   it("uses PlayerActivity clan name in output when local clan context is complete", async () => {


### PR DESCRIPTION
- render `discord-id` suggestions with the raw snowflake by default
- fall back to `@username` only when the raw label cannot be rendered