### PR TITLE
fix(migration): reorder war mail lifecycle pk change

### DIFF
--- a/prisma/migrations/20260416090000_scope_war_mail_lifecycle_by_start_time/migration.sql
+++ b/prisma/migrations/20260416090000_scope_war_mail_lifecycle_by_start_time/migration.sql
@@ -53,11 +53,11 @@ WHERE cw."guildId" = wml."guildId"
   AND wml."warStartTime" IS NULL;
 
 ALTER TABLE "WarMailLifecycle"
-  ALTER COLUMN "id" SET NOT NULL,
-  ALTER COLUMN "warId" DROP NOT NULL;
+  DROP CONSTRAINT IF EXISTS "WarMailLifecycle_pkey";
 
 ALTER TABLE "WarMailLifecycle"
-  DROP CONSTRAINT IF EXISTS "WarMailLifecycle_pkey";
+  ALTER COLUMN "id" SET NOT NULL,
+  ALTER COLUMN "warId" DROP NOT NULL;
 
 ALTER TABLE "WarMailLifecycle"
   ADD CONSTRAINT "WarMailLifecycle_pkey" PRIMARY KEY ("id");


### PR DESCRIPTION
- drop the old primary key before making warId nullable
- keep the active-war identity backfill and new unique indexes intact