### PR TITLE
fix(help): cap detail embeds at ten pages

### DIFF
--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -743,6 +743,8 @@ const DISCORD_EMBED_LIMITS = {
   totalChars: 5800,
 } as const;
 
+const HELP_DETAIL_MAX_EMBEDS = 10;
+
 function truncateForDiscord(text: string, maxLength: number): string {
   if (text.length <= maxLength) return text;
   if (maxLength <= 1) return text.slice(0, maxLength);
@@ -823,10 +825,16 @@ function pageCharCount(page: HelpEmbedPage, title: string, footer: string): numb
   );
 }
 
-function toEmbed(page: HelpEmbedPage, title: string, footer: string): EmbedBuilder {
+function toEmbed(
+  page: HelpEmbedPage,
+  title: string,
+  footer: string,
+): EmbedBuilder {
   const embed = new EmbedBuilder().setTitle(
     truncateForDiscord(title, DISCORD_EMBED_LIMITS.title),
-  ).setColor(0x57f287);
+  );
+
+  embed.setColor(0x57f287);
 
   if (page.description) {
     embed.setDescription(truncateForDiscord(page.description, DISCORD_EMBED_LIMITS.description));
@@ -892,15 +900,22 @@ export function buildHelpDetailEmbeds(
 
   pages.push(current);
 
-  return pages.map((page, index) =>
-    toEmbed(
-      page,
-      baseTitle,
-      pages.length === 1
+  const cappedPages = pages.slice(0, HELP_DETAIL_MAX_EMBEDS);
+  const truncatedPages = pages.length - cappedPages.length;
+  const totalPages = cappedPages.length;
+
+  return cappedPages.map((page, index) => {
+    const isLastCappedPage = index === cappedPages.length - 1;
+    const footer =
+      totalPages === 1
         ? "Select another command or click Back to overview."
-        : `Help details page ${index + 1}/${pages.length}. Select another command or click Back to overview.`,
-    ),
-  );
+        : `Help details page ${index + 1}/${totalPages}. Select another command or click Back to overview.`;
+    const suffix =
+      truncatedPages > 0 && isLastCappedPage
+        ? ` Continued/truncated: ${truncatedPages} additional page(s) omitted to stay within Discord's 10-embed limit.`
+        : "";
+    return toEmbed(page, baseTitle, `${footer}${suffix}`);
+  });
 }
 
 type RenderState = {

--- a/tests/commandCoverage.test.ts
+++ b/tests/commandCoverage.test.ts
@@ -51,7 +51,7 @@ describe("command coverage", () => {
     expect(missing).toEqual([]);
   });
 
-  it("splits oversized help docs into safe embed pages", () => {
+  it("caps oversized help docs at ten embeds", () => {
     const embeds = buildHelpDetailEmbeds(
       {
         name: "oversized",
@@ -60,16 +60,19 @@ describe("command coverage", () => {
       },
       {
         summary: "y".repeat(5000),
-        details: Array.from({ length: 80 }, (_value, index) =>
-          `Detail ${index + 1} ${"d".repeat(120)}`,
+        details: Array.from({ length: 220 }, (_value, index) =>
+          `Detail ${index + 1} ${"d".repeat(260)}`,
         ),
-        examples: Array.from({ length: 80 }, (_value, index) =>
-          `Example ${index + 1} ${"e".repeat(120)}`,
+        examples: Array.from({ length: 220 }, (_value, index) =>
+          `Example ${index + 1} ${"e".repeat(260)}`,
         ),
       },
     );
 
-    expect(embeds.length).toBeGreaterThan(1);
+    expect(embeds).toHaveLength(10);
+    expect(embeds.at(-1)?.toJSON().footer?.text?.toLowerCase()).toContain(
+      "continued/truncated",
+    );
     for (const embed of embeds) {
       const json = embed.toJSON() as any;
       expect(json.description?.length ?? 0).toBeLessThanOrEqual(4096);
@@ -79,6 +82,21 @@ describe("command coverage", () => {
         expect(field.value.length).toBeLessThanOrEqual(1024);
       }
       expect(embedCharCount(json)).toBeLessThanOrEqual(6000);
+    }
+  });
+
+  it("keeps real /fwa help detail pages within the ten-embed limit", () => {
+    const fwa = Commands.find((command) => command.name === "fwa");
+    expect(fwa).toBeTruthy();
+
+    const embeds = buildHelpDetailEmbeds(fwa!);
+    expect(embeds.length).toBeLessThanOrEqual(10);
+    expect(embeds[0]?.toJSON().title).toBe("/fwa");
+
+    if (embeds.length === 10) {
+      expect(embeds.at(-1)?.toJSON().footer?.text?.toLowerCase()).toContain(
+        "continued/truncated",
+      );
     }
   });
 


### PR DESCRIPTION
- keep safe chunking but stop help detail responses at Discord's 10-embed limit
- add regression tests for oversized docs and the real /fwa help path