### PR TITLE
fix(cwl): hydrate tracked clan metadata during cwl actions

### DIFF
--- a/src/commands/Cwl.ts
+++ b/src/commands/Cwl.ts
@@ -2155,7 +2155,10 @@ async function handleRotationExportSubcommand(interaction: ChatInputCommandInter
   });
 }
 
-export async function handleRosterSignupSubcommand(interaction: ChatInputCommandInteraction): Promise<void> {
+export async function handleRosterSignupSubcommand(
+  interaction: ChatInputCommandInteraction,
+  cocService: CoCService,
+): Promise<void> {
   if (!interaction.inGuild() || !interaction.guildId) {
     await interaction.editReply("This command can only be used in a server.");
     return;
@@ -2214,6 +2217,7 @@ export async function handleRosterSignupSubcommand(interaction: ChatInputCommand
     lifecycleState: ROSTER_LIFECYCLE_STATE.OPEN,
     createdByDiscordUserId: interaction.user.id,
     updatedByDiscordUserId: interaction.user.id,
+    cocService,
   });
 
   const payload = await rosterService.buildRosterSignupPayload(roster.id);
@@ -3187,7 +3191,7 @@ export const Cwl: Command = {
         return;
       }
       if (!group && subcommand === "signup") {
-        await handleRosterSignupSubcommand(interaction);
+        await handleRosterSignupSubcommand(interaction, cocService);
         return;
       }
       if (group === "roster") {

--- a/src/commands/Roster.ts
+++ b/src/commands/Roster.ts
@@ -813,7 +813,10 @@ export async function handleRosterPostClearButtonInteraction(
   });
 }
 
-async function handleRosterCreateSubcommand(interaction: ChatInputCommandInteraction): Promise<void> {
+async function handleRosterCreateSubcommand(
+  interaction: ChatInputCommandInteraction,
+  cocService: CoCService,
+): Promise<void> {
   if (!interaction.inGuild() || !interaction.guildId) {
     await interaction.editReply("This command can only be used in a server.");
     return;
@@ -936,6 +939,7 @@ async function handleRosterCreateSubcommand(interaction: ChatInputCommandInterac
     lifecycleState: ROSTER_LIFECYCLE_STATE.OPEN,
     createdByDiscordUserId: interaction.user.id,
     updatedByDiscordUserId: interaction.user.id,
+    cocService,
   });
   if (importMembers) {
     await syncRosterRolesForRoster(interaction, roster.id).catch(() => undefined);
@@ -1793,7 +1797,7 @@ export const Roster: Command = {
     try {
       const subcommand = interaction.options.getSubcommand(true);
       if (subcommand === "create") {
-        await handleRosterCreateSubcommand(interaction);
+        await handleRosterCreateSubcommand(interaction, cocService);
         return;
       }
       if (subcommand === "list") {

--- a/src/commands/TrackedClan.ts
+++ b/src/commands/TrackedClan.ts
@@ -20,7 +20,7 @@ import { runWithCoCQueueContext } from "../services/CoCQueueContext";
 import { normalizeClanTag } from "../services/PlayerLinkService";
 import {
   addCwlClanTagsForSeason,
-  hydrateMissingCwlClanNamesForSeason,
+  ensureAndHydrateCwlTrackedClanMetadataForSeason,
   listCwlTrackedClansForSeason,
   removeTrackedClanTagFromRegistries,
   resolveCurrentCwlSeasonKey,
@@ -740,6 +740,22 @@ export const TrackedClan: Command = {
         const result = await addCwlClanTagsForSeason({
           rawTags: rawCwlTags,
         });
+        const hydrationTags = [...new Set([...result.added, ...result.alreadyExisting])];
+        const hydrationPromise =
+          cocService && hydrationTags.length > 0
+            ? ensureAndHydrateCwlTrackedClanMetadataForSeason({
+                season: result.season,
+                clanTags: hydrationTags,
+                cocService,
+                ensureRows: false,
+              })
+            : Promise.resolve({
+                season: result.season,
+                requestedCount: 0,
+                ensuredCount: 0,
+                hydratedCount: 0,
+                skippedCount: 0,
+              });
 
         await safeReply(interaction, {
           ephemeral: true,
@@ -754,18 +770,11 @@ export const TrackedClan: Command = {
         console.info(
           `[tracked-clan] stage=cwl_tags_final_reply_sent season=${result.season} added_count=${result.added.length} existing_count=${result.alreadyExisting.length}`,
         );
-
-        if (cocService && typeof cocService.getClan === "function") {
-          void hydrateMissingCwlClanNamesForSeason({
-            rawTags: rawCwlTags,
-            season: result.season,
-            cocService,
-          }).catch((err) => {
-            console.error(
-              `[tracked-clan] stage=cwl_tags_name_hydration_unhandled_error season=${result.season} error=${formatError(err)}`,
-            );
-          });
-        }
+        await hydrationPromise.catch((err) => {
+          console.error(
+            `[tracked-clan] stage=cwl_tags_metadata_hydration_unhandled_error season=${result.season} error=${formatError(err)}`,
+          );
+        });
         return;
       }
 

--- a/src/services/CwlRegistryService.ts
+++ b/src/services/CwlRegistryService.ts
@@ -52,6 +52,10 @@ function formatCwlTagStageDetails(details?: CwlTagStageDetails): string {
   return parts.length > 0 ? ` ${parts.join(" ")}` : "";
 }
 
+function normalizeUniqueCwlClanTags(input: string[]): string[] {
+  return [...new Set(input.map((tag) => normalizeClanTag(String(tag ?? ""))).filter(Boolean))];
+}
+
 async function runBoundedCwlTagStage<T>(input: {
   stage: string;
   timeoutMs: number;
@@ -236,33 +240,58 @@ export async function addCwlClanTagsForSeason(input: {
   };
 }
 
-/** Purpose: hydrate missing CWL clan names as best-effort enrichment after rows exist. */
-export async function hydrateMissingCwlClanNamesForSeason(input: {
-  rawTags: string;
+/** Purpose: ensure tracked CWL clan rows exist and hydrate clan metadata from live CoC in one bounded step. */
+export async function ensureAndHydrateCwlTrackedClanMetadataForSeason(input: {
+  clanTags: string[];
   season?: string;
   cocService: CoCService;
-}): Promise<void> {
+  ensureRows?: boolean;
+}): Promise<{
+  season: string;
+  requestedCount: number;
+  ensuredCount: number;
+  hydratedCount: number;
+  skippedCount: number;
+}> {
   const season = input.season ?? resolveCurrentCwlSeasonKey();
-  const parsed = parseCwlClanTagsInput(input.rawTags);
-  console.info(
-    `[tracked-clan] stage=cwl_tags_name_hydration_started season=${season} valid_count=${parsed.validTags.length}`,
-  );
-  if (parsed.validTags.length <= 0) {
-    console.info(
-      `[tracked-clan] stage=cwl_tags_name_hydration_completed season=${season} hydrated_count=0 skipped_count=0`,
-    );
-    return;
+  const clanTags = normalizeUniqueCwlClanTags(input.clanTags);
+  if (clanTags.length <= 0) {
+    return {
+      season,
+      requestedCount: 0,
+      ensuredCount: 0,
+      hydratedCount: 0,
+      skippedCount: 0,
+    };
   }
+
+  const ensured = input.ensureRows === false
+    ? { count: 0 }
+    : await runBoundedCwlTagStage({
+        stage: "cwl_tags_ensure_rows",
+        timeoutMs: CWL_TAG_DB_STAGE_TIMEOUT_MS,
+        details: { season, requested_count: clanTags.length },
+        action: () =>
+          prisma.cwlTrackedClan.createMany({
+            data: clanTags.map((tag) => ({
+              season,
+              tag,
+              name: null,
+              leagueLabel: null,
+            })),
+            skipDuplicates: true,
+          }),
+      });
 
   const missingRows = await runBoundedCwlTagStage({
     stage: "cwl_tags_missing_metadata_rows_query",
     timeoutMs: CWL_TAG_DB_STAGE_TIMEOUT_MS,
-    details: { season, valid_count: parsed.validTags.length },
+    details: { season, requested_count: clanTags.length },
     action: () =>
       prisma.cwlTrackedClan.findMany({
         where: {
           season,
-          tag: { in: parsed.validTags },
+          tag: { in: clanTags },
           OR: [
             { name: null },
             { name: "" },
@@ -276,9 +305,15 @@ export async function hydrateMissingCwlClanNamesForSeason(input: {
 
   if (missingRows.length <= 0) {
     console.info(
-      `[tracked-clan] stage=cwl_tags_name_hydration_completed season=${season} hydrated_count=0 skipped_count=0`,
+      `[tracked-clan] stage=cwl_tags_metadata_hydration_completed season=${season} requested_count=${clanTags.length} ensured_count=${ensured.count} hydrated_count=0 skipped_count=0`,
     );
-    return;
+    return {
+      season,
+      requestedCount: clanTags.length,
+      ensuredCount: ensured.count,
+      hydratedCount: 0,
+      skippedCount: 0,
+    };
   }
 
   let hydratedCount = 0;
@@ -298,7 +333,7 @@ export async function hydrateMissingCwlClanNamesForSeason(input: {
         if (!clanName && !leagueLabel) {
           skippedCount += 1;
           console.info(
-            `[tracked-clan] stage=cwl_tags_name_hydration_skipped season=${season} tag=${tag} reason=empty_name_and_league`,
+            `[tracked-clan] stage=cwl_tags_metadata_hydration_skipped season=${season} tag=${tag} reason=empty_name_and_league`,
           );
           return;
         }
@@ -332,14 +367,50 @@ export async function hydrateMissingCwlClanNamesForSeason(input: {
       } catch (err) {
         skippedCount += 1;
         console.error(
-          `[tracked-clan] stage=cwl_tags_name_hydration_failed season=${season} tag=${tag} error=${formatError(err)}`,
+          `[tracked-clan] stage=cwl_tags_metadata_hydration_failed season=${season} tag=${tag} error=${formatError(err)}`,
         );
       }
     }),
   );
 
   console.info(
-    `[tracked-clan] stage=cwl_tags_name_hydration_completed season=${season} hydrated_count=${hydratedCount} skipped_count=${skippedCount}`,
+    `[tracked-clan] stage=cwl_tags_metadata_hydration_completed season=${season} requested_count=${clanTags.length} ensured_count=${ensured.count} hydrated_count=${hydratedCount} skipped_count=${skippedCount}`,
+  );
+
+  return {
+    season,
+    requestedCount: clanTags.length,
+    ensuredCount: ensured.count,
+    hydratedCount,
+    skippedCount,
+  };
+}
+
+/** Purpose: hydrate missing CWL clan names as best-effort enrichment after rows exist. */
+export async function hydrateMissingCwlClanNamesForSeason(input: {
+  rawTags: string;
+  season?: string;
+  cocService: CoCService;
+}): Promise<void> {
+  const parsed = parseCwlClanTagsInput(input.rawTags);
+  const season = input.season ?? resolveCurrentCwlSeasonKey();
+  console.info(
+    `[tracked-clan] stage=cwl_tags_name_hydration_started season=${season} valid_count=${parsed.validTags.length}`,
+  );
+  if (parsed.validTags.length <= 0) {
+    console.info(
+      `[tracked-clan] stage=cwl_tags_name_hydration_completed season=${season} hydrated_count=0 skipped_count=0`,
+    );
+    return;
+  }
+
+  const result = await ensureAndHydrateCwlTrackedClanMetadataForSeason({
+    season,
+    clanTags: parsed.validTags,
+    cocService: input.cocService,
+  });
+  console.info(
+    `[tracked-clan] stage=cwl_tags_name_hydration_completed season=${result.season} hydrated_count=${result.hydratedCount} skipped_count=${result.skippedCount}`,
   );
 }
 

--- a/src/services/RosterService.ts
+++ b/src/services/RosterService.ts
@@ -16,7 +16,10 @@ import {
   normalizeDiscordUserId,
   normalizePlayerTag,
 } from "./PlayerLinkService";
-import { resolveCurrentCwlSeasonKey } from "./CwlRegistryService";
+import {
+  ensureAndHydrateCwlTrackedClanMetadataForSeason,
+  resolveCurrentCwlSeasonKey,
+} from "./CwlRegistryService";
 import { cwlStateService } from "./CwlStateService";
 import { todoSnapshotService } from "./TodoSnapshotService";
 import { normalizeSyncTimeZone } from "./syncTimeZone";
@@ -274,6 +277,7 @@ export type CreateRosterInput = {
   createdByDiscordUserId?: string | null;
   updatedByDiscordUserId?: string | null;
   groups?: RosterGroupSeed[];
+  cocService?: CoCService | null;
 };
 
 export type SignupLinkedAccountsResult =
@@ -2013,6 +2017,17 @@ export class RosterService {
     }
 
     const roster = mapRosterRecord(created);
+    if (roster.rosterType === "CWL" && roster.clanTag && input.cocService) {
+      await ensureAndHydrateCwlTrackedClanMetadataForSeason({
+        clanTags: [roster.clanTag],
+        season: resolveCurrentCwlSeasonKey(),
+        cocService: input.cocService,
+      }).catch((err) => {
+        console.error(
+          `[roster] stage=cwl_metadata_hydration_failed roster_id=${roster.id} clan_tag=${roster.clanTag} error=${String((err as Error)?.message ?? err)}`,
+        );
+      });
+    }
     if (importMembers) {
       await this.importRosterMembers({ rosterId: roster.id });
     }
@@ -2050,6 +2065,8 @@ export class RosterService {
       where: { id: rosterId },
       select: {
         id: true,
+        rosterType: true,
+        clanTag: true,
       },
     });
     if (!roster) return null;
@@ -2066,6 +2083,18 @@ export class RosterService {
           cocService,
         });
       }
+    }
+
+    if (cocService && roster.rosterType === "CWL" && roster.clanTag) {
+      await ensureAndHydrateCwlTrackedClanMetadataForSeason({
+        clanTags: [roster.clanTag],
+        season: resolveCurrentCwlSeasonKey(),
+        cocService,
+      }).catch((err) => {
+        console.error(
+          `[roster] stage=cwl_metadata_refresh_failed roster_id=${roster.id} clan_tag=${roster.clanTag} error=${String((err as Error)?.message ?? err)}`,
+        );
+      });
     }
 
     return this.buildRosterSignupPayload(rosterId, cocService ?? null);

--- a/tests/cwl.command.test.ts
+++ b/tests/cwl.command.test.ts
@@ -336,6 +336,12 @@ describe("/cwl command", () => {
       ],
     });
     (rosterService.recordRosterPostedMessage as any).mockResolvedValue(undefined);
+    const cocService = {
+      getClan: vi.fn().mockResolvedValue({
+        name: "CWL Alpha",
+        warLeague: { name: "Champion League II" },
+      }),
+    };
 
     const interaction = makeInteraction({
       subcommand: "signup",
@@ -353,7 +359,7 @@ describe("/cwl command", () => {
       }),
     };
 
-    await Cwl.run({} as any, interaction as any, {} as any);
+    await Cwl.run({} as any, interaction as any, cocService as any);
 
     expect(rosterService.createRoster).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -363,6 +369,7 @@ describe("/cwl command", () => {
         clanTag: "#2QG2C08UP",
         timezone: "America/Los_Angeles",
         displayTimezone: "America/Los_Angeles",
+        cocService,
       }),
     );
     expect(interaction.channel.send).toHaveBeenCalledTimes(1);

--- a/tests/cwlRegistry.service.test.ts
+++ b/tests/cwlRegistry.service.test.ts
@@ -14,6 +14,7 @@ vi.mock("../src/prisma", () => ({
 
 import {
   addCwlClanTagsForSeason,
+  ensureAndHydrateCwlTrackedClanMetadataForSeason,
   hydrateMissingCwlClanNamesForSeason,
 } from "../src/services/CwlRegistryService";
 
@@ -147,5 +148,64 @@ describe("CwlRegistryService helpers", () => {
       (call) => String(call[0] ?? ""),
     );
     expect(errorLogs.some((line) => line.includes("stage=cwl_tags_name_lookup"))).toBe(true);
+  });
+
+  it("ensures tracked CWL rows and hydrates clan name and league label in one pass", async () => {
+    prismaMock.cwlTrackedClan.findMany.mockResolvedValueOnce([
+      { tag: "#PYLQ0289" },
+      { tag: "#QGRJ2222" },
+    ]);
+    prismaMock.cwlTrackedClan.updateMany.mockResolvedValue({ count: 1 });
+    const cocService = {
+      getClan: vi.fn(async (tag: string) => ({
+        name: tag === "#PYLQ0289" ? "CWL Alpha" : "CWL Beta",
+        warLeague: { name: tag === "#PYLQ0289" ? "Champion League II" : "Champion League I" },
+      })),
+    };
+
+    const result = await ensureAndHydrateCwlTrackedClanMetadataForSeason({
+      clanTags: ["#PYLQ0289", "#QGRJ2222"],
+      season: "2026-03",
+      cocService: cocService as any,
+    });
+
+    expect(prismaMock.cwlTrackedClan.createMany).toHaveBeenCalledWith({
+      data: [
+        { season: "2026-03", tag: "#PYLQ0289", name: null, leagueLabel: null },
+        { season: "2026-03", tag: "#QGRJ2222", name: null, leagueLabel: null },
+      ],
+      skipDuplicates: true,
+    });
+    expect(cocService.getClan).toHaveBeenCalledWith("#PYLQ0289");
+    expect(cocService.getClan).toHaveBeenCalledWith("#QGRJ2222");
+    expect(prismaMock.cwlTrackedClan.updateMany).toHaveBeenCalledWith({
+      where: {
+        season: "2026-03",
+        tag: "#PYLQ0289",
+        OR: [{ name: null }, { name: "" }, { leagueLabel: null }, { leagueLabel: "" }],
+      },
+      data: {
+        name: "CWL Alpha",
+        leagueLabel: "Champion League II",
+      },
+    });
+    expect(prismaMock.cwlTrackedClan.updateMany).toHaveBeenCalledWith({
+      where: {
+        season: "2026-03",
+        tag: "#QGRJ2222",
+        OR: [{ name: null }, { name: "" }, { leagueLabel: null }, { leagueLabel: "" }],
+      },
+      data: {
+        name: "CWL Beta",
+        leagueLabel: "Champion League I",
+      },
+    });
+    expect(result).toEqual({
+      season: "2026-03",
+      requestedCount: 2,
+      ensuredCount: 0,
+      hydratedCount: 2,
+      skippedCount: 0,
+    });
   });
 });

--- a/tests/roster.service.test.ts
+++ b/tests/roster.service.test.ts
@@ -32,7 +32,10 @@ const prismaMock = vi.hoisted(() => ({
     findMany: vi.fn(),
   },
   cwlTrackedClan: {
+    findMany: vi.fn(),
     findFirst: vi.fn(),
+    createMany: vi.fn(),
+    updateMany: vi.fn(),
   },
   todoPlayerSnapshot: {
     findMany: vi.fn(),
@@ -98,6 +101,7 @@ import {
   ROSTER_DEFAULT_GROUPS,
   rosterService,
 } from "../src/services/RosterService";
+import { resolveCurrentCwlSeasonKey } from "../src/services/CwlRegistryService";
 
 describe("RosterService", () => {
   function mockConflictLookupForLifecycleState(
@@ -230,10 +234,13 @@ describe("RosterService", () => {
     prismaMock.playerLink.findMany.mockResolvedValue([]);
     prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue([]);
     prismaMock.fwaPlayerCatalog.findMany.mockResolvedValue([]);
+    prismaMock.cwlTrackedClan.findMany.mockResolvedValue([]);
     prismaMock.cwlTrackedClan.findFirst.mockResolvedValue({
       name: "CWL Alpha",
       leagueLabel: "Champion League II",
     });
+    prismaMock.cwlTrackedClan.createMany.mockResolvedValue({ count: 0 });
+    prismaMock.cwlTrackedClan.updateMany.mockResolvedValue({ count: 0 });
     prismaMock.todoPlayerSnapshot.findMany.mockResolvedValue([]);
     prismaMock.todoPlayerSnapshot.aggregate.mockResolvedValue({
       _count: { _all: 0 },
@@ -251,6 +258,7 @@ describe("RosterService", () => {
     });
     cocServiceMock.getClan.mockReset();
     cocServiceMock.getClan.mockResolvedValue({
+      name: "CWL Alpha",
       warLeague: { name: "Champion League II" },
     });
   });
@@ -284,6 +292,46 @@ describe("RosterService", () => {
           }),
         ),
       ),
+    });
+  });
+
+  it("hydrates CWL tracked-clan metadata while creating a CWL roster", async () => {
+    prismaMock.cwlTrackedClan.findMany.mockResolvedValueOnce([{ tag: "#2QG2C08UP" }]);
+    prismaMock.cwlTrackedClan.updateMany.mockResolvedValue({ count: 1 });
+
+    await rosterService.createRoster({
+      guildId: "guild-1",
+      rosterType: "cwl",
+      title: "CWL Alpha Signup",
+      clanTag: "#2QG2C08UP",
+      timezone: "PST",
+      createdByDiscordUserId: "111111111111111111",
+      cocService: cocServiceMock as any,
+    });
+
+    const season = resolveCurrentCwlSeasonKey();
+    expect(prismaMock.cwlTrackedClan.createMany).toHaveBeenCalledWith({
+      data: [
+        {
+          season,
+          tag: "#2QG2C08UP",
+          name: null,
+          leagueLabel: null,
+        },
+      ],
+      skipDuplicates: true,
+    });
+    expect(cocServiceMock.getClan).toHaveBeenCalledWith("#2QG2C08UP");
+    expect(prismaMock.cwlTrackedClan.updateMany).toHaveBeenCalledWith({
+      where: {
+        season,
+        tag: "#2QG2C08UP",
+        OR: [{ name: null }, { name: "" }, { leagueLabel: null }, { leagueLabel: "" }],
+      },
+      data: {
+        name: "CWL Alpha",
+        leagueLabel: "Champion League II",
+      },
     });
   });
 
@@ -926,6 +974,8 @@ describe("RosterService", () => {
         },
       },
     ] as any);
+    prismaMock.cwlTrackedClan.findMany.mockResolvedValueOnce([{ tag: "#2QG2C08UP" }]);
+    prismaMock.cwlTrackedClan.updateMany.mockResolvedValue({ count: 1 });
     todoSnapshotServiceMock.listSnapshotsByPlayerTags.mockResolvedValue([
       {
         playerTag: "#PQL0289",
@@ -965,6 +1015,18 @@ describe("RosterService", () => {
         cocService: cocServiceMock,
       }),
     );
+    expect(cocServiceMock.getClan).toHaveBeenCalledWith("#2QG2C08UP");
+    expect(prismaMock.cwlTrackedClan.updateMany).toHaveBeenCalledWith({
+      where: {
+        season: resolveCurrentCwlSeasonKey(),
+        tag: "#2QG2C08UP",
+        OR: [{ name: null }, { name: "" }, { leagueLabel: null }, { leagueLabel: "" }],
+      },
+      data: {
+        name: "CWL Alpha",
+        leagueLabel: "Champion League II",
+      },
+    });
     expect(payload).toBeTruthy();
     expect(String(payload?.embed.toJSON().title ?? "")).toBe("CWL Alpha");
     expect(String(payload?.embed.toJSON().description ?? "")).toContain(

--- a/tests/trackedClan.command.test.ts
+++ b/tests/trackedClan.command.test.ts
@@ -168,6 +168,54 @@ describe("/tracked-clan command behavior", () => {
     expect(infoLogs.some((line: string) => line.includes("stage=cwl_tags_final_reply_sent"))).toBe(true);
   });
 
+  it("hydrates CWL metadata immediately after adding tracked clans when clan lookups succeed", async () => {
+    prismaMock.cwlTrackedClan.findMany
+      .mockResolvedValueOnce([{ tag: "#QGRJ2222" }])
+      .mockResolvedValueOnce([{ tag: "#PYLQ0289" }, { tag: "#QGRJ2222" }])
+      .mockResolvedValueOnce([{ tag: "#PYLQ0289" }, { tag: "#QGRJ2222" }]);
+    prismaMock.cwlTrackedClan.updateMany.mockResolvedValue({ count: 1 });
+    const interaction = createInteraction({
+      subcommand: "cwl-tags",
+      strings: {
+        "cwl-tags": "[#PYLQ0289,QGRJ2222]",
+      },
+    });
+    const cocService = {
+      getClan: vi.fn(async (tag: string) => ({
+        name: tag === "#PYLQ0289" ? "CWL Alpha" : "CWL Beta",
+        warLeague: { name: tag === "#PYLQ0289" ? "Champion League II" : "Champion League I" },
+      })),
+    };
+
+    await TrackedClan.run({} as any, interaction as any, cocService as any);
+
+    expect(cocService.getClan).toHaveBeenCalledWith("#PYLQ0289");
+    expect(cocService.getClan).toHaveBeenCalledWith("#QGRJ2222");
+    expect(prismaMock.cwlTrackedClan.updateMany).toHaveBeenCalledWith({
+      where: {
+        season: "2026-03",
+        tag: "#PYLQ0289",
+        OR: [{ name: null }, { name: "" }, { leagueLabel: null }, { leagueLabel: "" }],
+      },
+      data: {
+        name: "CWL Alpha",
+        leagueLabel: "Champion League II",
+      },
+    });
+    expect(prismaMock.cwlTrackedClan.updateMany).toHaveBeenCalledWith({
+      where: {
+        season: "2026-03",
+        tag: "#QGRJ2222",
+        OR: [{ name: null }, { name: "" }, { leagueLabel: null }, { leagueLabel: "" }],
+      },
+      data: {
+        name: "CWL Beta",
+        leagueLabel: "Champion League I",
+      },
+    });
+    expect(getReplyContent(interaction)).toContain("Updated CWL tracked clans for season 2026-03.");
+  });
+
   it("adds raid tags with optional upgrades and refreshes joinType best-effort", async () => {
     prismaMock.raidTrackedClan.findMany.mockResolvedValueOnce([]);
     const interaction = createInteraction({


### PR DESCRIPTION
- persist clan name and league label during tracked-clan, roster-create, and refresh flows
- keep normal roster rendering db-first while exposing the hydrated CWL league label