### PR TITLE
feat(compo): add matchrate lines to advice output

### DIFF
--- a/src/commands/Compo.ts
+++ b/src/commands/Compo.ts
@@ -1,4 +1,4 @@
-import {
+﻿import {
   ActionRowBuilder,
   APIActionRowComponent,
   APIComponentInMessageActionRow,
@@ -19,6 +19,10 @@ import type { HeatMapRef } from "@prisma/client";
 import {
   COMPO_ADVICE_VIEW_LABELS,
   COMPO_ADVICE_VIEWS,
+  COMPO_ADVICE_DEVIATION_PENALTY_CONSTANT,
+  estimateMatchrateFromDeviation,
+  formatMatchratePercent,
+  getAdjacentHeatMapRefs,
   stepCompoAdviceCustomBandIndexByCount,
   type CompoAdviceView,
 } from "../helper/compoAdviceEngine";
@@ -30,6 +34,7 @@ import {
 import {
   buildHeatMapRefDisplayRows,
 } from "../helper/heatMapRefDisplay";
+import { formatHeatMapRefBandLabel, getHeatMapRefBandKey } from "../helper/compoHeatMap";
 import { formatError } from "../helper/formatError";
 import { getCompoWarDisplayBucket } from "../helper/compoWarWeightBuckets";
 import { normalizeCompoClanDisplayName } from "../helper/compoDisplay";
@@ -1108,6 +1113,17 @@ function buildCompoAdviceFooterText(refreshLine: string | null): string {
   return refreshLine ? `${refreshLine} • ${note}` : note;
 }
 
+function getCompoAdviceBandMatchrate(input: {
+  summary: Extract<CompoAdviceReadResult, { kind: "ready" }>["summary"];
+  heatMapRef: HeatMapRef | null;
+}): number | null {
+  if (!input.heatMapRef) {
+    return null;
+  }
+  const bandKey = getHeatMapRefBandKey(input.heatMapRef);
+  return input.summary.bandMatchRatesByBandKey?.get(bandKey) ?? null;
+}
+
 async function buildCompoAdviceEmbed(input: {
   advice: CompoAdviceReadResult;
   client: Client;
@@ -1119,6 +1135,25 @@ async function buildCompoAdviceEmbed(input: {
   if (input.advice.kind === "ready") {
     const summary = input.advice.summary;
     const embed = new EmbedBuilder().setTitle(title);
+    const selectedHeatMapRef = summary.currentProjection.selectedHeatMapRef;
+    const selectedBandMatchrate = getCompoAdviceBandMatchrate({
+      summary,
+      heatMapRef: selectedHeatMapRef,
+    });
+    const currentMatchrate = estimateMatchrateFromDeviation({
+      bandMatchrate: selectedBandMatchrate,
+      deviationScore: summary.currentScore,
+      penaltyConstant: COMPO_ADVICE_DEVIATION_PENALTY_CONSTANT,
+    });
+    const resultingMatchrate = estimateMatchrateFromDeviation({
+      bandMatchrate: selectedBandMatchrate,
+      deviationScore: summary.resultingScore,
+      penaltyConstant: COMPO_ADVICE_DEVIATION_PENALTY_CONSTANT,
+    });
+    const adjacentBands = getAdjacentHeatMapRefs({
+      heatMapRefs: summary.heatMapRefs,
+      selectedHeatMapRef,
+    });
     const currentDeltas = [
       `TH18: ${formatSignedValue(summary.currentProjection.deltaByBucket.TH18)}`,
       `TH17: ${formatSignedValue(summary.currentProjection.deltaByBucket.TH17)}`,
@@ -1142,14 +1177,17 @@ async function buildCompoAdviceEmbed(input: {
       [
         `Current Weight: ${formatCompoAdviceFullWeight(summary.currentWeight)}`,
         `Current Deviation Score: **${formatAdviceScore(summary.currentScore)}**`,
+        `Matchrate: ${formatMatchratePercent(currentMatchrate)}`,
       ].join("\n"),
     );
     const targetValue = await renderCompoAdviceEmojiShortcodes(
       input.client,
       [
         `Target Band: **${summary.currentBandLabel}**`,
+        `Perfect compo matchrate: ${formatMatchratePercent(selectedBandMatchrate)}`,
         `Distance to Midpoint: ${formatCompoAdviceDistanceToMidpoint(summary)}`,
         `Resulting Deviation Score: **${formatAdviceScore(summary.resultingScore)}**`,
+        `Matchrate: ${formatMatchratePercent(resultingMatchrate)}`,
       ].join("\n"),
     );
     const recommendationValue = await renderCompoAdviceEmojiShortcodes(
@@ -1160,6 +1198,29 @@ async function buildCompoAdviceEmbed(input: {
       ]
         .filter((line): line is string => line !== null)
         .join("\n"),
+    );
+    const adjacentBandsValue = await renderCompoAdviceEmojiShortcodes(
+      input.client,
+      [
+        `Lower band: ${
+          adjacentBands.lower ? `**${formatHeatMapRefBandLabel(adjacentBands.lower)}**` : "N/A"
+        }`,
+        `Matchrate: ${formatMatchratePercent(
+          getCompoAdviceBandMatchrate({
+            summary,
+            heatMapRef: adjacentBands.lower,
+          }),
+        )}`,
+        `Higher band: ${
+          adjacentBands.higher ? `**${formatHeatMapRefBandLabel(adjacentBands.higher)}**` : "N/A"
+        }`,
+        `Matchrate: ${formatMatchratePercent(
+          getCompoAdviceBandMatchrate({
+            summary,
+            heatMapRef: adjacentBands.higher,
+          }),
+        )}`,
+      ].join("\n"),
     );
 
     embed.addFields(
@@ -1186,6 +1247,11 @@ async function buildCompoAdviceEmbed(input: {
       {
         name: "Current Deltas",
         value: currentDeltas,
+        inline: false,
+      },
+      {
+        name: "Adjacent Bands",
+        value: adjacentBandsValue,
         inline: false,
       },
     );
@@ -1222,17 +1288,17 @@ async function buildCompoAdviceResponsePayload(input: {
 /*
   const recommendedRows = params.recommended.map(
     (c) =>
-      `${abbreviateClan(normalizeCompoClanDisplayName(c.clanName))} â€” needs ${Math.abs(c.delta)} ${params.bucket}`,
+      `${abbreviateClan(normalizeCompoClanDisplayName(c.clanName))} Ã¢â‚¬â€ needs ${Math.abs(c.delta)} ${params.bucket}`,
   );
   const vacancyRows = params.vacancyList.map(
     (c) =>
-      `${abbreviateClan(normalizeCompoClanDisplayName(c.clanName))} â€” ${
+      `${abbreviateClan(normalizeCompoClanDisplayName(c.clanName))} Ã¢â‚¬â€ ${
         c.liveMemberCount !== null ? `${c.liveMemberCount}/50` : "unknown/50"
       }`,
   );
   const compositionRows = params.compositionList.map(
     (c) =>
-      `${abbreviateClan(normalizeCompoClanDisplayName(c.clanName))} â€” ${c.delta}`,
+      `${abbreviateClan(normalizeCompoClanDisplayName(c.clanName))} Ã¢â‚¬â€ ${c.delta}`,
   );
 
   return new EmbedBuilder()

--- a/src/helper/compoAdviceEngine.ts
+++ b/src/helper/compoAdviceEngine.ts
@@ -63,6 +63,8 @@ export const COMPO_ADVICE_VIEW_LABELS: Record<CompoAdviceView, string> = {
   custom: "Custom",
 };
 
+export const COMPO_ADVICE_DEVIATION_PENALTY_CONSTANT = 0.0018;
+
 export type CompoAdviceAction =
   | {
       kind: "add";
@@ -93,6 +95,8 @@ export type CompoAdviceSummary = {
   view: CompoAdviceView;
   viewLabel: string;
   currentProjection: CompoActualStateProjection;
+  heatMapRefs: readonly HeatMapRef[];
+  bandMatchRatesByBandKey?: ReadonlyMap<string, number | null>;
   currentWeight: number | null;
   targetBandMidpoint: number | null;
   currentScore: number | null;
@@ -122,6 +126,43 @@ function formatFullWeight(value: number | null | undefined): string {
     return "unknown";
   }
   return Math.trunc(value).toLocaleString("en-US");
+}
+
+function normalizeMatchrate(value: number | null | undefined): number | null {
+  if (value === null || value === undefined || !Number.isFinite(value)) {
+    return null;
+  }
+
+  const normalized = Math.abs(value) > 1 ? value / 100 : value;
+  return Math.max(0, Math.min(1, normalized));
+}
+
+export function formatMatchratePercent(value: number | null | undefined): string {
+  const normalized = normalizeMatchrate(value);
+  return normalized === null ? "Unknown" : `${(normalized * 100).toFixed(2)}%`;
+}
+
+export function estimateMatchrateFromDeviation(input: {
+  bandMatchrate: number | null | undefined;
+  deviationScore: number | null | undefined;
+  penaltyConstant?: number;
+}): number | null {
+  if (
+    input.deviationScore === null ||
+    input.deviationScore === undefined ||
+    !Number.isFinite(input.deviationScore)
+  ) {
+    return null;
+  }
+
+  const bandMatchrate = normalizeMatchrate(input.bandMatchrate);
+  if (bandMatchrate === null) {
+    return null;
+  }
+
+  const penaltyConstant = input.penaltyConstant ?? COMPO_ADVICE_DEVIATION_PENALTY_CONSTANT;
+  const estimated = bandMatchrate - input.deviationScore * penaltyConstant;
+  return Math.max(0, Math.min(1, estimated));
 }
 
 function formatCompactWeight(value: number | null | undefined): string {
@@ -165,6 +206,42 @@ export function formatSignedCompoAdviceDelta(delta: number | null | undefined): 
 
 function getBandLabel(ref: HeatMapRef | null): string {
   return ref ? formatHeatMapRefBandLabel(ref) : "(no band)";
+}
+
+export function getAdjacentHeatMapRefs(input: {
+  heatMapRefs: readonly HeatMapRef[];
+  selectedHeatMapRef: HeatMapRef | null;
+}): {
+  lower: HeatMapRef | null;
+  higher: HeatMapRef | null;
+} {
+  if (!input.selectedHeatMapRef || input.heatMapRefs.length === 0) {
+    return { lower: null, higher: null };
+  }
+
+  const selectedKey = getHeatMapRefBandKey(input.selectedHeatMapRef);
+  const index = input.heatMapRefs.findIndex(
+    (ref) => getHeatMapRefBandKey(ref) === selectedKey,
+  );
+  if (index < 0) {
+    return { lower: null, higher: null };
+  }
+
+  return {
+    lower: index > 0 ? input.heatMapRefs[index - 1] ?? null : null,
+    higher: index < input.heatMapRefs.length - 1 ? input.heatMapRefs[index + 1] ?? null : null,
+  };
+}
+
+function getBandMatchrate(input: {
+  summary: Pick<CompoAdviceSummary, "currentProjection" | "bandMatchRatesByBandKey">;
+  heatMapRef: HeatMapRef | null;
+}): number | null {
+  if (!input.heatMapRef) {
+    return null;
+  }
+  const bandKey = getHeatMapRefBandKey(input.heatMapRef);
+  return input.summary.bandMatchRatesByBandKey?.get(bandKey) ?? null;
 }
 
 function getDisplayBucketPriority(bucket: CompoWarDisplayBucket): number {
@@ -648,6 +725,7 @@ export function evaluateCompoAdvice(input: {
     view: input.view,
     viewLabel: COMPO_ADVICE_VIEW_LABELS[input.view],
     currentProjection,
+    heatMapRefs: projectionState.heatMapRefs,
     currentWeight,
     targetBandMidpoint,
     currentScore,
@@ -681,6 +759,19 @@ export function buildCompoAdviceContentLines(input: {
   lines.push(`Current Deviation Score: **${formatScore(input.summary.currentScore)}**`);
   lines.push(`Target Band: **${input.summary.currentBandLabel}**`);
   lines.push(`Current Weight: ${formatFullWeight(input.summary.currentWeight)}`);
+  const currentMatchrate = estimateMatchrateFromDeviation({
+    bandMatchrate: getBandMatchrate({
+      summary: input.summary,
+      heatMapRef: input.summary.currentProjection.selectedHeatMapRef,
+    }),
+    deviationScore: input.summary.currentScore,
+  });
+  lines.push(`Matchrate: ${formatMatchratePercent(currentMatchrate)}`);
+  const perfectMatchrate = getBandMatchrate({
+    summary: input.summary,
+    heatMapRef: input.summary.currentProjection.selectedHeatMapRef,
+  });
+  lines.push(`Perfect compo matchrate: ${formatMatchratePercent(perfectMatchrate)}`);
   lines.push(
     `Distance to Midpoint: ${formatSignedCompoAdviceDelta(
       input.summary.currentWeight === null || input.summary.targetBandMidpoint === null
@@ -690,6 +781,38 @@ export function buildCompoAdviceContentLines(input: {
   );
   lines.push(`Recommendation: :arrow_arrow: __${input.summary.recommendationText}__`);
   lines.push(`Resulting Deviation Score: **${formatScore(input.summary.resultingScore)}**`);
+  const resultingMatchrate = estimateMatchrateFromDeviation({
+    bandMatchrate: getBandMatchrate({
+      summary: input.summary,
+      heatMapRef: input.summary.currentProjection.selectedHeatMapRef,
+    }),
+    deviationScore: input.summary.resultingScore,
+  });
+  lines.push(`Matchrate: ${formatMatchratePercent(resultingMatchrate)}`);
+  const adjacent = getAdjacentHeatMapRefs({
+    heatMapRefs: input.summary.heatMapRefs,
+    selectedHeatMapRef: input.summary.currentProjection.selectedHeatMapRef,
+  });
+  lines.push(
+    `Lower band: ${
+      adjacent.lower ? `**${formatHeatMapRefBandLabel(adjacent.lower)}**` : "N/A"
+    }`,
+  );
+  lines.push(
+    `Matchrate: ${formatMatchratePercent(
+      getBandMatchrate({ summary: input.summary, heatMapRef: adjacent.lower }),
+    )}`,
+  );
+  lines.push(
+    `Higher band: ${
+      adjacent.higher ? `**${formatHeatMapRefBandLabel(adjacent.higher)}**` : "N/A"
+    }`,
+  );
+  lines.push(
+    `Matchrate: ${formatMatchratePercent(
+      getBandMatchrate({ summary: input.summary, heatMapRef: adjacent.higher }),
+    )}`,
+  );
   if (input.summary.statusText) {
     lines.push(input.summary.statusText);
   }
@@ -744,4 +867,7 @@ export const resolveCustomHeatMapRefForTest = resolveCustomHeatMapRef;
 export const buildCompoAdviceContentLinesForTest = buildCompoAdviceContentLines;
 export const formatFullWeightForTest = formatFullWeight;
 export const formatSignedCompoAdviceDeltaForTest = formatSignedCompoAdviceDelta;
+export const formatMatchratePercentForTest = formatMatchratePercent;
+export const estimateMatchrateFromDeviationForTest = estimateMatchrateFromDeviation;
+export const getAdjacentHeatMapRefsForTest = getAdjacentHeatMapRefs;
 export const resolveAdviceTargetBandMidpointForTest = resolveAdviceTargetBandMidpoint;

--- a/src/services/CompoAdviceService.ts
+++ b/src/services/CompoAdviceService.ts
@@ -10,6 +10,7 @@ import {
 import {
   type CompoActualStateView,
 } from "../helper/compoActualStateView";
+import { HeatMapRefDisplayService } from "./HeatMapRefDisplayService";
 import { normalizeTag } from "./war-events/core";
 import {
   CompoActualStateService,
@@ -191,6 +192,7 @@ function buildEmptyResult(input: {
 export class CompoAdviceService {
   private readonly actualStateService = new CompoActualStateService();
   private readonly warStateService = new CompoWarStateService();
+  private readonly heatMapRefDisplayService = new HeatMapRefDisplayService();
 
   async readAdvice(input: {
     guildId?: string | null;
@@ -273,6 +275,9 @@ export class CompoAdviceService {
               heatMapRefs: context.heatMapRefs,
               view,
             });
+      const bandMatchRatesByBandKey = await this.heatMapRefDisplayService.readHeatMapRefBandMatchRates({
+        heatMapRefs: summary.heatMapRefs,
+      });
       return buildReadyResult({
         mode: input.mode,
         selectedView: view,
@@ -280,7 +285,10 @@ export class CompoAdviceService {
         trackedClanChoices,
         clanTag: clan.clanTag,
         clanName: clan.clanName,
-        summary,
+        summary: {
+          ...summary,
+          bandMatchRatesByBandKey,
+        },
         members: clan.members,
         refreshLine: buildPersistedRefreshLine(context.latestSourceSyncedAt),
       });
@@ -334,6 +342,9 @@ export class CompoAdviceService {
       },
       heatMapRefs: context.heatMapRefs,
     });
+    const bandMatchRatesByBandKey = await this.heatMapRefDisplayService.readHeatMapRefBandMatchRates({
+      heatMapRefs: summary.heatMapRefs,
+    });
     return buildReadyResult({
       mode: input.mode,
       selectedView: view,
@@ -341,7 +352,10 @@ export class CompoAdviceService {
       trackedClanChoices,
       clanTag: clan.clanTag,
       clanName: clan.clanName,
-      summary,
+      summary: {
+        ...summary,
+        bandMatchRatesByBandKey,
+      },
       members: [],
       refreshLine: buildPersistedRefreshLine(context.latestRefreshAt),
     });

--- a/src/services/HeatMapRefDisplayService.ts
+++ b/src/services/HeatMapRefDisplayService.ts
@@ -29,6 +29,11 @@ type HeatMapRefMatchStatsRow = {
   evaluatedWarCount: number;
 };
 
+type HeatMapRefBandMatchRateStats = {
+  matchRate: number | null;
+  evaluatedWarCount: number;
+};
+
 function buildSourceRosters(members: readonly HeatMapRefSourceMember[]): HeatMapRefRebuildSourceRoster[] {
   const byClanTag = new Map<string, HeatMapRefRebuildSourceRoster>();
   for (const member of members) {
@@ -91,6 +96,18 @@ export class HeatMapRefDisplayService {
     return this.buildDisplayData(heatMapRefs);
   }
 
+  async readHeatMapRefBandMatchRates(input?: {
+    heatMapRefs?: readonly HeatMapRef[];
+  }): Promise<ReadonlyMap<string, number | null>> {
+    const heatMapRefs =
+      input?.heatMapRefs ??
+      (await prisma.heatMapRef.findMany({
+        orderBy: [{ weightMinInclusive: "asc" }, { weightMaxInclusive: "asc" }],
+      }));
+    const statsByBandKey = await this.buildMatchRateStatsByBandKey(heatMapRefs);
+    return new Map([...statsByBandKey.entries()].map(([bandKey, stats]) => [bandKey, stats.matchRate]));
+  }
+
   private async buildDisplayData(heatMapRefs: readonly HeatMapRef[]): Promise<{
     rows: string[][];
     copyText: string;
@@ -100,6 +117,33 @@ export class HeatMapRefDisplayService {
         rows: buildHeatMapRefDisplayRows({ heatMapRefs }),
         copyText: buildHeatMapRefCopyText({ heatMapRefs }),
       };
+    }
+
+    const matchRateStatsByBandKey = await this.buildMatchRateStatsByBandKey(heatMapRefs);
+    const matchPercentByBandKey = new Map<string, string>(
+      [...matchRateStatsByBandKey.entries()].map(([bandKey, stats]) => [
+        bandKey,
+        formatMatchPercent(stats.matchRate ?? 0, stats.evaluatedWarCount),
+      ]),
+    );
+
+    return {
+      rows: buildHeatMapRefDisplayRows({
+        heatMapRefs,
+        matchPercentByBandKey,
+      }),
+      copyText: buildHeatMapRefCopyText({
+        heatMapRefs,
+        matchPercentByBandKey,
+      }),
+    };
+  }
+
+  private async buildMatchRateStatsByBandKey(
+    heatMapRefs: readonly HeatMapRef[],
+  ): Promise<ReadonlyMap<string, HeatMapRefBandMatchRateStats>> {
+    if (heatMapRefs.length === 0) {
+      return new Map();
     }
 
     const clanTagRows = await prisma.fwaClanCatalog.findMany({
@@ -170,48 +214,27 @@ export class HeatMapRefDisplayService {
       ]),
     );
 
-    const matchPercentByBandKey = this.buildMatchPercentByBandKeyFromStats({
-      heatMapRefs,
-      contributingTagsByBandKey,
-      statsByClanTag,
-    });
-
-    return {
-      rows: buildHeatMapRefDisplayRows({
-        heatMapRefs,
-        matchPercentByBandKey,
-      }),
-      copyText: buildHeatMapRefCopyText({
-        heatMapRefs,
-        matchPercentByBandKey,
-      }),
-    };
-  }
-
-  private buildMatchPercentByBandKeyFromStats(input: {
-    heatMapRefs: readonly HeatMapRef[];
-    contributingTagsByBandKey: ReadonlyMap<string, string[]>;
-    statsByClanTag: ReadonlyMap<string, HeatMapRefMatchStatsRow>;
-  }): ReadonlyMap<string, string> {
-    const matchPercentByBandKey = new Map<string, string>();
-    for (const heatMapRef of input.heatMapRefs) {
+    const matchRateByBandKey = new Map<string, HeatMapRefBandMatchRateStats>();
+    for (const heatMapRef of heatMapRefs) {
       const bandKey = getHeatMapRefBandKey(heatMapRef);
-      const contributors = input.contributingTagsByBandKey.get(bandKey) ?? [];
+      const contributors = contributingTagsByBandKey.get(bandKey) ?? [];
       let weightedSum = 0;
       let denominator = 0;
       for (const clanTag of contributors) {
-        const stats = input.statsByClanTag.get(clanTag);
+        const stats = statsByClanTag.get(clanTag);
         if (!stats || stats.evaluatedWarCount <= 0) {
           continue;
         }
         weightedSum += stats.matchRate * stats.evaluatedWarCount;
         denominator += stats.evaluatedWarCount;
       }
-      matchPercentByBandKey.set(
+      matchRateByBandKey.set(
         bandKey,
-        denominator > 0 ? formatMatchPercent(weightedSum / denominator, denominator) : "0%",
+        denominator > 0
+          ? { matchRate: weightedSum / denominator, evaluatedWarCount: denominator }
+          : { matchRate: null, evaluatedWarCount: 0 },
       );
     }
-    return matchPercentByBandKey;
+    return matchRateByBandKey;
   }
 }

--- a/tests/compo.commandSheetRead.test.ts
+++ b/tests/compo.commandSheetRead.test.ts
@@ -80,9 +80,23 @@ describe("/compo advice command", () => {
           mode: "actual",
           view: "auto",
           viewLabel: "Auto-Detect Band",
+          heatMapRefs: [
+            { weightMinInclusive: 0, weightMaxInclusive: 999_999 },
+            { weightMinInclusive: 1_000_000, weightMaxInclusive: 2_000_000 },
+            { weightMinInclusive: 2_000_001, weightMaxInclusive: 3_000_000 },
+          ],
+          bandMatchRatesByBandKey: new Map([
+            ["0-999999", 0.7],
+            ["1000000-2000000", 0.7214],
+            ["2000001-3000000", 0.74],
+          ]),
           currentProjection: {
             totalWeight: 1_500_000,
             memberCount: 50,
+            selectedHeatMapRef: {
+              weightMinInclusive: 1_000_000,
+              weightMaxInclusive: 2_000_000,
+            },
             deltaByBucket: {
               TH18: 0,
               TH17: 0,
@@ -134,17 +148,24 @@ describe("/compo advice command", () => {
     expect(String(embed?.description ?? "")).toBe("");
     expect(
       (embed?.fields ?? []).map((field: { name?: unknown }) => String(field.name ?? "")),
-    ).toEqual(["Overview", "Current", "Target", "Recommendation", "Current Deltas"]);
+    ).toEqual([
+      "Overview",
+      "Current",
+      "Target",
+      "Recommendation",
+      "Current Deltas",
+      "Adjacent Bands",
+    ]);
     expect(JSON.stringify(embed?.fields ?? [])).toContain("Mode: **ACTUAL**");
     expect(JSON.stringify(embed?.fields ?? [])).toContain(
       "Advice View: **Auto-Detect Band**",
     );
     expect(JSON.stringify(embed?.fields ?? [])).toContain("Current Weight: 1,500,000");
+    expect(JSON.stringify(embed?.fields ?? [])).toContain("Current Deviation Score: **0**");
+    expect(JSON.stringify(embed?.fields ?? [])).toContain("Matchrate: 72.14%");
+    expect(JSON.stringify(embed?.fields ?? [])).toContain("Perfect compo matchrate: 72.14%");
     expect(JSON.stringify(embed?.fields ?? [])).toContain(
       "Distance to Midpoint: -> +0",
-    );
-    expect(JSON.stringify(embed?.fields ?? [])).toContain(
-      "Current Deviation Score: **0**",
     );
     expect(String(embed?.title ?? "")).toContain("Alpha Clan (#AAA111)");
     expect(JSON.stringify(embed?.fields ?? [])).not.toContain("Alternates");
@@ -155,7 +176,12 @@ describe("/compo advice command", () => {
     expect(JSON.stringify(embed?.fields ?? [])).toContain(
       "Resulting Deviation Score: **0**",
     );
-    expect(JSON.stringify(embed?.fields ?? [])).not.toContain("Resulting Band");
+    expect(JSON.stringify(embed?.fields ?? [])).toContain("Lower band: **0 - 999,999**");
+    expect(JSON.stringify(embed?.fields ?? [])).toContain(
+      "Higher band: **2,000,001 - 3,000,000**",
+    );
+    expect(JSON.stringify(embed?.fields ?? [])).toContain("Matchrate: 70.00%");
+    expect(JSON.stringify(embed?.fields ?? [])).toContain("Matchrate: 74.00%");
     expect(String(embed?.footer?.text ?? "")).toBe(
       "RAW Data last refreshed: <t:1709900000:F> • Lower deviation score is better.",
     );
@@ -187,9 +213,17 @@ describe("/compo advice command", () => {
         mode: "war",
         view: "raw",
         viewLabel: "Raw Data",
+        heatMapRefs: [
+          { weightMinInclusive: 0, weightMaxInclusive: 9_999_999 },
+        ],
+        bandMatchRatesByBandKey: new Map([["0-9999999", 0.5]]),
         currentProjection: {
           totalWeight: 1_500_000,
           memberCount: 50,
+          selectedHeatMapRef: {
+            weightMinInclusive: 0,
+            weightMaxInclusive: 9_999_999,
+          },
           deltaByBucket: {
             TH18: 0,
             TH17: 0,

--- a/tests/compoAdvice.engine.test.ts
+++ b/tests/compoAdvice.engine.test.ts
@@ -4,6 +4,8 @@ import {
   buildCompoAdviceContentLinesForTest,
   evaluateCompoAdvice,
   formatFullWeightForTest,
+  formatMatchratePercentForTest,
+  estimateMatchrateFromDeviationForTest,
   formatSignedCompoAdviceDeltaForTest,
   resolveAdviceTargetBandMidpointForTest,
   stepCompoAdviceCustomBandIndexByCount,
@@ -259,6 +261,30 @@ describe("CompoAdviceEngine", () => {
     expect(formatSignedCompoAdviceDeltaForTest(null)).toBe("unknown");
   });
 
+  it("formats and estimates matchrates using the shared compo advice helper", () => {
+    expect(formatMatchratePercentForTest(0.7214)).toBe("72.14%");
+    expect(formatMatchratePercentForTest(72.14)).toBe("72.14%");
+    expect(formatMatchratePercentForTest(null)).toBe("Unknown");
+    expect(
+      estimateMatchrateFromDeviationForTest({
+        bandMatchrate: 0.7214,
+        deviationScore: 0,
+      }),
+    ).toBe(0.7214);
+    expect(
+      estimateMatchrateFromDeviationForTest({
+        bandMatchrate: 0.7214,
+        deviationScore: 32.5,
+      }),
+    ).toBeCloseTo(0.6629, 4);
+    expect(
+      estimateMatchrateFromDeviationForTest({
+        bandMatchrate: null,
+        deviationScore: 32.5,
+      }),
+    ).toBeNull();
+  });
+
   it("renders unknown fallback lines when current weight or midpoint is missing", () => {
     const lines = buildCompoAdviceContentLinesForTest({
       modeLabel: "ACTUAL",
@@ -269,7 +295,10 @@ describe("CompoAdviceEngine", () => {
         currentBandLabel: "(no band)",
         currentProjection: {
           totalWeight: NaN,
+          selectedHeatMapRef: null,
         } as any,
+        heatMapRefs: [],
+        bandMatchRatesByBandKey: new Map(),
         currentWeight: null,
         targetBandMidpoint: null,
         recommendationText: "No improvement found.",
@@ -282,6 +311,51 @@ describe("CompoAdviceEngine", () => {
 
     expect(lines).toContain("Current Weight: unknown");
     expect(lines).toContain("Distance to Midpoint: unknown");
+    expect(lines).toContain("Matchrate: Unknown");
+  });
+
+  it("renders current, target, and adjacent matchrate lines from band rates and deviation penalties", () => {
+    const refs = [
+      makeHeatMapRef({ weightMinInclusive: 0, weightMaxInclusive: 999_999 }),
+      makeHeatMapRef({ weightMinInclusive: 1_000_000, weightMaxInclusive: 2_000_000 }),
+      makeHeatMapRef({ weightMinInclusive: 2_000_001, weightMaxInclusive: 3_000_000 }),
+    ];
+    const lines = buildCompoAdviceContentLinesForTest({
+      modeLabel: "ACTUAL",
+      refreshLine: null,
+      summary: {
+        viewLabel: "Auto-Detect Band",
+        currentScore: 32.5,
+        currentBandLabel: "1,000,000 - 2,000,000",
+        currentProjection: {
+          totalWeight: 1_500_000,
+          selectedHeatMapRef: refs[1],
+        } as any,
+        heatMapRefs: refs,
+        bandMatchRatesByBandKey: new Map([
+          ["0-999999", 0.7],
+          ["1000000-2000000", 0.7214],
+          ["2000001-3000000", 0.74],
+        ]),
+        currentWeight: 1_500_000,
+        targetBandMidpoint: 1_500_000,
+        recommendationText: "Add TH17",
+        resultingScore: 12.5,
+        resultingBandLabel: "1,000,000 - 2,000,000",
+        alternateTexts: [],
+        statusText: null,
+      } as any,
+    });
+
+    expect(lines).toContain("Current Deviation Score: **32.5**");
+    expect(lines).toContain("Matchrate: 66.29%");
+    expect(lines).toContain("Perfect compo matchrate: 72.14%");
+    expect(lines).toContain("Resulting Deviation Score: **12.5**");
+    expect(lines).toContain("Matchrate: 69.89%");
+    expect(lines).toContain("Lower band: **0 - 999,999**");
+    expect(lines).toContain("Higher band: **2,000,001 - 3,000,000**");
+    expect(lines).toContain("Matchrate: 70.00%");
+    expect(lines).toContain("Matchrate: 74.00%");
   });
 
   it("steps Custom band indices deterministically and respects bounds", () => {

--- a/tests/compoAdvice.service.test.ts
+++ b/tests/compoAdvice.service.test.ts
@@ -12,10 +12,19 @@ const prismaMock = vi.hoisted(() => ({
   fwaClanMemberCurrent: {
     findMany: vi.fn(),
   },
+  fwaClanCatalog: {
+    findMany: vi.fn(),
+  },
+  fwaWarMemberCurrent: {
+    findMany: vi.fn(),
+  },
   fwaTrackedClanWarRosterCurrent: {
     findMany: vi.fn(),
   },
   fwaTrackedClanWarRosterMemberCurrent: {
+    findMany: vi.fn(),
+  },
+  fwaClanMatchStatsCurrent: {
     findMany: vi.fn(),
   },
   heatMapRef: {
@@ -141,10 +150,16 @@ describe("CompoAdviceService", () => {
     vi.restoreAllMocks();
     prismaMock.trackedClan.findMany.mockReset();
     prismaMock.fwaClanMemberCurrent.findMany.mockReset();
+    prismaMock.fwaClanCatalog.findMany.mockReset();
+    prismaMock.fwaWarMemberCurrent.findMany.mockReset();
     prismaMock.fwaTrackedClanWarRosterCurrent.findMany.mockReset();
     prismaMock.fwaTrackedClanWarRosterMemberCurrent.findMany.mockReset();
+    prismaMock.fwaClanMatchStatsCurrent.findMany.mockReset();
     prismaMock.heatMapRef.findMany.mockReset();
     prismaMock.weightInputDeferment.findMany.mockReset();
+    prismaMock.fwaClanCatalog.findMany.mockResolvedValue([]);
+    prismaMock.fwaWarMemberCurrent.findMany.mockResolvedValue([]);
+    prismaMock.fwaClanMatchStatsCurrent.findMany.mockResolvedValue([]);
   });
 
   it("loads ACTUAL advice from DB-backed state, defaults to Auto-Detect Band, and computes rushed members without sheet reads", async () => {
@@ -166,6 +181,14 @@ describe("CompoAdviceService", () => {
         townHall: 13,
         weight: 135000,
       }),
+    ]);
+    prismaMock.fwaClanCatalog.findMany.mockResolvedValue([{ clanTag: "#AAA111" }]);
+    prismaMock.fwaClanMatchStatsCurrent.findMany.mockResolvedValue([
+      {
+        clanTag: "#AAA111",
+        matchRate: 0.72,
+        evaluatedWarCount: 10,
+      },
     ]);
     prismaMock.weightInputDeferment.findMany.mockResolvedValue([]);
     prismaMock.fwaTrackedClanWarRosterMemberCurrent.findMany.mockResolvedValue([]);
@@ -265,6 +288,14 @@ describe("CompoAdviceService", () => {
         clanName: "Alpha Clan-war",
         totalEffectiveWeight: 8_100_000,
       }),
+    ]);
+    prismaMock.fwaClanCatalog.findMany.mockResolvedValue([{ clanTag: "#AAA111" }]);
+    prismaMock.fwaClanMatchStatsCurrent.findMany.mockResolvedValue([
+      {
+        clanTag: "#AAA111",
+        matchRate: 0.72,
+        evaluatedWarCount: 10,
+      },
     ]);
     prismaMock.fwaTrackedClanWarRosterMemberCurrent.findMany.mockResolvedValue([
       ...Array.from({ length: 50 }, (_, index) =>

--- a/tests/compoAdviceClanSelect.command.test.ts
+++ b/tests/compoAdviceClanSelect.command.test.ts
@@ -61,8 +61,16 @@ describe("handleCompoAdviceClanSelectMenuInteraction", () => {
           mode: "actual",
           view: "custom",
           viewLabel: "Custom",
+          heatMapRefs: [
+            { weightMinInclusive: 0, weightMaxInclusive: 9_999_999 },
+          ],
+          bandMatchRatesByBandKey: new Map([["0-9999999", 0.5]]),
           currentProjection: {
             memberCount: 50,
+            selectedHeatMapRef: {
+              weightMinInclusive: 0,
+              weightMaxInclusive: 9_999_999,
+            },
             deltaByBucket: {
               TH18: 0,
               TH17: 0,

--- a/tests/compoRefresh.logic.test.ts
+++ b/tests/compoRefresh.logic.test.ts
@@ -254,8 +254,16 @@ describe("compo refresh button behavior", () => {
         mode: "actual",
         view: "best",
         viewLabel: "Best Fit",
+        heatMapRefs: [
+          { weightMinInclusive: 0, weightMaxInclusive: 9_999_999 },
+        ],
+        bandMatchRatesByBandKey: new Map([["0-9999999", 0.5]]),
         currentProjection: {
           memberCount: 49,
+          selectedHeatMapRef: {
+            weightMinInclusive: 0,
+            weightMaxInclusive: 9_999_999,
+          },
           deltaByBucket: {
             TH18: 1,
             TH17: 0,
@@ -351,8 +359,20 @@ describe("compo refresh button behavior", () => {
         mode: "actual",
         view: "custom",
         viewLabel: "Custom",
+        heatMapRefs: [
+          { weightMinInclusive: 1_500_000, weightMaxInclusive: 1_999_999 },
+          { weightMinInclusive: 2_000_000, weightMaxInclusive: 2_499_999 },
+        ],
+        bandMatchRatesByBandKey: new Map([
+          ["1500000-1999999", 0.5],
+          ["2000000-2499999", 0.55],
+        ]),
         currentProjection: {
           memberCount: 50,
+          selectedHeatMapRef: {
+            weightMinInclusive: 1_500_000,
+            weightMaxInclusive: 1_999_999,
+          },
           deltaByBucket: {
             TH18: 0,
             TH17: -1,


### PR DESCRIPTION
- derive current, target, and adjacent band matchrates from HeatMapRef data
- keep advice ranking and presentation layout intact while extending the render