### PR TITLE
fix(build): raise tsc heap for deploy builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "vitest": "^0.34.6"
   },
   "scripts": {
-    "build": "prisma generate && tsc",
+    "build": "prisma generate && node scripts/compile-typescript.js",
     "lint": "eslint \"src/**/*.ts\" \"tests/**/*.ts\"",
     "lint:fix": "eslint \"src/**/*.ts\" \"tests/**/*.ts\" --fix",
     "seed:fwa-layouts": "ts-node src/scripts/seedFwaLayouts.ts",

--- a/scripts/compile-typescript.js
+++ b/scripts/compile-typescript.js
@@ -1,0 +1,33 @@
+const { spawnSync } = require("node:child_process");
+
+function normalizeNodeOptions(input) {
+  const tokens = String(input ?? "")
+    .split(/\s+/g)
+    .map((token) => token.trim())
+    .filter(Boolean)
+    .filter((token) => !token.startsWith("--max-old-space-size="));
+  tokens.push("--max-old-space-size=1024");
+  return tokens.join(" ");
+}
+
+function main() {
+  const env = {
+    ...process.env,
+    NODE_OPTIONS: normalizeNodeOptions(process.env.NODE_OPTIONS),
+  };
+  const tscPath = require.resolve("typescript/bin/tsc");
+  const result = spawnSync(process.execPath, [tscPath], {
+    stdio: "inherit",
+    env,
+  });
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.signal) {
+    process.kill(process.pid, result.signal);
+    return;
+  }
+  process.exit(result.status ?? 1);
+}
+
+main();


### PR DESCRIPTION
- keep prisma generate unchanged and boost heap only for TypeScript compile
- add a portable node wrapper so deploy and CI use the same build-time heap limit
- document the 1024 MB build heap in the change for future deploy debugging