### PR TITLE
fix(accounts): group linked clans by live clan data

### DIFF
--- a/src/commands/Accounts.ts
+++ b/src/commands/Accounts.ts
@@ -18,11 +18,15 @@ type AccountRow = {
   name: string;
   clanTag: string | null;
   clanName: string | null;
+  clanAlias: string | null;
+  clanRole: "leader" | "coleader" | null;
 };
 
 type ClanGroup = {
   key: string;
-  title: string;
+  clanTag: string | null;
+  clanName: string | null;
+  clanAlias: string | null;
   entries: AccountRow[];
 };
 
@@ -57,6 +61,13 @@ function sanitizeDisplayText(input: unknown): string | null {
   return normalized.length > 0 ? normalized : null;
 }
 
+function normalizeClanMemberRole(input: unknown): "leader" | "coleader" | null {
+  const normalized = String(input ?? "").trim().toLowerCase();
+  if (normalized === "leader") return "leader";
+  if (normalized === "coleader") return "coleader";
+  return null;
+}
+
 function normalizeAutocompleteQuery(input: string): string {
   return String(input ?? "")
     .trim()
@@ -69,6 +80,32 @@ function normalizeDiscordIdAutocompleteQuery(input: string): string {
     .trim()
     .toLowerCase()
     .replace(/^@+/, "");
+}
+
+function buildClanProfileMarkdownLink(
+  clanName: string | null,
+  clanTag: string | null,
+): string {
+  const normalizedClanTag = normalizeTag(clanTag ?? "");
+  const label = sanitizeDisplayText(clanName) || normalizedClanTag || "Unknown Clan";
+  if (!normalizedClanTag) return label;
+  const encodedTag = normalizedClanTag.replace(/^#/, "");
+  return `[${label}](https://link.clashofclans.com/en?action=OpenClanProfile&tag=${encodedTag})`;
+}
+
+function buildClanHeadingLabel(group: Pick<ClanGroup, "clanAlias" | "clanName" | "clanTag">): string {
+  const fallbackTag = normalizeTag(group.clanTag ?? "") || "Unknown Clan";
+  return (
+    sanitizeDisplayText(group.clanAlias) ??
+    sanitizeDisplayText(group.clanName) ??
+    fallbackTag
+  );
+}
+
+function buildClanHeadingMarkdown(group: Pick<ClanGroup, "clanAlias" | "clanName" | "clanTag">): string {
+  const label = buildClanHeadingLabel(group);
+  const clanTag = normalizeTag(group.clanTag ?? "");
+  return clanTag ? buildClanProfileMarkdownLink(label, clanTag) : label;
 }
 
 export function resolveDiscordIdAutocompleteLabel(
@@ -239,18 +276,26 @@ function buildAccountsDiscordIdAutocompleteChoices(
 }
 
 function buildGroups(rows: AccountRow[]): ClanGroup[] {
-  const grouped = new Map<string, { title: string; entries: AccountRow[] }>();
+  const grouped = new Map<string, ClanGroup>();
 
   for (const row of rows) {
-    const clanName = row.clanName?.trim() || null;
+    const clanName = sanitizeDisplayText(row.clanName);
     const clanTag = row.clanTag ? normalizeTag(row.clanTag) : null;
+    const clanAlias = sanitizeDisplayText(row.clanAlias);
     const key = clanTag ?? "__NO_CLAN__";
-    const title = clanTag ? `${clanName ?? "Unknown Clan"} (${clanTag})` : "No Clan";
 
     const bucket = grouped.get(key);
     if (!bucket) {
-      grouped.set(key, { title, entries: [row] });
+      grouped.set(key, {
+        key,
+        clanTag,
+        clanName,
+        clanAlias,
+        entries: [row],
+      });
     } else {
+      if (clanAlias && !bucket.clanAlias) bucket.clanAlias = clanAlias;
+      if (clanName && !bucket.clanName) bucket.clanName = clanName;
       bucket.entries.push(row);
     }
   }
@@ -259,9 +304,11 @@ function buildGroups(rows: AccountRow[]): ClanGroup[] {
     .sort((a, b) => {
       if (a[0] === "__NO_CLAN__") return 1;
       if (b[0] === "__NO_CLAN__") return -1;
-      return a[1].title.localeCompare(b[1].title);
+      return buildClanHeadingLabel(a[1]).localeCompare(buildClanHeadingLabel(b[1]), undefined, {
+        sensitivity: "base",
+      });
     })
-    .map(([key, value]) => ({ key, ...value }));
+    .map(([, value]) => value);
 
   for (const group of groups) {
     group.entries.sort((a, b) => a.name.localeCompare(b.name));
@@ -277,9 +324,10 @@ function buildPages(groups: ClanGroup[]): string[] {
 
   for (const group of groups) {
     const groupLines: string[] = [];
-    groupLines.push(`**${group.title}**`);
+    groupLines.push(`**${group.clanTag ? buildClanHeadingMarkdown(group) : "No Clan"}**`);
     for (const entry of group.entries) {
-      groupLines.push(`- ${entry.name} \`${entry.tag}\``);
+      const marker = entry.clanRole === "coleader" ? ":crown:" : "-";
+      groupLines.push(`${marker} ${entry.name} \`${entry.tag}\``);
     }
 
     const groupAccountCount = group.entries.length;
@@ -365,7 +413,7 @@ export const Accounts: Command = {
   run: async (
     _client: Client,
     interaction: ChatInputCommandInteraction,
-    _cocService: unknown
+    cocService: unknown
   ) => {
     if (!interaction.guildId) {
       await interaction.reply({ ephemeral: true, content: "This command can only be used in a server." });
@@ -444,38 +492,65 @@ export const Accounts: Command = {
     const activityByTag = new Map(
       activity.map((a) => [normalizeTag(a.tag), a])
     );
-    const candidateClanTags = [...new Set(
-      activity
+    const coc = cocService as { getPlayerRaw?: (tag: string) => Promise<any> } | null;
+    const livePlayerByTag = new Map<string, any | null>();
+    const getPlayerRaw = coc?.getPlayerRaw ?? null;
+    if (getPlayerRaw) {
+      const liveRows = await Promise.all(
+        uniqueTags.map(async (tag) => [tag, await getPlayerRaw(tag).catch(() => null)] as const),
+      );
+      for (const [tag, player] of liveRows) {
+        livePlayerByTag.set(tag, player);
+      }
+    }
+    const candidateClanTags = [...new Set([
+      ...activity
         .map((row) => (row.clanTag ? normalizeTag(row.clanTag) : ""))
-        .filter(Boolean)
-    )];
+        .filter(Boolean),
+      ...[...livePlayerByTag.values()]
+        .map((player) => (player?.clan?.tag ? normalizeTag(player.clan.tag) : ""))
+        .filter(Boolean),
+    ])];
     const trackedClanRows =
       candidateClanTags.length > 0
         ? await prisma.trackedClan.findMany({
             where: { tag: { in: candidateClanTags } },
-            select: { tag: true, name: true },
+            select: { tag: true, name: true, shortName: true },
           })
         : [];
     const trackedClanNameByTag = new Map(
-      trackedClanRows
-        .map((row) => [normalizeTag(row.tag), sanitizeDisplayText(row.name)] as const)
-        .filter((entry): entry is [string, string] => Boolean(entry[0] && entry[1]))
+      trackedClanRows.map((row) => [
+        normalizeTag(row.tag),
+        {
+          name: sanitizeDisplayText(row.name),
+          alias: sanitizeDisplayText(row.shortName),
+        },
+      ] as const)
     );
     const rows: AccountRow[] = uniqueTags.map((tag) => {
       const linkedName = linkedNameByTag.get(tag) ?? null;
       const fallback = activityByTag.get(tag);
+      const livePlayer = livePlayerByTag.get(tag) ?? null;
+      const liveClanTag = livePlayer?.clan?.tag ? normalizeTag(livePlayer.clan.tag) : null;
       const fallbackClanTag = fallback?.clanTag ? normalizeTag(fallback.clanTag) : null;
-      const clanTag = fallbackClanTag ?? "";
+      const clanTag = liveClanTag ?? fallbackClanTag ?? null;
       const activityName = sanitizeDisplayText(fallback?.name);
+      const liveName = sanitizeDisplayText(livePlayer?.name);
+      const liveClanName = sanitizeDisplayText(livePlayer?.clan?.name);
+      const trackedClan = clanTag ? trackedClanNameByTag.get(clanTag) ?? null : null;
       const clanName =
+        liveClanName ??
         sanitizeDisplayText(fallback?.clanName) ??
-        (clanTag ? trackedClanNameByTag.get(clanTag) ?? null : null);
+        trackedClan?.name ??
+        null;
 
       return {
         tag,
-        name: linkedName ?? activityName ?? tag,
-        clanTag: clanTag || null,
+        name: linkedName ?? activityName ?? liveName ?? tag,
+        clanTag,
         clanName,
+        clanAlias: trackedClan?.alias ?? null,
+        clanRole: normalizeClanMemberRole(livePlayer?.role),
       };
     });
 

--- a/tests/accounts.command.test.ts
+++ b/tests/accounts.command.test.ts
@@ -91,6 +91,12 @@ function makeAutocompleteInteraction(
   };
 }
 
+function makeCocService(playersByTag: Record<string, any> = {}) {
+  return {
+    getPlayerRaw: vi.fn(async (tag: string) => playersByTag[tag] ?? null),
+  };
+}
+
 function getEmbedDescription(interaction: any): string {
   const payload = interaction.editReply.mock.calls.find(
     (call: unknown[]) => call[0] && typeof call[0] === "object" && Array.isArray(call[0].embeds)
@@ -109,7 +115,7 @@ describe("/accounts command", () => {
     prismaMock.trackedClan.findMany.mockResolvedValue([]);
   });
 
-  it("uses PlayerLink.playerName first when present and keeps render DB-only", async () => {
+  it("renders tracked clan headings as alias hyperlinks and keeps rows under that clan", async () => {
     prismaMock.playerLink.findMany.mockResolvedValue([
       {
         playerTag: "#PYLQ0289",
@@ -120,16 +126,25 @@ describe("/accounts command", () => {
     prismaMock.playerActivity.findMany.mockResolvedValue([
       { tag: "#PYLQ0289", name: "Activity Alpha", clanTag: "#PQL0289", clanName: "Stored Clan" },
     ]);
-    const cocService = {
-      getPlayerRaw: vi.fn(),
-    };
+    prismaMock.trackedClan.findMany.mockResolvedValue([
+      { tag: "#PQL0289", name: "Stored Clan", shortName: "SC" },
+    ]);
+    const cocService = makeCocService({
+      "#PYLQ0289": {
+        name: "Live Alpha",
+        clan: { tag: "#PQL0289", name: "Stored Clan" },
+        role: "member",
+      },
+    });
     const interaction = makeInteraction();
 
     await Accounts.run({} as any, interaction as any, cocService as any);
 
-    expect(cocService.getPlayerRaw).not.toHaveBeenCalled();
-    expect(getEmbedDescription(interaction)).toContain("- Linked Alpha `#PYLQ0289`");
-    expect(prismaMock.playerLink.updateMany).not.toHaveBeenCalled();
+    const description = getEmbedDescription(interaction);
+    expect(description).toContain(
+      "**[SC](https://link.clashofclans.com/en?action=OpenClanProfile&tag=PQL0289)**",
+    );
+    expect(description).toContain("- Linked Alpha `#PYLQ0289`");
   });
 
   it("falls back to playerActivity.name when playerName is missing", async () => {
@@ -148,19 +163,18 @@ describe("/accounts command", () => {
         clanName: "Clan One",
       },
     ]);
-    const cocService = {
-      getPlayerRaw: vi.fn().mockResolvedValue({
+    const cocService = makeCocService({
+      "#QGRJ2222": {
         name: "Live Bravo",
         clan: { tag: "#PQL0289", name: "Clan One" },
-      }),
-    };
+        role: "member",
+      },
+    });
     const interaction = makeInteraction();
 
     await Accounts.run({} as any, interaction as any, cocService as any);
 
-    expect(cocService.getPlayerRaw).not.toHaveBeenCalled();
     expect(getEmbedDescription(interaction)).toContain("- Activity Bravo `#QGRJ2222`");
-    expect(prismaMock.playerLink.updateMany).not.toHaveBeenCalled();
   });
 
   it("falls back to raw tag when neither local name source exists", async () => {
@@ -172,16 +186,57 @@ describe("/accounts command", () => {
       },
     ]);
     prismaMock.playerActivity.findMany.mockResolvedValue([]);
-    const cocService = {
-      getPlayerRaw: vi.fn().mockRejectedValue(new Error("coc unavailable")),
-    };
+    const cocService = makeCocService({
+      "#CUV9082": null,
+    });
     const interaction = makeInteraction();
 
     await Accounts.run({} as any, interaction as any, cocService as any);
 
-    expect(cocService.getPlayerRaw).not.toHaveBeenCalled();
+    expect(getEmbedDescription(interaction)).toContain("**No Clan**");
     expect(getEmbedDescription(interaction)).toContain("- #CUV9082 `#CUV9082`");
-    expect(prismaMock.playerLink.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("groups untracked clans under their current clan heading and renders co-leader crowns", async () => {
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      {
+        playerTag: "#PYLQ0289",
+        playerName: "Alpha",
+        createdAt: new Date("2026-03-01T00:00:00.000Z"),
+      },
+      {
+        playerTag: "#QGRJ2222",
+        playerName: "Bravo",
+        createdAt: new Date("2026-03-02T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.playerActivity.findMany.mockResolvedValue([
+      { tag: "#PYLQ0289", name: "Alpha", clanTag: "#UNTRK1", clanName: "Untracked Clan" },
+      { tag: "#QGRJ2222", name: "Bravo", clanTag: "#UNTRK1", clanName: "Untracked Clan" },
+    ]);
+    prismaMock.trackedClan.findMany.mockResolvedValue([]);
+    const cocService = makeCocService({
+      "#PYLQ0289": {
+        name: "Alpha",
+        clan: { tag: "#UNTRK1", name: "Untracked Clan" },
+        role: "coLeader",
+      },
+      "#QGRJ2222": {
+        name: "Bravo",
+        clan: { tag: "#UNTRK1", name: "Untracked Clan" },
+        role: "member",
+      },
+    });
+    const interaction = makeInteraction();
+
+    await Accounts.run({} as any, interaction as any, cocService as any);
+
+    const description = getEmbedDescription(interaction);
+    expect(description).toContain(
+      "**[Untracked Clan](https://link.clashofclans.com/en?action=OpenClanProfile&tag=UNTRK1)**",
+    );
+    expect(description).toContain(":crown: Alpha `#PYLQ0289`");
+    expect(description).toContain("- Bravo `#QGRJ2222`");
   });
 
   it("autocompletes player tags from PlayerLink and ignores tracked clans", async () => {
@@ -343,15 +398,23 @@ describe("/accounts command", () => {
     prismaMock.playerActivity.findMany.mockResolvedValue([
       { tag: "#PYLQ0289", name: "Activity Delta", clanTag: "#PQL0289", clanName: "Saved Clan Name" },
     ]);
-    const cocService = {
-      getPlayerRaw: vi.fn(),
-    };
+    prismaMock.trackedClan.findMany.mockResolvedValue([
+      { tag: "#PQL0289", name: "Saved Clan Name", shortName: "SAVED" },
+    ]);
+    const cocService = makeCocService({
+      "#PYLQ0289": {
+        name: "Live Delta",
+        clan: { tag: "#PQL0289", name: "Saved Clan Name" },
+        role: "member",
+      },
+    });
     const interaction = makeInteraction();
 
     await Accounts.run({} as any, interaction as any, cocService as any);
 
-    expect(cocService.getPlayerRaw).not.toHaveBeenCalled();
-    expect(getEmbedDescription(interaction)).toContain("**Saved Clan Name (#PQL0289)**");
+    expect(getEmbedDescription(interaction)).toContain(
+      "**[SAVED](https://link.clashofclans.com/en?action=OpenClanProfile&tag=PQL0289)**",
+    );
   });
 
   it("uses tracked clan fallback name when playerActivity.clanTag exists but clanName is missing", async () => {
@@ -366,16 +429,21 @@ describe("/accounts command", () => {
       { tag: "#QGRJ2222", name: "Activity Echo", clanTag: "#2QG2C08UP", clanName: null },
     ]);
     prismaMock.trackedClan.findMany.mockResolvedValue([
-      { tag: "#2QG2C08UP", name: "Tracked Clan Name" },
+      { tag: "#2QG2C08UP", name: "Tracked Clan Name", shortName: null },
     ]);
-    const cocService = {
-      getPlayerRaw: vi.fn().mockRejectedValue(new Error("coc unavailable")),
-    };
+    const cocService = makeCocService({
+      "#QGRJ2222": {
+        name: "Live Echo",
+        clan: { tag: "#2QG2C08UP", name: "Tracked Clan Name" },
+        role: "member",
+      },
+    });
     const interaction = makeInteraction();
 
     await Accounts.run({} as any, interaction as any, cocService as any);
 
-    expect(cocService.getPlayerRaw).not.toHaveBeenCalled();
-    expect(getEmbedDescription(interaction)).toContain("**Tracked Clan Name (#2QG2C08UP)**");
+    expect(getEmbedDescription(interaction)).toContain(
+      "**[Tracked Clan Name](https://link.clashofclans.com/en?action=OpenClanProfile&tag=2QG2C08UP)**",
+    );
   });
 });


### PR DESCRIPTION
- render tracked and untracked clans under their current clan headings
- add co-leader crown markers and alias-linked clan headings