### PR TITLE
feat(roster): merge clan autocomplete sources

### DIFF
--- a/src/commands/Roster.ts
+++ b/src/commands/Roster.ts
@@ -2053,10 +2053,37 @@ async function autocompleteRosterOption(interaction: AutocompleteInteraction): P
   );
 }
 
+function normalizeRosterTrackedClanAutocompleteName(input: string | null | undefined): string | null {
+  const trimmed = String(input ?? "")
+    .replace(/\s+/g, " ")
+    .trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
 function buildRosterTrackedClanChoiceLabel(clan: { name: string | null; tag: string }): string {
   const tag = normalizeClanTag(clan.tag);
-  const name = clan.name?.trim();
+  const name = normalizeRosterTrackedClanAutocompleteName(clan.name);
   return name ? `${name} (${tag})` : tag;
+}
+
+function upsertRosterTrackedClanAutocompleteChoice(
+  choiceByTag: Map<string, { tag: string; name: string | null }>,
+  tagInput: string,
+  nameInput: string | null | undefined,
+): void {
+  const tag = normalizeClanTag(tagInput);
+  if (!tag) return;
+
+  const name = normalizeRosterTrackedClanAutocompleteName(nameInput);
+  const existing = choiceByTag.get(tag);
+  if (!existing) {
+    choiceByTag.set(tag, { tag, name });
+    return;
+  }
+
+  if (!existing.name && name) {
+    choiceByTag.set(tag, { tag, name });
+  }
 }
 
 async function autocompleteRosterTrackedClan(interaction: AutocompleteInteraction): Promise<void> {
@@ -2074,24 +2101,47 @@ async function autocompleteRosterTrackedClan(interaction: AutocompleteInteractio
   const query = String(focused.value ?? "")
     .trim()
     .toLowerCase();
-  const tracked = await prisma.trackedClan.findMany({
-    orderBy: [{ createdAt: "asc" }, { tag: "asc" }],
-    select: { name: true, tag: true },
-  });
+  const season = resolveCurrentCwlSeasonKey();
+  const [trackedRows, raidRows, cwlRows] = await Promise.all([
+    prisma.trackedClan.findMany({
+      orderBy: [{ createdAt: "asc" }, { tag: "asc" }],
+      select: { name: true, tag: true },
+    }),
+    prisma.raidTrackedClan.findMany({
+      orderBy: [{ createdAt: "asc" }, { clanTag: "asc" }],
+      select: { name: true, clanTag: true },
+    }),
+    prisma.cwlTrackedClan.findMany({
+      where: { season },
+      orderBy: [{ createdAt: "asc" }, { tag: "asc" }],
+      select: { name: true, tag: true },
+    }),
+  ]);
 
-  await interaction.respond(
-    tracked
-      .map((clan) => {
-        const value = normalizeClanTag(clan.tag);
-        const name = buildRosterTrackedClanChoiceLabel(clan);
-        return { name: name.slice(0, 100), value };
-      })
-      .filter(
-        (choice) =>
-          choice.name.toLowerCase().includes(query) || choice.value.toLowerCase().includes(query),
-      )
-      .slice(0, 25),
-  );
+  const choiceByTag = new Map<string, { tag: string; name: string | null }>();
+  for (const clan of trackedRows) {
+    upsertRosterTrackedClanAutocompleteChoice(choiceByTag, clan.tag, clan.name);
+  }
+  for (const clan of raidRows) {
+    upsertRosterTrackedClanAutocompleteChoice(choiceByTag, clan.clanTag, clan.name);
+  }
+  for (const clan of cwlRows) {
+    upsertRosterTrackedClanAutocompleteChoice(choiceByTag, clan.tag, clan.name);
+  }
+
+  const choices = [...choiceByTag.values()]
+    .map((clan) => {
+      const name = buildRosterTrackedClanChoiceLabel(clan).slice(0, 100);
+      return { name, value: clan.tag };
+    })
+    .sort((a, b) => a.name.localeCompare(b.name) || a.value.localeCompare(b.value))
+    .filter(
+      (choice) =>
+        choice.name.toLowerCase().includes(query) || choice.value.toLowerCase().includes(query),
+    )
+    .slice(0, 25);
+
+  await interaction.respond(choices);
 }
 
 async function autocompleteRosterGroup(interaction: AutocompleteInteraction): Promise<void> {

--- a/tests/roster.command.test.ts
+++ b/tests/roster.command.test.ts
@@ -6,8 +6,12 @@ const prismaMock = vi.hoisted(() => ({
   trackedClan: {
     findMany: vi.fn(),
   },
+  raidTrackedClan: {
+    findMany: vi.fn(),
+  },
   cwlTrackedClan: {
     findFirst: vi.fn(),
+    findMany: vi.fn(),
   },
 }));
 
@@ -184,8 +188,12 @@ describe("/roster command", () => {
     prismaMock.$queryRaw.mockResolvedValue([]);
     prismaMock.trackedClan.findMany.mockReset();
     prismaMock.trackedClan.findMany.mockResolvedValue([]);
+    prismaMock.raidTrackedClan.findMany.mockReset();
+    prismaMock.raidTrackedClan.findMany.mockResolvedValue([]);
 
     prismaMock.cwlTrackedClan.findFirst.mockResolvedValue({ tag: "#2QG2C08UP", name: "CWL Alpha" });
+    prismaMock.cwlTrackedClan.findMany.mockReset();
+    prismaMock.cwlTrackedClan.findMany.mockResolvedValue([]);
     vi.spyOn(rosterService, "createRoster");
     vi.spyOn(rosterService, "buildRosterSignupPayload");
     vi.spyOn(rosterService, "refreshRosterSignupPayload");
@@ -2076,15 +2084,24 @@ describe("/roster command", () => {
     ]);
   });
 
-  it("autocompletes tracked clans for roster clan fields and filters deterministically", async () => {
+  it("autocompletes tracked clans across FWA, raid, and CWL sources without duplicates", async () => {
     prismaMock.trackedClan.findMany.mockResolvedValue([
-      { name: "Beta", tag: "#2QG2C08UP" },
-      { name: "Alpha", tag: "#9GLGQCCU" },
+      { name: "Alpha FWA", tag: "#9GLGQCCU" },
+      { name: null, tag: "#2QG2C08UP" },
+    ]);
+    prismaMock.raidTrackedClan.findMany.mockResolvedValue([
+      { name: "Alpha Raid", clanTag: "9GLGQCCU" },
+      { name: "Raid Beta", clanTag: "2RVGJYLC0" },
+    ]);
+    prismaMock.cwlTrackedClan.findMany.mockResolvedValue([
+      { name: "Alpha CWL", tag: "#9GLGQCCU" },
+      { name: "CWL Gamma", tag: "#2QG2C08UP" },
+      { name: "CWL Gamma Duplicate", tag: "#2QG2C08UP" },
     ]);
 
     const interaction = makeAutocompleteInteraction({
       focusedName: "clan",
-      focusedValue: "alpha",
+      focusedValue: "",
       subcommand: "edit",
     }) as any;
 
@@ -2094,8 +2111,19 @@ describe("/roster command", () => {
       orderBy: [{ createdAt: "asc" }, { tag: "asc" }],
       select: { name: true, tag: true },
     });
+    expect(prismaMock.raidTrackedClan.findMany).toHaveBeenCalledWith({
+      orderBy: [{ createdAt: "asc" }, { clanTag: "asc" }],
+      select: { name: true, clanTag: true },
+    });
+    expect(prismaMock.cwlTrackedClan.findMany).toHaveBeenCalledWith({
+      where: { season: expect.any(String) },
+      orderBy: [{ createdAt: "asc" }, { tag: "asc" }],
+      select: { name: true, tag: true },
+    });
     expect(interaction.respond).toHaveBeenCalledWith([
-      { name: "Alpha (#9GLGQCCU)", value: "#9GLGQCCU" },
+      { name: "Alpha FWA (#9GLGQCCU)", value: "#9GLGQCCU" },
+      { name: "CWL Gamma (#2QG2C08UP)", value: "#2QG2C08UP" },
+      { name: "Raid Beta (#2RVGJYLC0)", value: "#2RVGJYLC0" },
     ]);
   });
 


### PR DESCRIPTION
- union FWA, raid, and CWL tracked clans for roster clan autocomplete
- dedupe by normalized clan tag while keeping the best available display name