### PR TITLE
fix(roster): add snapshot and live fallback for town hall data

### DIFF
--- a/prisma/migrations/20260421000000_add_todo_player_snapshot_townhall/migration.sql
+++ b/prisma/migrations/20260421000000_add_todo_player_snapshot_townhall/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "TodoPlayerSnapshot"
+ADD COLUMN "townHall" INTEGER;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -119,6 +119,7 @@ model UnlinkedPlayer {
 model TodoPlayerSnapshot {
   playerTag       String   @id
   playerName      String
+  townHall        Int?
   clanTag         String?
   clanName        String?
   cwlClanTag      String?

--- a/src/commands/Cwl.ts
+++ b/src/commands/Cwl.ts
@@ -2246,7 +2246,10 @@ export async function handleRosterSignupSubcommand(interaction: ChatInputCommand
   );
 }
 
-export async function handleRosterManagerSubcommand(interaction: ChatInputCommandInteraction): Promise<void> {
+export async function handleRosterManagerSubcommand(
+  interaction: ChatInputCommandInteraction,
+  cocService: CoCService,
+): Promise<void> {
   if (!interaction.inGuild() || !interaction.guildId) {
     await interaction.editReply("This command can only be used in a server.");
     return;
@@ -2352,6 +2355,7 @@ export async function handleRosterManagerSubcommand(interaction: ChatInputComman
         groupKey,
         playerTags,
         updatedByDiscordUserId: interaction.user.id,
+        cocService,
       });
       if (result.outcome === "roster_not_found") {
         await interaction.editReply("That roster is no longer available.");
@@ -2986,6 +2990,7 @@ export async function handleRosterSelectionMenuInteraction(
 
 export async function handleRosterSelectionActionButtonInteraction(
   interaction: ButtonInteraction,
+  cocService?: CoCService | null,
 ): Promise<void> {
   const parsed = parseRosterSelectionActionButtonCustomId(interaction.customId);
   if (!parsed) return;
@@ -3021,6 +3026,7 @@ export async function handleRosterSelectionActionButtonInteraction(
   const result = await rosterService.confirmRosterSelectionPanel({
     sessionId: parsed.sessionId,
     discordUserId: interaction.user.id,
+    cocService: cocService ?? null,
   });
   if (result.outcome === "session_not_found") {
     await interaction.reply({
@@ -3164,6 +3170,7 @@ export const Cwl: Command = {
   run: async (
     client: Client,
     interaction: ChatInputCommandInteraction,
+    cocService: CoCService,
   ) => {
     const visibility = interaction.options.getString("visibility", false) ?? "private";
     const isPublic = visibility === "public";
@@ -3181,7 +3188,7 @@ export const Cwl: Command = {
         return;
       }
       if (group === "roster") {
-        await handleRosterManagerSubcommand(interaction);
+        await handleRosterManagerSubcommand(interaction, cocService);
         return;
       }
       if (group === "rotations" && subcommand === "create") {

--- a/src/commands/Roster.ts
+++ b/src/commands/Roster.ts
@@ -8,6 +8,7 @@ import {
 import { Command } from "../Command";
 import { formatError } from "../helper/formatError";
 import { prisma } from "../prisma";
+import { CoCService } from "../services/CoCService";
 import { resolveCurrentCwlSeasonKey } from "../services/CwlRegistryService";
 import { normalizeClanTag, normalizePlayerTag } from "../services/PlayerLinkService";
 import { autocompleteSyncTimeZones, normalizeSyncTimeZone } from "../services/syncTimeZone";
@@ -620,7 +621,10 @@ async function handleRosterRefreshSubcommand(interaction: ChatInputCommandIntera
   await interaction.editReply(`Refreshed the posted roster for ${roster.title}.`);
 }
 
-async function handleRosterManageSubcommand(interaction: ChatInputCommandInteraction): Promise<void> {
+async function handleRosterManageSubcommand(
+  interaction: ChatInputCommandInteraction,
+  cocService: CoCService,
+): Promise<void> {
   if (!interaction.inGuild() || !interaction.guildId) {
     await interaction.editReply("This command can only be used in a server.");
     return;
@@ -675,6 +679,7 @@ async function handleRosterManageSubcommand(interaction: ChatInputCommandInterac
         groupKey,
         playerTags,
         updatedByDiscordUserId: interaction.user.id,
+        cocService,
       });
       await syncRosterRolesForRoster(interaction, roster.id).catch(() => undefined);
       await refreshExistingRosterPost(interaction, roster.id).catch(() => undefined);
@@ -1350,7 +1355,7 @@ export const Roster: Command = {
       ],
     },
   ],
-  run: async (_client: Client, interaction: ChatInputCommandInteraction) => {
+  run: async (_client: Client, interaction: ChatInputCommandInteraction, cocService: CoCService) => {
     await interaction.deferReply({ ephemeral: true });
 
     try {
@@ -1368,7 +1373,7 @@ export const Roster: Command = {
         return;
       }
       if (subcommand === "manage") {
-        await handleRosterManageSubcommand(interaction);
+        await handleRosterManageSubcommand(interaction, cocService);
         return;
       }
       if (subcommand === "edit") {

--- a/src/listeners/interactionCreate.ts
+++ b/src/listeners/interactionCreate.ts
@@ -627,7 +627,7 @@ const handleButtonInteraction = async (
 
   if (isRosterSelectionActionButtonCustomId(interaction.customId)) {
     try {
-      await handleRosterSelectionActionButtonInteraction(interaction);
+      await handleRosterSelectionActionButtonInteraction(interaction, cocService);
     } catch (err) {
       console.error(`Roster selection action button failed: ${formatError(err)}`);
       if (!interaction.replied && !interaction.deferred) {

--- a/src/services/RosterService.ts
+++ b/src/services/RosterService.ts
@@ -8,6 +8,7 @@ import {
 import { randomUUID } from "crypto";
 import { prisma } from "../prisma";
 import { truncateDiscordContent } from "../helper/discordContent";
+import { CoCService } from "./CoCService";
 import {
   listPlayerLinksForDiscordUser,
   normalizeClanTag,
@@ -16,6 +17,7 @@ import {
 } from "./PlayerLinkService";
 import { resolveCurrentCwlSeasonKey } from "./CwlRegistryService";
 import { cwlStateService, type CwlSeasonRosterEntry } from "./CwlStateService";
+import { todoSnapshotService } from "./TodoSnapshotService";
 import { normalizeSyncTimeZone } from "./syncTimeZone";
 
 export const ROSTER_LIFECYCLE_STATE = {
@@ -1141,6 +1143,8 @@ async function loadRosterPlayerTownHallMap(input: {
   rosterType: string;
   clanTag: string | null;
   playerTags: string[];
+  allowLiveFetch?: boolean;
+  cocService?: CoCService | null;
 }): Promise<Map<string, number>> {
   const normalizedTags = [...new Set(input.playerTags.map((tag) => normalizePlayerTag(tag)).filter(Boolean))];
   if (normalizedTags.length <= 0) {
@@ -1148,37 +1152,75 @@ async function loadRosterPlayerTownHallMap(input: {
   }
 
   const normalizedRosterType = normalizeRosterType(input.rosterType);
-  if ((normalizedRosterType === "CWL" || normalizedRosterType === "FWA") && !input.clanTag) {
-    return new Map();
-  }
+  const result = new Map<string, number>();
+  const missingAfterPrimary = new Set(normalizedTags);
 
   if (normalizedRosterType === "CWL" && input.clanTag) {
     const rosterEntries = await cwlStateService.listSeasonRosterForClan({ clanTag: input.clanTag });
-    const result = new Map<string, number>();
     for (const entry of rosterEntries) {
       const playerTag = normalizePlayerTag(entry.playerTag);
       const townHall = normalizeRosterInt(entry.townHall);
-      if (!playerTag || townHall === null || !normalizedTags.includes(playerTag)) continue;
+      if (!playerTag || townHall === null || !missingAfterPrimary.has(playerTag)) continue;
       result.set(playerTag, townHall);
+      missingAfterPrimary.delete(playerTag);
     }
+  } else if (normalizedRosterType === "FWA") {
+    const rows = await prisma.fwaPlayerCatalog.findMany({
+      where: { playerTag: { in: normalizedTags } },
+      select: {
+        playerTag: true,
+        latestTownHall: true,
+      },
+    });
+    for (const row of rows) {
+      const playerTag = normalizePlayerTag(row.playerTag);
+      const townHall = normalizeRosterInt(row.latestTownHall);
+      if (!playerTag || townHall === null || !missingAfterPrimary.has(playerTag)) continue;
+      result.set(playerTag, townHall);
+      missingAfterPrimary.delete(playerTag);
+    }
+  }
+
+  if (missingAfterPrimary.size <= 0) {
     return result;
   }
 
-  const rows = await prisma.fwaPlayerCatalog.findMany({
-    where: { playerTag: { in: normalizedTags } },
-    select: {
-      playerTag: true,
-      latestTownHall: true,
-    },
+  const missingTagsAfterPrimary = [...missingAfterPrimary];
+  const snapshotRows = await todoSnapshotService.listSnapshotsByPlayerTags({
+    playerTags: missingTagsAfterPrimary,
   });
-
-  const result = new Map<string, number>();
-  for (const row of rows) {
+  for (const row of snapshotRows) {
     const playerTag = normalizePlayerTag(row.playerTag);
-    const townHall = normalizeRosterInt(row.latestTownHall);
-    if (!playerTag || townHall === null) continue;
+    const townHall = normalizeRosterInt((row as { townHall?: unknown }).townHall ?? null);
+    if (!playerTag || townHall === null || !missingAfterPrimary.has(playerTag)) continue;
     result.set(playerTag, townHall);
+    missingAfterPrimary.delete(playerTag);
   }
+
+  if (!input.allowLiveFetch || missingAfterPrimary.size <= 0) {
+    return result;
+  }
+
+  const cocService = input.cocService ?? null;
+  if (!cocService) {
+    return result;
+  }
+
+  await todoSnapshotService.refreshSnapshotsForPlayerTags({
+    playerTags: [...missingAfterPrimary],
+    cocService,
+  });
+  const refreshedRows = await todoSnapshotService.listSnapshotsByPlayerTags({
+    playerTags: [...missingAfterPrimary],
+  });
+  for (const row of refreshedRows) {
+    const playerTag = normalizePlayerTag(row.playerTag);
+    const townHall = normalizeRosterInt((row as { townHall?: unknown }).townHall ?? null);
+    if (!playerTag || townHall === null || !missingAfterPrimary.has(playerTag)) continue;
+    result.set(playerTag, townHall);
+    missingAfterPrimary.delete(playerTag);
+  }
+
   return result;
 }
 
@@ -1400,6 +1442,7 @@ async function loadRosterView(rosterId: string): Promise<RosterSignupView | null
     rosterType: roster.rosterType,
     clanTag: roster.clanTag,
     playerTags: signups.map((signup) => signup.playerTag),
+    allowLiveFetch: false,
   });
   const signupsWithTownHall = signups.map((signup) => ({
     ...signup,
@@ -2146,6 +2189,7 @@ export class RosterService {
     groupKey: string;
     playerTags?: string[] | null;
     updatedByDiscordUserId?: string | null;
+    cocService?: CoCService | null;
   }): Promise<SignupLinkedAccountsResult> {
     const roster = await prisma.roster.findUnique({
       where: { id: input.rosterId },
@@ -2253,6 +2297,8 @@ export class RosterService {
         rosterType: roster.rosterType,
         clanTag: roster.clanTag,
         playerTags: createdTags,
+        allowLiveFetch: true,
+        cocService: input.cocService ?? null,
       });
       const minTownhall = normalizeRosterInt(roster.minTownhall);
       const maxTownhall = normalizeRosterInt(roster.maxTownhall);
@@ -2645,6 +2691,7 @@ export class RosterService {
   async confirmRosterSelectionPanel(input: {
     sessionId: string;
     discordUserId: string;
+    cocService?: CoCService | null;
   }): Promise<RosterSelectionCommitResult> {
     const session = getRosterSelectionSession(input.sessionId);
     if (!session) {
@@ -2662,6 +2709,7 @@ export class RosterService {
           groupKey: session.groupKey ?? "",
           discordUserId: session.ownerDiscordUserId,
           playerTags: session.selectedTags,
+          cocService: input.cocService ?? null,
         });
         deleteRosterSelectionSession(session.sessionId);
         return { outcome: "signup", result };
@@ -2707,6 +2755,7 @@ export class RosterService {
     groupKey: string;
     discordUserId: string;
     playerTags?: string[] | null;
+    cocService?: CoCService | null;
   }): Promise<SignupLinkedAccountsResult> {
     const roster = await prisma.roster.findUnique({
       where: { id: input.rosterId },
@@ -2867,6 +2916,8 @@ export class RosterService {
           rosterType: roster.rosterType,
           clanTag: roster.clanTag,
           playerTags: createdCandidates,
+          allowLiveFetch: true,
+          cocService: input.cocService ?? null,
         });
         const minTownhall = normalizeRosterInt(roster.minTownhall);
         const maxTownhall = normalizeRosterInt(roster.maxTownhall);

--- a/src/services/TodoSnapshotService.ts
+++ b/src/services/TodoSnapshotService.ts
@@ -24,6 +24,7 @@ import { parseCocTime } from "./war-events/core";
 const TODO_SNAPSHOT_SELECT = {
   playerTag: true,
   playerName: true,
+  townHall: true,
   clanTag: true,
   clanName: true,
   cwlClanTag: true,
@@ -158,6 +159,14 @@ const TODO_GAMES_TARGET_POINTS = 4000;
 const TODO_GAMES_POINTS_MAX = 4000;
 const TODO_GAMES_REWARD_COLLECTION_DURATION_MS = 7 * 24 * 60 * 60 * 1000;
 const TODO_SNAPSHOT_WRITE_CHUNK_SIZE = 50;
+
+function normalizeRosterInt(input: unknown): number | null {
+  const value = Number(input);
+  if (!Number.isFinite(value)) return null;
+  const normalized = Math.trunc(value);
+  return normalized >= 0 ? normalized : null;
+}
+
 /** Purpose: keep all Todo snapshot reads/writes in one service boundary. */
 export class TodoSnapshotService {
   private readonly refreshByBatchKey = new Map<
@@ -187,6 +196,7 @@ export class TodoSnapshotService {
       .map((row) => ({
         ...row,
         playerTag: normalizePlayerTag(row.playerTag),
+        townHall: Number.isFinite(Number(row.townHall)) ? Math.trunc(Number(row.townHall)) : null,
         clanTag: row.clanTag ? normalizeClanTag(row.clanTag) : null,
         cwlClanTag: row.cwlClanTag ? normalizeClanTag(row.cwlClanTag) : null,
       }))
@@ -531,7 +541,8 @@ export class TodoSnapshotService {
     const cwlDiscoveryClanTagByPlayerTag = new Map<string, string | null>();
     for (const playerTag of normalizedTags) {
       const existing = existingByTag.get(playerTag) ?? null;
-      const liveClanTag = liveClanTagByPlayerTag.get(playerTag) ?? "";
+      const livePlayer = liveClanTagByPlayerTag.get(playerTag) ?? { clanTag: "", townHall: null };
+      const liveClanTag = livePlayer.clanTag ?? "";
       const fromMember = latestClanMemberByTag.get(playerTag)?.clanTag ?? "";
       const fromExisting = existingByTag.get(playerTag)?.clanTag ?? "";
       const pinnedEventClanTag =
@@ -907,6 +918,7 @@ export class TodoSnapshotService {
         latestCatalogNameByTag.get(playerTag) ||
         sanitizeDisplayText(existing?.playerName ?? "") ||
         playerTag;
+      const livePlayer = liveClanTagByPlayerTag.get(playerTag) ?? { clanTag: "", townHall: null };
 
       const currentWar = resolvedClanTag
         ? currentWarByClanTag.get(resolvedClanTag) ?? null
@@ -954,6 +966,9 @@ export class TodoSnapshotService {
 
       const data = {
         playerName: resolvedPlayerName,
+        townHall:
+          livePlayer.townHall ??
+          normalizeRosterInt(existing?.townHall ?? null),
         clanTag: resolvedClanTag,
         clanName: resolvedClanName,
         cwlClanTag: resolvedCwlClanTag,
@@ -1672,7 +1687,7 @@ async function loadLiveClanTagsByPlayerTag(input: {
   cocService?: CoCService;
   playerTags: string[];
   producer?: WarEventLinkedPlayerRefreshProducer | null;
-}): Promise<Map<string, string>> {
+}): Promise<Map<string, { clanTag: string; townHall: number | null }>> {
   if (!input.cocService || typeof input.cocService.getPlayerRaw !== "function") {
     return new Map();
   }
@@ -1690,7 +1705,7 @@ async function loadLiveClanTagsByPlayerTag(input: {
     );
   }
 
-  const entries: Array<readonly [string, string]> = [];
+  const entries: Array<readonly [string, { clanTag: string; townHall: number | null }]> = [];
   let enqueuedCount = 0;
   let deferredCount = 0;
   for (let chunkIndex = 0; chunkIndex < chunkedTags.length; chunkIndex += 1) {
@@ -1720,15 +1735,16 @@ async function loadLiveClanTagsByPlayerTag(input: {
         `[todo-snapshot] event=war_event_player_refresh_chunk source=${input.producer.source} chunk_index=${chunkIndex + 1} chunk_count=${chunkedTags.length} chunk_size=${chunk.length} background_depth=${queueStatus.backgroundQueueDepth}`,
       );
     }
-    const chunkEntries = await Promise.all(
-      chunk.map(async (playerTag) => {
-        const player = await input.cocService!
-          .getPlayerRaw(playerTag, { suppressTelemetry: true })
-          .catch(() => null);
-        const clanTag = normalizeClanTag(String(player?.clan?.tag ?? ""));
-        return [playerTag, clanTag] as const;
-      }),
-    );
+      const chunkEntries = await Promise.all(
+        chunk.map(async (playerTag) => {
+          const player = await input.cocService!
+            .getPlayerRaw(playerTag, { suppressTelemetry: true })
+            .catch(() => null);
+          const clanTag = normalizeClanTag(String(player?.clan?.tag ?? ""));
+          const townHall = normalizeRosterInt(player?.townHallLevel ?? player?.townHall ?? null);
+          return [playerTag, { clanTag, townHall }] as const;
+        }),
+      );
     entries.push(...chunkEntries);
     enqueuedCount += chunk.length;
   }
@@ -1740,7 +1756,10 @@ async function loadLiveClanTagsByPlayerTag(input: {
   }
 
   return new Map(
-    entries.filter((entry): entry is [string, string] => Boolean(entry[0] && entry[1])),
+    entries.filter(
+      (entry): entry is [string, { clanTag: string; townHall: number | null }] =>
+        Boolean(entry[0] && entry[1].clanTag),
+    ),
   );
 }
 

--- a/tests/cwl.command.test.ts
+++ b/tests/cwl.command.test.ts
@@ -528,6 +528,7 @@ describe("/cwl command", () => {
     expect(rosterService.confirmRosterSelectionPanel).toHaveBeenCalledWith({
       sessionId: "session-2",
       discordUserId: "111111111111111111",
+      cocService: null,
     });
     expect(confirmInteraction.update).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/tests/roster.service.test.ts
+++ b/tests/roster.service.test.ts
@@ -25,6 +25,9 @@ const prismaMock = vi.hoisted(() => ({
   playerLink: {
     findMany: vi.fn(),
   },
+  fwaPlayerCatalog: {
+    findMany: vi.fn(),
+  },
 }));
 
 const playerLinkServiceMock = vi.hoisted(() => ({
@@ -33,6 +36,11 @@ const playerLinkServiceMock = vi.hoisted(() => ({
 
 const cwlStateServiceMock = vi.hoisted(() => ({
   listSeasonRosterForClan: vi.fn(),
+}));
+
+const todoSnapshotServiceMock = vi.hoisted(() => ({
+  listSnapshotsByPlayerTags: vi.fn(),
+  refreshSnapshotsForPlayerTags: vi.fn(),
 }));
 
 vi.mock("../src/prisma", () => ({
@@ -56,6 +64,16 @@ vi.mock("../src/services/CwlStateService", async () => {
   return {
     ...actual,
     cwlStateService: cwlStateServiceMock,
+  };
+});
+
+vi.mock("../src/services/TodoSnapshotService", async () => {
+  const actual = await vi.importActual<typeof import("../src/services/TodoSnapshotService")>(
+    "../src/services/TodoSnapshotService",
+  );
+  return {
+    ...actual,
+    todoSnapshotService: todoSnapshotServiceMock,
   };
 });
 
@@ -193,8 +211,14 @@ describe("RosterService", () => {
     prismaMock.rosterSignup.updateMany.mockResolvedValue({ count: 0 });
     prismaMock.rosterSignup.deleteMany.mockResolvedValue({ count: 0 });
     prismaMock.playerLink.findMany.mockResolvedValue([]);
+    prismaMock.fwaPlayerCatalog.findMany.mockResolvedValue([]);
     playerLinkServiceMock.listPlayerLinksForDiscordUser.mockResolvedValue([]);
     cwlStateServiceMock.listSeasonRosterForClan.mockResolvedValue([]);
+    todoSnapshotServiceMock.listSnapshotsByPlayerTags.mockResolvedValue([]);
+    todoSnapshotServiceMock.refreshSnapshotsForPlayerTags.mockResolvedValue({
+      playerCount: 0,
+      updatedCount: 0,
+    });
   });
 
   it("creates a roster with default Confirmed and Substitute groups", async () => {
@@ -320,6 +344,293 @@ describe("RosterService", () => {
     });
     expect(cwlStateServiceMock.listSeasonRosterForClan).toHaveBeenCalledWith({
       clanTag: "#2QG2C08UP",
+    });
+  });
+
+  it("uses the CWL season roster town hall before snapshot fallback when available", async () => {
+    playerLinkServiceMock.listPlayerLinksForDiscordUser.mockResolvedValue([
+      { playerTag: "#PQL0289", linkedName: "Alpha", linkedAt: new Date("2026-04-20T00:00:00.000Z") },
+    ]);
+    prismaMock.roster.findUnique.mockResolvedValueOnce({
+      id: "roster-1",
+      guildId: "guild-1",
+      rosterType: "CWL",
+      rosterCategory: "signup",
+      title: "CWL Alpha Signup",
+      clanTag: "#2QG2C08UP",
+      startsAt: new Date("2026-04-20T00:00:00.000Z"),
+      endsAt: null,
+      timezone: "America/Los_Angeles",
+      displayTimezone: "America/Los_Angeles",
+      maxMembers: null,
+      maxAccountsPerUser: null,
+      minTownhall: 13,
+      maxTownhall: null,
+      rosterRoleId: null,
+      allowMultiSignup: true,
+      sortBy: null,
+      importMembers: false,
+      lifecycleState: "OPEN",
+      postedChannelId: null,
+      postedMessageId: null,
+      postedMessageUrl: null,
+      postedAt: null,
+      createdByDiscordUserId: "111111111111111111",
+      updatedByDiscordUserId: "111111111111111111",
+      createdAt: new Date("2026-04-20T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-20T00:00:00.000Z"),
+    } as any);
+    cwlStateServiceMock.listSeasonRosterForClan.mockResolvedValue([
+      { playerTag: "#PQL0289", playerName: "Alpha", townHall: 16 },
+    ]);
+
+    const result = await rosterService.signupLinkedAccounts({
+      rosterId: "roster-1",
+      groupKey: "confirmed",
+      discordUserId: "111111111111111111",
+    });
+
+    expect(result).toMatchObject({
+      outcome: "created",
+      createdTags: ["#PQL0289"],
+    });
+    expect(todoSnapshotServiceMock.listSnapshotsByPlayerTags).not.toHaveBeenCalled();
+  });
+
+  it("uses the FWA catalog town hall before snapshot fallback when available", async () => {
+    playerLinkServiceMock.listPlayerLinksForDiscordUser.mockResolvedValue([
+      { playerTag: "#PQL0289", linkedName: "Alpha", linkedAt: new Date("2026-04-20T00:00:00.000Z") },
+    ]);
+    prismaMock.roster.findUnique.mockResolvedValueOnce({
+      id: "roster-1",
+      guildId: "guild-1",
+      rosterType: "FWA",
+      rosterCategory: "signup",
+      title: "FWA Alpha Signup",
+      clanTag: "#2QG2C08UP",
+      startsAt: new Date("2026-04-20T00:00:00.000Z"),
+      endsAt: null,
+      timezone: "America/Los_Angeles",
+      displayTimezone: "America/Los_Angeles",
+      maxMembers: null,
+      maxAccountsPerUser: null,
+      minTownhall: 13,
+      maxTownhall: null,
+      rosterRoleId: null,
+      allowMultiSignup: true,
+      sortBy: null,
+      importMembers: false,
+      lifecycleState: "OPEN",
+      postedChannelId: null,
+      postedMessageId: null,
+      postedMessageUrl: null,
+      postedAt: null,
+      createdByDiscordUserId: "111111111111111111",
+      updatedByDiscordUserId: "111111111111111111",
+      createdAt: new Date("2026-04-20T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-20T00:00:00.000Z"),
+    } as any);
+    prismaMock.fwaPlayerCatalog.findMany.mockResolvedValue([
+      { playerTag: "#PQL0289", latestTownHall: 15 },
+    ]);
+
+    const result = await rosterService.signupLinkedAccounts({
+      rosterId: "roster-1",
+      groupKey: "confirmed",
+      discordUserId: "111111111111111111",
+    });
+
+    expect(result).toMatchObject({
+      outcome: "created",
+      createdTags: ["#PQL0289"],
+    });
+    expect(todoSnapshotServiceMock.listSnapshotsByPlayerTags).not.toHaveBeenCalled();
+  });
+
+  it("falls back to persisted player snapshots when the primary roster source misses town hall", async () => {
+    playerLinkServiceMock.listPlayerLinksForDiscordUser.mockResolvedValue([
+      { playerTag: "#PQL0289", linkedName: "Alpha", linkedAt: new Date("2026-04-20T00:00:00.000Z") },
+    ]);
+    prismaMock.roster.findUnique.mockResolvedValueOnce({
+      id: "roster-1",
+      guildId: "guild-1",
+      rosterType: "CWL",
+      rosterCategory: "signup",
+      title: "CWL Alpha Signup",
+      clanTag: "#2QG2C08UP",
+      startsAt: new Date("2026-04-20T00:00:00.000Z"),
+      endsAt: null,
+      timezone: "America/Los_Angeles",
+      displayTimezone: "America/Los_Angeles",
+      maxMembers: null,
+      maxAccountsPerUser: null,
+      minTownhall: 13,
+      maxTownhall: null,
+      rosterRoleId: null,
+      allowMultiSignup: true,
+      sortBy: null,
+      importMembers: false,
+      lifecycleState: "OPEN",
+      postedChannelId: null,
+      postedMessageId: null,
+      postedMessageUrl: null,
+      postedAt: null,
+      createdByDiscordUserId: "111111111111111111",
+      updatedByDiscordUserId: "111111111111111111",
+      createdAt: new Date("2026-04-20T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-20T00:00:00.000Z"),
+    } as any);
+    cwlStateServiceMock.listSeasonRosterForClan.mockResolvedValue([
+      { playerTag: "#PQL0289", playerName: "Alpha", townHall: null },
+    ]);
+    todoSnapshotServiceMock.listSnapshotsByPlayerTags.mockResolvedValue([
+      { playerTag: "#PQL0289", townHall: 15 },
+    ]);
+
+    const result = await rosterService.signupLinkedAccounts({
+      rosterId: "roster-1",
+      groupKey: "confirmed",
+      discordUserId: "111111111111111111",
+    });
+
+    expect(result).toMatchObject({
+      outcome: "created",
+      createdTags: ["#PQL0289"],
+    });
+    expect(todoSnapshotServiceMock.listSnapshotsByPlayerTags).toHaveBeenCalledWith({
+      playerTags: ["#PQL0289"],
+    });
+  });
+
+  it("uses a live player refresh for only the still-missing tags and reuses the persisted snapshot on later checks", async () => {
+    playerLinkServiceMock.listPlayerLinksForDiscordUser.mockResolvedValue([
+      { playerTag: "#PQL0289", linkedName: "Alpha", linkedAt: new Date("2026-04-20T00:00:00.000Z") },
+    ]);
+    prismaMock.roster.findUnique.mockResolvedValue({
+      id: "roster-1",
+      guildId: "guild-1",
+      rosterType: "CWL",
+      rosterCategory: "signup",
+      title: "CWL Alpha Signup",
+      clanTag: "#2QG2C08UP",
+      startsAt: new Date("2026-04-20T00:00:00.000Z"),
+      endsAt: null,
+      timezone: "America/Los_Angeles",
+      displayTimezone: "America/Los_Angeles",
+      maxMembers: null,
+      maxAccountsPerUser: null,
+      minTownhall: 13,
+      maxTownhall: null,
+      rosterRoleId: null,
+      allowMultiSignup: true,
+      sortBy: null,
+      importMembers: false,
+      lifecycleState: "OPEN",
+      postedChannelId: null,
+      postedMessageId: null,
+      postedMessageUrl: null,
+      postedAt: null,
+      createdByDiscordUserId: "111111111111111111",
+      updatedByDiscordUserId: "111111111111111111",
+      createdAt: new Date("2026-04-20T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-20T00:00:00.000Z"),
+    } as any);
+    cwlStateServiceMock.listSeasonRosterForClan.mockResolvedValue([
+      { playerTag: "#PQL0289", playerName: "Alpha", townHall: null },
+    ]);
+    todoSnapshotServiceMock.listSnapshotsByPlayerTags
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ playerTag: "#PQL0289", townHall: 14 }])
+      .mockResolvedValueOnce([{ playerTag: "#PQL0289", townHall: 14 }]);
+    todoSnapshotServiceMock.refreshSnapshotsForPlayerTags.mockResolvedValue({
+      playerCount: 1,
+      updatedCount: 1,
+    });
+    const cocService = { getPlayerRaw: vi.fn() } as any;
+
+    const first = await rosterService.signupLinkedAccounts({
+      rosterId: "roster-1",
+      groupKey: "confirmed",
+      discordUserId: "111111111111111111",
+      cocService,
+    });
+    const second = await rosterService.signupLinkedAccounts({
+      rosterId: "roster-1",
+      groupKey: "confirmed",
+      discordUserId: "111111111111111111",
+      cocService,
+    });
+
+    expect(first).toMatchObject({
+      outcome: "created",
+      createdTags: ["#PQL0289"],
+    });
+    expect(second).toMatchObject({
+      outcome: "created",
+      createdTags: ["#PQL0289"],
+    });
+    expect(todoSnapshotServiceMock.refreshSnapshotsForPlayerTags).toHaveBeenCalledTimes(1);
+    expect(todoSnapshotServiceMock.refreshSnapshotsForPlayerTags).toHaveBeenCalledWith({
+      playerTags: ["#PQL0289"],
+      cocService,
+    });
+  });
+
+  it("still blocks when the recovered town hall is out of range", async () => {
+    playerLinkServiceMock.listPlayerLinksForDiscordUser.mockResolvedValue([
+      { playerTag: "#PQL0289", linkedName: "Alpha", linkedAt: new Date("2026-04-20T00:00:00.000Z") },
+    ]);
+    prismaMock.roster.findUnique.mockResolvedValueOnce({
+      id: "roster-1",
+      guildId: "guild-1",
+      rosterType: "CWL",
+      rosterCategory: "signup",
+      title: "CWL Alpha Signup",
+      clanTag: "#2QG2C08UP",
+      startsAt: new Date("2026-04-20T00:00:00.000Z"),
+      endsAt: null,
+      timezone: "America/Los_Angeles",
+      displayTimezone: "America/Los_Angeles",
+      maxMembers: null,
+      maxAccountsPerUser: null,
+      minTownhall: 15,
+      maxTownhall: null,
+      rosterRoleId: null,
+      allowMultiSignup: true,
+      sortBy: null,
+      importMembers: false,
+      lifecycleState: "OPEN",
+      postedChannelId: null,
+      postedMessageId: null,
+      postedMessageUrl: null,
+      postedAt: null,
+      createdByDiscordUserId: "111111111111111111",
+      updatedByDiscordUserId: "111111111111111111",
+      createdAt: new Date("2026-04-20T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-20T00:00:00.000Z"),
+    } as any);
+    cwlStateServiceMock.listSeasonRosterForClan.mockResolvedValue([
+      { playerTag: "#PQL0289", playerName: "Alpha", townHall: null },
+    ]);
+    todoSnapshotServiceMock.listSnapshotsByPlayerTags
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ playerTag: "#PQL0289", townHall: 13 }]);
+    todoSnapshotServiceMock.refreshSnapshotsForPlayerTags.mockResolvedValue({
+      playerCount: 1,
+      updatedCount: 1,
+    });
+
+    const result = await rosterService.signupLinkedAccounts({
+      rosterId: "roster-1",
+      groupKey: "confirmed",
+      discordUserId: "111111111111111111",
+      cocService: { getPlayerRaw: vi.fn() } as any,
+    });
+
+    expect(result).toMatchObject({
+      outcome: "townhall_out_of_range",
+      blockedTags: ["#PQL0289"],
+      blockedAccounts: [{ playerTag: "#PQL0289", playerName: "Alpha" }],
     });
   });
 

--- a/tests/todoSnapshot.service.test.ts
+++ b/tests/todoSnapshot.service.test.ts
@@ -431,6 +431,7 @@ describe("TodoSnapshotService", () => {
       getPlayerRaw: vi.fn().mockResolvedValue({
         tag: "#PYLQ0289",
         clan: { tag: "#2CJYQ0U82", name: "Infinity Meow" },
+        townHallLevel: 16,
       }),
       getClanWarLeagueGroup: vi.fn().mockImplementation(async (clanTag: string) => {
         if (clanTag !== "#2CJYQ0U82") {
@@ -493,6 +494,7 @@ describe("TodoSnapshotService", () => {
     expect(prismaMock.todoPlayerSnapshot.upsert).toHaveBeenCalledWith(
       expect.objectContaining({
         update: expect.objectContaining({
+          townHall: 16,
           cwlClanTag: "#2CJYQ0U82",
           cwlClanName: "Infinity Meow",
           cwlActive: true,


### PR DESCRIPTION
- resolve roster town hall from the primary source, persisted PlayerSnapshot, then a narrow live fetch
- persist live-fetched town hall back into the shared snapshot owner for future roster checks