### PR TITLE
feat(roster): add ping preview and confirm flow

### DIFF
--- a/src/commands/Roster.ts
+++ b/src/commands/Roster.ts
@@ -38,6 +38,7 @@ import {
   parseRosterPostRefreshButtonCustomId,
   parseRosterPostSettingsButtonCustomId,
   parseRosterPostSettingsMenuCustomId,
+  parseRosterPingActionButtonCustomId,
   parseRosterPostUsersActionButtonCustomId,
   parseRosterPostUsersGroupSelectMenuCustomId,
   parseRosterPostUsersPlayerSelectMenuCustomId,
@@ -129,6 +130,15 @@ function buildRosterLifecycleSummary(roster: RosterRecord, lifecycleState: Roste
         ? "closed"
         : "archived";
   return `${roster.title} was ${label}.`;
+}
+
+function normalizeRosterPingOptionChoice(input: string | null | undefined): string | null {
+  const normalized = String(input ?? "").trim().toLowerCase();
+  if (!normalized) return null;
+  if (normalized === "unregistered" || normalized === "missing" || normalized === "everyone") {
+    return normalized;
+  }
+  return null;
 }
 
 function describeRosterDisplayColumns(columns: string[] | null | undefined): string {
@@ -1649,6 +1659,60 @@ export async function handleRosterPostSettingsActionButtonInteraction(
   });
 }
 
+export async function handleRosterPingActionButtonInteraction(interaction: ButtonInteraction): Promise<void> {
+  const parsed = parseRosterPingActionButtonCustomId(interaction.customId);
+  if (!parsed) return;
+
+  await interaction.deferUpdate().catch(() => undefined);
+  const result = await rosterService.confirmRosterPingSelectionPanel({
+    sessionId: parsed.sessionId,
+    discordUserId: interaction.user.id,
+  });
+
+  if (result.outcome === "session_not_found") {
+    await interaction.followUp({
+      content: "That roster ping preview has expired. Please start again.",
+      ephemeral: true,
+    }).catch(() => undefined);
+    return;
+  }
+  if (result.outcome === "forbidden") {
+    await interaction.followUp({
+      content: "Only the original requester can use this roster ping preview.",
+      ephemeral: true,
+    }).catch(() => undefined);
+    return;
+  }
+
+  const channel = interaction.channel;
+  if (!channel?.isTextBased() || !("send" in channel)) {
+    await interaction.editReply({
+      content: "Could not post the ping to this channel.",
+      embeds: [],
+      components: [],
+    }).catch(() => undefined);
+    return;
+  }
+
+  try {
+    await channel.send({
+      content: result.messageContent,
+    });
+    await interaction.editReply({
+      content: `Posted ping for ${result.targetCount} player${result.targetCount === 1 ? "" : "s"}.`,
+      embeds: [],
+      components: [],
+    });
+  } catch (error) {
+    console.error(`[roster] ping_post_failed error=${formatError(error)}`);
+    await interaction.editReply({
+      content: "Failed to post the ping to the channel.",
+      embeds: [],
+      components: [],
+    }).catch(() => undefined);
+  }
+}
+
 function formatRosterManageWeightK(weight: number): string {
   return `${Math.trunc(weight / 1000)}k`;
 }
@@ -2171,6 +2235,52 @@ async function handleRosterReportSubcommand(interaction: ChatInputCommandInterac
 
 async function handleRosterReadinessSubcommand(interaction: ChatInputCommandInteraction): Promise<void> {
   await handleRosterReportSubcommand(interaction);
+}
+
+async function handleRosterPingSubcommand(interaction: ChatInputCommandInteraction): Promise<void> {
+  if (!interaction.inGuild() || !interaction.guildId) {
+    await interaction.editReply("This command can only be used in a server.");
+    return;
+  }
+
+  if (!(await canUseRosterPostTarget(interaction, "roster:manage"))) {
+    await interaction.editReply("You do not have permission to manage this roster.");
+    return;
+  }
+
+  const roster = await resolveRosterForGuild(interaction, interaction.options.getString("roster", true));
+  if (!roster) {
+    return;
+  }
+
+  const pingOption = normalizeRosterPingOptionChoice(interaction.options.getString("ping_option", false)) ?? "everyone";
+  const message = interaction.options.getString("message", false)?.trim() ?? null;
+  const groupKey = interaction.options.getString("group", false);
+  const panel = await rosterService.createRosterPingSelectionPanel({
+    rosterId: roster.id,
+    discordUserId: interaction.user.id,
+    pingOption,
+    groupKey,
+    message,
+  });
+
+  if (panel.outcome === "roster_not_found") {
+    await interaction.editReply("That roster is no longer available.");
+    return;
+  }
+  if (panel.outcome === "group_not_found") {
+    await interaction.editReply("That roster group is no longer available.");
+    return;
+  }
+  if (panel.outcome === "no_targets") {
+    await interaction.editReply("No linked roster members matched that ping selection.");
+    return;
+  }
+
+  await interaction.editReply({
+    embeds: [panel.panel.embed],
+    components: panel.panel.components,
+  });
 }
 
 async function handleRosterRefreshSubcommand(
@@ -3011,6 +3121,44 @@ export const Roster: Command = {
       ],
     },
     {
+      name: "ping",
+      description: "Preview and ping roster-related members",
+      type: ApplicationCommandOptionType.Subcommand,
+      options: [
+        {
+          name: "roster",
+          description: "Roster to ping from",
+          type: ApplicationCommandOptionType.String,
+          required: true,
+          autocomplete: true,
+        },
+        {
+          name: "message",
+          description: "Optional custom ping message",
+          type: ApplicationCommandOptionType.String,
+          required: false,
+        },
+        {
+          name: "ping_option",
+          description: "Who to ping",
+          type: ApplicationCommandOptionType.String,
+          required: false,
+          choices: [
+            { name: "Unregistered", value: "unregistered" },
+            { name: "Missing", value: "missing" },
+            { name: "Everyone", value: "everyone" },
+          ],
+        },
+        {
+          name: "group",
+          description: "Restrict to a roster group",
+          type: ApplicationCommandOptionType.String,
+          required: false,
+          autocomplete: true,
+        },
+      ],
+    },
+    {
       name: "manage",
       description: "Mutate roster signups or lifecycle state",
       type: ApplicationCommandOptionType.Subcommand,
@@ -3249,6 +3397,10 @@ export const Roster: Command = {
       }
       if (subcommand === "post") {
         await handleRosterPostSubcommand(interaction, cocService);
+        return;
+      }
+      if (subcommand === "ping") {
+        await handleRosterPingSubcommand(interaction);
         return;
       }
       if (subcommand === "manage") {

--- a/src/commands/Roster.ts
+++ b/src/commands/Roster.ts
@@ -1695,9 +1695,11 @@ export async function handleRosterPingActionButtonInteraction(interaction: Butto
   }
 
   try {
-    await channel.send({
-      content: result.messageContent,
-    });
+    for (const content of result.messageContents) {
+      await channel.send({
+        content,
+      });
+    }
     await interaction.editReply({
       content: `Posted ping for ${result.targetCount} player${result.targetCount === 1 ? "" : "s"}.`,
       embeds: [],

--- a/src/listeners/interactionCreate.ts
+++ b/src/listeners/interactionCreate.ts
@@ -113,6 +113,7 @@ import {
 } from "../commands/Cwl";
 import {
   handleRosterPostSettingsActionButtonInteraction,
+  handleRosterPingActionButtonInteraction,
   handleRosterPostSettingsGroupSelectInteraction,
   handleRosterPostSettingsPlayerSelectInteraction,
   handleRosterPostSettingsUserSelectInteraction,
@@ -142,6 +143,7 @@ import {
   isRosterPostRefreshButtonCustomId,
   isRosterPostSettingsButtonCustomId,
   isRosterPostSettingsMenuCustomId,
+  isRosterPingActionButtonCustomId,
   isRosterPostUsersActionButtonCustomId,
   isRosterPostUsersGroupSelectMenuCustomId,
   isRosterPostUsersPlayerSelectMenuCustomId,
@@ -785,6 +787,21 @@ const handleButtonInteraction = async (
         await interaction.reply({
           ephemeral: true,
           content: "Failed to update roster settings.",
+        });
+      }
+    }
+    return;
+  }
+
+  if (isRosterPingActionButtonCustomId(interaction.customId)) {
+    try {
+      await handleRosterPingActionButtonInteraction(interaction);
+    } catch (err) {
+      console.error(`Roster ping confirmation button failed: ${formatError(err)}`);
+      if (!interaction.replied && !interaction.deferred) {
+        await interaction.reply({
+          ephemeral: true,
+          content: "Failed to post the roster ping.",
         });
       }
     }

--- a/src/services/RosterService.ts
+++ b/src/services/RosterService.ts
@@ -245,7 +245,7 @@ export type RosterPingConfirmResult =
       outcome: "posted";
       rosterId: string;
       targetCount: number;
-      messageContent: string;
+      messageContents: string[];
     }
   | { outcome: "session_not_found"; sessionId: string }
   | { outcome: "forbidden"; sessionId: string };
@@ -1593,17 +1593,96 @@ function buildRosterPingPreviewLines(session: RosterPingSession): string[] {
   return lines;
 }
 
-function buildRosterPingPublicMessageContent(session: RosterPingSession): string {
+const ROSTER_PING_MESSAGE_LIMIT = 2000;
+
+function splitRosterPingMessageLine(line: string, maxLength: number): string[] {
+  const normalized = String(line ?? "");
+  if (normalized.length <= maxLength) {
+    return [normalized];
+  }
+  const segments: string[] = [];
+  for (let index = 0; index < normalized.length; index += maxLength) {
+    segments.push(normalized.slice(index, index + maxLength));
+  }
+  return segments;
+}
+
+function buildRosterPingPublicMessageContents(session: RosterPingSession): string[] {
   const headerLabel = `${session.rosterTitle} - ${session.clanName} (${session.clanTag})`;
-  const lines = [buildClanProfileMarkdownLink(headerLabel, session.clanTag)];
-  for (const target of session.targets) {
-    lines.push(buildRosterPingTargetLine(target));
-  }
+  const headerLine = buildClanProfileMarkdownLink(headerLabel, session.clanTag);
+  const messageLines: string[] = [];
   if (session.message) {
-    lines.push("");
-    lines.push(session.message);
+    messageLines.push("");
+    messageLines.push("Message:");
+    for (const line of String(session.message).split(/\r?\n/)) {
+      messageLines.push(...splitRosterPingMessageLine(line, ROSTER_PING_MESSAGE_LIMIT - headerLine.length - 1));
+    }
+    messageLines.push("");
   }
-  return truncateDiscordContent(lines.join("\n"), 2000);
+  const targetLines = session.targets.map((target) => buildRosterPingTargetLine(target));
+
+  const chunks: string[] = [];
+  let currentLines: string[] = [headerLine];
+  let currentLength = headerLine.length;
+
+  const flush = (): void => {
+    if (currentLines.length > 0) {
+      chunks.push(currentLines.join("\n"));
+    }
+    currentLines = [headerLine];
+    currentLength = headerLine.length;
+  };
+
+  const appendLine = (line: string, allowSplit = false): void => {
+    const lineText = String(line ?? "");
+    const nextLength = currentLength + 1 + lineText.length;
+    if (nextLength <= ROSTER_PING_MESSAGE_LIMIT) {
+      currentLines.push(lineText);
+      currentLength = nextLength;
+      return;
+    }
+
+    if (currentLines.length > 1) {
+      flush();
+      appendLine(lineText, allowSplit);
+      return;
+    }
+
+    if (!allowSplit || lineText.length <= 0) {
+      currentLines.push(lineText);
+      currentLength = nextLength;
+      return;
+    }
+
+    const available = Math.max(1, ROSTER_PING_MESSAGE_LIMIT - currentLength - 1);
+    const segments = splitRosterPingMessageLine(lineText, available);
+    if (segments.length <= 1) {
+      currentLines.push(lineText);
+      currentLength = nextLength;
+      return;
+    }
+    for (const segment of segments) {
+      const segmentLength = currentLength + 1 + segment.length;
+      if (segmentLength > ROSTER_PING_MESSAGE_LIMIT && currentLines.length > 1) {
+        flush();
+      }
+      currentLines.push(segment);
+      currentLength = currentLines.join("\n").length;
+    }
+  };
+
+  for (const line of messageLines) {
+    appendLine(line, true);
+  }
+  for (const line of targetLines) {
+    appendLine(line, false);
+  }
+
+  if (currentLines.length > 1 || chunks.length <= 0) {
+    chunks.push(currentLines.join("\n"));
+  }
+
+  return chunks.filter((chunk) => chunk.length > 0 && chunk.length <= ROSTER_PING_MESSAGE_LIMIT);
 }
 
 function buildRosterPingSelectionPayload(session: RosterPingSession): RosterPingSelectionPanel {
@@ -4525,7 +4604,7 @@ export class RosterService {
       outcome: "posted",
       rosterId: session.rosterId,
       targetCount: session.targets.length,
-      messageContent: buildRosterPingPublicMessageContent(session),
+      messageContents: buildRosterPingPublicMessageContents(session),
     };
   }
 

--- a/src/services/RosterService.ts
+++ b/src/services/RosterService.ts
@@ -63,6 +63,7 @@ export const ROSTER_SELECTION_PREFIX = "roster-selection";
 export const ROSTER_POST_ACTION_PREFIX = "roster-post-action";
 export const ROSTER_POST_SETTINGS_PREFIX = "roster-post-settings";
 export const ROSTER_POST_USERS_PREFIX = "roster-post-users";
+export const ROSTER_PING_PREFIX = "roster-ping";
 const ROSTER_MANAGER_PLAYER_PAGE_ROW_COUNT = 3;
 const ROSTER_SELECTION_SESSION_TTL_MS = 15 * 60 * 1000;
 const ROSTER_CONFLICT_LIFECYCLE_STATES: readonly RosterLifecycleState[] = [
@@ -176,6 +177,22 @@ export type RosterSelectionPanel = {
   selectedTags: string[];
 };
 
+export type RosterPingOption = "unregistered" | "missing" | "everyone";
+
+export type RosterPingTargetRecord = {
+  playerTag: string;
+  playerName: string;
+  discordUserId: string;
+  discordMention: string;
+};
+
+export type RosterPingSelectionPanel = {
+  sessionId: string;
+  embed: EmbedBuilder;
+  components: ActionRowBuilder<ButtonBuilder>[];
+  targetCount: number;
+};
+
 export type RosterSelectionOpenResult =
   | { outcome: "ready"; panel: RosterSelectionPanel }
   | { outcome: "roster_not_found"; rosterId: string }
@@ -216,6 +233,22 @@ type RosterSelectionSignupLoadResult =
 type RosterSelectionRemoveLoadResult =
   | RosterSelectionRemoveLoadReadyResult
   | RosterSelectionLoadErrorResult;
+
+export type RosterPingOpenResult =
+  | { outcome: "ready"; panel: RosterPingSelectionPanel }
+  | { outcome: "roster_not_found"; rosterId: string }
+  | { outcome: "group_not_found"; rosterId: string; groupKey: string }
+  | { outcome: "no_targets"; rosterId: string; pingOption: RosterPingOption; groupKey: string | null };
+
+export type RosterPingConfirmResult =
+  | {
+      outcome: "posted";
+      rosterId: string;
+      targetCount: number;
+      messageContent: string;
+    }
+  | { outcome: "session_not_found"; sessionId: string }
+  | { outcome: "forbidden"; sessionId: string };
 
 export type RosterSelectionUpdateResult =
   | { outcome: "updated"; panel: RosterSelectionPanel }
@@ -1039,6 +1072,10 @@ function buildRosterPostUsersActionButtonCustomId(
   return `${ROSTER_POST_USERS_PREFIX}:action:${action}:${String(sessionId ?? "").trim()}`;
 }
 
+function buildRosterPingActionButtonCustomId(sessionId: string): string {
+  return `${ROSTER_PING_PREFIX}:confirm:${String(sessionId ?? "").trim()}`;
+}
+
 export function buildRosterPostActionButtonCustomId(action: "refresh" | "signup" | "optout" | "settings", rosterId: string): string {
   return `${ROSTER_POST_ACTION_PREFIX}:${action}:${String(rosterId ?? "").trim()}`;
 }
@@ -1094,6 +1131,51 @@ function getRosterSelectionSession(sessionId: string): RosterSelectionSession | 
 
 function deleteRosterSelectionSession(sessionId: string): void {
   rosterSelectionSessions.delete(sessionId);
+}
+
+type RosterPingSession = {
+  sessionId: string;
+  rosterId: string;
+  rosterTitle: string;
+  clanName: string;
+  clanTag: string;
+  pingOption: RosterPingOption;
+  groupKey: string | null;
+  groupName: string | null;
+  message: string | null;
+  ownerDiscordUserId: string;
+  createdAtMs: number;
+  targets: RosterPingTargetRecord[];
+};
+
+const rosterPingSessions = new Map<string, RosterPingSession>();
+
+function pruneExpiredRosterPingSessions(nowMs = Date.now()): void {
+  for (const [sessionId, session] of rosterPingSessions.entries()) {
+    if (session.createdAtMs + ROSTER_SELECTION_SESSION_TTL_MS <= nowMs) {
+      rosterPingSessions.delete(sessionId);
+    }
+  }
+}
+
+function createRosterPingSession(input: Omit<RosterPingSession, "sessionId" | "createdAtMs">): RosterPingSession {
+  const session: RosterPingSession = {
+    ...input,
+    sessionId: randomUUID().replace(/-/g, "").slice(0, 18),
+    createdAtMs: Date.now(),
+  };
+  rosterPingSessions.set(session.sessionId, session);
+  pruneExpiredRosterPingSessions();
+  return session;
+}
+
+function getRosterPingSession(sessionId: string): RosterPingSession | null {
+  pruneExpiredRosterPingSessions();
+  return rosterPingSessions.get(sessionId) ?? null;
+}
+
+function deleteRosterPingSession(sessionId: string): void {
+  rosterPingSessions.delete(sessionId);
 }
 
 function buildRosterSelectionDescription(input: {
@@ -1469,6 +1551,81 @@ function buildRosterSelectionPayload(session: RosterSelectionSession): RosterSel
     embed,
     components,
     selectedTags,
+  };
+}
+
+function normalizeRosterPingOption(input: string | null | undefined): RosterPingOption | null {
+  const normalized = String(input ?? "")
+    .trim()
+    .toLowerCase();
+  if (!normalized) return null;
+  if (normalized === "unregistered" || normalized === "missing" || normalized === "everyone") {
+    return normalized;
+  }
+  return null;
+}
+
+function buildRosterPingTargetLine(target: RosterPingTargetRecord, includeBullet = false): string {
+  const prefix = includeBullet ? "- " : "";
+  return `${prefix}${target.playerName} (${target.playerTag}) ${target.discordMention}`;
+}
+
+function buildRosterPingPreviewLines(session: RosterPingSession): string[] {
+  const lines: string[] = [
+    `Roster: ${session.rosterTitle}`,
+    `Clan: ${session.clanName} (${session.clanTag})`,
+    `Ping option: ${session.pingOption}`,
+    `Targets: ${session.targets.length}`,
+  ];
+  if (session.groupName) {
+    lines.push(`Group: ${session.groupName}${session.pingOption === "unregistered" ? " (not applied)" : ""}`);
+  }
+  if (session.message) {
+    lines.push("");
+    lines.push("Message:");
+    lines.push(session.message);
+  }
+  if (session.targets.length > 0) {
+    lines.push("");
+    lines.push("Targets:");
+    lines.push(...session.targets.map((target) => buildRosterPingTargetLine(target, true)));
+  }
+  return lines;
+}
+
+function buildRosterPingPublicMessageContent(session: RosterPingSession): string {
+  const headerLabel = `${session.rosterTitle} - ${session.clanName} (${session.clanTag})`;
+  const lines = [buildClanProfileMarkdownLink(headerLabel, session.clanTag)];
+  for (const target of session.targets) {
+    lines.push(buildRosterPingTargetLine(target));
+  }
+  if (session.message) {
+    lines.push("");
+    lines.push(session.message);
+  }
+  return truncateDiscordContent(lines.join("\n"), 2000);
+}
+
+function buildRosterPingSelectionPayload(session: RosterPingSession): RosterPingSelectionPanel {
+  const embed = new EmbedBuilder()
+    .setColor(0x5865f2)
+    .setTitle(`Ping preview for ${session.rosterTitle}`)
+    .setDescription(truncateDiscordContent(buildRosterPingPreviewLines(session).join("\n"), 4096));
+
+  const components = [
+    new ActionRowBuilder<ButtonBuilder>().addComponents(
+      new ButtonBuilder()
+        .setCustomId(buildRosterPingActionButtonCustomId(session.sessionId))
+        .setLabel("Confirm and ping")
+        .setStyle(ButtonStyle.Success),
+    ),
+  ];
+
+  return {
+    sessionId: session.sessionId,
+    embed,
+    components,
+    targetCount: session.targets.length,
   };
 }
 
@@ -2041,6 +2198,97 @@ function buildRosterManagerReadinessLines(view: RosterManagerReadinessView): str
   return lines;
 }
 
+async function loadRosterPingTargets(input: {
+  rosterId: string;
+  pingOption: RosterPingOption;
+  groupKey: string | null;
+}): Promise<
+  | {
+      outcome: "ready";
+      roster: RosterRecord;
+      clanName: string;
+      groupKey: string | null;
+      groupName: string | null;
+      targets: RosterPingTargetRecord[];
+    }
+  | { outcome: "roster_not_found"; rosterId: string }
+  | { outcome: "group_not_found"; rosterId: string; groupKey: string }
+> {
+  const view = await loadRosterView(input.rosterId);
+  if (!view) {
+    return { outcome: "roster_not_found", rosterId: input.rosterId };
+  }
+
+  const normalizedGroupKey = input.groupKey ? normalizeRosterGroupKey(input.groupKey) : null;
+  const group = normalizedGroupKey
+    ? view.groups.find((entry) => entry.key === normalizedGroupKey) ?? null
+    : null;
+  if (normalizedGroupKey && !group) {
+    return { outcome: "group_not_found", rosterId: view.roster.id, groupKey: normalizedGroupKey };
+  }
+
+  const [trackedClanRoster, signupLinks] = await Promise.all([
+    loadRosterManagerTrackedClanMembers(view.roster),
+    listPlayerLinksForClanMembers({
+      memberTagsInOrder: view.signups.map((signup) => signup.playerTag),
+    }),
+  ]);
+  const signupTagSet = new Set(view.signups.map((signup) => normalizePlayerTag(signup.playerTag)).filter(Boolean));
+  const trackedTagSet = new Set(trackedClanRoster.map((member) => normalizePlayerTag(member.playerTag)).filter(Boolean));
+  const signupLinkByTag = new Map(signupLinks.map((link) => [link.playerTag, link] as const));
+
+  const signupsByGroup = view.signups.filter((signup) => {
+    if (!normalizedGroupKey) return true;
+    return signup.group?.key === normalizedGroupKey;
+  });
+
+  const targets: RosterPingTargetRecord[] =
+    input.pingOption === "unregistered"
+      ? trackedClanRoster
+          .filter((member) => member.linkedDiscordUserId && !signupTagSet.has(member.playerTag))
+          .map((member) => ({
+            playerTag: member.playerTag,
+            playerName: normalizeRosterText(member.playerName) ?? member.playerTag,
+            discordUserId: member.linkedDiscordUserId as string,
+            discordMention: `<@${member.linkedDiscordUserId}>`,
+          }))
+      : input.pingOption === "missing"
+        ? signupsByGroup
+            .filter((signup) => !trackedTagSet.has(signup.playerTag))
+            .map((signup) => {
+              const link = signupLinkByTag.get(signup.playerTag) ?? null;
+              if (!link?.discordUserId) return null;
+              return {
+                playerTag: signup.playerTag,
+                playerName: normalizeRosterText(signup.playerName ?? null) ?? signup.playerTag,
+                discordUserId: link.discordUserId,
+                discordMention: `<@${link.discordUserId}>`,
+              } as RosterPingTargetRecord;
+            })
+            .filter((target): target is RosterPingTargetRecord => Boolean(target))
+        : signupsByGroup
+            .map((signup) => {
+              const link = signupLinkByTag.get(signup.playerTag) ?? null;
+              if (!link?.discordUserId) return null;
+              return {
+                playerTag: signup.playerTag,
+                playerName: normalizeRosterText(signup.playerName ?? null) ?? signup.playerTag,
+                discordUserId: link.discordUserId,
+                discordMention: `<@${link.discordUserId}>`,
+              } as RosterPingTargetRecord;
+            })
+            .filter((target): target is RosterPingTargetRecord => Boolean(target));
+
+  return {
+    outcome: "ready",
+    roster: view.roster,
+    clanName: normalizeRosterText(view.clanDisplayName ?? null) ?? normalizeRosterText(view.roster.title) ?? view.roster.clanTag ?? "Roster",
+    groupKey: group?.key ?? null,
+    groupName: group?.name ?? null,
+    targets,
+  };
+}
+
 function buildRosterGroupsWithSignups(view: RosterSignupView): Array<
   RosterGroupRecord & {
     signupCount: number;
@@ -2123,7 +2371,7 @@ function formatRosterBoardWeightValue(weight: number | null | undefined): string
   return `${Math.trunc(normalized / 1000)}k`;
 }
 
-function buildClanProfileMarkdownLink(clanName: string | null, clanTag: string | null): string {
+export function buildClanProfileMarkdownLink(clanName: string | null, clanTag: string | null): string {
   const normalizedClanTag = normalizeClanTag(clanTag ?? "");
   const label = sanitizeRosterBoardText(clanName) || normalizedClanTag || "Unknown Clan";
   if (!normalizedClanTag) return label;
@@ -2741,6 +2989,10 @@ export function isRosterPostUsersActionButtonCustomId(customId: string): boolean
   return String(customId ?? "").startsWith(`${ROSTER_POST_USERS_PREFIX}:action:`);
 }
 
+export function isRosterPingActionButtonCustomId(customId: string): boolean {
+  return String(customId ?? "").startsWith(`${ROSTER_PING_PREFIX}:confirm:`);
+}
+
 export function parseRosterPostUsersUserSelectMenuCustomId(customId: string): { sessionId: string } | null {
   const parts = String(customId ?? "").split(":");
   if (parts.length !== 3 || parts[0] !== ROSTER_POST_USERS_PREFIX || parts[1] !== "user") {
@@ -2784,6 +3036,15 @@ export function parseRosterPostUsersActionButtonCustomId(
   }
   const sessionId = parts[3]?.trim() ?? "";
   return sessionId ? { action, sessionId } : null;
+}
+
+export function parseRosterPingActionButtonCustomId(customId: string): { sessionId: string } | null {
+  const parts = String(customId ?? "").split(":");
+  if (parts.length !== 3 || parts[0] !== ROSTER_PING_PREFIX || parts[1] !== "confirm") {
+    return null;
+  }
+  const sessionId = parts[2]?.trim() ?? "";
+  return sessionId ? { sessionId } : null;
 }
 
 export class RosterService {
@@ -4109,6 +4370,51 @@ export class RosterService {
     };
   }
 
+  async createRosterPingSelectionPanel(input: {
+    rosterId: string;
+    discordUserId: string;
+    pingOption?: string | null;
+    groupKey?: string | null;
+    message?: string | null;
+  }): Promise<RosterPingOpenResult> {
+    const pingOption = normalizeRosterPingOption(input.pingOption) ?? "everyone";
+    const selectedGroupKey = input.groupKey ? normalizeRosterGroupKey(input.groupKey) : null;
+    const loaded = await loadRosterPingTargets({
+      rosterId: input.rosterId,
+      pingOption,
+      groupKey: selectedGroupKey,
+    });
+    if (loaded.outcome !== "ready") {
+      return loaded;
+    }
+    if (loaded.targets.length <= 0) {
+      return {
+        outcome: "no_targets",
+        rosterId: loaded.roster.id,
+        pingOption,
+        groupKey: loaded.groupKey,
+      };
+    }
+
+    const session = createRosterPingSession({
+      rosterId: loaded.roster.id,
+      rosterTitle: loaded.roster.title,
+      clanName: loaded.clanName,
+      clanTag: normalizeRosterText(loaded.roster.clanTag ?? null) ?? loaded.roster.clanTag ?? "unknown",
+      pingOption,
+      groupKey: loaded.groupKey,
+      groupName: loaded.groupName,
+      message: String(input.message ?? "").trim() || null,
+      ownerDiscordUserId: normalizeDiscordUserId(input.discordUserId) ?? input.discordUserId,
+      targets: loaded.targets,
+    });
+
+    return {
+      outcome: "ready",
+      panel: buildRosterPingSelectionPayload(session),
+    };
+  }
+
   async updateRosterSelectionPanel(input: {
     sessionId: string;
     discordUserId: string;
@@ -4198,6 +4504,28 @@ export class RosterService {
     return {
       outcome: "updated",
       panel: buildRosterSelectionPayload(session),
+    };
+  }
+
+  async confirmRosterPingSelectionPanel(input: {
+    sessionId: string;
+    discordUserId: string;
+  }): Promise<RosterPingConfirmResult> {
+    const session = getRosterPingSession(input.sessionId);
+    if (!session) {
+      return { outcome: "session_not_found", sessionId: input.sessionId };
+    }
+    const normalizedDiscordUserId = normalizeDiscordUserId(input.discordUserId) ?? input.discordUserId;
+    if (session.ownerDiscordUserId !== normalizedDiscordUserId) {
+      return { outcome: "forbidden", sessionId: input.sessionId };
+    }
+
+    deleteRosterPingSession(session.sessionId);
+    return {
+      outcome: "posted",
+      rosterId: session.rosterId,
+      targetCount: session.targets.length,
+      messageContent: buildRosterPingPublicMessageContent(session),
     };
   }
 

--- a/src/services/RosterService.ts
+++ b/src/services/RosterService.ts
@@ -4242,6 +4242,7 @@ export class RosterService {
         outcome: "roster_archived",
         rosterId: roster.id,
         removedTags: [],
+        removedAccounts: [],
         ignoredTags: selectedTags,
         notOwnedTags: [],
       };
@@ -4252,16 +4253,24 @@ export class RosterService {
         rosterId: roster.id,
         playerTag: { in: selectedTags },
       },
-      select: { playerTag: true },
+      select: { playerTag: true, playerName: true },
     });
     const existingTags = normalizeRosterPlayerTags(existing.map((entry) => entry.playerTag));
     const notOwnedTags = selectedTags.filter((tag) => !existingTags.includes(tag));
+    const removedAccounts = existingTags.map((playerTag) => {
+      const existingEntry = existing.find((entry) => normalizePlayerTag(entry.playerTag) === playerTag) ?? null;
+      return {
+        playerTag,
+        playerName: normalizeRosterText(existingEntry?.playerName ?? null),
+      };
+    });
 
     if (existingTags.length <= 0) {
       return {
         outcome: "nothing_removed",
         rosterId: roster.id,
         removedTags: [],
+        removedAccounts: [],
         ignoredTags: selectedTags,
         notOwnedTags,
       };
@@ -4278,6 +4287,7 @@ export class RosterService {
       outcome: deleteResult.count > 0 ? "removed" : "nothing_removed",
       rosterId: roster.id,
       removedTags: existingTags,
+      removedAccounts,
       ignoredTags: selectedTags.filter((tag) => !existingTags.includes(tag)),
       notOwnedTags,
     };
@@ -5004,6 +5014,13 @@ export class RosterService {
       requestedTags,
       linkedTags: selectedTags,
       createdTags,
+      createdAccounts: createdTags.map((playerTag) => {
+        const linked = linkedByTag.get(playerTag) ?? null;
+        return {
+          playerTag,
+          playerName: normalizeRosterText(linked?.linkedName ?? null),
+        };
+      }),
       duplicateTags,
       missingLinkedTags,
     };
@@ -5031,6 +5048,7 @@ export class RosterService {
         outcome: "nothing_removed",
         rosterId: input.rosterId,
         removedTags: [],
+        removedAccounts: [],
         ignoredTags: [],
         notOwnedTags: [],
       };
@@ -5041,6 +5059,7 @@ export class RosterService {
         outcome: "roster_not_found",
         rosterId: input.rosterId,
         removedTags: [],
+        removedAccounts: [],
         ignoredTags: selectedTags,
         notOwnedTags: [],
       };

--- a/tests/roster.command.test.ts
+++ b/tests/roster.command.test.ts
@@ -25,6 +25,7 @@ import {
   handleRosterPostCustomizeMenuInteraction,
   handleRosterManageWeightOpenButtonInteraction,
   handleRosterManageWeightModalSubmit,
+  handleRosterPingActionButtonInteraction,
   handleRosterPostRefreshButtonInteraction,
   handleRosterPostSettingsButtonInteraction,
   handleRosterPostSettingsActionButtonInteraction,
@@ -39,6 +40,7 @@ type RosterSubcommand =
   | "create"
   | "list"
   | "post"
+  | "ping"
   | "manage"
   | "edit"
   | "delete"
@@ -56,8 +58,10 @@ function makeInteraction(input: {
   title?: string | null;
   roster?: string | null;
   action?: string | null;
+  message?: string | null;
   group?: string | null;
   players?: string | null;
+  pingOption?: string | null;
   timezone?: string | null;
   displayTimezone?: string | null;
   startTime?: string | null;
@@ -78,6 +82,9 @@ function makeInteraction(input: {
     user: { id: "111111111111111111" },
     guildId: "guild-1",
     inGuild: () => true,
+    memberPermissions: {
+      has: vi.fn().mockReturnValue(true),
+    },
     options: {
       getSubcommand: vi.fn(() => input.subcommand),
       getString: vi.fn((name: string) => {
@@ -87,8 +94,10 @@ function makeInteraction(input: {
         if (name === "title") return input.title ?? null;
         if (name === "roster") return input.roster ?? null;
         if (name === "action") return input.action ?? null;
+        if (name === "message") return input.message ?? null;
         if (name === "group") return input.group ?? null;
         if (name === "players") return input.players ?? null;
+        if (name === "ping_option") return input.pingOption ?? null;
         if (name === "timezone") return input.timezone ?? null;
         if (name === "display-timezone") return input.displayTimezone ?? null;
         if (name === "start_time") return input.startTime ?? null;
@@ -222,8 +231,10 @@ describe("/roster command", () => {
     vi.spyOn(rosterService, "updateRoster");
     vi.spyOn(rosterService, "deleteRoster");
     vi.spyOn(rosterService, "createRosterManagerUserSelectionPanel");
+    vi.spyOn(rosterService, "createRosterPingSelectionPanel");
     vi.spyOn(rosterService, "updateRosterSelectionPanel");
     vi.spyOn(rosterService, "confirmRosterSelectionPanel");
+    vi.spyOn(rosterService, "confirmRosterPingSelectionPanel");
     vi.spyOn(rosterService, "clearRosterSignups");
     vi.spyOn(rosterService, "getRosterView");
     vi.spyOn(rosterService, "getRosterRoleSyncTargets").mockResolvedValue(null as any);
@@ -1196,6 +1207,101 @@ describe("/roster command", () => {
       cocService: null,
     });
     expect(String(interaction.editReply.mock.calls.at(-1)?.[0]?.content ?? "")).toBe(expectedContent);
+  });
+
+  it("opens the roster ping preview with the requested target set", async () => {
+    (rosterService.createRosterPingSelectionPanel as any).mockResolvedValue({
+      outcome: "ready",
+      panel: {
+        sessionId: "session-1",
+        embed: new EmbedBuilder().setTitle("Ping preview for CWL Alpha Signup"),
+        components: [],
+        targetCount: 2,
+      },
+    });
+    (rosterService.findGuildRosterById as any).mockResolvedValue({
+      id: "roster-1",
+      guildId: "guild-1",
+      rosterType: "CWL",
+      rosterCategory: "signup",
+      title: "CWL Alpha Signup",
+      clanTag: "#2QG2C08UP",
+      startsAt: new Date("2026-04-20T00:00:00.000Z"),
+      endsAt: null,
+      timezone: "America/Los_Angeles",
+      displayTimezone: "America/Los_Angeles",
+      lifecycleState: "OPEN",
+      postedChannelId: "channel-1",
+      postedMessageId: "message-1",
+      postedMessageUrl: "https://discord.com/channels/guild-1/channel-1/message-1",
+      postedAt: null,
+      createdByDiscordUserId: "111111111111111111",
+      updatedByDiscordUserId: "111111111111111111",
+      createdAt: new Date("2026-04-20T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-20T00:00:00.000Z"),
+    });
+
+    const interaction = makeInteraction({
+      subcommand: "ping",
+      roster: "roster-1",
+      message: "Good luck tonight!",
+      pingOption: "everyone",
+      group: "confirmed",
+    }) as any;
+
+    await Roster.run({} as any, interaction as any);
+
+    expect(rosterService.createRosterPingSelectionPanel).toHaveBeenCalledWith({
+      rosterId: "roster-1",
+      discordUserId: "111111111111111111",
+      pingOption: "everyone",
+      groupKey: "confirmed",
+      message: "Good luck tonight!",
+    });
+    expect(interaction.editReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        embeds: [expect.any(EmbedBuilder)],
+        components: [],
+      }),
+    );
+  });
+
+  it("posts the roster ping message once the preview confirm button is pressed", async () => {
+    (rosterService.confirmRosterPingSelectionPanel as any).mockResolvedValue({
+      outcome: "posted",
+      rosterId: "roster-1",
+      targetCount: 2,
+      messageContent:
+        "[CWL Alpha Signup - CWL Alpha](https://link.example)\nAlpha (#PQL0289) <@222222222222222222>\nBravo (#QGRJ2222) <@333333333333333333>",
+    });
+
+    const sendMock = vi.fn().mockResolvedValue(undefined);
+    const interaction = {
+      customId: "roster-ping:confirm:session-1",
+      user: { id: "111111111111111111" },
+      guildId: "guild-1",
+      inGuild: () => true,
+      deferUpdate: vi.fn().mockResolvedValue(undefined),
+      editReply: vi.fn().mockResolvedValue(undefined),
+      followUp: vi.fn().mockResolvedValue(undefined),
+      channel: {
+        isTextBased: () => true,
+        send: sendMock,
+      },
+    } as any;
+
+    await handleRosterPingActionButtonInteraction(interaction);
+
+    expect(rosterService.confirmRosterPingSelectionPanel).toHaveBeenCalledWith({
+      sessionId: "session-1",
+      discordUserId: "111111111111111111",
+    });
+    expect(sendMock).toHaveBeenCalledWith({
+      content: expect.stringContaining("CWL Alpha Signup - CWL Alpha"),
+    });
+    expect(String(interaction.editReply.mock.calls.at(-1)?.[0]?.content ?? "")).toBe(
+      "Posted ping for 2 players.",
+    );
   });
 
   it("opens the roster customization panel when Settings -> Customize is selected", async () => {

--- a/tests/roster.command.test.ts
+++ b/tests/roster.command.test.ts
@@ -1271,8 +1271,10 @@ describe("/roster command", () => {
       outcome: "posted",
       rosterId: "roster-1",
       targetCount: 2,
-      messageContent:
-        "[CWL Alpha Signup - CWL Alpha](https://link.example)\nAlpha (#PQL0289) <@222222222222222222>\nBravo (#QGRJ2222) <@333333333333333333>",
+      messageContents: [
+        "[CWL Alpha Signup - CWL Alpha](https://link.example)\nAlpha (#PQL0289) <@222222222222222222>",
+        "[CWL Alpha Signup - CWL Alpha](https://link.example)\nBravo (#QGRJ2222) <@333333333333333333>",
+      ],
     });
 
     const sendMock = vi.fn().mockResolvedValue(undefined);
@@ -1296,9 +1298,9 @@ describe("/roster command", () => {
       sessionId: "session-1",
       discordUserId: "111111111111111111",
     });
-    expect(sendMock).toHaveBeenCalledWith({
-      content: expect.stringContaining("CWL Alpha Signup - CWL Alpha"),
-    });
+    expect(sendMock).toHaveBeenCalledTimes(2);
+    expect(sendMock.mock.calls[0]?.[0]?.content).toContain("Alpha (#PQL0289)");
+    expect(sendMock.mock.calls[1]?.[0]?.content).toContain("Bravo (#QGRJ2222)");
     expect(String(interaction.editReply.mock.calls.at(-1)?.[0]?.content ?? "")).toBe(
       "Posted ping for 2 players.",
     );

--- a/tests/roster.commandShape.test.ts
+++ b/tests/roster.commandShape.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from "vitest";
 import { Roster } from "../src/commands/Roster";
 
 describe("/roster command shape", () => {
-  it("registers create, list, post, manage, edit, delete, report, readiness, and refresh without flat manager drift", () => {
+  it("registers create, list, post, ping, manage, edit, delete, report, readiness, and refresh without flat manager drift", () => {
     const create = Roster.options?.find(
       (option) =>
         option.type === ApplicationCommandOptionType.Subcommand &&
@@ -11,6 +11,7 @@ describe("/roster command shape", () => {
     );
     const list = Roster.options?.find((option) => option.name === "list");
     const post = Roster.options?.find((option) => option.name === "post");
+    const ping = Roster.options?.find((option) => option.name === "ping");
     const manage = Roster.options?.find((option) => option.name === "manage");
     const edit = Roster.options?.find((option) => option.name === "edit");
     const deleteOption = Roster.options?.find((option) => option.name === "delete");
@@ -22,6 +23,7 @@ describe("/roster command shape", () => {
     expect(list?.type).toBe(ApplicationCommandOptionType.Subcommand);
     expect(list?.options?.map((option: any) => option.name)).toEqual(["name", "user", "player", "clan"]);
     expect(post?.type).toBe(ApplicationCommandOptionType.Subcommand);
+    expect(ping?.type).toBe(ApplicationCommandOptionType.Subcommand);
     expect(manage?.type).toBe(ApplicationCommandOptionType.Subcommand);
     expect(edit?.type).toBe(ApplicationCommandOptionType.Subcommand);
     expect(deleteOption?.type).toBe(ApplicationCommandOptionType.Subcommand);
@@ -64,6 +66,14 @@ describe("/roster command shape", () => {
     );
 
     expect(post?.options?.find((option: any) => option.name === "roster")?.required).toBe(true);
+    expect(ping?.options?.find((option: any) => option.name === "roster")?.required).toBe(true);
+    expect(ping?.options?.find((option: any) => option.name === "message")?.required).toBe(false);
+    expect(ping?.options?.find((option: any) => option.name === "ping_option")?.choices?.map((choice: any) => choice.value)).toEqual([
+      "unregistered",
+      "missing",
+      "everyone",
+    ]);
+    expect(ping?.options?.find((option: any) => option.name === "group")?.autocomplete).toBe(true);
     expect(report?.options?.find((option: any) => option.name === "roster")?.required).toBe(true);
     expect(readiness?.options?.find((option: any) => option.name === "roster")?.required).toBe(true);
     expect(refresh?.options?.find((option: any) => option.name === "roster")?.required).toBe(true);

--- a/tests/roster.service.test.ts
+++ b/tests/roster.service.test.ts
@@ -2490,8 +2490,9 @@ describe("RosterService", () => {
     });
     if (confirmed.outcome !== "posted") return;
 
-    expect(confirmed.messageContent).toContain("CWL Alpha Signup - CWL Alpha");
-    expect(confirmed.messageContent).toContain(`Alpha (${alphaTag}) <@111111111111111111>`);
+    expect(confirmed.messageContents).toHaveLength(1);
+    expect(confirmed.messageContents[0]).toContain("CWL Alpha Signup - CWL Alpha");
+    expect(confirmed.messageContents[0]).toContain(`Alpha (${alphaTag}) <@111111111111111111>`);
 
     const replay = await rosterService.confirmRosterPingSelectionPanel({
       sessionId: opened.panel.sessionId,
@@ -2501,6 +2502,80 @@ describe("RosterService", () => {
       outcome: "session_not_found",
       sessionId: opened.panel.sessionId,
     });
+  });
+
+  it("chunks roster ping output without dropping targets when the public message exceeds Discord limits", async () => {
+    const targetCount = 80;
+    const signups = Array.from({ length: targetCount }, (_, index) => {
+      const playerTag = makeValidRosterPlayerTag(index + 1);
+      return {
+        id: `signup-${index + 1}`,
+        rosterId: "roster-1",
+        groupId: "group-confirmed",
+        playerTag,
+        playerName: `Player ${String(index + 1).padStart(2, "0")}`,
+        discordUserId: `11111111111111${String(index + 1).padStart(5, "0")}`,
+        signedUpAt: new Date("2026-04-20T00:00:00.000Z"),
+        createdAt: new Date("2026-04-20T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-20T00:00:00.000Z"),
+        group: {
+          id: "group-confirmed",
+          key: "confirmed",
+          name: "Confirmed",
+          description: "Primary roster members",
+          sortOrder: 0,
+        },
+      };
+    });
+
+    prismaMock.rosterSignup.findMany.mockResolvedValue(signups as any);
+    prismaMock.playerLink.findMany.mockImplementation(async (args: any) => {
+      const tagList = (args?.where?.playerTag?.in ?? []) as string[];
+      const select = args?.select ?? {};
+      if (!select.discordUserId) {
+        return [];
+      }
+      return tagList.map((playerTag, index) => ({
+        playerTag,
+        discordUserId: `11111111111111${String(index + 1).padStart(5, "0")}`,
+        discordUsername: `user-${String(index + 1).padStart(2, "0")}`,
+        createdAt: new Date("2026-04-20T00:00:00.000Z"),
+      }));
+    });
+    todoSnapshotServiceMock.listSnapshotsByClanTag.mockResolvedValue([] as any);
+
+    const opened = await rosterService.createRosterPingSelectionPanel({
+      rosterId: "roster-1",
+      discordUserId: "111111111111111111",
+      pingOption: "everyone",
+    });
+    expect(opened).toMatchObject({ outcome: "ready" });
+    if (opened.outcome !== "ready") {
+      throw new Error("Expected roster ping preview to open.");
+    }
+    expect(opened.panel.targetCount).toBe(targetCount);
+
+    const confirmed = await rosterService.confirmRosterPingSelectionPanel({
+      sessionId: opened.panel.sessionId,
+      discordUserId: "111111111111111111",
+    });
+    expect(confirmed).toMatchObject({
+      outcome: "posted",
+      rosterId: "roster-1",
+      targetCount,
+    });
+    if (confirmed.outcome !== "posted") return;
+
+    expect(confirmed.messageContents.length).toBeGreaterThan(1);
+    expect(confirmed.messageContents.every((content) => content.length <= 2000)).toBe(true);
+    expect(confirmed.messageContents[0]).toContain("CWL Alpha Signup - CWL Alpha");
+    expect(confirmed.messageContents.every((content) => content.startsWith("[CWL Alpha Signup"))).toBe(true);
+    const joined = confirmed.messageContents.join("\n");
+    expect((joined.match(/<@/g) ?? []).length).toBe(targetCount);
+    for (const signup of signups) {
+      expect(joined).toContain(signup.playerTag);
+      expect(joined).toContain(signup.playerName);
+    }
   });
 
   it("signs up multiple selected accounts through the roster selection session", async () => {

--- a/tests/roster.service.test.ts
+++ b/tests/roster.service.test.ts
@@ -2271,6 +2271,238 @@ describe("RosterService", () => {
     }
   });
 
+  it("builds roster ping previews for everyone, missing, and unregistered targets", async () => {
+    const alphaTag = makeValidRosterPlayerTag(1);
+    const bravoTag = makeValidRosterPlayerTag(2);
+    const charlieTag = makeValidRosterPlayerTag(3);
+    const deltaTag = makeValidRosterPlayerTag(4);
+    prismaMock.rosterSignup.findMany.mockResolvedValue([
+      {
+        id: "signup-a",
+        rosterId: "roster-1",
+        groupId: "group-confirmed",
+        playerTag: alphaTag,
+        playerName: "Alpha",
+        discordUserId: "111111111111111111",
+        signedUpAt: new Date("2026-04-20T00:00:00.000Z"),
+        createdAt: new Date("2026-04-20T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-20T00:00:00.000Z"),
+        group: {
+          id: "group-confirmed",
+          key: "confirmed",
+          name: "Confirmed",
+          description: "Primary roster members",
+          sortOrder: 0,
+        },
+      },
+      {
+        id: "signup-b",
+        rosterId: "roster-1",
+        groupId: "group-substitute",
+        playerTag: bravoTag,
+        playerName: "Bravo",
+        discordUserId: "222222222222222222",
+        signedUpAt: new Date("2026-04-20T00:00:00.000Z"),
+        createdAt: new Date("2026-04-20T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-20T00:00:00.000Z"),
+        group: {
+          id: "group-substitute",
+          key: "substitute",
+          name: "Substitute",
+          description: "Reserve roster members",
+          sortOrder: 1,
+        },
+      },
+      {
+        id: "signup-c",
+        rosterId: "roster-1",
+        groupId: "group-confirmed",
+        playerTag: charlieTag,
+        playerName: "Charlie",
+        discordUserId: "333333333333333333",
+        signedUpAt: new Date("2026-04-20T00:00:00.000Z"),
+        createdAt: new Date("2026-04-20T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-20T00:00:00.000Z"),
+        group: {
+          id: "group-confirmed",
+          key: "confirmed",
+          name: "Confirmed",
+          description: "Primary roster members",
+          sortOrder: 0,
+        },
+      },
+    ] as any);
+    prismaMock.playerLink.findMany.mockImplementation(async (args: any) => {
+      const select = args?.select ?? {};
+      const tagList = (args?.where?.playerTag?.in ?? []) as string[];
+      if (select.discordUserId) {
+        const rows = tagList.includes(deltaTag)
+          ? [
+              {
+                playerTag: alphaTag,
+                discordUserId: "111111111111111111",
+                discordUsername: "alpha",
+                createdAt: new Date("2026-04-20T00:00:00.000Z"),
+              },
+              {
+                playerTag: deltaTag,
+                discordUserId: "444444444444444444",
+                discordUsername: "delta",
+                createdAt: new Date("2026-04-20T00:00:00.000Z"),
+              },
+            ]
+          : [
+              {
+                playerTag: alphaTag,
+                discordUserId: "111111111111111111",
+                discordUsername: "alpha",
+                createdAt: new Date("2026-04-20T00:00:00.000Z"),
+              },
+              {
+                playerTag: bravoTag,
+                discordUserId: "222222222222222222",
+                discordUsername: "bravo",
+                createdAt: new Date("2026-04-20T00:00:00.000Z"),
+              },
+            ];
+        return rows.filter((row) => tagList.includes(row.playerTag));
+      }
+      return [
+        { playerTag: alphaTag, discordUsername: "alpha", createdAt: new Date("2026-04-20T00:00:00.000Z") },
+        { playerTag: bravoTag, discordUsername: "bravo", createdAt: new Date("2026-04-20T00:00:00.000Z") },
+      ].filter((row) => tagList.includes(row.playerTag));
+    });
+    todoSnapshotServiceMock.listSnapshotsByClanTag.mockResolvedValue([
+      {
+        playerTag: alphaTag,
+        playerName: "Alpha",
+        clanTag: "#2QG2C08UP",
+        clanName: "CWL Alpha",
+        townHall: 15,
+      },
+      {
+        playerTag: deltaTag,
+        playerName: "Delta",
+        clanTag: "#2QG2C08UP",
+        clanName: "CWL Alpha",
+        townHall: 16,
+      },
+    ] as any);
+
+    const everyone = await rosterService.createRosterPingSelectionPanel({
+      rosterId: "roster-1",
+      discordUserId: "111111111111111111",
+      pingOption: "everyone",
+      groupKey: "confirmed",
+      message: "Good luck tonight!",
+    });
+    const missing = await rosterService.createRosterPingSelectionPanel({
+      rosterId: "roster-1",
+      discordUserId: "111111111111111111",
+      pingOption: "missing",
+    });
+    const unregistered = await rosterService.createRosterPingSelectionPanel({
+      rosterId: "roster-1",
+      discordUserId: "111111111111111111",
+      pingOption: "unregistered",
+      groupKey: "confirmed",
+    });
+
+    expect(everyone).toMatchObject({ outcome: "ready" });
+    expect(missing).toMatchObject({ outcome: "ready" });
+    expect(unregistered).toMatchObject({ outcome: "ready" });
+    if (everyone.outcome !== "ready" || missing.outcome !== "ready" || unregistered.outcome !== "ready") {
+      throw new Error("Expected roster ping previews to open.");
+    }
+
+    expect(everyone.panel.targetCount).toBe(1);
+    expect(String(everyone.panel.embed.toJSON().description ?? "")).toContain("Ping option: everyone");
+    expect(String(everyone.panel.embed.toJSON().description ?? "")).toContain(`Alpha (${alphaTag}) <@111111111111111111>`);
+    expect(String(everyone.panel.embed.toJSON().description ?? "")).not.toContain(`Bravo (${bravoTag})`);
+
+    expect(missing.panel.targetCount).toBe(1);
+    expect(String(missing.panel.embed.toJSON().description ?? "")).toContain("Ping option: missing");
+    expect(String(missing.panel.embed.toJSON().description ?? "")).toContain(`Bravo (${bravoTag}) <@222222222222222222>`);
+
+    expect(unregistered.panel.targetCount).toBe(1);
+    expect(String(unregistered.panel.embed.toJSON().description ?? "")).toContain("Ping option: unregistered");
+    expect(String(unregistered.panel.embed.toJSON().description ?? "")).toContain("Group: Confirmed (not applied)");
+    expect(String(unregistered.panel.embed.toJSON().description ?? "")).toContain(`Delta (${deltaTag}) <@444444444444444444>`);
+  });
+
+  it("confirms a roster ping session once and builds the consolidated public message", async () => {
+    const alphaTag = makeValidRosterPlayerTag(1);
+    prismaMock.rosterSignup.findMany.mockResolvedValue([
+      {
+        id: "signup-a",
+        rosterId: "roster-1",
+        groupId: "group-confirmed",
+        playerTag: alphaTag,
+        playerName: "Alpha",
+        discordUserId: "111111111111111111",
+        signedUpAt: new Date("2026-04-20T00:00:00.000Z"),
+        createdAt: new Date("2026-04-20T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-20T00:00:00.000Z"),
+        group: {
+          id: "group-confirmed",
+          key: "confirmed",
+          name: "Confirmed",
+          description: "Primary roster members",
+          sortOrder: 0,
+        },
+      },
+    ] as any);
+    prismaMock.playerLink.findMany.mockImplementation(async (args: any) => {
+      const select = args?.select ?? {};
+      const tagList = (args?.where?.playerTag?.in ?? []) as string[];
+      if (select.discordUserId) {
+        return [
+          {
+            playerTag: alphaTag,
+            discordUserId: "111111111111111111",
+            discordUsername: "alpha",
+            createdAt: new Date("2026-04-20T00:00:00.000Z"),
+          },
+        ];
+      }
+      return [{ playerTag: alphaTag, discordUsername: "alpha", createdAt: new Date("2026-04-20T00:00:00.000Z") }].filter(
+        (row) => tagList.includes(row.playerTag),
+      );
+    });
+
+    const opened = await rosterService.createRosterPingSelectionPanel({
+      rosterId: "roster-1",
+      discordUserId: "111111111111111111",
+      pingOption: "everyone",
+    });
+    if (opened.outcome !== "ready") {
+      throw new Error("Expected roster ping preview to open.");
+    }
+
+    const confirmed = await rosterService.confirmRosterPingSelectionPanel({
+      sessionId: opened.panel.sessionId,
+      discordUserId: "111111111111111111",
+    });
+    expect(confirmed).toMatchObject({
+      outcome: "posted",
+      rosterId: "roster-1",
+      targetCount: 1,
+    });
+    if (confirmed.outcome !== "posted") return;
+
+    expect(confirmed.messageContent).toContain("CWL Alpha Signup - CWL Alpha");
+    expect(confirmed.messageContent).toContain(`Alpha (${alphaTag}) <@111111111111111111>`);
+
+    const replay = await rosterService.confirmRosterPingSelectionPanel({
+      sessionId: opened.panel.sessionId,
+      discordUserId: "111111111111111111",
+    });
+    expect(replay).toEqual({
+      outcome: "session_not_found",
+      sessionId: opened.panel.sessionId,
+    });
+  });
+
   it("signs up multiple selected accounts through the roster selection session", async () => {
     playerLinkServiceMock.listPlayerLinksForDiscordUser.mockResolvedValue([
       { playerTag: "#PQL0289", linkedName: "Alpha", linkedAt: new Date("2026-04-20T00:00:00.000Z") },


### PR DESCRIPTION
- add /roster ping with ephemeral preview targeting roster-related members
- route confirm button presses to one consolidated public ping message
- cover command shape, service targeting, and confirm-time posting behavior