### PR TITLE
fix(roster): tighten roster board and current clan readiness

### DIFF
--- a/prisma/migrations/20260421020000_add_cwl_tracked_clan_league_label/migration.sql
+++ b/prisma/migrations/20260421020000_add_cwl_tracked_clan_league_label/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "CwlTrackedClan"
+ADD COLUMN "leagueLabel" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -320,6 +320,7 @@ model CwlTrackedClan {
   season    String
   tag       String
   name      String?
+  leagueLabel String?
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 

--- a/src/services/CwlRegistryService.ts
+++ b/src/services/CwlRegistryService.ts
@@ -194,6 +194,7 @@ export async function addCwlClanTagsForSeason(input: {
             season,
             tag,
             name: null,
+            leagueLabel: null,
           })),
           skipDuplicates: true,
         }),
@@ -254,7 +255,7 @@ export async function hydrateMissingCwlClanNamesForSeason(input: {
   }
 
   const missingRows = await runBoundedCwlTagStage({
-    stage: "cwl_tags_missing_name_rows_query",
+    stage: "cwl_tags_missing_metadata_rows_query",
     timeoutMs: CWL_TAG_DB_STAGE_TIMEOUT_MS,
     details: { season, valid_count: parsed.validTags.length },
     action: () =>
@@ -262,7 +263,12 @@ export async function hydrateMissingCwlClanNamesForSeason(input: {
         where: {
           season,
           tag: { in: parsed.validTags },
-          OR: [{ name: null }, { name: "" }],
+          OR: [
+            { name: null },
+            { name: "" },
+            { leagueLabel: null },
+            { leagueLabel: "" },
+          ],
         },
         select: { tag: true },
       }),
@@ -288,10 +294,11 @@ export async function hydrateMissingCwlClanNamesForSeason(input: {
           action: () => input.cocService.getClan(tag),
         });
         const clanName = String(clan?.name ?? "").trim();
-        if (!clanName) {
+        const leagueLabel = String(clan?.warLeague?.name ?? "").trim();
+        if (!clanName && !leagueLabel) {
           skippedCount += 1;
           console.info(
-            `[tracked-clan] stage=cwl_tags_name_hydration_skipped season=${season} tag=${tag} reason=empty_name`,
+            `[tracked-clan] stage=cwl_tags_name_hydration_skipped season=${season} tag=${tag} reason=empty_name_and_league`,
           );
           return;
         }
@@ -304,10 +311,16 @@ export async function hydrateMissingCwlClanNamesForSeason(input: {
               where: {
                 season,
                 tag,
-                OR: [{ name: null }, { name: "" }],
+                OR: [
+                  { name: null },
+                  { name: "" },
+                  { leagueLabel: null },
+                  { leagueLabel: "" },
+                ],
               },
               data: {
-                name: clanName,
+                ...(clanName ? { name: clanName } : {}),
+                ...(leagueLabel ? { leagueLabel } : {}),
               },
             }),
         });

--- a/src/services/RosterService.ts
+++ b/src/services/RosterService.ts
@@ -1725,6 +1725,7 @@ async function loadRosterView(rosterId: string): Promise<RosterSignupView | null
           },
           select: {
             name: true,
+            leagueLabel: true,
           },
         })
       : null;
@@ -1749,7 +1750,7 @@ async function loadRosterView(rosterId: string): Promise<RosterSignupView | null
   return {
     roster,
     clanDisplayName,
-    clanLeagueLabel: null,
+    clanLeagueLabel: normalizeRosterText(trackedClan?.leagueLabel ?? null) ?? null,
     groups: groups.map((group) => ({
       ...group,
       signupCount: signupCountByGroupId.get(group.id) ?? 0,

--- a/src/services/RosterService.ts
+++ b/src/services/RosterService.ts
@@ -1277,12 +1277,15 @@ async function loadCurrentCwlRosterManagerMembers(clanTag: string): Promise<Arra
   playerName: string;
   townHall: number | null;
 }>> {
-  const currentRound = await cwlStateService.getCurrentRoundForClan({ clanTag });
-  if (!currentRound || currentRound.members.length <= 0) {
+  const currentClanRows = await todoSnapshotService.listSnapshotsByClanTag({
+    clanTag,
+    source: "cwlClanTag",
+  });
+  if (currentClanRows.length <= 0) {
     return [];
   }
 
-  return currentRound.members.map((member) => ({
+  return currentClanRows.map((member) => ({
     playerTag: member.playerTag,
     playerName: member.playerName,
     townHall: member.townHall,
@@ -1406,20 +1409,11 @@ function normalizeRosterPostButtonMode(input: unknown): RosterPostButtonMode {
   return "standard";
 }
 
-function getRosterCurrentClanLabel(view: RosterSignupView): string {
-  const currentClanTag = normalizeClanTag(view.roster.clanTag ?? "") || null;
-  const currentClanName = normalizeRosterText(view.clanDisplayName ?? null);
-  if (currentClanName && currentClanTag && currentClanName !== currentClanTag) {
-    return `${currentClanName} (${currentClanTag})`;
-  }
-  return currentClanName ?? currentClanTag ?? "unscoped";
-}
-
-const ROSTER_BOARD_COLUMN_WIDTHS = {
+const ROSTER_BOARD_COLUMN_LIMITS = {
   th: 2,
-  player: 16,
-  discord: 16,
-  clan: 16,
+  player: 12,
+  discord: 12,
+  clan: 12,
 } as const;
 
 function sanitizeRosterBoardText(input: string | null | undefined): string {
@@ -1432,61 +1426,132 @@ function formatRosterBoardCell(input: string | null | undefined, width: number):
   return trimmed.padEnd(width, " ");
 }
 
-function buildRosterBoardLine(columns: {
-  th: string;
-  player: string;
-  discord: string | null;
-  clan: string;
-}): string {
-  const th = formatRosterBoardCell(columns.th, ROSTER_BOARD_COLUMN_WIDTHS.th);
-  const player = formatRosterBoardCell(columns.player, ROSTER_BOARD_COLUMN_WIDTHS.player);
-  const discord = formatRosterBoardCell(columns.discord, ROSTER_BOARD_COLUMN_WIDTHS.discord);
-  const clan = formatRosterBoardCell(columns.clan, ROSTER_BOARD_COLUMN_WIDTHS.clan);
+function buildClanProfileMarkdownLink(clanName: string | null, clanTag: string | null): string {
+  const normalizedClanTag = normalizeClanTag(clanTag ?? "");
+  const label = sanitizeRosterBoardText(clanName) || normalizedClanTag || "Unknown Clan";
+  if (!normalizedClanTag) return label;
+  const encodedTag = normalizedClanTag.replace(/^#/, "");
+  return `[${label}](https://link.clashofclans.com/en?action=OpenClanProfile&tag=${encodedTag})`;
+}
+
+function measureRosterBoardColumnWidths(signups: RosterSignupViewRecord[]): {
+  th: number;
+  player: number;
+  discord: number;
+  clan: number;
+} {
+  const playerWidth = signups.reduce(
+    (max, signup) => Math.max(max, sanitizeRosterBoardText(signup.playerName || signup.playerTag).length),
+    "Player".length,
+  );
+  const discordWidth = signups.reduce(
+    (max, signup) => Math.max(max, sanitizeRosterBoardText(signup.discordUsername).length),
+    "Discord".length,
+  );
+  const clanWidth = signups.reduce(
+    (max, signup) =>
+      Math.max(max, sanitizeRosterBoardText(signup.clanName || signup.clanTag || "-").length),
+    "Clan".length,
+  );
+  return {
+    th: ROSTER_BOARD_COLUMN_LIMITS.th,
+    player: Math.min(playerWidth, ROSTER_BOARD_COLUMN_LIMITS.player),
+    discord: Math.min(discordWidth, ROSTER_BOARD_COLUMN_LIMITS.discord),
+    clan: Math.min(clanWidth, ROSTER_BOARD_COLUMN_LIMITS.clan),
+  };
+}
+
+function buildRosterBoardLine(
+  columns: {
+    th: string;
+    player: string;
+    discord: string | null;
+    clan: string;
+  },
+  widths: {
+    th: number;
+    player: number;
+    discord: number;
+    clan: number;
+  },
+): string {
+  const th = formatRosterBoardCell(columns.th, widths.th);
+  const player = formatRosterBoardCell(columns.player, widths.player);
+  const discord = formatRosterBoardCell(columns.discord, widths.discord);
+  const clan = formatRosterBoardCell(columns.clan, widths.clan);
   return `${th} ${player} ${discord} ${clan}`.trimEnd();
 }
 
-function buildRosterBoardHeaderLine(): string {
-  return buildRosterBoardLine({
-    th: "TH",
-    player: "Player",
-    discord: "Discord",
-    clan: "Clan",
-  });
+function buildRosterBoardHeaderLine(widths: {
+  th: number;
+  player: number;
+  discord: number;
+  clan: number;
+}): string {
+  return buildRosterBoardLine(
+    {
+      th: "TH",
+      player: "Player",
+      discord: "Discord",
+      clan: "Clan",
+    },
+    widths,
+  );
 }
 
-function buildRosterBoardRowLine(signup: RosterSignupViewRecord): string {
-  return buildRosterBoardLine({
-    th: signup.townHall === null ? "-" : String(signup.townHall),
-    player: signup.playerName || signup.playerTag,
-    discord: signup.discordUsername,
-    clan: signup.clanName || signup.clanTag || "-",
-  });
+function buildRosterBoardRowLine(
+  signup: RosterSignupViewRecord,
+  widths: {
+    th: number;
+    player: number;
+    discord: number;
+    clan: number;
+  },
+): string {
+  return buildRosterBoardLine(
+    {
+      th: signup.townHall === null ? "-" : String(signup.townHall),
+      player: signup.playerName || signup.playerTag,
+      discord: signup.discordUsername,
+      clan: signup.clanName || signup.clanTag || "-",
+    },
+    widths,
+  );
 }
 
-function buildRosterBoardRowLines(signups: RosterSignupViewRecord[]): string[] {
+function buildRosterBoardRowLines(
+  signups: RosterSignupViewRecord[],
+  widths: {
+    th: number;
+    player: number;
+    discord: number;
+    clan: number;
+  },
+): string[] {
   if (signups.length <= 0) {
     return ["`- None`"];
   }
-  return signups.map((signup) => `\`${buildRosterBoardRowLine(signup)}\``);
+  return signups.map((signup) => `\`${buildRosterBoardRowLine(signup, widths)}\``);
 }
 
 function buildRosterSignupPayloadFromView(view: RosterSignupView): RosterSignupPayload {
-  const title = view.roster.title || "Roster Signup";
+  const title = normalizeRosterText(view.clanDisplayName ?? null) ?? normalizeClanTag(view.roster.clanTag ?? "") ?? "Roster";
   const groups = buildRosterGroupsWithSignups(view);
-  const currentClanLabel = getRosterCurrentClanLabel(view);
-  const rosterLabel = `${title} ${view.clanLeagueLabel ?? view.roster.rosterType}`.trim();
+  const widths = measureRosterBoardColumnWidths(groups.flatMap((group) => group.signups));
+  const rosterLabel = `## ${buildClanProfileMarkdownLink(view.roster.title || "Roster Signup", view.roster.clanTag)} ${
+    view.clanLeagueLabel ?? view.roster.rosterType
+  }`.trim();
   const maxMembersLabel = view.roster.maxMembers === null || view.roster.maxMembers === undefined ? "-" : String(view.roster.maxMembers);
   const minTownHallLabel = view.roster.minTownhall === null || view.roster.minTownhall === undefined ? "##" : String(view.roster.minTownhall);
   const lines: string[] = [
-    currentClanLabel,
     rosterLabel,
     "",
-    `\`${buildRosterBoardHeaderLine()}\``,
+    `\`${buildRosterBoardHeaderLine(widths)}\``,
   ];
 
   for (const group of groups) {
     lines.push(`**${group.name} - ${group.signupCount}**`);
-    lines.push(...buildRosterBoardRowLines(group.signups));
+    lines.push(...buildRosterBoardRowLines(group.signups, widths));
     lines.push("");
   }
 
@@ -1618,6 +1683,18 @@ async function loadRosterView(rosterId: string): Promise<RosterSignupView | null
   const snapshotRows = await todoSnapshotService.listSnapshotsByPlayerTags({
     playerTags: signups.map((signup) => signup.playerTag),
   });
+  const currentClanRows =
+    roster.clanTag && roster.rosterType === "CWL"
+      ? await todoSnapshotService.listSnapshotsByClanTag({
+          clanTag: roster.clanTag,
+          source: "cwlClanTag",
+        })
+      : roster.clanTag
+        ? await todoSnapshotService.listSnapshotsByClanTag({
+            clanTag: roster.clanTag,
+            source: "clanTag",
+          })
+        : [];
   const linkedPlayerRows = await prisma.playerLink.findMany({
     where: {
       playerTag: { in: signups.map((signup) => normalizePlayerTag(signup.playerTag)).filter(Boolean) },
@@ -1633,8 +1710,12 @@ async function loadRosterView(rosterId: string): Promise<RosterSignupView | null
       .filter((entry): entry is readonly [string, string] => Boolean(entry[0])),
   );
   const snapshotByTag = new Map(snapshotRows.map((row) => [normalizePlayerTag(row.playerTag), row] as const));
-  const snapshotClanName =
-    snapshotRows.find((row) => normalizeRosterText(row.clanName ?? null))?.clanName ?? null;
+  const currentClanName =
+    currentClanRows.find((row) => normalizeRosterText(row.cwlClanName ?? row.clanName ?? null))
+      ?.cwlClanName ??
+    currentClanRows.find((row) => normalizeRosterText(row.clanName ?? null))?.clanName ??
+    snapshotRows.find((row) => normalizeRosterText(row.clanName ?? null))?.clanName ??
+    null;
   const trackedClan =
     roster.rosterType === "CWL" && roster.clanTag
       ? await prisma.cwlTrackedClan.findFirst({
@@ -1655,8 +1736,8 @@ async function loadRosterView(rosterId: string): Promise<RosterSignupView | null
     clanName: snapshotByTag.get(normalizePlayerTag(signup.playerTag))?.clanName ?? null,
   }));
   const clanDisplayName =
+    normalizeRosterText(currentClanName ?? null) ??
     normalizeRosterText(trackedClan?.name ?? null) ??
-    normalizeRosterText(snapshotClanName ?? null) ??
     null;
   const sortedSignups = sortRosterSignupsForRoster(signupsWithTownHall, roster.sortBy);
   const signupCountByGroupId = new Map<string, number>();

--- a/src/services/TodoSnapshotService.ts
+++ b/src/services/TodoSnapshotService.ts
@@ -211,6 +211,33 @@ export class TodoSnapshotService {
       });
   }
 
+  /** Purpose: load ordered snapshot rows for one clan tag using the requested current-clan source. */
+  async listSnapshotsByClanTag(input: {
+    clanTag: string;
+    source?: "clanTag" | "cwlClanTag";
+  }): Promise<TodoSnapshotRecord[]> {
+    const normalizedClanTag = normalizeClanTag(input.clanTag);
+    if (!normalizedClanTag) return [];
+
+    const source = input.source ?? "clanTag";
+    const rows = await prisma.todoPlayerSnapshot.findMany({
+      where:
+        source === "cwlClanTag"
+          ? { cwlClanTag: normalizedClanTag }
+          : { clanTag: normalizedClanTag },
+      select: TODO_SNAPSHOT_SELECT,
+      orderBy: [{ playerName: "asc" }, { playerTag: "asc" }],
+    });
+
+    return rows.map((row) => ({
+      ...row,
+      playerTag: normalizePlayerTag(row.playerTag),
+      townHall: Number.isFinite(Number(row.townHall)) ? Math.trunc(Number(row.townHall)) : null,
+      clanTag: row.clanTag ? normalizeClanTag(row.clanTag) : null,
+      cwlClanTag: row.cwlClanTag ? normalizeClanTag(row.cwlClanTag) : null,
+    })) as TodoSnapshotRecord[];
+  }
+
   /** Purpose: return compact snapshot-version metadata for cache-key construction. */
   async getSnapshotVersion(input: {
     playerTags: string[];

--- a/tests/cwl.command.test.ts
+++ b/tests/cwl.command.test.ts
@@ -633,7 +633,7 @@ describe("/cwl command", () => {
       updatedAt: new Date("2026-04-20T00:00:00.000Z"),
     });
     (rosterService.buildRosterManagerReadinessText as any).mockResolvedValue(
-      "CWL Alpha Signup\nUnsigned tracked clan members:\n- Bravo `#QGRJ2222` <@222222222222222222>",
+      "CWL Alpha Signup\nUnregistered members:\n- Bravo `#QGRJ2222` <@222222222222222222>",
     );
 
     const interaction = makeInteraction({
@@ -655,7 +655,7 @@ describe("/cwl command", () => {
     expect(rosterService.buildRosterManagerReadinessText).toHaveBeenCalledWith({
       rosterId: "roster-1",
     });
-    expect(getEditedDescription(interaction)).toContain("Unsigned tracked clan members:");
+    expect(getEditedDescription(interaction)).toContain("Unregistered members:");
   });
 
   it.each([

--- a/tests/cwlRegistry.service.test.ts
+++ b/tests/cwlRegistry.service.test.ts
@@ -47,8 +47,8 @@ describe("CwlRegistryService helpers", () => {
 
     expect(prismaMock.cwlTrackedClan.createMany).toHaveBeenCalledWith({
       data: [
-        { season: "2026-03", tag: "#PYLQ0289", name: null },
-        { season: "2026-03", tag: "#QGRJ2222", name: null },
+        { season: "2026-03", tag: "#PYLQ0289", name: null, leagueLabel: null },
+        { season: "2026-03", tag: "#QGRJ2222", name: null, leagueLabel: null },
       ],
       skipDuplicates: true,
     });
@@ -84,7 +84,7 @@ describe("CwlRegistryService helpers", () => {
     const cocService = {
       getClan: vi.fn(async (tag: string) => {
         if (tag === "#PYLQ0289") {
-          return { name: "CWL Alpha" };
+          return { name: "CWL Alpha", warLeague: { name: "Champion League II" } };
         }
         throw new Error("boom");
       }),
@@ -101,10 +101,11 @@ describe("CwlRegistryService helpers", () => {
       where: {
         season: "2026-03",
         tag: "#PYLQ0289",
-        OR: [{ name: null }, { name: "" }],
+        OR: [{ name: null }, { name: "" }, { leagueLabel: null }, { leagueLabel: "" }],
       },
       data: {
         name: "CWL Alpha",
+        leagueLabel: "Champion League II",
       },
     });
 

--- a/tests/roster.command.test.ts
+++ b/tests/roster.command.test.ts
@@ -1257,7 +1257,7 @@ describe("/roster command", () => {
         updatedAt: new Date("2026-04-20T00:00:00.000Z"),
       });
       (rosterService.buildRosterManagerReadinessText as any).mockResolvedValue(
-        "CWL Alpha Signup\nUnsigned tracked clan members:\n- Bravo `#QGRJ2222` <@222222222222222222>",
+        "CWL Alpha Signup\nUnregistered members:\n- Bravo `#QGRJ2222` <@222222222222222222>",
       );
 
       const interaction = makeInteraction({
@@ -1274,7 +1274,7 @@ describe("/roster command", () => {
       expect(rosterService.buildRosterManagerReadinessText).toHaveBeenCalledWith({
         rosterId: "roster-1",
       });
-      expect(getEditedDescription(interaction)).toContain("Unsigned tracked clan members:");
+      expect(getEditedDescription(interaction)).toContain("Unregistered members:");
     },
   );
 });

--- a/tests/roster.service.test.ts
+++ b/tests/roster.service.test.ts
@@ -56,6 +56,7 @@ const cocServiceMock = vi.hoisted(() => ({
 
 const todoSnapshotServiceMock = vi.hoisted(() => ({
   listSnapshotsByPlayerTags: vi.fn(),
+  listSnapshotsByClanTag: vi.fn(),
   refreshSnapshotsForPlayerTags: vi.fn(),
 }));
 
@@ -242,6 +243,7 @@ describe("RosterService", () => {
     cwlStateServiceMock.listSeasonRosterForClan.mockResolvedValue([]);
     cwlStateServiceMock.getCurrentRoundForClan.mockResolvedValue(null);
     todoSnapshotServiceMock.listSnapshotsByPlayerTags.mockResolvedValue([]);
+    todoSnapshotServiceMock.listSnapshotsByClanTag.mockResolvedValue([]);
     todoSnapshotServiceMock.refreshSnapshotsForPlayerTags.mockResolvedValue({
       playerCount: 0,
       updatedCount: 0,
@@ -815,6 +817,24 @@ describe("RosterService", () => {
         clanName: "Gabbar",
       },
     ] as any);
+    todoSnapshotServiceMock.listSnapshotsByClanTag.mockResolvedValue([
+      {
+        playerTag: "#PQL0289",
+        playerName: "Alpha",
+        clanTag: "#2QG2C08UP",
+        clanName: "Rising Crowns",
+        cwlClanTag: "#2QG2C08UP",
+        cwlClanName: "Rising Crowns",
+      },
+      {
+        playerTag: "#QGRJ2222",
+        playerName: "Bravo",
+        clanTag: "#2QG2C08UP",
+        clanName: "Rising Crowns",
+        cwlClanTag: "#2QG2C08UP",
+        cwlClanName: "Rising Crowns",
+      },
+    ] as any);
     cwlStateServiceMock.listSeasonRosterForClan.mockResolvedValue([
       {
         playerTag: "#PQL0289",
@@ -826,12 +846,18 @@ describe("RosterService", () => {
         playerName: "Bravo",
         townHall: 15,
       },
+      {
+        playerTag: "#OLD1111",
+        playerName: "OldTimer",
+        townHall: 14,
+      },
     ] as any);
 
     const payload = await rosterService.buildRosterSignupPayload("roster-1");
 
     expect(payload).toBeTruthy();
     const description = payload?.embed.toJSON().description ?? "";
+    const embedTitle = payload?.embed.toJSON().title ?? "";
     const lines = description.split("\n");
     const headerLine = lines.find((line) => line.startsWith("`TH "));
     const confirmedRow = lines.find((line) => line.startsWith("`16 Alpha"));
@@ -839,8 +865,8 @@ describe("RosterService", () => {
     expect(headerLine).toBeTruthy();
     expect(confirmedRow).toBeTruthy();
     expect(substituteRow).toBeTruthy();
-    expect(description).toContain("CWL Alpha (#2QG2C08UP)");
-    expect(description).toContain("CWL Alpha Signup CWL");
+    expect(embedTitle).toBe("Rising Crowns");
+    expect(description).toContain("## [CWL Alpha Signup](https://link.clashofclans.com/en?action=OpenClanProfile&tag=2QG2C08UP) CWL");
     expect(description).toContain("**Confirmed - 1**");
     expect(description).toContain("**Substitute - 1**");
     expect(description).toContain("TonyLee");
@@ -905,6 +931,24 @@ describe("RosterService", () => {
         clanName: "CWL Alpha",
       },
     ] as any);
+    todoSnapshotServiceMock.listSnapshotsByClanTag.mockResolvedValue([
+      {
+        playerTag: "#PQL0289",
+        playerName: "Alpha",
+        townHall: 15,
+        clanTag: "#2QG2C08UP",
+        clanName: "CWL Alpha",
+        cwlClanTag: "#2QG2C08UP",
+        cwlClanName: "CWL Alpha",
+      },
+    ] as any);
+    cwlStateServiceMock.listSeasonRosterForClan.mockResolvedValue([
+      {
+        playerTag: "#PQL0289",
+        playerName: "Alpha",
+        townHall: 15,
+      },
+    ] as any);
     todoSnapshotServiceMock.refreshSnapshotsForPlayerTags.mockResolvedValue({
       playerCount: 1,
       updatedCount: 1,
@@ -919,7 +963,10 @@ describe("RosterService", () => {
       }),
     );
     expect(payload).toBeTruthy();
-    expect(String(payload?.embed.toJSON().description ?? "")).toContain("CWL Alpha (#2QG2C08UP)");
+    expect(String(payload?.embed.toJSON().title ?? "")).toBe("CWL Alpha");
+    expect(String(payload?.embed.toJSON().description ?? "")).toContain(
+      "## [CWL Alpha Signup](https://link.clashofclans.com/en?action=OpenClanProfile&tag=2QG2C08UP) CWL",
+    );
   });
 
   it("builds a signup selection panel that lets a user choose linked accounts", async () => {
@@ -1362,38 +1409,43 @@ describe("RosterService", () => {
         sortOrder: 1,
       },
     ]);
-    cwlStateServiceMock.getCurrentRoundForClan.mockResolvedValue({
-      season: "2026-04",
-      clanTag: "#2QG2C08UP",
-      clanName: "Current Clan",
-      roundDay: 4,
-      roundState: "inWar",
-      opponentTag: "#OPPONENT",
-      opponentName: "Opponent Clan",
-      teamSize: 15,
-      attacksPerMember: 1,
-      preparationStartTime: new Date("2026-04-20T00:00:00.000Z"),
-      startTime: new Date("2026-04-20T01:00:00.000Z"),
-      endTime: new Date("2026-04-20T02:00:00.000Z"),
-      sourceUpdatedAt: new Date("2026-04-20T00:00:00.000Z"),
-      members: [
-        {
-          season: "2026-04",
-          clanTag: "#2QG2C08UP",
-          playerTag: "#QGRJ2222",
-          roundDay: 4,
-          playerName: "Bravo",
-          mapPosition: 2,
-          townHall: 15,
-          attacksUsed: 0,
-          attacksAvailable: 1,
-          stars: 0,
-          destruction: 0,
-          subbedIn: true,
-          subbedOut: false,
-        },
-      ],
-    } as any);
+    todoSnapshotServiceMock.listSnapshotsByClanTag.mockResolvedValue([
+      {
+        playerTag: "#PQL0289",
+        playerName: "Alpha",
+        townHall: 16,
+        clanTag: "#2QG2C08UP",
+        clanName: "Rising Crowns",
+        cwlClanTag: "#2QG2C08UP",
+        cwlClanName: "Rising Crowns",
+      },
+      {
+        playerTag: "#QGRJ2222",
+        playerName: "Bravo",
+        townHall: 15,
+        clanTag: "#2QG2C08UP",
+        clanName: "Rising Crowns",
+        cwlClanTag: "#2QG2C08UP",
+        cwlClanName: "Rising Crowns",
+      },
+    ] as any);
+    cwlStateServiceMock.listSeasonRosterForClan.mockResolvedValue([
+      {
+        playerTag: "#PQL0289",
+        playerName: "Alpha",
+        townHall: 16,
+      },
+      {
+        playerTag: "#QGRJ2222",
+        playerName: "Bravo",
+        townHall: 15,
+      },
+      {
+        playerTag: "#OLD1111",
+        playerName: "OldTimer",
+        townHall: 14,
+      },
+    ] as any);
     prismaMock.playerLink.findMany.mockResolvedValue([
       {
         playerTag: "#PQL0289",
@@ -1413,6 +1465,7 @@ describe("RosterService", () => {
     expect(report).toContain("Current clan members:");
     expect(report).toContain("Unregistered members:");
     expect(report).toContain("- Bravo `#QGRJ2222` <@222222222222222222>");
+    expect(report).not.toContain("None");
     expect(report).toContain("Out-of-clan signups:");
     expect(report).toContain("- Outlier `#ZZZZ1111` <@333333333333333333>");
     expect(report).not.toContain("#OLD1111");

--- a/tests/roster.service.test.ts
+++ b/tests/roster.service.test.ts
@@ -232,6 +232,7 @@ describe("RosterService", () => {
     prismaMock.fwaPlayerCatalog.findMany.mockResolvedValue([]);
     prismaMock.cwlTrackedClan.findFirst.mockResolvedValue({
       name: "CWL Alpha",
+      leagueLabel: "Champion League II",
     });
     prismaMock.todoPlayerSnapshot.findMany.mockResolvedValue([]);
     prismaMock.todoPlayerSnapshot.aggregate.mockResolvedValue({
@@ -866,7 +867,9 @@ describe("RosterService", () => {
     expect(confirmedRow).toBeTruthy();
     expect(substituteRow).toBeTruthy();
     expect(embedTitle).toBe("Rising Crowns");
-    expect(description).toContain("## [CWL Alpha Signup](https://link.clashofclans.com/en?action=OpenClanProfile&tag=2QG2C08UP) CWL");
+    expect(description).toContain(
+      "## [CWL Alpha Signup](https://link.clashofclans.com/en?action=OpenClanProfile&tag=2QG2C08UP) Champion League II",
+    );
     expect(description).toContain("**Confirmed - 1**");
     expect(description).toContain("**Substitute - 1**");
     expect(description).toContain("TonyLee");
@@ -964,6 +967,52 @@ describe("RosterService", () => {
     );
     expect(payload).toBeTruthy();
     expect(String(payload?.embed.toJSON().title ?? "")).toBe("CWL Alpha");
+    expect(String(payload?.embed.toJSON().description ?? "")).toContain(
+      "## [CWL Alpha Signup](https://link.clashofclans.com/en?action=OpenClanProfile&tag=2QG2C08UP) Champion League II",
+    );
+  });
+
+  it("falls back cleanly when no persisted CWL league label is available", async () => {
+    prismaMock.cwlTrackedClan.findFirst.mockResolvedValueOnce({
+      name: "CWL Alpha",
+      leagueLabel: null,
+    });
+    prismaMock.roster.findUnique.mockResolvedValueOnce({
+      id: "roster-1",
+      guildId: "guild-1",
+      rosterType: "CWL",
+      rosterCategory: "signup",
+      title: "CWL Alpha Signup",
+      clanTag: "#2QG2C08UP",
+      startsAt: new Date("2026-04-20T00:00:00.000Z"),
+      endsAt: null,
+      timezone: "America/Los_Angeles",
+      displayTimezone: "America/Los_Angeles",
+      lifecycleState: "OPEN",
+      postedChannelId: null,
+      postedMessageId: null,
+      postedMessageUrl: null,
+      postedAt: null,
+      createdByDiscordUserId: "111111111111111111",
+      updatedByDiscordUserId: "111111111111111111",
+      createdAt: new Date("2026-04-20T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-20T00:00:00.000Z"),
+    } as any);
+    prismaMock.rosterGroup.findMany.mockResolvedValueOnce([
+      {
+        id: "group-confirmed",
+        rosterId: "roster-1",
+        key: "confirmed",
+        name: "Confirmed",
+        description: "Primary roster members",
+        sortOrder: 0,
+        createdAt: new Date("2026-04-20T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-20T00:00:00.000Z"),
+      },
+    ] as any);
+    prismaMock.rosterSignup.findMany.mockResolvedValueOnce([] as any);
+    prismaMock.rosterSignup.count.mockResolvedValueOnce(0);
+    const payload = await rosterService.buildRosterSignupPayload("roster-1");
     expect(String(payload?.embed.toJSON().description ?? "")).toContain(
       "## [CWL Alpha Signup](https://link.clashofclans.com/en?action=OpenClanProfile&tag=2QG2C08UP) CWL",
     );

--- a/tests/trackedClan.command.test.ts
+++ b/tests/trackedClan.command.test.ts
@@ -143,6 +143,7 @@ describe("/tracked-clan command behavior", () => {
           season: "2026-03",
           tag: "#PYLQ0289",
           name: null,
+          leagueLabel: null,
         },
       ],
       skipDuplicates: true,


### PR DESCRIPTION
- render roster posts from compact shared-width lines with a clan-link header
- source unregistered members from current CWL snapshot clan membership
- keep the embed title on the clan name and update readiness coverage