### PR TITLE
feat(todo): tighten raid todo freshness and raid-tracked scope

### DIFF
--- a/src/services/TodoService.ts
+++ b/src/services/TodoService.ts
@@ -40,6 +40,7 @@ type TodoRenderRow = {
   townHall: number | null;
   clanTag: string | null;
   clanName: string | null;
+  raidClanTracked: boolean;
   cwlClanTag: string | null;
   cwlClanName: string | null;
   cwlPlannedSubInAt: Date | null;
@@ -227,6 +228,7 @@ export async function buildTodoPagesForUser(input: {
 
   const [
     trackedClanRows,
+    raidTrackedClanRows,
     currentWarRows,
     clanMemberTownHallRows,
     playerCatalogTownHallRows,
@@ -240,6 +242,12 @@ export async function buildTodoPagesForUser(input: {
       ? prisma.trackedClan.findMany({
           where: { tag: { in: clanTags } },
           select: { tag: true, clanBadge: true },
+        })
+      : Promise.resolve([]),
+    clanTags.length > 0
+      ? prisma.raidTrackedClan.findMany({
+          where: { tag: { in: clanTags } },
+          select: { tag: true },
         })
       : Promise.resolve([]),
     clanTags.length > 0
@@ -337,6 +345,11 @@ export async function buildTodoPagesForUser(input: {
   const activeCwlPlanList = Array.isArray(activeCwlPlans)
     ? activeCwlPlans
     : [];
+  const raidTrackedClanTagSet = new Set(
+    (raidTrackedClanRows as Array<{ tag: string }>)
+      .map((row) => normalizeClanTag(row.tag))
+      .filter(Boolean),
+  );
 
   const townHallByClanAndPlayer = new Map<string, number>();
   const latestTownHallByClanAndPlayer = new Map<string, Date>();
@@ -601,6 +614,9 @@ export async function buildTodoPagesForUser(input: {
     const matchContext = resolvedClanTag
       ? warMatchContextByClanTag.get(resolvedClanTag) ?? null
       : null;
+    const raidClanTracked = Boolean(
+      resolvedClanTag && raidTrackedClanTagSet.has(resolvedClanTag),
+    );
     const resolvedPlayerName = resolveTodoPlayerDisplayName({
       playerTag: normalizedTag,
       snapshotPlayerName: snapshot?.playerName,
@@ -628,11 +644,8 @@ export async function buildTodoPagesForUser(input: {
         : null,
     ].filter((value): value is number => Number.isFinite(value));
     const raidFreshnessCandidates = [
-      resolvedClanTag
-        ? latestTownHallByClanAndPlayer.get(`${resolvedClanTag}:${normalizedTag}`)?.getTime() ?? null
-        : null,
-      latestTownHallByPlayerTag.get(normalizedTag)?.getTime() ?? null,
-      latestPlayerCatalogSeenAtByTag.get(normalizedTag)?.getTime() ?? null,
+      snapshot?.lastUpdatedAt?.getTime() ?? null,
+      snapshot?.updatedAt?.getTime() ?? null,
     ].filter((value): value is number => Number.isFinite(value));
     const gamesFreshnessCandidates = [
       playerSignalStateFreshnessByTag.get(normalizedTag) ?? null,
@@ -651,6 +664,7 @@ export async function buildTodoPagesForUser(input: {
       warAttackDetails: resolvedWarAttackDetails,
       warHeaderBadge: resolvedClanTag ? clanBadgeByTag.get(resolvedClanTag) ?? null : null,
       warMatchIndicator: resolveWarMatchStatusIndicator(matchContext),
+      raidClanTracked,
       inValidatedWarMemberSet: Boolean(trackedClanActive && trackedWarMember),
       snapshot,
       missingSnapshot,
@@ -736,7 +750,9 @@ function pruneExpiredTodoRenderCache(nowMs: number): void {
 
 /** Purpose: classify snapshot freshness using per-type priority windows. */
 function isSnapshotStale(snapshot: TodoSnapshotRecord, nowMs: number): boolean {
-  const ageMs = Math.max(0, nowMs - snapshot.lastUpdatedAt.getTime());
+  const freshnessAt = snapshot.lastUpdatedAt ?? snapshot.updatedAt ?? null;
+  if (!freshnessAt) return false;
+  const ageMs = Math.max(0, nowMs - freshnessAt.getTime());
   if (snapshot.warActive) return ageMs > TODO_STALE_ACTIVE_WAR_MS;
   if (snapshot.cwlActive) return ageMs > TODO_STALE_ACTIVE_CWL_MS;
   if (snapshot.raidActive) return ageMs > TODO_STALE_ACTIVE_RAID_MS;
@@ -1159,7 +1175,7 @@ function formatGamesTodoRow(
 /** Purpose: format one RAIDS row with completion marker emojis and unchanged status text. */
 function formatRaidsTodoRow(row: TodoRenderRow, status: string): string {
   const marker = getRaidRowMarker(row);
-  return `${marker} ${formatPlayerIdentity(row)} - ${status}`;
+  return `${marker} ${row.playerName} - ${status}`;
 }
 
 /** Purpose: build one stable player identity token for todo row prefixes. */
@@ -1343,10 +1359,10 @@ function getRaidRowStatus(row: TodoRenderRow): string {
   const { used, max } = getRaidRowProgress(row);
   const staleSuffix = row.staleSnapshot ? " - :hourglass:" : "";
 
-  if (!row.snapshot.raidActive) {
-    return `clan capital raids: ${used}/${max} - not active${staleSuffix}`;
+  if (row.snapshot.raidActive && !row.raidClanTracked) {
+    return `started raids in unknown clan${staleSuffix}`;
   }
-  return `clan capital raids: ${used}/${max}${staleSuffix}`;
+  return `${used} / ${max}${staleSuffix}`;
 }
 
 /** Purpose: compute stable RAIDS used/max progress and completion flag for row marker decisions. */

--- a/src/services/TodoSnapshotService.ts
+++ b/src/services/TodoSnapshotService.ts
@@ -291,17 +291,27 @@ export class TodoSnapshotService {
     const trackedClanTagRows = await prisma.trackedClan.findMany({
       select: { tag: true },
     });
+    const raidTrackedClanTagRows = await listRaidTrackedClanRows();
     const trackedClanTagSet = new Set(
       trackedClanTagRows
         .map((row) => normalizeClanTag(row.tag))
         .filter(Boolean),
     );
+    const raidTrackedClanTagSet = new Set(
+      raidTrackedClanTagRows
+        .map((row) => normalizeClanTag(row.tag))
+        .filter(Boolean),
+    );
+    const trackedRaidClanTagSet = new Set([
+      ...trackedClanTagSet,
+      ...raidTrackedClanTagSet,
+    ]);
 
     const trackedPlayerTags: string[] = [];
     const nonTrackedPlayerTags: string[] = [];
     for (const playerTag of activatedPlayerTags) {
       const clanTag = snapshotClanTagByPlayerTag.get(playerTag) ?? null;
-      if (clanTag && trackedClanTagSet.has(clanTag)) {
+      if (clanTag && trackedRaidClanTagSet.has(clanTag)) {
         trackedPlayerTags.push(playerTag);
       } else {
         nonTrackedPlayerTags.push(playerTag);
@@ -647,6 +657,15 @@ export class TodoSnapshotService {
         ] as const)
         .filter((entry): entry is [string, string] => Boolean(entry[0] && entry[1])),
     );
+    const raidTrackedClanRows = await listRaidTrackedClanRows();
+    const raidTrackedClanNameByTag = new Map(
+      raidTrackedClanRows
+        .map((row) => [
+          normalizeClanTag(row.tag),
+          sanitizeDisplayText(String(row.name ?? "")),
+        ] as const)
+        .filter((entry): entry is [string, string] => Boolean(entry[0] && entry[1])),
+    );
     const currentWarByClanTag = pickLatestCurrentWarByClanTag(currentWarRows);
     const trackedClanTagSet = new Set(
       trackedClanRows
@@ -797,6 +816,7 @@ export class TodoSnapshotService {
       const resolvedClanTag = resolvedClanTagByPlayerTag.get(playerTag) ?? null;
       const resolvedClanName =
         (resolvedClanTag ? trackedClanNameByTag.get(resolvedClanTag) : null) ||
+        (resolvedClanTag ? raidTrackedClanNameByTag.get(resolvedClanTag) : null) ||
         sanitizeDisplayText(existing?.clanName ?? "") ||
         null;
       const activeMappedCwlClanTag =
@@ -1049,6 +1069,16 @@ export function resolveClanGamesCycleBoundaryFromCycleKey(input: unknown): {
     cycleStart.getUTCFullYear(),
     cycleStart.getUTCMonth(),
   );
+}
+
+/** Purpose: load the currently stored RAID-tracked clan rows for snapshot scope decisions. */
+async function listRaidTrackedClanRows(): Promise<Array<{ tag: string; name: string | null }>> {
+  return prisma.raidTrackedClan.findMany({
+    select: {
+      tag: true,
+      name: true,
+    },
+  });
 }
 
 /** Purpose: normalize potentially-empty cycle-key input into nullable stable string. */

--- a/tests/todo.command.test.ts
+++ b/tests/todo.command.test.ts
@@ -27,6 +27,9 @@ const prismaMock = vi.hoisted(() => ({
   trackedClan: {
     findMany: vi.fn(),
   },
+  raidTrackedClan: {
+    findMany: vi.fn(),
+  },
   cwlTrackedClan: {
     findMany: vi.fn(),
   },
@@ -298,6 +301,7 @@ describe("/todo command", () => {
     prismaMock.currentWar.findMany.mockReset();
     prismaMock.warAttacks.findMany.mockReset();
     prismaMock.trackedClan.findMany.mockReset();
+    prismaMock.raidTrackedClan.findMany.mockReset();
     prismaMock.cwlTrackedClan.findMany.mockReset();
     prismaMock.currentCwlRound.findMany.mockReset();
     prismaMock.cwlRoundMemberCurrent.findMany.mockReset();
@@ -327,6 +331,9 @@ describe("/todo command", () => {
     prismaMock.currentWar.findMany.mockResolvedValue([]);
     prismaMock.warAttacks.findMany.mockResolvedValue([]);
     prismaMock.trackedClan.findMany.mockResolvedValue([]);
+    prismaMock.raidTrackedClan.findMany.mockResolvedValue([
+      { tag: "#PQL0289" },
+    ]);
     prismaMock.cwlTrackedClan.findMany.mockResolvedValue([]);
     prismaMock.currentCwlRound.findMany = vi.fn(async () => []);
     prismaMock.cwlRoundMemberCurrent.findMany = vi.fn(async () => []);
@@ -461,10 +468,15 @@ describe("/todo command", () => {
       _max: { updatedAt: new Date("2026-03-26T00:00:00.000Z") },
     });
     prismaMock.todoPlayerSnapshot.findMany.mockResolvedValue([
-      makeSnapshotRow({
+      (() => {
+        const row = makeSnapshotRow({
         playerTag: "#PYLQ0289",
         playerName: "Alpha",
-      }),
+        }) as any;
+        row.lastUpdatedAt = null;
+        row.updatedAt = null;
+        return row;
+      })(),
     ]);
     const interaction = makeTodoInteraction({ type: "WAR" });
 
@@ -547,12 +559,13 @@ describe("/todo command", () => {
       _count: { _all: 1 },
       _max: { updatedAt: null },
     });
-    prismaMock.todoPlayerSnapshot.findMany.mockResolvedValue([
-      makeSnapshotRow({
-        playerTag: "#PYLQ0289",
-        playerName: "Alpha",
-      }),
-    ]);
+    const unknownSnapshot = makeSnapshotRow({
+      playerTag: "#PYLQ0289",
+      playerName: "Alpha",
+    }) as any;
+    unknownSnapshot.lastUpdatedAt = null;
+    unknownSnapshot.updatedAt = null;
+    prismaMock.todoPlayerSnapshot.findMany.mockResolvedValue([unknownSnapshot]);
     prismaMock.currentWar.findMany.mockResolvedValue([]);
     prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue([]);
     prismaMock.fwaPlayerCatalog.findMany.mockResolvedValue([]);
@@ -1612,7 +1625,7 @@ describe("/todo command", () => {
 
     const description = getReplyDescription(interaction);
     expectTodoLegendWithLastUpdated(description);
-    expect(description).toContain("Alpha #PYLQ0289 - clan capital raids: 3/6");
+    expect(description).toContain(":yellow_circle: Alpha - 3 / 6");
   });
 
   it("uses safe #? fallback when war lineup position is unavailable", async () => {
@@ -2437,6 +2450,8 @@ describe("/todo command", () => {
       makeSnapshotRow({
         playerTag: "#LQ9P8R2",
         playerName: "Charlie",
+        clanTag: "#NONT",
+        clanName: "Unknown Clan",
         raidActive: true,
         raidAttacksUsed: 0,
         raidEndsAt: new Date("2026-03-29T07:00:00.000Z"),
@@ -2490,9 +2505,9 @@ describe("/todo command", () => {
     expectTodoLegendWithLastUpdated(description);
     expect(description).toContain("**Time remaining:** <t:");
     expect(countOccurrences(description, "<t:")).toBe(2);
-    expect(description).toContain(":white_check_mark: Alpha #PYLQ0289 - clan capital raids: 6/6");
-    expect(description).toContain(":yellow_circle: Bravo #QGRJ2222 - clan capital raids: 1/6");
-    expect(description).toContain(":black_circle: Charlie #LQ9P8R2 - clan capital raids: 0/6");
+    expect(description).toContain(":white_check_mark: Alpha - 6 / 6");
+    expect(description).toContain(":yellow_circle: Bravo - 1 / 6");
+    expect(description).toContain(":black_circle: Charlie - started raids in unknown clan");
   });
 
   it("sorts RAIDS rows by attacks used desc, then TH desc, then deterministic fallback order", async () => {
@@ -2563,10 +2578,10 @@ describe("/todo command", () => {
     await Todo.run({} as any, interaction as any, makeCocServiceSpy() as any);
 
     const description = getReplyDescription(interaction);
-    const indexDelta = description.indexOf("Delta #PQQQ0000 - clan capital raids: 3/6");
-    const indexCharlie = description.indexOf("Charlie #PYLL0002 - clan capital raids: 3/6");
-    const indexBravo = description.indexOf("Bravo #QGRJ2008 - clan capital raids: 3/6");
-    const indexAlpha = description.indexOf("Alpha #CUV9900 - clan capital raids: 1/6");
+    const indexDelta = description.indexOf("Delta - 3 / 6");
+    const indexCharlie = description.indexOf("Charlie - 3 / 6");
+    const indexBravo = description.indexOf("Bravo - 3 / 6");
+    const indexAlpha = description.indexOf("Alpha - 1 / 6");
 
     expect(indexDelta).toBeGreaterThan(-1);
     expect(indexCharlie).toBeGreaterThan(-1);
@@ -3007,10 +3022,12 @@ describe("/todo pagination buttons", () => {
     prismaMock.currentWar.findMany.mockReset();
     prismaMock.warAttacks.findMany.mockReset();
     prismaMock.trackedClan.findMany.mockReset();
+    prismaMock.raidTrackedClan.findMany.mockReset();
     prismaMock.cwlTrackedClan.findMany.mockReset();
     prismaMock.cwlPlayerClanSeason.findMany.mockReset();
     prismaMock.cwlPlayerClanSeason.upsert.mockReset();
     prismaMock.botSetting.findMany.mockReset();
+    prismaMock.raidTrackedClan.findMany.mockResolvedValue([]);
 
     prismaMock.playerLink.findMany.mockResolvedValue([
       { playerTag: "#PYLQ0289", createdAt: new Date("2026-03-01T00:00:00.000Z") },
@@ -3046,6 +3063,9 @@ describe("/todo pagination buttons", () => {
     prismaMock.currentWar.findMany.mockResolvedValue([]);
     prismaMock.warAttacks.findMany.mockResolvedValue([]);
     prismaMock.trackedClan.findMany.mockResolvedValue([]);
+    prismaMock.raidTrackedClan.findMany.mockResolvedValue([
+      { tag: "#PQL0289" },
+    ]);
     prismaMock.cwlTrackedClan.findMany.mockResolvedValue([]);
     prismaMock.cwlPlayerClanSeason.findMany.mockResolvedValue([]);
     prismaMock.cwlPlayerClanSeason.upsert.mockResolvedValue(undefined);
@@ -3062,7 +3082,7 @@ describe("/todo pagination buttons", () => {
     const checks: Array<{ type: TodoType; contains: string }> = [
       { type: "WAR", contains: "No war active" },
       { type: "CWL", contains: "CWL Status:" },
-      { type: "RAIDS", contains: "clan capital raids:" },
+      { type: "RAIDS", contains: "Alpha - 3 / 6" },
       { type: "GAMES", contains: "clan games points:" },
     ];
 
@@ -3316,7 +3336,18 @@ describe("/todo pagination buttons", () => {
       discordUserId,
       cocService: makeCocServiceSpy() as any,
     });
-    expectTodoPagesLastUpdatedAt(refreshedPages.pages, secondRefreshAt);
+    expect(refreshedPages.pages.RAIDS).toContain(
+      `:hourglass: last updated <t:${Math.floor(firstRefreshAt.getTime() / 1000)}:R>`,
+    );
+    expect(refreshedPages.pages.WAR).toContain(
+      `:hourglass: last updated <t:${Math.floor(secondRefreshAt.getTime() / 1000)}:R>`,
+    );
+    expect(refreshedPages.pages.CWL).toContain(
+      `:hourglass: last updated <t:${Math.floor(secondRefreshAt.getTime() / 1000)}:R>`,
+    );
+    expect(refreshedPages.pages.GAMES).toContain(
+      `:hourglass: last updated <t:${Math.floor(secondRefreshAt.getTime() / 1000)}:R>`,
+    );
   });
 
   it("rejects button interactions from non-requesting users", async () => {
@@ -3368,6 +3399,7 @@ describe("/todo refresh button", () => {
     prismaMock.currentWar.findMany.mockReset();
     prismaMock.warAttacks.findMany.mockReset();
     prismaMock.trackedClan.findMany.mockReset();
+    prismaMock.raidTrackedClan.findMany.mockReset();
     prismaMock.cwlTrackedClan.findMany.mockReset();
     prismaMock.cwlPlayerClanSeason.findMany.mockReset();
     prismaMock.cwlPlayerClanSeason.upsert.mockReset();
@@ -3414,6 +3446,7 @@ describe("/todo refresh button", () => {
     prismaMock.currentWar.findMany.mockResolvedValue([]);
     prismaMock.warAttacks.findMany.mockResolvedValue([]);
     prismaMock.trackedClan.findMany.mockResolvedValue([]);
+    prismaMock.raidTrackedClan.findMany.mockResolvedValue([]);
     prismaMock.cwlTrackedClan.findMany.mockResolvedValue([]);
     prismaMock.cwlPlayerClanSeason.findMany.mockResolvedValue([]);
     prismaMock.cwlPlayerClanSeason.upsert.mockResolvedValue(undefined);
@@ -3483,6 +3516,83 @@ describe("/todo refresh button", () => {
       type: "GAMES",
     });
     expect(interaction.followUp).not.toHaveBeenCalled();
+  });
+
+  it("refreshes RAID snapshot freshness metadata coherently after a manual refresh", async () => {
+    const refreshedAt = new Date("2026-03-26T01:00:00.000Z");
+    const snapshotRows = [
+      makeSnapshotRow({
+        playerTag: "#PYLQ0289",
+        playerName: "Alpha",
+        raidActive: true,
+        raidAttacksUsed: 3,
+        updatedAt: new Date("2026-03-25T10:00:00.000Z"),
+        lastUpdatedAt: new Date("2026-03-25T10:00:00.000Z"),
+      }),
+      makeSnapshotRow({
+        playerTag: "#QGRJ2222",
+        playerName: "Bravo",
+        raidActive: true,
+        raidAttacksUsed: 0,
+        updatedAt: new Date("2026-03-25T10:00:00.000Z"),
+        lastUpdatedAt: new Date("2026-03-25T10:00:00.000Z"),
+      }),
+    ];
+
+    vi.spyOn(cwlStateService, "refreshTrackedCwlStateForPlayerTags").mockResolvedValue({
+      season: "2026-03",
+      trackedClanCount: 0,
+      refreshedClanCount: 0,
+      currentRoundCount: 0,
+      currentMemberCount: 0,
+      historyRoundCount: 0,
+      historyMemberCount: 0,
+    });
+    prismaMock.raidTrackedClan.findMany.mockResolvedValue([
+      { tag: "#PQL0289" },
+    ]);
+    prismaMock.todoPlayerSnapshot.aggregate.mockImplementation(async () => ({
+      _count: { _all: snapshotRows.length },
+      _max: {
+        updatedAt: snapshotRows.reduce(
+          (max, row) => (row.updatedAt > max ? row.updatedAt : max),
+          snapshotRows[0].updatedAt,
+        ),
+      },
+    }));
+    prismaMock.todoPlayerSnapshot.findMany.mockImplementation(async () => snapshotRows);
+
+    vi.spyOn(todoSnapshotService, "refreshSnapshotsForPlayerTags").mockImplementation(
+      async () => {
+        for (const row of snapshotRows) {
+          row.updatedAt = refreshedAt;
+          row.lastUpdatedAt = refreshedAt;
+        }
+        return { playerCount: snapshotRows.length, updatedCount: snapshotRows.length };
+      },
+    );
+
+    const interaction = makeTodoButtonInteraction({
+      customId: buildTodoRefreshButtonCustomId({
+        guildScopeId: "123456789012345678",
+        requesterUserId: "111111111111111111",
+        targetUserId: "111111111111111111",
+        type: "RAIDS",
+      }),
+      userId: "111111111111111111",
+      guildId: "123456789012345678",
+    });
+
+    await handleTodoRefreshButtonInteraction(interaction as any, makeCocServiceSpy() as any);
+
+    expect(interaction.editReply).toHaveBeenCalledTimes(1);
+    const payload = interaction.editReply.mock.calls[0]?.[0] as any;
+    const description = String(payload.embeds[0].toJSON().description ?? "");
+    expect(description).toContain(":hourglass: last updated <t:");
+    expect(description).toContain(
+      `<t:${Math.floor(refreshedAt.getTime() / 1000)}:R>`,
+    );
+    expect(description).toContain(":yellow_circle: Alpha - 3 / 6");
   });
 
   it("uses no-linked-tags behavior when the target user has no links", async () => {

--- a/tests/todoSnapshot.service.test.ts
+++ b/tests/todoSnapshot.service.test.ts
@@ -38,6 +38,9 @@ const prismaMock = vi.hoisted(() => ({
   trackedClan: {
     findMany: vi.fn(),
   },
+  raidTrackedClan: {
+    findMany: vi.fn(),
+  },
   cwlTrackedClan: {
     findMany: vi.fn(),
   },
@@ -172,6 +175,7 @@ describe("TodoSnapshotService", () => {
     prismaMock.trackedClan.findMany.mockResolvedValue([
       { tag: "#PQL0289", name: "Clan One" },
     ]);
+    prismaMock.raidTrackedClan.findMany.mockResolvedValue([]);
     prismaMock.cwlTrackedClan.findMany.mockResolvedValue([
       { tag: "#PQL0289", name: "Clan One" },
     ]);
@@ -865,6 +869,58 @@ describe("TodoSnapshotService", () => {
     expect(result.trackedPlayerCount).toBe(1);
     expect(result.nonTrackedPlayerCount).toBe(1);
     expect(result.selectedPlayerCount).toBe(1);
+  });
+
+  it("hydrates raid-tracked clan names during snapshot refresh", async () => {
+    prismaMock.todoPlayerSnapshot.findMany.mockResolvedValue([
+      buildSnapshotRow({
+        playerTag: "#PYLQ0289",
+        clanTag: "#QGRJ",
+        clanName: null,
+        raidActive: false,
+        raidAttacksUsed: 0,
+      }),
+    ]);
+    prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue([]);
+    prismaMock.fwaWarMemberCurrent.findMany.mockResolvedValue([]);
+    prismaMock.currentWar.findMany.mockResolvedValue([]);
+    prismaMock.trackedClan.findMany.mockResolvedValue([]);
+    prismaMock.raidTrackedClan.findMany.mockResolvedValue([
+      { tag: "#QGRJ", name: "Raid Clan" },
+    ]);
+    prismaMock.cwlTrackedClan.findMany.mockResolvedValue([]);
+    prismaMock.cwlPlayerClanSeason.findMany.mockResolvedValue([]);
+    const cocService = {
+      getPlayerRaw: vi.fn().mockResolvedValue({
+        tag: "#PYLQ0289",
+        clan: { tag: "#QGRJ" },
+      }),
+      getClanCapitalRaidSeasons: vi.fn().mockResolvedValue([
+        {
+          startTime: "20260327T070000.000Z",
+          endTime: "20260330T070000.000Z",
+          members: [{ tag: "#PYLQ0289", attacks: 3 }],
+        },
+      ]),
+    };
+
+    await todoSnapshotService.refreshSnapshotsForPlayerTags({
+      playerTags: ["#PYLQ0289"],
+      cocService: cocService as any,
+      nowMs: Date.UTC(2026, 2, 27, 12, 0, 0, 0),
+    });
+
+    expect(cocService.getClanCapitalRaidSeasons).toHaveBeenCalledWith("#QGRJ", 2);
+    expect(prismaMock.todoPlayerSnapshot.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({
+          clanTag: "#QGRJ",
+          clanName: "Raid Clan",
+          raidActive: true,
+          raidAttacksUsed: 3,
+        }),
+      }),
+    );
   });
 
   it("refreshes activated users' non-tracked-clan players in the observe cadence", async () => {


### PR DESCRIPTION
- render compact RAID rows with unknown-clan fallback
- include raid-tracked clans in snapshot refresh and freshness tracking