### PR TITLE
feat(roster): add ping preview and confirm flow

### DIFF
--- a/src/commands/Roster.ts
+++ b/src/commands/Roster.ts
@@ -2163,7 +2163,7 @@ async function handleRosterListSubcommand(interaction: ChatInputCommandInteracti
   const rosters = await rosterService.listGuildRosters({
     guildId: interaction.guildId,
     name: interaction.options.getString("name", false),
-    user: interaction.options.getString("user", false),
+    user: interaction.options.getUser("user", false)?.id ?? null,
     player: interaction.options.getString("player", false),
     clan: interaction.options.getString("clan", false),
   });
@@ -2888,7 +2888,7 @@ async function autocompleteRosterGroup(interaction: AutocompleteInteraction): Pr
   );
 }
 
-async function autocompleteRosterPlayers(interaction: AutocompleteInteraction): Promise<void> {
+async function autocompleteRosterManagePlayers(interaction: AutocompleteInteraction): Promise<void> {
   if (!interaction.inGuild()) {
     await interaction.respond([]);
     return;
@@ -2900,65 +2900,67 @@ async function autocompleteRosterPlayers(interaction: AutocompleteInteraction): 
     return;
   }
 
+  const rosterId = interaction.options.getString("roster", false)?.trim();
+  const action = interaction.options.getString("action", false)?.trim().toLowerCase();
+  if (!rosterId || !action || (action !== "add" && action !== "move" && action !== "remove")) {
+    await interaction.respond([]);
+    return;
+  }
+
+  const rosterView = await rosterService.getRosterView(rosterId);
+  if (!rosterView || rosterView.roster.lifecycleState === ROSTER_LIFECYCLE_STATE.ARCHIVED) {
+    await interaction.respond([]);
+    return;
+  }
+
+  const groupKey = interaction.options.getString("group", false)?.trim() ?? "";
+  if (action === "move" && !groupKey) {
+    await interaction.respond([]);
+    return;
+  }
+
   const query = String(focused.value ?? "")
     .trim()
     .toLowerCase()
     .replace(/^#/, "");
-  const links = await listPlayerLinksForDiscordUser({ discordUserId: interaction.user.id });
+  const existingTags = new Set(
+    rosterView.signups.map((signup) => normalizePlayerTag(signup.playerTag)).filter(Boolean),
+  );
+
+  const choices =
+    action === "add"
+      ? (
+          await listPlayerLinksForDiscordUser({ discordUserId: interaction.user.id })
+        )
+          .filter((link) => !existingTags.has(normalizePlayerTag(link.playerTag)))
+          .map((link) => {
+            const value = normalizePlayerTag(link.playerTag);
+            const label = link.linkedName ? `${link.linkedName} (${value})` : value;
+            return { name: label.slice(0, 100), value };
+          })
+      : rosterView.signups
+          .filter((signup) => {
+            if (action === "move") {
+              const signupGroupKey = String(signup.group?.key ?? "").trim().toLowerCase();
+              return signupGroupKey === groupKey.toLowerCase();
+            }
+            return true;
+          })
+          .map((signup) => {
+            const value = normalizePlayerTag(signup.playerTag);
+            const label = signup.playerName ? `${signup.playerName} (${value})` : value;
+            return { name: label.slice(0, 100), value };
+          });
 
   await interaction.respond(
-    links
-      .map((link) => {
-        const value = normalizePlayerTag(link.playerTag);
-        const label = link.linkedName ? `${link.linkedName} (${value})` : value;
-        return { name: label.slice(0, 100), value };
-      })
+    choices
       .filter((choice) => {
         const searchable = `${choice.name} ${choice.value}`.toLowerCase();
         return searchable.includes(query);
       })
+      .sort((a, b) => a.name.localeCompare(b.name) || a.value.localeCompare(b.value))
       .slice(0, 25),
   );
-}
-
-async function autocompleteRosterUsers(interaction: AutocompleteInteraction): Promise<void> {
-  if (!interaction.inGuild()) {
-    await interaction.respond([]);
-    return;
-  }
-
-  const focused = interaction.options.getFocused(true);
-  if (focused.name !== "user") {
-    await interaction.respond([]);
-    return;
-  }
-
-  const members = interaction.guild?.members?.cache;
-  if (!members) {
-    await interaction.respond([]);
-    return;
-  }
-
-  const query = String(focused.value ?? "")
-    .trim()
-    .toLowerCase();
-
-  const choices = [...members.values()]
-    .filter((member) => Boolean(member?.id) && !member.user?.bot)
-    .map((member) => {
-      const displayName = String(member.displayName ?? "").trim();
-      const username = String(member.user?.username ?? "").trim();
-      const value = String(member.id ?? "").trim();
-      const label = displayName ? `${displayName} (@${username || value})` : `@${username || value}`;
-      const searchable = `${displayName} ${username} ${value}`.toLowerCase();
-      return { name: label.slice(0, 100), value, searchable };
-    })
-    .filter((choice) => choice.searchable.includes(query))
-    .sort((a, b) => a.name.localeCompare(b.name) || a.value.localeCompare(b.value))
-    .slice(0, 25)
-    .map(({ searchable: _searchable, ...choice }) => choice);
-
-  await interaction.respond(choices);
 }
 
 export const Roster: Command = {
@@ -3088,10 +3090,9 @@ export const Roster: Command = {
         },
         {
           name: "user",
-          description: "Filter by Discord user ID",
-          type: ApplicationCommandOptionType.String,
+          description: "Filter by Discord user",
+          type: ApplicationCommandOptionType.User,
           required: false,
-          autocomplete: true,
         },
         {
           name: "player",
@@ -3451,11 +3452,11 @@ export const Roster: Command = {
       return;
     }
     if (focused.name === "players") {
-      await autocompleteRosterPlayers(interaction);
-      return;
-    }
-    if (focused.name === "user") {
-      await autocompleteRosterUsers(interaction);
+      if (interaction.options.getSubcommand(false) === "manage") {
+        await autocompleteRosterManagePlayers(interaction);
+      } else {
+        await interaction.respond([]);
+      }
       return;
     }
     if (focused.name === "roster") {

--- a/src/commands/Roster.ts
+++ b/src/commands/Roster.ts
@@ -2918,6 +2918,14 @@ async function autocompleteRosterManagePlayers(interaction: AutocompleteInteract
     await interaction.respond([]);
     return;
   }
+  const normalizedGroupKey = String(groupKey ?? "").trim().toLowerCase();
+  const rosterGroups = Array.isArray((rosterView as { groups?: Array<{ key: string }> }).groups)
+    ? (rosterView as { groups: Array<{ key: string }> }).groups
+    : [];
+  if (action === "move" && !rosterGroups.some((group) => String(group.key ?? "").trim().toLowerCase() === normalizedGroupKey)) {
+    await interaction.respond([]);
+    return;
+  }
 
   const query = String(focused.value ?? "")
     .trim()
@@ -2942,7 +2950,7 @@ async function autocompleteRosterManagePlayers(interaction: AutocompleteInteract
           .filter((signup) => {
             if (action === "move") {
               const signupGroupKey = String(signup.group?.key ?? "").trim().toLowerCase();
-              return signupGroupKey === groupKey.toLowerCase();
+              return signupGroupKey !== normalizedGroupKey;
             }
             return true;
           })

--- a/tests/roster.command.test.ts
+++ b/tests/roster.command.test.ts
@@ -2547,6 +2547,10 @@ describe("/roster command", () => {
         id: "roster-1",
         lifecycleState: "OPEN",
       },
+      groups: [
+        { id: "group-confirmed", key: "confirmed", name: "Confirmed", description: null, sortOrder: 0 },
+        { id: "group-substitute", key: "substitute", name: "Substitute", description: null, sortOrder: 1 },
+      ],
       signups: [
         {
           id: "signup-1",
@@ -2624,9 +2628,19 @@ describe("/roster command", () => {
     }) as any;
     await Roster.autocomplete(moveInteraction);
     expect(moveInteraction.respond).toHaveBeenCalledWith([
-      { name: "Alpha (#PYLQ0289)", value: "#PYLQ0289" },
-      { name: "Bravo (#QGRJ2222)", value: "#QGRJ2222" },
+      { name: "Charlie (#CUV02898)", value: "#CUV02898" },
     ]);
+
+    const invalidMoveInteraction = makeAutocompleteInteraction({
+      focusedName: "players",
+      focusedValue: "",
+      subcommand: "manage",
+      roster: "roster-1",
+      action: "move",
+      group: "not-real",
+    }) as any;
+    await Roster.autocomplete(invalidMoveInteraction);
+    expect(invalidMoveInteraction.respond).toHaveBeenCalledWith([]);
 
     const removeInteraction = makeAutocompleteInteraction({
       focusedName: "players",

--- a/tests/roster.command.test.ts
+++ b/tests/roster.command.test.ts
@@ -62,6 +62,7 @@ function makeInteraction(input: {
   group?: string | null;
   players?: string | null;
   pingOption?: string | null;
+  userId?: string | null;
   timezone?: string | null;
   displayTimezone?: string | null;
   startTime?: string | null;
@@ -104,9 +105,16 @@ function makeInteraction(input: {
         if (name === "end_time") return input.endTime ?? null;
         if (name === "roster_role") return input.rosterRole ?? null;
         if (name === "sort_by") return input.sortBy ?? null;
-        if (name === "user") return input.user ?? null;
         if (name === "player") return input.player ?? null;
         return null;
+      }),
+      getUser: vi.fn((name: string) => {
+        if (name !== "user" || !input.userId) return null;
+        return {
+          id: input.userId,
+          bot: false,
+          username: "selected-user",
+        };
       }),
       getInteger: vi.fn((name: string) => {
         if (name === "max_members") return input.maxMembers ?? null;
@@ -138,6 +146,8 @@ function makeAutocompleteInteraction(input: {
   focusedValue?: string;
   subcommand: RosterSubcommand;
   roster?: string | null;
+  action?: string | null;
+  group?: string | null;
   guildMembers?: Array<{
     id: string;
     displayName: string;
@@ -171,6 +181,8 @@ function makeAutocompleteInteraction(input: {
       getSubcommand: vi.fn(() => input.subcommand),
       getString: vi.fn((name: string) => {
         if (name === "roster") return input.roster ?? null;
+        if (name === "action") return input.action ?? null;
+        if (name === "group") return input.group ?? null;
         return null;
       }),
     },
@@ -546,6 +558,27 @@ describe("/roster command", () => {
     expect(String(embed?.fields?.[0]?.value ?? "")).toContain("Groups: 2 | Signups: 5");
     expect(String(embed?.fields?.[1]?.value ?? "")).toContain("Posted: No");
     expect(String(embed?.fields?.[1]?.value ?? "")).toContain("Clan: none");
+  });
+
+  it("passes the selected Discord user picker id through roster list filters", async () => {
+    (rosterService.listGuildRosters as any).mockResolvedValue([]);
+
+    const interaction = makeInteraction({
+      subcommand: "list",
+      userId: "222222222222222222",
+    }) as any;
+
+    await Roster.run({} as any, interaction as any);
+
+    expect(rosterService.listGuildRosters).toHaveBeenCalledWith(
+      expect.objectContaining({
+        guildId: "guild-1",
+        name: null,
+        user: "222222222222222222",
+        player: null,
+        clan: null,
+      }),
+    );
   });
 
   it("routes roster manage actions to the existing add, move, remove, and lifecycle helpers", async () => {
@@ -2508,25 +2541,120 @@ describe("/roster command", () => {
     ]);
   });
 
-  it("autocompletes linked player accounts for the invoking user", async () => {
+  it("scopes roster manage player autocomplete by roster, action, and group context", async () => {
+    (rosterService.getRosterView as any).mockResolvedValue({
+      roster: {
+        id: "roster-1",
+        lifecycleState: "OPEN",
+      },
+      signups: [
+        {
+          id: "signup-1",
+          rosterId: "roster-1",
+          groupId: "group-confirmed",
+          playerTag: "#PYLQ0289",
+          playerName: "Alpha",
+          discordUserId: "111111111111111111",
+          signedUpAt: new Date("2026-04-01T00:00:00.000Z"),
+          createdAt: new Date("2026-04-01T00:00:00.000Z"),
+          updatedAt: new Date("2026-04-01T00:00:00.000Z"),
+          group: { key: "confirmed" },
+        },
+        {
+          id: "signup-2",
+          rosterId: "roster-1",
+          groupId: "group-confirmed",
+          playerTag: "#QGRJ2222",
+          playerName: "Bravo",
+          discordUserId: "222222222222222222",
+          signedUpAt: new Date("2026-04-01T00:00:00.000Z"),
+          createdAt: new Date("2026-04-01T00:00:00.000Z"),
+          updatedAt: new Date("2026-04-01T00:00:00.000Z"),
+          group: { key: "confirmed" },
+        },
+        {
+          id: "signup-3",
+          rosterId: "roster-1",
+          groupId: "group-substitute",
+          playerTag: "#CUV02898",
+          playerName: "Charlie",
+          discordUserId: "333333333333333333",
+          signedUpAt: new Date("2026-04-01T00:00:00.000Z"),
+          createdAt: new Date("2026-04-01T00:00:00.000Z"),
+          updatedAt: new Date("2026-04-01T00:00:00.000Z"),
+          group: { key: "substitute" },
+        },
+      ],
+      clanDisplayName: null,
+      clanLeagueLabel: null,
+      totalSignupCount: 3,
+    });
     vi.spyOn(playerLinkService, "listPlayerLinksForDiscordUser").mockResolvedValue([
       { playerTag: "#PYLQ0289", linkedAt: new Date("2026-04-01T00:00:00.000Z"), linkedName: "Alpha Prime" },
       { playerTag: "#QGRJ2222", linkedAt: new Date("2026-04-02T00:00:00.000Z"), linkedName: null },
+      { playerTag: "#VJQ28888", linkedAt: new Date("2026-04-03T00:00:00.000Z"), linkedName: "Delta" },
     ] as any);
 
-    const interaction = makeAutocompleteInteraction({
+    const noRosterInteraction = makeAutocompleteInteraction({
       focusedName: "players",
-      focusedValue: "alpha",
+      focusedValue: "",
       subcommand: "manage",
+      action: "remove",
     }) as any;
+    await Roster.autocomplete(noRosterInteraction);
+    expect(noRosterInteraction.respond).toHaveBeenCalledWith([]);
 
-    await Roster.autocomplete(interaction);
+    const moveMissingGroupInteraction = makeAutocompleteInteraction({
+      focusedName: "players",
+      focusedValue: "",
+      subcommand: "manage",
+      roster: "roster-1",
+      action: "move",
+    }) as any;
+    await Roster.autocomplete(moveMissingGroupInteraction);
+    expect(moveMissingGroupInteraction.respond).toHaveBeenCalledWith([]);
 
+    const moveInteraction = makeAutocompleteInteraction({
+      focusedName: "players",
+      focusedValue: "",
+      subcommand: "manage",
+      roster: "roster-1",
+      action: "move",
+      group: "confirmed",
+    }) as any;
+    await Roster.autocomplete(moveInteraction);
+    expect(moveInteraction.respond).toHaveBeenCalledWith([
+      { name: "Alpha (#PYLQ0289)", value: "#PYLQ0289" },
+      { name: "Bravo (#QGRJ2222)", value: "#QGRJ2222" },
+    ]);
+
+    const removeInteraction = makeAutocompleteInteraction({
+      focusedName: "players",
+      focusedValue: "",
+      subcommand: "manage",
+      roster: "roster-1",
+      action: "remove",
+    }) as any;
+    await Roster.autocomplete(removeInteraction);
+    expect(removeInteraction.respond).toHaveBeenCalledWith([
+      { name: "Alpha (#PYLQ0289)", value: "#PYLQ0289" },
+      { name: "Bravo (#QGRJ2222)", value: "#QGRJ2222" },
+      { name: "Charlie (#CUV02898)", value: "#CUV02898" },
+    ]);
+
+    const addInteraction = makeAutocompleteInteraction({
+      focusedName: "players",
+      focusedValue: "",
+      subcommand: "manage",
+      roster: "roster-1",
+      action: "add",
+    }) as any;
+    await Roster.autocomplete(addInteraction);
     expect(playerLinkService.listPlayerLinksForDiscordUser).toHaveBeenCalledWith({
       discordUserId: "111111111111111111",
     });
-    expect(interaction.respond).toHaveBeenCalledWith([
-      { name: "Alpha Prime (#PYLQ0289)", value: "#PYLQ0289" },
+    expect(addInteraction.respond).toHaveBeenCalledWith([
+      { name: "Delta (#VJQ28888)", value: "#VJQ28888" },
     ]);
   });
 
@@ -2682,21 +2810,4 @@ describe("/roster command", () => {
     ]);
   });
 
-  it("autocompletes roster user filters from guild display names and usernames", async () => {
-    const interaction = makeAutocompleteInteraction({
-      focusedName: "user",
-      focusedValue: "sin",
-      subcommand: "list",
-      guildMembers: [
-        { id: "111111111111111111", displayName: "Sin Display", username: "SinUser" },
-        { id: "222222222222222222", displayName: "Bravado", username: "BravoUser" },
-      ],
-    }) as any;
-
-    await Roster.autocomplete(interaction);
-
-    expect(interaction.respond).toHaveBeenCalledWith([
-      { name: "Sin Display (@SinUser)", value: "111111111111111111" },
-    ]);
-  });
 });

--- a/tests/roster.commandShape.test.ts
+++ b/tests/roster.commandShape.test.ts
@@ -150,7 +150,7 @@ describe("/roster command shape", () => {
     }
   });
 
-  it("autocompletes roster list user and clan options, plus edit/create clan selectors", () => {
+  it("uses a native Discord user selector for roster list user and autocompletes clan selectors", () => {
     const create = Roster.options?.find(
       (option) =>
         option.type === ApplicationCommandOptionType.Subcommand &&
@@ -158,7 +158,10 @@ describe("/roster command shape", () => {
     );
     const list = Roster.options?.find((option) => option.name === "list");
     const edit = Roster.options?.find((option) => option.name === "edit");
-    expect(list?.options?.find((option: any) => option.name === "user")?.autocomplete).toBe(true);
+    expect(list?.options?.find((option: any) => option.name === "user")?.type).toBe(
+      ApplicationCommandOptionType.User,
+    );
+    expect(list?.options?.find((option: any) => option.name === "user")?.autocomplete).not.toBe(true);
     expect(list?.options?.find((option: any) => option.name === "clan")?.autocomplete).toBe(true);
     expect(create?.options?.find((option: any) => option.name === "clan")?.autocomplete).toBe(true);
     expect(edit?.options?.find((option: any) => option.name === "clan")?.autocomplete).toBe(true);


### PR DESCRIPTION
- add /roster ping with ephemeral preview targeting roster-related members
- route confirm button presses to one consolidated public ping message
- cover command shape, service targeting, and confirm-time posting behavior fix(roster): chunk ping output without dropping targets

- repeat the roster header on each chunk and preserve line boundaries
- return the full posted target count when confirm sends multiple messages fix(roster): scope roster autocomplete to command context

- filter manage player autocomplete by roster, action, and group
- switch roster list user filtering to Discord's native user selector