### PR TITLE
feat(roster): include clan names in manage autocomplete labels

### DIFF
--- a/src/commands/Roster.ts
+++ b/src/commands/Roster.ts
@@ -2044,13 +2044,84 @@ async function autocompleteRosterOption(interaction: AutocompleteInteraction): P
     name: focused,
   });
 
+  const clanNameByTag = await buildRosterAutocompleteClanNameMap(rosters);
+
   await interaction.respond(
-    rosters.slice(0, 25).map((roster) => ({
-      name: `${roster.title} • ${roster.clanTag ?? "no clan"} • ${buildRosterStateLabel(roster.lifecycleState)}`.slice(0, 100),
-      value: roster.id,
-      description: `Type ${roster.rosterType}${roster.rosterCategory ? ` / ${roster.rosterCategory}` : ""} • ${roster.postedMessageId ? "posted" : "unposted"} • ${roster.signupCount} signups`.slice(0, 100),
-    })),
+    rosters.slice(0, 25).map((roster) => {
+      const clanTag = normalizeClanTag(roster.clanTag ?? "") || null;
+      const clanName = clanTag ? clanNameByTag.get(clanTag) ?? null : null;
+      const labelParts = [roster.title];
+      if (clanName) {
+        labelParts.push(clanName);
+      }
+      if (clanTag) {
+        labelParts.push(clanTag);
+      }
+      labelParts.push(buildRosterStateLabel(roster.lifecycleState));
+      return {
+        name: labelParts.join(" • ").slice(0, 100),
+        value: roster.id,
+        description: `Type ${roster.rosterType}${roster.rosterCategory ? ` / ${roster.rosterCategory}` : ""} • ${roster.postedMessageId ? "posted" : "unposted"} • ${roster.signupCount} signups`.slice(0, 100),
+      };
+    }),
   );
+}
+
+async function buildRosterAutocompleteClanNameMap(
+  rosters: Array<Pick<RosterSummaryRecord, "clanTag">>,
+): Promise<Map<string, string>> {
+  const rosterTags = [...new Set(rosters.map((roster) => normalizeClanTag(roster.clanTag ?? "")).filter(Boolean))];
+  if (rosterTags.length <= 0) {
+    return new Map();
+  }
+
+  const season = resolveCurrentCwlSeasonKey();
+  const [trackedRows, raidRows, cwlRows] = await Promise.all([
+    prisma.trackedClan.findMany({
+      where: { tag: { in: rosterTags } },
+      orderBy: [{ createdAt: "asc" }, { tag: "asc" }],
+      select: { tag: true, name: true },
+    }),
+    prisma.raidTrackedClan.findMany({
+      where: {
+        clanTag: {
+          in: rosterTags.map((tag) => tag.replace(/^#/, "")),
+        },
+      },
+      orderBy: [{ createdAt: "asc" }, { clanTag: "asc" }],
+      select: { clanTag: true, name: true },
+    }),
+    prisma.cwlTrackedClan.findMany({
+      where: { season, tag: { in: rosterTags } },
+      orderBy: [{ createdAt: "asc" }, { tag: "asc" }],
+      select: { tag: true, name: true },
+    }),
+  ]);
+
+  const clanNameByTag = new Map<string, string>();
+  for (const row of trackedRows) {
+    const tag = normalizeClanTag(row.tag);
+    const name = normalizeRosterTrackedClanAutocompleteName(row.name);
+    if (tag && name && !clanNameByTag.has(tag)) {
+      clanNameByTag.set(tag, name);
+    }
+  }
+  for (const row of raidRows) {
+    const tag = normalizeClanTag(row.clanTag);
+    const name = normalizeRosterTrackedClanAutocompleteName(row.name);
+    if (tag && name && !clanNameByTag.has(tag)) {
+      clanNameByTag.set(tag, name);
+    }
+  }
+  for (const row of cwlRows) {
+    const tag = normalizeClanTag(row.tag);
+    const name = normalizeRosterTrackedClanAutocompleteName(row.name);
+    if (tag && name && !clanNameByTag.has(tag)) {
+      clanNameByTag.set(tag, name);
+    }
+  }
+
+  return clanNameByTag;
 }
 
 function normalizeRosterTrackedClanAutocompleteName(input: string | null | undefined): string | null {

--- a/tests/roster.command.test.ts
+++ b/tests/roster.command.test.ts
@@ -2084,6 +2084,115 @@ describe("/roster command", () => {
     ]);
   });
 
+  it("autocompletes roster picker labels with clan name between roster name and clan tag", async () => {
+    (rosterService.listGuildRosters as any).mockResolvedValue([
+      {
+        id: "roster-1",
+        guildId: "guild-1",
+        rosterType: "CWL",
+        rosterCategory: "signup",
+        title: "Roster One",
+        clanTag: "#9GLGQCCU",
+        startsAt: new Date("2026-04-20T00:00:00.000Z"),
+        endsAt: null,
+        timezone: "America/Los_Angeles",
+        displayTimezone: "America/Los_Angeles",
+        lifecycleState: "OPEN",
+        postedChannelId: null,
+        postedMessageId: null,
+        postedMessageUrl: null,
+        postedAt: null,
+        createdByDiscordUserId: "111111111111111111",
+        updatedByDiscordUserId: "111111111111111111",
+        createdAt: new Date("2026-04-20T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-20T00:00:00.000Z"),
+        groupCount: 0,
+        signupCount: 0,
+      },
+      {
+        id: "roster-2",
+        guildId: "guild-1",
+        rosterType: "FWA",
+        rosterCategory: "signup",
+        title: "Roster Two",
+        clanTag: "#2RVGJYLC0",
+        startsAt: new Date("2026-04-20T00:00:00.000Z"),
+        endsAt: null,
+        timezone: "America/Los_Angeles",
+        displayTimezone: "America/Los_Angeles",
+        lifecycleState: "ARCHIVED",
+        postedChannelId: null,
+        postedMessageId: null,
+        postedMessageUrl: null,
+        postedAt: null,
+        createdByDiscordUserId: "111111111111111111",
+        updatedByDiscordUserId: "111111111111111111",
+        createdAt: new Date("2026-04-20T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-20T00:00:00.000Z"),
+        groupCount: 0,
+        signupCount: 0,
+      },
+      {
+        id: "roster-3",
+        guildId: "guild-1",
+        rosterType: "CWL",
+        rosterCategory: "signup",
+        title: "Roster Three",
+        clanTag: null,
+        startsAt: new Date("2026-04-20T00:00:00.000Z"),
+        endsAt: null,
+        timezone: "America/Los_Angeles",
+        displayTimezone: "America/Los_Angeles",
+        lifecycleState: "CLOSED",
+        postedChannelId: null,
+        postedMessageId: null,
+        postedMessageUrl: null,
+        postedAt: null,
+        createdByDiscordUserId: "111111111111111111",
+        updatedByDiscordUserId: "111111111111111111",
+        createdAt: new Date("2026-04-20T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-20T00:00:00.000Z"),
+        groupCount: 0,
+        signupCount: 0,
+      },
+    ]);
+    prismaMock.trackedClan.findMany.mockResolvedValue([{ name: "Alpha Clan", tag: "#9GLGQCCU" }]);
+    prismaMock.raidTrackedClan.findMany.mockResolvedValue([{ name: "Raid Clan", clanTag: "2RVGJYLC0" }]);
+    prismaMock.cwlTrackedClan.findMany.mockResolvedValue([]);
+
+    const interaction = makeAutocompleteInteraction({
+      focusedName: "roster",
+      focusedValue: "",
+      subcommand: "manage",
+    }) as any;
+
+    await Roster.autocomplete(interaction);
+
+    expect(rosterService.listGuildRosters).toHaveBeenCalledWith(
+      expect.objectContaining({
+        guildId: "guild-1",
+        name: "",
+      }),
+    );
+    expect(interaction.respond).toHaveBeenCalledWith([
+      {
+        name: "Roster One • Alpha Clan • #9GLGQCCU • Open",
+        value: "roster-1",
+        description: expect.any(String),
+      },
+      {
+        name: "Roster Two • Raid Clan • #2RVGJYLC0 • Archived",
+        value: "roster-2",
+        description: expect.any(String),
+      },
+      {
+        name: "Roster Three • Closed",
+        value: "roster-3",
+        description: expect.any(String),
+      },
+    ]);
+  });
+
   it("autocompletes tracked clans across FWA, raid, and CWL sources without duplicates", async () => {
     prismaMock.trackedClan.findMany.mockResolvedValue([
       { name: "Alpha FWA", tag: "#9GLGQCCU" },


### PR DESCRIPTION
- show clan name between roster name and clan tag when available
- keep roster picker fallback clean when clan names are missing