### PR TITLE
fix(fwa): fetch fresh points proof for manual matchup rendering

### DIFF
--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -8807,6 +8807,41 @@ function resolveForceSyncMatchupEvidence(input: {
   };
 }
 
+type FreshMatchupEvidence = {
+  primarySnapshot: PointsSnapshot;
+  opponentSnapshot: PointsSnapshot | null;
+  siteCurrent: boolean;
+  siteCurrentFromPrimary: boolean;
+  usedTrackedFallback: boolean;
+};
+
+/** Purpose: fetch fresh points proof for manual match rendering before applying the strict currentness check. */
+async function resolveFreshMatchupEvidence(input: {
+  trackedClanTag: string;
+  opponentTag: string;
+  sourceSync: number | null;
+  fetchClanPoints: (tag: string) => Promise<PointsSnapshot>;
+}): Promise<FreshMatchupEvidence> {
+  const primarySnapshot = await input.fetchClanPoints(input.trackedClanTag);
+  const directOpponentSnapshot = input.opponentTag
+    ? await input.fetchClanPoints(input.opponentTag).catch(() => null)
+    : null;
+  const evidence = resolveForceSyncMatchupEvidence({
+    trackedClanTag: input.trackedClanTag,
+    opponentTag: input.opponentTag,
+    sourceSync: input.sourceSync,
+    primarySnapshot,
+    directOpponentSnapshot,
+  });
+  return {
+    primarySnapshot,
+    ...evidence,
+  };
+}
+
+export const resolveFreshMatchupEvidenceForTest =
+  resolveFreshMatchupEvidence;
+
 type ActualSheetClanSnapshot = {
   totalWeight: string | null;
   weightCompo: string | null;
@@ -13863,33 +13898,19 @@ export const Fwa: Command = {
           return;
         }
 
-        const warScopedSnapshot = resolveWarScopedSnapshotForMatch({
-          rows: warScopedSyncRowsByClanTag.get(tag) ?? [],
-          clanTag: tag,
-          warId: warIdForReuse,
-          warStartTime: warStartTimeForReuse,
-          opponentTag,
-          currentSyncNumber: resolvedCurrentSyncNum,
-          sourceSyncNumber: sourceSync,
-        });
-        const primary = await getClanPointsCached(
-          settings,
-          cocService,
-          tag,
-          resolvedCurrentSyncNum,
-          warLookupCache,
-          {
-            requiredOpponentTag: opponentTag,
-            fetchReason: "match_render",
-            warScopedSnapshot,
-          },
-        );
-        let opponent: PointsSnapshot;
-        const siteUpdatedFromPrimary = isPointsSiteUpdatedForOpponent(
-          primary,
+        const freshMatchupEvidence = await resolveFreshMatchupEvidence({
+          trackedClanTag: tag,
           opponentTag,
           sourceSync,
-        );
+          fetchClanPoints: (clanTag) =>
+            scrapeClanPoints(clanTag, "manual_refresh", {
+              manualForceBypass: true,
+              caller: "command",
+            }),
+        });
+        const primary = freshMatchupEvidence.primarySnapshot;
+        let opponent: PointsSnapshot | null = freshMatchupEvidence.opponentSnapshot;
+        const siteUpdatedFromPrimary = freshMatchupEvidence.siteCurrentFromPrimary;
         const opponentFromPrimary = siteUpdatedFromPrimary
           ? deriveOpponentBalanceFromPrimarySnapshot(primary, tag, opponentTag)
           : null;
@@ -13907,18 +13928,17 @@ export const Fwa: Command = {
             activeFwa: null,
             winnerBoxHasTag: true,
           };
-        } else {
-          opponent = await getClanPointsCached(
-            settings,
-            cocService,
-            opponentTag,
-            resolvedCurrentSyncNum,
-            warLookupCache,
-            {
-              fetchReason: "match_render",
-              fallbackTrackedClanTag: tag,
-            },
+        } else if (!opponent) {
+          opponent = await scrapeClanPoints(opponentTag, "manual_refresh", {
+            manualForceBypass: true,
+            caller: "command",
+          }).catch(() => null);
+        }
+        if (!opponent) {
+          await editReplySafe(
+            `Could not fetch point balance for #${opponentTag}.`,
           );
+          return;
         }
         const fallbackResolution = await resolveMatchTypeWithFallback({
           guildId: interaction.guildId ?? null,
@@ -13934,33 +13954,6 @@ export const Fwa: Command = {
           existingMatchType: subscription?.matchType ?? null,
           existingInferredMatchType: subscription?.inferredMatchType ?? null,
         });
-        if (fallbackResolution.confirmedCurrent === null) {
-          const opponentForInference = await getClanPointsCached(
-            settings,
-            cocService,
-            opponentTag,
-            resolvedCurrentSyncNum,
-            warLookupCache,
-            {
-              fetchReason: "match_render",
-              fallbackTrackedClanTag: tag,
-            },
-          ).catch(() => null);
-          if (opponentForInference) {
-            const hasDerivedOpponentBalance =
-              opponent.balance !== null &&
-              opponent.balance !== undefined &&
-              !Number.isNaN(opponent.balance);
-            const hasFetchedOpponentBalance =
-              opponentForInference.balance !== null &&
-              opponentForInference.balance !== undefined &&
-              !Number.isNaN(opponentForInference.balance);
-            opponent =
-              hasDerivedOpponentBalance && !hasFetchedOpponentBalance
-                ? { ...opponentForInference, balance: opponent.balance }
-                : opponentForInference;
-          }
-        }
         const trackedPair = await prisma.trackedClan.findMany({
           select: { name: true, tag: true },
         });
@@ -13975,12 +13968,7 @@ export const Fwa: Command = {
           primary.balance !== null && !Number.isNaN(primary.balance);
         const hasOpponentPoints =
           opponent.balance !== null && !Number.isNaN(opponent.balance);
-        const siteUpdated = isPointsValidationCurrentForMatchup({
-          primarySnapshot: primary,
-          opponentSnapshot: opponent,
-          opponentTag,
-          sourceSync,
-        });
+        const siteUpdated = freshMatchupEvidence.siteCurrent;
         const siteSyncObservedForWrite = resolveObservedSyncNumberForMatchup({
           primarySnapshot: primary,
           opponentSnapshot: opponent,

--- a/tests/fwaMatchFreshMatchupEvidence.logic.test.ts
+++ b/tests/fwaMatchFreshMatchupEvidence.logic.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "vitest";
+import { resolveFreshMatchupEvidenceForTest } from "../src/commands/Fwa";
+
+function buildSnapshot(overrides: Record<string, unknown>): any {
+  return {
+    version: 5,
+    tag: "2TRACK",
+    url: "https://points.fwafarm.com/clan?tag=2TRACK",
+    snapshotSource: "direct",
+    lookupState: "ok",
+    balance: 1200,
+    clanName: "Tracked Clan",
+    activeFwa: true,
+    notFound: false,
+    winnerBoxText: "Winner Box",
+    winnerBoxTags: ["2TRACK", "2OPP"],
+    winnerBoxSync: 477,
+    effectiveSync: 477,
+    syncMode: "high",
+    winnerBoxHasTag: true,
+    headerPrimaryTag: "2TRACK",
+    headerOpponentTag: "2OPP",
+    headerPrimaryBalance: 1200,
+    headerOpponentBalance: 980,
+    warEndMs: null,
+    lastWarCheckAtMs: 0,
+    fetchedAtMs: 0,
+    refreshedForWarEndMs: null,
+    ...overrides,
+  };
+}
+
+describe("fwa manual fresh matchup evidence", () => {
+  it("fetches fresh proof for both clans before classifying currentness", async () => {
+    const calls: string[] = [];
+    const primary = buildSnapshot({
+      tag: "2TRACK",
+      url: "https://points.fwafarm.com/clan?tag=2TRACK",
+      winnerBoxTags: ["2TRACK", "2OPP"],
+      winnerBoxSync: 477,
+      effectiveSync: 477,
+      headerPrimaryTag: "2TRACK",
+      headerOpponentTag: "2OPP",
+      headerOpponentBalance: 980,
+    });
+    const opponent = buildSnapshot({
+      tag: "2OPP",
+      url: "https://points.fwafarm.com/clan?tag=2OPP",
+      snapshotSource: "direct",
+      lookupState: "ok",
+      balance: 980,
+      clanName: "Opponent Clan",
+      activeFwa: false,
+      notFound: false,
+      winnerBoxTags: ["2TRACK", "2OPP"],
+      winnerBoxSync: 477,
+      effectiveSync: 477,
+      headerPrimaryTag: "2TRACK",
+      headerOpponentTag: "2OPP",
+      headerPrimaryBalance: 1200,
+      headerOpponentBalance: 980,
+      winnerBoxHasTag: true,
+    });
+
+    const resolved = await resolveFreshMatchupEvidenceForTest({
+      trackedClanTag: "2TRACK",
+      opponentTag: "2OPP",
+      sourceSync: 476,
+      fetchClanPoints: async (tag: string) => {
+        calls.push(tag);
+        return tag === "2TRACK" ? primary : opponent;
+      },
+    });
+
+    expect(calls).toEqual(["2TRACK", "2OPP"]);
+    expect(resolved.siteCurrent).toBe(true);
+    expect(resolved.siteCurrentFromPrimary).toBe(true);
+  });
+
+  it("still rejects stale freshness even with fresh proof sourcing", async () => {
+    const resolved = await resolveFreshMatchupEvidenceForTest({
+      trackedClanTag: "2TRACK",
+      opponentTag: "2OPP",
+      sourceSync: 477,
+      fetchClanPoints: async (tag: string) =>
+        buildSnapshot({
+          tag,
+          url: `https://points.fwafarm.com/clan?tag=${tag}`,
+          winnerBoxTags: ["2TRACK", "2OPP"],
+          winnerBoxSync: 477,
+          effectiveSync: 477,
+          headerPrimaryTag: "2TRACK",
+          headerOpponentTag: "2OPP",
+          headerOpponentBalance: 980,
+        }),
+    });
+
+    expect(resolved.siteCurrent).toBe(false);
+    expect(resolved.siteCurrentFromPrimary).toBe(false);
+  });
+
+  it("keeps opponent-tag mismatches out of currentness", async () => {
+    const resolved = await resolveFreshMatchupEvidenceForTest({
+      trackedClanTag: "2TRACK",
+      opponentTag: "2OPP",
+      sourceSync: 476,
+      fetchClanPoints: async (tag: string) =>
+        buildSnapshot({
+          tag,
+          url: `https://points.fwafarm.com/clan?tag=${tag}`,
+          winnerBoxTags: ["2TRACK", "2OTHER"],
+          winnerBoxSync: 477,
+          effectiveSync: 477,
+          headerPrimaryTag: "2TRACK",
+          headerOpponentTag: "2OTHER",
+          headerOpponentBalance: 980,
+        }),
+    });
+
+    expect(resolved.siteCurrent).toBe(false);
+    expect(resolved.usedTrackedFallback).toBe(false);
+  });
+});


### PR DESCRIPTION
- avoid reusing war-scoped cached proof as final siteCurrent evidence
- preserve opponent-tag matching while keeping freshness strict