### PR TITLE
fix(tracked-clan): run raid refresh under CoC queue context

### DIFF
--- a/src/commands/TrackedClan.ts
+++ b/src/commands/TrackedClan.ts
@@ -16,6 +16,7 @@ import { safeReply } from "../helper/safeReply";
 import { prisma } from "../prisma";
 import { ActivityService } from "../services/ActivityService";
 import { CoCService } from "../services/CoCService";
+import { runWithCoCQueueContext } from "../services/CoCQueueContext";
 import { normalizeClanTag } from "../services/PlayerLinkService";
 import {
   addCwlClanTagsForSeason,
@@ -212,6 +213,18 @@ function buildRaidTrackedClanListComponents(
 function formatTagListForSummary(tags: string[]): string {
   if (tags.length <= 0) return "none";
   return tags.join(", ");
+}
+
+export async function refreshRaidTrackedClanListWithQueueContext(input: {
+  cocService: CoCService;
+}): Promise<Awaited<ReturnType<typeof refreshRaidTrackedClansMetadata>>> {
+  return runWithCoCQueueContext(
+    {
+      priority: "interactive",
+      source: "tracked-clan:list:raids:refresh",
+    },
+    () => refreshRaidTrackedClansMetadata({ cocService: input.cocService }),
+  );
 }
 
 async function normalizeClanBadgeInput(
@@ -553,7 +566,9 @@ export const TrackedClan: Command = {
                 });
 
                 try {
-                  const refreshResult = await refreshRaidTrackedClansMetadata({ cocService });
+                  const refreshResult = await refreshRaidTrackedClanListWithQueueContext({
+                    cocService,
+                  });
                   tracked = await listRaidTrackedClansForDisplay();
                   blocks = buildRaidTrackedClanListLines(tracked);
                   pages = paginateTextLines(blocks);

--- a/src/services/RaidTrackedClanService.ts
+++ b/src/services/RaidTrackedClanService.ts
@@ -1,7 +1,9 @@
 import { prisma } from "../prisma";
 import { normalizeClanTag } from "./PlayerLinkService";
 import { CoCService } from "./CoCService";
+import { formatError } from "../helper/formatError";
 import { RecruitingType } from "../generated/coc-api";
+import { toFailureTelemetry } from "./telemetry/ingest";
 
 export type RaidTrackedClanJoinType = "open" | "inviteOnly" | "closed";
 
@@ -125,6 +127,7 @@ export function getRaidTrackedClanJoinTypeEmoji(
 async function readRaidTrackedClanLiveData(input: {
   clanTag: string;
   cocService: CoCService;
+  source: string;
 }): Promise<{ clanName: string | null; joinType: RaidTrackedClanJoinType | null } | null> {
   try {
     const clan = await input.cocService.getClan(toDisplayTag(input.clanTag));
@@ -132,7 +135,13 @@ async function readRaidTrackedClanLiveData(input: {
       clanName: normalizeRaidTrackedClanName(clan?.name),
       joinType: normalizeRaidJoinType(clan?.type),
     };
-  } catch {
+  } catch (err) {
+    const failure = toFailureTelemetry(err);
+    if (failure.errorCode === "COC_QUEUE_CONTEXT_MISSING") {
+      console.error(
+        `[tracked-clan] stage=raid_live_fetch_failed source=${input.source} operation=getClan tag=${toDisplayTag(input.clanTag)} error=${formatError(err)}`,
+      );
+    }
     return null;
   }
 }
@@ -235,6 +244,7 @@ export async function upsertRaidTrackedClansForTags(input: {
     const liveData = await readRaidTrackedClanLiveData({
       clanTag: tag,
       cocService: input.cocService,
+      source: "tracked-clan:raid-tags",
     });
 
     if (!liveData) {
@@ -319,6 +329,7 @@ export async function refreshRaidTrackedClansMetadata(input: {
     const liveData = await readRaidTrackedClanLiveData({
       clanTag: normalizedTag,
       cocService: input.cocService,
+      source: "tracked-clan:list:raids:refresh",
     });
     if (!liveData) {
       joinTypeRefreshFailures.push(toDisplayTag(row.clanTag));

--- a/src/services/telemetry/errorTaxonomy.ts
+++ b/src/services/telemetry/errorTaxonomy.ts
@@ -67,5 +67,13 @@ export function classifyTelemetryError(error: unknown): TelemetryErrorInfo {
     return { category: "network", code: code || "NETWORK_ERROR", timeout: false };
   }
 
+  if (code.startsWith("COC_QUEUE_CONTEXT_MISSING") || msg.includes("coc_queue_context_missing")) {
+    return {
+      category: "internal",
+      code: "COC_QUEUE_CONTEXT_MISSING",
+      timeout: false,
+    };
+  }
+
   return { category: "internal", code: code || "INTERNAL_ERROR", timeout: false };
 }

--- a/tests/telemetryErrorTaxonomy.logic.test.ts
+++ b/tests/telemetryErrorTaxonomy.logic.test.ts
@@ -32,4 +32,10 @@ describe("telemetry error taxonomy", () => {
     const classified = classifyTelemetryError(new Error("boom"));
     expect(classified.category).toBe("internal");
   });
+
+  it("classifies missing CoC queue context explicitly", () => {
+    const classified = classifyTelemetryError(new Error("COC_QUEUE_CONTEXT_MISSING:getClan"));
+    expect(classified.category).toBe("internal");
+    expect(classified.code).toBe("COC_QUEUE_CONTEXT_MISSING");
+  });
 });

--- a/tests/trackedClan.command.test.ts
+++ b/tests/trackedClan.command.test.ts
@@ -36,11 +36,22 @@ const prismaMock = vi.hoisted(() => ({
   }),
 }));
 
+const cocQueueMock = vi.hoisted(() => ({
+  runWithCoCQueueContext: vi.fn(async (_context: unknown, run: () => Promise<unknown>) => run()),
+}));
+
 vi.mock("../src/prisma", () => ({
   prisma: prismaMock,
 }));
 
-import { TrackedClan } from "../src/commands/TrackedClan";
+vi.mock("../src/services/CoCQueueContext", () => ({
+  runWithCoCQueueContext: cocQueueMock.runWithCoCQueueContext,
+}));
+
+import {
+  TrackedClan,
+  refreshRaidTrackedClanListWithQueueContext,
+} from "../src/commands/TrackedClan";
 
 type InteractionInput = {
   subcommand: string;
@@ -190,6 +201,41 @@ describe("/tracked-clan command behavior", () => {
     expect(getReplyContent(interaction)).toContain("already-existing: none");
     expect(getReplyContent(interaction)).toContain("duplicates-ignored: none");
     expect(prismaMock.raidTrackedClan.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("wraps RAID refresh metadata fetches in a CoC queue context", async () => {
+    prismaMock.raidTrackedClan.findMany.mockResolvedValueOnce([
+      {
+        clanTag: "2RVGJYLC0",
+        name: null,
+        joinType: null,
+        createdAt: new Date("2026-04-15T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-15T00:00:00.000Z"),
+      },
+    ]);
+    const cocService = {
+      getClan: vi.fn().mockResolvedValue({ name: "Vanilla", type: "open" }),
+    };
+
+    const result = await refreshRaidTrackedClanListWithQueueContext({
+      cocService: cocService as any,
+    });
+
+    expect(cocQueueMock.runWithCoCQueueContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        priority: "interactive",
+        source: "tracked-clan:list:raids:refresh",
+      }),
+      expect.any(Function),
+    );
+    expect(prismaMock.raidTrackedClan.updateMany).toHaveBeenCalledWith({
+      where: { clanTag: "2RVGJYLC0" },
+      data: {
+        name: "Vanilla",
+        joinType: "open",
+      },
+    });
+    expect(result.joinTypeRefreshFailures).toEqual([]);
   });
 
   it("rejects upgrades when multiple raid tags are provided", async () => {


### PR DESCRIPTION
- wrap RAID refresh metadata fetches in an interactive CoC queue context
- classify queue-context-missing errors explicitly instead of generic INTERNAL_ERROR
- add regression tests for the refresh wrapper and telemetry classification