### PR TITLE
feat(reminders): add reminder self-link buttons

### DIFF
--- a/src/commands/Link.ts
+++ b/src/commands/Link.ts
@@ -35,6 +35,13 @@ import {
   normalizePlayerTag,
 } from "../services/PlayerLinkService";
 import { PlayerLinkSyncService } from "../services/PlayerLinkSyncService";
+import {
+  buildReminderLinkCancelCustomId,
+  buildReminderLinkConfirmCustomId,
+  parseReminderLinkButtonCustomId,
+  parseReminderLinkCancelCustomId,
+  parseReminderLinkConfirmCustomId,
+} from "../services/reminders/ReminderLinkActions";
 
 const permissionService = new CommandPermissionService();
 const LINK_LIST_SELECT_PREFIX = "link-list-select";
@@ -1070,6 +1077,64 @@ export function isLinkEmbedAccountButtonCustomId(customId: string): boolean {
   return String(customId ?? "").startsWith(`${LINK_EMBED_BUTTON_PREFIX}:`);
 }
 
+function buildReminderLinkConfirmationRows(input: {
+  channelId: string;
+  messageId: string;
+  playerTag: string;
+}): ActionRowBuilder<ButtonBuilder>[] {
+  return [
+    new ActionRowBuilder<ButtonBuilder>().addComponents(
+      new ButtonBuilder()
+        .setCustomId(
+          buildReminderLinkConfirmCustomId({
+            channelId: input.channelId,
+            messageId: input.messageId,
+            playerTag: input.playerTag,
+          }),
+        )
+        .setLabel("Confirm")
+        .setStyle(ButtonStyle.Success),
+      new ButtonBuilder()
+        .setCustomId(
+          buildReminderLinkCancelCustomId({
+            channelId: input.channelId,
+            messageId: input.messageId,
+            playerTag: input.playerTag,
+          }),
+        )
+        .setLabel("Cancel")
+        .setStyle(ButtonStyle.Secondary),
+    ),
+  ];
+}
+
+export function isReminderLinkButtonCustomId(customId: string): boolean {
+  return parseReminderLinkButtonCustomId(customId) !== null;
+}
+
+export function isReminderLinkConfirmButtonCustomId(customId: string): boolean {
+  return parseReminderLinkConfirmCustomId(customId) !== null;
+}
+
+export function isReminderLinkCancelButtonCustomId(customId: string): boolean {
+  return parseReminderLinkCancelCustomId(customId) !== null;
+}
+
+function buildReminderLinkRejectedMessage(input: {
+  playerTag: string;
+  existingDiscordUserId?: string | null;
+  outcome: PlayerLinkCreateResult["outcome"];
+  targetDiscordUserId: string;
+}): string {
+  return formatLinkCreateResultMessage({
+    outcome: input.outcome,
+    playerTag: input.playerTag,
+    existingDiscordUserId: input.existingDiscordUserId ?? null,
+    targetDiscordUserId: input.targetDiscordUserId,
+    isSelfCreate: true,
+  });
+}
+
 export function isLinkEmbedModalCustomId(customId: string): boolean {
   const input = String(customId ?? "");
   return (
@@ -1234,6 +1299,147 @@ export async function handleLinkEmbedButtonInteraction(
     );
 
   await interaction.showModal(modal);
+}
+
+export async function handleReminderLinkButtonInteraction(
+  interaction: ButtonInteraction,
+): Promise<void> {
+  const parsed = parseReminderLinkButtonCustomId(interaction.customId);
+  if (!parsed) return;
+
+  if (!interaction.guildId || interaction.guildId !== parsed.guildId) {
+    await interaction.reply({
+      ephemeral: true,
+      content:
+        "invalid_context: this reminder link button can only be used in its original server.",
+    });
+    return;
+  }
+
+  if (!interaction.channelId) {
+    await interaction.reply({
+      ephemeral: true,
+      content: "invalid_context: unable to open reminder link confirmation.",
+    });
+    return;
+  }
+
+  await interaction.reply({
+    ephemeral: true,
+    content: `Link \`${parsed.playerTag}\` to your Discord account?`,
+    components: buildReminderLinkConfirmationRows({
+      channelId: interaction.channelId,
+      messageId: interaction.message.id,
+      playerTag: parsed.playerTag,
+    }),
+  });
+}
+
+export async function handleReminderLinkConfirmButtonInteraction(
+  interaction: ButtonInteraction,
+): Promise<void> {
+  const parsed = parseReminderLinkConfirmCustomId(interaction.customId);
+  if (!parsed) return;
+
+  if (!interaction.guildId || interaction.channelId !== parsed.channelId) {
+    await interaction.reply({
+      ephemeral: true,
+      content:
+        "invalid_context: this reminder link confirmation can only be used in its original channel.",
+    });
+    return;
+  }
+
+  await interaction.deferUpdate();
+
+  const result = await createPlayerLink({
+    playerTag: parsed.playerTag,
+    targetDiscordUserId: interaction.user.id,
+    selfService: true,
+  });
+
+  if (result.outcome === "created") {
+    await disableReminderLinkButtonOnOriginalMessage({
+      interaction,
+      channelId: parsed.channelId,
+      messageId: parsed.messageId,
+      playerTag: parsed.playerTag,
+    });
+  }
+
+  await interaction.editReply(
+    buildReminderLinkRejectedMessage({
+      outcome: result.outcome,
+      playerTag: result.playerTag,
+      existingDiscordUserId: result.existingDiscordUserId,
+      targetDiscordUserId: interaction.user.id,
+    }),
+  );
+}
+
+export async function handleReminderLinkCancelButtonInteraction(
+  interaction: ButtonInteraction,
+): Promise<void> {
+  const parsed = parseReminderLinkCancelCustomId(interaction.customId);
+  if (!parsed) return;
+
+  if (!interaction.guildId || interaction.channelId !== parsed.channelId) {
+    await interaction.reply({
+      ephemeral: true,
+      content:
+        "invalid_context: this reminder link cancellation can only be used in its original channel.",
+    });
+    return;
+  }
+
+  await interaction.update({
+    content: "Canceled.",
+    components: [],
+  });
+}
+
+function disableReminderLinkButtonOnOriginalMessage(input: {
+  interaction: ButtonInteraction;
+  channelId: string;
+  messageId: string;
+  playerTag: string;
+}): Promise<void> {
+  return (async () => {
+    const channel = await input.interaction.client.channels.fetch(input.channelId).catch(() => null);
+    if (!channel || !channel.isTextBased() || !("messages" in channel)) {
+      return;
+    }
+
+    const message = await channel.messages.fetch(input.messageId).catch(() => null);
+    if (!message) return;
+
+    const updatedComponents = message.components.map((row) => {
+      const rowJson = row.toJSON() as {
+        type?: number;
+        components?: Array<Record<string, unknown>>;
+      };
+      return {
+        ...rowJson,
+        components: Array.isArray(rowJson.components)
+          ? rowJson.components.map((component) => {
+              const customId = String(component.custom_id ?? component.customId ?? "");
+              if (
+                customId.startsWith("reminder-link:claim:") &&
+                customId.endsWith(`:${input.playerTag}`)
+              ) {
+                return {
+                  ...component,
+                  disabled: true,
+                };
+              }
+              return component;
+            })
+          : [],
+      };
+    });
+
+    await message.edit({ components: updatedComponents as any }).catch(() => undefined);
+  })();
 }
 
 export async function handleLinkEmbedModalSubmit(

--- a/src/listeners/interactionCreate.ts
+++ b/src/listeners/interactionCreate.ts
@@ -88,9 +88,15 @@ import {
 import {
   handleLinkEmbedButtonInteraction,
   handleLinkEmbedModalSubmit,
+  handleReminderLinkButtonInteraction,
+  handleReminderLinkCancelButtonInteraction,
+  handleReminderLinkConfirmButtonInteraction,
   handleLinkListSelectMenu,
   handleLinkListSortButton,
   isLinkEmbedAccountButtonCustomId,
+  isReminderLinkButtonCustomId,
+  isReminderLinkCancelButtonCustomId,
+  isReminderLinkConfirmButtonCustomId,
   isLinkEmbedModalCustomId,
   isLinkListSelectCustomId,
   isLinkListSortButtonCustomId,
@@ -481,6 +487,51 @@ const handleButtonInteraction = async (
         await interaction.reply({
           ephemeral: true,
           content: "Failed to open link modal.",
+        });
+      }
+    }
+    return;
+  }
+
+  if (isReminderLinkButtonCustomId(interaction.customId)) {
+    try {
+      await handleReminderLinkButtonInteraction(interaction);
+    } catch (err) {
+      console.error(`Reminder link button failed: ${formatError(err)}`);
+      if (!interaction.replied && !interaction.deferred) {
+        await interaction.reply({
+          ephemeral: true,
+          content: "Failed to open reminder link confirmation.",
+        });
+      }
+    }
+    return;
+  }
+
+  if (isReminderLinkConfirmButtonCustomId(interaction.customId)) {
+    try {
+      await handleReminderLinkConfirmButtonInteraction(interaction);
+    } catch (err) {
+      console.error(`Reminder link confirm button failed: ${formatError(err)}`);
+      if (!interaction.replied && !interaction.deferred) {
+        await interaction.reply({
+          ephemeral: true,
+          content: "Failed to confirm reminder link.",
+        });
+      }
+    }
+    return;
+  }
+
+  if (isReminderLinkCancelButtonCustomId(interaction.customId)) {
+    try {
+      await handleReminderLinkCancelButtonInteraction(interaction);
+    } catch (err) {
+      console.error(`Reminder link cancel button failed: ${formatError(err)}`);
+      if (!interaction.replied && !interaction.deferred) {
+        await interaction.reply({
+          ephemeral: true,
+          content: "Failed to cancel reminder link.",
         });
       }
     }

--- a/src/services/PlayerLinkService.ts
+++ b/src/services/PlayerLinkService.ts
@@ -144,20 +144,77 @@ export async function createPlayerLink(input: {
     };
   }
 
-  if (existing) {
-    await prisma.playerLink.update({
+  try {
+    if (existing) {
+      const updated = await prisma.playerLink.updateMany({
+        where: {
+          playerTag: normalizedTag,
+          OR: [{ discordUserId: null }, { discordUserId: normalizedUserId }],
+        },
+        data: {
+          discordUserId: normalizedUserId,
+        },
+      });
+
+      if (updated.count <= 0) {
+        const racedExisting = await prisma.playerLink.findUnique({
+          where: { playerTag: normalizedTag },
+          select: { discordUserId: true },
+        });
+        if (racedExisting?.discordUserId) {
+          if (racedExisting.discordUserId === normalizedUserId) {
+            return {
+              outcome: input.selfService ? "already_linked_to_you" : "already_linked_to_target_user",
+              playerTag: normalizedTag,
+              discordUserId: normalizedUserId,
+              existingDiscordUserId: racedExisting.discordUserId,
+            };
+          }
+          return {
+            outcome: "already_linked_to_other_user",
+            playerTag: normalizedTag,
+            discordUserId: normalizedUserId,
+            existingDiscordUserId: racedExisting.discordUserId,
+          };
+        }
+
+        await prisma.playerLink.create({
+          data: {
+            playerTag: normalizedTag,
+            discordUserId: normalizedUserId,
+          },
+        });
+      }
+    } else {
+      await prisma.playerLink.create({
+        data: {
+          playerTag: normalizedTag,
+          discordUserId: normalizedUserId,
+        },
+      });
+    }
+  } catch (err) {
+    const code = (err as { code?: string } | null | undefined)?.code ?? "";
+    if (code !== "P2002") throw err;
+
+    const racedExisting = await prisma.playerLink.findUnique({
       where: { playerTag: normalizedTag },
-      data: {
-        discordUserId: normalizedUserId,
-      },
+      select: { discordUserId: true },
     });
-  } else {
-    await prisma.playerLink.create({
-      data: {
+    if (racedExisting?.discordUserId === normalizedUserId) {
+      return {
+        outcome: input.selfService ? "already_linked_to_you" : "already_linked_to_target_user",
         playerTag: normalizedTag,
         discordUserId: normalizedUserId,
-      },
-    });
+        existingDiscordUserId: racedExisting.discordUserId,
+      };
+    }
+    return {
+      outcome: "already_linked_to_other_user",
+      playerTag: normalizedTag,
+      discordUserId: normalizedUserId,
+      existingDiscordUserId: racedExisting?.discordUserId ?? null,
+    };
   }
   return {
     outcome: "created",

--- a/src/services/reminders/ReminderDispatchService.ts
+++ b/src/services/reminders/ReminderDispatchService.ts
@@ -1,12 +1,15 @@
 import { ReminderType } from "@prisma/client";
-import { Client } from "discord.js";
+import { ActionRowBuilder, ButtonBuilder, ButtonStyle, Client } from "discord.js";
 import type { ClanWar } from "../../generated/coc-api";
 import { formatError } from "../../helper/formatError";
-import { splitDiscordLineMessages } from "../../helper/discordLineMessageSplit";
+import { truncateDiscordContent } from "../../helper/discordContent";
 import { prisma } from "../../prisma";
 import { resolveCurrentWarMatchTypeSignal } from "../MatchTypeResolutionService";
 import { CoCService, type ClanCapitalRaidSeason } from "../CoCService";
 import { normalizeClanTag, normalizePlayerTag } from "../PlayerLinkService";
+import {
+  buildReminderLinkButtonCustomId,
+} from "./ReminderLinkActions";
 import { parseCocTime } from "../war-events/core";
 
 export type ReminderDispatchInput = {
@@ -55,7 +58,19 @@ type ReminderRosterEntry = {
 
 type ReminderRosterResolveResult = {
   windowActive: boolean;
-  lines: string[];
+  roster: ReminderRosterEntry[];
+};
+
+type ReminderDispatchMessage = {
+  content: string;
+  components: ActionRowBuilder<ButtonBuilder>[];
+};
+
+type ReminderDispatchLine = {
+  text: string;
+  button?: {
+    playerTag: string;
+  } | null;
 };
 
 type ConfirmedWarHeadline = {
@@ -84,7 +99,7 @@ export class ReminderDispatchService {
         };
       }
 
-      const contents = await buildReminderDispatchContents({
+      const contents = await buildReminderDispatchMessages({
         input,
         nowMs: this.getNowMs(),
         cocService: this.getCoCService(),
@@ -98,10 +113,11 @@ export class ReminderDispatchService {
       let firstMessageId: string | null = null;
       for (const content of contents) {
         const sent = await channel.send({
-          content,
+          content: content.content,
           allowedMentions: {
             parse: ["users"],
           },
+          ...(content.components.length > 0 ? { components: content.components } : {}),
         });
         if (!firstMessageId) {
           firstMessageId = sent.id;
@@ -146,11 +162,11 @@ export class ReminderDispatchService {
 export const reminderDispatchService = new ReminderDispatchService();
 
 /** Purpose: build one to three reminder messages with optional attack-remaining roster continuation for send-time reminder posts. */
-async function buildReminderDispatchContents(input: {
+async function buildReminderDispatchMessages(input: {
   input: ReminderDispatchInput;
   nowMs: number;
   cocService: ReminderDispatchCoCClient | null;
-}): Promise<string[]> {
+}): Promise<ReminderDispatchMessage[]> {
   const payload = input.input;
   const semantic = resolveReminderRosterSemantic({
     reminderType: payload.type,
@@ -162,7 +178,7 @@ async function buildReminderDispatchContents(input: {
           clanTag: payload.clanTag,
         })
       : Promise.resolve<ConfirmedWarHeadline | null>(null),
-    resolveReminderRosterLines({
+    resolveReminderRosterEntries({
       input: payload,
       semantic,
       cocService: input.cocService,
@@ -177,10 +193,12 @@ async function buildReminderDispatchContents(input: {
     nowMs: input.nowMs,
     warHeadline,
   });
-  return buildReminderContentsWithRosterOverflow({
+  return buildReminderMessagesWithRosterOverflow({
     headerLines,
-    rosterLines: roster.lines,
+    rosterEntries: roster.roster,
     includeRosterHeading: semantic !== "WAR",
+    input: payload,
+    semantic,
   });
 }
 
@@ -224,14 +242,14 @@ function resolveReminderRosterSemantic(input: {
 }
 
 /** Purpose: resolve and format all send-time roster lines with linked-user mentions for eligible members with attacks remaining. */
-async function resolveReminderRosterLines(input: {
+async function resolveReminderRosterEntries(input: {
   input: ReminderDispatchInput;
   semantic: ReminderRosterSemantic;
   cocService: ReminderDispatchCoCClient | null;
   nowMs: number;
 }): Promise<ReminderRosterResolveResult> {
   if (input.semantic === "OTHER") {
-    return { windowActive: true, lines: [] };
+    return { windowActive: true, roster: [] };
   }
 
   let windowActive = false;
@@ -262,7 +280,7 @@ async function resolveReminderRosterLines(input: {
   if (!windowActive || roster.length <= 0) {
     return {
       windowActive,
-      lines: [],
+      roster: [],
     };
   }
 
@@ -294,12 +312,7 @@ async function resolveReminderRosterLines(input: {
 
   return {
     windowActive,
-    lines: sortedRoster.map((entry) =>
-      formatReminderRosterLine({
-        entry,
-        semantic: input.semantic,
-      }),
-    ),
+    roster: sortedRoster,
   };
 }
 
@@ -642,21 +655,129 @@ async function resolveActiveCwlBattleWarForClan(input: {
 }
 
 /** Purpose: build final one-to-three message output with line-safe overflow handling and hard cap at three messages. */
-function buildReminderContentsWithRosterOverflow(input: {
+function buildReminderMessagesWithRosterOverflow(input: {
   headerLines: string[];
-  rosterLines: string[];
+  rosterEntries: ReminderRosterEntry[];
   includeRosterHeading: boolean;
-}): string[] {
-  const lines =
-    input.rosterLines.length > 0
-      ? input.includeRosterHeading
-        ? [...input.headerLines, "", "Players With Attacks Remaining:", ...input.rosterLines]
-        : [...input.headerLines, "", ...input.rosterLines]
-      : [...input.headerLines];
-  return splitDiscordLineMessages({
+  input: ReminderDispatchInput;
+  semantic: ReminderRosterSemantic;
+}): ReminderDispatchMessage[] {
+  const lines: ReminderDispatchLine[] =
+    input.rosterEntries.length > 0
+      ? [
+          ...input.headerLines.map((text) => ({ text }) satisfies ReminderDispatchLine),
+          { text: "" },
+          ...(input.includeRosterHeading
+            ? [{ text: "Players With Attacks Remaining:" }]
+            : []),
+          ...input.rosterEntries.flatMap((entry) => {
+            const line = formatReminderRosterLine({
+              entry,
+              semantic: input.semantic,
+            });
+            return entry.discordUserId
+              ? [{ text: line }]
+              : [
+                  {
+                    text: line,
+                    button: {
+                      playerTag: entry.playerTag,
+                    },
+                  },
+                ];
+          }),
+        ]
+      : input.headerLines.map((text) => ({ text }) satisfies ReminderDispatchLine);
+
+  return splitReminderDispatchMessages({
     lines,
     maxMessages: MAX_REMINDER_MESSAGES,
+    reminderInput: input.input,
   });
+}
+
+/** Purpose: split reminder render lines and matching component rows into Discord-safe messages without breaking line boundaries. */
+function splitReminderDispatchMessages(input: {
+  lines: ReminderDispatchLine[];
+  maxMessages: number;
+  reminderInput: ReminderDispatchInput;
+}): ReminderDispatchMessage[] {
+  const messages: ReminderDispatchMessage[] = [];
+  let currentLines: string[] = [];
+  let currentButtonTags: string[] = [];
+  const promptLine = "Is this you?";
+
+  const flushCurrent = (): void => {
+    if (currentLines.length <= 0 || messages.length >= input.maxMessages) return;
+    messages.push({
+      content:
+        currentButtonTags.length > 0
+          ? [...currentLines, promptLine].join("\n")
+          : currentLines.join("\n"),
+      components: buildReminderLinkButtonRows({
+        guildId: input.reminderInput.guildId,
+        reminderId: input.reminderInput.reminderId,
+        playerTags: currentButtonTags,
+      }),
+    });
+    currentLines = [];
+    currentButtonTags = [];
+  };
+
+  for (const rawLine of input.lines) {
+    if (messages.length >= input.maxMessages) break;
+
+    const line = truncateDiscordContent(rawLine.text, 2000);
+    const nextButtonTags = rawLine.button
+      ? [...currentButtonTags, rawLine.button.playerTag]
+      : currentButtonTags;
+    const candidate =
+      currentLines.length > 0 ? [...currentLines, line].join("\n") : line;
+    const candidateLength =
+      candidate.length + (nextButtonTags.length > 0 ? 1 + promptLine.length : 0);
+
+    if (candidateLength > 2000 || nextButtonTags.length > 25) {
+      flushCurrent();
+      if (messages.length >= input.maxMessages) break;
+    }
+
+    currentLines.push(line);
+    if (rawLine.button) {
+      currentButtonTags.push(rawLine.button.playerTag);
+    }
+  }
+
+  flushCurrent();
+  return messages;
+}
+
+/** Purpose: build reminder self-link button rows grouped into Discord-safe rows of five buttons each. */
+function buildReminderLinkButtonRows(input: {
+  guildId: string;
+  reminderId: string;
+  playerTags: string[];
+}): ActionRowBuilder<ButtonBuilder>[] {
+  const rows: ActionRowBuilder<ButtonBuilder>[] = [];
+  for (let index = 0; index < input.playerTags.length; index += 5) {
+    const group = input.playerTags.slice(index, index + 5);
+    const row = new ActionRowBuilder<ButtonBuilder>();
+    for (const playerTag of group) {
+      row.addComponents(
+        new ButtonBuilder()
+          .setCustomId(
+            buildReminderLinkButtonCustomId({
+              guildId: input.guildId,
+              reminderId: input.reminderId,
+              playerTag,
+            }),
+          )
+          .setLabel("Link player")
+          .setStyle(ButtonStyle.Primary),
+      );
+    }
+    rows.push(row);
+  }
+  return rows;
 }
 
 /** Purpose: compare roster rows by lineup position first, then stable name/tag fallback ordering. */
@@ -745,4 +866,13 @@ function formatOffsetLabel(offsetSeconds: number): string {
   return `${hours}h${minutes}m`;
 }
 
-export const buildReminderDispatchContentsForTest = buildReminderDispatchContents;
+/** Purpose: expose reminder message builder for tests without exporting internal message splitting helpers. */
+export const buildReminderDispatchMessagesForTest = buildReminderDispatchMessages;
+
+/** Purpose: expose reminder content builder for tests without exporting internal message splitting helpers. */
+export const buildReminderDispatchContentsForTest = async (
+  input: Parameters<typeof buildReminderDispatchMessages>[0],
+): Promise<string[]> => {
+  const messages = await buildReminderDispatchMessages(input);
+  return messages.map((message) => message.content);
+};

--- a/src/services/reminders/ReminderLinkActions.ts
+++ b/src/services/reminders/ReminderLinkActions.ts
@@ -1,0 +1,80 @@
+/** Purpose: identify the reminder self-link button custom-id namespace. */
+export const REMINDER_LINK_BUTTON_PREFIX = "reminder-link";
+
+/** Purpose: build one reminder self-link claim button custom-id. */
+export function buildReminderLinkButtonCustomId(input: {
+  guildId: string;
+  reminderId: string;
+  playerTag: string;
+}): string {
+  return `${REMINDER_LINK_BUTTON_PREFIX}:claim:${String(input.guildId ?? "").trim()}:${String(
+    input.reminderId ?? "",
+  ).trim()}:${String(input.playerTag ?? "").trim()}`;
+}
+
+/** Purpose: parse one reminder self-link claim button custom-id. */
+export function parseReminderLinkButtonCustomId(
+  customId: string,
+): { guildId: string; reminderId: string; playerTag: string } | null {
+  const parts = String(customId ?? "").split(":");
+  if (parts.length !== 5 || parts[0] !== REMINDER_LINK_BUTTON_PREFIX || parts[1] !== "claim") {
+    return null;
+  }
+  const guildId = parts[2]?.trim() ?? "";
+  const reminderId = parts[3]?.trim() ?? "";
+  const playerTag = parts[4]?.trim() ?? "";
+  if (!guildId || !reminderId || !playerTag) return null;
+  return { guildId, reminderId, playerTag };
+}
+
+/** Purpose: build one reminder self-link confirmation button custom-id. */
+export function buildReminderLinkConfirmCustomId(input: {
+  channelId: string;
+  messageId: string;
+  playerTag: string;
+}): string {
+  return `reminder-link:confirm:${String(input.channelId ?? "").trim()}:${String(input.messageId ?? "").trim()}:${String(
+    input.playerTag ?? "",
+  ).trim()}`;
+}
+
+/** Purpose: parse one reminder self-link confirmation button custom-id. */
+export function parseReminderLinkConfirmCustomId(
+  customId: string,
+): { channelId: string; messageId: string; playerTag: string } | null {
+  const parts = String(customId ?? "").split(":");
+  if (parts.length !== 5 || parts[0] !== "reminder-link" || parts[1] !== "confirm") {
+    return null;
+  }
+  const channelId = parts[2]?.trim() ?? "";
+  const messageId = parts[3]?.trim() ?? "";
+  const playerTag = parts[4]?.trim() ?? "";
+  if (!channelId || !messageId || !playerTag) return null;
+  return { channelId, messageId, playerTag };
+}
+
+/** Purpose: build one reminder self-link cancel button custom-id. */
+export function buildReminderLinkCancelCustomId(input: {
+  channelId: string;
+  messageId: string;
+  playerTag: string;
+}): string {
+  return `reminder-link:cancel:${String(input.channelId ?? "").trim()}:${String(input.messageId ?? "").trim()}:${String(
+    input.playerTag ?? "",
+  ).trim()}`;
+}
+
+/** Purpose: parse one reminder self-link cancel button custom-id. */
+export function parseReminderLinkCancelCustomId(
+  customId: string,
+): { channelId: string; messageId: string; playerTag: string } | null {
+  const parts = String(customId ?? "").split(":");
+  if (parts.length !== 5 || parts[0] !== "reminder-link" || parts[1] !== "cancel") {
+    return null;
+  }
+  const channelId = parts[2]?.trim() ?? "";
+  const messageId = parts[3]?.trim() ?? "";
+  const playerTag = parts[4]?.trim() ?? "";
+  if (!channelId || !messageId || !playerTag) return null;
+  return { channelId, messageId, playerTag };
+}

--- a/tests/link.command.run.test.ts
+++ b/tests/link.command.run.test.ts
@@ -10,6 +10,7 @@ const prismaMock = vi.hoisted(() => ({
     create: vi.fn(),
     delete: vi.fn(),
     findMany: vi.fn(),
+    updateMany: vi.fn(),
   },
   trackedClan: {
     findMany: vi.fn(),
@@ -36,15 +37,26 @@ import {
   buildLinkEmbedTagModalCustomId,
   buildLinkListSelectCustomId,
   buildLinkListSortButtonCustomId,
+  handleReminderLinkButtonInteraction,
+  handleReminderLinkCancelButtonInteraction,
+  handleReminderLinkConfirmButtonInteraction,
   handleLinkEmbedButtonInteraction,
   handleLinkEmbedModalSubmit,
   handleLinkListSelectMenu,
   handleLinkListSortButton,
   isLinkEmbedAccountButtonCustomId,
   isLinkEmbedModalCustomId,
+  isReminderLinkButtonCustomId,
+  isReminderLinkCancelButtonCustomId,
+  isReminderLinkConfirmButtonCustomId,
   Link,
 } from "../src/commands/Link";
 import { CommandPermissionService } from "../src/services/CommandPermissionService";
+import {
+  buildReminderLinkButtonCustomId,
+  buildReminderLinkCancelCustomId,
+  buildReminderLinkConfirmCustomId,
+} from "../src/services/reminders/ReminderLinkActions";
 
 type InteractionInput = {
   subcommand: "create" | "delete" | "list" | "embed" | "sync-clashperk";
@@ -172,6 +184,57 @@ function getInlineRows(description: string): string[] {
     .filter((line) => /^(?:✅|❌|<a?:yes:\d+>|<a?:no:\d+>) `/.test(line));
 }
 
+function makeReminderButtonInteraction(input: {
+  customId: string;
+  guildId?: string;
+  channelId?: string;
+  messageId?: string;
+  userId?: string;
+  messageComponents?: Array<{ toJSON: () => unknown }>;
+}) {
+  const edit = vi.fn().mockResolvedValue(undefined);
+  const channel = {
+    id: input.channelId ?? "channel-1",
+    guildId: input.guildId ?? "guild-1",
+    isTextBased: () => true,
+    messages: {
+      fetch: vi.fn().mockResolvedValue({
+        id: input.messageId ?? "message-1",
+        components: input.messageComponents ?? [],
+        edit,
+      }),
+    },
+  };
+  const interaction: any = {
+    customId: input.customId,
+    guildId: input.guildId ?? "guild-1",
+    channelId: input.channelId ?? "channel-1",
+    user: { id: input.userId ?? "user-1" },
+    message: {
+      id: input.messageId ?? "message-1",
+      components: input.messageComponents ?? [],
+    },
+    client: {
+      channels: {
+        fetch: vi.fn().mockResolvedValue(channel),
+      },
+    },
+    replied: false,
+    deferred: false,
+    reply: vi.fn(async () => {
+      interaction.replied = true;
+    }),
+    deferUpdate: vi.fn(async () => {
+      interaction.deferred = true;
+    }),
+    update: vi.fn(async () => {
+      interaction.replied = true;
+    }),
+    editReply: vi.fn().mockResolvedValue(undefined),
+  };
+  return interaction;
+}
+
 describe("/link run", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -180,6 +243,7 @@ describe("/link run", () => {
     prismaMock.playerLink.create.mockReset();
     prismaMock.playerLink.delete.mockReset();
     prismaMock.playerLink.findMany.mockReset();
+    prismaMock.playerLink.updateMany.mockReset();
     prismaMock.trackedClan.findMany.mockReset();
     prismaMock.trackedClan.findUnique.mockReset();
     prismaMock.currentWar.findMany.mockReset();
@@ -1739,5 +1803,256 @@ describe("/link embed interactions", () => {
       isLinkEmbedModalCustomId(buildLinkEmbedTagModalCustomId("guild-1")),
     ).toBe(true);
     expect(isLinkEmbedModalCustomId("other:modal")).toBe(false);
+  });
+});
+
+describe("/reminder link interactions", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+    prismaMock.playerLink.findUnique.mockReset();
+    prismaMock.playerLink.create.mockReset();
+    prismaMock.playerLink.updateMany.mockReset();
+  });
+
+  it("opens an ephemeral confirmation for the clicked reminder player", async () => {
+    const interaction = makeReminderButtonInteraction({
+      customId: buildReminderLinkButtonCustomId({
+        guildId: "guild-1",
+        reminderId: "rem-1",
+        playerTag: "#PYLQ0289",
+      }),
+      messageId: "message-1",
+      channelId: "channel-1",
+      guildId: "guild-1",
+      userId: "111111111111111111",
+    });
+
+    await handleReminderLinkButtonInteraction(interaction as any);
+
+    expect(interaction.reply).toHaveBeenCalledWith({
+      ephemeral: true,
+      content: "Link `#PYLQ0289` to your Discord account?",
+      components: expect.any(Array),
+    });
+    const payload = interaction.reply.mock.calls[0]?.[0] as any;
+    expect(payload.components[0].toJSON().components.map((button: any) => button.label)).toEqual([
+      "Confirm",
+      "Cancel",
+    ]);
+  });
+
+  it("confirms a reminder link and disables the original reminder button", async () => {
+    prismaMock.playerLink.findUnique.mockResolvedValue(null);
+    prismaMock.playerLink.create.mockResolvedValue({});
+    const messageEdit = vi.fn().mockResolvedValue(undefined);
+    const originalMessage = {
+      id: "message-1",
+      components: [
+        {
+          toJSON: () => ({
+            type: 1,
+            components: [
+              {
+                type: 2,
+                style: 1,
+                label: "Link player",
+                custom_id: buildReminderLinkButtonCustomId({
+                  guildId: "guild-1",
+                  reminderId: "rem-1",
+                  playerTag: "#PYLQ0289",
+                }),
+                disabled: false,
+              },
+            ],
+          }),
+        },
+      ],
+      edit: messageEdit,
+    };
+    const interaction = makeReminderButtonInteraction({
+      customId: buildReminderLinkConfirmCustomId({
+        channelId: "channel-1",
+        messageId: "message-1",
+        playerTag: "#PYLQ0289",
+      }),
+      messageId: "message-1",
+      channelId: "channel-1",
+      guildId: "guild-1",
+      userId: "111111111111111111",
+    });
+    interaction.client.channels.fetch.mockResolvedValue({
+      id: "channel-1",
+      guildId: "guild-1",
+      isTextBased: () => true,
+      messages: {
+        fetch: vi.fn().mockResolvedValue(originalMessage),
+      },
+    });
+
+    await handleReminderLinkConfirmButtonInteraction(interaction as any);
+
+    expect(prismaMock.playerLink.create).toHaveBeenCalledWith({
+      data: { playerTag: "#PYLQ0289", discordUserId: "111111111111111111" },
+    });
+    expect(interaction.editReply).toHaveBeenCalledWith(
+      "created: #PYLQ0289 linked to you.",
+    );
+    expect(messageEdit).toHaveBeenCalledWith({
+      components: [
+        {
+          type: 1,
+          components: [
+            expect.objectContaining({
+              custom_id: buildReminderLinkButtonCustomId({
+                guildId: "guild-1",
+                reminderId: "rem-1",
+                playerTag: "#PYLQ0289",
+              }),
+              disabled: true,
+            }),
+          ],
+        },
+      ],
+    });
+  });
+
+  it("cancels a reminder link confirmation without changing state", async () => {
+    const interaction = makeReminderButtonInteraction({
+      customId: buildReminderLinkCancelCustomId({
+        channelId: "channel-1",
+        messageId: "message-1",
+        playerTag: "#PYLQ0289",
+      }),
+      messageId: "message-1",
+      channelId: "channel-1",
+      guildId: "guild-1",
+      userId: "111111111111111111",
+    });
+
+    await handleReminderLinkCancelButtonInteraction(interaction as any);
+
+    expect(prismaMock.playerLink.create).not.toHaveBeenCalled();
+    expect(interaction.update).toHaveBeenCalledWith({
+      content: "Canceled.",
+      components: [],
+    });
+  });
+
+  it("rejects stale reminder confirmations when the channel context no longer matches", async () => {
+    const interaction = makeReminderButtonInteraction({
+      customId: buildReminderLinkConfirmCustomId({
+        channelId: "channel-1",
+        messageId: "message-1",
+        playerTag: "#PYLQ0289",
+      }),
+      messageId: "message-1",
+      channelId: "channel-2",
+      guildId: "guild-1",
+      userId: "111111111111111111",
+    });
+
+    await handleReminderLinkConfirmButtonInteraction(interaction as any);
+
+    expect(prismaMock.playerLink.create).not.toHaveBeenCalled();
+    expect(interaction.reply).toHaveBeenCalledWith({
+      ephemeral: true,
+      content:
+        "invalid_context: this reminder link confirmation can only be used in its original channel.",
+    });
+  });
+
+  it("rejects stale reminder confirmations when the player is already linked", async () => {
+    prismaMock.playerLink.findUnique.mockResolvedValue({
+      discordUserId: "222222222222222222",
+    });
+    const interaction = makeReminderButtonInteraction({
+      customId: buildReminderLinkConfirmCustomId({
+        channelId: "channel-1",
+        messageId: "message-1",
+        playerTag: "#PYLQ0289",
+      }),
+      messageId: "message-1",
+      channelId: "channel-1",
+      guildId: "guild-1",
+      userId: "111111111111111111",
+    });
+
+    await handleReminderLinkConfirmButtonInteraction(interaction as any);
+
+    expect(prismaMock.playerLink.create).not.toHaveBeenCalled();
+    expect(interaction.editReply).toHaveBeenCalledWith(
+      "already_linked_to_other_user: #PYLQ0289 is linked to <@222222222222222222>. delete-first is required.",
+    );
+  });
+
+  it("allows only one user to claim the same unlinked reminder player", async () => {
+    prismaMock.playerLink.findUnique
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ discordUserId: "111111111111111111" });
+    prismaMock.playerLink.create.mockResolvedValue({});
+    const first = makeReminderButtonInteraction({
+      customId: buildReminderLinkConfirmCustomId({
+        channelId: "channel-1",
+        messageId: "message-1",
+        playerTag: "#PYLQ0289",
+      }),
+      messageId: "message-1",
+      channelId: "channel-1",
+      guildId: "guild-1",
+      userId: "111111111111111111",
+    });
+    const second = makeReminderButtonInteraction({
+      customId: buildReminderLinkConfirmCustomId({
+        channelId: "channel-1",
+        messageId: "message-1",
+        playerTag: "#PYLQ0289",
+      }),
+      messageId: "message-1",
+      channelId: "channel-1",
+      guildId: "guild-1",
+      userId: "222222222222222222",
+    });
+
+    await handleReminderLinkConfirmButtonInteraction(first as any);
+    await handleReminderLinkConfirmButtonInteraction(second as any);
+
+    expect(prismaMock.playerLink.create).toHaveBeenCalledTimes(1);
+    expect(first.editReply).toHaveBeenCalledWith(
+      "created: #PYLQ0289 linked to you.",
+    );
+    expect(second.editReply).toHaveBeenCalledWith(
+      "already_linked_to_other_user: #PYLQ0289 is linked to <@111111111111111111>. delete-first is required.",
+    );
+  });
+
+  it("treats reminder link custom ids as stable guards", () => {
+    expect(
+      isReminderLinkButtonCustomId(
+        buildReminderLinkButtonCustomId({
+          guildId: "guild-1",
+          reminderId: "rem-1",
+          playerTag: "#PYLQ0289",
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isReminderLinkConfirmButtonCustomId(
+        buildReminderLinkConfirmCustomId({
+          channelId: "channel-1",
+          messageId: "message-1",
+          playerTag: "#PYLQ0289",
+        }),
+      ),
+    ).toBe(true);
+    expect(
+      isReminderLinkCancelButtonCustomId(
+        buildReminderLinkCancelCustomId({
+          channelId: "channel-1",
+          messageId: "message-1",
+          playerTag: "#PYLQ0289",
+        }),
+      ),
+    ).toBe(true);
   });
 });

--- a/tests/playerLink.service.test.ts
+++ b/tests/playerLink.service.test.ts
@@ -17,6 +17,7 @@ vi.mock("../src/prisma", () => ({
 }));
 
 import {
+  createPlayerLink,
   createPlayerLinkFromEmbed,
   backfillMissingDiscordUsernamesForClanMembers,
   listCurrentWeightsForClanMembers,
@@ -224,6 +225,26 @@ describe("PlayerLinkService link identity", () => {
     expect(result).toEqual({
       outcome: "already_linked",
       playerTag: "#PYL0289",
+      discordUserId: "111111111111111111",
+      existingDiscordUserId: "222222222222222222",
+    });
+  });
+
+  it("maps self-link create races to deterministic conflict outcomes", async () => {
+    prismaMock.playerLink.findUnique
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ discordUserId: "222222222222222222" });
+    prismaMock.playerLink.create.mockRejectedValue({ code: "P2002" });
+
+    const result = await createPlayerLink({
+      playerTag: "#PYLQ0289",
+      targetDiscordUserId: "111111111111111111",
+      selfService: true,
+    });
+
+    expect(result).toEqual({
+      outcome: "already_linked_to_other_user",
+      playerTag: "#PYLQ0289",
       discordUserId: "111111111111111111",
       existingDiscordUserId: "222222222222222222",
     });

--- a/tests/reminderDispatch.service.test.ts
+++ b/tests/reminderDispatch.service.test.ts
@@ -22,8 +22,10 @@ vi.mock("../src/prisma", () => ({
 
 import {
   ReminderDispatchService,
+  buildReminderDispatchMessagesForTest,
   buildReminderDispatchContentsForTest,
 } from "../src/services/reminders/ReminderDispatchService";
+import { buildReminderLinkButtonCustomId } from "../src/services/reminders/ReminderLinkActions";
 
 function buildValidPlayerTag(index: number): string {
   const alphabet = "PYLQGRJCUV0289";
@@ -133,6 +135,50 @@ describe("ReminderDispatchService roster rendering", () => {
 
     expect(contents[0]).toContain("#12 - ❌ PlayerName `#PYLQ0289` - 1 / 2");
     expect(contents[0]).not.toContain("Players With Attacks Remaining:");
+  });
+
+  it("attaches a Link player action to unlinked reminder rows", async () => {
+    prismaMock.warAttacks.findMany.mockResolvedValue([
+      { playerTag: "#PYLQ0289", playerName: "PlayerName", playerPosition: 12, attacksUsed: 1 },
+    ]);
+    prismaMock.currentWar.findFirst.mockResolvedValue({
+      state: "inWar",
+      warId: 9,
+      matchType: "BL",
+      inferredMatchType: false,
+      outcome: null,
+    });
+
+    const messages = await buildReminderDispatchMessagesForTest({
+      input: {
+        guildId: "guild-1",
+        channelId: "channel-1",
+        reminderId: "rem-1",
+        type: ReminderType.WAR_CWL,
+        clanTag: "#PYLQ",
+        clanName: "Alpha Clan",
+        offsetSeconds: 3600,
+        eventIdentity: "WAR:war-id:9",
+        eventEndsAt: new Date("2026-04-10T01:00:00.000Z"),
+        eventLabel: "war end",
+      },
+      nowMs: Date.parse("2026-04-10T00:30:00.000Z"),
+      cocService: null,
+    });
+
+    expect(messages).toHaveLength(1);
+    expect(messages[0].content).toContain("Is this you?");
+    expect(messages[0].components).toHaveLength(1);
+    const row = messages[0].components[0]?.toJSON() as any;
+    expect(row.components).toHaveLength(1);
+    expect(row.components[0].label).toBe("Link player");
+    expect(row.components[0].custom_id).toBe(
+      buildReminderLinkButtonCustomId({
+        guildId: "guild-1",
+        reminderId: "rem-1",
+        playerTag: "#PYLQ0289",
+      }),
+    );
   });
 
   it.each([
@@ -432,7 +478,7 @@ describe("ReminderDispatchService roster rendering", () => {
       cocService: null,
     });
 
-    expect(contents).toHaveLength(2);
+    expect(contents).toHaveLength(3);
     expect(contents.every((content) => content.length <= 2000)).toBe(true);
     expect(contents[1]).not.toContain("Clan: Overflow Clan #PYLQ");
 


### PR DESCRIPTION
- add reminder confirmation flow for unlinked players
- reuse shared player-link validation with race-safe writes
- keep reminder message splits and tests component-aware