### PR TITLE
feat(roster): add ephemeral add/remove confirmation feedback

### DIFF
--- a/src/commands/Roster.ts
+++ b/src/commands/Roster.ts
@@ -302,6 +302,65 @@ function buildRosterRemoveResultSummary(
   return `Removed ${removed}${ignored}.`;
 }
 
+function normalizeRosterMutationLabel(value: string | null | undefined, fallback: string): string {
+  const normalized = String(value ?? "")
+    .replace(/\s+/g, " ")
+    .trim();
+  return normalized || fallback;
+}
+
+function buildRosterMutationConfirmationLine(
+  action: "add" | "remove",
+  account: { playerTag: string; playerName: string | null },
+  rosterName: string,
+  clanName: string,
+): string {
+  const verb = action === "add" ? "Added" : "Removed";
+  const direction = action === "add" ? "to" : "from";
+  const playerName = normalizeRosterMutationLabel(account.playerName, account.playerTag);
+  return `${verb} ${playerName} (${account.playerTag}) ${direction} ${rosterName} - ${clanName}`;
+}
+
+async function buildRosterMutationConfirmationContent(
+  action: "add" | "remove",
+  result: Awaited<ReturnType<typeof rosterService.addRosterSignupsForManager>> | Awaited<ReturnType<typeof rosterService.removeRosterSignupsAsManager>>,
+): Promise<string> {
+  const addResult = result as Awaited<ReturnType<typeof rosterService.addRosterSignupsForManager>>;
+  const removeResult = result as Awaited<ReturnType<typeof rosterService.removeRosterSignupsAsManager>>;
+  const summary =
+    action === "add"
+      ? buildRosterSignupResultSummary(addResult)
+      : buildRosterRemoveResultSummary(removeResult);
+  const rosterView = await rosterService.getRosterView(result.rosterId).catch(() => null);
+  if (!rosterView) {
+    return summary;
+  }
+
+  const rosterName = normalizeRosterMutationLabel(rosterView.roster.title, "Roster");
+  const clanName = normalizeRosterMutationLabel(
+    rosterView.clanDisplayName ?? normalizeClanTag(rosterView.roster.clanTag ?? "") ?? null,
+    "Unknown Clan",
+  );
+  const accounts =
+    action === "add"
+      ? addResult.createdAccounts
+      : removeResult.removedAccounts;
+  if (accounts.length <= 0) {
+    return summary;
+  }
+
+  const lines = accounts.map((account) =>
+    buildRosterMutationConfirmationLine(action, account, rosterName, clanName),
+  );
+  const hasMixedFailure =
+    action === "add" ? addResult.duplicateTags.length > 0 : removeResult.notOwnedTags.length > 0;
+  if (!hasMixedFailure) {
+    return lines.join("\n");
+  }
+
+  return `${lines.join("\n")}\n\n${summary}`;
+}
+
 function formatRosterListClanLine(clanName: string | null, clanTag: string | null): string {
   const normalizedClanName = String(clanName ?? "")
     .replace(/\s+/g, " ")
@@ -1550,8 +1609,9 @@ export async function handleRosterPostSettingsActionButtonInteraction(
   if (result.outcome === "add_user") {
     await syncRosterRoleAssignments(interaction.client, result.result.rosterId).catch(() => undefined);
     await refreshExistingRosterPost(interaction as unknown as ChatInputCommandInteraction, result.result.rosterId, cocService ?? null).catch(() => undefined);
+    const confirmationContent = await buildRosterMutationConfirmationContent("add", result.result);
     await interaction.editReply({
-      content: buildRosterSignupResultSummary(result.result),
+      content: confirmationContent,
       embeds: [],
       components: [],
     });
@@ -1561,8 +1621,9 @@ export async function handleRosterPostSettingsActionButtonInteraction(
   if (result.outcome === "remove_user") {
     await syncRosterRoleAssignments(interaction.client, result.result.rosterId).catch(() => undefined);
     await refreshExistingRosterPost(interaction as unknown as ChatInputCommandInteraction, result.result.rosterId, cocService ?? null).catch(() => undefined);
+    const confirmationContent = await buildRosterMutationConfirmationContent("remove", result.result);
     await interaction.editReply({
-      content: buildRosterRemoveResultSummary(result.result),
+      content: confirmationContent,
       embeds: [],
       components: [],
     });

--- a/src/services/RosterService.ts
+++ b/src/services/RosterService.ts
@@ -319,6 +319,7 @@ export type SignupLinkedAccountsResult =
       requestedTags: string[];
       linkedTags: string[];
       createdTags: string[];
+      createdAccounts: RosterAccountIdentity[];
       duplicateTags: string[];
       missingLinkedTags: string[];
     }
@@ -330,6 +331,7 @@ export type SignupLinkedAccountsResult =
       requestedTags: string[];
       linkedTags: string[];
       createdTags: string[];
+      createdAccounts: RosterAccountIdentity[];
       duplicateTags: string[];
       missingLinkedTags: string[];
       blockedTags: string[];
@@ -342,6 +344,7 @@ export type SignupLinkedAccountsResult =
       requestedTags: string[];
       linkedTags: string[];
       createdTags: string[];
+      createdAccounts: RosterAccountIdentity[];
       duplicateTags: string[];
       missingLinkedTags: string[];
       blockedTags: string[];
@@ -354,6 +357,7 @@ export type SignupLinkedAccountsResult =
       requestedTags: string[];
       linkedTags: string[];
       createdTags: string[];
+      createdAccounts: RosterAccountIdentity[];
       duplicateTags: string[];
       missingLinkedTags: string[];
       blockedTags: string[];
@@ -367,6 +371,7 @@ export type SignupLinkedAccountsResult =
       requestedTags: string[];
       linkedTags: string[];
       createdTags: string[];
+      createdAccounts: RosterAccountIdentity[];
       duplicateTags: string[];
       missingLinkedTags: string[];
       blockedTags: string[];
@@ -380,6 +385,7 @@ export type SignupLinkedAccountsResult =
       requestedTags: string[];
       linkedTags: string[];
       createdTags: string[];
+      createdAccounts: RosterAccountIdentity[];
       duplicateTags: string[];
       missingLinkedTags: string[];
       blockedTags: string[];
@@ -393,6 +399,7 @@ export type SignupLinkedAccountsResult =
       requestedTags: string[];
       linkedTags: string[];
       createdTags: string[];
+      createdAccounts: RosterAccountIdentity[];
       duplicateTags: string[];
       missingLinkedTags: string[];
     }
@@ -404,6 +411,7 @@ export type SignupLinkedAccountsResult =
       requestedTags: string[];
       linkedTags: string[];
       createdTags: string[];
+      createdAccounts: RosterAccountIdentity[];
       duplicateTags: string[];
       missingLinkedTags: string[];
     }
@@ -415,6 +423,7 @@ export type SignupLinkedAccountsResult =
       requestedTags: string[];
       linkedTags: string[];
       createdTags: string[];
+      createdAccounts: RosterAccountIdentity[];
       duplicateTags: string[];
       missingLinkedTags: string[];
     }
@@ -426,6 +435,7 @@ export type SignupLinkedAccountsResult =
       requestedTags: string[];
       linkedTags: string[];
       createdTags: string[];
+      createdAccounts: RosterAccountIdentity[];
       duplicateTags: string[];
       missingLinkedTags: string[];
     }
@@ -437,6 +447,7 @@ export type SignupLinkedAccountsResult =
       requestedTags: string[];
       linkedTags: string[];
       createdTags: string[];
+      createdAccounts: RosterAccountIdentity[];
       duplicateTags: string[];
       missingLinkedTags: string[];
     }
@@ -448,6 +459,7 @@ export type SignupLinkedAccountsResult =
       requestedTags: string[];
       linkedTags: string[];
       createdTags: string[];
+      createdAccounts: RosterAccountIdentity[];
       duplicateTags: string[];
       missingLinkedTags: string[];
     };
@@ -457,6 +469,7 @@ export type RemoveRosterSignupsResult =
       outcome: "removed";
       rosterId: string;
       removedTags: string[];
+      removedAccounts: RosterAccountIdentity[];
       ignoredTags: string[];
       notOwnedTags: string[];
     }
@@ -464,6 +477,7 @@ export type RemoveRosterSignupsResult =
       outcome: "nothing_removed";
       rosterId: string;
       removedTags: string[];
+      removedAccounts: RosterAccountIdentity[];
       ignoredTags: string[];
       notOwnedTags: string[];
     }
@@ -471,6 +485,7 @@ export type RemoveRosterSignupsResult =
       outcome: "roster_not_found";
       rosterId: string;
       removedTags: string[];
+      removedAccounts: RosterAccountIdentity[];
       ignoredTags: string[];
       notOwnedTags: string[];
     }
@@ -478,6 +493,7 @@ export type RemoveRosterSignupsResult =
       outcome: "roster_archived";
       rosterId: string;
       removedTags: string[];
+      removedAccounts: RosterAccountIdentity[];
       ignoredTags: string[];
       notOwnedTags: string[];
     };
@@ -3557,6 +3573,7 @@ export class RosterService {
         requestedTags,
         linkedTags: [],
         createdTags: [],
+        createdAccounts: [],
         duplicateTags: [],
         missingLinkedTags: requestedTags,
       };
@@ -3570,6 +3587,7 @@ export class RosterService {
         requestedTags,
         linkedTags: [],
         createdTags: [],
+        createdAccounts: [],
         duplicateTags: [],
         missingLinkedTags: requestedTags,
       };
@@ -3604,6 +3622,7 @@ export class RosterService {
         requestedTags,
         linkedTags,
         createdTags: [],
+        createdAccounts: [],
         duplicateTags: [],
         missingLinkedTags,
       };
@@ -3618,6 +3637,7 @@ export class RosterService {
         requestedTags,
         linkedTags: [],
         createdTags: [],
+        createdAccounts: [],
         duplicateTags: [],
         missingLinkedTags,
       };
@@ -3686,6 +3706,7 @@ export class RosterService {
           requestedTags,
           linkedTags,
           createdTags: [],
+          createdAccounts: [],
           duplicateTags,
           missingLinkedTags,
           blockedTags: blockedUnavailableTags,
@@ -3701,6 +3722,7 @@ export class RosterService {
           requestedTags,
           linkedTags,
           createdTags: [],
+          createdAccounts: [],
           duplicateTags,
           missingLinkedTags,
           blockedTags: blockedOutOfRangeTags,
@@ -3724,6 +3746,13 @@ export class RosterService {
         skipDuplicates: true,
       });
     }
+    const createdAccounts = createdTags.map((playerTag) => {
+      const linked = linkedByTag.get(playerTag) ?? null;
+      return {
+        playerTag,
+        playerName: normalizeRosterText(linked?.playerName ?? null),
+      };
+    });
 
     return {
       outcome: createdTags.length > 0 ? "created" : "already_signed_up",
@@ -3733,6 +3762,7 @@ export class RosterService {
       requestedTags,
       linkedTags,
       createdTags,
+      createdAccounts,
       duplicateTags,
       missingLinkedTags,
     };
@@ -3851,6 +3881,7 @@ export class RosterService {
         outcome: "nothing_removed",
         rosterId: input.rosterId,
         removedTags: [],
+        removedAccounts: [],
         ignoredTags: [],
         notOwnedTags: [],
       };
@@ -3861,6 +3892,7 @@ export class RosterService {
         outcome: "roster_not_found",
         rosterId: input.rosterId,
         removedTags: [],
+        removedAccounts: [],
         ignoredTags: selectedTags,
         notOwnedTags: [],
       };
@@ -4315,6 +4347,7 @@ export class RosterService {
         requestedTags,
         linkedTags: selectedTags,
         createdTags: [],
+        createdAccounts: [],
         duplicateTags: [],
         missingLinkedTags,
       };
@@ -4329,6 +4362,7 @@ export class RosterService {
         requestedTags,
         linkedTags: selectedTags,
         createdTags: [],
+        createdAccounts: [],
         duplicateTags: [],
         missingLinkedTags,
       };
@@ -4343,6 +4377,7 @@ export class RosterService {
         requestedTags,
         linkedTags: selectedTags,
         createdTags: [],
+        createdAccounts: [],
         duplicateTags: [],
         missingLinkedTags,
       };
@@ -4357,6 +4392,7 @@ export class RosterService {
         requestedTags,
         linkedTags: [],
         createdTags: [],
+        createdAccounts: [],
         duplicateTags: [],
         missingLinkedTags,
       } as const;
@@ -4390,6 +4426,7 @@ export class RosterService {
           requestedTags,
           linkedTags: selectedTags,
           createdTags: [],
+          createdAccounts: [],
           duplicateTags,
           missingLinkedTags,
           blockedTags: createdCandidates,
@@ -4416,6 +4453,7 @@ export class RosterService {
             requestedTags,
             linkedTags: selectedTags,
             createdTags: [],
+            createdAccounts: [],
             duplicateTags,
             missingLinkedTags,
             blockedTags: createdCandidates,
@@ -4474,6 +4512,7 @@ export class RosterService {
             requestedTags,
             linkedTags: selectedTags,
             createdTags: [],
+            createdAccounts: [],
             duplicateTags,
             missingLinkedTags,
             blockedTags: blockedUnavailableTags,
@@ -4489,6 +4528,7 @@ export class RosterService {
             requestedTags,
             linkedTags: selectedTags,
             createdTags: [],
+            createdAccounts: [],
             duplicateTags,
             missingLinkedTags,
             blockedTags: blockedOutOfRangeTags,
@@ -4522,6 +4562,7 @@ export class RosterService {
           requestedTags,
           linkedTags: selectedTags,
           createdTags: [],
+          createdAccounts: [],
           duplicateTags,
           missingLinkedTags,
           blockedTags: conflictingTags,
@@ -4607,17 +4648,26 @@ export class RosterService {
       },
       select: {
         playerTag: true,
+        playerName: true,
       },
     });
     const ownedTags = [...new Set(ownedEntries.map((entry) => normalizePlayerTag(entry.playerTag)).filter(Boolean))];
     const ownedTagSet = new Set(ownedTags);
     const notOwnedTags = selectedTags.filter((tag) => !ownedTagSet.has(tag));
+    const ownedAccounts = ownedTags.map((playerTag) => {
+      const ownedEntry = ownedEntries.find((entry) => normalizePlayerTag(entry.playerTag) === playerTag) ?? null;
+      return {
+        playerTag,
+        playerName: normalizeRosterText(ownedEntry?.playerName ?? null),
+      };
+    });
 
     if (ownedTags.length <= 0) {
       return {
         outcome: "nothing_removed",
         rosterId: roster.id,
         removedTags: [],
+        removedAccounts: [],
         ignoredTags: selectedTags,
         notOwnedTags,
       };
@@ -4635,6 +4685,7 @@ export class RosterService {
       outcome: deleteResult.count > 0 ? "removed" : "nothing_removed",
       rosterId: roster.id,
       removedTags: ownedTags,
+      removedAccounts: ownedAccounts,
       ignoredTags: selectedTags.filter((tag) => !ownedTagSet.has(tag)),
       notOwnedTags,
     };

--- a/tests/roster.command.test.ts
+++ b/tests/roster.command.test.ts
@@ -27,6 +27,7 @@ import {
   handleRosterManageWeightModalSubmit,
   handleRosterPostRefreshButtonInteraction,
   handleRosterPostSettingsButtonInteraction,
+  handleRosterPostSettingsActionButtonInteraction,
   handleRosterPostSettingsMenuInteraction,
 } from "../src/commands/Roster";
 import { rosterService } from "../src/services/RosterService";
@@ -1109,6 +1110,93 @@ describe("/roster command", () => {
       );
     },
   );
+
+  it.each([
+    {
+      action: "add_user" as const,
+      customId: "roster-post-users:action:confirm:session-1",
+      result: {
+        outcome: "created" as const,
+        rosterId: "roster-1",
+        groupKey: "confirmed",
+        groupName: "Confirmed",
+        requestedTags: ["#PQL0289", "#QGRJ2222"],
+        linkedTags: ["#PQL0289", "#QGRJ2222"],
+        createdTags: ["#PQL0289", "#QGRJ2222"],
+        createdAccounts: [
+          { playerTag: "#PQL0289", playerName: "Alpha" },
+          { playerTag: "#QGRJ2222", playerName: "Bravo" },
+        ],
+        duplicateTags: [],
+        missingLinkedTags: [],
+      },
+      expectedContent:
+        "Added Alpha (#PQL0289) to CWL Alpha Signup - CWL Alpha\nAdded Bravo (#QGRJ2222) to CWL Alpha Signup - CWL Alpha",
+    },
+    {
+      action: "remove_user" as const,
+      customId: "roster-post-users:action:confirm:session-2",
+      result: {
+        outcome: "removed" as const,
+        rosterId: "roster-1",
+        removedTags: ["#PQL0289", "#QGRJ2222"],
+        removedAccounts: [
+          { playerTag: "#PQL0289", playerName: "Alpha" },
+          { playerTag: "#QGRJ2222", playerName: "Bravo" },
+        ],
+        ignoredTags: [],
+        notOwnedTags: [],
+      },
+      expectedContent:
+        "Removed Alpha (#PQL0289) from CWL Alpha Signup - CWL Alpha\nRemoved Bravo (#QGRJ2222) from CWL Alpha Signup - CWL Alpha",
+    },
+  ])("confirms Settings -> %s with ephemeral success feedback", async ({ action, customId, result, expectedContent }) => {
+    (rosterService.confirmRosterSelectionPanel as any).mockResolvedValue({
+      outcome: action,
+      result,
+    });
+    (rosterService.getRosterView as any).mockResolvedValue({
+      roster: {
+        id: "roster-1",
+        title: "CWL Alpha Signup",
+        clanTag: "#2QG2C08UP",
+        postedChannelId: null,
+        postedMessageId: null,
+        rosterRoleId: null,
+      },
+      clanDisplayName: "CWL Alpha",
+      groups: [],
+      signups: [],
+      totalSignupCount: 0,
+    });
+
+    const interaction = {
+      customId,
+      user: { id: "111111111111111111" },
+      guildId: "guild-1",
+      inGuild: () => true,
+      memberPermissions: {
+        has: vi.fn().mockReturnValue(true),
+      },
+      deferUpdate: vi.fn().mockResolvedValue(undefined),
+      editReply: vi.fn().mockResolvedValue(undefined),
+      followUp: vi.fn().mockResolvedValue(undefined),
+      client: {
+        channels: {
+          fetch: vi.fn().mockResolvedValue(null),
+        },
+      },
+    } as any;
+
+    await handleRosterPostSettingsActionButtonInteraction(interaction);
+
+    expect(rosterService.confirmRosterSelectionPanel).toHaveBeenCalledWith({
+      sessionId: customId.split(":").at(-1),
+      discordUserId: "111111111111111111",
+      cocService: null,
+    });
+    expect(String(interaction.editReply.mock.calls.at(-1)?.[0]?.content ?? "")).toBe(expectedContent);
+  });
 
   it("opens the roster customization panel when Settings -> Customize is selected", async () => {
     (rosterService.findGuildRosterById as any).mockResolvedValue({

--- a/tests/roster.service.test.ts
+++ b/tests/roster.service.test.ts
@@ -173,7 +173,7 @@ describe("RosterService", () => {
   }
 
   beforeEach(() => {
-    vi.clearAllMocks();
+    vi.resetAllMocks();
     prismaMock.$transaction.mockImplementation(async (callback: (tx: typeof prismaMock) => Promise<unknown>) =>
       callback(prismaMock as any),
     );
@@ -2445,8 +2445,8 @@ describe("RosterService", () => {
           { playerTag: "#QGRJ2222", groupId: "group-confirmed" },
         ] as any)
         .mockResolvedValueOnce([
-          { playerTag: "#PQL0289" },
-          { playerTag: "#QGRJ2222" },
+          { playerTag: "#PQL0289", playerName: "Alpha" },
+          { playerTag: "#QGRJ2222", playerName: "Bravo" },
         ] as any);
       prismaMock.rosterSignup.createMany.mockResolvedValue({ count: 2 });
       prismaMock.rosterSignup.updateMany.mockResolvedValue({ count: 1 });
@@ -2488,6 +2488,10 @@ describe("RosterService", () => {
         outcome: "created",
         linkedTags: ["#PQL0289", "#QGRJ2222"],
         createdTags: ["#PQL0289", "#QGRJ2222"],
+        createdAccounts: [
+          { playerTag: "#PQL0289", playerName: "Alpha" },
+          { playerTag: "#QGRJ2222", playerName: "Bravo" },
+        ],
         duplicateTags: [],
         missingLinkedTags: [],
       });


### PR DESCRIPTION
- include per-player success lines for roster post add/remove confirmations
- preserve posted roster refresh while reusing service result metadata