### PR TITLE
fix(roster): use current clan members for readiness

### DIFF
--- a/src/services/RosterService.ts
+++ b/src/services/RosterService.ts
@@ -10,13 +10,14 @@ import { CoCService } from "./CoCService";
 import { prisma } from "../prisma";
 import { truncateDiscordContent } from "../helper/discordContent";
 import {
+  listPlayerLinksForClanMembers,
   listPlayerLinksForDiscordUser,
   normalizeClanTag,
   normalizeDiscordUserId,
   normalizePlayerTag,
 } from "./PlayerLinkService";
 import { resolveCurrentCwlSeasonKey } from "./CwlRegistryService";
-import { cwlStateService, type CwlSeasonRosterEntry } from "./CwlStateService";
+import { cwlStateService } from "./CwlStateService";
 import { todoSnapshotService } from "./TodoSnapshotService";
 import { normalizeSyncTimeZone } from "./syncTimeZone";
 
@@ -507,10 +508,18 @@ export type RosterManagerMoveSignupsResult =
 
 export type RosterManagerReadinessView = {
   roster: RosterRecord;
-  trackedClanRoster: CwlSeasonRosterEntry[];
+  trackedClanRoster: RosterManagerTrackedClanMemberRecord[];
   signupView: RosterSignupView;
   signedUpButUntracked: RosterSignupViewRecord[];
-  unsignedTrackedMembers: CwlSeasonRosterEntry[];
+  unsignedTrackedMembers: RosterManagerTrackedClanMemberRecord[];
+};
+
+type RosterManagerTrackedClanMemberRecord = {
+  playerTag: string;
+  playerName: string;
+  townHall: number | null;
+  linkedDiscordUserId: string | null;
+  linkedDiscordUsername: string | null;
 };
 
 function normalizeRosterType(input: string): string {
@@ -1258,9 +1267,65 @@ function buildRosterManagerGroupSummaryLine(group: RosterGroupRecord & { signupC
   return `${group.name} (${group.signupCount})`;
 }
 
-function buildRosterManagerMemberLine(entry: CwlSeasonRosterEntry): string {
+function buildRosterManagerMemberLine(entry: RosterManagerTrackedClanMemberRecord): string {
   const discordLabel = entry.linkedDiscordUserId ? ` <@${entry.linkedDiscordUserId}>` : "";
   return `- ${entry.playerName} \`${entry.playerTag}\`${discordLabel}`;
+}
+
+async function loadCurrentCwlRosterManagerMembers(clanTag: string): Promise<Array<{
+  playerTag: string;
+  playerName: string;
+  townHall: number | null;
+}>> {
+  const currentRound = await cwlStateService.getCurrentRoundForClan({ clanTag });
+  if (!currentRound || currentRound.members.length <= 0) {
+    return [];
+  }
+
+  return currentRound.members.map((member) => ({
+    playerTag: member.playerTag,
+    playerName: member.playerName,
+    townHall: member.townHall,
+  }));
+}
+
+async function loadRosterManagerTrackedClanMembers(roster: RosterRecord): Promise<RosterManagerTrackedClanMemberRecord[]> {
+  const trackedClanTag = normalizeClanTag(roster.clanTag ?? "");
+  if (!trackedClanTag) return [];
+
+  const rawMembers =
+    roster.rosterType === "FWA"
+      ? await prisma.fwaClanMemberCurrent.findMany({
+          where: { clanTag: trackedClanTag },
+          orderBy: [{ playerName: "asc" }, { playerTag: "asc" }],
+          select: {
+            playerTag: true,
+            playerName: true,
+            townHall: true,
+          },
+        })
+      : roster.rosterType === "CWL"
+        ? await loadCurrentCwlRosterManagerMembers(trackedClanTag)
+        : [];
+
+  if (rawMembers.length <= 0) {
+    return [];
+  }
+
+  const links = await listPlayerLinksForClanMembers({
+    memberTagsInOrder: rawMembers.map((member) => member.playerTag),
+  });
+  const linkByTag = new Map(links.map((link) => [link.playerTag, link] as const));
+  return rawMembers.map((member) => {
+    const link = linkByTag.get(member.playerTag) ?? null;
+    return {
+      playerTag: member.playerTag,
+      playerName: normalizeRosterText(member.playerName) ?? member.playerTag,
+      townHall: Number.isFinite(Number(member.townHall)) ? Math.trunc(Number(member.townHall)) : null,
+      linkedDiscordUserId: link?.discordUserId ?? null,
+      linkedDiscordUsername: link?.discordUsername ?? null,
+    };
+  });
 }
 
 function buildRosterManagerReadinessLines(view: RosterManagerReadinessView): string[] {
@@ -1270,8 +1335,8 @@ function buildRosterManagerReadinessLines(view: RosterManagerReadinessView): str
     `Clan: ${view.roster.clanTag ?? "unscoped"}`,
     `Posted message: ${view.roster.postedMessageUrl ?? "not posted"}`,
     `Signed up: ${view.signupView.totalSignupCount}`,
-    `Tracked clan roster: ${view.trackedClanRoster.length}`,
-    `Unsigned tracked clan members: ${view.unsignedTrackedMembers.length}`,
+    `Current clan members: ${view.trackedClanRoster.length}`,
+    `Unregistered members: ${view.unsignedTrackedMembers.length}`,
     `Out-of-clan signups: ${view.signedUpButUntracked.length}`,
   ];
 
@@ -1294,7 +1359,7 @@ function buildRosterManagerReadinessLines(view: RosterManagerReadinessView): str
   }
 
   lines.push("");
-  lines.push("Unsigned tracked clan members:");
+  lines.push("Unregistered members:");
   if (view.unsignedTrackedMembers.length <= 0) {
     lines.push("- None");
   } else {
@@ -2870,11 +2935,7 @@ export class RosterService {
     const view = await loadRosterView(input.rosterId);
     if (!view) return null;
 
-    const trackedClanTag = view.roster.clanTag ? normalizeClanTag(view.roster.clanTag) : null;
-    const trackedClanRoster =
-      trackedClanTag && view.roster.rosterType === "CWL"
-        ? await cwlStateService.listSeasonRosterForClan({ clanTag: trackedClanTag })
-        : [];
+    const trackedClanRoster = await loadRosterManagerTrackedClanMembers(view.roster);
     const trackedTagSet = new Set(trackedClanRoster.map((entry) => normalizePlayerTag(entry.playerTag)).filter(Boolean));
     const signupsByTag = new Map(view.signups.map((signup) => [normalizePlayerTag(signup.playerTag), signup] as const));
     const signedUpButUntracked = view.signups.filter((signup) => {

--- a/tests/roster.service.test.ts
+++ b/tests/roster.service.test.ts
@@ -25,6 +25,9 @@ const prismaMock = vi.hoisted(() => ({
   playerLink: {
     findMany: vi.fn(),
   },
+  fwaClanMemberCurrent: {
+    findMany: vi.fn(),
+  },
   fwaPlayerCatalog: {
     findMany: vi.fn(),
   },
@@ -44,6 +47,7 @@ const playerLinkServiceMock = vi.hoisted(() => ({
 
 const cwlStateServiceMock = vi.hoisted(() => ({
   listSeasonRosterForClan: vi.fn(),
+  getCurrentRoundForClan: vi.fn(),
 }));
 
 const cocServiceMock = vi.hoisted(() => ({
@@ -223,6 +227,7 @@ describe("RosterService", () => {
     prismaMock.rosterSignup.updateMany.mockResolvedValue({ count: 0 });
     prismaMock.rosterSignup.deleteMany.mockResolvedValue({ count: 0 });
     prismaMock.playerLink.findMany.mockResolvedValue([]);
+    prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue([]);
     prismaMock.fwaPlayerCatalog.findMany.mockResolvedValue([]);
     prismaMock.cwlTrackedClan.findFirst.mockResolvedValue({
       name: "CWL Alpha",
@@ -235,6 +240,7 @@ describe("RosterService", () => {
     prismaMock.todoPlayerSnapshot.upsert.mockResolvedValue({} as never);
     playerLinkServiceMock.listPlayerLinksForDiscordUser.mockResolvedValue([]);
     cwlStateServiceMock.listSeasonRosterForClan.mockResolvedValue([]);
+    cwlStateServiceMock.getCurrentRoundForClan.mockResolvedValue(null);
     todoSnapshotServiceMock.listSnapshotsByPlayerTags.mockResolvedValue([]);
     todoSnapshotServiceMock.refreshSnapshotsForPlayerTags.mockResolvedValue({
       playerCount: 0,
@@ -1301,7 +1307,7 @@ describe("RosterService", () => {
     expect(prismaMock.rosterSignup.deleteMany).not.toHaveBeenCalled();
   });
 
-  it("builds a manager readiness view that surfaces unsigned and out-of-clan players", async () => {
+  it("builds a manager readiness view from current CWL clan members, not stale season roster participants", async () => {
     prismaMock.rosterSignup.findMany.mockResolvedValue([
       {
         id: "signup-1",
@@ -1356,38 +1362,147 @@ describe("RosterService", () => {
         sortOrder: 1,
       },
     ]);
-    cwlStateServiceMock.listSeasonRosterForClan.mockResolvedValue([
+    cwlStateServiceMock.getCurrentRoundForClan.mockResolvedValue({
+      season: "2026-04",
+      clanTag: "#2QG2C08UP",
+      clanName: "Current Clan",
+      roundDay: 4,
+      roundState: "inWar",
+      opponentTag: "#OPPONENT",
+      opponentName: "Opponent Clan",
+      teamSize: 15,
+      attacksPerMember: 1,
+      preparationStartTime: new Date("2026-04-20T00:00:00.000Z"),
+      startTime: new Date("2026-04-20T01:00:00.000Z"),
+      endTime: new Date("2026-04-20T02:00:00.000Z"),
+      sourceUpdatedAt: new Date("2026-04-20T00:00:00.000Z"),
+      members: [
+        {
+          season: "2026-04",
+          clanTag: "#2QG2C08UP",
+          playerTag: "#QGRJ2222",
+          roundDay: 4,
+          playerName: "Bravo",
+          mapPosition: 2,
+          townHall: 15,
+          attacksUsed: 0,
+          attacksAvailable: 1,
+          stars: 0,
+          destruction: 0,
+          subbedIn: true,
+          subbedOut: false,
+        },
+      ],
+    } as any);
+    prismaMock.playerLink.findMany.mockResolvedValue([
       {
-        season: "2026-04",
-        clanTag: "#2QG2C08UP",
         playerTag: "#PQL0289",
-        playerName: "Alpha",
-        townHall: 16,
-        linkedDiscordUserId: "111111111111111111",
-        linkedDiscordUsername: "alpha-user",
-        daysParticipated: 2,
-        currentRound: null,
+        discordUserId: "111111111111111111",
+        discordUsername: "alpha-user",
       },
       {
-        season: "2026-04",
-        clanTag: "#2QG2C08UP",
         playerTag: "#QGRJ2222",
-        playerName: "Bravo",
-        townHall: 15,
-        linkedDiscordUserId: "222222222222222222",
-        linkedDiscordUsername: "bravo-user",
-        daysParticipated: 1,
-        currentRound: null,
+        discordUserId: "222222222222222222",
+        discordUsername: "bravo-user",
       },
-    ]);
+    ] as any);
 
     const report = await rosterService.buildRosterManagerReadinessText({ rosterId: "roster-1" });
 
     expect(report).toContain("CWL Alpha Signup");
-    expect(report).toContain("Unsigned tracked clan members:");
+    expect(report).toContain("Current clan members:");
+    expect(report).toContain("Unregistered members:");
     expect(report).toContain("- Bravo `#QGRJ2222` <@222222222222222222>");
     expect(report).toContain("Out-of-clan signups:");
     expect(report).toContain("- Outlier `#ZZZZ1111` <@333333333333333333>");
+    expect(report).not.toContain("#OLD1111");
+  });
+
+  it("builds a manager readiness view from the current FWA clan membership table", async () => {
+    prismaMock.roster.findUnique.mockResolvedValueOnce({
+      id: "roster-2",
+      guildId: "guild-1",
+      rosterType: "FWA",
+      rosterCategory: "signup",
+      title: "FWA Alpha Signup",
+      clanTag: "#2QG2C08UP",
+      startsAt: new Date("2026-04-20T00:00:00.000Z"),
+      endsAt: null,
+      timezone: "America/Los_Angeles",
+      displayTimezone: "America/Los_Angeles",
+      lifecycleState: "OPEN",
+      postedChannelId: null,
+      postedMessageId: null,
+      postedMessageUrl: null,
+      postedAt: null,
+      createdByDiscordUserId: "111111111111111111",
+      updatedByDiscordUserId: "111111111111111111",
+      createdAt: new Date("2026-04-20T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-20T00:00:00.000Z"),
+    });
+    prismaMock.rosterSignup.findMany.mockResolvedValueOnce([
+      {
+        id: "signup-1",
+        rosterId: "roster-2",
+        groupId: "group-confirmed",
+        playerTag: "#PQL0289",
+        playerName: "Alpha",
+        discordUserId: "111111111111111111",
+        signedUpAt: new Date("2026-04-20T00:00:00.000Z"),
+        createdAt: new Date("2026-04-20T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-20T00:00:00.000Z"),
+        group: {
+          id: "group-confirmed",
+          key: "confirmed",
+          name: "Confirmed",
+          description: "Primary roster members",
+          sortOrder: 0,
+        },
+      },
+    ] as any);
+    prismaMock.rosterGroup.findMany.mockResolvedValueOnce([
+      {
+        id: "group-confirmed",
+        key: "confirmed",
+        name: "Confirmed",
+        description: "Primary roster members",
+        sortOrder: 0,
+      },
+    ]);
+    prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValueOnce([
+      {
+        clanTag: "#2QG2C08UP",
+        playerTag: "#PQL0289",
+        playerName: "Alpha",
+        townHall: 16,
+      },
+      {
+        clanTag: "#2QG2C08UP",
+        playerTag: "#QGRJ2222",
+        playerName: "Bravo",
+        townHall: 15,
+      },
+    ] as any);
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      {
+        playerTag: "#PQL0289",
+        discordUserId: "111111111111111111",
+        discordUsername: "alpha-user",
+      },
+      {
+        playerTag: "#QGRJ2222",
+        discordUserId: "222222222222222222",
+        discordUsername: "bravo-user",
+      },
+    ] as any);
+
+    const report = await rosterService.buildRosterManagerReadinessText({ rosterId: "roster-2" });
+
+    expect(report).toContain("FWA Alpha Signup");
+    expect(report).toContain("Current clan members:");
+    expect(report).toContain("Unregistered members:");
+    expect(report).toContain("- Bravo `#QGRJ2222` <@222222222222222222>");
+    expect(report).not.toContain("#OLD1111");
   });
 
   it("renders closed rosters with disabled signup controls", async () => {


### PR DESCRIPTION
- source unregistered members from current clan membership
- keep missing members inverse semantics intact