### PR TITLE
fix(fwa): clear stale validation after same-war confirmation

### DIFF
--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -2561,6 +2561,7 @@ async function markMatchLiveDataChanged(params: {
   guildId: string;
   tag: string;
   channelId: string;
+  needsValidation?: boolean;
 }): Promise<void> {
   const current = await getCurrentWarMailConfig(params.guildId, params.tag);
   const live = await prisma.currentWar.findUnique({
@@ -2591,15 +2592,23 @@ async function markMatchLiveDataChanged(params: {
     channelId: params.channelId,
     mailConfig: next,
   });
-  await pointsSyncService
-    .markNeedsValidation({
-      guildId: params.guildId,
-      clanTag: params.tag,
-      warId: live?.warId ?? null,
-      warStartTime: live?.startTime ?? null,
-    })
-    .catch(() => undefined);
+  const lifecycleUpdate = params.needsValidation === false
+    ? pointsSyncService.clearNeedsValidation({
+        guildId: params.guildId,
+        clanTag: params.tag,
+        warId: live?.warId ?? null,
+        warStartTime: live?.startTime ?? null,
+      })
+    : pointsSyncService.markNeedsValidation({
+        guildId: params.guildId,
+        clanTag: params.tag,
+        warId: live?.warId ?? null,
+        warStartTime: live?.startTime ?? null,
+      });
+  await lifecycleUpdate.catch(() => undefined);
 }
+
+export const markMatchLiveDataChangedForTest = markMatchLiveDataChanged;
 
 function buildMatchStatusHeader(params: {
   clanName: string;
@@ -5619,6 +5628,7 @@ export async function handleFwaMatchTypeActionButton(
           guildId: interaction.guildId,
           tag: parsed.tag,
           channelId: interaction.channelId,
+          needsValidation: false,
         });
       }
       const draftPayload: FwaMatchCopyPayload = {

--- a/src/services/PointsSyncService.ts
+++ b/src/services/PointsSyncService.ts
@@ -307,6 +307,49 @@ export class PointsSyncService {
     return true;
   }
 
+  /** Purpose: clear lifecycle validation dirtiness for a targeted war row after same-war confirmation. */
+  async clearNeedsValidation(params: {
+    guildId: string;
+    clanTag: string;
+    warId?: string | number | null;
+    warStartTime?: Date | null;
+  }): Promise<boolean> {
+    const clanTag = normalizeTag(params.clanTag);
+    if (params.warStartTime) {
+      const updated = await prisma.clanPointsSync.updateMany({
+        where: {
+          guildId: params.guildId,
+          clanTag,
+          warStartTime: params.warStartTime,
+        },
+        data: { needsValidation: false },
+      });
+      return updated.count > 0;
+    }
+    if (params.warId !== null && params.warId !== undefined) {
+      const updated = await prisma.clanPointsSync.updateMany({
+        where: {
+          guildId: params.guildId,
+          clanTag,
+          warId: String(params.warId),
+        },
+        data: { needsValidation: false },
+      });
+      return updated.count > 0;
+    }
+    const latest = await prisma.clanPointsSync.findFirst({
+      where: { guildId: params.guildId, clanTag },
+      orderBy: [{ warStartTime: "desc" }, { updatedAt: "desc" }],
+      select: { id: true },
+    });
+    if (!latest?.id) return false;
+    await prisma.clanPointsSync.update({
+      where: { id: latest.id },
+      data: { needsValidation: false },
+    });
+    return true;
+  }
+
   /** Purpose: checkpoint a trusted current-war sync number without rewriting full points fields. */
   async checkpointCurrentWarSync(params: {
     guildId: string;

--- a/tests/fwaMatchConfirmationValidation.logic.test.ts
+++ b/tests/fwaMatchConfirmationValidation.logic.test.ts
@@ -1,0 +1,73 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const prismaMock = vi.hoisted(() => ({
+  currentWar: {
+    findUnique: vi.fn(),
+  },
+  trackedClan: {
+    findUnique: vi.fn(),
+    update: vi.fn(),
+  },
+}));
+
+const pointsSyncServiceMock = vi.hoisted(() => {
+  const instance = {
+    markNeedsValidation: vi.fn().mockResolvedValue(true),
+    clearNeedsValidation: vi.fn().mockResolvedValue(true),
+  };
+  return { instance };
+});
+
+vi.mock("../src/prisma", () => ({
+  prisma: prismaMock,
+}));
+
+vi.mock("../src/services/PointsSyncService", () => ({
+  PointsSyncService: vi.fn().mockImplementation(() => pointsSyncServiceMock.instance),
+}));
+
+import { markMatchLiveDataChangedForTest } from "../src/commands/Fwa";
+
+describe("fwa match type confirmation validation lifecycle", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("clears same-war needs-validation dirtiness when a confirmed match type is applied", async () => {
+    const warStartTime = new Date("2026-03-12T08:00:00.000Z");
+    prismaMock.currentWar.findUnique.mockResolvedValue({
+      matchType: "FWA",
+      outcome: "WIN",
+      warId: "2001",
+      startTime: warStartTime,
+    });
+    prismaMock.trackedClan.findUnique.mockResolvedValue({
+      mailConfig: {
+        lastWarId: "2001",
+        lastOpponentTag: "2OPP",
+        lastMatchType: "BL",
+        lastExpectedOutcome: "LOSE",
+        lastDataChangedAtUnix: 0,
+      },
+    });
+    prismaMock.trackedClan.update.mockResolvedValue({} as never);
+
+    await markMatchLiveDataChangedForTest({
+      guildId: "guild-1",
+      tag: "2TRACK",
+      channelId: "chan-1",
+      needsValidation: false,
+    });
+
+    expect(pointsSyncServiceMock.instance.clearNeedsValidation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        guildId: "guild-1",
+        clanTag: "2TRACK",
+        warId: "2001",
+        warStartTime,
+      }),
+    );
+    expect(pointsSyncServiceMock.instance.markNeedsValidation).not.toHaveBeenCalled();
+    expect(prismaMock.trackedClan.update).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/pointsSync.service.test.ts
+++ b/tests/pointsSync.service.test.ts
@@ -5,6 +5,7 @@ const prismaMock = vi.hoisted(() => ({
     findFirst: vi.fn(),
     findUnique: vi.fn(),
     upsert: vi.fn(),
+    update: vi.fn(),
     updateMany: vi.fn(),
   },
 }));
@@ -166,6 +167,56 @@ describe("PointsSyncService.checkpointCurrentWarSync", () => {
 
     expect(updated).toBe(false);
     expect(prismaMock.clanPointsSync.updateMany).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("PointsSyncService.clearNeedsValidation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("clears the dirty flag for a targeted same-war row by war start time", async () => {
+    prismaMock.clanPointsSync.updateMany.mockResolvedValue({ count: 1 });
+    const service = new PointsSyncService();
+    const warStartTime = new Date("2026-03-11T08:00:00.000Z");
+
+    const updated = await service.clearNeedsValidation({
+      guildId: "guild-1",
+      clanTag: "#AAA111",
+      warStartTime,
+    });
+
+    expect(updated).toBe(true);
+    expect(prismaMock.clanPointsSync.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          guildId: "guild-1",
+          clanTag: "#AAA111",
+          warStartTime,
+        }),
+        data: { needsValidation: false },
+      }),
+    );
+  });
+
+  it("falls back to the latest same-clan row when no war identity is provided", async () => {
+    prismaMock.clanPointsSync.findFirst.mockResolvedValue({ id: 42 });
+    prismaMock.clanPointsSync.update.mockResolvedValue({ id: 42 });
+    const service = new PointsSyncService();
+
+    const updated = await service.clearNeedsValidation({
+      guildId: "guild-1",
+      clanTag: "#AAA111",
+    });
+
+    expect(updated).toBe(true);
+    expect(prismaMock.clanPointsSync.findFirst).toHaveBeenCalledTimes(1);
+    expect(prismaMock.clanPointsSync.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 42 },
+        data: { needsValidation: false },
+      }),
+    );
   });
 });
 


### PR DESCRIPTION
- clear same-war needs-validation dirtiness when confirming match type
- add regression coverage for the validation clear path