### PR TITLE
fix(roster): bold the roster heading link

### DIFF
--- a/src/services/RosterService.ts
+++ b/src/services/RosterService.ts
@@ -1542,7 +1542,7 @@ function buildRosterSignupPayloadFromView(view: RosterSignupView): RosterSignupP
   const title = normalizeRosterText(view.clanDisplayName ?? null) ?? normalizeClanTag(view.roster.clanTag ?? "") ?? "Roster";
   const groups = buildRosterGroupsWithSignups(view);
   const widths = measureRosterBoardColumnWidths(groups.flatMap((group) => group.signups));
-  const rosterLabel = `## ${buildClanProfileMarkdownLink(view.roster.title || "Roster Signup", view.roster.clanTag)} ${
+  const rosterLabel = `**${buildClanProfileMarkdownLink(view.roster.title || "Roster Signup", view.roster.clanTag)}** ${
     view.clanLeagueLabel ?? view.roster.rosterType
   }`.trim();
   const maxMembersLabel = view.roster.maxMembers === null || view.roster.maxMembers === undefined ? "-" : String(view.roster.maxMembers);

--- a/tests/roster.service.test.ts
+++ b/tests/roster.service.test.ts
@@ -916,7 +916,7 @@ describe("RosterService", () => {
     expect(substituteRow).toBeTruthy();
     expect(embedTitle).toBe("Rising Crowns");
     expect(description).toContain(
-      "## [CWL Alpha Signup](https://link.clashofclans.com/en?action=OpenClanProfile&tag=2QG2C08UP) Champion League II",
+      "**[CWL Alpha Signup](https://link.clashofclans.com/en?action=OpenClanProfile&tag=2QG2C08UP)** Champion League II",
     );
     expect(description).toContain("**Confirmed - 1**");
     expect(description).toContain("**Substitute - 1**");
@@ -1030,7 +1030,7 @@ describe("RosterService", () => {
     expect(payload).toBeTruthy();
     expect(String(payload?.embed.toJSON().title ?? "")).toBe("CWL Alpha");
     expect(String(payload?.embed.toJSON().description ?? "")).toContain(
-      "## [CWL Alpha Signup](https://link.clashofclans.com/en?action=OpenClanProfile&tag=2QG2C08UP) Champion League II",
+      "**[CWL Alpha Signup](https://link.clashofclans.com/en?action=OpenClanProfile&tag=2QG2C08UP)** Champion League II",
     );
   });
 
@@ -1076,7 +1076,7 @@ describe("RosterService", () => {
     prismaMock.rosterSignup.count.mockResolvedValueOnce(0);
     const payload = await rosterService.buildRosterSignupPayload("roster-1");
     expect(String(payload?.embed.toJSON().description ?? "")).toContain(
-      "## [CWL Alpha Signup](https://link.clashofclans.com/en?action=OpenClanProfile&tag=2QG2C08UP) CWL",
+      "**[CWL Alpha Signup](https://link.clashofclans.com/en?action=OpenClanProfile&tag=2QG2C08UP)** CWL",
     );
   });
 


### PR DESCRIPTION
- remove the markdown header prefix from the roster heading
- render the roster name as a bold clan-profile hyperlink with the league label beside it