### PR TITLE
fix(roster): reuse refreshed town hall for posted roster rebuild

### DIFF
--- a/src/commands/Cwl.ts
+++ b/src/commands/Cwl.ts
@@ -259,8 +259,14 @@ function buildRosterManagerLifecycleSummary(
   return `${rosterTitle} was ${label}.`;
 }
 
-async function refreshRosterSignupPost(interaction: ChatInputCommandInteraction | ButtonInteraction | StringSelectMenuInteraction, rosterId: string): Promise<void> {
-  const payload = await rosterService.buildRosterSignupPayload(rosterId);
+async function refreshRosterSignupPost(
+  interaction: ChatInputCommandInteraction | ButtonInteraction | StringSelectMenuInteraction,
+  rosterId: string,
+  cocService?: CoCService | null,
+): Promise<void> {
+  const payload = cocService
+    ? await rosterService.refreshRosterSignupPayload(rosterId, cocService)
+    : await rosterService.buildRosterSignupPayload(rosterId);
   const rosterView = await rosterService.getRosterView(rosterId);
   if (!payload || !rosterView?.roster.postedChannelId || !rosterView.roster.postedMessageId) {
     return;
@@ -2314,7 +2320,7 @@ export async function handleRosterManagerSubcommand(
   }
 
   if (subcommand === "refresh") {
-    await refreshRosterSignupPost(interaction, roster.id).catch(() => undefined);
+    await refreshRosterSignupPost(interaction, roster.id, cocService).catch(() => undefined);
     await interaction.editReply(`Refreshed the posted CWL roster for ${rosterLabel}.`);
     return;
   }
@@ -2335,7 +2341,7 @@ export async function handleRosterManagerSubcommand(
       await interaction.editReply("That roster is no longer available.");
       return;
     }
-    await refreshRosterSignupPost(interaction, roster.id).catch(() => undefined);
+    await refreshRosterSignupPost(interaction, roster.id, cocService).catch(() => undefined);
     await interaction.editReply(buildRosterManagerLifecycleSummary(rosterLabel, lifecycleState));
     return;
   }
@@ -2366,7 +2372,7 @@ export async function handleRosterManagerSubcommand(
         await interaction.editReply("That roster is no longer available.");
         return;
       }
-      await refreshRosterSignupPost(interaction, roster.id).catch(() => undefined);
+      await refreshRosterSignupPost(interaction, roster.id, cocService).catch(() => undefined);
       await interaction.editReply(formatRosterSignupResultSummary(result));
       return;
     }
@@ -2385,7 +2391,7 @@ export async function handleRosterManagerSubcommand(
       await interaction.editReply("That roster group is no longer available.");
       return;
     }
-    await refreshRosterSignupPost(interaction, roster.id).catch(() => undefined);
+    await refreshRosterSignupPost(interaction, roster.id, cocService).catch(() => undefined);
     await interaction.editReply(formatRosterManagerMoveResultSummary(result));
     return;
   }
@@ -2400,7 +2406,7 @@ export async function handleRosterManagerSubcommand(
       await interaction.editReply("That roster is no longer available.");
       return;
     }
-    await refreshRosterSignupPost(interaction, roster.id).catch(() => undefined);
+    await refreshRosterSignupPost(interaction, roster.id, cocService).catch(() => undefined);
     await interaction.editReply(formatRosterManagerRemoveResultSummary(result));
     return;
   }
@@ -3052,7 +3058,7 @@ export async function handleRosterSelectionActionButtonInteraction(
 
   if (result.outcome === "signup") {
     await syncRosterRoleAssignments(interaction.client, result.result.rosterId).catch(() => undefined);
-    await refreshRosterSignupPost(interaction, result.result.rosterId).catch(() => undefined);
+    await refreshRosterSignupPost(interaction, result.result.rosterId, cocService).catch(() => undefined);
     await interaction.update({
       content: formatRosterSignupResultSummary(result.result),
       embeds: [],
@@ -3061,7 +3067,7 @@ export async function handleRosterSelectionActionButtonInteraction(
     return;
   }
 
-  await refreshRosterSignupPost(interaction, result.result.rosterId).catch(() => undefined);
+  await refreshRosterSignupPost(interaction, result.result.rosterId, cocService).catch(() => undefined);
   await interaction.update({
     content: formatRosterRemoveResultSummary(result.result),
     embeds: [],

--- a/tests/roster.service.test.ts
+++ b/tests/roster.service.test.ts
@@ -1556,6 +1556,73 @@ describe("RosterService", () => {
     );
   });
 
+  it("keeps a live-recovered town hall visible when the posted roster payload is rebuilt", async () => {
+    prismaMock.rosterSignup.findMany.mockResolvedValue([
+      {
+        id: "signup-1",
+        rosterId: "roster-1",
+        groupId: "group-confirmed",
+        playerTag: "#298CG8UJG",
+        playerName: "Player 298",
+        discordUserId: "111111111111111111",
+        signedUpAt: new Date("2026-04-20T00:00:00.000Z"),
+        createdAt: new Date("2026-04-20T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-20T00:00:00.000Z"),
+        group: {
+          id: "group-confirmed",
+          key: "confirmed",
+          name: "Confirmed",
+          description: "Primary roster members",
+          sortOrder: 0,
+        },
+      },
+    ] as any);
+    todoSnapshotServiceMock.refreshSnapshotsForPlayerTags.mockImplementation(async ({ cocService }) => {
+      await cocService?.getPlayerRaw("#298CG8UJG", { suppressTelemetry: true });
+      return {
+        playerCount: 1,
+        updatedCount: 1,
+      };
+    });
+    todoSnapshotServiceMock.listSnapshotsByPlayerTags.mockResolvedValue([
+      {
+        playerTag: "#298CG8UJG",
+        townHall: 15,
+        clanTag: "#2QG2C08UP",
+        clanName: "CWL Alpha",
+        cwlClanTag: "#2QG2C08UP",
+        cwlClanName: "CWL Alpha",
+      },
+    ] as any);
+    cwlStateServiceMock.listSeasonRosterForClan.mockResolvedValue([
+      {
+        playerTag: "#298CG8UJG",
+        playerName: "Player 298",
+        townHall: null,
+      },
+    ] as any);
+    const cocService = {
+      getPlayerRaw: vi.fn().mockResolvedValue({
+        townHallLevel: 15,
+        clan: { tag: "#2QG2C08UP" },
+      }),
+    } as any;
+
+    const payload = await rosterService.refreshRosterSignupPayload("roster-1", cocService);
+
+    expect(todoSnapshotServiceMock.refreshSnapshotsForPlayerTags).toHaveBeenCalledWith({
+      playerTags: ["#298CG8UJG"],
+      cocService,
+    });
+    expect(cocService.getPlayerRaw).toHaveBeenCalledWith("#298CG8UJG", {
+      suppressTelemetry: true,
+    });
+    expect(payload).toBeTruthy();
+    const description = String(payload?.embed.toJSON().description ?? "");
+    expect(description).toContain("`15 Player 298");
+    expect(description).not.toContain("`- Player 298");
+  });
+
   it("falls back cleanly when no persisted CWL league label is available", async () => {
     prismaMock.cwlTrackedClan.findFirst.mockResolvedValue({
       name: "CWL Alpha",


### PR DESCRIPTION
- rebuild posted rosters with the interactive refresh path when CoC is available
- preserve the live-recovered town hall so signup and board rendering stay in sync