### PR TITLE
fix(roster): show missing town hall accounts in signup errors

### DIFF
--- a/src/commands/Cwl.ts
+++ b/src/commands/Cwl.ts
@@ -106,6 +106,14 @@ function buildDescription(lines: string[]): string {
   return `${description.slice(0, DISCORD_DESCRIPTION_LIMIT - 13)}\n...truncated`;
 }
 
+function formatRosterAccountIdentity(account: { playerTag: string; playerName: string | null }): string {
+  return account.playerName ? `${account.playerName} \`${account.playerTag}\`` : `\`${account.playerTag}\``;
+}
+
+function formatRosterAccountIdentityList(accounts: Array<{ playerTag: string; playerName: string | null }>): string {
+  return accounts.map(formatRosterAccountIdentity).join(", ");
+}
+
 function formatRosterSignupResultSummary(result: Awaited<ReturnType<typeof rosterService.signupLinkedAccounts>>): string {
   if (result.outcome === "roster_not_found") {
     return "That roster no longer exists.";
@@ -123,10 +131,16 @@ function formatRosterSignupResultSummary(result: Awaited<ReturnType<typeof roste
     return "You have reached the maximum accounts allowed on that roster.";
   }
   if (result.outcome === "townhall_unavailable") {
-    return "Town hall data is unavailable for some selected accounts.";
+    return result.blockedAccounts.length > 0
+      ? `Town hall data is unavailable for: ${formatRosterAccountIdentityList(result.blockedAccounts)}.`
+      : "Town hall data is unavailable for some selected accounts.";
   }
   if (result.outcome === "townhall_out_of_range") {
-    return "Some selected accounts do not meet the town hall requirements.";
+    return result.blockedAccounts.length > 0
+      ? `Some selected accounts do not meet the town hall requirements: ${formatRosterAccountIdentityList(
+          result.blockedAccounts,
+        )}.`
+      : "Some selected accounts do not meet the town hall requirements.";
   }
   if (result.outcome === "roster_conflict") {
     return "Some selected accounts are already signed up on another roster of this type.";

--- a/src/commands/Roster.ts
+++ b/src/commands/Roster.ts
@@ -42,6 +42,14 @@ function parseRosterPlayerTags(input: string): string[] {
   ];
 }
 
+function formatRosterAccountIdentity(account: { playerTag: string; playerName: string | null }): string {
+  return account.playerName ? `${account.playerName} \`${account.playerTag}\`` : `\`${account.playerTag}\``;
+}
+
+function formatRosterAccountIdentityList(accounts: Array<{ playerTag: string; playerName: string | null }>): string {
+  return accounts.map(formatRosterAccountIdentity).join(", ");
+}
+
 function buildRosterStateLabel(state: RosterRecord["lifecycleState"]): string {
   if (state === ROSTER_LIFECYCLE_STATE.ACTIVE) return "Active";
   if (state === ROSTER_LIFECYCLE_STATE.CLOSED) return "Closed";
@@ -73,10 +81,16 @@ function buildRosterSignupResultSummary(result: Awaited<ReturnType<typeof roster
     return "That user has reached the maximum accounts allowed on this roster.";
   }
   if (result.outcome === "townhall_unavailable") {
-    return "Town hall data is unavailable for some selected accounts.";
+    return result.blockedAccounts.length > 0
+      ? `Town hall data is unavailable for: ${formatRosterAccountIdentityList(result.blockedAccounts)}.`
+      : "Town hall data is unavailable for some selected accounts.";
   }
   if (result.outcome === "townhall_out_of_range") {
-    return "Some selected accounts do not meet the town hall requirements.";
+    return result.blockedAccounts.length > 0
+      ? `Some selected accounts do not meet the town hall requirements: ${formatRosterAccountIdentityList(
+          result.blockedAccounts,
+        )}.`
+      : "Some selected accounts do not meet the town hall requirements.";
   }
   if (result.outcome === "roster_conflict") {
     return "Some selected accounts are already signed up on another roster of this type.";

--- a/src/services/RosterService.ts
+++ b/src/services/RosterService.ts
@@ -128,6 +128,11 @@ export type RosterSelectionOption = {
   description: string | null;
 };
 
+export type RosterAccountIdentity = {
+  playerTag: string;
+  playerName: string | null;
+};
+
 export type RosterSelectionPanel = {
   sessionId: string;
   mode: RosterSelectionMode;
@@ -302,6 +307,7 @@ export type SignupLinkedAccountsResult =
       duplicateTags: string[];
       missingLinkedTags: string[];
       blockedTags: string[];
+      blockedAccounts: RosterAccountIdentity[];
     }
   | {
       outcome: "townhall_out_of_range";
@@ -314,6 +320,7 @@ export type SignupLinkedAccountsResult =
       duplicateTags: string[];
       missingLinkedTags: string[];
       blockedTags: string[];
+      blockedAccounts: RosterAccountIdentity[];
     }
   | {
       outcome: "roster_conflict";
@@ -525,6 +532,10 @@ function normalizeRosterInt(input: unknown): number | null {
   if (input === null || input === undefined || input === "") return null;
   const parsed = Math.trunc(Number(input));
   return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+function isRosterTownHallGated(roster: { minTownhall: number | null; maxTownhall: number | null }): boolean {
+  return normalizeRosterInt(roster.minTownhall) !== null || normalizeRosterInt(roster.maxTownhall) !== null;
 }
 
 export const ROSTER_SORT_BY = {
@@ -2105,6 +2116,10 @@ export class RosterService {
       where: { id: input.rosterId },
       select: {
         id: true,
+        rosterType: true,
+        clanTag: true,
+        minTownhall: true,
+        maxTownhall: true,
         lifecycleState: true,
       },
     });
@@ -2136,6 +2151,10 @@ export class RosterService {
       where: { id: input.rosterId },
       select: {
         id: true,
+        rosterType: true,
+        clanTag: true,
+        minTownhall: true,
+        maxTownhall: true,
         lifecycleState: true,
       },
     });
@@ -2217,6 +2236,7 @@ export class RosterService {
       };
     }
 
+    const townHallGated = isRosterTownHallGated(roster);
     const existing = await prisma.rosterSignup.findMany({
       where: {
         rosterId: roster.id,
@@ -2227,6 +2247,67 @@ export class RosterService {
     const existingTags = new Set(existing.map((row) => normalizePlayerTag(row.playerTag)).filter(Boolean));
     const createdTags = linkedTags.filter((tag) => !existingTags.has(tag));
     const duplicateTags = linkedTags.filter((tag) => existingTags.has(tag));
+
+    if (townHallGated && createdTags.length > 0) {
+      const playerTownHallByTag = await loadRosterPlayerTownHallMap({
+        rosterType: roster.rosterType,
+        clanTag: roster.clanTag,
+        playerTags: createdTags,
+      });
+      const minTownhall = normalizeRosterInt(roster.minTownhall);
+      const maxTownhall = normalizeRosterInt(roster.maxTownhall);
+      const blockedUnavailableTags: string[] = [];
+      const blockedUnavailableAccounts: RosterAccountIdentity[] = [];
+      const blockedOutOfRangeTags: string[] = [];
+      const blockedOutOfRangeAccounts: RosterAccountIdentity[] = [];
+      for (const tag of createdTags) {
+        const linked = linkedByTag.get(tag) ?? null;
+        const blockedAccount = {
+          playerTag: tag,
+          playerName: normalizeRosterText(linked?.playerName ?? null),
+        };
+        const townHall = playerTownHallByTag.get(tag) ?? null;
+        if (townHall === null) {
+          blockedUnavailableTags.push(tag);
+          blockedUnavailableAccounts.push(blockedAccount);
+          continue;
+        }
+        if ((minTownhall !== null && townHall < minTownhall) || (maxTownhall !== null && townHall > maxTownhall)) {
+          blockedOutOfRangeTags.push(tag);
+          blockedOutOfRangeAccounts.push(blockedAccount);
+        }
+      }
+      if (blockedUnavailableTags.length > 0) {
+        return {
+          outcome: "townhall_unavailable",
+          rosterId: roster.id,
+          groupKey: group.key,
+          groupName: group.name,
+          requestedTags,
+          linkedTags,
+          createdTags: [],
+          duplicateTags,
+          missingLinkedTags,
+          blockedTags: blockedUnavailableTags,
+          blockedAccounts: blockedUnavailableAccounts,
+        };
+      }
+      if (blockedOutOfRangeTags.length > 0) {
+        return {
+          outcome: "townhall_out_of_range",
+          rosterId: roster.id,
+          groupKey: group.key,
+          groupName: group.name,
+          requestedTags,
+          linkedTags,
+          createdTags: [],
+          duplicateTags,
+          missingLinkedTags,
+          blockedTags: blockedOutOfRangeTags,
+          blockedAccounts: blockedOutOfRangeAccounts,
+        };
+      }
+    }
 
     if (createdTags.length > 0) {
       await prisma.rosterSignup.createMany({
@@ -2781,55 +2862,66 @@ export class RosterService {
         }
       }
 
-    const playerTownHallByTag = await loadRosterPlayerTownHallMap({
-      rosterType: roster.rosterType,
-      clanTag: roster.clanTag,
-      playerTags: createdCandidates,
-    });
-    if (normalizeRosterInt(roster.minTownhall) !== null || normalizeRosterInt(roster.maxTownhall) !== null) {
-      const blockedUnavailableTags: string[] = [];
-      const blockedOutOfRangeTags: string[] = [];
-      for (const tag of createdCandidates) {
-        const townHall = playerTownHallByTag.get(tag) ?? null;
-        if (townHall === null) {
-          blockedUnavailableTags.push(tag);
-          continue;
-        }
+      if (isRosterTownHallGated(roster)) {
+        const playerTownHallByTag = await loadRosterPlayerTownHallMap({
+          rosterType: roster.rosterType,
+          clanTag: roster.clanTag,
+          playerTags: createdCandidates,
+        });
         const minTownhall = normalizeRosterInt(roster.minTownhall);
         const maxTownhall = normalizeRosterInt(roster.maxTownhall);
-        if ((minTownhall !== null && townHall < minTownhall) || (maxTownhall !== null && townHall > maxTownhall)) {
-          blockedOutOfRangeTags.push(tag);
+        const blockedUnavailableTags: string[] = [];
+        const blockedUnavailableAccounts: RosterAccountIdentity[] = [];
+        const blockedOutOfRangeTags: string[] = [];
+        const blockedOutOfRangeAccounts: RosterAccountIdentity[] = [];
+        for (const tag of createdCandidates) {
+          const linked = linkedByTag.get(tag) ?? null;
+          const blockedAccount = {
+            playerTag: tag,
+            playerName: normalizeRosterText(linked?.linkedName ?? null),
+          };
+          const townHall = playerTownHallByTag.get(tag) ?? null;
+          if (townHall === null) {
+            blockedUnavailableTags.push(tag);
+            blockedUnavailableAccounts.push(blockedAccount);
+            continue;
+          }
+          if ((minTownhall !== null && townHall < minTownhall) || (maxTownhall !== null && townHall > maxTownhall)) {
+            blockedOutOfRangeTags.push(tag);
+            blockedOutOfRangeAccounts.push(blockedAccount);
+          }
+        }
+        if (blockedUnavailableTags.length > 0) {
+          return {
+            outcome: "townhall_unavailable",
+            rosterId: roster.id,
+            groupKey: group.key,
+            groupName: group.name,
+            requestedTags,
+            linkedTags: selectedTags,
+            createdTags: [],
+            duplicateTags,
+            missingLinkedTags,
+            blockedTags: blockedUnavailableTags,
+            blockedAccounts: blockedUnavailableAccounts,
+          };
+        }
+        if (blockedOutOfRangeTags.length > 0) {
+          return {
+            outcome: "townhall_out_of_range",
+            rosterId: roster.id,
+            groupKey: group.key,
+            groupName: group.name,
+            requestedTags,
+            linkedTags: selectedTags,
+            createdTags: [],
+            duplicateTags,
+            missingLinkedTags,
+            blockedTags: blockedOutOfRangeTags,
+            blockedAccounts: blockedOutOfRangeAccounts,
+          };
         }
       }
-      if (blockedUnavailableTags.length > 0) {
-        return {
-          outcome: "townhall_unavailable",
-          rosterId: roster.id,
-          groupKey: group.key,
-          groupName: group.name,
-          requestedTags,
-          linkedTags: selectedTags,
-          createdTags: [],
-          duplicateTags,
-          missingLinkedTags,
-          blockedTags: blockedUnavailableTags,
-        };
-      }
-      if (blockedOutOfRangeTags.length > 0) {
-        return {
-          outcome: "townhall_out_of_range",
-          rosterId: roster.id,
-          groupKey: group.key,
-          groupName: group.name,
-          requestedTags,
-          linkedTags: selectedTags,
-          createdTags: [],
-          duplicateTags,
-          missingLinkedTags,
-          blockedTags: blockedOutOfRangeTags,
-        };
-      }
-    }
 
       const conflictingRows = await prisma.rosterSignup.findMany({
         where: {

--- a/tests/cwl.command.test.ts
+++ b/tests/cwl.command.test.ts
@@ -555,6 +555,50 @@ describe("/cwl command", () => {
     );
   });
 
+  it("shows exactly which selected accounts are missing town hall data when selection confirm is blocked", async () => {
+    (rosterService.confirmRosterSelectionPanel as any).mockResolvedValue({
+      outcome: "signup",
+      result: {
+        outcome: "townhall_unavailable",
+        rosterId: "roster-1",
+        groupKey: "confirmed",
+        groupName: "Confirmed",
+        requestedTags: ["#P1", "#P2"],
+        linkedTags: ["#P1", "#P2"],
+        createdTags: [],
+        duplicateTags: [],
+        missingLinkedTags: [],
+        blockedTags: ["#P1", "#P2"],
+        blockedAccounts: [
+          { playerTag: "#P1", playerName: "Alpha" },
+          { playerTag: "#P2", playerName: null },
+        ],
+      },
+    });
+
+    const confirmInteraction = {
+      customId: "roster-selection:confirm:session-2",
+      user: { id: "111111111111111111" },
+      update: vi.fn().mockResolvedValue(undefined),
+      reply: vi.fn().mockResolvedValue(undefined),
+      client: {
+        channels: {
+          fetch: vi.fn().mockResolvedValue(null),
+        },
+      },
+    };
+
+    await handleRosterSelectionActionButtonInteraction(confirmInteraction as any);
+
+    expect(confirmInteraction.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining("Town hall data is unavailable for: Alpha `#P1`, `#P2`."),
+        embeds: [],
+        components: [],
+      }),
+    );
+  });
+
   it("renders a manager readiness report for /cwl roster report", async () => {
     (rosterService.findCwlRosterForClan as any).mockResolvedValue({
       id: "roster-1",

--- a/tests/roster.command.test.ts
+++ b/tests/roster.command.test.ts
@@ -477,6 +477,70 @@ describe("/roster command", () => {
     expect(String(archiveInteraction.editReply.mock.calls.at(-1)?.[0] ?? "")).toContain("was archived");
   });
 
+  it("shows exactly which selected accounts are missing town hall data when roster add is blocked", async () => {
+    (rosterService.findGuildRosterById as any).mockResolvedValue({
+      id: "roster-1",
+      guildId: "guild-1",
+      rosterType: "CWL",
+      rosterCategory: "signup",
+      title: "CWL Alpha Signup",
+      clanTag: "#2QG2C08UP",
+      startsAt: new Date("2026-04-20T00:00:00.000Z"),
+      endsAt: null,
+      timezone: "America/Los_Angeles",
+      displayTimezone: "America/Los_Angeles",
+      lifecycleState: "OPEN",
+      postedChannelId: null,
+      postedMessageId: null,
+      postedMessageUrl: null,
+      postedAt: null,
+      createdByDiscordUserId: "111111111111111111",
+      updatedByDiscordUserId: "111111111111111111",
+      createdAt: new Date("2026-04-20T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-20T00:00:00.000Z"),
+    });
+    (rosterService.getRosterView as any).mockResolvedValue({
+      roster: {
+        id: "roster-1",
+        postedChannelId: null,
+        postedMessageId: null,
+      },
+      groups: [],
+      signups: [],
+      totalSignupCount: 0,
+    });
+    (rosterService.addRosterSignupsForManager as any).mockResolvedValue({
+      outcome: "townhall_unavailable",
+      rosterId: "roster-1",
+      groupKey: "confirmed",
+      groupName: "Confirmed",
+      requestedTags: ["#PQL0289", "#QGRJ2222"],
+      linkedTags: ["#PQL0289", "#QGRJ2222"],
+      createdTags: [],
+      duplicateTags: [],
+      missingLinkedTags: [],
+      blockedTags: ["#PQL0289", "#QGRJ2222"],
+      blockedAccounts: [
+        { playerTag: "#PQL0289", playerName: "Alpha" },
+        { playerTag: "#QGRJ2222", playerName: null },
+      ],
+    });
+
+    const interaction = makeInteraction({
+      subcommand: "manage",
+      roster: "roster-1",
+      action: "add",
+      group: "confirmed",
+      players: "#PQL0289 #QGRJ2222",
+    }) as any;
+
+    await Roster.run({} as any, interaction as any);
+
+    expect(String(interaction.editReply.mock.calls.at(-1)?.[0] ?? "")).toContain(
+      "Town hall data is unavailable for: Alpha `#PQL0289`, `#QGRJ2222`.",
+    );
+  });
+
   it("edits roster metadata and can refresh the posted roster from DB truth", async () => {
     (rosterService.findGuildRosterById as any).mockResolvedValue({
       id: "roster-1",

--- a/tests/roster.service.test.ts
+++ b/tests/roster.service.test.ts
@@ -269,6 +269,81 @@ describe("RosterService", () => {
     });
   });
 
+  it("reports the specific linked accounts missing town hall data when town hall gating is configured", async () => {
+    playerLinkServiceMock.listPlayerLinksForDiscordUser.mockResolvedValue([
+      { playerTag: "#PQL0289", linkedName: "Alpha", linkedAt: new Date("2026-04-20T00:00:00.000Z") },
+      { playerTag: "#QGRJ2222", linkedName: "Bravo", linkedAt: new Date("2026-04-20T00:00:00.000Z") },
+    ]);
+    prismaMock.roster.findUnique.mockResolvedValueOnce({
+      id: "roster-1",
+      guildId: "guild-1",
+      rosterType: "CWL",
+      rosterCategory: "signup",
+      title: "CWL Alpha Signup",
+      clanTag: "#2QG2C08UP",
+      startsAt: new Date("2026-04-20T00:00:00.000Z"),
+      endsAt: null,
+      timezone: "America/Los_Angeles",
+      displayTimezone: "America/Los_Angeles",
+      maxMembers: null,
+      maxAccountsPerUser: null,
+      minTownhall: 13,
+      maxTownhall: null,
+      rosterRoleId: null,
+      allowMultiSignup: true,
+      sortBy: null,
+      importMembers: false,
+      lifecycleState: "OPEN",
+      postedChannelId: null,
+      postedMessageId: null,
+      postedMessageUrl: null,
+      postedAt: null,
+      createdByDiscordUserId: "111111111111111111",
+      updatedByDiscordUserId: "111111111111111111",
+      createdAt: new Date("2026-04-20T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-20T00:00:00.000Z"),
+    } as any);
+
+    const result = await rosterService.signupLinkedAccounts({
+      rosterId: "roster-1",
+      groupKey: "confirmed",
+      discordUserId: "111111111111111111",
+    });
+
+    expect(result).toMatchObject({
+      outcome: "townhall_unavailable",
+      blockedTags: ["#PQL0289", "#QGRJ2222"],
+      blockedAccounts: [
+        { playerTag: "#PQL0289", playerName: "Alpha" },
+        { playerTag: "#QGRJ2222", playerName: "Bravo" },
+      ],
+    });
+    expect(cwlStateServiceMock.listSeasonRosterForClan).toHaveBeenCalledWith({
+      clanTag: "#2QG2C08UP",
+    });
+  });
+
+  it("allows signup to proceed when town hall data is missing and no town hall gating is configured", async () => {
+    playerLinkServiceMock.listPlayerLinksForDiscordUser.mockResolvedValue([
+      { playerTag: "#PQL0289", linkedName: "Alpha", linkedAt: new Date("2026-04-20T00:00:00.000Z") },
+    ]);
+
+    const result = await rosterService.signupLinkedAccounts({
+      rosterId: "roster-1",
+      groupKey: "confirmed",
+      discordUserId: "111111111111111111",
+    });
+
+    expect(result).toMatchObject({
+      outcome: "created",
+      linkedTags: ["#PQL0289"],
+      createdTags: ["#PQL0289"],
+      duplicateTags: [],
+      missingLinkedTags: [],
+    });
+    expect(cwlStateServiceMock.listSeasonRosterForClan).not.toHaveBeenCalled();
+  });
+
   it.each(["OPEN", "CLOSED", "ACTIVE"] as const)(
     "blocks signup when the same player is already signed up on another relevant %s roster",
     async (conflictLifecycleState) => {


### PR DESCRIPTION
- return specific blocked account identities when town hall data is missing
- keep town hall gating DB-first and skip the gate entirely when no TH limits are configured