### PR TITLE
fix(inactive): scope wars list to ended-war participation

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -12,7 +12,7 @@
 - `/permission list [command:<name>]` - List role policy for one command target, or all if omitted.
 - `/lastseen tag:<playerTag>` - Show a player's last seen activity, with drill-down button for tracked signal timestamps.
 - `/inactive days:<number>` - List players inactive for N days.
-- `/inactive wars:<number>` - List tracked-clan members who used 0/2 attacks in each of the last N ended wars (requires war-history tracking window).
+- `/inactive wars:<number>` - List tracked-clan members who used 0/2 attacks in each of the last N ended wars they actually participated in (requires war-history tracking window).
 - `/clan-health [visibility:private|public] tag:<trackedClanTag>` - Leadership snapshot from persisted data only: match rate and win rate (last 30 ended wars), inactive counts (missed-both in last 3 ended FWA wars + last-seen >=7d), and missing Discord links among observed members.
 - `/role-users role:<discordRole>` - List users in a role with pagination.
 - `/layout [th:<number>] [type:RISINGDAWN|BASIC|ICE] [edit:<layout-link>] [img-url:<url>]` - Fetch or list stored FWA layouts; `edit` upserts are admin-only at runtime, and `img-url` is only valid when `edit` is provided.

--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -107,7 +107,7 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
     summary: "List players inactive for a given number of days.",
     details: [
       "Shows oldest inactive players first.",
-      "Supports `wars` mode to list tracked members who used 0/2 attacks in each of the last X ended wars.",
+      "Supports `wars` mode to list tracked members who used 0/2 attacks in each of the last X ended wars they actually participated in.",
       "Large results are clipped to keep replies readable.",
     ],
     examples: ["/inactive days:7", "/inactive days:30", "/inactive wars:3"],

--- a/src/commands/Inactive.ts
+++ b/src/commands/Inactive.ts
@@ -7,10 +7,10 @@ import {
   ComponentType,
   EmbedBuilder,
 } from "discord.js";
-import { Prisma } from "@prisma/client";
 import { Command } from "../Command";
 import { prisma } from "../prisma";
 import { CoCService } from "../services/CoCService";
+import { InactiveWarService, type InactiveWarSummary } from "../services/InactiveWarService";
 import { formatError } from "../helper/formatError";
 
 const DEFAULT_STALE_HOURS = 6;
@@ -96,16 +96,7 @@ type InactiveDaysEntry = {
   daysAgo: number;
 };
 
-type InactiveWarRow = {
-  clanTag: string;
-  playerTag: string;
-  playerName: string;
-  missedWars: number;
-  totalTrueStars: number;
-  avgAttackDelay: number | null;
-  lateAttacks: number;
-  warsAvailable: number;
-};
+const inactiveWarService = new InactiveWarService();
 
 async function fetchInactiveDaysEntries(
   interaction: ChatInputCommandInteraction,
@@ -233,114 +224,14 @@ async function fetchInactiveDaysEntries(
 async function fetchInactiveWarEntries(
   interaction: ChatInputCommandInteraction,
   wars: number
-): Promise<{
-  results: InactiveWarRow[];
-  trackedTags: string[];
-  trackedNameByTag: Map<string, string>;
-  warnings: string[];
-}> {
+): Promise<InactiveWarSummary> {
   if (!interaction.guildId) {
     throw new Error("This command can only be used in a server.");
   }
-
-  const trackedClans = await prisma.trackedClan.findMany({
-    orderBy: { createdAt: "asc" },
-    select: { tag: true, name: true },
+  return inactiveWarService.listInactiveWarPlayers({
+    guildId: interaction.guildId,
+    wars,
   });
-  const trackedTags = trackedClans.map((c) => c.tag);
-  const trackedNameByTag = new Map(trackedClans.map((c) => [c.tag, c.name?.trim() || c.tag]));
-  if (trackedTags.length === 0) {
-    return { results: [], trackedTags, trackedNameByTag, warnings: [] };
-  }
-
-  const results = await prisma.$queryRaw<InactiveWarRow[]>(
-    Prisma.sql`
-      WITH available AS (
-        SELECT
-          ended_wars."clanTag",
-          COUNT(*)::int AS "warsAvailable"
-        FROM (
-          SELECT DISTINCT "clanTag", "warId"
-          FROM "ClanWarParticipation"
-          WHERE "guildId" = ${interaction.guildId}
-            AND "clanTag" IN (${Prisma.join(trackedTags)})
-            AND "matchType" = 'FWA'
-        ) ended_wars
-        GROUP BY ended_wars."clanTag"
-      ),
-      ranked AS (
-        SELECT
-          cwp."clanTag",
-          cwp."playerTag",
-          FIRST_VALUE(COALESCE(NULLIF(BTRIM(cwp."playerName"), ''), cwp."playerTag"))
-            OVER (
-              PARTITION BY cwp."clanTag", cwp."playerTag"
-              ORDER BY cwp."warStartTime" DESC, cwp."createdAt" DESC
-            ) AS "playerName",
-          cwp."missedBoth",
-          cwp."trueStars",
-          cwp."attackDelayMinutes",
-          cwp."attackWindowMissed",
-          ROW_NUMBER() OVER (
-            PARTITION BY cwp."clanTag", cwp."playerTag"
-            ORDER BY cwp."warStartTime" DESC, cwp."createdAt" DESC
-          ) AS rn
-        FROM "ClanWarParticipation" cwp
-        WHERE cwp."guildId" = ${interaction.guildId}
-          AND cwp."clanTag" IN (${Prisma.join(trackedTags)})
-          AND cwp."matchType" = 'FWA'
-      ),
-      selected AS (
-        SELECT *
-        FROM ranked
-        WHERE rn <= ${wars}
-      )
-      SELECT
-        s."clanTag",
-        s."playerTag",
-        MAX(s."playerName") AS "playerName",
-        COUNT(*) FILTER (WHERE s."missedBoth" = true)::int AS "missedWars",
-        COALESCE(SUM(s."trueStars"), 0)::int AS "totalTrueStars",
-        AVG(s."attackDelayMinutes")::float8 AS "avgAttackDelay",
-        COUNT(*) FILTER (WHERE s."attackWindowMissed" = true)::int AS "lateAttacks",
-        COALESCE(MAX(a."warsAvailable"), 0)::int AS "warsAvailable"
-      FROM selected s
-      LEFT JOIN available a
-        ON a."clanTag" = s."clanTag"
-      GROUP BY s."clanTag", s."playerTag"
-      HAVING COUNT(*) FILTER (WHERE s."missedBoth" = true) > 0
-      ORDER BY s."clanTag" ASC, "missedWars" DESC, MAX(s."playerName") ASC
-    `
-  );
-
-  const availableRows = await prisma.$queryRaw<Array<{ clanTag: string; warsAvailable: number }>>(
-    Prisma.sql`
-      SELECT
-        ended_wars."clanTag",
-        COUNT(*)::int AS "warsAvailable"
-      FROM (
-        SELECT DISTINCT "clanTag", "warId"
-        FROM "ClanWarParticipation"
-        WHERE "guildId" = ${interaction.guildId}
-          AND "clanTag" IN (${Prisma.join(trackedTags)})
-          AND "matchType" = 'FWA'
-      ) ended_wars
-      GROUP BY ended_wars."clanTag"
-    `
-  );
-  const availableByClan = new Map<string, number>(
-    availableRows.map((row) => [row.clanTag, row.warsAvailable])
-  );
-  const warnings = trackedTags
-    .map((clanTag) => {
-      const warsAvailable = availableByClan.get(clanTag) ?? 0;
-      return warsAvailable < wars
-        ? `${trackedNameByTag.get(clanTag) ?? clanTag}: only ${warsAvailable}/${wars} ended FWA wars tracked`
-        : null;
-    })
-    .filter((value): value is string => value !== null);
-
-  return { results, trackedTags, trackedNameByTag, warnings };
 }
 
 async function renderEmbedsWithPager(
@@ -625,7 +516,7 @@ async function runWarsMode(
     results,
     (e) => trackedNameByTag.get(e.clanTag) ?? e.clanTag,
     (e) =>
-      `- **${e.playerName}** (${e.playerTag}) - missed both in ${e.missedWars}/${Math.min(wars, e.warsAvailable)} war(s), true stars ${e.totalTrueStars}, avg delay ${e.avgAttackDelay !== null ? `${Math.round(e.avgAttackDelay)}m` : "n/a"}, late attacks ${e.lateAttacks}`
+      `- **${e.playerName}** (${e.playerTag}) - missed both in ${e.missedWars}/${e.participationWars} war(s), true stars ${e.totalTrueStars}, avg delay ${e.avgAttackDelay !== null ? `${Math.round(e.avgAttackDelay)}m` : "n/a"}, late attacks ${e.lateAttacks}`
   );
 
   const footerSuffix = warnings.length > 0 ? ` • Partial data: ${warnings.length} clan(s)` : "";
@@ -662,6 +553,7 @@ async function runCombinedMode(
       playerName: string;
       daysAgo: number | null;
       missedWars: number | null;
+      participationWars: number | null;
       warsAvailable: number | null;
       totalTrueStars: number | null;
       avgAttackDelay: number | null;
@@ -677,6 +569,7 @@ async function runCombinedMode(
       playerName: entry.playerName,
       daysAgo: entry.daysAgo,
       missedWars: null,
+      participationWars: null,
       warsAvailable: null,
       totalTrueStars: null,
       avgAttackDelay: null,
@@ -694,6 +587,7 @@ async function runCombinedMode(
       playerName: existing?.playerName ?? entry.playerName,
       daysAgo: existing?.daysAgo ?? null,
       missedWars: entry.missedWars,
+      participationWars: entry.participationWars,
       warsAvailable: entry.warsAvailable,
       totalTrueStars: entry.totalTrueStars,
       avgAttackDelay: entry.avgAttackDelay,
@@ -733,9 +627,7 @@ async function runCombinedMode(
       const reasons: string[] = [];
       if (e.daysAgo !== null) reasons.push(`${e.daysAgo}d inactive`);
       if (e.missedWars !== null) {
-        reasons.push(
-          `missed both in ${e.missedWars}/${Math.min(wars, e.warsAvailable ?? wars)} war(s)`
-        );
+        reasons.push(`missed both in ${e.missedWars}/${e.participationWars ?? 0} war(s)`);
       }
       const metrics =
         e.missedWars !== null

--- a/src/services/InactiveWarService.ts
+++ b/src/services/InactiveWarService.ts
@@ -1,0 +1,315 @@
+import { prisma } from "../prisma";
+
+type TrackedClanRow = {
+  tag: string;
+  name: string | null;
+};
+
+type ClanWarHistoryRow = {
+  warId: number;
+  clanTag: string;
+  clanName: string | null;
+  warStartTime: Date;
+  warEndTime: Date | null;
+};
+
+type ClanWarParticipationRow = {
+  clanTag: string;
+  playerTag: string;
+  playerName: string | null;
+  warId: string;
+  missedBoth: boolean;
+  trueStars: number;
+  attackDelayMinutes: number | null;
+  attackWindowMissed: boolean | null;
+  warStartTime: Date;
+  createdAt: Date;
+};
+
+export type InactiveWarRow = {
+  clanTag: string;
+  playerTag: string;
+  playerName: string;
+  missedWars: number;
+  participationWars: number;
+  totalTrueStars: number;
+  avgAttackDelay: number | null;
+  lateAttacks: number;
+  warsAvailable: number;
+};
+
+export type InactiveWarSummary = {
+  results: InactiveWarRow[];
+  trackedTags: string[];
+  trackedNameByTag: Map<string, string>;
+  warnings: string[];
+};
+
+function normalizeClanTagInput(input: string): string {
+  return input.trim().toUpperCase().replace(/^#/, "");
+}
+
+function normalizePlayerName(playerName: string | null | undefined, playerTag: string): string {
+  const trimmed = String(playerName ?? "").trim();
+  return trimmed || playerTag;
+}
+
+function buildTrackedNameMap(trackedClans: TrackedClanRow[]): Map<string, string> {
+  return new Map(
+    trackedClans.map((clan) => {
+      const clanTag = normalizeClanTagInput(clan.tag);
+      return [clanTag, String(clan.name ?? "").trim() || clanTag] as const;
+    })
+  );
+}
+
+function buildRecentEndedWarSelection(input: {
+  trackedClans: TrackedClanRow[];
+  historyRows: ClanWarHistoryRow[];
+  wars: number;
+}): Map<
+  string,
+  {
+    clanTag: string;
+    clanName: string;
+    warsAvailable: number;
+    selectedWarIds: string[];
+  }
+> {
+  const trackedNameByTag = buildTrackedNameMap(input.trackedClans);
+  const selectionByClan = new Map<
+    string,
+    {
+      clanTag: string;
+      clanName: string;
+      warsAvailable: number;
+      selectedWarIds: string[];
+    }
+  >();
+
+  for (const clan of input.trackedClans) {
+    const clanTag = normalizeClanTagInput(clan.tag);
+    if (!clanTag) continue;
+    selectionByClan.set(clanTag, {
+      clanTag,
+      clanName: trackedNameByTag.get(clanTag) ?? clanTag,
+      warsAvailable: 0,
+      selectedWarIds: [],
+    });
+  }
+
+  const sortedHistoryRows = [...input.historyRows].sort((a, b) => {
+    const clanA = normalizeClanTagInput(a.clanTag);
+    const clanB = normalizeClanTagInput(b.clanTag);
+    if (clanA !== clanB) return clanA.localeCompare(clanB);
+    const endA = a.warEndTime?.getTime() ?? 0;
+    const endB = b.warEndTime?.getTime() ?? 0;
+    if (endA !== endB) return endB - endA;
+    const startA = a.warStartTime?.getTime() ?? 0;
+    const startB = b.warStartTime?.getTime() ?? 0;
+    if (startA !== startB) return startB - startA;
+    return b.warId - a.warId;
+  });
+
+  for (const row of sortedHistoryRows) {
+    const clanTag = normalizeClanTagInput(row.clanTag);
+    const selection = selectionByClan.get(clanTag);
+    if (!selection) continue;
+    selection.warsAvailable += 1;
+    if (selection.selectedWarIds.length < input.wars) {
+      selection.selectedWarIds.push(String(row.warId));
+    }
+    const resolvedClanName = String(row.clanName ?? "").trim();
+    if (resolvedClanName && selection.clanName === clanTag) {
+      selection.clanName = resolvedClanName;
+    }
+  }
+
+  return selectionByClan;
+}
+
+function aggregateInactiveWarRows(input: {
+  selectionByClan: Map<
+    string,
+    {
+      clanTag: string;
+      clanName: string;
+      warsAvailable: number;
+      selectedWarIds: string[];
+    }
+  >;
+  participationRows: ClanWarParticipationRow[];
+}): InactiveWarRow[] {
+  const rowsByKey = new Map<
+    string,
+    {
+      clanTag: string;
+      playerTag: string;
+      playerName: string;
+      missedWars: number;
+      participationWars: number;
+      totalTrueStars: number;
+      avgAttackDelaySum: number;
+      avgAttackDelayCount: number;
+      lateAttacks: number;
+      warsAvailable: number;
+    }
+  >();
+
+  for (const row of input.participationRows) {
+    const clanTag = normalizeClanTagInput(row.clanTag);
+    const clanSelection = input.selectionByClan.get(clanTag);
+    if (!clanSelection) continue;
+
+    const playerTag = normalizeClanTagInput(row.playerTag);
+    if (!playerTag) continue;
+
+    const key = `${clanTag}:${playerTag}`;
+    const existing = rowsByKey.get(key) ?? {
+      clanTag,
+      playerTag,
+      playerName: normalizePlayerName(row.playerName, playerTag),
+      missedWars: 0,
+      participationWars: 0,
+      totalTrueStars: 0,
+      avgAttackDelaySum: 0,
+      avgAttackDelayCount: 0,
+      lateAttacks: 0,
+      warsAvailable: clanSelection.warsAvailable,
+    };
+
+    if (!rowsByKey.has(key)) {
+      rowsByKey.set(key, existing);
+    }
+
+    if (existing.playerName === existing.playerTag) {
+      const resolvedPlayerName = normalizePlayerName(row.playerName, playerTag);
+      if (resolvedPlayerName) existing.playerName = resolvedPlayerName;
+    }
+
+    existing.participationWars += 1;
+    if (row.missedBoth) existing.missedWars += 1;
+    existing.totalTrueStars += Number(row.trueStars ?? 0);
+
+    const attackDelayMinutes = row.attackDelayMinutes;
+    if (attackDelayMinutes !== null && Number.isFinite(Number(attackDelayMinutes))) {
+      existing.avgAttackDelaySum += Number(attackDelayMinutes);
+      existing.avgAttackDelayCount += 1;
+    }
+
+    if (row.attackWindowMissed === true) {
+      existing.lateAttacks += 1;
+    }
+  }
+
+  return [...rowsByKey.values()]
+    .filter((row) => row.participationWars > 0 && row.missedWars === row.participationWars)
+    .map((row) => ({
+      clanTag: row.clanTag,
+      playerTag: row.playerTag,
+      playerName: row.playerName,
+      missedWars: row.missedWars,
+      participationWars: row.participationWars,
+      totalTrueStars: row.totalTrueStars,
+      avgAttackDelay:
+        row.avgAttackDelayCount > 0 ? row.avgAttackDelaySum / row.avgAttackDelayCount : null,
+      lateAttacks: row.lateAttacks,
+      warsAvailable: row.warsAvailable,
+    }));
+}
+
+export class InactiveWarService {
+  async listInactiveWarPlayers(input: {
+    guildId: string;
+    wars: number;
+  }): Promise<InactiveWarSummary> {
+    const trackedClans = await prisma.trackedClan.findMany({
+      orderBy: { createdAt: "asc" },
+      select: { tag: true, name: true },
+    });
+    const trackedTags = trackedClans.map((clan) => normalizeClanTagInput(clan.tag));
+    const trackedNameByTag = buildTrackedNameMap(trackedClans);
+    if (trackedTags.length === 0) {
+      return { results: [], trackedTags, trackedNameByTag, warnings: [] };
+    }
+
+    const historyRows = await prisma.clanWarHistory.findMany({
+      where: {
+        clanTag: { in: trackedTags },
+        warEndTime: { not: null },
+        matchType: "FWA",
+      },
+      orderBy: [
+        { clanTag: "asc" },
+        { warEndTime: "desc" },
+        { warStartTime: "desc" },
+        { warId: "desc" },
+      ],
+      select: {
+        warId: true,
+        clanTag: true,
+        clanName: true,
+        warStartTime: true,
+        warEndTime: true,
+      },
+    });
+    const selectionByClan = buildRecentEndedWarSelection({
+      trackedClans,
+      historyRows,
+      wars: input.wars,
+    });
+    const selectedWarIds = [
+      ...new Set(
+        [...selectionByClan.values()].flatMap((entry) => entry.selectedWarIds)
+      ),
+    ];
+
+    const participationRows = selectedWarIds.length > 0
+      ? await prisma.clanWarParticipation.findMany({
+          where: {
+            guildId: input.guildId,
+            clanTag: { in: trackedTags },
+            warId: { in: selectedWarIds },
+            matchType: "FWA",
+          },
+          orderBy: [
+            { clanTag: "asc" },
+            { playerTag: "asc" },
+            { warStartTime: "desc" },
+            { createdAt: "desc" },
+          ],
+          select: {
+            clanTag: true,
+            playerTag: true,
+            playerName: true,
+            warId: true,
+            missedBoth: true,
+            trueStars: true,
+            attackDelayMinutes: true,
+            attackWindowMissed: true,
+            warStartTime: true,
+            createdAt: true,
+          },
+        })
+      : [];
+
+    const results = aggregateInactiveWarRows({
+      selectionByClan,
+      participationRows,
+    });
+    const warnings = trackedTags
+      .map((clanTag) => {
+        const selection = selectionByClan.get(clanTag);
+        const warsAvailable = selection?.warsAvailable ?? 0;
+        return warsAvailable < input.wars
+          ? `${trackedNameByTag.get(clanTag) ?? clanTag}: only ${warsAvailable}/${input.wars} ended FWA wars tracked`
+          : null;
+      })
+      .filter((value): value is string => value !== null);
+
+    return { results, trackedTags, trackedNameByTag, warnings };
+  }
+}
+
+export const buildRecentEndedWarSelectionForTest = buildRecentEndedWarSelection;
+export const aggregateInactiveWarRowsForTest = aggregateInactiveWarRows;

--- a/tests/inactive.command.test.ts
+++ b/tests/inactive.command.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const inactiveWarServiceMock = vi.hoisted(() => ({
+  listInactiveWarPlayers: vi.fn(),
+}));
+
+vi.mock("../src/services/InactiveWarService", async () => {
+  const actual = await vi.importActual("../src/services/InactiveWarService");
+  return {
+    ...actual,
+    InactiveWarService: class {
+      listInactiveWarPlayers = inactiveWarServiceMock.listInactiveWarPlayers;
+    },
+  };
+});
+
+import { Inactive } from "../src/commands/Inactive";
+
+function makeInteraction(warsValue: number | null) {
+  const deferReply = vi.fn().mockResolvedValue(undefined);
+  const editReply = vi.fn().mockResolvedValue(undefined);
+  return {
+    guildId: "guild-1",
+    deferReply,
+    editReply,
+    options: {
+      getInteger: vi.fn((name: string) => {
+        if (name === "wars") return warsValue;
+        if (name === "days") return null;
+        return null;
+      }),
+    },
+  };
+}
+
+describe("/inactive command", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders wars mode output from the inactive war service", async () => {
+    inactiveWarServiceMock.listInactiveWarPlayers.mockResolvedValue({
+      results: [
+        {
+          clanTag: "#AAA111",
+          playerTag: "#B",
+          playerName: "Bravo",
+          missedWars: 3,
+          participationWars: 3,
+          totalTrueStars: 0,
+          avgAttackDelay: 47.5,
+          lateAttacks: 1,
+          warsAvailable: 3,
+        },
+      ],
+      trackedTags: ["#AAA111"],
+      trackedNameByTag: new Map([["#AAA111", "Alpha"]]),
+      warnings: [],
+    });
+
+    const interaction = makeInteraction(3);
+    const cocService = {} as any;
+
+    await Inactive.run({} as any, interaction as any, cocService);
+
+    expect(inactiveWarServiceMock.listInactiveWarPlayers).toHaveBeenCalledWith({
+      guildId: "guild-1",
+      wars: 3,
+    });
+    expect(interaction.editReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        embeds: expect.any(Array),
+      })
+    );
+    const payload = interaction.editReply.mock.calls.at(-1)?.[0];
+    const embed = payload.embeds[0].toJSON();
+    expect(embed.title).toContain("Missed Both Attacks - Last 3 War(s) (1)");
+    expect(embed.description).toContain("Bravo");
+    expect(embed.description).toContain("missed both in 3/3 war(s)");
+  });
+});

--- a/tests/inactiveWar.service.test.ts
+++ b/tests/inactiveWar.service.test.ts
@@ -1,0 +1,243 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const prismaMock = vi.hoisted(() => ({
+  trackedClan: {
+    findMany: vi.fn(),
+  },
+  clanWarHistory: {
+    findMany: vi.fn(),
+  },
+  clanWarParticipation: {
+    findMany: vi.fn(),
+  },
+}));
+
+vi.mock("../src/prisma", () => ({
+  prisma: prismaMock,
+}));
+
+import { InactiveWarService } from "../src/services/InactiveWarService";
+
+function makeHistoryRow(warId: number, clanTag: string, endedAt: string) {
+  const warEndTime = new Date(endedAt);
+  return {
+    warId,
+    clanTag,
+    clanName: `${clanTag}-name`,
+    warStartTime: new Date(warEndTime.getTime() - 24 * 60 * 60 * 1000),
+    warEndTime,
+  };
+}
+
+function makeParticipationRow(input: {
+  clanTag: string;
+  playerTag: string;
+  playerName: string;
+  warId: string;
+  missedBoth: boolean;
+  trueStars?: number;
+  attackDelayMinutes?: number | null;
+  attackWindowMissed?: boolean | null;
+}) {
+  return {
+    clanTag: input.clanTag,
+    playerTag: input.playerTag,
+    playerName: input.playerName,
+    warId: input.warId,
+    missedBoth: input.missedBoth,
+    trueStars: input.trueStars ?? 0,
+    attackDelayMinutes: input.attackDelayMinutes ?? null,
+    attackWindowMissed: input.attackWindowMissed ?? null,
+    warStartTime: new Date("2026-04-01T00:00:00.000Z"),
+    createdAt: new Date("2026-04-01T00:00:00.000Z"),
+  };
+}
+
+describe("InactiveWarService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("selects only the latest ended wars and excludes older participation rows", async () => {
+    prismaMock.trackedClan.findMany.mockResolvedValue([{ tag: "#AAA111", name: "Alpha" }]);
+    prismaMock.clanWarHistory.findMany.mockResolvedValue([
+      makeHistoryRow(400, "#AAA111", "2026-04-04T00:00:00.000Z"),
+      makeHistoryRow(399, "#AAA111", "2026-04-03T00:00:00.000Z"),
+      makeHistoryRow(398, "#AAA111", "2026-04-02T00:00:00.000Z"),
+      makeHistoryRow(397, "#AAA111", "2026-04-01T00:00:00.000Z"),
+    ]);
+    const participationRows = [
+      makeParticipationRow({
+        clanTag: "#AAA111",
+        playerTag: "#OLD",
+        playerName: "Old Timer",
+        warId: "397",
+        missedBoth: true,
+      }),
+    ];
+    prismaMock.clanWarParticipation.findMany.mockImplementation(async (args: any) => {
+      const warIds = new Set((args?.where?.warId?.in ?? []).map((value: string) => String(value)));
+      return participationRows.filter((row) => warIds.has(String(row.warId)));
+    });
+
+    const service = new InactiveWarService();
+    const summary = await service.listInactiveWarPlayers({
+      guildId: "guild-1",
+      wars: 3,
+    });
+
+    expect(prismaMock.clanWarParticipation.findMany).toHaveBeenCalledTimes(1);
+    expect(prismaMock.clanWarParticipation.findMany.mock.calls[0]?.[0]?.where?.warId?.in).toEqual([
+      "400",
+      "399",
+      "398",
+    ]);
+    expect(summary.results).toEqual([]);
+    expect(summary.warnings).toEqual([]);
+  });
+
+  it("flags a player inactive only when every counted participation row is missedBoth", async () => {
+    prismaMock.trackedClan.findMany.mockResolvedValue([{ tag: "#AAA111", name: "Alpha" }]);
+    prismaMock.clanWarHistory.findMany.mockResolvedValue([
+      makeHistoryRow(400, "#AAA111", "2026-04-04T00:00:00.000Z"),
+      makeHistoryRow(399, "#AAA111", "2026-04-03T00:00:00.000Z"),
+      makeHistoryRow(398, "#AAA111", "2026-04-02T00:00:00.000Z"),
+    ]);
+    const participationRows = [
+      makeParticipationRow({
+        clanTag: "#AAA111",
+        playerTag: "#B",
+        playerName: "Bravo",
+        warId: "400",
+        missedBoth: true,
+        trueStars: 0,
+        attackDelayMinutes: 40,
+        attackWindowMissed: true,
+      }),
+      makeParticipationRow({
+        clanTag: "#AAA111",
+        playerTag: "#B",
+        playerName: "Bravo",
+        warId: "399",
+        missedBoth: true,
+        trueStars: 0,
+        attackDelayMinutes: 55,
+        attackWindowMissed: false,
+      }),
+      makeParticipationRow({
+        clanTag: "#AAA111",
+        playerTag: "#B",
+        playerName: "Bravo",
+        warId: "398",
+        missedBoth: true,
+        trueStars: 0,
+        attackDelayMinutes: null,
+        attackWindowMissed: null,
+      }),
+    ];
+    prismaMock.clanWarParticipation.findMany.mockImplementation(async (args: any) => {
+      const warIds = new Set((args?.where?.warId?.in ?? []).map((value: string) => String(value)));
+      return participationRows.filter((row) => warIds.has(String(row.warId)));
+    });
+
+    const service = new InactiveWarService();
+    const summary = await service.listInactiveWarPlayers({
+      guildId: "guild-1",
+      wars: 3,
+    });
+
+    expect(summary.results).toHaveLength(1);
+    expect(summary.results[0]).toMatchObject({
+      clanTag: "AAA111",
+      playerTag: "B",
+      playerName: "Bravo",
+      missedWars: 3,
+      participationWars: 3,
+      totalTrueStars: 0,
+      lateAttacks: 1,
+      warsAvailable: 3,
+    });
+    expect(summary.results[0]?.avgAttackDelay).toBeCloseTo(47.5);
+  });
+
+  it("excludes a player who was active in any counted participation row", async () => {
+    prismaMock.trackedClan.findMany.mockResolvedValue([{ tag: "#AAA111", name: "Alpha" }]);
+    prismaMock.clanWarHistory.findMany.mockResolvedValue([
+      makeHistoryRow(400, "#AAA111", "2026-04-04T00:00:00.000Z"),
+      makeHistoryRow(399, "#AAA111", "2026-04-03T00:00:00.000Z"),
+      makeHistoryRow(398, "#AAA111", "2026-04-02T00:00:00.000Z"),
+    ]);
+    const participationRows = [
+      makeParticipationRow({
+        clanTag: "#AAA111",
+        playerTag: "#C",
+        playerName: "Charlie",
+        warId: "400",
+        missedBoth: true,
+      }),
+      makeParticipationRow({
+        clanTag: "#AAA111",
+        playerTag: "#C",
+        playerName: "Charlie",
+        warId: "399",
+        missedBoth: false,
+      }),
+    ];
+    prismaMock.clanWarParticipation.findMany.mockImplementation(async (args: any) => {
+      const warIds = new Set((args?.where?.warId?.in ?? []).map((value: string) => String(value)));
+      return participationRows.filter((row) => warIds.has(String(row.warId)));
+    });
+
+    const service = new InactiveWarService();
+    const summary = await service.listInactiveWarPlayers({
+      guildId: "guild-1",
+      wars: 3,
+    });
+
+    expect(summary.results).toEqual([]);
+  });
+
+  it("treats partial roster participation as inactive only when all counted participation rows are missedBoth", async () => {
+    prismaMock.trackedClan.findMany.mockResolvedValue([{ tag: "#AAA111", name: "Alpha" }]);
+    prismaMock.clanWarHistory.findMany.mockResolvedValue([
+      makeHistoryRow(400, "#AAA111", "2026-04-04T00:00:00.000Z"),
+      makeHistoryRow(399, "#AAA111", "2026-04-03T00:00:00.000Z"),
+      makeHistoryRow(398, "#AAA111", "2026-04-02T00:00:00.000Z"),
+    ]);
+    const participationRows = [
+      makeParticipationRow({
+        clanTag: "#AAA111",
+        playerTag: "#D",
+        playerName: "Delta",
+        warId: "400",
+        missedBoth: true,
+      }),
+      makeParticipationRow({
+        clanTag: "#AAA111",
+        playerTag: "#D",
+        playerName: "Delta",
+        warId: "398",
+        missedBoth: true,
+      }),
+    ];
+    prismaMock.clanWarParticipation.findMany.mockImplementation(async (args: any) => {
+      const warIds = new Set((args?.where?.warId?.in ?? []).map((value: string) => String(value)));
+      return participationRows.filter((row) => warIds.has(String(row.warId)));
+    });
+
+    const service = new InactiveWarService();
+    const summary = await service.listInactiveWarPlayers({
+      guildId: "guild-1",
+      wars: 3,
+    });
+
+    expect(summary.results).toHaveLength(1);
+    expect(summary.results[0]).toMatchObject({
+      clanTag: "AAA111",
+      playerTag: "D",
+      playerName: "Delta",
+      missedWars: 2,
+      participationWars: 2,
+    });
+  });
+});


### PR DESCRIPTION
- select the last N ended wars from ClanWarHistory before reading participation
- only flag players when all counted participation rows are missedBoth
- update inactive help/docs and add regression coverage