### PR TITLE
feat(reminders): split unlinked reminder self-links into follow-up me…

### DIFF
--- a/src/commands/Link.ts
+++ b/src/commands/Link.ts
@@ -1108,6 +1108,35 @@ function buildReminderLinkConfirmationRows(input: {
   ];
 }
 
+function resolveReminderLinkPlayerDisplayName(input: {
+  messageContent: string;
+  playerTag: string;
+}): string {
+  const normalizedTag = normalizePlayerTag(input.playerTag);
+  const firstLine = sanitizeTableText(String(input.messageContent ?? "").split("\n")[0] ?? "");
+  if (!normalizedTag || !firstLine) return normalizedTag || "";
+
+  const backtickedTag = `\`${normalizedTag}\``;
+  const backtickedIndex = firstLine.indexOf(backtickedTag);
+  if (backtickedIndex >= 0) {
+    const beforeTag = firstLine.slice(0, backtickedIndex);
+    const displayName = sanitizeTableText(
+      beforeTag.replace(/^(?:#\d+\s*-\s*)?(?:❌|âŒ|:no:)\s+/, ""),
+    );
+    if (displayName) return displayName;
+  }
+
+  const rowMatch = firstLine.match(
+    /^(?:#\d+\s*-\s*)?(?:❌|âŒ|:no:)\s+(.+?)\s+-\s+\d+\s+\/\s+\d+$/,
+  );
+  if (rowMatch?.[1]) {
+    const displayName = sanitizeTableText(rowMatch[1]);
+    if (displayName) return displayName;
+  }
+
+  return normalizedTag;
+}
+
 export function isReminderLinkButtonCustomId(customId: string): boolean {
   return parseReminderLinkButtonCustomId(customId) !== null;
 }
@@ -1324,9 +1353,18 @@ export async function handleReminderLinkButtonInteraction(
     return;
   }
 
+  const playerName = resolveReminderLinkPlayerDisplayName({
+    messageContent: interaction.message?.content ?? "",
+    playerTag: parsed.playerTag,
+  });
+  const confirmationIdentity =
+    playerName && playerName !== parsed.playerTag
+      ? `${playerName} ${parsed.playerTag}`
+      : parsed.playerTag;
+
   await interaction.reply({
     ephemeral: true,
-    content: `Link \`${parsed.playerTag}\` to your Discord account?`,
+    content: `Link ${confirmationIdentity} to your Discord account?`,
     components: buildReminderLinkConfirmationRows({
       channelId: interaction.channelId,
       messageId: interaction.message.id,

--- a/src/services/reminders/ReminderDispatchService.ts
+++ b/src/services/reminders/ReminderDispatchService.ts
@@ -66,13 +66,6 @@ type ReminderDispatchMessage = {
   components: ActionRowBuilder<ButtonBuilder>[];
 };
 
-type ReminderDispatchLine = {
-  text: string;
-  button?: {
-    playerTag: string;
-  } | null;
-};
-
 type ConfirmedWarHeadline = {
   label: "BL" | "MM" | "FWA-WIN" | "FWA-LOSE";
   emoji: "⚫" | "⚪" | "🟢" | "🔴";
@@ -193,13 +186,21 @@ async function buildReminderDispatchMessages(input: {
     nowMs: input.nowMs,
     warHeadline,
   });
-  return buildReminderMessagesWithRosterOverflow({
-    headerLines,
-    rosterEntries: roster.roster,
-    includeRosterHeading: semantic !== "WAR",
-    input: payload,
-    semantic,
-  });
+  const linkedRosterEntries = roster.roster.filter((entry) => entry.discordUserId);
+  const unlinkedRosterEntries = roster.roster.filter((entry) => !entry.discordUserId);
+  return [
+    ...buildReminderLinkedRosterMessages({
+      headerLines,
+      rosterEntries: linkedRosterEntries,
+      includeRosterHeading: semantic !== "WAR",
+      semantic,
+    }),
+    ...buildReminderUnlinkedFollowUpMessages({
+      rosterEntries: unlinkedRosterEntries,
+      input: payload,
+      semantic,
+    }),
+  ];
 }
 
 /** Purpose: build deterministic core reminder header lines shared by all reminder dispatch messages. */
@@ -654,97 +655,91 @@ async function resolveActiveCwlBattleWarForClan(input: {
   return null;
 }
 
-/** Purpose: build final one-to-three message output with line-safe overflow handling and hard cap at three messages. */
-function buildReminderMessagesWithRosterOverflow(input: {
+/** Purpose: build final main reminder message output with line-safe overflow handling and hard cap at three messages. */
+function buildReminderLinkedRosterMessages(input: {
   headerLines: string[];
   rosterEntries: ReminderRosterEntry[];
   includeRosterHeading: boolean;
-  input: ReminderDispatchInput;
   semantic: ReminderRosterSemantic;
 }): ReminderDispatchMessage[] {
-  const lines: ReminderDispatchLine[] =
+  const lines =
     input.rosterEntries.length > 0
       ? [
-          ...input.headerLines.map((text) => ({ text }) satisfies ReminderDispatchLine),
-          { text: "" },
+          ...input.headerLines,
+          "",
           ...(input.includeRosterHeading
-            ? [{ text: "Players With Attacks Remaining:" }]
+            ? ["Players With Attacks Remaining:"]
             : []),
-          ...input.rosterEntries.flatMap((entry) => {
-            const line = formatReminderRosterLine({
+          ...input.rosterEntries.map((entry) =>
+            formatReminderRosterLine({
               entry,
               semantic: input.semantic,
-            });
-            return entry.discordUserId
-              ? [{ text: line }]
-              : [
-                  {
-                    text: line,
-                    button: {
-                      playerTag: entry.playerTag,
-                    },
-                  },
-                ];
-          }),
+            }),
+          ),
         ]
-      : input.headerLines.map((text) => ({ text }) satisfies ReminderDispatchLine);
+      : input.headerLines;
 
   return splitReminderDispatchMessages({
     lines,
     maxMessages: MAX_REMINDER_MESSAGES,
-    reminderInput: input.input,
   });
 }
 
-/** Purpose: split reminder render lines and matching component rows into Discord-safe messages without breaking line boundaries. */
+/** Purpose: build one follow-up reminder message per unlinked player with a single self-link button. */
+function buildReminderUnlinkedFollowUpMessages(input: {
+  rosterEntries: ReminderRosterEntry[];
+  input: ReminderDispatchInput;
+  semantic: ReminderRosterSemantic;
+}): ReminderDispatchMessage[] {
+  return input.rosterEntries.map((entry) => {
+    const row = truncateDiscordContent(
+      formatReminderRosterLine({
+        entry,
+        semantic: input.semantic,
+      }),
+      2000,
+    );
+    return {
+      content: [row, "Is this you?"].join("\n"),
+      components: buildReminderLinkButtonRows({
+        guildId: input.input.guildId,
+        reminderId: input.input.reminderId,
+        playerTags: [entry.playerTag],
+      }),
+    };
+  });
+}
+
+/** Purpose: split reminder render lines into Discord-safe messages without breaking line boundaries. */
 function splitReminderDispatchMessages(input: {
-  lines: ReminderDispatchLine[];
+  lines: string[];
   maxMessages: number;
-  reminderInput: ReminderDispatchInput;
 }): ReminderDispatchMessage[] {
   const messages: ReminderDispatchMessage[] = [];
   let currentLines: string[] = [];
-  let currentButtonTags: string[] = [];
-  const promptLine = "Is this you?";
 
   const flushCurrent = (): void => {
     if (currentLines.length <= 0 || messages.length >= input.maxMessages) return;
     messages.push({
-      content:
-        currentButtonTags.length > 0
-          ? [...currentLines, promptLine].join("\n")
-          : currentLines.join("\n"),
-      components: buildReminderLinkButtonRows({
-        guildId: input.reminderInput.guildId,
-        reminderId: input.reminderInput.reminderId,
-        playerTags: currentButtonTags,
-      }),
+      content: currentLines.join("\n"),
+      components: [],
     });
     currentLines = [];
-    currentButtonTags = [];
   };
 
   for (const rawLine of input.lines) {
     if (messages.length >= input.maxMessages) break;
 
-    const line = truncateDiscordContent(rawLine.text, 2000);
-    const nextButtonTags = rawLine.button
-      ? [...currentButtonTags, rawLine.button.playerTag]
-      : currentButtonTags;
+    const line = truncateDiscordContent(rawLine, 2000);
     const candidate =
       currentLines.length > 0 ? [...currentLines, line].join("\n") : line;
-    const candidateLength =
-      candidate.length + (nextButtonTags.length > 0 ? 1 + promptLine.length : 0);
 
-    if (candidateLength > 2000 || nextButtonTags.length > 25) {
+    if (candidate.length > 2000) {
       flushCurrent();
       if (messages.length >= input.maxMessages) break;
     }
 
     currentLines.push(line);
-    if (rawLine.button) {
-      currentButtonTags.push(rawLine.button.playerTag);
-    }
   }
 
   flushCurrent();

--- a/tests/link.command.run.test.ts
+++ b/tests/link.command.run.test.ts
@@ -190,6 +190,7 @@ function makeReminderButtonInteraction(input: {
   channelId?: string;
   messageId?: string;
   userId?: string;
+  messageContent?: string;
   messageComponents?: Array<{ toJSON: () => unknown }>;
 }) {
   const edit = vi.fn().mockResolvedValue(undefined);
@@ -212,6 +213,7 @@ function makeReminderButtonInteraction(input: {
     user: { id: input.userId ?? "user-1" },
     message: {
       id: input.messageId ?? "message-1",
+      content: input.messageContent ?? "",
       components: input.messageComponents ?? [],
     },
     client: {
@@ -1826,13 +1828,14 @@ describe("/reminder link interactions", () => {
       channelId: "channel-1",
       guildId: "guild-1",
       userId: "111111111111111111",
+      messageContent: "#12 - ❌ RASEL RAJ `#PYLQ0289` - 1 / 2\nIs this you?",
     });
 
     await handleReminderLinkButtonInteraction(interaction as any);
 
     expect(interaction.reply).toHaveBeenCalledWith({
       ephemeral: true,
-      content: "Link `#PYLQ0289` to your Discord account?",
+      content: "Link RASEL RAJ #PYLQ0289 to your Discord account?",
       components: expect.any(Array),
     });
     const payload = interaction.reply.mock.calls[0]?.[0] as any;

--- a/tests/reminderDispatch.service.test.ts
+++ b/tests/reminderDispatch.service.test.ts
@@ -47,7 +47,7 @@ describe("ReminderDispatchService roster rendering", () => {
     prismaMock.currentWar.findFirst.mockResolvedValue({ state: "inWar", warId: 9 });
   });
 
-  it("renders WAR reminder content in plain text with inline mentions and updated header lines", async () => {
+  it("renders WAR reminder content in plain text with linked players in the main post and unlinked players in follow-ups", async () => {
     prismaMock.warAttacks.findMany.mockResolvedValue([
       { playerTag: "#PYLG", playerName: "Bravo", playerPosition: 2, attacksUsed: 1 },
       { playerTag: "#PYLQ", playerName: "Alpha", playerPosition: 1, attacksUsed: 0 },
@@ -83,7 +83,7 @@ describe("ReminderDispatchService roster rendering", () => {
       cocService: null,
     });
 
-    expect(contents).toHaveLength(1);
+    expect(contents).toHaveLength(2);
     const lines = contents[0].split("\n");
     expect(lines[0]).toBe("### BL war ends in 1h ⚫");
     expect(lines[1]).toBe("Clan: Alpha Clan #PYLQ");
@@ -98,13 +98,15 @@ describe("ReminderDispatchService roster rendering", () => {
     const rosterLines = lines.filter((line) => /^#\d+ /.test(line));
     expect(rosterLines).toEqual([
       "#1 - Alpha - <@111> - 2 / 2",
-      "#2 - ❌ Bravo `#PYLG` - 1 / 2",
       "#3 - Charlie - <@333> - 2 / 2",
     ]);
+    expect(contents[0]).not.toContain("Bravo");
     expect(contents[0]).not.toContain("Done");
+    expect(contents[1].split("\n")[0]).toBe("#2 - ❌ Bravo `#PYLG` - 1 / 2");
+    expect(contents[1]).toContain("Is this you?");
   });
 
-  it("renders unlinked WAR reminder rows with a cross and backticked player tag", async () => {
+  it("renders unlinked WAR reminder rows as dedicated follow-up messages", async () => {
     prismaMock.warAttacks.findMany.mockResolvedValue([
       { playerTag: "#PYLQ0289", playerName: "PlayerName", playerPosition: 12, attacksUsed: 1 },
     ]);
@@ -133,13 +135,17 @@ describe("ReminderDispatchService roster rendering", () => {
       cocService: null,
     });
 
-    expect(contents[0]).toContain("#12 - ❌ PlayerName `#PYLQ0289` - 1 / 2");
+    expect(contents).toHaveLength(2);
+    expect(contents[0]).not.toContain("PlayerName");
     expect(contents[0]).not.toContain("Players With Attacks Remaining:");
+    expect(contents[1].split("\n")[0]).toBe("#12 - ❌ PlayerName `#PYLQ0289` - 1 / 2");
+    expect(contents[1]).toContain("Is this you?");
   });
 
-  it("attaches a Link player action to unlinked reminder rows", async () => {
+  it("creates one follow-up message per unlinked reminder player", async () => {
     prismaMock.warAttacks.findMany.mockResolvedValue([
       { playerTag: "#PYLQ0289", playerName: "PlayerName", playerPosition: 12, attacksUsed: 1 },
+      { playerTag: "#PYLQ0290", playerName: "PlayerTwo", playerPosition: 13, attacksUsed: 0 },
     ]);
     prismaMock.currentWar.findFirst.mockResolvedValue({
       state: "inWar",
@@ -166,19 +172,37 @@ describe("ReminderDispatchService roster rendering", () => {
       cocService: null,
     });
 
-    expect(messages).toHaveLength(1);
-    expect(messages[0].content).toContain("Is this you?");
-    expect(messages[0].components).toHaveLength(1);
-    const row = messages[0].components[0]?.toJSON() as any;
-    expect(row.components).toHaveLength(1);
-    expect(row.components[0].label).toBe("Link player");
-    expect(row.components[0].custom_id).toBe(
+    expect(messages).toHaveLength(3);
+    expect(messages[0].content).not.toContain("Is this you?");
+    expect(messages[1].content).toContain("Is this you?");
+    expect(messages[2].content).toContain("Is this you?");
+    expect(messages[0].components).toHaveLength(0);
+    expect(messages[1].components).toHaveLength(1);
+    expect(messages[2].components).toHaveLength(1);
+
+    const firstRow = messages[1].components[0]?.toJSON() as any;
+    expect(firstRow.components).toHaveLength(1);
+    expect(firstRow.components[0].label).toBe("Link player");
+    expect(firstRow.components[0].custom_id).toBe(
       buildReminderLinkButtonCustomId({
         guildId: "guild-1",
         reminderId: "rem-1",
         playerTag: "#PYLQ0289",
       }),
     );
+    expect(messages[1].content).toContain("#12 - ❌ PlayerName `#PYLQ0289` - 1 / 2");
+
+    const secondRow = messages[2].components[0]?.toJSON() as any;
+    expect(secondRow.components).toHaveLength(1);
+    expect(secondRow.components[0].label).toBe("Link player");
+    expect(secondRow.components[0].custom_id).toBe(
+      buildReminderLinkButtonCustomId({
+        guildId: "guild-1",
+        reminderId: "rem-1",
+        playerTag: "#PYLQ0290",
+      }),
+    );
+    expect(messages[2].content).toContain("#13 - ❌ PlayerTwo `#PYLQ0290` - 2 / 2");
   });
 
   it.each([
@@ -328,11 +352,14 @@ describe("ReminderDispatchService roster rendering", () => {
       cocService: null,
     });
 
+    expect(contents).toHaveLength(2);
     expect(contents[0].split("\n").filter((line) => /^#\d+ /.test(line))).toEqual([
       "#1 - First - <@111> - 2 / 2",
       "#3 - Second - <@111> - 2 / 2",
-      "#2 - ❌ Middle `#PYLG` - 2 / 2",
     ]);
+    expect(contents[0]).not.toContain("Middle");
+    expect(contents[1].split("\n")[0]).toBe("#2 - ❌ Middle `#PYLG` - 2 / 2");
+    expect(contents[1]).toContain("Is this you?");
   });
 
   it("renders CWL roster from active CWL war participants only and sorts by map position", async () => {
@@ -380,15 +407,18 @@ describe("ReminderDispatchService roster rendering", () => {
       cocService,
     });
 
+    expect(contents).toHaveLength(2);
     const rosterLines = contents[0]
       .split("\n")
       .filter((line) => /^#\d+ /.test(line));
     expect(rosterLines).toEqual([
-      "#1 - :no: One - 1 / 1",
       "#2 - Two - <@222> - 1 / 1",
     ]);
+    expect(contents[0]).not.toContain("One");
     expect(contents[0]).not.toContain("Outside");
     expect(contents[0]).not.toContain("Done");
+    expect(contents[1].split("\n")[0]).toBe("#1 - :no: One - 1 / 1");
+    expect(contents[1]).toContain("Is this you?");
   });
 
   it("renders RAIDS roster sorted by remaining attacks then player name and excludes non-season members", async () => {
@@ -438,26 +468,34 @@ describe("ReminderDispatchService roster rendering", () => {
       cocService,
     });
 
+    expect(contents).toHaveLength(2);
     const rosterLines = contents[0]
       .split("\n")
       .filter((line) => line.includes("/ 6"));
     expect(rosterLines).toEqual([
       "Alpha - <@333> - 1 / 6",
-      ":no: Zulu - 1 / 6",
       "Bravo - <@222> - 6 / 6",
     ]);
+    expect(contents[0]).not.toContain("Zulu");
     expect(contents[0]).not.toContain("Spent");
     expect(contents[0]).not.toContain("IneligibleElsewhere");
     expect(contents[0]).not.toContain("#1 -");
+    expect(contents[1].split("\n")[0]).toBe(":no: Zulu - 1 / 6");
+    expect(contents[1]).toContain("Is this you?");
   });
 
   it("splits long reminder output into two plain-text messages on whole lines only", async () => {
-    prismaMock.warAttacks.findMany.mockResolvedValue(
-      Array.from({ length: 30 }, (_, index) => ({
-        playerTag: buildValidPlayerTag(index),
-        playerName: `Player_${String(index + 1).padStart(2, "0")}_${"X".repeat(90)}`,
-        playerPosition: index + 1,
-        attacksUsed: 0,
+    const roster = Array.from({ length: 30 }, (_, index) => ({
+      playerTag: buildValidPlayerTag(index),
+      playerName: `Player_${String(index + 1).padStart(2, "0")}_${"X".repeat(90)}`,
+      playerPosition: index + 1,
+      attacksUsed: 0,
+    }));
+    prismaMock.warAttacks.findMany.mockResolvedValue(roster);
+    prismaMock.playerLink.findMany.mockResolvedValue(
+      roster.map((entry, index) => ({
+        playerTag: entry.playerTag,
+        discordUserId: String(100000000000000000n + BigInt(index)),
       })),
     );
 
@@ -478,7 +516,8 @@ describe("ReminderDispatchService roster rendering", () => {
       cocService: null,
     });
 
-    expect(contents).toHaveLength(3);
+    expect(contents.length).toBeGreaterThan(1);
+    expect(contents.length).toBeLessThanOrEqual(3);
     expect(contents.every((content) => content.length <= 2000)).toBe(true);
     expect(contents[1]).not.toContain("Clan: Overflow Clan #PYLQ");
 
@@ -488,18 +527,23 @@ describe("ReminderDispatchService roster rendering", () => {
     expect(combinedRosterLines).toHaveLength(30);
     expect(
       combinedRosterLines.every((line) =>
-        /^#\d+ - ❌ Player_\d{2}_X+ `#.+` - 2 \/ 2$/.test(line),
+        /^#\d+ - Player_\d{2}_X+ - <@\d+> - 2 \/ 2$/.test(line),
       ),
     ).toBe(true);
   });
 
   it("splits overflow into at most three messages and stops after the third message", async () => {
-    prismaMock.warAttacks.findMany.mockResolvedValue(
-      Array.from({ length: 240 }, (_, index) => ({
-        playerTag: buildValidPlayerTag(index + 1000),
-        playerName: `Player_${String(index + 1).padStart(3, "0")}_${"Y".repeat(80)}`,
-        playerPosition: index + 1,
-        attacksUsed: 0,
+    const roster = Array.from({ length: 240 }, (_, index) => ({
+      playerTag: buildValidPlayerTag(index + 1000),
+      playerName: `Player_${String(index + 1).padStart(3, "0")}_${"Y".repeat(80)}`,
+      playerPosition: index + 1,
+      attacksUsed: 0,
+    }));
+    prismaMock.warAttacks.findMany.mockResolvedValue(roster);
+    prismaMock.playerLink.findMany.mockResolvedValue(
+      roster.map((entry, index) => ({
+        playerTag: entry.playerTag,
+        discordUserId: String(200000000000000000n + BigInt(index)),
       })),
     );
 


### PR DESCRIPTION
…ssages

- keep linked players in the main reminder roster
- send one self-link follow-up per unlinked player
- include player name in the reminder confirmation prompt