### PR TITLE
feat(dump): add guild-scoped plain-text dump link command

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -16,6 +16,7 @@
 - `/clan-health [visibility:private|public] tag:<trackedClanTag>` - Leadership snapshot from persisted data only: match rate and win rate (last 30 ended wars), inactive counts (missed-both in last 3 ended FWA wars + last-seen >=7d), and missing Discord links among observed members.
 - `/role-users role:<discordRole>` - List users in a role with pagination.
 - `/layout [th:<number>] [type:RISINGDAWN|BASIC|ICE] [edit:<layout-link>] [img-url:<url>]` - Fetch or list stored FWA layouts; `edit` upserts are admin-only at runtime, and `img-url` is only valid when `edit` is provided.
+- `/dump [edit:<link>]` - Show the stored guild dump link as plain text wrapped in angle brackets to suppress Discord embeds. `edit` is admin-only at runtime and stores one link per guild/server.
 - `/tracked-clan configure tag:<tag> [lose-style:triple-top-30|traditional] [mail-channel:<discordChannel>] [log-channel:<discordChannel>] [clan-role:<discordRole>] [clan-badge:<emoji>] [short-name:<abbr>]` - Add/update tracked clan settings.
 - `/tracked-clan cwl-tags cwl-tags:[<tag-array-or-comma-list>]` - Add one batch of seasonal CWL tracked clans (supports tags with or without `#`), with partial-success summary buckets for added/already-existing/invalid/duplicates.
 - `/tracked-clan remove tag:<tag> [type:FWA|CWL]` - Remove tracked clan from FWA or current-season CWL registry. When `type` is omitted and a tag exists in both registries, command returns an explicit ambiguity prompt instead of deleting.

--- a/prisma/migrations/20260415090000_add_dump_link_table/migration.sql
+++ b/prisma/migrations/20260415090000_add_dump_link_table/migration.sql
@@ -1,0 +1,13 @@
+-- CreateTable
+CREATE TABLE "DumpLink" (
+    "guildId" TEXT NOT NULL,
+    "link" TEXT NOT NULL,
+    "updatedByDiscordUserId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "DumpLink_pkey" PRIMARY KEY ("guildId")
+);
+
+-- CreateIndex
+CREATE INDEX "DumpLink_updatedAt_idx" ON "DumpLink"("updatedAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -70,6 +70,16 @@ model PlayerLink {
   @@index([discordUserId])
 }
 
+model DumpLink {
+  guildId               String   @id
+  link                  String
+  updatedByDiscordUserId String
+  createdAt             DateTime @default(now())
+  updatedAt             DateTime @updatedAt
+
+  @@index([updatedAt])
+}
+
 model UnlinkedAlertConfig {
   guildId    String   @id
   channelId  String

--- a/src/Commands.ts
+++ b/src/Commands.ts
@@ -22,6 +22,7 @@ import { Telemetry } from "./commands/Telemetry";
 import { ClanHealth } from "./commands/ClanHealth";
 import { Defer } from "./commands/Defer";
 import { Link } from "./commands/Link";
+import { Dump } from "./commands/Dump";
 import { Layout } from "./commands/Layout";
 import { Say } from "./commands/Say";
 import { BotLogs } from "./commands/BotLogs";
@@ -59,6 +60,7 @@ export const Commands = [
   ClanHealth,
   Defer,
   Force,
+  Dump,
   Post,
   Say,
   BotLogs,

--- a/src/commands/Dump.ts
+++ b/src/commands/Dump.ts
@@ -1,0 +1,91 @@
+import {
+  ApplicationCommandOptionType,
+  ChatInputCommandInteraction,
+  Client,
+  PermissionFlagsBits,
+} from "discord.js";
+import { Command } from "../Command";
+import { safeReply } from "../helper/safeReply";
+import {
+  getDumpLinkForGuild,
+  normalizeDumpLink,
+  upsertDumpLinkForGuild,
+} from "../services/DumpLinkService";
+
+function formatDumpLink(link: string): string {
+  return `<${link}>`;
+}
+
+export const Dump: Command = {
+  name: "dump",
+  description: "Show or update the stored dump link",
+  options: [
+    {
+      name: "edit",
+      description: "Update the stored dump link",
+      type: ApplicationCommandOptionType.String,
+      required: false,
+    },
+  ],
+  run: async (
+    _client: Client,
+    interaction: ChatInputCommandInteraction,
+  ) => {
+    if (!interaction.inGuild() || !interaction.guildId) {
+      await safeReply(interaction, {
+        ephemeral: true,
+        content: "This command can only be used in a server.",
+      });
+      return;
+    }
+
+    const edit = interaction.options.getString("edit", false)?.trim() ?? "";
+    if (edit) {
+      const isAdmin = interaction.memberPermissions?.has(
+        PermissionFlagsBits.Administrator,
+      );
+      if (!isAdmin) {
+        await safeReply(interaction, {
+          ephemeral: true,
+          content: "not_allowed: only admins can edit the dump link.",
+        });
+        return;
+      }
+
+      const normalizedLink = normalizeDumpLink(edit);
+      if (!normalizedLink) {
+        await safeReply(interaction, {
+          ephemeral: true,
+          content: "Invalid URL. Provide a valid http or https link.",
+        });
+        return;
+      }
+
+      const record = await upsertDumpLinkForGuild({
+        guildId: interaction.guildId,
+        link: normalizedLink,
+        updatedByDiscordUserId: interaction.user.id,
+      });
+
+      await safeReply(interaction, {
+        ephemeral: true,
+        content: formatDumpLink(record.link),
+      });
+      return;
+    }
+
+    const record = await getDumpLinkForGuild(interaction.guildId);
+    if (!record) {
+      await safeReply(interaction, {
+        ephemeral: true,
+        content: "No dump link configured for this server.",
+      });
+      return;
+    }
+
+    await safeReply(interaction, {
+      ephemeral: true,
+      content: formatDumpLink(record.link),
+    });
+  },
+};

--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -150,6 +150,15 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
       "/layout th:12 type:RISINGDAWN edit:https://link.clashofclans.com/en?action=OpenLayout&id=TH12... img-url:https://i.imgur.com/example.png",
     ],
   },
+  dump: {
+    summary: "Show or update the stored dump link without embed previews.",
+    details: [
+      "Use `/dump` to show the configured guild link as plain text wrapped in angle brackets.",
+      "Wrapping the link in `< >` prevents Discord from building an embed preview.",
+      "`edit` is admin-only and stores one link per guild/server.",
+    ],
+    examples: ["/dump", "/dump edit:https://example.com/dump"],
+  },
   "tracked-clan": {
     summary: "Manage tracked clans used by activity features.",
     details: [

--- a/src/services/CommandPermissionService.ts
+++ b/src/services/CommandPermissionService.ts
@@ -27,6 +27,7 @@ export const COMMAND_PERMISSION_TARGETS = [
   "reminders:edit",
   "link",
   "layout",
+  "dump",
   "link:create",
   "link:create:other-user",
   "link:delete",

--- a/src/services/DumpLinkService.ts
+++ b/src/services/DumpLinkService.ts
@@ -1,0 +1,78 @@
+import { prisma } from "../prisma";
+
+export type DumpLinkRecord = {
+  guildId: string;
+  link: string;
+  updatedByDiscordUserId: string;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export function normalizeDumpLink(input: string): string | null {
+  const trimmed = String(input ?? "").trim();
+  if (!trimmed) return null;
+
+  const unwrapped =
+    trimmed.startsWith("<") && trimmed.endsWith(">")
+      ? trimmed.slice(1, -1).trim()
+      : trimmed;
+  if (!unwrapped) return null;
+
+  try {
+    const parsed = new URL(unwrapped);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return null;
+    }
+    return unwrapped;
+  } catch {
+    return null;
+  }
+}
+
+export async function getDumpLinkForGuild(
+  guildId: string,
+): Promise<DumpLinkRecord | null> {
+  const normalizedGuildId = String(guildId ?? "").trim();
+  if (!normalizedGuildId) return null;
+
+  return prisma.dumpLink.findUnique({
+    where: { guildId: normalizedGuildId },
+    select: {
+      guildId: true,
+      link: true,
+      updatedByDiscordUserId: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+  });
+}
+
+export async function upsertDumpLinkForGuild(input: {
+  guildId: string;
+  link: string;
+  updatedByDiscordUserId: string;
+}): Promise<DumpLinkRecord> {
+  const guildId = String(input.guildId ?? "").trim();
+  const link = String(input.link ?? "").trim();
+  const updatedByDiscordUserId = String(input.updatedByDiscordUserId ?? "").trim();
+
+  return prisma.dumpLink.upsert({
+    where: { guildId },
+    create: {
+      guildId,
+      link,
+      updatedByDiscordUserId,
+    },
+    update: {
+      link,
+      updatedByDiscordUserId,
+    },
+    select: {
+      guildId: true,
+      link: true,
+      updatedByDiscordUserId: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+  });
+}

--- a/tests/dump.command.test.ts
+++ b/tests/dump.command.test.ts
@@ -1,0 +1,242 @@
+import { ApplicationCommandOptionType } from "discord.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const prismaMock = vi.hoisted(() => {
+  const dumpLinks = new Map<
+    string,
+    {
+      guildId: string;
+      link: string;
+      updatedByDiscordUserId: string;
+      createdAt: Date;
+      updatedAt: Date;
+    }
+  >();
+
+  return {
+    dumpLinks,
+    dumpLink: {
+      findUnique: vi.fn(async ({ where }: { where: { guildId: string } }) => {
+        return dumpLinks.get(where.guildId) ?? null;
+      }),
+      upsert: vi.fn(
+        async ({
+          where,
+          create,
+          update,
+        }: {
+          where: { guildId: string };
+          create: {
+            guildId: string;
+            link: string;
+            updatedByDiscordUserId: string;
+          };
+          update: {
+            link: string;
+            updatedByDiscordUserId: string;
+          };
+        }) => {
+          const existing = dumpLinks.get(where.guildId);
+          const now = new Date("2026-04-15T00:00:00.000Z");
+          const next = existing
+            ? {
+                ...existing,
+                ...update,
+                updatedAt: now,
+              }
+            : {
+                guildId: create.guildId,
+                link: create.link,
+                updatedByDiscordUserId: create.updatedByDiscordUserId,
+                createdAt: now,
+                updatedAt: now,
+              };
+
+          dumpLinks.set(where.guildId, next);
+          return next;
+        },
+      ),
+    },
+  };
+});
+
+vi.mock("../src/prisma", () => ({
+  prisma: prismaMock,
+}));
+
+import { Dump } from "../src/commands/Dump";
+
+function makeInteraction(input?: {
+  guildId?: string;
+  isAdmin?: boolean;
+  edit?: string | null;
+}) {
+  return {
+    inGuild: vi.fn().mockReturnValue(true),
+    guildId: input?.guildId ?? "111111111111111111",
+    user: { id: "222222222222222222" },
+    memberPermissions: {
+      has: vi.fn().mockReturnValue(input?.isAdmin ?? true),
+    },
+    options: {
+      getString: vi.fn((name: string) => {
+        if (name === "edit") return input?.edit ?? null;
+        return null;
+      }),
+    },
+    reply: vi.fn().mockResolvedValue(undefined),
+    editReply: vi.fn().mockResolvedValue(undefined),
+    deferred: false,
+    replied: false,
+  };
+}
+
+describe("/dump command shape", () => {
+  it("registers an optional string edit option without autocomplete", () => {
+    const editOption = Dump.options?.find((option) => option.name === "edit");
+
+    expect(editOption?.type).toBe(ApplicationCommandOptionType.String);
+    expect(editOption?.required).toBe(false);
+    expect(editOption?.autocomplete).toBeUndefined();
+  });
+});
+
+describe("/dump command behavior", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prismaMock.dumpLinks.clear();
+  });
+
+  it("returns a no-config message when the guild has no stored link", async () => {
+    const interaction = makeInteraction();
+
+    await Dump.run({} as any, interaction as any, {} as any);
+
+    expect(prismaMock.dumpLink.findUnique).toHaveBeenCalledWith({
+      where: { guildId: "111111111111111111" },
+      select: {
+        guildId: true,
+        link: true,
+        updatedByDiscordUserId: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+    expect(interaction.reply).toHaveBeenCalledWith({
+      ephemeral: true,
+      content: "No dump link configured for this server.",
+    });
+  });
+
+  it("returns the stored link wrapped in angle brackets", async () => {
+    prismaMock.dumpLinks.set("111111111111111111", {
+      guildId: "111111111111111111",
+      link: "https://example.com/dump",
+      updatedByDiscordUserId: "222222222222222222",
+      createdAt: new Date("2026-04-15T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-15T00:00:00.000Z"),
+    });
+    const interaction = makeInteraction();
+
+    await Dump.run({} as any, interaction as any, {} as any);
+
+    expect(interaction.reply).toHaveBeenCalledWith({
+      ephemeral: true,
+      content: "<https://example.com/dump>",
+    });
+  });
+
+  it("upserts a valid edit link for admins and confirms with wrapped text", async () => {
+    const interaction = makeInteraction({
+      edit: "https://example.com/dump",
+      isAdmin: true,
+    });
+
+    await Dump.run({} as any, interaction as any, {} as any);
+
+    expect(prismaMock.dumpLink.upsert).toHaveBeenCalledWith({
+      where: { guildId: "111111111111111111" },
+      create: {
+        guildId: "111111111111111111",
+        link: "https://example.com/dump",
+        updatedByDiscordUserId: "222222222222222222",
+      },
+      update: {
+        link: "https://example.com/dump",
+        updatedByDiscordUserId: "222222222222222222",
+      },
+      select: {
+        guildId: true,
+        link: true,
+        updatedByDiscordUserId: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+    expect(interaction.reply).toHaveBeenCalledWith({
+      ephemeral: true,
+      content: "<https://example.com/dump>",
+    });
+  });
+
+  it("rejects edits from non-admin users", async () => {
+    const interaction = makeInteraction({
+      edit: "https://example.com/dump",
+      isAdmin: false,
+    });
+
+    await Dump.run({} as any, interaction as any, {} as any);
+
+    expect(prismaMock.dumpLink.upsert).not.toHaveBeenCalled();
+    expect(interaction.reply).toHaveBeenCalledWith({
+      ephemeral: true,
+      content: "not_allowed: only admins can edit the dump link.",
+    });
+  });
+
+  it("rejects invalid edit URLs", async () => {
+    const interaction = makeInteraction({
+      edit: "notaurl",
+      isAdmin: true,
+    });
+
+    await Dump.run({} as any, interaction as any, {} as any);
+
+    expect(prismaMock.dumpLink.upsert).not.toHaveBeenCalled();
+    expect(interaction.reply).toHaveBeenCalledWith({
+      ephemeral: true,
+      content: "Invalid URL. Provide a valid http or https link.",
+    });
+  });
+
+  it("stores guild links independently per guild", async () => {
+    const guildA = makeInteraction({
+      guildId: "111111111111111111",
+      edit: "https://example.com/a",
+      isAdmin: true,
+    });
+    const guildB = makeInteraction({
+      guildId: "222222222222222222",
+      edit: "https://example.com/b",
+      isAdmin: true,
+    });
+
+    await Dump.run({} as any, guildA as any, {} as any);
+    await Dump.run({} as any, guildB as any, {} as any);
+
+    const readA = makeInteraction({ guildId: "111111111111111111" });
+    const readB = makeInteraction({ guildId: "222222222222222222" });
+
+    await Dump.run({} as any, readA as any, {} as any);
+    await Dump.run({} as any, readB as any, {} as any);
+
+    expect(readA.reply).toHaveBeenCalledWith({
+      ephemeral: true,
+      content: "<https://example.com/a>",
+    });
+    expect(readB.reply).toHaveBeenCalledWith({
+      ephemeral: true,
+      content: "<https://example.com/b>",
+    });
+  });
+});


### PR DESCRIPTION
- add a dedicated guild-scoped DumpLink model and service
- expose /dump with admin-only edit support and plain wrapped output