### PR TITLE
fix(roster): tighten compact post board spacing and reopen flow

### DIFF
--- a/src/commands/Roster.ts
+++ b/src/commands/Roster.ts
@@ -47,6 +47,7 @@ const rosterPermissionService = new CommandPermissionService();
 type RosterMutationAction = "add" | "move" | "remove" | "open" | "close" | "archive";
 type RosterPostSettingsAction =
   | "roster_info"
+  | "open_roster"
   | "close_roster"
   | "clear_roster"
   | "hide_buttons"
@@ -401,17 +402,31 @@ async function deletePostedRosterMessage(
   }
 }
 
-const ROSTER_POST_SETTINGS_ACTIONS = [
-  { label: "Roster info", value: "roster_info", description: "Show roster settings and state" },
-  { label: "Close roster", value: "close_roster", description: "Prevent new signups" },
-  { label: "Clear roster", value: "clear_roster", description: "Remove all roster signups" },
-  { label: "Hide buttons", value: "hide_buttons", description: "Hide member buttons" },
-  { label: "Archive mode", value: "archive_mode", description: "Disable the post actions" },
-  { label: "Unregistered members", value: "unregistered_members", description: "List clan members who did not sign up" },
-  { label: "Missing members", value: "missing_members", description: "List signups not currently in clan" },
-] as const;
+function buildRosterPostSettingsActions(lifecycleState: RosterRecord["lifecycleState"]) {
+  const lifecycleAction =
+    lifecycleState === ROSTER_LIFECYCLE_STATE.CLOSED
+      ? { label: "Open roster", value: "open_roster", description: "Reopen the roster for signups" }
+      : { label: "Close roster", value: "close_roster", description: "Prevent new signups" };
 
-function buildRosterPostSettingsMenu(rosterId: string): ActionRowBuilder<StringSelectMenuBuilder> {
+  return [
+    { label: "Roster info", value: "roster_info", description: "Show roster settings and state" },
+    lifecycleAction,
+    { label: "Clear roster", value: "clear_roster", description: "Remove all roster signups" },
+    { label: "Hide buttons", value: "hide_buttons", description: "Hide member buttons" },
+    { label: "Archive mode", value: "archive_mode", description: "Disable the post actions" },
+    {
+      label: "Unregistered members",
+      value: "unregistered_members",
+      description: "List clan members who did not sign up",
+    },
+    { label: "Missing members", value: "missing_members", description: "List signups not currently in clan" },
+  ] as const;
+}
+
+function buildRosterPostSettingsMenu(
+  rosterId: string,
+  lifecycleState: RosterRecord["lifecycleState"],
+): ActionRowBuilder<StringSelectMenuBuilder> {
   return new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
     new StringSelectMenuBuilder()
       .setCustomId(buildRosterPostSettingsMenuCustomId(rosterId))
@@ -419,7 +434,7 @@ function buildRosterPostSettingsMenu(rosterId: string): ActionRowBuilder<StringS
       .setMinValues(1)
       .setMaxValues(1)
       .addOptions(
-        ROSTER_POST_SETTINGS_ACTIONS.map((option) => ({
+        buildRosterPostSettingsActions(lifecycleState).map((option) => ({
           label: option.label,
           value: option.value,
           description: option.description,
@@ -472,6 +487,8 @@ async function buildRosterSettingsPanel(rosterId: string): Promise<{
   embed: EmbedBuilder;
   components: ActionRowBuilder<StringSelectMenuBuilder>[];
 } | null> {
+  const view = await rosterService.getRosterView(rosterId);
+  if (!view) return null;
   const info = await buildRosterInfoText(rosterId);
   if (!info) return null;
 
@@ -480,7 +497,7 @@ async function buildRosterSettingsPanel(rosterId: string): Promise<{
       .setColor(0xfee75c)
       .setTitle("Roster settings")
       .setDescription(info),
-    components: [buildRosterPostSettingsMenu(rosterId)],
+    components: [buildRosterPostSettingsMenu(rosterId, view.roster.lifecycleState)],
   };
 }
 
@@ -630,10 +647,12 @@ export async function handleRosterPostSettingsMenuInteraction(
     return;
   }
 
-  if (choice === "close_roster") {
+  if (choice === "open_roster" || choice === "close_roster") {
+    const lifecycleState =
+      choice === "open_roster" ? ROSTER_LIFECYCLE_STATE.OPEN : ROSTER_LIFECYCLE_STATE.CLOSED;
     await rosterService.updateRosterLifecycleState({
       rosterId: roster.id,
-      lifecycleState: ROSTER_LIFECYCLE_STATE.CLOSED,
+      lifecycleState,
       updatedByDiscordUserId: interaction.user.id,
     });
     const refreshed = await refreshExistingRosterPost(
@@ -642,7 +661,7 @@ export async function handleRosterPostSettingsMenuInteraction(
       cocService,
     );
     await interaction.update({
-      content: "Roster closed.",
+      content: lifecycleState === ROSTER_LIFECYCLE_STATE.OPEN ? "Roster opened." : "Roster closed.",
       embeds: [],
       components: [],
     });

--- a/src/services/RosterService.ts
+++ b/src/services/RosterService.ts
@@ -1350,6 +1350,13 @@ function getRosterCurrentClanLabel(view: RosterSignupView): string {
   return currentClanName ?? currentClanTag ?? "unscoped";
 }
 
+const ROSTER_BOARD_COLUMN_WIDTHS = {
+  th: 2,
+  player: 16,
+  discord: 16,
+  clan: 16,
+} as const;
+
 function sanitizeRosterBoardText(input: string | null | undefined): string {
   return (normalizeRosterText(input ?? null) ?? "").replace(/`/g, "'");
 }
@@ -1360,19 +1367,42 @@ function formatRosterBoardCell(input: string | null | undefined, width: number):
   return trimmed.padEnd(width, " ");
 }
 
-function buildRosterBoardLine(signup: RosterSignupViewRecord): string {
-  const th = formatRosterBoardCell(signup.townHall === null ? "-" : String(signup.townHall), 2);
-  const player = formatRosterBoardCell(signup.playerName || signup.playerTag, 18);
-  const discord = formatRosterBoardCell(signup.discordUsername, 18);
-  const clan = formatRosterBoardCell(signup.clanName || signup.clanTag || "-", 18);
+function buildRosterBoardLine(columns: {
+  th: string;
+  player: string;
+  discord: string | null;
+  clan: string;
+}): string {
+  const th = formatRosterBoardCell(columns.th, ROSTER_BOARD_COLUMN_WIDTHS.th);
+  const player = formatRosterBoardCell(columns.player, ROSTER_BOARD_COLUMN_WIDTHS.player);
+  const discord = formatRosterBoardCell(columns.discord, ROSTER_BOARD_COLUMN_WIDTHS.discord);
+  const clan = formatRosterBoardCell(columns.clan, ROSTER_BOARD_COLUMN_WIDTHS.clan);
   return `${th} ${player} ${discord} ${clan}`.trimEnd();
+}
+
+function buildRosterBoardHeaderLine(): string {
+  return buildRosterBoardLine({
+    th: "TH",
+    player: "Player",
+    discord: "Discord",
+    clan: "Clan",
+  });
+}
+
+function buildRosterBoardRowLine(signup: RosterSignupViewRecord): string {
+  return buildRosterBoardLine({
+    th: signup.townHall === null ? "-" : String(signup.townHall),
+    player: signup.playerName || signup.playerTag,
+    discord: signup.discordUsername,
+    clan: signup.clanName || signup.clanTag || "-",
+  });
 }
 
 function buildRosterBoardRowLines(signups: RosterSignupViewRecord[]): string[] {
   if (signups.length <= 0) {
     return ["`- None`"];
   }
-  return signups.map((signup) => `\`${buildRosterBoardLine(signup)}\``);
+  return signups.map((signup) => `\`${buildRosterBoardRowLine(signup)}\``);
 }
 
 function buildRosterSignupPayloadFromView(view: RosterSignupView): RosterSignupPayload {
@@ -1386,7 +1416,7 @@ function buildRosterSignupPayloadFromView(view: RosterSignupView): RosterSignupP
     currentClanLabel,
     rosterLabel,
     "",
-    "`TH Player              Discord             Clan`",
+    `\`${buildRosterBoardHeaderLine()}\``,
   ];
 
   for (const group of groups) {

--- a/tests/roster.command.test.ts
+++ b/tests/roster.command.test.ts
@@ -531,7 +531,8 @@ describe("/roster command", () => {
     );
     const payload = interaction.reply.mock.calls[0]?.[0] as any;
     const menu = payload.components[0]?.toJSON?.().components?.[0];
-    expect(menu?.options?.map((option: any) => option.value)).toEqual([
+    const optionValues = menu?.options?.map((option: any) => option.value) ?? [];
+    expect(optionValues).toEqual([
       "roster_info",
       "close_roster",
       "clear_roster",
@@ -540,6 +541,48 @@ describe("/roster command", () => {
       "unregistered_members",
       "missing_members",
     ]);
+    expect(optionValues).not.toContain("open_roster");
+  });
+
+  it("shows open roster instead of close roster when the roster is already closed", async () => {
+    (rosterService.getRosterView as any).mockResolvedValue({
+      roster: {
+        id: "roster-1",
+        title: "CWL Alpha Signup",
+        clanTag: "#2QG2C08UP",
+        lifecycleState: "CLOSED",
+        postedMessageUrl: "https://discord.com/channels/guild-1/channel-1/message-1",
+        postedChannelId: "channel-1",
+        postedMessageId: "message-1",
+        postButtonMode: "standard",
+        minTownhall: 13,
+        maxTownhall: null,
+        rosterRoleId: null,
+      },
+      clanDisplayName: "CWL Alpha",
+      clanLeagueLabel: "Champion League II",
+      groups: [],
+      signups: [],
+      totalSignupCount: 0,
+    });
+    const interaction = {
+      customId: "roster-post-action:settings:roster-1",
+      user: { id: "111111111111111111" },
+      guildId: "guild-1",
+      inGuild: () => true,
+      memberPermissions: {
+        has: vi.fn().mockReturnValue(true),
+      },
+      reply: vi.fn().mockResolvedValue(undefined),
+    } as any;
+
+    await handleRosterPostSettingsButtonInteraction(interaction);
+
+    const payload = interaction.reply.mock.calls[0]?.[0] as any;
+    const menu = payload.components[0]?.toJSON?.().components?.[0];
+    const optionValues = menu?.options?.map((option: any) => option.value) ?? [];
+    expect(optionValues).toContain("open_roster");
+    expect(optionValues).not.toContain("close_roster");
   });
 
   it("refreshes the posted roster from the service-owned current-clan refresh path", async () => {
@@ -797,6 +840,27 @@ describe("/roster command", () => {
         },
       },
     } as any;
+
+    await handleRosterPostSettingsMenuInteraction(
+      { ...baseInteraction, customId: "roster-post-settings:roster-1", values: ["open_roster"] } as any,
+      {} as any,
+    );
+    expect(rosterService.updateRosterLifecycleState).toHaveBeenCalledWith(
+      expect.objectContaining({
+        rosterId: "roster-1",
+        lifecycleState: "OPEN",
+        updatedByDiscordUserId: "111111111111111111",
+      }),
+    );
+    expect(rosterService.refreshRosterSignupPayload).toHaveBeenCalledWith("roster-1", expect.anything());
+    expect(editedMessage.edit).toHaveBeenCalledWith(expect.objectContaining({ embeds: [expect.any(EmbedBuilder)] }));
+    expect(baseInteraction.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: "Roster opened.",
+        embeds: [],
+        components: [],
+      }),
+    );
 
     await handleRosterPostSettingsMenuInteraction(
       { ...baseInteraction, customId: "roster-post-settings:roster-1", values: ["close_roster"] } as any,

--- a/tests/roster.service.test.ts
+++ b/tests/roster.service.test.ts
@@ -826,19 +826,27 @@ describe("RosterService", () => {
 
     expect(payload).toBeTruthy();
     const description = payload?.embed.toJSON().description ?? "";
+    const lines = description.split("\n");
+    const headerLine = lines.find((line) => line.startsWith("`TH "));
+    const confirmedRow = lines.find((line) => line.startsWith("`16 Alpha"));
+    const substituteRow = lines.find((line) => line.startsWith("`15 Bravo"));
+    expect(headerLine).toBeTruthy();
+    expect(confirmedRow).toBeTruthy();
+    expect(substituteRow).toBeTruthy();
     expect(description).toContain("CWL Alpha (#2QG2C08UP)");
     expect(description).toContain("CWL Alpha Signup CWL");
-    expect(description).toContain("`TH Player");
     expect(description).toContain("**Confirmed - 1**");
     expect(description).toContain("**Substitute - 1**");
-    expect(description).toContain("`16 Alpha");
     expect(description).toContain("TonyLee");
     expect(description).toContain("Rising Dawn");
-    expect(description).toContain("`15 Bravo");
     expect(description).toContain("Gabbar");
     expect(description).toContain("\nTotal 2/");
     expect(description).not.toContain("```");
     expect(description).not.toContain("<@");
+    expect((headerLine ?? "").replace(/`/g, "").indexOf("Player")).toBe((confirmedRow ?? "").replace(/`/g, "").indexOf("Alpha"));
+    expect((headerLine ?? "").replace(/`/g, "").indexOf("Discord")).toBe((confirmedRow ?? "").replace(/`/g, "").indexOf("TonyLee"));
+    expect((headerLine ?? "").replace(/`/g, "").indexOf("Clan")).toBe((confirmedRow ?? "").replace(/`/g, "").indexOf("Rising Dawn"));
+    expect((headerLine ?? "").replace(/`/g, "").indexOf("Discord")).toBe((substituteRow ?? "").replace(/`/g, "").indexOf("-"));
     expect(cocServiceMock.getClan).not.toHaveBeenCalled();
     const componentIds = payload?.components.flatMap((row) => {
       const rowJson = row.toJSON() as any;


### PR DESCRIPTION
- align compact roster board rows and header with a shared column model
- switch closed roster settings action to open roster and rerender posts
- keep the compact board and settings menu behavior architecture-safe