### PR TITLE
fix(reminders): add bounded catch-up grace for scheduler offsets

### DIFF
--- a/scripts/script_of_scripts.md
+++ b/scripts/script_of_scripts.md
@@ -11,15 +11,31 @@ Use loaded context as the source of truth:
 # 2) Start branch
 ./scripts/start-feature.sh <short-feature-name>
 
-After Step 2, stop and explicitly report:
+Immediately after Step 2, self-verify the branch before doing any other work.
+
+Required verification output:
 - current branch name
 - `git status --short --branch`
-- whether the branch is based on latest `origin/dev`
+- `git rev-parse HEAD`
+- `git rev-parse origin/dev`
 
-Do not start Step 3 until that confirmation has been shown.
+Required verification rule:
+- before any file reads, edits, or Step 3 work, `HEAD` must exactly equal `origin/dev`
+- do not rely on assumption; verify with the commands above
 
-If the branch confirmation is missing or ambiguous, stop and do not continue.
-Do not read other files, edit files, or run Step 3 until branch confirmation has been shown.
+If verification passes:
+- continue automatically to Step 3 without asking me to confirm
+
+If verification fails:
+- stop Step 3
+- fix it yourself by creating a fresh feature branch from the latest `origin/dev`
+- rerun the verification block
+- only continue once `HEAD == origin/dev`
+
+Hard rules:
+- do not ask me whether to continue if the verification passes
+- do not read other files, edit files, or run Step 3 until verification has passed
+- do not continue on a branch that is not based exactly on the latest `origin/dev`
 
 # 3) Task
 (Paste task here)

--- a/src/services/reminders/ReminderSchedulerService.ts
+++ b/src/services/reminders/ReminderSchedulerService.ts
@@ -11,6 +11,7 @@ import { normalizeClanTag } from "../PlayerLinkService";
 import { reminderDispatchService, type ReminderDispatchService } from "./ReminderDispatchService";
 
 const DEFAULT_REMINDER_SCHEDULER_INTERVAL_MS = 60 * 1000;
+const DEFAULT_REMINDER_SCHEDULER_CATCH_UP_GRACE_MS = 2 * 60 * 1000;
 
 type ReminderSchedulerRow = {
   id: string;
@@ -18,6 +19,7 @@ type ReminderSchedulerRow = {
   channelId: string;
   type: ReminderType;
   isEnabled: boolean;
+  createdAt: Date | null;
   times: Array<{ offsetSeconds: number }>;
   targetClans: Array<{ clanTag: string; clanType: ReminderTargetClanType }>;
 };
@@ -172,6 +174,7 @@ export async function runReminderSchedulerCycle(input: {
     channelId: row.channelId,
     type: row.type,
     isEnabled: row.isEnabled,
+    createdAt: row.createdAt ?? null,
     times: row.times,
     targetClans: row.targetClans,
   }));
@@ -203,6 +206,7 @@ export async function runReminderSchedulerCycle(input: {
             intervalMs,
             eventEndsAtMs: context.eventEndsAt.getTime(),
             offsetSeconds,
+            reminderCreatedAtMs: reminder.createdAt?.getTime() ?? null,
           })
         ) {
           continue;
@@ -282,14 +286,20 @@ function shouldReminderOffsetFire(input: {
   intervalMs: number;
   eventEndsAtMs: number;
   offsetSeconds: number;
+  reminderCreatedAtMs?: number | null;
 }): boolean {
   const offsetMs = Math.max(1, Math.trunc(input.offsetSeconds)) * 1000;
   const triggerAtMs = input.eventEndsAtMs - offsetMs;
   if (!Number.isFinite(triggerAtMs)) return false;
   if (input.nowMs >= input.eventEndsAtMs) return false;
-  const previousTickMs = input.nowMs - Math.max(1, input.intervalMs);
-  const crossedThisCycle = triggerAtMs > previousTickMs && triggerAtMs <= input.nowMs;
-  return crossedThisCycle;
+  if (Number.isFinite(input.reminderCreatedAtMs) && triggerAtMs < Number(input.reminderCreatedAtMs)) {
+    return false;
+  }
+  const allowedGraceMs = Math.max(
+    Math.max(1, Math.trunc(input.intervalMs)),
+    DEFAULT_REMINDER_SCHEDULER_CATCH_UP_GRACE_MS,
+  );
+  return triggerAtMs <= input.nowMs && triggerAtMs >= input.nowMs - allowedGraceMs;
 }
 
 /** Purpose: build deterministic dedupe key per reminder+clan+event identity+offset. */

--- a/tests/reminderScheduler.service.test.ts
+++ b/tests/reminderScheduler.service.test.ts
@@ -239,31 +239,73 @@ describe("ReminderSchedulerService v1 trigger semantics", () => {
     );
   });
 
-  it("fires only when the scheduler window crosses the offset boundary and never after event end", () => {
-    const endMs = Date.parse("2026-04-05T02:00:00.000Z");
+  it("fires a 24h WAR_CWL reminder when the scheduler lands shortly after battle day start", () => {
+    const eventEndsAtMs = Date.parse("2026-04-06T00:00:00.000Z");
+    const battleDayStartMs = eventEndsAtMs - 24 * 60 * 60 * 1000;
 
-    const crossed = shouldReminderOffsetFireForTest({
-      nowMs: endMs - 30 * 60 * 1000,
+    const slightlyLate = shouldReminderOffsetFireForTest({
+      nowMs: battleDayStartMs + 90_000,
       intervalMs: 60_000,
-      eventEndsAtMs: endMs,
-      offsetSeconds: 30 * 60,
+      eventEndsAtMs,
+      offsetSeconds: 24 * 60 * 60,
+      reminderCreatedAtMs: battleDayStartMs - 10 * 60 * 1000,
     });
-    const lateFire = shouldReminderOffsetFireForTest({
-      nowMs: endMs - 5 * 60 * 1000,
+    const tooLate = shouldReminderOffsetFireForTest({
+      nowMs: battleDayStartMs + 3 * 60 * 1000,
       intervalMs: 60_000,
-      eventEndsAtMs: endMs,
-      offsetSeconds: 30 * 60,
+      eventEndsAtMs,
+      offsetSeconds: 24 * 60 * 60,
+      reminderCreatedAtMs: battleDayStartMs - 10 * 60 * 1000,
     });
     const expired = shouldReminderOffsetFireForTest({
-      nowMs: endMs + 1,
+      nowMs: eventEndsAtMs + 1,
       intervalMs: 60_000,
-      eventEndsAtMs: endMs,
-      offsetSeconds: 30 * 60,
+      eventEndsAtMs,
+      offsetSeconds: 24 * 60 * 60,
+      reminderCreatedAtMs: battleDayStartMs - 10 * 60 * 1000,
     });
 
-    expect(crossed).toBe(true);
-    expect(lateFire).toBe(false);
+    expect(slightlyLate).toBe(true);
+    expect(tooLate).toBe(false);
     expect(expired).toBe(false);
+  });
+
+  it("does not fire after the bounded grace window has passed", () => {
+    const eventEndsAtMs = Date.parse("2026-04-05T02:00:00.000Z");
+
+    const withinGrace = shouldReminderOffsetFireForTest({
+      nowMs: eventEndsAtMs - 30 * 60 * 1000 + 90_000,
+      intervalMs: 60_000,
+      eventEndsAtMs,
+      offsetSeconds: 30 * 60,
+      reminderCreatedAtMs: eventEndsAtMs - 60 * 60 * 1000,
+    });
+    const beyondGrace = shouldReminderOffsetFireForTest({
+      nowMs: eventEndsAtMs - 30 * 60 * 1000 + 3 * 60 * 1000,
+      intervalMs: 60_000,
+      eventEndsAtMs,
+      offsetSeconds: 30 * 60,
+      reminderCreatedAtMs: eventEndsAtMs - 60 * 60 * 1000,
+    });
+
+    expect(withinGrace).toBe(true);
+    expect(beyondGrace).toBe(false);
+  });
+
+  it("does not backfill a reminder that was created after the trigger time", () => {
+    const eventEndsAtMs = Date.parse("2026-04-06T00:00:00.000Z");
+    const battleDayStartMs = eventEndsAtMs - 24 * 60 * 60 * 1000;
+    const reminderCreatedAtMs = battleDayStartMs + 30_000;
+
+    const backfillBlocked = shouldReminderOffsetFireForTest({
+      nowMs: battleDayStartMs + 90_000,
+      intervalMs: 60_000,
+      eventEndsAtMs,
+      offsetSeconds: 24 * 60 * 60,
+      reminderCreatedAtMs,
+    });
+
+    expect(backfillBlocked).toBe(false);
   });
 
   it("skips already-missed offsets for a newly created active-war reminder", async () => {


### PR DESCRIPTION
- allow WAR/CWL reminders to fire slightly late across scheduler jitter
- keep newly created reminders from backfilling already-missed offsets