### PR TITLE
fix(compo): restore custom current scores and result matchrate

### DIFF
--- a/src/helper/compoAdviceEngine.ts
+++ b/src/helper/compoAdviceEngine.ts
@@ -387,8 +387,8 @@ function buildCustomProjection(input: {
 
   if (!selection.selectedHeatMapRef) {
     return {
-      currentProjection: rawProjection,
-      targetProjection: rawProjection,
+      currentProjection: scoreProjectionIfNeeded(rawProjection),
+      targetProjection: scoreProjectionIfNeeded(rawProjection),
       selectedCustomBandIndex: null,
       heatMapRefs: selection.heatMapRefs,
     };
@@ -400,7 +400,7 @@ function buildCustomProjection(input: {
   );
 
   return {
-    currentProjection: rawProjection,
+    currentProjection: scoreProjectionIfNeeded(rawProjection),
     targetProjection: {
       ...rawProjection,
       selectedHeatMapRef: selection.selectedHeatMapRef,
@@ -479,36 +479,11 @@ function projectAdviceState(input: {
     });
   }
 
-  const projection = projectCompoActualStateView({
+  const projection = scoreProjectionIfNeeded(projectCompoActualStateView({
     view: input.view,
     base: input.base,
     heatMapRefs: input.heatMapRefs,
-  });
-  if (projection.deviationScore === null && projection.selectedHeatMapRef) {
-    return {
-      currentProjection: {
-        ...projection,
-        deviationScore: calculateCompoDeviationScore({
-          displayCounts: projection.displayCounts,
-          heatMapRef: projection.selectedHeatMapRef,
-        }),
-      },
-      targetProjection: {
-        ...projection,
-        deviationScore: calculateCompoDeviationScore({
-          displayCounts: projection.displayCounts,
-          heatMapRef: projection.selectedHeatMapRef,
-        }),
-      },
-      selectedCustomBandIndex:
-        getHeatMapRefIndex(
-          sortHeatMapRefs(input.heatMapRefs),
-          projection.selectedHeatMapRef,
-        ) ??
-        (input.heatMapRefs.length > 0 ? 0 : null),
-      heatMapRefs: sortHeatMapRefs(input.heatMapRefs),
-    };
-  }
+  }));
   return {
     currentProjection: projection,
     targetProjection: projection,
@@ -516,6 +491,19 @@ function projectAdviceState(input: {
       getHeatMapRefIndex(sortHeatMapRefs(input.heatMapRefs), projection.selectedHeatMapRef) ??
       (input.heatMapRefs.length > 0 ? 0 : null),
     heatMapRefs: sortHeatMapRefs(input.heatMapRefs),
+  };
+}
+
+function scoreProjectionIfNeeded(projection: CompoActualStateProjection): CompoActualStateProjection {
+  if (projection.deviationScore !== null || projection.selectedHeatMapRef === null) {
+    return projection;
+  }
+  return {
+    ...projection,
+    deviationScore: calculateCompoDeviationScore({
+      displayCounts: projection.displayCounts,
+      heatMapRef: projection.selectedHeatMapRef,
+    }),
   };
 }
 
@@ -755,10 +743,6 @@ export function evaluateCompoAdvice(input: {
     bandMatchrate: currentBandMatchrate,
     deviationScore: currentScore,
   });
-  const targetMatchrate = estimateMatchrateFromDeviation({
-    bandMatchrate: targetBandMatchrate,
-    deviationScore: targetScore,
-  });
   const targetBandMidpoint = resolveAdviceTargetBandMidpoint({
     heatMapRefs: projectionState.heatMapRefs,
     selectedHeatMapRef: targetProjection.selectedHeatMapRef,
@@ -809,7 +793,10 @@ export function evaluateCompoAdvice(input: {
     targetBandMidpoint,
     currentMatchrate,
     targetBandMatchrate,
-    resultingMatchrate: targetMatchrate,
+    resultingMatchrate: estimateMatchrateFromDeviation({
+      bandMatchrate: targetBandMatchrate,
+      deviationScore: resultingScore,
+    }),
     currentScore,
     currentBandLabel,
     targetBandLabel,

--- a/tests/compoAdvice.engine.test.ts
+++ b/tests/compoAdvice.engine.test.ts
@@ -173,12 +173,11 @@ describe("CompoAdviceEngine", () => {
 
   it("changes Custom advice when the target band changes", () => {
     const base = {
-      resolvedTotalWeight: 49 * 135000 + 145000,
+      resolvedTotalWeight: 350_000,
       unresolvedWeightCount: 0,
       memberCount: 50,
       bucketCounts: makeBucketCounts({
-        TH14: 49,
-        TH15: 1,
+        TH15: 50,
       }),
     };
     const heatMapRefs = [
@@ -218,12 +217,14 @@ describe("CompoAdviceEngine", () => {
     expect(first.viewLabel).toBe("Custom");
     expect(second.viewLabel).toBe("Custom");
     expect(first.currentBandLabel).toBe(second.currentBandLabel);
+    expect(first.currentBandLabel).not.toBe("(no band)");
     expect(first.targetBandLabel).not.toBe(second.targetBandLabel);
     expect(first.currentMatchrate).toBeCloseTo(second.currentMatchrate ?? 0, 6);
     expect(first.targetBandMatchrate).not.toBe(second.targetBandMatchrate);
     expect(first.resultingMatchrate).not.toBe(second.resultingMatchrate);
     expect(first.recommendationText).not.toBe(second.recommendationText);
     expect(first.currentScore).toBe(second.currentScore);
+    expect(first.currentScore).not.toBeNull();
   });
 
   it("computes midpoint advice using middle-band arithmetic and end-band offsets", () => {
@@ -275,6 +276,18 @@ describe("CompoAdviceEngine", () => {
     expect(formatMatchratePercentForTest(0.7214)).toBe("72.14%");
     expect(formatMatchratePercentForTest(72.14)).toBe("72.14%");
     expect(formatMatchratePercentForTest(null)).toBe("Unknown");
+    const currentMatchrate = estimateMatchrateFromDeviationForTest({
+      bandMatchrate: 0.7214,
+      deviationScore: 23,
+    });
+    const resultingMatchrate = estimateMatchrateFromDeviationForTest({
+      bandMatchrate: 0.7214,
+      deviationScore: 15,
+    });
+    expect(currentMatchrate).toBeCloseTo(0.68, 4);
+    expect(resultingMatchrate).toBeCloseTo(0.6944, 4);
+    expect(resultingMatchrate).toBeGreaterThan(currentMatchrate ?? 0);
+    expect(resultingMatchrate).not.toBe(currentMatchrate);
     expect(
       estimateMatchrateFromDeviationForTest({
         bandMatchrate: 0.7214,

--- a/tests/compoAdvice.service.test.ts
+++ b/tests/compoAdvice.service.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GoogleSheetsService } from "../src/services/GoogleSheetsService";
+import { HeatMapRefDisplayService } from "../src/services/HeatMapRefDisplayService";
 import {
   CompoAdviceService,
   countRushedCompoMembers,
@@ -277,6 +278,82 @@ describe("CompoAdviceService", () => {
     expect(result.trackedClanChoices).toEqual([
       { tag: "#AAA111", name: "Alpha Clan-actual" },
     ]);
+  });
+
+  it("keeps Custom current score and matchrate populated while shifting the target band", async () => {
+    prismaMock.trackedClan.findMany.mockResolvedValue([
+      makeTrackedClan("#AAA111", "Alpha Clan-actual"),
+    ]);
+    prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue([
+      makeCurrentMember({
+        clanTag: "#AAA111",
+        playerTag: "#P000001",
+        playerName: "P1",
+        townHall: 15,
+        weight: 175000,
+      }),
+      makeCurrentMember({
+        clanTag: "#AAA111",
+        playerTag: "#P000002",
+        playerName: "P2",
+        townHall: 15,
+        weight: 175000,
+      }),
+    ]);
+    prismaMock.weightInputDeferment.findMany.mockResolvedValue([]);
+    prismaMock.fwaTrackedClanWarRosterMemberCurrent.findMany.mockResolvedValue([]);
+    prismaMock.heatMapRef.findMany.mockResolvedValue([
+      makeHeatMapRef({
+        weightMinInclusive: 0,
+        weightMaxInclusive: 299_999,
+        th14Count: 50,
+      }),
+      makeHeatMapRef({
+        weightMinInclusive: 300_000,
+        weightMaxInclusive: 599_999,
+        th15Count: 50,
+      }),
+    ]);
+    vi.spyOn(
+      HeatMapRefDisplayService.prototype,
+      "readHeatMapRefBandMatchRates",
+    ).mockResolvedValue(
+      new Map([
+        ["0-299999", 0.7025],
+        ["300000-599999", 0.7412],
+      ]),
+    );
+
+    const first = await new CompoAdviceService().readAdvice({
+      guildId: "guild-1",
+      targetTag: "#AAA111",
+      mode: "actual",
+      view: "custom",
+      customBandIndex: 0,
+    });
+    const second = await new CompoAdviceService().readAdvice({
+      guildId: "guild-1",
+      targetTag: "#AAA111",
+      mode: "actual",
+      view: "custom",
+      customBandIndex: 1,
+    });
+
+    expect(first.kind).toBe("ready");
+    expect(second.kind).toBe("ready");
+    expect(first.summary.viewLabel).toBe("Custom");
+    expect(second.summary.viewLabel).toBe("Custom");
+    expect(first.summary.currentBandLabel).not.toBe("(no band)");
+    expect(first.summary.currentBandLabel).toBe(second.summary.currentBandLabel);
+    expect(first.summary.currentScore).not.toBeNull();
+    expect(first.summary.currentMatchrate).not.toBeNull();
+    expect(first.summary.currentScore).toBe(second.summary.currentScore);
+    expect(first.summary.currentMatchrate).toBeCloseTo(
+      second.summary.currentMatchrate ?? 0,
+      6,
+    );
+    expect(first.summary.targetBandLabel).not.toBe(second.summary.targetBandLabel);
+    expect(first.summary.targetBandMatchrate).not.toBe(second.summary.targetBandMatchrate);
   });
 
   it("loads WAR advice from DB-backed tracked war state without sheet reads", async () => {


### PR DESCRIPTION
- score custom current projections against the raw band so current matchrate stays populated
- derive result matchrate from the post-recommendation score instead of copying target matchrate