### PR TITLE
feat(compo): refresh compo advice embed layout

### DIFF
--- a/src/commands/Compo.ts
+++ b/src/commands/Compo.ts
@@ -38,7 +38,6 @@ import { formatHeatMapRefBandLabel, getHeatMapRefBandKey } from "../helper/compo
 import { formatError } from "../helper/formatError";
 import { getCompoWarDisplayBucket } from "../helper/compoWarWeightBuckets";
 import { normalizeCompoClanDisplayName } from "../helper/compoDisplay";
-import { formatSignedCompoAdviceDelta } from "../helper/compoAdviceEngine";
 import { emojiResolverService } from "../services/emoji/EmojiResolverService";
 import { prisma } from "../prisma";
 import { safeReply } from "../helper/safeReply";
@@ -50,6 +49,7 @@ import {
 import { CompoActualStateService } from "../services/CompoActualStateService";
 import { CompoPlaceService } from "../services/CompoPlaceService";
 import { CompoWarStateService } from "../services/CompoWarStateService";
+import { buildFwaWeightPageUrl } from "../services/FwaStatsWeightService";
 import { HeatMapRefDisplayService } from "../services/HeatMapRefDisplayService";
 import {
   GoogleSheetMode,
@@ -1086,31 +1086,64 @@ function formatCompoAdviceFullWeight(value: number | null): string {
   return Math.trunc(value).toLocaleString("en-US");
 }
 
-async function renderCompoAdviceEmojiShortcodes(client: Client, text: string): Promise<string> {
-  return emojiResolverService.replaceShortcodes(client, text).catch(() => text);
+function formatCompoAdviceCompactWeight(value: number | null): string {
+  if (value === null || !Number.isFinite(value)) {
+    return "unknown";
+  }
+
+  const magnitude = Math.abs(Math.trunc(value));
+  const formatScaled = (scaled: number, suffix: string): string => {
+    const text = scaled.toFixed(3).replace(/\.?0+$/, "");
+    return `${text}${suffix}`;
+  };
+
+  if (magnitude >= 1_000_000_000) {
+    return formatScaled(magnitude / 1_000_000_000, "b");
+  }
+  if (magnitude >= 1_000_000) {
+    return formatScaled(magnitude / 1_000_000, "m");
+  }
+  if (magnitude >= 1_000) {
+    return formatScaled(magnitude / 1_000, "k");
+  }
+  return `${magnitude}`;
 }
 
-function formatCompoAdviceDistanceToMidpoint(summary: {
+function formatCompoAdviceSignedDistance(value: number | null): string {
+  if (value === null || !Number.isFinite(value)) {
+    return "unknown";
+  }
+
+  const normalized = Math.trunc(value);
+  const sign = normalized >= 0 ? "+" : "-";
+  return `${sign}${formatCompoAdviceCompactWeight(Math.abs(normalized))}`;
+}
+
+function formatCompoAdviceBandMidpointLine(input: {
   currentWeight: number | null;
   targetBandMidpoint: number | null;
+  selectedHeatMapRef: HeatMapRef | null;
 }): string {
-  const currentWeight = summary.currentWeight;
-  const targetBandMidpoint = summary.targetBandMidpoint;
+  const { currentWeight, targetBandMidpoint, selectedHeatMapRef } = input;
   if (
     currentWeight === null ||
     targetBandMidpoint === null ||
+    selectedHeatMapRef === null ||
     !Number.isFinite(currentWeight) ||
     !Number.isFinite(targetBandMidpoint)
   ) {
     return "unknown";
   }
 
-  return formatSignedCompoAdviceDelta(currentWeight - targetBandMidpoint);
+  const withinDisplayedBand =
+    currentWeight >= selectedHeatMapRef.weightMinInclusive &&
+    currentWeight <= selectedHeatMapRef.weightMaxInclusive;
+  const warning = withinDisplayedBand ? "" : ":warning: ";
+  return `${warning}${formatCompoAdviceSignedDistance(targetBandMidpoint - currentWeight)}`;
 }
 
-function buildCompoAdviceFooterText(refreshLine: string | null): string {
-  const note = "Lower deviation score is better.";
-  return refreshLine ? `${refreshLine} • ${note}` : note;
+async function renderCompoAdviceEmojiShortcodes(client: Client, text: string): Promise<string> {
+  return emojiResolverService.replaceShortcodes(client, text).catch(() => text);
 }
 
 function getCompoAdviceBandMatchrate(input: {
@@ -1169,6 +1202,11 @@ async function buildCompoAdviceEmbed(input: {
         `Mode: **${input.advice.mode.toUpperCase()}**`,
         `Advice View: **${COMPO_ADVICE_VIEW_LABELS[input.advice.selectedView]}**`,
         `Members: ${summary.currentProjection.memberCount} / 50`,
+        `Missing weights: ${summary.currentProjection.missingWeights}${
+          summary.currentProjection.missingWeights > 0 && input.advice.clanTag
+            ? ` [FWA Stats](${buildFwaWeightPageUrl(input.advice.clanTag)})`
+            : ""
+        }`,
         `Rushed: ${input.advice.rushedCount}`,
       ].join("\n"),
     );
@@ -1184,10 +1222,12 @@ async function buildCompoAdviceEmbed(input: {
       input.client,
       [
         `Target Band: **${summary.currentBandLabel}**`,
-        `Perfect compo matchrate: ${formatMatchratePercent(selectedBandMatchrate)}`,
-        `Distance to Midpoint: ${formatCompoAdviceDistanceToMidpoint(summary)}`,
-        `Resulting Deviation Score: **${formatAdviceScore(summary.resultingScore)}**`,
-        `Matchrate: ${formatMatchratePercent(resultingMatchrate)}`,
+        `Band matchrate: ${formatMatchratePercent(selectedBandMatchrate)}`,
+        `Band midpoint: ${formatCompoAdviceBandMidpointLine({
+          currentWeight: summary.currentWeight,
+          targetBandMidpoint: summary.targetBandMidpoint,
+          selectedHeatMapRef: selectedHeatMapRef ?? null,
+        })}`,
       ].join("\n"),
     );
     const recommendationValue = await renderCompoAdviceEmojiShortcodes(
@@ -1198,6 +1238,13 @@ async function buildCompoAdviceEmbed(input: {
       ]
         .filter((line): line is string => line !== null)
         .join("\n"),
+    );
+    const resultValue = await renderCompoAdviceEmojiShortcodes(
+      input.client,
+      [
+        `Deviation Score: **${formatAdviceScore(summary.resultingScore)}**`,
+        `Matchrate: ${formatMatchratePercent(resultingMatchrate)}`,
+      ].join("\n"),
     );
     const adjacentBandsValue = await renderCompoAdviceEmojiShortcodes(
       input.client,
@@ -1245,6 +1292,11 @@ async function buildCompoAdviceEmbed(input: {
         inline: false,
       },
       {
+        name: "Result",
+        value: resultValue,
+        inline: false,
+      },
+      {
         name: "Current Deltas",
         value: currentDeltas,
         inline: false,
@@ -1255,9 +1307,6 @@ async function buildCompoAdviceEmbed(input: {
         inline: false,
       },
     );
-    embed.setFooter({
-      text: buildCompoAdviceFooterText(input.advice.refreshLine),
-    });
     return embed;
   }
 
@@ -1270,9 +1319,6 @@ async function buildCompoAdviceEmbed(input: {
       ].join("\n"),
     );
 
-  embed.setFooter({
-    text: buildCompoAdviceFooterText(input.advice.refreshLine),
-  });
   return embed;
 }
 
@@ -1281,6 +1327,7 @@ async function buildCompoAdviceResponsePayload(input: {
   client: Client;
 }): Promise<CompoRenderPayload> {
   return {
+    content: input.advice.refreshLine ?? undefined,
     embeds: [await buildCompoAdviceEmbed({ advice: input.advice, client: input.client })],
   };
 }

--- a/src/helper/compoAdviceEngine.ts
+++ b/src/helper/compoAdviceEngine.ts
@@ -13,6 +13,7 @@ import {
   getHeatMapRefBandMidpoint,
   getHeatMapRefAdviceMidpoint,
 } from "./compoHeatMap";
+import { buildFwaWeightPageUrl } from "../services/FwaStatsWeightService";
 import type { CompoWarBucketCounts } from "./compoWarBucketCounts";
 import type { CompoWarDisplayBucket } from "./compoWarWeightBuckets";
 
@@ -186,6 +187,40 @@ function formatCompactWeight(value: number | null | undefined): string {
     return formatScaled(magnitude / 1_000, "k");
   }
   return `${magnitude}`;
+}
+
+function formatSignedCompactWeight(value: number | null | undefined): string {
+  if (value === null || value === undefined || !Number.isFinite(value)) {
+    return "unknown";
+  }
+
+  const normalized = Math.trunc(value);
+  const sign = normalized >= 0 ? "+" : "-";
+  return `${sign}${formatCompactWeight(Math.abs(normalized))}`;
+}
+
+function formatBandMidpointLine(input: {
+  currentWeight: number | null | undefined;
+  targetBandMidpoint: number | null | undefined;
+  selectedHeatMapRef: HeatMapRef | null;
+}): string {
+  if (
+    input.currentWeight === null ||
+    input.currentWeight === undefined ||
+    input.targetBandMidpoint === null ||
+    input.targetBandMidpoint === undefined ||
+    input.selectedHeatMapRef === null ||
+    !Number.isFinite(input.currentWeight) ||
+    !Number.isFinite(input.targetBandMidpoint)
+  ) {
+    return "unknown";
+  }
+
+  const withinDisplayedBand =
+    input.currentWeight >= input.selectedHeatMapRef.weightMinInclusive &&
+    input.currentWeight <= input.selectedHeatMapRef.weightMaxInclusive;
+  const warning = withinDisplayedBand ? "" : ":warning: ";
+  return `${warning}${formatSignedCompactWeight(input.targetBandMidpoint - input.currentWeight)}`;
 }
 
 export function formatSignedCompoAdviceDelta(delta: number | null | undefined): string {
@@ -749,16 +784,22 @@ export function buildCompoAdviceContentLines(input: {
   summary: CompoAdviceSummary;
   modeLabel: string;
   refreshLine: string | null;
+  clanTag?: string | null;
 }): string[] {
   const lines: string[] = [];
-  if (input.refreshLine) {
-    lines.push(input.refreshLine);
-  }
+  void input.refreshLine;
   lines.push(`Mode: **${input.modeLabel}**`);
   lines.push(`Advice View: **${input.summary.viewLabel}**`);
   lines.push(`Current Deviation Score: **${formatScore(input.summary.currentScore)}**`);
   lines.push(`Target Band: **${input.summary.currentBandLabel}**`);
   lines.push(`Current Weight: ${formatFullWeight(input.summary.currentWeight)}`);
+  lines.push(
+    `Missing weights: ${input.summary.currentProjection.missingWeights}${
+      input.summary.currentProjection.missingWeights > 0 && input.clanTag
+        ? ` [FWA Stats](${buildFwaWeightPageUrl(input.clanTag)})`
+        : ""
+    }`,
+  );
   const currentMatchrate = estimateMatchrateFromDeviation({
     bandMatchrate: getBandMatchrate({
       summary: input.summary,
@@ -771,16 +812,16 @@ export function buildCompoAdviceContentLines(input: {
     summary: input.summary,
     heatMapRef: input.summary.currentProjection.selectedHeatMapRef,
   });
-  lines.push(`Perfect compo matchrate: ${formatMatchratePercent(perfectMatchrate)}`);
+  lines.push(`Band matchrate: ${formatMatchratePercent(perfectMatchrate)}`);
   lines.push(
-    `Distance to Midpoint: ${formatSignedCompoAdviceDelta(
-      input.summary.currentWeight === null || input.summary.targetBandMidpoint === null
-        ? null
-        : input.summary.currentWeight - input.summary.targetBandMidpoint,
-    )}`,
+    `Band midpoint: ${formatBandMidpointLine({
+      currentWeight: input.summary.currentWeight,
+      targetBandMidpoint: input.summary.targetBandMidpoint,
+      selectedHeatMapRef: input.summary.currentProjection.selectedHeatMapRef,
+    })}`,
   );
   lines.push(`Recommendation: :arrow_arrow: __${input.summary.recommendationText}__`);
-  lines.push(`Resulting Deviation Score: **${formatScore(input.summary.resultingScore)}**`);
+  lines.push(`Deviation Score: **${formatScore(input.summary.resultingScore)}**`);
   const resultingMatchrate = estimateMatchrateFromDeviation({
     bandMatchrate: getBandMatchrate({
       summary: input.summary,

--- a/tests/compo.commandSheetRead.test.ts
+++ b/tests/compo.commandSheetRead.test.ts
@@ -93,6 +93,7 @@ describe("/compo advice command", () => {
           currentProjection: {
             totalWeight: 1_500_000,
             memberCount: 50,
+            missingWeights: 2,
             selectedHeatMapRef: {
               weightMinInclusive: 1_000_000,
               weightMaxInclusive: 2_000_000,
@@ -143,6 +144,7 @@ describe("/compo advice command", () => {
     expect(readCompoLinkedValuesSpy).not.toHaveBeenCalled();
 
     const payload = interaction.editReply.mock.calls.at(-1)?.[0];
+    expect(String(payload?.content ?? "")).toBe("RAW Data last refreshed: <t:1709900000:F>");
     expect(Array.isArray(payload?.embeds)).toBe(true);
     const embed = payload?.embeds?.[0]?.data ?? {};
     expect(String(embed?.description ?? "")).toBe("");
@@ -153,6 +155,7 @@ describe("/compo advice command", () => {
       "Current",
       "Target",
       "Recommendation",
+      "Result",
       "Current Deltas",
       "Adjacent Bands",
     ]);
@@ -163,28 +166,25 @@ describe("/compo advice command", () => {
     expect(JSON.stringify(embed?.fields ?? [])).toContain("Current Weight: 1,500,000");
     expect(JSON.stringify(embed?.fields ?? [])).toContain("Current Deviation Score: **0**");
     expect(JSON.stringify(embed?.fields ?? [])).toContain("Matchrate: 72.14%");
-    expect(JSON.stringify(embed?.fields ?? [])).toContain("Perfect compo matchrate: 72.14%");
     expect(JSON.stringify(embed?.fields ?? [])).toContain(
-      "Distance to Midpoint: -> +0",
+      "Missing weights: 2 [FWA Stats](https://fwastats.com/Clan/AAA111/Weight)",
     );
+    expect(JSON.stringify(embed?.fields ?? [])).toContain("Band matchrate: 72.14%");
+    expect(JSON.stringify(embed?.fields ?? [])).toContain("Band midpoint: +0");
     expect(String(embed?.title ?? "")).toContain("Alpha Clan (#AAA111)");
     expect(JSON.stringify(embed?.fields ?? [])).not.toContain("Alternates");
     expect(JSON.stringify(embed?.fields ?? [])).not.toContain("Snapshot");
     expect(JSON.stringify(embed?.fields ?? [])).toContain(
       ":arrow_arrow: __Add TH17__",
     );
-    expect(JSON.stringify(embed?.fields ?? [])).toContain(
-      "Resulting Deviation Score: **0**",
-    );
+    expect(JSON.stringify(embed?.fields ?? [])).toContain("Deviation Score: **0**");
     expect(JSON.stringify(embed?.fields ?? [])).toContain("Lower band: **0 - 999,999**");
     expect(JSON.stringify(embed?.fields ?? [])).toContain(
       "Higher band: **2,000,001 - 3,000,000**",
     );
     expect(JSON.stringify(embed?.fields ?? [])).toContain("Matchrate: 70.00%");
     expect(JSON.stringify(embed?.fields ?? [])).toContain("Matchrate: 74.00%");
-    expect(String(embed?.footer?.text ?? "")).toBe(
-      "RAW Data last refreshed: <t:1709900000:F> • Lower deviation score is better.",
-    );
+    expect(embed?.footer).toBeUndefined();
     expect(getComponentCustomIds(payload)).toEqual(
       expect.arrayContaining([
         "compo-refresh:advice:user-1:actual:auto:LQQ99UV8:1:0",
@@ -255,15 +255,41 @@ describe("/compo advice command", () => {
     await Compo.run({} as any, interaction as any, {} as any);
 
     const payload = interaction.editReply.mock.calls.at(-1)?.[0];
+    expect(String(payload?.content ?? "")).toBe("RAW Data last refreshed: <t:1709900000:F>");
     expect(JSON.stringify(payload?.embeds?.[0]?.data?.fields ?? [])).toContain(
       "Advice View: **Raw Data**",
     );
-    expect(String(payload?.embeds?.[0]?.data?.footer?.text ?? "")).toBe(
-      "RAW Data last refreshed: <t:1709900000:F> • Lower deviation score is better.",
-    );
+    expect(payload?.embeds?.[0]?.data?.footer).toBeUndefined();
     expect(getComponentCustomIds(payload)).toEqual([
       "compo-refresh:advice:user-1:war:LQQ99UV8",
       "compo-refresh:advice-clan:user-1:war:AAA111",
     ]);
+  });
+
+  it("renders empty advice with refresh content below the embed and no footer note", async () => {
+    vi.spyOn(CompoAdviceService.prototype, "readAdvice").mockResolvedValue({
+      kind: "empty",
+      mode: "actual",
+      selectedView: "auto",
+      trackedClanTags: ["#AAA111"],
+      trackedClanChoices: [{ tag: "#AAA111", name: "Alpha Clan-actual" }],
+      clanTag: null,
+      clanName: null,
+      message: "No tracked clan matched tag `#LQQ99UV8`.",
+      refreshLine: "RAW Data last refreshed: <t:1709900000:F>",
+    });
+
+    const interaction = makeInteraction({
+      subcommand: "advice",
+      tag: "#LQQ99UV8",
+    });
+    await Compo.run({} as any, interaction as any, {} as any);
+
+    const payload = interaction.editReply.mock.calls.at(-1)?.[0];
+    expect(String(payload?.content ?? "")).toBe("RAW Data last refreshed: <t:1709900000:F>");
+    expect(String(payload?.embeds?.[0]?.data?.description ?? "")).toContain(
+      "No tracked clan matched tag `#LQQ99UV8`.",
+    );
+    expect(payload?.embeds?.[0]?.data?.footer).toBeUndefined();
   });
 });

--- a/tests/compoAdvice.engine.test.ts
+++ b/tests/compoAdvice.engine.test.ts
@@ -295,6 +295,7 @@ describe("CompoAdviceEngine", () => {
         currentBandLabel: "(no band)",
         currentProjection: {
           totalWeight: NaN,
+          missingWeights: 0,
           selectedHeatMapRef: null,
         } as any,
         heatMapRefs: [],
@@ -310,7 +311,8 @@ describe("CompoAdviceEngine", () => {
     });
 
     expect(lines).toContain("Current Weight: unknown");
-    expect(lines).toContain("Distance to Midpoint: unknown");
+    expect(lines).toContain("Missing weights: 0");
+    expect(lines).toContain("Band midpoint: unknown");
     expect(lines).toContain("Matchrate: Unknown");
   });
 
@@ -323,12 +325,14 @@ describe("CompoAdviceEngine", () => {
     const lines = buildCompoAdviceContentLinesForTest({
       modeLabel: "ACTUAL",
       refreshLine: null,
+      clanTag: "#AAA111",
       summary: {
         viewLabel: "Auto-Detect Band",
         currentScore: 32.5,
         currentBandLabel: "1,000,000 - 2,000,000",
         currentProjection: {
           totalWeight: 1_500_000,
+          missingWeights: 2,
           selectedHeatMapRef: refs[1],
         } as any,
         heatMapRefs: refs,
@@ -348,14 +352,52 @@ describe("CompoAdviceEngine", () => {
     });
 
     expect(lines).toContain("Current Deviation Score: **32.5**");
+    expect(lines).toContain(
+      "Missing weights: 2 [FWA Stats](https://fwastats.com/Clan/AAA111/Weight)",
+    );
     expect(lines).toContain("Matchrate: 66.29%");
-    expect(lines).toContain("Perfect compo matchrate: 72.14%");
-    expect(lines).toContain("Resulting Deviation Score: **12.5**");
+    expect(lines).toContain("Band matchrate: 72.14%");
+    expect(lines).toContain("Band midpoint: +0");
+    expect(lines).toContain("Deviation Score: **12.5**");
     expect(lines).toContain("Matchrate: 69.89%");
     expect(lines).toContain("Lower band: **0 - 999,999**");
     expect(lines).toContain("Higher band: **2,000,001 - 3,000,000**");
     expect(lines).toContain("Matchrate: 70.00%");
     expect(lines).toContain("Matchrate: 74.00%");
+  });
+
+  it("prefixes the midpoint line with a warning when the current weight is outside the selected band", () => {
+    const lines = buildCompoAdviceContentLinesForTest({
+      modeLabel: "ACTUAL",
+      refreshLine: null,
+      clanTag: "#AAA111",
+      summary: {
+        viewLabel: "Custom",
+        currentScore: 5,
+        currentBandLabel: "2,000,000 - 2,500,000",
+        currentProjection: {
+          totalWeight: 1_500_000,
+          missingWeights: 1,
+          selectedHeatMapRef: makeHeatMapRef({
+            weightMinInclusive: 2_000_000,
+            weightMaxInclusive: 2_500_000,
+          }),
+        } as any,
+        heatMapRefs: [makeHeatMapRef({ weightMinInclusive: 2_000_000, weightMaxInclusive: 2_500_000 })],
+        bandMatchRatesByBandKey: new Map([["2000000-2500000", 0.6]]),
+        currentWeight: 1_500_000,
+        targetBandMidpoint: 1_420_000,
+        recommendationText: "Add TH17",
+        resultingScore: 4,
+        resultingBandLabel: "2,000,000 - 2,500,000",
+        alternateTexts: [],
+        statusText: null,
+      } as any,
+    });
+
+    expect(lines).toContain("Band midpoint: :warning: -80k");
+    expect(lines.join("\n")).not.toContain(":small_red_triangle");
+    expect(lines.join("\n")).not.toContain(":small_red_triangle_down");
   });
 
   it("steps Custom band indices deterministically and respects bounds", () => {


### PR DESCRIPTION
- move the advice refresh line into message content
- split target and result fields, plus add missing weights context
- update midpoint formatting and render tests