### PR TITLE
fix(todo): preserve raid attacks from tracked raid clans

### DIFF
--- a/src/services/TodoSnapshotService.ts
+++ b/src/services/TodoSnapshotService.ts
@@ -803,7 +803,10 @@ export class TodoSnapshotService {
       await loadLiveRaidAttacksUsedByPlayerTag({
         cocService: input.cocService,
         raidWindow,
-        resolvedClanTagByPlayerTag,
+        primaryClanTagByPlayerTag: resolvedClanTagByPlayerTag,
+        fallbackClanTags: raidTrackedClanRows
+          .map((row) => normalizeClanTag(row.clanTag))
+          .filter(Boolean),
       });
 
     const snapshotUpserts: Array<
@@ -1734,7 +1737,8 @@ async function loadLiveClanTagsByPlayerTag(input: {
 async function loadLiveRaidAttacksUsedByPlayerTag(input: {
   cocService?: CoCService;
   raidWindow: TodoWindow;
-  resolvedClanTagByPlayerTag: Map<string, string | null>;
+  primaryClanTagByPlayerTag: Map<string, string | null>;
+  fallbackClanTags: string[];
 }): Promise<Map<string, number>> {
   if (
     !input.raidWindow.active ||
@@ -1744,20 +1748,22 @@ async function loadLiveRaidAttacksUsedByPlayerTag(input: {
     return new Map();
   }
 
-  const playerTagsByClanTag = new Map<string, string[]>();
-  for (const [playerTag, clanTag] of input.resolvedClanTagByPlayerTag.entries()) {
-    if (!clanTag) continue;
-    const existing = playerTagsByClanTag.get(clanTag);
-    if (existing) {
-      existing.push(playerTag);
-      continue;
-    }
-    playerTagsByClanTag.set(clanTag, [playerTag]);
+  const primaryClanTagsByPlayerTag = new Map<string, string | null>();
+  for (const [playerTag, clanTag] of input.primaryClanTagByPlayerTag.entries()) {
+    primaryClanTagsByPlayerTag.set(playerTag, clanTag ? normalizeClanTag(clanTag) || null : null);
   }
-  if (playerTagsByClanTag.size <= 0) return new Map();
+
+  const clanTags = [
+    ...new Set(
+      [
+        ...primaryClanTagsByPlayerTag.values(),
+        ...input.fallbackClanTags.map((tag) => normalizeClanTag(tag)).filter(Boolean),
+      ].filter((value): value is string => Boolean(value)),
+    ),
+  ];
+  if (clanTags.length <= 0) return new Map();
 
   const attacksByPlayerTag = new Map<string, number>();
-  const clanTags = [...playerTagsByClanTag.keys()];
   const clanMemberMaps = await Promise.all(
     clanTags.map(async (clanTag) => {
       const seasons = await input.cocService!
@@ -1778,14 +1784,23 @@ async function loadLiveRaidAttacksUsedByPlayerTag(input: {
   );
   const memberAttacksByClanTag = new Map(clanMemberMaps);
 
-  for (const [clanTag, playerTags] of playerTagsByClanTag.entries()) {
-    const memberAttacksByTag = memberAttacksByClanTag.get(clanTag) ?? new Map<string, number>();
-    for (const playerTag of playerTags) {
-      attacksByPlayerTag.set(
-        playerTag,
-        clampInt(memberAttacksByTag.get(playerTag), 0, 6),
-      );
+  const fallbackClanTags = input.fallbackClanTags
+    .map((tag) => normalizeClanTag(tag))
+    .filter(Boolean);
+  for (const [playerTag, primaryClanTag] of primaryClanTagsByPlayerTag.entries()) {
+    const primaryAttacks =
+      primaryClanTag !== null
+        ? clampInt(memberAttacksByClanTag.get(primaryClanTag)?.get(playerTag), 0, 6)
+        : 0;
+    if (primaryAttacks > 0) {
+      attacksByPlayerTag.set(playerTag, primaryAttacks);
+      continue;
     }
+
+    const fallbackAttacks = fallbackClanTags
+      .map((clanTag) => clampInt(memberAttacksByClanTag.get(clanTag)?.get(playerTag), 0, 6))
+      .find((attacks) => attacks > 0);
+    attacksByPlayerTag.set(playerTag, fallbackAttacks ?? primaryAttacks);
   }
 
   return attacksByPlayerTag;

--- a/tests/todoSnapshot.service.test.ts
+++ b/tests/todoSnapshot.service.test.ts
@@ -923,6 +923,77 @@ describe("TodoSnapshotService", () => {
     );
   });
 
+  it("falls back to tracked raid clans when current clan returns zero raid attacks", async () => {
+    prismaMock.todoPlayerSnapshot.findMany.mockResolvedValue([
+      buildSnapshotRow({
+        playerTag: "#G2RG9JCRL",
+        clanTag: "#2RYGLU2UY",
+        clanName: "Tracked FWA",
+        raidActive: false,
+        raidAttacksUsed: 0,
+      }),
+    ]);
+    prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue([
+      {
+        playerTag: "#G2RG9JCRL",
+        clanTag: "#2RYGLU2UY",
+        playerName: "Gamma",
+        sourceSyncedAt: new Date("2026-03-26T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.fwaWarMemberCurrent.findMany.mockResolvedValue([]);
+    prismaMock.currentWar.findMany.mockResolvedValue([]);
+    prismaMock.trackedClan.findMany.mockResolvedValue([
+      { tag: "#2RYGLU2UY", name: "Tracked FWA" },
+    ]);
+    prismaMock.raidTrackedClan.findMany.mockResolvedValue([
+      { clanTag: "#QGRJ", name: "Raid Clan" },
+    ]);
+    prismaMock.cwlTrackedClan.findMany.mockResolvedValue([]);
+    prismaMock.cwlPlayerClanSeason.findMany.mockResolvedValue([]);
+    const cocService = {
+      getPlayerRaw: vi.fn().mockResolvedValue({
+        tag: "#G2RG9JCRL",
+        clan: { tag: "#2RYGLU2UY" },
+      }),
+      getClanCapitalRaidSeasons: vi.fn().mockImplementation(async (clanTag: string) => {
+        if (clanTag === "#QGRJ") {
+          return [
+            {
+              startTime: "20260327T070000.000Z",
+              endTime: "20260330T070000.000Z",
+              members: [{ tag: "#G2RG9JCRL", attacks: 1 }],
+            },
+          ];
+        }
+        return [
+          {
+            startTime: "20260327T070000.000Z",
+            endTime: "20260330T070000.000Z",
+            members: [],
+          },
+        ];
+      }),
+    };
+
+    await todoSnapshotService.refreshSnapshotsForPlayerTags({
+      playerTags: ["#G2RG9JCRL"],
+      cocService: cocService as any,
+      nowMs: Date.UTC(2026, 2, 27, 12, 0, 0, 0),
+    });
+
+    expect(cocService.getClanCapitalRaidSeasons).toHaveBeenCalledWith("#2RYGLU2UY", 2);
+    expect(cocService.getClanCapitalRaidSeasons).toHaveBeenCalledWith("#QGRJ", 2);
+    expect(prismaMock.todoPlayerSnapshot.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({
+          raidActive: true,
+          raidAttacksUsed: 1,
+        }),
+      }),
+    );
+  });
+
   it("refreshes activated users' non-tracked-clan players in the observe cadence", async () => {
     prismaMock.playerLink.findMany.mockResolvedValue([
       { discordUserId: "111111111111111111", playerTag: "#PYLQ0289" },


### PR DESCRIPTION
- fall back to tracked raid clans when current clan resolves to zero attacks
- add regression coverage for current-clan mismatch raid refreshes