### PR TITLE
fix(compo): restore custom current scores and result matchrate

### DIFF
--- a/src/services/TodoSnapshotService.ts
+++ b/src/services/TodoSnapshotService.ts
@@ -812,6 +812,8 @@ export class TodoSnapshotService {
     const snapshotUpserts: Array<
       Parameters<typeof prisma.todoPlayerSnapshot.upsert>[0]
     > = [];
+    let raidActiveTrueCount = 0;
+    let raidActiveFalseCount = 0;
 
     for (const playerTag of normalizedTags) {
       const existing = existingByTag.get(playerTag);
@@ -981,6 +983,11 @@ export class TodoSnapshotService {
         gamesEndsAt: new Date(gamesWindow.endMs),
         lastUpdatedAt: now,
       };
+      if (data.raidActive) {
+        raidActiveTrueCount += 1;
+      } else {
+        raidActiveFalseCount += 1;
+      }
 
       snapshotUpserts.push({
         where: { playerTag },
@@ -991,6 +998,10 @@ export class TodoSnapshotService {
         },
       });
     }
+
+    console.info(
+      `[todo-snapshot] event=raid_snapshot_refresh now_ms=${nowMs} raid_start_ms=${raidWindow.startMs} raid_end_ms=${raidWindow.endMs} raid_active=${raidWindow.active} player_count=${normalizedTags.length} raid_active_rows=${raidActiveTrueCount} raid_inactive_rows=${raidActiveFalseCount}`,
+    );
 
     try {
       await runChunkedWrites(
@@ -1854,17 +1865,16 @@ function resolveRaidWeekendWindow(nowMs: number): TodoWindow {
     0,
     0,
   );
-  const weekStartMs = dayStartMs - now.getUTCDay() * dayMs;
-  const fridayStartMs = weekStartMs + 5 * dayMs + 7 * hourMs;
+  const fridayDayOffset = (now.getUTCDay() - 5 + 7) % 7;
+  let fridayStartMs = dayStartMs - fridayDayOffset * dayMs + 7 * hourMs;
+  if (nowMs < fridayStartMs) {
+    fridayStartMs -= 7 * dayMs;
+  }
   const raidEndMs = fridayStartMs + 3 * dayMs;
 
   if (nowMs >= fridayStartMs && nowMs < raidEndMs) {
     return { active: true, startMs: fridayStartMs, endMs: raidEndMs };
   }
-  if (nowMs < fridayStartMs) {
-    return { active: false, startMs: fridayStartMs, endMs: raidEndMs };
-  }
-
   const nextStartMs = fridayStartMs + 7 * dayMs;
   return {
     active: false,
@@ -1872,6 +1882,9 @@ function resolveRaidWeekendWindow(nowMs: number): TodoWindow {
     endMs: nextStartMs + 3 * dayMs,
   };
 }
+
+/** Purpose: expose raid-weekend window resolution for isolated tests. */
+export const resolveRaidWeekendWindowForTest = resolveRaidWeekendWindow;
 
 /** Purpose: build one UTC-safe Clan Games cycle boundary set for a specific calendar month. */
 function buildClanGamesCycleBoundary(

--- a/tests/todo.command.test.ts
+++ b/tests/todo.command.test.ts
@@ -3619,6 +3619,7 @@ describe("/todo refresh button", () => {
     expect(description).toContain(
       `<t:${Math.floor(refreshedAt.getTime() / 1000)}:R>`,
     );
+    expect(description).not.toContain("No raids active");
     expect(description).toContain(":yellow_circle: Alpha - 3 / 6");
   });
 

--- a/tests/todoSnapshot.service.test.ts
+++ b/tests/todoSnapshot.service.test.ts
@@ -83,6 +83,7 @@ vi.mock("../src/services/CoCRequestQueueService", () => ({
 
 import {
   resolveClanGamesWindowForTest,
+  resolveRaidWeekendWindowForTest,
   resolveWarEventLinkedPlayerRefreshPlanForTest,
   resetTodoSnapshotServiceForTest,
   todoSnapshotService,
@@ -1214,6 +1215,117 @@ describe("TodoSnapshotService", () => {
         }),
       }),
     );
+  });
+
+  it("resolves raid weekend windows across the Friday UTC start and Monday UTC end", () => {
+    const beforeStart = resolveRaidWeekendWindowForTest(
+      Date.UTC(2026, 2, 27, 6, 59, 59, 999),
+    );
+    const atStart = resolveRaidWeekendWindowForTest(
+      Date.UTC(2026, 2, 27, 7, 0, 0, 0),
+    );
+    const midWeekend = resolveRaidWeekendWindowForTest(
+      Date.UTC(2026, 2, 29, 12, 0, 0, 0),
+    );
+    const beforeEnd = resolveRaidWeekendWindowForTest(
+      Date.UTC(2026, 2, 30, 6, 59, 59, 999),
+    );
+    const atEnd = resolveRaidWeekendWindowForTest(
+      Date.UTC(2026, 2, 30, 7, 0, 0, 0),
+    );
+    const afterEnd = resolveRaidWeekendWindowForTest(
+      Date.UTC(2026, 2, 30, 7, 0, 0, 1),
+    );
+
+    expect(beforeStart.active).toBe(false);
+    expect(beforeStart.startMs).toBe(Date.UTC(2026, 2, 27, 7, 0, 0, 0));
+    expect(beforeStart.endMs).toBe(Date.UTC(2026, 2, 30, 7, 0, 0, 0));
+
+    expect(atStart.active).toBe(true);
+    expect(atStart.startMs).toBe(Date.UTC(2026, 2, 27, 7, 0, 0, 0));
+    expect(atStart.endMs).toBe(Date.UTC(2026, 2, 30, 7, 0, 0, 0));
+
+    expect(midWeekend.active).toBe(true);
+    expect(midWeekend.startMs).toBe(Date.UTC(2026, 2, 27, 7, 0, 0, 0));
+    expect(midWeekend.endMs).toBe(Date.UTC(2026, 2, 30, 7, 0, 0, 0));
+
+    expect(beforeEnd.active).toBe(true);
+    expect(beforeEnd.startMs).toBe(Date.UTC(2026, 2, 27, 7, 0, 0, 0));
+    expect(beforeEnd.endMs).toBe(Date.UTC(2026, 2, 30, 7, 0, 0, 0));
+
+    expect(atEnd.active).toBe(false);
+    expect(atEnd.startMs).toBe(Date.UTC(2026, 3, 3, 7, 0, 0, 0));
+    expect(atEnd.endMs).toBe(Date.UTC(2026, 3, 6, 7, 0, 0, 0));
+
+    expect(afterEnd.active).toBe(false);
+    expect(afterEnd.startMs).toBe(Date.UTC(2026, 3, 3, 7, 0, 0, 0));
+    expect(afterEnd.endMs).toBe(Date.UTC(2026, 3, 6, 7, 0, 0, 0));
+  });
+
+  it("writes raidActive=true for snapshots refreshed during an active raid weekend and false outside it", async () => {
+    prismaMock.todoPlayerSnapshot.findMany.mockResolvedValue([
+      buildSnapshotRow({
+        playerTag: "#PYLQ0289",
+        playerName: "Alpha",
+        raidActive: false,
+        raidAttacksUsed: 0,
+      }),
+    ]);
+    prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue([]);
+    prismaMock.fwaWarMemberCurrent.findMany.mockResolvedValue([]);
+    prismaMock.currentWar.findMany.mockResolvedValue([]);
+    prismaMock.trackedClan.findMany.mockResolvedValue([]);
+    prismaMock.raidTrackedClan.findMany.mockResolvedValue([]);
+    prismaMock.cwlTrackedClan.findMany.mockResolvedValue([]);
+    prismaMock.cwlPlayerClanSeason.findMany.mockResolvedValue([]);
+    const cocService = {
+      getPlayerRaw: vi.fn().mockResolvedValue({
+        tag: "#PYLQ0289",
+        clan: { tag: "#PQL0289" },
+      }),
+      getClanCapitalRaidSeasons: vi.fn().mockResolvedValue([
+        {
+          startTime: "20260327T070000.000Z",
+          endTime: "20260330T070000.000Z",
+          members: [{ tag: "#PYLQ0289", attacks: 3 }],
+        },
+      ]),
+    };
+
+    await todoSnapshotService.refreshSnapshotsForPlayerTags({
+      playerTags: ["#PYLQ0289"],
+      cocService: cocService as any,
+      nowMs: Date.UTC(2026, 2, 29, 12, 0, 0, 0),
+    });
+
+    expect(prismaMock.todoPlayerSnapshot.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({
+          raidActive: true,
+          raidAttacksUsed: 3,
+        }),
+      }),
+    );
+    expect(cocService.getClanCapitalRaidSeasons).toHaveBeenCalledWith("#PQL0289", 2);
+
+    prismaMock.todoPlayerSnapshot.upsert.mockClear();
+    (cocService.getClanCapitalRaidSeasons as ReturnType<typeof vi.fn>).mockClear();
+
+    await todoSnapshotService.refreshSnapshotsForPlayerTags({
+      playerTags: ["#PYLQ0289"],
+      cocService: cocService as any,
+      nowMs: Date.UTC(2026, 3, 2, 12, 0, 0, 0),
+    });
+
+    expect(prismaMock.todoPlayerSnapshot.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({
+          raidActive: false,
+          raidAttacksUsed: 0,
+        }),
+      }),
+    );
+    expect(cocService.getClanCapitalRaidSeasons).not.toHaveBeenCalled();
   });
 
   it("preserves the active war clan context when a linked account moves clans", async () => {


### PR DESCRIPTION
- score custom current projections against the raw band so current matchrate stays populated
- derive result matchrate from the post-recommendation score instead of copying target matchrate fix(todo): restore raid weekend active window

- anchor raid weekend detection to the most recent Friday 07:00 UTC
- add structured refresh logging and regressions for active and inactive raid snapshots