### PR TITLE
feat(compo): add midpoint summary to advice output

### DIFF
--- a/src/commands/Compo.ts
+++ b/src/commands/Compo.ts
@@ -19,6 +19,7 @@ import type { HeatMapRef } from "@prisma/client";
 import {
   COMPO_ADVICE_VIEW_LABELS,
   COMPO_ADVICE_VIEWS,
+  buildCompoAdviceContentLines,
   stepCompoAdviceCustomBandIndexByCount,
   type CompoAdviceView,
 } from "../helper/compoAdviceEngine";
@@ -1082,11 +1083,11 @@ function buildCompoAdviceEmbed(input: { advice: CompoAdviceReadResult }): EmbedB
     const embed = new EmbedBuilder()
       .setTitle(title)
       .setDescription(
-        [
-          `Advice View: **${summary.viewLabel}**`,
-          `Target Band: **${summary.currentBandLabel}**`,
-          `Current Score: **${formatAdviceScore(summary.currentScore)}**`,
-        ].join("\n"),
+        buildCompoAdviceContentLines({
+          summary,
+          modeLabel: input.advice.mode.toUpperCase(),
+          refreshLine: input.advice.refreshLine,
+        }).join("\n"),
       );
     const currentDeltas = [
       `TH18: ${formatSignedValue(summary.currentProjection.deltaByBucket.TH18)}`,

--- a/src/helper/compoAdviceEngine.ts
+++ b/src/helper/compoAdviceEngine.ts
@@ -11,6 +11,7 @@ import {
   formatHeatMapRefBandLabel,
   getHeatMapRefBandKey,
   getHeatMapRefBandMidpoint,
+  getHeatMapRefAdviceMidpoint,
 } from "./compoHeatMap";
 import type { CompoWarBucketCounts } from "./compoWarBucketCounts";
 import type { CompoWarDisplayBucket } from "./compoWarWeightBuckets";
@@ -92,6 +93,8 @@ export type CompoAdviceSummary = {
   view: CompoAdviceView;
   viewLabel: string;
   currentProjection: CompoActualStateProjection;
+  currentWeight: number | null;
+  targetBandMidpoint: number | null;
   currentScore: number | null;
   currentBandLabel: string;
   recommendationText: string;
@@ -112,6 +115,51 @@ function formatScore(value: number | null): string {
     return "n/a";
   }
   return Number.isInteger(value) ? `${value}` : value.toFixed(1);
+}
+
+function formatFullWeight(value: number | null | undefined): string {
+  if (value === null || value === undefined || !Number.isFinite(value)) {
+    return "unknown";
+  }
+  return Math.trunc(value).toLocaleString("en-US");
+}
+
+function formatCompactWeight(value: number | null | undefined): string {
+  if (value === null || value === undefined || !Number.isFinite(value)) {
+    return "unknown";
+  }
+
+  const magnitude = Math.abs(value);
+  const formatScaled = (scaled: number, suffix: string): string => {
+    const text = scaled.toFixed(3).replace(/\.?0+$/, "");
+    return `${text}${suffix}`;
+  };
+
+  if (magnitude >= 1_000_000_000) {
+    return formatScaled(magnitude / 1_000_000_000, "b");
+  }
+  if (magnitude >= 1_000_000) {
+    return formatScaled(magnitude / 1_000_000, "m");
+  }
+  if (magnitude >= 1_000) {
+    return formatScaled(magnitude / 1_000, "k");
+  }
+  return `${magnitude}`;
+}
+
+function formatSignedCompoAdviceDelta(delta: number | null | undefined): string {
+  if (delta === null || delta === undefined || !Number.isFinite(delta)) {
+    return "unknown";
+  }
+
+  const normalized = Number(delta);
+  if (Math.abs(normalized) < Number.EPSILON) {
+    return "→ +0";
+  }
+
+  const arrow = normalized > 0 ? "↑" : "↓";
+  const sign = normalized > 0 ? "+" : "-";
+  return `${arrow} ${sign}${formatCompactWeight(Math.abs(normalized))}`;
 }
 
 function getBandLabel(ref: HeatMapRef | null): string {
@@ -485,6 +533,13 @@ function resolveCurrentProjectionBandIndex(input: {
   };
 }
 
+function resolveAdviceTargetBandMidpoint(input: {
+  heatMapRefs: readonly HeatMapRef[];
+  selectedHeatMapRef: HeatMapRef | null;
+}): number | null {
+  return getHeatMapRefAdviceMidpoint(input.heatMapRefs, input.selectedHeatMapRef);
+}
+
 export function stepCompoAdviceCustomBandIndex(input: {
   heatMapRefs: readonly HeatMapRef[];
   currentBandIndex: number;
@@ -545,6 +600,13 @@ export function evaluateCompoAdvice(input: {
   const currentProjection = projectionState.projection;
   const currentScore = currentProjection.deviationScore;
   const currentBandLabel = getBandLabel(currentProjection.selectedHeatMapRef);
+  const currentWeight = Number.isFinite(currentProjection.totalWeight)
+    ? currentProjection.totalWeight
+    : null;
+  const targetBandMidpoint = resolveAdviceTargetBandMidpoint({
+    heatMapRefs: projectionState.heatMapRefs,
+    selectedHeatMapRef: currentProjection.selectedHeatMapRef,
+  });
   const actions = generateAdviceActions({
     base: input.base,
     currentProjection,
@@ -585,6 +647,8 @@ export function evaluateCompoAdvice(input: {
     view: input.view,
     viewLabel: COMPO_ADVICE_VIEW_LABELS[input.view],
     currentProjection,
+    currentWeight,
+    targetBandMidpoint,
     currentScore,
     currentBandLabel,
     recommendationText,
@@ -614,7 +678,15 @@ export function buildCompoAdviceContentLines(input: {
   lines.push(`Mode: **${input.modeLabel}**`);
   lines.push(`Advice View: **${input.summary.viewLabel}**`);
   lines.push(`Current Score: **${formatScore(input.summary.currentScore)}**`);
-  lines.push(`Current Band: **${input.summary.currentBandLabel}**`);
+  lines.push(`Target Band: **${input.summary.currentBandLabel}**`);
+  lines.push(`Current Weight: ${formatFullWeight(input.summary.currentWeight)}`);
+  lines.push(
+    `Distance to Midpoint: ${formatSignedCompoAdviceDelta(
+      input.summary.currentWeight === null || input.summary.targetBandMidpoint === null
+        ? null
+        : input.summary.currentWeight - input.summary.targetBandMidpoint,
+    )}`,
+  );
   lines.push(`Recommendation: **${input.summary.recommendationText}**`);
   lines.push(`Resulting Score: **${formatScore(input.summary.resultingScore)}**`);
   lines.push(`Resulting Band: **${input.summary.resultingBandLabel}**`);
@@ -675,3 +747,7 @@ export const evaluateAdviceActionForTest = evaluateAdviceAction;
 export const compareEvaluationsForTest = compareEvaluations;
 export const sortHeatMapRefsForTest = sortHeatMapRefs;
 export const resolveCustomHeatMapRefForTest = resolveCustomHeatMapRef;
+export const buildCompoAdviceContentLinesForTest = buildCompoAdviceContentLines;
+export const formatFullWeightForTest = formatFullWeight;
+export const formatSignedCompoAdviceDeltaForTest = formatSignedCompoAdviceDelta;
+export const resolveAdviceTargetBandMidpointForTest = resolveAdviceTargetBandMidpoint;

--- a/src/helper/compoHeatMap.ts
+++ b/src/helper/compoHeatMap.ts
@@ -26,6 +26,44 @@ export function getHeatMapRefBandMidpoint(
   return (ref.weightMinInclusive + ref.weightMaxInclusive) / 2;
 }
 
+/** Purpose: compute the advice-display midpoint for one HeatMapRef band using edge-band special cases. */
+export function getHeatMapRefAdviceMidpoint(
+  refs: readonly HeatMapRef[],
+  target: Pick<HeatMapRef, "weightMinInclusive" | "weightMaxInclusive"> | null,
+): number | null {
+  if (!target) return null;
+  if (refs.length <= 1) {
+    return getHeatMapRefBandMidpoint(target);
+  }
+
+  const sortedRefs = [...refs].sort((left, right) => {
+    if (left.weightMinInclusive !== right.weightMinInclusive) {
+      return left.weightMinInclusive - right.weightMinInclusive;
+    }
+    if (left.weightMaxInclusive !== right.weightMaxInclusive) {
+      return left.weightMaxInclusive - right.weightMaxInclusive;
+    }
+    return `${left.weightMinInclusive}-${left.weightMaxInclusive}`.localeCompare(
+      `${right.weightMinInclusive}-${right.weightMaxInclusive}`,
+    );
+  });
+  const targetIndex = sortedRefs.findIndex(
+    (ref) =>
+      ref.weightMinInclusive === target.weightMinInclusive &&
+      ref.weightMaxInclusive === target.weightMaxInclusive,
+  );
+  if (targetIndex < 0) {
+    return getHeatMapRefBandMidpoint(target);
+  }
+  if (targetIndex === 0) {
+    return target.weightMaxInclusive - 50_000;
+  }
+  if (targetIndex === sortedRefs.length - 1) {
+    return target.weightMinInclusive + 50_000;
+  }
+  return getHeatMapRefBandMidpoint(target);
+}
+
 /** Purpose: render one HeatMapRef band in a compact, user-facing range format. */
 export function formatHeatMapRefBandLabel(
   ref: Pick<HeatMapRef, "weightMinInclusive" | "weightMaxInclusive">,

--- a/tests/compo.commandSheetRead.test.ts
+++ b/tests/compo.commandSheetRead.test.ts
@@ -81,6 +81,7 @@ describe("/compo advice command", () => {
           view: "auto",
           viewLabel: "Auto-Detect Band",
           currentProjection: {
+            totalWeight: 1_500_000,
             memberCount: 50,
             deltaByBucket: {
               TH18: 0,
@@ -91,6 +92,8 @@ describe("/compo advice command", () => {
               "<=TH13": 0,
             },
           } as any,
+          currentWeight: 1_500_000,
+          targetBandMidpoint: 1_500_000,
           currentScore: 0,
           currentBandLabel: "1,000,000 - 2,000,000",
           recommendationText: "Add TH17",
@@ -132,6 +135,12 @@ describe("/compo advice command", () => {
     );
     expect(String(payload?.embeds?.[0]?.data?.description ?? "")).toContain(
       "Target Band: **1,000,000 - 2,000,000**",
+    );
+    expect(String(payload?.embeds?.[0]?.data?.description ?? "")).toContain(
+      "Current Weight: 1,500,000",
+    );
+    expect(String(payload?.embeds?.[0]?.data?.description ?? "")).toContain(
+      "Distance to Midpoint: → +0",
     );
     expect(String(payload?.embeds?.[0]?.data?.description ?? "")).toContain(
       "Current Score: **0**",
@@ -177,6 +186,7 @@ describe("/compo advice command", () => {
         view: "raw",
         viewLabel: "Raw Data",
         currentProjection: {
+          totalWeight: 1_500_000,
           memberCount: 50,
           deltaByBucket: {
             TH18: 0,
@@ -187,6 +197,8 @@ describe("/compo advice command", () => {
             "<=TH13": 0,
           },
         } as any,
+        currentWeight: 1_500_000,
+        targetBandMidpoint: 1_500_000,
         currentScore: 0,
         currentBandLabel: "0 - 9999999",
         recommendationText: "No improvement found.",

--- a/tests/compoAdvice.engine.test.ts
+++ b/tests/compoAdvice.engine.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
   compareEvaluationsForTest,
+  buildCompoAdviceContentLinesForTest,
   evaluateCompoAdvice,
+  formatFullWeightForTest,
+  formatSignedCompoAdviceDeltaForTest,
+  resolveAdviceTargetBandMidpointForTest,
   stepCompoAdviceCustomBandIndexByCount,
   type CompoAdviceEvaluation,
 } from "../src/helper/compoAdviceEngine";
@@ -208,6 +212,76 @@ describe("CompoAdviceEngine", () => {
     expect(first.currentBandLabel).not.toBe(second.currentBandLabel);
     expect(first.recommendationText).not.toBe(second.recommendationText);
     expect(first.currentScore).not.toBe(second.currentScore);
+  });
+
+  it("computes midpoint advice using middle-band arithmetic and end-band offsets", () => {
+    const refs = [
+      makeHeatMapRef({
+        weightMinInclusive: 0,
+        weightMaxInclusive: 99_999,
+      }),
+      makeHeatMapRef({
+        weightMinInclusive: 1_000_000,
+        weightMaxInclusive: 1_199_998,
+      }),
+      makeHeatMapRef({
+        weightMinInclusive: 2_000_000,
+        weightMaxInclusive: 2_099_999,
+      }),
+    ];
+
+    expect(
+      resolveAdviceTargetBandMidpointForTest({
+        heatMapRefs: refs,
+        selectedHeatMapRef: refs[1] ?? null,
+      }),
+    ).toBe(1_099_999);
+    expect(
+      resolveAdviceTargetBandMidpointForTest({
+        heatMapRefs: refs,
+        selectedHeatMapRef: refs[0] ?? null,
+      }),
+    ).toBe(49_999);
+    expect(
+      resolveAdviceTargetBandMidpointForTest({
+        heatMapRefs: refs,
+        selectedHeatMapRef: refs[2] ?? null,
+      }),
+    ).toBe(2_050_000);
+  });
+
+  it("formats current weight and midpoint distances for advice summaries", () => {
+    expect(formatFullWeightForTest(7_245_000)).toBe("7,245,000");
+    expect(formatFullWeightForTest(null)).toBe("unknown");
+    expect(formatSignedCompoAdviceDeltaForTest(125_000)).toBe("↑ +125k");
+    expect(formatSignedCompoAdviceDeltaForTest(-80_000)).toBe("↓ -80k");
+    expect(formatSignedCompoAdviceDeltaForTest(0)).toBe("→ +0");
+    expect(formatSignedCompoAdviceDeltaForTest(null)).toBe("unknown");
+  });
+
+  it("renders unknown fallback lines when current weight or midpoint is missing", () => {
+    const lines = buildCompoAdviceContentLinesForTest({
+      modeLabel: "ACTUAL",
+      refreshLine: null,
+      summary: {
+        viewLabel: "Raw Data",
+        currentScore: null,
+        currentBandLabel: "(no band)",
+        currentProjection: {
+          totalWeight: NaN,
+        } as any,
+        currentWeight: null,
+        targetBandMidpoint: null,
+        recommendationText: "No improvement found.",
+        resultingScore: null,
+        resultingBandLabel: "(no band)",
+        alternateTexts: [],
+        statusText: null,
+      } as any,
+    });
+
+    expect(lines).toContain("Current Weight: unknown");
+    expect(lines).toContain("Distance to Midpoint: unknown");
   });
 
   it("steps Custom band indices deterministically and respects bounds", () => {


### PR DESCRIPTION
- show current weight and distance to midpoint under target band
- reuse shared midpoint helpers and cover fallback rendering