### PR TITLE
fix(roster): add staging roster registration diagnostics

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -88,6 +88,7 @@ Recommended localhost-only port mapping on the droplet:
   - `HEALTHCHECK_LIVE_PATH=/livez`
   - `HEALTHCHECK_READY_PATH=/healthz`
 - These defaults are currently relied on directly; no extra env overrides are required unless you intentionally want non-default paths or ports.
+- Startup command registration logs now include the runtime environment, bot identity, guild scope, and the `/roster create` option names so staging deploys can verify the published slash-command shape.
 
 ## Droplet Dependency Cache
 

--- a/src/listeners/ready.ts
+++ b/src/listeners/ready.ts
@@ -21,6 +21,7 @@ import { refreshAllTrackedWarMailPosts } from "../commands/Fwa";
 import { backfillMissingDiscordUsernamesForClanMembers } from "../services/PlayerLinkService";
 import { HeatMapRefRebuildService } from "../services/HeatMapRefRebuildService";
 import {
+  buildCommandRegistrationDebugSummary,
   formatStartupLogFields,
   getCommandRegistrationConfigFromEnv,
   getStartupErrorDiagnostics,
@@ -51,6 +52,7 @@ import { runWithCoCQueueContext } from "../services/CoCQueueContext";
 import {
   isActivePollingMode,
   resolveMirrorSyncIntervalMsFromEnv,
+  resolveRuntimeEnvironment,
   resolvePollingMode,
 } from "../services/PollingModeService";
 import {
@@ -326,6 +328,23 @@ export default (client: Client, cocService: CoCService): void => {
 
     // Register ONLY guild commands
     const commandsWithVisibility = Commands.map((cmd) => injectVisibilityOptions(cmd));
+    const registrationDebugSummary = buildCommandRegistrationDebugSummary(commandsWithVisibility);
+    const runtimeEnvironment = resolveRuntimeEnvironment(process.env);
+    console.log(
+      `[startup:commands] env=${runtimeEnvironment} bot_id=${client.user?.id ?? "unknown"} bot_username=${
+        client.user?.username ?? "unknown"
+      } guild_id=${guildId} scope=guild payload_count=${registrationDebugSummary.commandCount} roster_included=${
+        registrationDebugSummary.rosterIncluded ? 1 : 0
+      } roster_create_options=${
+        registrationDebugSummary.rosterCreateOptionNames.length > 0
+          ? registrationDebugSummary.rosterCreateOptionNames.join(",")
+          : "none"
+      } roster_edit_options=${
+        registrationDebugSummary.rosterEditOptionNames.length > 0
+          ? registrationDebugSummary.rosterEditOptionNames.join(",")
+          : "none"
+      }`
+    );
     const registrationConfig = getCommandRegistrationConfigFromEnv(process.env);
     const registrationResult = await registerGuildCommandsWithRetry({
       guild,

--- a/src/services/StartupCommandRegistrationService.ts
+++ b/src/services/StartupCommandRegistrationService.ts
@@ -56,6 +56,13 @@ export type RunWithTransientRetryResult<T> =
   | { status: "success"; attempts: number; value: T }
   | { status: "failed"; attempts: number; transient: boolean; error: unknown };
 
+export type CommandRegistrationDebugSummary = {
+  commandCount: number;
+  rosterIncluded: boolean;
+  rosterCreateOptionNames: string[];
+  rosterEditOptionNames: string[];
+};
+
 export type StartupErrorDiagnostics = {
   code: string;
   name: string;
@@ -217,6 +224,39 @@ function computeBackoffMs(config: TransientRetryConfig, attempt: number): number
   const exponent = Math.max(0, attempt - 1);
   const candidate = config.baseBackoffMs * Math.pow(2, exponent);
   return Math.min(config.maxBackoffMs, Math.floor(candidate));
+}
+
+function normalizeOptionNameList(input: unknown): string[] {
+  if (!Array.isArray(input)) return [];
+  return input
+    .map((option) => String((option as { name?: unknown } | null | undefined)?.name ?? "").trim())
+    .filter((name) => name.length > 0);
+}
+
+function findSubcommandOptionNames(command: unknown, subcommandName: string): string[] {
+  if (!command || typeof command !== "object") return [];
+  const commandOptions = Array.isArray((command as { options?: unknown }).options)
+    ? ((command as { options?: unknown[] }).options ?? [])
+    : [];
+  const subcommand = commandOptions.find(
+    (option) => String((option as { name?: unknown } | null | undefined)?.name ?? "").trim() === subcommandName
+  );
+  return normalizeOptionNameList((subcommand as { options?: unknown } | null | undefined)?.options);
+}
+
+/** Purpose: build a compact startup summary for command registration diagnostics. */
+export function buildCommandRegistrationDebugSummary(
+  commands: unknown[]
+): CommandRegistrationDebugSummary {
+  const roster = commands.find(
+    (command) => String((command as { name?: unknown } | null | undefined)?.name ?? "").trim() === "roster"
+  );
+  return {
+    commandCount: Array.isArray(commands) ? commands.length : 0,
+    rosterIncluded: Boolean(roster),
+    rosterCreateOptionNames: findSubcommandOptionNames(roster, "create"),
+    rosterEditOptionNames: findSubcommandOptionNames(roster, "edit"),
+  };
 }
 
 /** Purpose: run one async operation with transient-aware retry policy. */

--- a/tests/startupCommandRegistration.service.test.ts
+++ b/tests/startupCommandRegistration.service.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  buildCommandRegistrationDebugSummary,
   formatStartupLogFields,
   getCommandRegistrationConfigFromEnv,
   getDiscordRestTimeoutMsFromEnv,
@@ -12,6 +13,7 @@ import {
   runWithTransientRetry,
   shouldEmitStartupRetrySummary,
 } from "../src/services/StartupCommandRegistrationService";
+import { Roster } from "../src/commands/Roster";
 
 describe("StartupCommandRegistrationService config", () => {
   it("uses deterministic defaults when env is missing or invalid", () => {
@@ -294,5 +296,20 @@ describe("StartupCommandRegistrationService shared retry helper", () => {
     expect(result.transient).toBe(true);
     expect(sleep).toHaveBeenCalledTimes(1);
     expect(sleep).toHaveBeenCalledWith(1000);
+  });
+});
+
+describe("StartupCommandRegistrationService registration summary", () => {
+  it("captures the roster create/edit option names for runtime diagnostics", () => {
+    const summary = buildCommandRegistrationDebugSummary([Roster, { name: "emoji" }]);
+
+    expect(summary.commandCount).toBe(2);
+    expect(summary.rosterIncluded).toBe(true);
+    expect(summary.rosterCreateOptionNames).toEqual(
+      expect.arrayContaining(["name", "title"]),
+    );
+    expect(summary.rosterEditOptionNames).toEqual(
+      expect.arrayContaining(["name", "title"]),
+    );
   });
 });


### PR DESCRIPTION
- log the runtime environment, bot identity, guild scope, and roster create/edit option names at startup
- add a summary helper and tests that prove the registered roster payload includes name and title