### PR TITLE
fix(roster): render townhall icons and gate refresh buttons

### DIFF
--- a/src/commands/Cwl.ts
+++ b/src/commands/Cwl.ts
@@ -264,11 +264,16 @@ async function refreshRosterSignupPost(
   rosterId: string,
   cocService?: CoCService | null,
 ): Promise<void> {
-  const payload = cocService
-    ? await rosterService.refreshRosterSignupPayload(rosterId, cocService)
-    : await rosterService.buildRosterSignupPayload(rosterId);
   const rosterView = await rosterService.getRosterView(rosterId);
-  if (!payload || !rosterView?.roster.postedChannelId || !rosterView.roster.postedMessageId) {
+  if (!rosterView?.roster.postedChannelId || !rosterView.roster.postedMessageId) {
+    return;
+  }
+
+  const loadingPayload = await rosterService.buildRosterSignupPayload(rosterId, null, {
+    emojiClient: interaction.client,
+    refreshButtonDisabled: true,
+  });
+  if (!loadingPayload) {
     return;
   }
 
@@ -279,6 +284,34 @@ async function refreshRosterSignupPost(
 
   const message = await channel.messages.fetch(rosterView.roster.postedMessageId).catch(() => null);
   if (!message) return;
+  await message.edit({
+    embeds: [loadingPayload.embed],
+    components: loadingPayload.components,
+  }).catch(() => undefined);
+
+  const payload = cocService
+    ? await rosterService.refreshRosterSignupPayload(rosterId, cocService, {
+        emojiClient: interaction.client,
+        refreshButtonDisabled: false,
+      })
+    : await rosterService.buildRosterSignupPayload(rosterId, null, {
+        emojiClient: interaction.client,
+        refreshButtonDisabled: false,
+      });
+  if (!payload) {
+    const restoredPayload = await rosterService.buildRosterSignupPayload(rosterId, null, {
+      emojiClient: interaction.client,
+      refreshButtonDisabled: false,
+    });
+    if (restoredPayload) {
+      await message.edit({
+        embeds: [restoredPayload.embed],
+        components: restoredPayload.components,
+      }).catch(() => undefined);
+    }
+    return;
+  }
+
   await message.edit({
     embeds: [payload.embed],
     components: payload.components,
@@ -2226,7 +2259,9 @@ export async function handleRosterSignupSubcommand(
     cocService,
   });
 
-  const payload = await rosterService.buildRosterSignupPayload(roster.id);
+  const payload = await rosterService.buildRosterSignupPayload(roster.id, null, {
+    emojiClient: interaction.client,
+  });
   if (!payload) {
     await interaction.editReply("Failed to build the CWL signup post.");
     return;

--- a/src/commands/Roster.ts
+++ b/src/commands/Roster.ts
@@ -422,10 +422,12 @@ async function refreshExistingRosterPost(
     return false;
   }
 
-  const payload = await rosterService.refreshRosterSignupPayload(rosterId, cocService ?? null, {
+  const loadingPayload = await rosterService.buildRosterSignupPayload(rosterId, null, {
     discordDisplayNamesByUserId: buildRosterDiscordDisplayNameMap(interaction),
+    emojiClient: interaction.client,
+    refreshButtonDisabled: true,
   });
-  if (!payload) {
+  if (!loadingPayload) {
     return false;
   }
 
@@ -436,6 +438,31 @@ async function refreshExistingRosterPost(
 
   const message = await channel.messages.fetch(rosterView.roster.postedMessageId).catch(() => null);
   if (!message) {
+    return false;
+  }
+
+  await message.edit({
+    embeds: [loadingPayload.embed],
+    components: loadingPayload.components,
+  }).catch(() => undefined);
+
+  const payload = await rosterService.refreshRosterSignupPayload(rosterId, cocService ?? null, {
+    discordDisplayNamesByUserId: buildRosterDiscordDisplayNameMap(interaction),
+    emojiClient: interaction.client,
+    refreshButtonDisabled: false,
+  });
+  if (!payload) {
+    const restoredPayload = await rosterService.buildRosterSignupPayload(rosterId, null, {
+      discordDisplayNamesByUserId: buildRosterDiscordDisplayNameMap(interaction),
+      emojiClient: interaction.client,
+      refreshButtonDisabled: false,
+    });
+    if (restoredPayload) {
+      await message.edit({
+        embeds: [restoredPayload.embed],
+        components: restoredPayload.components,
+      }).catch(() => undefined);
+    }
     return false;
   }
 
@@ -465,6 +492,7 @@ async function postRosterSignupMessage(
 
   const payload = await rosterService.buildRosterSignupPayload(rosterId, cocService ?? null, {
     discordDisplayNamesByUserId: buildRosterDiscordDisplayNameMap(interaction),
+    emojiClient: interaction.client,
   });
   if (!payload) {
     return { outcome: "no_payload", postedMessageUrl: rosterView.roster.postedMessageUrl ?? null };
@@ -931,11 +959,42 @@ export async function handleRosterPostRefreshButtonInteraction(
 
   await interaction.deferUpdate();
 
+  const loadingPayload = await rosterService.buildRosterSignupPayload(parsed.rosterId, null, {
+    discordDisplayNamesByUserId: buildRosterDiscordDisplayNameMap(interaction),
+    emojiClient: interaction.client,
+    refreshButtonDisabled: true,
+  });
+  if (!loadingPayload) {
+    await interaction.editReply("That roster is no longer available.");
+    return;
+  }
+
+  await interaction.editReply({
+    embeds: [loadingPayload.embed],
+    components: loadingPayload.components,
+  });
+
   const payload = await rosterService.refreshRosterSignupPayload(parsed.rosterId, cocService, {
     discordDisplayNamesByUserId: buildRosterDiscordDisplayNameMap(interaction),
+    emojiClient: interaction.client,
+    refreshButtonDisabled: false,
   });
   if (!payload) {
-    await interaction.editReply("That roster is no longer available.");
+    const restoredPayload = await rosterService.buildRosterSignupPayload(parsed.rosterId, null, {
+      discordDisplayNamesByUserId: buildRosterDiscordDisplayNameMap(interaction),
+      emojiClient: interaction.client,
+      refreshButtonDisabled: false,
+    });
+    if (restoredPayload) {
+      await interaction.editReply({
+        embeds: [restoredPayload.embed],
+        components: restoredPayload.components,
+      });
+    }
+    await interaction.followUp({
+      content: "That roster is no longer available.",
+      ephemeral: true,
+    }).catch(() => undefined);
     return;
   }
 

--- a/src/services/RosterService.ts
+++ b/src/services/RosterService.ts
@@ -2,6 +2,7 @@ import {
   ActionRowBuilder,
   ButtonBuilder,
   ButtonStyle,
+  Client,
   EmbedBuilder,
   StringSelectMenuBuilder,
 } from "discord.js";
@@ -9,6 +10,7 @@ import { randomUUID } from "crypto";
 import { CoCService } from "./CoCService";
 import { prisma } from "../prisma";
 import { truncateDiscordContent } from "../helper/discordContent";
+import { emojiResolverService } from "./emoji/EmojiResolverService";
 import {
   listPlayerLinksForClanMembers,
   listPlayerLinksForDiscordUser,
@@ -146,6 +148,11 @@ export type RosterSignupPayload = {
 export type RosterSelectionMode = "signup" | "remove";
 
 type RosterPostButtonMode = "standard" | "hidden" | "archived";
+
+type RosterSignupPayloadBuildOptions = RosterViewLoadOptions & {
+  emojiClient?: Client | null;
+  refreshButtonDisabled?: boolean;
+};
 
 export type RosterSelectionOption = {
   value: string;
@@ -1781,7 +1788,7 @@ const ROSTER_BOARD_COLUMN_LIMITS: Record<RosterDisplayColumn, number> = {
 
 const ROSTER_BOARD_COLUMN_HEADERS: Record<RosterDisplayColumn, string> = {
   [ROSTER_DISPLAY_COLUMNS.TH_LEVEL]: "TH",
-  [ROSTER_DISPLAY_COLUMNS.TOWNHALL_ICONS]: "TH ICONS",
+  [ROSTER_DISPLAY_COLUMNS.TOWNHALL_ICONS]: ":house:",
   [ROSTER_DISPLAY_COLUMNS.INDEX]: "INDEX",
   [ROSTER_DISPLAY_COLUMNS.DISCORD_NAME]: "DISCORD",
   [ROSTER_DISPLAY_COLUMNS.DISCORD_USERNAME]: "USERNAME",
@@ -1921,6 +1928,33 @@ function buildRosterBoardLine(
     .join(" ");
 }
 
+function buildRosterBoardDisplayLine(
+  columns: readonly RosterDisplayColumn[],
+  values: Record<RosterDisplayColumn, string | null>,
+  widths: Record<RosterDisplayColumn, number>,
+): string {
+  const townhallIconColumnIndex = columns.indexOf(ROSTER_DISPLAY_COLUMNS.TOWNHALL_ICONS);
+  if (townhallIconColumnIndex < 0) {
+    return `\`${buildRosterBoardLine(columns, values, widths)}\``;
+  }
+
+  const parts: string[] = [];
+  const prefixColumns = columns.slice(0, townhallIconColumnIndex);
+  const suffixColumns = columns.slice(townhallIconColumnIndex + 1);
+
+  if (prefixColumns.length > 0) {
+    parts.push(`\`${buildRosterBoardLine(prefixColumns, values, widths)}\``);
+  }
+
+  parts.push(formatRosterBoardCell(values[ROSTER_DISPLAY_COLUMNS.TOWNHALL_ICONS], widths[ROSTER_DISPLAY_COLUMNS.TOWNHALL_ICONS]));
+
+  if (suffixColumns.length > 0) {
+    parts.push(`\`${buildRosterBoardLine(suffixColumns, values, widths)}\``);
+  }
+
+  return parts.join(" ");
+}
+
 function buildRosterBoardHeaderLine(
   columns: readonly RosterDisplayColumn[],
   widths: Record<RosterDisplayColumn, number>,
@@ -1929,7 +1963,7 @@ function buildRosterBoardHeaderLine(
     RosterDisplayColumn,
     string | null
   >;
-  return buildRosterBoardLine(columns, values, widths);
+  return buildRosterBoardDisplayLine(columns, values, widths);
 }
 
 function buildRosterBoardRowLine(
@@ -1941,7 +1975,7 @@ function buildRosterBoardRowLine(
   const values = Object.fromEntries(
     columns.map((column) => [column, getRosterDisplayColumnValue(signup, column, rowIndex)] as const),
   ) as Record<RosterDisplayColumn, string | null>;
-  return buildRosterBoardLine(columns, values, widths);
+  return buildRosterBoardDisplayLine(columns, values, widths);
 }
 
 function buildRosterBoardRowLines(
@@ -1955,14 +1989,22 @@ function buildRosterBoardRowLines(
   }
   let rowIndex = startIndex;
   const lines = signups.map((signup) => {
-    const line = `\`${buildRosterBoardRowLine(signup, columns, widths, rowIndex)}\``;
+    const line = buildRosterBoardRowLine(signup, columns, widths, rowIndex);
     rowIndex += 1;
     return line;
   });
   return { lines, nextIndex: rowIndex };
 }
 
-function buildRosterSignupPayloadFromView(view: RosterSignupView): RosterSignupPayload {
+async function renderRosterBoardShortcodes(text: string, client?: Client | null): Promise<string> {
+  if (!client) return text;
+  return emojiResolverService.replaceShortcodes(client, text).catch(() => text);
+}
+
+async function buildRosterSignupPayloadFromView(
+  view: RosterSignupView,
+  options?: RosterSignupPayloadBuildOptions,
+): Promise<RosterSignupPayload> {
   const title = normalizeRosterText(view.clanDisplayName ?? null) ?? normalizeClanTag(view.roster.clanTag ?? "") ?? "Roster";
   const groups = buildRosterGroupsWithSignups(view);
   const columns =
@@ -1976,7 +2018,7 @@ function buildRosterSignupPayloadFromView(view: RosterSignupView): RosterSignupP
   const lines: string[] = [
     rosterLabel,
     "",
-    `\`${buildRosterBoardHeaderLine(columns, widths)}\``,
+    buildRosterBoardHeaderLine(columns, widths),
   ];
 
   let rowIndex = 1;
@@ -1994,12 +2036,14 @@ function buildRosterSignupPayloadFromView(view: RosterSignupView): RosterSignupP
   lines.push("");
   lines.push(`Total ${view.totalSignupCount}/${maxMembersLabel} | Min. TH ${minTownHallLabel}`);
 
+  const renderedDescription = await renderRosterBoardShortcodes(lines.join("\n"), options?.emojiClient ?? null);
   const embed = new EmbedBuilder()
     .setColor(0xfee75c)
     .setTitle(title)
-    .setDescription(truncateDiscordContent(lines.join("\n"), 4096));
+    .setDescription(truncateDiscordContent(renderedDescription, 4096));
 
   const buttonMode = normalizeRosterPostButtonMode(view.roster.postButtonMode);
+  const refreshButtonDisabled = options?.refreshButtonDisabled ?? false;
   const buttonRows: ActionRowBuilder<ButtonBuilder>[] = [];
   if (buttonMode !== "archived") {
     const rowButtons: ButtonBuilder[] = [
@@ -2008,6 +2052,7 @@ function buildRosterSignupPayloadFromView(view: RosterSignupView): RosterSignupP
         .setEmoji("🔄")
         .setStyle(ButtonStyle.Secondary),
     ];
+    rowButtons[0].setDisabled(refreshButtonDisabled);
     if (buttonMode === "standard") {
       rowButtons.push(
         new ButtonBuilder()
@@ -2511,17 +2556,17 @@ export class RosterService {
   async buildRosterSignupPayload(
     rosterId: string,
     _cocService?: CoCService | null,
-    options?: RosterViewLoadOptions,
+    options?: RosterSignupPayloadBuildOptions,
   ): Promise<RosterSignupPayload | null> {
     const view = await loadRosterView(rosterId, options);
     if (!view) return null;
-    return buildRosterSignupPayloadFromView(view);
+    return buildRosterSignupPayloadFromView(view, options);
   }
 
   async refreshRosterSignupPayload(
     rosterId: string,
     cocService?: CoCService | null,
-    options?: RosterViewLoadOptions,
+    options?: RosterSignupPayloadBuildOptions,
   ): Promise<RosterSignupPayload | null> {
     const roster = await prisma.roster.findUnique({
       where: { id: rosterId },

--- a/tests/cwl.command.test.ts
+++ b/tests/cwl.command.test.ts
@@ -213,6 +213,21 @@ function makeParticipationCounts(entries: Array<[string, number]>): Map<string, 
   return new Map(entries);
 }
 
+function makeRosterRefreshPayload(refreshDisabled: boolean, title: string) {
+  return {
+    embed: new EmbedBuilder().setTitle(title),
+    components: [
+      new ActionRowBuilder<ButtonBuilder>().addComponents(
+        new ButtonBuilder()
+          .setCustomId("roster-post-action:refresh:roster-1")
+          .setLabel("Refresh")
+          .setStyle(ButtonStyle.Secondary)
+          .setDisabled(refreshDisabled),
+      ),
+    ],
+  };
+}
+
 describe("/cwl command", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -238,6 +253,14 @@ describe("/cwl command", () => {
     vi.spyOn(rosterService, "moveRosterSignups");
     vi.spyOn(rosterService, "removeRosterSignupsAsManager");
     vi.spyOn(rosterService, "buildRosterManagerReadinessText");
+    (rosterService.buildRosterSignupPayload as any).mockResolvedValue({
+      embed: new EmbedBuilder().setTitle("Roster Signup"),
+      components: [],
+    });
+    (rosterService.refreshRosterSignupPayload as any).mockResolvedValue({
+      embed: new EmbedBuilder().setTitle("Roster Signup"),
+      components: [],
+    });
     vi.spyOn(cwlRotationSheetService, "buildImportPreview");
     vi.spyOn(cwlRotationSheetService, "confirmImport");
     vi.spyOn(cwlRotationSheetService, "exportActivePlans");
@@ -740,9 +763,20 @@ describe("/cwl command", () => {
       createdAt: new Date("2026-04-20T00:00:00.000Z"),
       updatedAt: new Date("2026-04-20T00:00:00.000Z"),
     });
+    (rosterService.buildRosterSignupPayload as any).mockResolvedValue(
+      makeRosterRefreshPayload(true, "CWL Alpha Signup (Loading)"),
+    );
     (rosterService.refreshRosterSignupPayload as any).mockResolvedValue({
       embed: new EmbedBuilder().setTitle("CWL Alpha Signup"),
-      components: [],
+      components: [
+        new ActionRowBuilder<ButtonBuilder>().addComponents(
+          new ButtonBuilder()
+            .setCustomId("roster-post-action:refresh:roster-1")
+            .setLabel("Refresh")
+            .setStyle(ButtonStyle.Secondary)
+            .setDisabled(false),
+        ),
+      ],
     });
     (rosterService.getRosterView as any).mockResolvedValue({
       roster: {
@@ -797,11 +831,35 @@ describe("/cwl command", () => {
 
     expect(channelFetch).toHaveBeenCalledWith("channel-1");
     expect(messageFetch).toHaveBeenCalledWith("message-1");
-    expect(messageEdit).toHaveBeenCalledWith(
+    expect(rosterService.buildRosterSignupPayload).toHaveBeenCalledWith(
+      "roster-1",
+      null,
       expect.objectContaining({
-        embeds: [expect.any(EmbedBuilder)],
+        refreshButtonDisabled: true,
       }),
     );
+    expect(rosterService.refreshRosterSignupPayload).toHaveBeenCalledWith(
+      "roster-1",
+      expect.anything(),
+      expect.objectContaining({
+        refreshButtonDisabled: false,
+      }),
+    );
+    expect(messageEdit).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        embeds: [expect.any(EmbedBuilder)],
+        components: [expect.any(ActionRowBuilder)],
+      }),
+    );
+    expect(messageEdit.mock.calls[0]?.[0]?.components?.[0]?.toJSON?.().components?.[0]?.disabled).toBe(true);
+    expect(messageEdit).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        embeds: [expect.any(EmbedBuilder)],
+        components: [expect.any(ActionRowBuilder)],
+      }),
+    );
+    expect(messageEdit.mock.calls.at(-1)?.[0]?.components?.[0]?.toJSON?.().components?.[0]?.disabled).toBe(false);
     expect(String(interaction.editReply.mock.calls.at(-1)?.[0] ?? "")).toContain(
       "Refreshed the posted CWL roster for CWL Alpha.",
     );

--- a/tests/roster.command.test.ts
+++ b/tests/roster.command.test.ts
@@ -180,6 +180,21 @@ function getEditedEmbed(interaction: any): any {
   return payload?.embeds?.[0]?.toJSON?.() ?? null;
 }
 
+function makeRosterRefreshPayload(refreshDisabled: boolean, title: string) {
+  return {
+    embed: new EmbedBuilder().setTitle(title),
+    components: [
+      new ActionRowBuilder<ButtonBuilder>().addComponents(
+        new ButtonBuilder()
+          .setCustomId("roster-post-action:refresh:roster-1")
+          .setLabel("Refresh")
+          .setStyle(ButtonStyle.Secondary)
+          .setDisabled(refreshDisabled),
+      ),
+    ],
+  };
+}
+
 describe("/roster command", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -213,6 +228,12 @@ describe("/roster command", () => {
     vi.spyOn(rosterService, "removeRosterSignupsAsManager");
     vi.spyOn(rosterWeightService, "setManualWeightForRoster");
     vi.spyOn(rosterExportService, "createRosterExport");
+    (rosterService.buildRosterSignupPayload as any).mockResolvedValue(
+      makeRosterRefreshPayload(false, "Roster Signup"),
+    );
+    (rosterService.refreshRosterSignupPayload as any).mockResolvedValue(
+      makeRosterRefreshPayload(false, "Roster Signup"),
+    );
   });
 
   it("creates a roster object without posting it immediately", async () => {
@@ -1460,10 +1481,12 @@ describe("/roster command", () => {
   });
 
   it("refreshes the posted roster from the service-owned current-clan refresh path", async () => {
-    (rosterService.refreshRosterSignupPayload as any).mockResolvedValue({
-      embed: new EmbedBuilder().setTitle("CWL Alpha Signup (Refreshed)"),
-      components: [],
-    });
+    (rosterService.buildRosterSignupPayload as any).mockResolvedValueOnce(
+      makeRosterRefreshPayload(true, "CWL Alpha Signup (Loading)"),
+    );
+    (rosterService.refreshRosterSignupPayload as any).mockResolvedValueOnce(
+      makeRosterRefreshPayload(false, "CWL Alpha Signup (Refreshed)"),
+    );
     const deferUpdate = vi.fn().mockResolvedValue(undefined);
     const update = vi.fn().mockResolvedValue(undefined);
     const editReply = vi.fn().mockResolvedValue(undefined);
@@ -1485,24 +1508,46 @@ describe("/roster command", () => {
 
     expect(deferUpdate).toHaveBeenCalledTimes(1);
     expect(deferUpdate.mock.invocationCallOrder[0]).toBeLessThan(
-      (rosterService.refreshRosterSignupPayload as any).mock.invocationCallOrder[0],
+      (rosterService.buildRosterSignupPayload as any).mock.invocationCallOrder[0],
+    );
+    expect(rosterService.buildRosterSignupPayload).toHaveBeenCalledWith(
+      "roster-1",
+      null,
+      expect.objectContaining({
+        emojiClient: interaction.client,
+        refreshButtonDisabled: true,
+      }),
     );
     expect(rosterService.refreshRosterSignupPayload).toHaveBeenCalledWith(
       "roster-1",
       expect.anything(),
-      expect.anything(),
-    );
-    expect(editReply).toHaveBeenCalledWith(
       expect.objectContaining({
-        embeds: [expect.any(EmbedBuilder)],
-        components: [],
+        emojiClient: interaction.client,
+        refreshButtonDisabled: false,
       }),
     );
+    expect(editReply).toHaveBeenCalledTimes(2);
+    const loadingPayload = editReply.mock.calls[0]?.[0] as any;
+    const finalPayload = editReply.mock.calls.at(-1)?.[0] as any;
+    expect(loadingPayload).toEqual(
+      expect.objectContaining({
+        embeds: [expect.any(EmbedBuilder)],
+        components: [expect.any(ActionRowBuilder)],
+      }),
+    );
+    expect(loadingPayload.components[0]?.toJSON?.().components?.[0]?.disabled).toBe(true);
+    expect(finalPayload).toEqual(
+      expect.objectContaining({
+        embeds: [expect.any(EmbedBuilder)],
+        components: [expect.any(ActionRowBuilder)],
+      }),
+    );
+    expect(finalPayload.components[0]?.toJSON?.().components?.[0]?.disabled).toBe(false);
     expect(update).not.toHaveBeenCalled();
   });
 
   it("acknowledges the refresh button before reporting a missing roster", async () => {
-    (rosterService.refreshRosterSignupPayload as any).mockResolvedValue(null);
+    (rosterService.buildRosterSignupPayload as any).mockResolvedValue(null);
     const deferUpdate = vi.fn().mockResolvedValue(undefined);
     const editReply = vi.fn().mockResolvedValue(undefined);
     const interaction = {
@@ -1521,11 +1566,8 @@ describe("/roster command", () => {
     await handleRosterPostRefreshButtonInteraction(interaction, {} as any);
 
     expect(deferUpdate).toHaveBeenCalledTimes(1);
-    expect(rosterService.refreshRosterSignupPayload).toHaveBeenCalledWith(
-      "roster-1",
-      expect.anything(),
-      expect.anything(),
-    );
+    expect(rosterService.buildRosterSignupPayload).toHaveBeenCalledWith("roster-1", null, expect.anything());
+    expect(rosterService.refreshRosterSignupPayload).not.toHaveBeenCalled();
     expect(editReply).toHaveBeenCalledWith("That roster is no longer available.");
   });
 
@@ -1933,6 +1975,9 @@ describe("/roster command", () => {
       createdAt: new Date("2026-04-20T00:00:00.000Z"),
       updatedAt: new Date("2026-04-20T00:00:00.000Z"),
     });
+    (rosterService.buildRosterSignupPayload as any).mockResolvedValue(
+      makeRosterRefreshPayload(true, "CWL Alpha Signup (Loading)"),
+    );
     (rosterService.refreshRosterSignupPayload as any).mockResolvedValue({
       embed: new EmbedBuilder().setTitle("CWL Alpha Signup (Updated)"),
       components: [],
@@ -2018,7 +2063,20 @@ describe("/roster command", () => {
       guildId: "guild-1",
       rosterId: "roster-1",
     });
-    expect(rosterService.refreshRosterSignupPayload).toHaveBeenCalledWith("roster-1", null, expect.anything());
+    expect(rosterService.buildRosterSignupPayload).toHaveBeenCalledWith(
+      "roster-1",
+      null,
+      expect.objectContaining({
+        refreshButtonDisabled: true,
+      }),
+    );
+    expect(rosterService.refreshRosterSignupPayload).toHaveBeenCalledWith(
+      "roster-1",
+      null,
+      expect.objectContaining({
+        refreshButtonDisabled: false,
+      }),
+    );
     expect(String(refreshInteraction.editReply.mock.calls.at(-1)?.[0] ?? "")).toContain("Refreshed the posted roster for CWL Alpha Signup.");
 
     (rosterService.deleteRoster as any).mockResolvedValue({

--- a/tests/roster.service.test.ts
+++ b/tests/roster.service.test.ts
@@ -68,6 +68,29 @@ const todoSnapshotServiceMock = vi.hoisted(() => ({
   refreshSnapshotsForPlayerTags: vi.fn(),
 }));
 
+function makeRosterEmojiClient() {
+  const makeEmoji = (name: string, rendered: string) => ({
+    id: `${name}-id`,
+    name,
+    animated: false,
+    toString: () => rendered,
+  });
+
+  const emojis = new Map([
+    ["house", makeEmoji("house", "<:house:111>")],
+    ["th18", makeEmoji("th18", "<:th18:118>")],
+  ]);
+
+  return {
+    application: {
+      fetch: vi.fn().mockResolvedValue(undefined),
+      emojis: {
+        fetch: vi.fn().mockResolvedValue(emojis),
+      },
+    },
+  } as any;
+}
+
 vi.mock("../src/prisma", () => ({
   prisma: prismaMock,
 }));
@@ -1472,7 +1495,9 @@ describe("RosterService", () => {
     ] as any);
     prismaMock.cwlTrackedClan.findFirst.mockResolvedValueOnce(null as any);
 
-    const payload = await rosterService.buildRosterSignupPayload("roster-1");
+    const payload = await rosterService.buildRosterSignupPayload("roster-1", null, {
+      emojiClient: makeRosterEmojiClient(),
+    });
     const description = payload?.embed.toJSON().description ?? "";
     const lines = description.split("\n");
     const headerLine = lines.find((line) => line.startsWith("`PLAYER")) ?? "";
@@ -1482,12 +1507,12 @@ describe("RosterService", () => {
     const alphaRow = lines.find((line) => line.startsWith("`") && line.includes("Alpha")) ?? "";
 
     expect(headerLine).toContain("PLAYER");
-    expect(headerLine).toContain("TH ICONS");
+    expect(headerLine).toContain("<:house:111>");
     expect(headerLine).toContain("INDEX");
     expect(alphaRowIndex).toBeGreaterThan(-1);
     expect(bravoRowIndex).toBeGreaterThan(-1);
     expect(alphaRowIndex).toBeLessThan(bravoRowIndex);
-    expect(bravoRow).toContain(":th18:");
+    expect(bravoRow).toContain("<:th18:118>");
     expect(alphaRow).toContain("8");
     expect(alphaRow).toContain("1");
     expect(bravoRow).toContain("2");


### PR DESCRIPTION
- split Townhall Icons out of code blocks so app emojis render
- disable refresh during roster rebuilds and restore it on completion