### PR TITLE
fix(fwa): show tracked clan coverage in guild status

### DIFF
--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -1190,6 +1190,9 @@ function formatFwaPoliceStatusReport(report: FwaPoliceStatusReport): string {
       `Tracked clans with log enabled: ${report.trackedClanSummary.logEnabled}`,
       `Tracked clans with stored log-channel: ${report.trackedClanSummary.withTrackedLogChannel}`,
       `Log-enabled clans without tracked log-channel: ${report.trackedClanSummary.logEnabledWithoutTrackedLogChannel}`,
+      `Enabled clans: ${report.enabledClanShortNamesLine}`,
+      `DM enabled: ${report.dmEnabledClanShortNamesLine}`,
+      `Log enabled: ${report.logEnabledClanShortNamesLine}`,
     );
   }
 

--- a/src/services/FwaPoliceService.ts
+++ b/src/services/FwaPoliceService.ts
@@ -33,6 +33,7 @@ import { BotLogChannelService } from "./BotLogChannelService";
 type TrackedClanPoliceRow = {
   tag: string;
   name: string | null;
+  shortName: string | null;
   loseStyle: FwaLoseStyle;
   fwaPoliceDmEnabled: boolean;
   fwaPoliceLogEnabled: boolean;
@@ -112,6 +113,9 @@ export type FwaPoliceStatusReport = {
     withTrackedLogChannel: number;
     logEnabledWithoutTrackedLogChannel: number;
   };
+  enabledClanShortNamesLine: string;
+  dmEnabledClanShortNamesLine: string;
+  logEnabledClanShortNamesLine: string;
   clan: null | {
     clanTag: string;
     clanName: string | null;
@@ -216,6 +220,57 @@ function buildViolationKey(issue: WarComplianceIssue): string {
 
 function resolveClanLogChannelId(clan: TrackedClanPoliceRow): string | null {
   return normalizeFwaPoliceText(clan.logChannelId) || null;
+}
+
+/** Purpose: derive the compact clan label used in guild police-status coverage lines. */
+function formatTrackedClanCoverageLabel(clan: {
+  tag: string;
+  name: string | null;
+  shortName: string | null;
+}): string {
+  return (
+    normalizeFwaPoliceText(clan.shortName) ||
+    normalizeFwaPoliceText(clan.name) ||
+    normalizeClanTag(clan.tag) ||
+    clan.tag
+  );
+}
+
+/** Purpose: keep guild police-status coverage lists deterministic and compact. */
+function sortTrackedClanCoverageRows(
+  rows: TrackedClanPoliceRow[],
+): TrackedClanPoliceRow[] {
+  return [...rows].sort((a, b) => {
+    const labelA = formatTrackedClanCoverageLabel(a).toLowerCase();
+    const labelB = formatTrackedClanCoverageLabel(b).toLowerCase();
+    if (labelA !== labelB) return labelA.localeCompare(labelB);
+    const tagA = normalizeClanTag(a.tag) || a.tag;
+    const tagB = normalizeClanTag(b.tag) || b.tag;
+    return tagA.localeCompare(tagB);
+  });
+}
+
+/** Purpose: render a compact comma-separated clan coverage line with safe truncation. */
+function formatTrackedClanCoverageList(rows: TrackedClanPoliceRow[]): string {
+  if (rows.length <= 0) return "none";
+
+  const labels = sortTrackedClanCoverageRows(rows).map((row) =>
+    formatTrackedClanCoverageLabel(row),
+  );
+  const maxLength = 180;
+  let rendered = labels[0] ?? "none";
+  for (let index = 1; index < labels.length; index += 1) {
+    const next = labels[index];
+    const candidate = `${rendered}, ${next}`;
+    if (candidate.length <= maxLength) {
+      rendered = candidate;
+      continue;
+    }
+    const remaining = labels.length - index;
+    return `${rendered} ... (+${remaining} more)`;
+  }
+
+  return rendered;
 }
 
 function buildOffenderLabel(input: {
@@ -480,6 +535,7 @@ async function resolveTrackedClanByTag(
     select: {
       tag: true,
       name: true,
+      shortName: true,
       loseStyle: true,
       fwaPoliceDmEnabled: true,
       fwaPoliceLogEnabled: true,
@@ -673,6 +729,7 @@ export class FwaPoliceService {
       select: {
         tag: true,
         name: true,
+        shortName: true,
         loseStyle: true,
         fwaPoliceDmEnabled: true,
         fwaPoliceLogEnabled: true,
@@ -771,6 +828,15 @@ export class FwaPoliceService {
             "tracked-clan log-channel when configured, otherwise /bot-logs fallback, otherwise unresolved",
           enabledViolationTypes: [...FWA_POLICE_VIOLATIONS],
           trackedClanSummary,
+          enabledClanShortNamesLine: formatTrackedClanCoverageList(
+            trackedRows.filter((row) => Boolean(row.fwaPoliceDmEnabled || row.fwaPoliceLogEnabled)),
+          ),
+          dmEnabledClanShortNamesLine: formatTrackedClanCoverageList(
+            trackedRows.filter((row) => Boolean(row.fwaPoliceDmEnabled)),
+          ),
+          logEnabledClanShortNamesLine: formatTrackedClanCoverageList(
+            trackedRows.filter((row) => Boolean(row.fwaPoliceLogEnabled)),
+          ),
           clan: null,
           warnings,
         },
@@ -845,6 +911,15 @@ export class FwaPoliceService {
           "tracked-clan log-channel when configured, otherwise /bot-logs fallback, otherwise unresolved",
         enabledViolationTypes: [...FWA_POLICE_VIOLATIONS],
         trackedClanSummary,
+        enabledClanShortNamesLine: formatTrackedClanCoverageList(
+          trackedRows.filter((row) => Boolean(row.fwaPoliceDmEnabled || row.fwaPoliceLogEnabled)),
+        ),
+        dmEnabledClanShortNamesLine: formatTrackedClanCoverageList(
+          trackedRows.filter((row) => Boolean(row.fwaPoliceDmEnabled)),
+        ),
+        logEnabledClanShortNamesLine: formatTrackedClanCoverageList(
+          trackedRows.filter((row) => Boolean(row.fwaPoliceLogEnabled)),
+        ),
         clan: {
           clanTag,
           clanName: normalizeFwaPoliceText(tracked.name) || null,

--- a/tests/fwaPolice.commandOutput.test.ts
+++ b/tests/fwaPolice.commandOutput.test.ts
@@ -106,6 +106,9 @@ describe("/fwa police command output", () => {
           withTrackedLogChannel: 1,
           logEnabledWithoutTrackedLogChannel: 1,
         },
+        enabledClanShortNamesLine: "RD, GB",
+        dmEnabledClanShortNamesLine: "RD",
+        logEnabledClanShortNamesLine: "GB",
         clan: null,
         warnings: [],
       },
@@ -137,6 +140,50 @@ describe("/fwa police command output", () => {
     expect(content).toContain("FWA Police enabled: yes");
     expect(content).toContain("DM sending enabled: yes");
     expect(content).toContain("Stored /bot-logs fallback: <#bot-log-1> (ok)");
+    expect(content).toContain("Enabled clans: RD, GB");
+    expect(content).toContain("DM enabled: RD");
+    expect(content).toContain("Log enabled: GB");
+  });
+
+  it("renders guild police status coverage lists as none when empty", async () => {
+    fwaPoliceServiceMock.getStatusReport.mockResolvedValue({
+      ok: true,
+      report: {
+        scope: "guild",
+        policeEnabled: false,
+        dmEnabled: false,
+        logEnabled: false,
+        storedPoliceLogChannelOverrideId: null,
+        storedBotLogChannelId: null,
+        storedBotLogChannelHealth: "not_configured",
+        fallbackBehavior:
+          "tracked-clan log-channel when configured, otherwise /bot-logs fallback, otherwise unresolved",
+        enabledViolationTypes: [],
+        trackedClanSummary: {
+          total: 0,
+          policeEnabled: 0,
+          dmEnabled: 0,
+          logEnabled: 0,
+          withTrackedLogChannel: 0,
+          logEnabledWithoutTrackedLogChannel: 0,
+        },
+        enabledClanShortNamesLine: "none",
+        dmEnabledClanShortNamesLine: "none",
+        logEnabledClanShortNamesLine: "none",
+        clan: null,
+        warnings: [],
+      },
+    });
+
+    const run = makeInteraction({
+      subcommand: "status",
+    });
+    await Fwa.run({} as any, run.interaction as any, {} as any);
+
+    const content = String(run.editReply.mock.calls[0]?.[0]?.content ?? "");
+    expect(content).toContain("Enabled clans: none");
+    expect(content).toContain("DM enabled: none");
+    expect(content).toContain("Log enabled: none");
   });
 
   it("renders clan-scoped status and warnings when resolved channel is unavailable", async () => {
@@ -161,6 +208,9 @@ describe("/fwa police command output", () => {
           withTrackedLogChannel: 1,
           logEnabledWithoutTrackedLogChannel: 0,
         },
+        enabledClanShortNamesLine: "RD",
+        dmEnabledClanShortNamesLine: "RD",
+        logEnabledClanShortNamesLine: "RD",
         clan: {
           clanTag: "#2QG2C08UP",
           clanName: "Alpha",

--- a/tests/fwaPolice.service.test.ts
+++ b/tests/fwaPolice.service.test.ts
@@ -346,6 +346,121 @@ describe("FwaPoliceService", () => {
     }
   });
 
+  it("renders guild-scope tracked clan coverage lists with deterministic short-name ordering", async () => {
+    prismaMock.trackedClan.findMany.mockResolvedValue([
+      {
+        tag: "#1AAA",
+        name: "Alpha",
+        shortName: null,
+        loseStyle: "TRIPLE_TOP_30",
+        fwaPoliceDmEnabled: true,
+        fwaPoliceLogEnabled: false,
+        logChannelId: "channel-alpha",
+      },
+      {
+        tag: "#2BBB",
+        name: "Bravo",
+        shortName: "RD",
+        loseStyle: "TRIPLE_TOP_30",
+        fwaPoliceDmEnabled: false,
+        fwaPoliceLogEnabled: true,
+        logChannelId: "channel-bravo",
+      },
+    ]);
+    botLogServiceMock.getChannelId.mockResolvedValue(null);
+    const client = {
+      channels: {
+        fetch: vi.fn().mockResolvedValue({
+          isTextBased: () => true,
+          send: vi.fn(),
+        }),
+      },
+    } as any;
+    const service = new FwaPoliceService();
+
+    const result = await service.getStatusReport({
+      client,
+      guildId: "guild-1",
+      clanTag: null,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.report.scope).toBe("guild");
+      expect(result.report.enabledClanShortNamesLine).toBe("Alpha, RD");
+      expect(result.report.dmEnabledClanShortNamesLine).toBe("Alpha");
+      expect(result.report.logEnabledClanShortNamesLine).toBe("RD");
+    }
+  });
+
+  it("falls back to normalized clan tag when a tracked clan has no short name or clan name", async () => {
+    prismaMock.trackedClan.findMany.mockResolvedValue([
+      {
+        tag: "#2QG2C08UP",
+        name: null,
+        shortName: null,
+        loseStyle: "TRIPLE_TOP_30",
+        fwaPoliceDmEnabled: true,
+        fwaPoliceLogEnabled: false,
+        logChannelId: null,
+      },
+    ]);
+    botLogServiceMock.getChannelId.mockResolvedValue(null);
+    const client = {
+      channels: {
+        fetch: vi.fn(),
+      },
+    } as any;
+    const service = new FwaPoliceService();
+
+    const result = await service.getStatusReport({
+      client,
+      guildId: "guild-1",
+      clanTag: null,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.report.enabledClanShortNamesLine).toBe("#2QG2C08UP");
+      expect(result.report.dmEnabledClanShortNamesLine).toBe("#2QG2C08UP");
+      expect(result.report.logEnabledClanShortNamesLine).toBe("none");
+    }
+  });
+
+  it("renders none for guild-scope coverage lists when no clans are enabled", async () => {
+    prismaMock.trackedClan.findMany.mockResolvedValue([
+      {
+        tag: "#2QG2C08UP",
+        name: "Alpha",
+        shortName: "RD",
+        loseStyle: "TRIPLE_TOP_30",
+        fwaPoliceDmEnabled: false,
+        fwaPoliceLogEnabled: false,
+        logChannelId: null,
+      },
+    ]);
+    botLogServiceMock.getChannelId.mockResolvedValue(null);
+    const client = {
+      channels: {
+        fetch: vi.fn(),
+      },
+    } as any;
+    const service = new FwaPoliceService();
+
+    const result = await service.getStatusReport({
+      client,
+      guildId: "guild-1",
+      clanTag: null,
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.report.enabledClanShortNamesLine).toBe("none");
+      expect(result.report.dmEnabledClanShortNamesLine).toBe("none");
+      expect(result.report.logEnabledClanShortNamesLine).toBe("none");
+    }
+  });
+
   it("logs warning when live current-war compliance evaluation returns non-ok status", async () => {
     prismaMock.trackedClan.findFirst.mockResolvedValue({
       tag: "#2QG2C08UP",


### PR DESCRIPTION
- add compact enabled, DM, and log clan lists to guild-scope police status
- use tracked-clan short names with stable fallback labels