### PR TITLE
fix(prisma): make raid tracked clan name migration idempotent

### DIFF
--- a/prisma/migrations/20260417090000_add_raid_tracked_clan_name/migration.sql
+++ b/prisma/migrations/20260417090000_add_raid_tracked_clan_name/migration.sql
@@ -1,2 +1,2 @@
 -- AlterTable
-ALTER TABLE "RaidTrackedClan" ADD COLUMN "name" TEXT;
+ALTER TABLE IF EXISTS "RaidTrackedClan" ADD COLUMN IF NOT EXISTS "name" TEXT;


### PR DESCRIPTION
- use IF EXISTS and IF NOT EXISTS on the raid tracked clan name migration
- keep the schema change safe for staging recovery and production deploys