### PR TITLE
feat(roster): add change roster manager action

### DIFF
--- a/src/commands/Roster.ts
+++ b/src/commands/Roster.ts
@@ -64,7 +64,15 @@ export {
 
 const rosterPermissionService = new CommandPermissionService();
 
-type RosterMutationAction = "add" | "move" | "remove" | "set_weight" | "open" | "close" | "archive";
+type RosterMutationAction =
+  | "add"
+  | "move"
+  | "remove"
+  | "change_roster"
+  | "set_weight"
+  | "open"
+  | "close"
+  | "archive";
 type RosterPostSettingsAction =
   | "export"
   | "customize"
@@ -95,6 +103,19 @@ function formatRosterAccountIdentity(account: { playerTag: string; playerName: s
 
 function formatRosterAccountIdentityList(accounts: Array<{ playerTag: string; playerName: string | null }>): string {
   return accounts.map(formatRosterAccountIdentity).join(", ");
+}
+
+function getAutocompleteUserOptionId(interaction: AutocompleteInteraction): string | null {
+  const options = interaction.options as unknown as {
+    getUser?: (name: string, required?: boolean) => { id?: string } | null;
+    data?: Array<{ name?: string; value?: unknown }>;
+  };
+  const selectedUser = options.getUser?.("user", false);
+  if (selectedUser?.id && String(selectedUser.id).trim().length > 0) {
+    return String(selectedUser.id).trim();
+  }
+  const rawValue = options.data?.find((option) => option.name === "user")?.value;
+  return typeof rawValue === "string" && rawValue.trim().length > 0 ? rawValue.trim() : null;
 }
 
 function formatRosterDiscordUserSelectionLabel(
@@ -287,6 +308,61 @@ function buildRosterMoveResultSummary(result: Awaited<ReturnType<typeof rosterSe
   const missing =
     result.missingTags.length > 0 ? ` (${result.missingTags.length} not found on that roster)` : "";
   return `Moved ${moved} to ${result.groupKey}${duplicate}${missing}.`;
+}
+
+function buildRosterChangeResultSummary(
+  result: Awaited<ReturnType<typeof rosterService.changeRosterSignups>>,
+): string {
+  if (result.outcome === "roster_not_found") {
+    return "That source roster is no longer available.";
+  }
+  if (result.outcome === "target_roster_not_found") {
+    return "That target roster is no longer available.";
+  }
+  if (result.outcome === "same_roster") {
+    return "Source and target rosters must be different.";
+  }
+  if (result.outcome === "source_roster_archived") {
+    return "That source roster is archived and can no longer be modified.";
+  }
+  if (result.outcome === "target_roster_archived") {
+    return "That target roster is archived and can no longer be modified.";
+  }
+  if (result.outcome === "target_group_not_found") {
+    return "That target roster group is no longer available.";
+  }
+
+  const destinationForAccount = (account: { targetGroupName: string | null; targetGroupKey: string }) =>
+    account.targetGroupName ?? account.targetGroupKey;
+  const lines = result.movedAccounts.map((account) => {
+    const destination = destinationForAccount(account);
+    const destinationLabel = destination ? `${result.targetRosterTitle} - ${destination}` : result.targetRosterTitle;
+    return `Moved ${formatRosterAccountIdentity(account)} to ${destinationLabel}.`;
+  });
+
+  if (result.duplicateTags.length > 0) {
+    lines.push(`Already on the target roster: ${result.duplicateTags.join(", ")}.`);
+  }
+  if (result.missingTags.length > 0) {
+    lines.push(`Not found on the source roster: ${result.missingTags.join(", ")}.`);
+  }
+  if (result.blockedAccounts.length > 0) {
+    const reason =
+      result.outcome === "roster_full"
+        ? "Roster full"
+        : result.outcome === "account_limit_exceeded"
+          ? "Account limit exceeded"
+          : result.outcome === "townhall_unavailable"
+            ? "Town hall data unavailable"
+            : result.outcome === "townhall_out_of_range"
+              ? "Town hall out of range"
+              : result.outcome === "roster_conflict"
+                ? "Roster conflict"
+                : "Blocked";
+    lines.push(`${reason}: ${formatRosterAccountIdentityList(result.blockedAccounts)}.`);
+  }
+
+  return lines.length > 0 ? lines.join("\n") : "No roster signups were changed.";
 }
 
 function buildRosterRemoveResultSummary(
@@ -2325,6 +2401,8 @@ async function handleRosterManageSubcommand(
 
   const action = interaction.options.getString("action", true) as RosterMutationAction;
   const playersInput = interaction.options.getString("players", false) ?? "";
+  const targetRosterId = interaction.options.getString("target_roster", false)?.trim() ?? "";
+  const targetGroupKey = interaction.options.getString("target_group", false)?.trim() ?? null;
   const playerTags = parseRosterPlayerTags(playersInput);
 
   if (action === "set_weight") {
@@ -2378,6 +2456,75 @@ async function handleRosterManageSubcommand(
   if (playerTags.length <= 0) {
     await interaction.editReply("Provide one or more player tags to update.");
     return;
+  }
+
+  if (action === "change_roster") {
+    if (!targetRosterId) {
+      await interaction.editReply("Provide a target roster for this action.");
+      return;
+    }
+
+    const targetRoster = await rosterService.findGuildRosterById({
+      guildId: interaction.guildId,
+      rosterId: targetRosterId,
+    });
+    if (!targetRoster) {
+      await interaction.editReply("That target roster is no longer available.");
+      return;
+    }
+
+    const result = await rosterService.changeRosterSignups({
+      sourceRosterId: roster.id,
+      targetRosterId: targetRoster.id,
+      targetGroupKey,
+      playerTags,
+      updatedByDiscordUserId: interaction.user.id,
+      cocService,
+    });
+
+    if (
+      result.outcome === "changed" ||
+      result.outcome === "nothing_changed" ||
+      result.outcome === "roster_conflict" ||
+      result.outcome === "townhall_unavailable" ||
+      result.outcome === "townhall_out_of_range" ||
+      result.outcome === "roster_full" ||
+      result.outcome === "account_limit_exceeded"
+    ) {
+      if (result.movedTags.length > 0) {
+        await syncRosterRolesForRoster(interaction.client, roster.id).catch(() => undefined);
+        await syncRosterRolesForRoster(interaction.client, targetRoster.id).catch(() => undefined);
+        await refreshExistingRosterPost(interaction, roster.id, cocService).catch(() => undefined);
+        await refreshExistingRosterPost(interaction, targetRoster.id, cocService).catch(() => undefined);
+      }
+      await interaction.editReply(buildRosterChangeResultSummary(result));
+      return;
+    }
+
+    if (result.outcome === "roster_not_found") {
+      await interaction.editReply("That source roster is no longer available.");
+      return;
+    }
+    if (result.outcome === "target_roster_not_found") {
+      await interaction.editReply("That target roster is no longer available.");
+      return;
+    }
+    if (result.outcome === "same_roster") {
+      await interaction.editReply("Source and target rosters must be different.");
+      return;
+    }
+    if (result.outcome === "source_roster_archived") {
+      await interaction.editReply("That source roster is archived and can no longer be modified.");
+      return;
+    }
+    if (result.outcome === "target_roster_archived") {
+      await interaction.editReply("That target roster is archived and can no longer be modified.");
+      return;
+    }
+    if (result.outcome === "target_group_not_found") {
+      await interaction.editReply("That target roster group is no longer available.");
+      return;
+    }
   }
 
   if (action === "add" || action === "move") {
@@ -2660,7 +2807,10 @@ async function handleRosterDeleteSubcommand(interaction: ChatInputCommandInterac
   );
 }
 
-async function autocompleteRosterOption(interaction: AutocompleteInteraction): Promise<void> {
+async function autocompleteRosterOption(
+  interaction: AutocompleteInteraction,
+  excludeRosterId: string | null = null,
+): Promise<void> {
   if (!interaction.inGuild() || !interaction.guildId) {
     await interaction.respond([]);
     return;
@@ -2671,11 +2821,15 @@ async function autocompleteRosterOption(interaction: AutocompleteInteraction): P
     guildId: interaction.guildId,
     name: focused,
   });
+  const filteredRosters =
+    excludeRosterId && excludeRosterId.length > 0
+      ? rosters.filter((roster) => roster.id !== excludeRosterId)
+      : rosters;
 
-  const clanNameByTag = await buildRosterAutocompleteClanNameMap(rosters);
+  const clanNameByTag = await buildRosterAutocompleteClanNameMap(filteredRosters);
 
   await interaction.respond(
-    rosters.slice(0, 25).map((roster) => {
+    filteredRosters.slice(0, 25).map((roster) => {
       const clanTag = normalizeClanTag(roster.clanTag ?? "") || null;
       const clanName = clanTag ? clanNameByTag.get(clanTag) ?? null : null;
       const labelParts = [roster.title];
@@ -2850,12 +3004,14 @@ async function autocompleteRosterGroup(interaction: AutocompleteInteraction): Pr
   }
 
   const focused = interaction.options.getFocused(true);
-  if (focused.name !== "group") {
+  if (focused.name !== "group" && focused.name !== "target_group") {
     await interaction.respond([]);
     return;
   }
 
-  const rosterId = interaction.options.getString("roster", false)?.trim();
+  const rosterId = interaction.options
+    .getString(focused.name === "target_group" ? "target_roster" : "roster", false)
+    ?.trim();
   if (!rosterId) {
     await interaction.respond([]);
     return;
@@ -2902,7 +3058,11 @@ async function autocompleteRosterManagePlayers(interaction: AutocompleteInteract
 
   const rosterId = interaction.options.getString("roster", false)?.trim();
   const action = interaction.options.getString("action", false)?.trim().toLowerCase();
-  if (!rosterId || !action || (action !== "add" && action !== "move" && action !== "remove")) {
+  if (
+    !rosterId ||
+    !action ||
+    (action !== "add" && action !== "move" && action !== "remove" && action !== "change_roster")
+  ) {
     await interaction.respond([]);
     return;
   }
@@ -2922,7 +3082,10 @@ async function autocompleteRosterManagePlayers(interaction: AutocompleteInteract
   const rosterGroups = Array.isArray((rosterView as { groups?: Array<{ key: string }> }).groups)
     ? (rosterView as { groups: Array<{ key: string }> }).groups
     : [];
-  if (action === "move" && !rosterGroups.some((group) => String(group.key ?? "").trim().toLowerCase() === normalizedGroupKey)) {
+  if (
+    action === "move" &&
+    !rosterGroups.some((group) => String(group.key ?? "").trim().toLowerCase() === normalizedGroupKey)
+  ) {
     await interaction.respond([]);
     return;
   }
@@ -2934,6 +3097,27 @@ async function autocompleteRosterManagePlayers(interaction: AutocompleteInteract
   const existingTags = new Set(
     rosterView.signups.map((signup) => normalizePlayerTag(signup.playerTag)).filter(Boolean),
   );
+  const selectedUserId = getAutocompleteUserOptionId(interaction);
+  const targetRosterId = interaction.options.getString("target_roster", false)?.trim() ?? "";
+  const targetRosterView =
+    action === "change_roster" && targetRosterId ? await rosterService.getRosterView(targetRosterId) : null;
+  if (action === "change_roster") {
+    if (!targetRosterId || !targetRosterView) {
+      await interaction.respond([]);
+      return;
+    }
+    if (
+      targetRosterView.roster.id === rosterView.roster.id ||
+      targetRosterView.roster.lifecycleState === ROSTER_LIFECYCLE_STATE.ARCHIVED
+    ) {
+      await interaction.respond([]);
+      return;
+    }
+  }
+  const targetExistingTags =
+    action === "change_roster" && targetRosterView
+      ? new Set(targetRosterView.signups.map((signup) => normalizePlayerTag(signup.playerTag)).filter(Boolean))
+      : new Set<string>();
 
   const choices =
     action === "add"
@@ -2948,9 +3132,19 @@ async function autocompleteRosterManagePlayers(interaction: AutocompleteInteract
           })
       : rosterView.signups
           .filter((signup) => {
+            const signupTag = normalizePlayerTag(signup.playerTag);
             if (action === "move") {
               const signupGroupKey = String(signup.group?.key ?? "").trim().toLowerCase();
               return signupGroupKey !== normalizedGroupKey;
+            }
+            if (action === "change_roster") {
+              if (selectedUserId && String(signup.discordUserId ?? "").trim() !== selectedUserId) {
+                return false;
+              }
+              if (targetExistingTags.has(signupTag)) {
+                return false;
+              }
+              return true;
             }
             return true;
           })
@@ -3190,11 +3384,32 @@ export const Roster: Command = {
             { name: "Add players", value: "add" },
             { name: "Move players", value: "move" },
             { name: "Remove players", value: "remove" },
+            { name: "Change roster", value: "change_roster" },
             { name: "Set weight", value: "set_weight" },
             { name: "Open roster", value: "open" },
             { name: "Close roster", value: "close" },
             { name: "Archive roster", value: "archive" },
           ],
+        },
+        {
+          name: "target_roster",
+          description: "Target roster for change roster",
+          type: ApplicationCommandOptionType.String,
+          required: false,
+          autocomplete: true,
+        },
+        {
+          name: "target_group",
+          description: "Target roster group key",
+          type: ApplicationCommandOptionType.String,
+          required: false,
+          autocomplete: true,
+        },
+        {
+          name: "user",
+          description: "Filter source players by Discord user",
+          type: ApplicationCommandOptionType.User,
+          required: false,
         },
         {
           name: "group",
@@ -3455,7 +3670,16 @@ export const Roster: Command = {
       await autocompleteRosterTrackedClan(interaction);
       return;
     }
+    if (focused.name === "target_roster") {
+      const sourceRosterId = interaction.options.getString("roster", false)?.trim() ?? null;
+      await autocompleteRosterOption(interaction, sourceRosterId);
+      return;
+    }
     if (focused.name === "group") {
+      await autocompleteRosterGroup(interaction);
+      return;
+    }
+    if (focused.name === "target_group") {
       await autocompleteRosterGroup(interaction);
       return;
     }

--- a/src/services/RosterService.ts
+++ b/src/services/RosterService.ts
@@ -4711,12 +4711,21 @@ export class RosterService {
               cocService: input.cocService ?? null,
             })
           : null;
+      const blockedConflictTags: string[] = [];
+      const blockedConflictAccounts: RosterAccountIdentity[] = [];
+      const blockedRosterFullTags: string[] = [];
+      const blockedRosterFullAccounts: RosterAccountIdentity[] = [];
+      const blockedAccountLimitTags: string[] = [];
+      const blockedAccountLimitAccounts: RosterAccountIdentity[] = [];
       const blockedUnavailableTags: string[] = [];
+      const blockedUnavailableAccounts: RosterAccountIdentity[] = [];
       const blockedOutOfRangeTags: string[] = [];
+      const blockedOutOfRangeAccounts: RosterAccountIdentity[] = [];
+      const blockedOutcomeOrder: Array<
+        "roster_conflict" | "roster_full" | "account_limit_exceeded" | "townhall_unavailable" | "townhall_out_of_range"
+      > = [];
       const movedTags: string[] = [];
       const movedAccounts: RosterChangeRosterIdentity[] = [];
-      const blockedTags: string[] = [];
-      const blockedAccounts: RosterAccountIdentity[] = [];
       const movedRowsByGroupId = new Map<
         string,
         Array<{
@@ -4752,8 +4761,9 @@ export class RosterService {
           playerName: normalizeRosterText(sourceSignup.playerName ?? null),
         };
         if (conflictTags.has(tag)) {
-          blockedTags.push(tag);
-          blockedAccounts.push(blockedAccount);
+          blockedConflictTags.push(tag);
+          blockedConflictAccounts.push(blockedAccount);
+          blockedOutcomeOrder.push("roster_conflict");
           continue;
         }
 
@@ -4775,15 +4785,16 @@ export class RosterService {
             movedAccounts,
             duplicateTags,
             missingTags,
-            blockedTags,
-            blockedAccounts,
+            blockedTags: [],
+            blockedAccounts: [],
           } as const;
         }
 
         const maxMembers = normalizeRosterInt(targetRoster.maxMembers);
         if (maxMembers !== null && targetCount + movedTags.length + 1 > maxMembers) {
-          blockedTags.push(tag);
-          blockedAccounts.push(blockedAccount);
+          blockedRosterFullTags.push(tag);
+          blockedRosterFullAccounts.push(blockedAccount);
+          blockedOutcomeOrder.push("roster_full");
           continue;
         }
 
@@ -4795,8 +4806,9 @@ export class RosterService {
         if (effectiveMaxAccountsPerUser !== null) {
           const ownedCount = targetOwnedCountByUser.get(normalizedDiscordUserId) ?? 0;
           if (ownedCount + 1 > effectiveMaxAccountsPerUser) {
-            blockedTags.push(tag);
-            blockedAccounts.push(blockedAccount);
+            blockedAccountLimitTags.push(tag);
+            blockedAccountLimitAccounts.push(blockedAccount);
+            blockedOutcomeOrder.push("account_limit_exceeded");
             continue;
           }
         }
@@ -4805,14 +4817,16 @@ export class RosterService {
           const townHall = targetTownHallResolution.townHallByTag.get(tag) ?? null;
           if (townHall === null) {
             blockedUnavailableTags.push(tag);
-            blockedAccounts.push(blockedAccount);
+            blockedUnavailableAccounts.push(blockedAccount);
+            blockedOutcomeOrder.push("townhall_unavailable");
             continue;
           }
           const minTownhall = normalizeRosterInt(targetRoster.minTownhall);
           const maxTownhall = normalizeRosterInt(targetRoster.maxTownhall);
           if ((minTownhall !== null && townHall < minTownhall) || (maxTownhall !== null && townHall > maxTownhall)) {
             blockedOutOfRangeTags.push(tag);
-            blockedAccounts.push(blockedAccount);
+            blockedOutOfRangeAccounts.push(blockedAccount);
+            blockedOutcomeOrder.push("townhall_out_of_range");
             continue;
           }
         }
@@ -4872,8 +4886,20 @@ export class RosterService {
           movedAccounts,
           duplicateTags,
           missingTags,
-          blockedTags,
-          blockedAccounts,
+          blockedTags: [
+            ...blockedConflictTags,
+            ...blockedRosterFullTags,
+            ...blockedAccountLimitTags,
+            ...blockedUnavailableTags,
+            ...blockedOutOfRangeTags,
+          ],
+          blockedAccounts: [
+            ...blockedConflictAccounts,
+            ...blockedRosterFullAccounts,
+            ...blockedAccountLimitAccounts,
+            ...blockedUnavailableAccounts,
+            ...blockedOutOfRangeAccounts,
+          ],
         });
       }
 
@@ -4896,7 +4922,7 @@ export class RosterService {
           duplicateTags,
           missingTags,
           blockedTags: blockedUnavailableTags,
-          blockedAccounts,
+          blockedAccounts: blockedUnavailableAccounts,
         });
       }
       if (blockedOutOfRangeTags.length > 0) {
@@ -4918,16 +4944,31 @@ export class RosterService {
           duplicateTags,
           missingTags,
           blockedTags: blockedOutOfRangeTags,
-          blockedAccounts,
+          blockedAccounts: blockedOutOfRangeAccounts,
         });
       }
-      if (blockedTags.length > 0) {
-        const blockedOutcome =
-          conflictTags.size > 0
-            ? "roster_conflict"
-            : blockedTags.length > 0 && normalizeRosterInt(targetRoster.maxMembers) !== null
-              ? "roster_full"
-              : "account_limit_exceeded";
+      if (blockedOutcomeOrder.length > 0) {
+        const blockedOutcome = blockedOutcomeOrder[0];
+        const blockedTags =
+          blockedOutcome === "roster_conflict"
+            ? blockedConflictTags
+            : blockedOutcome === "roster_full"
+              ? blockedRosterFullTags
+              : blockedOutcome === "account_limit_exceeded"
+                ? blockedAccountLimitTags
+                : blockedOutcome === "townhall_unavailable"
+                  ? blockedUnavailableTags
+                  : blockedOutOfRangeTags;
+        const blockedAccounts =
+          blockedOutcome === "roster_conflict"
+            ? blockedConflictAccounts
+            : blockedOutcome === "roster_full"
+              ? blockedRosterFullAccounts
+              : blockedOutcome === "account_limit_exceeded"
+                ? blockedAccountLimitAccounts
+                : blockedOutcome === "townhall_unavailable"
+                  ? blockedUnavailableAccounts
+                  : blockedOutOfRangeAccounts;
         return buildSharedResult({
           outcome: blockedOutcome,
           sourceRosterId: sourceRoster.id,
@@ -4947,6 +4988,10 @@ export class RosterService {
           missingTags,
           blockedTags,
           blockedAccounts,
+          conflictingRosterIds:
+            blockedOutcome === "roster_conflict"
+              ? [...new Set(conflictRows.map((row) => row.rosterId))]
+              : undefined,
         } as any);
       }
 
@@ -4967,8 +5012,8 @@ export class RosterService {
         movedAccounts,
         duplicateTags,
         missingTags,
-        blockedTags,
-        blockedAccounts,
+        blockedTags: [],
+        blockedAccounts: [],
       });
     });
   }

--- a/src/services/RosterService.ts
+++ b/src/services/RosterService.ts
@@ -531,6 +531,218 @@ export type RemoveRosterSignupsResult =
       notOwnedTags: string[];
     };
 
+export type RosterChangeRosterIdentity = RosterAccountIdentity & {
+  targetGroupKey: string;
+  targetGroupName: string;
+};
+
+export type ChangeRosterSignupsResult =
+  | {
+      outcome: "changed";
+      sourceRosterId: string;
+      sourceRosterTitle: string;
+      targetRosterId: string;
+      targetRosterTitle: string;
+      targetRosterClanTag: string | null;
+      targetRosterClanName: string | null;
+      targetGroupKey: string | null;
+      targetGroupName: string | null;
+      requestedTags: string[];
+      movedTags: string[];
+      movedAccounts: RosterChangeRosterIdentity[];
+      duplicateTags: string[];
+      missingTags: string[];
+      blockedTags: string[];
+      blockedAccounts: RosterAccountIdentity[];
+    }
+  | {
+      outcome: "nothing_changed";
+      sourceRosterId: string;
+      sourceRosterTitle: string;
+      targetRosterId: string;
+      targetRosterTitle: string;
+      targetRosterClanTag: string | null;
+      targetRosterClanName: string | null;
+      targetGroupKey: string | null;
+      targetGroupName: string | null;
+      requestedTags: string[];
+      movedTags: string[];
+      movedAccounts: RosterChangeRosterIdentity[];
+      duplicateTags: string[];
+      missingTags: string[];
+      blockedTags: string[];
+      blockedAccounts: RosterAccountIdentity[];
+    }
+  | {
+      outcome: "roster_not_found";
+      sourceRosterId: string;
+      targetRosterId: string;
+      requestedTags: string[];
+      movedTags: string[];
+      movedAccounts: RosterChangeRosterIdentity[];
+      duplicateTags: string[];
+      missingTags: string[];
+      blockedTags: string[];
+      blockedAccounts: RosterAccountIdentity[];
+    }
+  | {
+      outcome: "target_roster_not_found";
+      sourceRosterId: string;
+      targetRosterId: string;
+      requestedTags: string[];
+      movedTags: string[];
+      movedAccounts: RosterChangeRosterIdentity[];
+      duplicateTags: string[];
+      missingTags: string[];
+      blockedTags: string[];
+      blockedAccounts: RosterAccountIdentity[];
+    }
+  | {
+      outcome: "same_roster";
+      sourceRosterId: string;
+      targetRosterId: string;
+      requestedTags: string[];
+      movedTags: string[];
+      movedAccounts: RosterChangeRosterIdentity[];
+      duplicateTags: string[];
+      missingTags: string[];
+      blockedTags: string[];
+      blockedAccounts: RosterAccountIdentity[];
+    }
+  | {
+      outcome: "source_roster_archived";
+      sourceRosterId: string;
+      sourceRosterTitle: string;
+      targetRosterId: string;
+      targetRosterTitle: string;
+      requestedTags: string[];
+      movedTags: string[];
+      movedAccounts: RosterChangeRosterIdentity[];
+      duplicateTags: string[];
+      missingTags: string[];
+      blockedTags: string[];
+      blockedAccounts: RosterAccountIdentity[];
+    }
+  | {
+      outcome: "target_roster_archived";
+      sourceRosterId: string;
+      sourceRosterTitle: string;
+      targetRosterId: string;
+      targetRosterTitle: string;
+      requestedTags: string[];
+      movedTags: string[];
+      movedAccounts: RosterChangeRosterIdentity[];
+      duplicateTags: string[];
+      missingTags: string[];
+      blockedTags: string[];
+      blockedAccounts: RosterAccountIdentity[];
+    }
+  | {
+      outcome: "target_group_not_found";
+      sourceRosterId: string;
+      sourceRosterTitle: string;
+      targetRosterId: string;
+      targetRosterTitle: string;
+      targetGroupKey: string;
+      requestedTags: string[];
+      movedTags: string[];
+      movedAccounts: RosterChangeRosterIdentity[];
+      duplicateTags: string[];
+      missingTags: string[];
+      blockedTags: string[];
+      blockedAccounts: RosterAccountIdentity[];
+    }
+  | {
+      outcome: "roster_full";
+      sourceRosterId: string;
+      sourceRosterTitle: string;
+      targetRosterId: string;
+      targetRosterTitle: string;
+      targetRosterClanTag: string | null;
+      targetRosterClanName: string | null;
+      targetGroupKey: string | null;
+      targetGroupName: string | null;
+      requestedTags: string[];
+      movedTags: string[];
+      movedAccounts: RosterChangeRosterIdentity[];
+      duplicateTags: string[];
+      missingTags: string[];
+      blockedTags: string[];
+      blockedAccounts: RosterAccountIdentity[];
+    }
+  | {
+      outcome: "account_limit_exceeded";
+      sourceRosterId: string;
+      sourceRosterTitle: string;
+      targetRosterId: string;
+      targetRosterTitle: string;
+      targetRosterClanTag: string | null;
+      targetRosterClanName: string | null;
+      targetGroupKey: string | null;
+      targetGroupName: string | null;
+      requestedTags: string[];
+      movedTags: string[];
+      movedAccounts: RosterChangeRosterIdentity[];
+      duplicateTags: string[];
+      missingTags: string[];
+      blockedTags: string[];
+      blockedAccounts: RosterAccountIdentity[];
+    }
+  | {
+      outcome: "townhall_unavailable";
+      sourceRosterId: string;
+      sourceRosterTitle: string;
+      targetRosterId: string;
+      targetRosterTitle: string;
+      targetRosterClanTag: string | null;
+      targetRosterClanName: string | null;
+      targetGroupKey: string | null;
+      targetGroupName: string | null;
+      requestedTags: string[];
+      movedTags: string[];
+      movedAccounts: RosterChangeRosterIdentity[];
+      duplicateTags: string[];
+      missingTags: string[];
+      blockedTags: string[];
+      blockedAccounts: RosterAccountIdentity[];
+    }
+  | {
+      outcome: "townhall_out_of_range";
+      sourceRosterId: string;
+      sourceRosterTitle: string;
+      targetRosterId: string;
+      targetRosterTitle: string;
+      targetRosterClanTag: string | null;
+      targetRosterClanName: string | null;
+      targetGroupKey: string | null;
+      targetGroupName: string | null;
+      requestedTags: string[];
+      movedTags: string[];
+      movedAccounts: RosterChangeRosterIdentity[];
+      duplicateTags: string[];
+      missingTags: string[];
+      blockedTags: string[];
+      blockedAccounts: RosterAccountIdentity[];
+    }
+  | {
+      outcome: "roster_conflict";
+      sourceRosterId: string;
+      sourceRosterTitle: string;
+      targetRosterId: string;
+      targetRosterTitle: string;
+      targetRosterClanTag: string | null;
+      targetRosterClanName: string | null;
+      targetGroupKey: string | null;
+      targetGroupName: string | null;
+      requestedTags: string[];
+      movedTags: string[];
+      movedAccounts: RosterChangeRosterIdentity[];
+      duplicateTags: string[];
+      missingTags: string[];
+      blockedTags: string[];
+      blockedAccounts: RosterAccountIdentity[];
+    };
+
 export type RosterLifecycleUpdateResult =
   | {
       outcome: "updated";
@@ -4200,6 +4412,565 @@ export class RosterService {
       duplicateTags,
       missingTags,
     };
+  }
+
+  async changeRosterSignups(input: {
+    sourceRosterId: string;
+    targetRosterId: string;
+    targetGroupKey?: string | null;
+    playerTags?: string[] | null;
+    updatedByDiscordUserId?: string | null;
+    cocService?: CoCService | null;
+  }): Promise<ChangeRosterSignupsResult> {
+    const requestedTags = normalizeRosterPlayerTags(Array.isArray(input.playerTags) ? input.playerTags : []);
+    if (requestedTags.length <= 0) {
+      return {
+        outcome: "nothing_changed",
+        sourceRosterId: input.sourceRosterId,
+        sourceRosterTitle: "Unknown Roster",
+        targetRosterId: input.targetRosterId,
+        targetRosterTitle: "Unknown Roster",
+        targetRosterClanTag: null,
+        targetRosterClanName: null,
+        targetGroupKey: null,
+        targetGroupName: null,
+        requestedTags,
+        movedTags: [],
+        movedAccounts: [],
+        duplicateTags: [],
+        missingTags: [],
+        blockedTags: [],
+        blockedAccounts: [],
+      };
+    }
+
+    return prisma.$transaction(async (tx: any) => {
+      const sourceRoster = await tx.roster.findUnique({
+        where: { id: input.sourceRosterId },
+        select: {
+          id: true,
+          guildId: true,
+          lifecycleState: true,
+          rosterType: true,
+          rosterCategory: true,
+          title: true,
+          clanTag: true,
+          maxMembers: true,
+          maxAccountsPerUser: true,
+          minTownhall: true,
+          maxTownhall: true,
+          allowMultiSignup: true,
+        },
+      });
+      if (!sourceRoster) {
+        return {
+          outcome: "roster_not_found",
+          sourceRosterId: input.sourceRosterId,
+          targetRosterId: input.targetRosterId,
+          requestedTags,
+          movedTags: [],
+          movedAccounts: [],
+          duplicateTags: [],
+          missingTags: requestedTags,
+          blockedTags: [],
+          blockedAccounts: [],
+        } as const;
+      }
+      if (!canManagerMutateRoster(sourceRoster.lifecycleState)) {
+        return {
+          outcome: "source_roster_archived",
+          sourceRosterId: sourceRoster.id,
+          sourceRosterTitle: sourceRoster.title,
+          targetRosterId: input.targetRosterId,
+          targetRosterTitle: "Unknown Roster",
+          requestedTags,
+          movedTags: [],
+          movedAccounts: [],
+          duplicateTags: [],
+          missingTags: requestedTags,
+          blockedTags: [],
+          blockedAccounts: [],
+        } as const;
+      }
+
+      const targetRoster = await tx.roster.findFirst({
+        where: {
+          id: input.targetRosterId,
+          guildId: sourceRoster.guildId,
+        },
+        select: {
+          id: true,
+          lifecycleState: true,
+          rosterType: true,
+          rosterCategory: true,
+          title: true,
+          clanTag: true,
+          maxMembers: true,
+          maxAccountsPerUser: true,
+          minTownhall: true,
+          maxTownhall: true,
+          allowMultiSignup: true,
+        },
+      });
+      if (!targetRoster) {
+        return {
+          outcome: "target_roster_not_found",
+          sourceRosterId: sourceRoster.id,
+          targetRosterId: input.targetRosterId,
+          requestedTags,
+          movedTags: [],
+          movedAccounts: [],
+          duplicateTags: [],
+          missingTags: requestedTags,
+          blockedTags: [],
+          blockedAccounts: [],
+        } as const;
+      }
+      if (sourceRoster.id === targetRoster.id) {
+        return {
+          outcome: "same_roster",
+          sourceRosterId: sourceRoster.id,
+          targetRosterId: targetRoster.id,
+          requestedTags,
+          movedTags: [],
+          movedAccounts: [],
+          duplicateTags: [],
+          missingTags: requestedTags,
+          blockedTags: [],
+          blockedAccounts: [],
+        } as const;
+      }
+      if (!canManagerMutateRoster(targetRoster.lifecycleState)) {
+        return {
+          outcome: "target_roster_archived",
+          sourceRosterId: sourceRoster.id,
+          sourceRosterTitle: sourceRoster.title,
+          targetRosterId: targetRoster.id,
+          targetRosterTitle: targetRoster.title,
+          requestedTags,
+          movedTags: [],
+          movedAccounts: [],
+          duplicateTags: [],
+          missingTags: requestedTags,
+          blockedTags: [],
+          blockedAccounts: [],
+        } as const;
+      }
+
+      type ChangeRosterGroupRow = {
+        id: string;
+        key: string;
+        name: string;
+        description: string | null;
+        sortOrder: number;
+      };
+      type ChangeRosterSignupRow = {
+        id: string;
+        rosterId: string;
+        groupId: string | null;
+        playerTag: string;
+        playerName: string | null;
+        discordUserId: string;
+        group: ChangeRosterGroupRow | null;
+      };
+
+      const targetGroups = (await tx.rosterGroup.findMany({
+        where: { rosterId: targetRoster.id },
+        orderBy: [{ sortOrder: "asc" }, { name: "asc" }],
+        select: {
+          id: true,
+          key: true,
+          name: true,
+          description: true,
+          sortOrder: true,
+        },
+      })) as ChangeRosterGroupRow[];
+      const targetGroupKeyInput = input.targetGroupKey !== undefined ? String(input.targetGroupKey ?? "").trim() : null;
+      const normalizedTargetGroupKey = targetGroupKeyInput ? normalizeRosterGroupKey(targetGroupKeyInput) : null;
+      const targetGroupByKey = new Map<string, ChangeRosterGroupRow>(
+        targetGroups.map((group) => [normalizeRosterGroupKey(group.key), group] as const),
+      );
+      const defaultTargetGroup = targetGroups[0] ?? null;
+      if (normalizedTargetGroupKey) {
+        if (!targetGroupByKey.has(normalizedTargetGroupKey)) {
+          return {
+            outcome: "target_group_not_found",
+            sourceRosterId: sourceRoster.id,
+            sourceRosterTitle: sourceRoster.title,
+            targetRosterId: targetRoster.id,
+            targetRosterTitle: targetRoster.title,
+            targetGroupKey: normalizedTargetGroupKey,
+            requestedTags,
+            movedTags: [],
+            movedAccounts: [],
+            duplicateTags: [],
+            missingTags: requestedTags,
+            blockedTags: [],
+            blockedAccounts: [],
+          } as const;
+        }
+      } else if (!defaultTargetGroup) {
+        return {
+          outcome: "target_group_not_found",
+          sourceRosterId: sourceRoster.id,
+          sourceRosterTitle: sourceRoster.title,
+          targetRosterId: targetRoster.id,
+          targetRosterTitle: targetRoster.title,
+          targetGroupKey: "",
+          requestedTags,
+          movedTags: [],
+          movedAccounts: [],
+          duplicateTags: [],
+          missingTags: requestedTags,
+          blockedTags: [],
+          blockedAccounts: [],
+        } as const;
+      }
+
+      const sourceSignups = (await tx.rosterSignup.findMany({
+        where: {
+          rosterId: sourceRoster.id,
+          playerTag: { in: requestedTags },
+        },
+        select: {
+          id: true,
+          rosterId: true,
+          groupId: true,
+          playerTag: true,
+          playerName: true,
+          discordUserId: true,
+          group: {
+            select: {
+              id: true,
+              key: true,
+              name: true,
+              description: true,
+              sortOrder: true,
+            },
+          },
+        },
+      })) as ChangeRosterSignupRow[];
+      const sourceByTag = new Map<string, ChangeRosterSignupRow>(
+        sourceSignups
+          .map((signup) => [normalizePlayerTag(signup.playerTag), signup] as const)
+          .filter((entry): entry is readonly [string, ChangeRosterSignupRow] => Boolean(entry[0])),
+      );
+      const sourceTags = requestedTags.filter((tag) => sourceByTag.has(tag));
+      const missingTags = requestedTags.filter((tag) => !sourceByTag.has(tag));
+
+      const targetExistingSignups = (await tx.rosterSignup.findMany({
+        where: {
+          rosterId: targetRoster.id,
+        },
+        select: {
+          playerTag: true,
+          discordUserId: true,
+        },
+      })) as Array<{ playerTag: string; discordUserId: string | null }>;
+      const targetExistingTags = new Set(
+        targetExistingSignups.map((signup) => normalizePlayerTag(signup.playerTag)).filter(Boolean),
+      );
+      const duplicateTags = sourceTags.filter((tag) => targetExistingTags.has(tag));
+      const candidateTags = sourceTags.filter((tag) => !targetExistingTags.has(tag));
+
+      let targetCount = targetExistingSignups.length;
+      const targetOwnedCountByUser = new Map<string, number>();
+      for (const signup of targetExistingSignups) {
+        const normalizedDiscordUserId = normalizeDiscordUserId(signup.discordUserId) ?? signup.discordUserId;
+        if (!normalizedDiscordUserId) continue;
+        targetOwnedCountByUser.set(normalizedDiscordUserId, (targetOwnedCountByUser.get(normalizedDiscordUserId) ?? 0) + 1);
+      }
+
+      const conflictRows =
+        candidateTags.length > 0
+          ? ((await tx.rosterSignup.findMany({
+              where: {
+                playerTag: { in: candidateTags },
+                rosterId: { notIn: [sourceRoster.id, targetRoster.id] },
+                roster: {
+                  rosterType: targetRoster.rosterType,
+                  rosterCategory: targetRoster.rosterCategory,
+                  lifecycleState: { in: ROSTER_CONFLICT_LIFECYCLE_STATES.filter(isRosterConflictEligible) },
+                },
+              },
+              select: {
+                playerTag: true,
+                rosterId: true,
+              },
+            })) as Array<{ playerTag: string; rosterId: string }>)
+          : [];
+      const conflictTags = new Set(normalizeRosterPlayerTags(conflictRows.map((row) => row.playerTag)));
+
+      const targetTownHallResolution =
+        isRosterTownHallGated(targetRoster) && candidateTags.length > 0
+          ? await resolveRosterPlayerTownHallMap({
+              rosterType: targetRoster.rosterType,
+              clanTag: targetRoster.clanTag,
+              playerTags: candidateTags,
+              allowLiveFetch: true,
+              cocService: input.cocService ?? null,
+            })
+          : null;
+      const blockedUnavailableTags: string[] = [];
+      const blockedOutOfRangeTags: string[] = [];
+      const movedTags: string[] = [];
+      const movedAccounts: RosterChangeRosterIdentity[] = [];
+      const blockedTags: string[] = [];
+      const blockedAccounts: RosterAccountIdentity[] = [];
+      const movedRowsByGroupId = new Map<
+        string,
+        Array<{
+          rosterId: string;
+          groupId: string;
+          playerTag: string;
+          playerName: string | null;
+          discordUserId: string;
+        }>
+      >();
+
+      if (targetTownHallResolution) {
+        logRosterTownHallResolutionDiagnostics({
+          rosterId: targetRoster.id,
+          rosterType: targetRoster.rosterType,
+          clanTag: targetRoster.clanTag,
+          requestedTags,
+          linkedTags: sourceTags,
+          resolution: targetTownHallResolution,
+          blockedUnavailableTags,
+          blockedOutOfRangeTags,
+          cocServicePresent: Boolean(input.cocService),
+        });
+      }
+
+      for (const tag of candidateTags) {
+        const sourceSignup = sourceByTag.get(tag) ?? null;
+        if (!sourceSignup) {
+          continue;
+        }
+        const blockedAccount = {
+          playerTag: tag,
+          playerName: normalizeRosterText(sourceSignup.playerName ?? null),
+        };
+        if (conflictTags.has(tag)) {
+          blockedTags.push(tag);
+          blockedAccounts.push(blockedAccount);
+          continue;
+        }
+
+        const sourceGroupKey = normalizeRosterGroupKey(sourceSignup.group?.key ?? "");
+        const resolvedTargetGroup =
+          normalizedTargetGroupKey && targetGroupByKey.has(normalizedTargetGroupKey)
+            ? targetGroupByKey.get(normalizedTargetGroupKey) ?? null
+            : (sourceGroupKey && targetGroupByKey.get(sourceGroupKey)) ?? defaultTargetGroup;
+        if (!resolvedTargetGroup) {
+          return {
+            outcome: "target_group_not_found",
+            sourceRosterId: sourceRoster.id,
+            sourceRosterTitle: sourceRoster.title,
+            targetRosterId: targetRoster.id,
+            targetRosterTitle: targetRoster.title,
+            targetGroupKey: normalizedTargetGroupKey ?? sourceGroupKey ?? "",
+            requestedTags,
+            movedTags,
+            movedAccounts,
+            duplicateTags,
+            missingTags,
+            blockedTags,
+            blockedAccounts,
+          } as const;
+        }
+
+        const maxMembers = normalizeRosterInt(targetRoster.maxMembers);
+        if (maxMembers !== null && targetCount + movedTags.length + 1 > maxMembers) {
+          blockedTags.push(tag);
+          blockedAccounts.push(blockedAccount);
+          continue;
+        }
+
+        const normalizedDiscordUserId = normalizeDiscordUserId(sourceSignup.discordUserId) ?? sourceSignup.discordUserId;
+        const effectiveMaxAccountsPerUser =
+          targetRoster.allowMultiSignup === false
+            ? 1
+            : normalizeRosterInt(targetRoster.maxAccountsPerUser);
+        if (effectiveMaxAccountsPerUser !== null) {
+          const ownedCount = targetOwnedCountByUser.get(normalizedDiscordUserId) ?? 0;
+          if (ownedCount + 1 > effectiveMaxAccountsPerUser) {
+            blockedTags.push(tag);
+            blockedAccounts.push(blockedAccount);
+            continue;
+          }
+        }
+
+        if (targetTownHallResolution) {
+          const townHall = targetTownHallResolution.townHallByTag.get(tag) ?? null;
+          if (townHall === null) {
+            blockedUnavailableTags.push(tag);
+            blockedAccounts.push(blockedAccount);
+            continue;
+          }
+          const minTownhall = normalizeRosterInt(targetRoster.minTownhall);
+          const maxTownhall = normalizeRosterInt(targetRoster.maxTownhall);
+          if ((minTownhall !== null && townHall < minTownhall) || (maxTownhall !== null && townHall > maxTownhall)) {
+            blockedOutOfRangeTags.push(tag);
+            blockedAccounts.push(blockedAccount);
+            continue;
+          }
+        }
+
+        const movedRow = {
+          rosterId: targetRoster.id,
+          groupId: resolvedTargetGroup.id,
+          playerTag: tag,
+          playerName: normalizeRosterText(sourceSignup.playerName ?? null),
+          discordUserId: normalizedDiscordUserId,
+        };
+        const rows = movedRowsByGroupId.get(resolvedTargetGroup.id) ?? [];
+        rows.push(movedRow);
+        movedRowsByGroupId.set(resolvedTargetGroup.id, rows);
+        movedTags.push(tag);
+        movedAccounts.push({
+          playerTag: tag,
+          playerName: normalizeRosterText(sourceSignup.playerName ?? null),
+          targetGroupKey: resolvedTargetGroup.key,
+          targetGroupName: resolvedTargetGroup.name,
+        });
+        targetCount += 1;
+        targetOwnedCountByUser.set(normalizedDiscordUserId, (targetOwnedCountByUser.get(normalizedDiscordUserId) ?? 0) + 1);
+      }
+
+      if (movedTags.length > 0) {
+        for (const rows of movedRowsByGroupId.values()) {
+          await tx.rosterSignup.createMany({
+            data: rows,
+            skipDuplicates: false,
+          });
+        }
+        await tx.rosterSignup.deleteMany({
+          where: {
+            rosterId: sourceRoster.id,
+            playerTag: { in: movedTags },
+          },
+        });
+      }
+
+      const buildSharedResult = <T extends { outcome: string }>(result: T): T => result;
+      if (movedTags.length > 0) {
+        return buildSharedResult({
+          outcome: "changed",
+          sourceRosterId: sourceRoster.id,
+          sourceRosterTitle: sourceRoster.title,
+          targetRosterId: targetRoster.id,
+          targetRosterTitle: targetRoster.title,
+          targetRosterClanTag: targetRoster.clanTag ?? null,
+          targetRosterClanName: null,
+          targetGroupKey: normalizedTargetGroupKey,
+          targetGroupName: normalizedTargetGroupKey
+            ? targetGroupByKey.get(normalizedTargetGroupKey)?.name ?? null
+            : null,
+          requestedTags,
+          movedTags,
+          movedAccounts,
+          duplicateTags,
+          missingTags,
+          blockedTags,
+          blockedAccounts,
+        });
+      }
+
+      if (blockedUnavailableTags.length > 0) {
+        return buildSharedResult({
+          outcome: "townhall_unavailable",
+          sourceRosterId: sourceRoster.id,
+          sourceRosterTitle: sourceRoster.title,
+          targetRosterId: targetRoster.id,
+          targetRosterTitle: targetRoster.title,
+          targetRosterClanTag: targetRoster.clanTag ?? null,
+          targetRosterClanName: null,
+          targetGroupKey: normalizedTargetGroupKey,
+          targetGroupName: normalizedTargetGroupKey
+            ? targetGroupByKey.get(normalizedTargetGroupKey)?.name ?? null
+            : null,
+          requestedTags,
+          movedTags,
+          movedAccounts,
+          duplicateTags,
+          missingTags,
+          blockedTags: blockedUnavailableTags,
+          blockedAccounts,
+        });
+      }
+      if (blockedOutOfRangeTags.length > 0) {
+        return buildSharedResult({
+          outcome: "townhall_out_of_range",
+          sourceRosterId: sourceRoster.id,
+          sourceRosterTitle: sourceRoster.title,
+          targetRosterId: targetRoster.id,
+          targetRosterTitle: targetRoster.title,
+          targetRosterClanTag: targetRoster.clanTag ?? null,
+          targetRosterClanName: null,
+          targetGroupKey: normalizedTargetGroupKey,
+          targetGroupName: normalizedTargetGroupKey
+            ? targetGroupByKey.get(normalizedTargetGroupKey)?.name ?? null
+            : null,
+          requestedTags,
+          movedTags,
+          movedAccounts,
+          duplicateTags,
+          missingTags,
+          blockedTags: blockedOutOfRangeTags,
+          blockedAccounts,
+        });
+      }
+      if (blockedTags.length > 0) {
+        const blockedOutcome =
+          conflictTags.size > 0
+            ? "roster_conflict"
+            : blockedTags.length > 0 && normalizeRosterInt(targetRoster.maxMembers) !== null
+              ? "roster_full"
+              : "account_limit_exceeded";
+        return buildSharedResult({
+          outcome: blockedOutcome,
+          sourceRosterId: sourceRoster.id,
+          sourceRosterTitle: sourceRoster.title,
+          targetRosterId: targetRoster.id,
+          targetRosterTitle: targetRoster.title,
+          targetRosterClanTag: targetRoster.clanTag ?? null,
+          targetRosterClanName: null,
+          targetGroupKey: normalizedTargetGroupKey,
+          targetGroupName: normalizedTargetGroupKey
+            ? targetGroupByKey.get(normalizedTargetGroupKey)?.name ?? null
+            : null,
+          requestedTags,
+          movedTags,
+          movedAccounts,
+          duplicateTags,
+          missingTags,
+          blockedTags,
+          blockedAccounts,
+        } as any);
+      }
+
+      return buildSharedResult({
+        outcome: "nothing_changed",
+        sourceRosterId: sourceRoster.id,
+        sourceRosterTitle: sourceRoster.title,
+        targetRosterId: targetRoster.id,
+        targetRosterTitle: targetRoster.title,
+        targetRosterClanTag: targetRoster.clanTag ?? null,
+        targetRosterClanName: null,
+        targetGroupKey: normalizedTargetGroupKey,
+        targetGroupName: normalizedTargetGroupKey
+          ? targetGroupByKey.get(normalizedTargetGroupKey)?.name ?? null
+          : null,
+        requestedTags,
+        movedTags,
+        movedAccounts,
+        duplicateTags,
+        missingTags,
+        blockedTags,
+        blockedAccounts,
+      });
+    });
   }
 
   async removeRosterSignupsAsManager(input: {

--- a/tests/roster.command.test.ts
+++ b/tests/roster.command.test.ts
@@ -60,6 +60,8 @@ function makeInteraction(input: {
   action?: string | null;
   message?: string | null;
   group?: string | null;
+  targetRoster?: string | null;
+  targetGroup?: string | null;
   players?: string | null;
   pingOption?: string | null;
   userId?: string | null;
@@ -96,6 +98,8 @@ function makeInteraction(input: {
         if (name === "roster") return input.roster ?? null;
         if (name === "action") return input.action ?? null;
         if (name === "message") return input.message ?? null;
+        if (name === "target_roster") return input.targetRoster ?? null;
+        if (name === "target_group") return input.targetGroup ?? null;
         if (name === "group") return input.group ?? null;
         if (name === "players") return input.players ?? null;
         if (name === "ping_option") return input.pingOption ?? null;
@@ -148,6 +152,9 @@ function makeAutocompleteInteraction(input: {
   roster?: string | null;
   action?: string | null;
   group?: string | null;
+  targetRoster?: string | null;
+  targetGroup?: string | null;
+  userId?: string | null;
   guildMembers?: Array<{
     id: string;
     displayName: string;
@@ -183,7 +190,17 @@ function makeAutocompleteInteraction(input: {
         if (name === "roster") return input.roster ?? null;
         if (name === "action") return input.action ?? null;
         if (name === "group") return input.group ?? null;
+        if (name === "target_roster") return input.targetRoster ?? null;
+        if (name === "target_group") return input.targetGroup ?? null;
         return null;
+      }),
+      getUser: vi.fn((name: string) => {
+        if (name !== "user" || !input.userId) return null;
+        return {
+          id: input.userId,
+          bot: false,
+          username: "selected-user",
+        };
       }),
     },
   };
@@ -253,6 +270,7 @@ describe("/roster command", () => {
     vi.spyOn(rosterService, "addRosterSignupsForManager");
     vi.spyOn(rosterService, "moveRosterSignups");
     vi.spyOn(rosterService, "removeRosterSignupsAsManager");
+    vi.spyOn(rosterService, "changeRosterSignups");
     vi.spyOn(rosterWeightService, "setManualWeightForRoster");
     vi.spyOn(rosterExportService, "createRosterExport");
     (rosterService.buildRosterSignupPayload as any).mockResolvedValue(
@@ -581,7 +599,7 @@ describe("/roster command", () => {
     );
   });
 
-  it("routes roster manage actions to the existing add, move, remove, and lifecycle helpers", async () => {
+  it("routes roster manage actions to the existing add, move, remove, change roster, and lifecycle helpers", async () => {
     (rosterService.findGuildRosterById as any).mockResolvedValue({
       id: "roster-1",
       guildId: "guild-1",
@@ -640,6 +658,37 @@ describe("/roster command", () => {
       ignoredTags: [],
       notOwnedTags: [],
     });
+    (rosterService.changeRosterSignups as any).mockResolvedValue({
+      outcome: "changed",
+      sourceRosterId: "roster-1",
+      sourceRosterTitle: "Source Roster",
+      targetRosterId: "roster-2",
+      targetRosterTitle: "Target Roster",
+      targetRosterClanTag: "#2QG2C08UP",
+      targetRosterClanName: null,
+      targetGroupKey: null,
+      targetGroupName: null,
+      requestedTags: ["#PQL0289", "#QGRJ2222"],
+      movedTags: ["#PQL0289", "#QGRJ2222"],
+      movedAccounts: [
+        {
+          playerTag: "#PQL0289",
+          playerName: "Alpha",
+          targetGroupKey: "confirmed",
+          targetGroupName: "Confirmed",
+        },
+        {
+          playerTag: "#QGRJ2222",
+          playerName: "Bravo",
+          targetGroupKey: "substitute",
+          targetGroupName: "Substitute",
+        },
+      ],
+      duplicateTags: [],
+      missingTags: [],
+      blockedTags: [],
+      blockedAccounts: [],
+    });
     (rosterService.updateRosterLifecycleState as any).mockResolvedValue({
       outcome: "updated",
       rosterId: "roster-1",
@@ -694,6 +743,74 @@ describe("/roster command", () => {
       }),
     );
     expect(String(removeInteraction.editReply.mock.calls.at(-1)?.[0] ?? "")).toContain("Removed #PQL0289");
+
+    const changeInteraction = makeInteraction({
+      subcommand: "manage",
+      roster: "roster-1",
+      action: "change_roster",
+      targetRoster: "roster-2",
+      targetGroup: "substitute",
+      players: "#PQL0289 #QGRJ2222",
+    }) as any;
+    (rosterService.findGuildRosterById as any).mockImplementation(({ rosterId }: { rosterId: string }) =>
+      Promise.resolve(
+        rosterId === "roster-1"
+          ? {
+              id: "roster-1",
+              guildId: "guild-1",
+              rosterType: "CWL",
+              rosterCategory: "signup",
+              title: "Source Roster",
+              clanTag: "#2QG2C08UP",
+              startsAt: new Date("2026-04-20T00:00:00.000Z"),
+              endsAt: null,
+              timezone: "America/Los_Angeles",
+              displayTimezone: "America/Los_Angeles",
+              lifecycleState: "OPEN",
+              postedChannelId: null,
+              postedMessageId: null,
+              postedMessageUrl: null,
+              postedAt: null,
+              createdByDiscordUserId: "111111111111111111",
+              updatedByDiscordUserId: "111111111111111111",
+              createdAt: new Date("2026-04-20T00:00:00.000Z"),
+              updatedAt: new Date("2026-04-20T00:00:00.000Z"),
+            }
+          : {
+              id: "roster-2",
+              guildId: "guild-1",
+              rosterType: "CWL",
+              rosterCategory: "signup",
+              title: "Target Roster",
+              clanTag: "#2QG2C08UP",
+              startsAt: new Date("2026-04-20T00:00:00.000Z"),
+              endsAt: null,
+              timezone: "America/Los_Angeles",
+              displayTimezone: "America/Los_Angeles",
+              lifecycleState: "OPEN",
+              postedChannelId: null,
+              postedMessageId: null,
+              postedMessageUrl: null,
+              postedAt: null,
+              createdByDiscordUserId: "111111111111111111",
+              updatedByDiscordUserId: "111111111111111111",
+              createdAt: new Date("2026-04-20T00:00:00.000Z"),
+              updatedAt: new Date("2026-04-20T00:00:00.000Z"),
+            },
+      ),
+    );
+    await Roster.run({} as any, changeInteraction as any);
+    expect(rosterService.changeRosterSignups).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sourceRosterId: "roster-1",
+        targetRosterId: "roster-2",
+        targetGroupKey: "substitute",
+        playerTags: ["#PQL0289", "#QGRJ2222"],
+      }),
+    );
+    expect(String(changeInteraction.editReply.mock.calls.at(-1)?.[0] ?? "")).toContain(
+      "Moved Alpha `#PQL0289` to Target Roster - Confirmed.",
+    );
 
     const closeInteraction = makeInteraction({
       subcommand: "manage",
@@ -2598,6 +2715,54 @@ describe("/roster command", () => {
       { playerTag: "#QGRJ2222", linkedAt: new Date("2026-04-02T00:00:00.000Z"), linkedName: null },
       { playerTag: "#VJQ28888", linkedAt: new Date("2026-04-03T00:00:00.000Z"), linkedName: "Delta" },
     ] as any);
+    (rosterService.listGuildRosters as any).mockResolvedValue([
+      {
+        id: "roster-1",
+        guildId: "guild-1",
+        rosterType: "CWL",
+        rosterCategory: "signup",
+        title: "CWL Alpha Signup",
+        clanTag: "#2QG2C08UP",
+        startsAt: new Date("2026-04-20T00:00:00.000Z"),
+        endsAt: null,
+        timezone: "America/Los_Angeles",
+        displayTimezone: "America/Los_Angeles",
+        lifecycleState: "OPEN",
+        postedChannelId: null,
+        postedMessageId: null,
+        postedMessageUrl: null,
+        postedAt: null,
+        createdByDiscordUserId: "111111111111111111",
+        updatedByDiscordUserId: "111111111111111111",
+        createdAt: new Date("2026-04-20T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-20T00:00:00.000Z"),
+        groupCount: 2,
+        signupCount: 3,
+      },
+      {
+        id: "roster-2",
+        guildId: "guild-1",
+        rosterType: "CWL",
+        rosterCategory: "signup",
+        title: "Target Roster",
+        clanTag: "#2QG2C08UP",
+        startsAt: new Date("2026-04-20T00:00:00.000Z"),
+        endsAt: null,
+        timezone: "America/Los_Angeles",
+        displayTimezone: "America/Los_Angeles",
+        lifecycleState: "OPEN",
+        postedChannelId: null,
+        postedMessageId: null,
+        postedMessageUrl: null,
+        postedAt: null,
+        createdByDiscordUserId: "111111111111111111",
+        updatedByDiscordUserId: "111111111111111111",
+        createdAt: new Date("2026-04-20T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-20T00:00:00.000Z"),
+        groupCount: 1,
+        signupCount: 1,
+      },
+    ] as any);
 
     const noRosterInteraction = makeAutocompleteInteraction({
       focusedName: "players",
@@ -2669,6 +2834,233 @@ describe("/roster command", () => {
     });
     expect(addInteraction.respond).toHaveBeenCalledWith([
       { name: "Delta (#VJQ28888)", value: "#VJQ28888" },
+    ]);
+
+    const changeTargetInteraction = makeAutocompleteInteraction({
+      focusedName: "target_roster",
+      focusedValue: "",
+      subcommand: "manage",
+      roster: "roster-1",
+    }) as any;
+    await Roster.autocomplete(changeTargetInteraction);
+    expect(rosterService.listGuildRosters).toHaveBeenCalledWith(
+      expect.objectContaining({
+        guildId: "guild-1",
+        name: "",
+      }),
+    );
+    expect(changeTargetInteraction.respond).toHaveBeenCalledWith([
+      expect.objectContaining({ value: expect.any(String) }),
+    ]);
+
+    const changeTargetGroupInteraction = makeAutocompleteInteraction({
+      focusedName: "target_group",
+      focusedValue: "con",
+      subcommand: "manage",
+      roster: "roster-1",
+      targetRoster: "roster-2",
+    }) as any;
+    (rosterService.getRosterView as any).mockResolvedValueOnce({
+      roster: {
+        id: "roster-2",
+        lifecycleState: "OPEN",
+      },
+      groups: [
+        { id: "group-confirmed", key: "confirmed", name: "Confirmed", description: null, sortOrder: 0 },
+        { id: "group-substitute", key: "substitute", name: "Substitute", description: null, sortOrder: 1 },
+      ],
+      signups: [],
+      clanDisplayName: null,
+      clanLeagueLabel: null,
+      totalSignupCount: 0,
+    });
+    await Roster.autocomplete(changeTargetGroupInteraction);
+    expect(changeTargetGroupInteraction.respond).toHaveBeenCalledWith([
+      { name: "Confirmed (confirmed)", value: "confirmed" },
+    ]);
+
+    const changeInteraction = makeAutocompleteInteraction({
+      focusedName: "players",
+      focusedValue: "",
+      subcommand: "manage",
+      roster: "roster-1",
+      action: "change_roster",
+      targetRoster: "roster-2",
+    }) as any;
+    (rosterService.getRosterView as any).mockResolvedValueOnce({
+      roster: {
+        id: "roster-1",
+        lifecycleState: "OPEN",
+      },
+      groups: [
+        { id: "group-confirmed", key: "confirmed", name: "Confirmed", description: null, sortOrder: 0 },
+        { id: "group-substitute", key: "substitute", name: "Substitute", description: null, sortOrder: 1 },
+      ],
+      signups: [
+        {
+          id: "signup-1",
+          rosterId: "roster-1",
+          groupId: "group-confirmed",
+          playerTag: "#PYLQ0289",
+          playerName: "Alpha",
+          discordUserId: "111111111111111111",
+          signedUpAt: new Date("2026-04-01T00:00:00.000Z"),
+          createdAt: new Date("2026-04-01T00:00:00.000Z"),
+          updatedAt: new Date("2026-04-01T00:00:00.000Z"),
+          group: { key: "confirmed" },
+        },
+        {
+          id: "signup-2",
+          rosterId: "roster-1",
+          groupId: "group-confirmed",
+          playerTag: "#QGRJ2222",
+          playerName: "Bravo",
+          discordUserId: "222222222222222222",
+          signedUpAt: new Date("2026-04-01T00:00:00.000Z"),
+          createdAt: new Date("2026-04-01T00:00:00.000Z"),
+          updatedAt: new Date("2026-04-01T00:00:00.000Z"),
+          group: { key: "confirmed" },
+        },
+        {
+          id: "signup-3",
+          rosterId: "roster-1",
+          groupId: "group-substitute",
+          playerTag: "#CUV02898",
+          playerName: "Charlie",
+          discordUserId: "333333333333333333",
+          signedUpAt: new Date("2026-04-01T00:00:00.000Z"),
+          createdAt: new Date("2026-04-01T00:00:00.000Z"),
+          updatedAt: new Date("2026-04-01T00:00:00.000Z"),
+          group: { key: "substitute" },
+        },
+      ],
+      clanDisplayName: null,
+      clanLeagueLabel: null,
+      totalSignupCount: 3,
+    });
+    (rosterService.getRosterView as any).mockResolvedValueOnce({
+      roster: {
+        id: "roster-2",
+        lifecycleState: "OPEN",
+      },
+      groups: [
+        { id: "group-confirmed", key: "confirmed", name: "Confirmed", description: null, sortOrder: 0 },
+        { id: "group-substitute", key: "substitute", name: "Substitute", description: null, sortOrder: 1 },
+      ],
+      signups: [
+        {
+          id: "signup-4",
+          rosterId: "roster-2",
+          groupId: "group-confirmed",
+          playerTag: "#QGRJ2222",
+          playerName: "Bravo",
+          discordUserId: "222222222222222222",
+          signedUpAt: new Date("2026-04-01T00:00:00.000Z"),
+          createdAt: new Date("2026-04-01T00:00:00.000Z"),
+          updatedAt: new Date("2026-04-01T00:00:00.000Z"),
+          group: { key: "confirmed" },
+        },
+      ],
+      clanDisplayName: null,
+      clanLeagueLabel: null,
+      totalSignupCount: 1,
+    });
+    await Roster.autocomplete(changeInteraction);
+    expect(changeInteraction.respond).toHaveBeenCalledWith([
+      { name: "Alpha (#PYLQ0289)", value: "#PYLQ0289" },
+      { name: "Charlie (#CUV02898)", value: "#CUV02898" },
+    ]);
+
+    (rosterService.getRosterView as any).mockResolvedValueOnce({
+      roster: {
+        id: "roster-1",
+        lifecycleState: "OPEN",
+      },
+      groups: [
+        { id: "group-confirmed", key: "confirmed", name: "Confirmed", description: null, sortOrder: 0 },
+        { id: "group-substitute", key: "substitute", name: "Substitute", description: null, sortOrder: 1 },
+      ],
+      signups: [
+        {
+          id: "signup-1",
+          rosterId: "roster-1",
+          groupId: "group-confirmed",
+          playerTag: "#PYLQ0289",
+          playerName: "Alpha",
+          discordUserId: "111111111111111111",
+          signedUpAt: new Date("2026-04-01T00:00:00.000Z"),
+          createdAt: new Date("2026-04-01T00:00:00.000Z"),
+          updatedAt: new Date("2026-04-01T00:00:00.000Z"),
+          group: { key: "confirmed" },
+        },
+        {
+          id: "signup-2",
+          rosterId: "roster-1",
+          groupId: "group-confirmed",
+          playerTag: "#QGRJ2222",
+          playerName: "Bravo",
+          discordUserId: "222222222222222222",
+          signedUpAt: new Date("2026-04-01T00:00:00.000Z"),
+          createdAt: new Date("2026-04-01T00:00:00.000Z"),
+          updatedAt: new Date("2026-04-01T00:00:00.000Z"),
+          group: { key: "confirmed" },
+        },
+        {
+          id: "signup-3",
+          rosterId: "roster-1",
+          groupId: "group-substitute",
+          playerTag: "#CUV02898",
+          playerName: "Charlie",
+          discordUserId: "333333333333333333",
+          signedUpAt: new Date("2026-04-01T00:00:00.000Z"),
+          createdAt: new Date("2026-04-01T00:00:00.000Z"),
+          updatedAt: new Date("2026-04-01T00:00:00.000Z"),
+          group: { key: "substitute" },
+        },
+      ],
+      clanDisplayName: null,
+      clanLeagueLabel: null,
+      totalSignupCount: 3,
+    });
+    (rosterService.getRosterView as any).mockResolvedValueOnce({
+      roster: {
+        id: "roster-2",
+        lifecycleState: "OPEN",
+      },
+      groups: [
+        { id: "group-confirmed", key: "confirmed", name: "Confirmed", description: null, sortOrder: 0 },
+        { id: "group-substitute", key: "substitute", name: "Substitute", description: null, sortOrder: 1 },
+      ],
+      signups: [
+        {
+          id: "signup-4",
+          rosterId: "roster-2",
+          groupId: "group-confirmed",
+          playerTag: "#QGRJ2222",
+          playerName: "Bravo",
+          discordUserId: "222222222222222222",
+          signedUpAt: new Date("2026-04-01T00:00:00.000Z"),
+          createdAt: new Date("2026-04-01T00:00:00.000Z"),
+          updatedAt: new Date("2026-04-01T00:00:00.000Z"),
+          group: { key: "confirmed" },
+        },
+      ],
+      clanDisplayName: null,
+      clanLeagueLabel: null,
+      totalSignupCount: 1,
+    });
+    const changeUserInteraction = makeAutocompleteInteraction({
+      focusedName: "players",
+      focusedValue: "",
+      subcommand: "manage",
+      roster: "roster-1",
+      action: "change_roster",
+      targetRoster: "roster-2",
+      userId: "111111111111111111",
+    }) as any;
+    await Roster.autocomplete(changeUserInteraction);
+    expect(changeUserInteraction.respond).toHaveBeenCalledWith([
+      { name: "Alpha (#PYLQ0289)", value: "#PYLQ0289" },
     ]);
   });
 

--- a/tests/roster.commandShape.test.ts
+++ b/tests/roster.commandShape.test.ts
@@ -81,11 +81,18 @@ describe("/roster command shape", () => {
 
     const manageRoster = manage?.options?.find((option: any) => option.name === "roster");
     const manageAction = manage?.options?.find((option: any) => option.name === "action");
+    const manageTargetRoster = manage?.options?.find((option: any) => option.name === "target_roster");
+    const manageTargetGroup = manage?.options?.find((option: any) => option.name === "target_group");
+    const manageUser = manage?.options?.find((option: any) => option.name === "user");
     const manageGroup = manage?.options?.find((option: any) => option.name === "group");
     const managePlayers = manage?.options?.find((option: any) => option.name === "players");
 
     expect(manageRoster?.required).toBe(true);
     expect(manageAction?.required).toBe(true);
+    expect(manageTargetRoster?.autocomplete).toBe(true);
+    expect(manageTargetGroup?.autocomplete).toBe(true);
+    expect(manageUser?.type).toBe(ApplicationCommandOptionType.User);
+    expect(manageUser?.autocomplete).not.toBe(true);
     expect(manageGroup?.required).toBe(false);
     expect(managePlayers?.required).toBe(false);
     expect(manageGroup?.autocomplete).toBe(true);
@@ -94,6 +101,7 @@ describe("/roster command shape", () => {
       "add",
       "move",
       "remove",
+      "change_roster",
       "set_weight",
       "open",
       "close",

--- a/tests/roster.service.test.ts
+++ b/tests/roster.service.test.ts
@@ -2552,6 +2552,238 @@ describe("RosterService", () => {
     expect(prismaMock.rosterSignup.deleteMany).not.toHaveBeenCalled();
   });
 
+  it("returns account_limit_exceeded when the target roster still has space but the player exceeds the per-user limit", async () => {
+    prismaMock.roster.findUnique.mockResolvedValueOnce({
+      id: "roster-1",
+      guildId: "guild-1",
+      rosterType: "CWL",
+      rosterCategory: "signup",
+      title: "Source Roster",
+      clanTag: "#2QG2C08UP",
+      startsAt: new Date("2026-04-20T00:00:00.000Z"),
+      endsAt: null,
+      timezone: "America/Los_Angeles",
+      displayTimezone: "America/Los_Angeles",
+      maxMembers: null,
+      maxAccountsPerUser: null,
+      minTownhall: null,
+      maxTownhall: null,
+      rosterRoleId: null,
+      allowMultiSignup: true,
+      sortBy: null,
+      importMembers: false,
+      lifecycleState: "OPEN",
+      postedChannelId: null,
+      postedMessageId: null,
+      postedMessageUrl: null,
+      postedAt: null,
+      createdByDiscordUserId: "111111111111111111",
+      updatedByDiscordUserId: "111111111111111111",
+      createdAt: new Date("2026-04-20T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-20T00:00:00.000Z"),
+    } as any);
+    prismaMock.roster.findFirst.mockResolvedValueOnce({
+      id: "roster-2",
+      guildId: "guild-1",
+      rosterType: "CWL",
+      rosterCategory: "signup",
+      title: "Target Roster",
+      clanTag: "#2QG2C08UP",
+      startsAt: new Date("2026-04-20T00:00:00.000Z"),
+      endsAt: null,
+      timezone: "America/Los_Angeles",
+      displayTimezone: "America/Los_Angeles",
+      maxMembers: 10,
+      maxAccountsPerUser: 1,
+      minTownhall: null,
+      maxTownhall: null,
+      rosterRoleId: null,
+      allowMultiSignup: true,
+      sortBy: null,
+      importMembers: false,
+      lifecycleState: "OPEN",
+      postedChannelId: null,
+      postedMessageId: null,
+      postedMessageUrl: null,
+      postedAt: null,
+      createdByDiscordUserId: "111111111111111111",
+      updatedByDiscordUserId: "111111111111111111",
+      createdAt: new Date("2026-04-20T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-20T00:00:00.000Z"),
+    } as any);
+    prismaMock.rosterGroup.findMany.mockResolvedValueOnce([
+      {
+        id: "group-confirmed",
+        key: "confirmed",
+        name: "Confirmed",
+        description: "Primary roster members",
+        sortOrder: 0,
+      },
+    ] as any);
+    prismaMock.rosterSignup.findMany
+      .mockResolvedValueOnce([
+        {
+          id: "signup-1",
+          rosterId: "roster-1",
+          groupId: "group-confirmed",
+          playerTag: "#PQL0289",
+          playerName: "Alpha",
+          discordUserId: "111111111111111111",
+          group: {
+            id: "group-confirmed",
+            key: "confirmed",
+            name: "Confirmed",
+            description: "Primary roster members",
+            sortOrder: 0,
+          },
+        },
+      ] as any)
+      .mockResolvedValueOnce([
+        {
+          playerTag: "#ZZZ99999",
+          discordUserId: "111111111111111111",
+        },
+      ] as any)
+      .mockResolvedValueOnce([] as any);
+
+    const result = await rosterService.changeRosterSignups({
+      sourceRosterId: "roster-1",
+      targetRosterId: "roster-2",
+      playerTags: ["#PQL0289"],
+      updatedByDiscordUserId: "111111111111111111",
+    });
+
+    expect(result).toMatchObject({
+      outcome: "account_limit_exceeded",
+      sourceRosterId: "roster-1",
+      targetRosterId: "roster-2",
+      requestedTags: ["#PQL0289"],
+      movedTags: [],
+      duplicateTags: [],
+      missingTags: [],
+      blockedTags: ["#PQL0289"],
+      blockedAccounts: [{ playerTag: "#PQL0289", playerName: "Alpha" }],
+    });
+    expect(prismaMock.rosterSignup.createMany).not.toHaveBeenCalled();
+    expect(prismaMock.rosterSignup.deleteMany).not.toHaveBeenCalled();
+  });
+
+  it("returns roster_full when the target roster capacity is exhausted", async () => {
+    prismaMock.roster.findUnique.mockResolvedValueOnce({
+      id: "roster-1",
+      guildId: "guild-1",
+      rosterType: "CWL",
+      rosterCategory: "signup",
+      title: "Source Roster",
+      clanTag: "#2QG2C08UP",
+      startsAt: new Date("2026-04-20T00:00:00.000Z"),
+      endsAt: null,
+      timezone: "America/Los_Angeles",
+      displayTimezone: "America/Los_Angeles",
+      maxMembers: null,
+      maxAccountsPerUser: null,
+      minTownhall: null,
+      maxTownhall: null,
+      rosterRoleId: null,
+      allowMultiSignup: true,
+      sortBy: null,
+      importMembers: false,
+      lifecycleState: "OPEN",
+      postedChannelId: null,
+      postedMessageId: null,
+      postedMessageUrl: null,
+      postedAt: null,
+      createdByDiscordUserId: "111111111111111111",
+      updatedByDiscordUserId: "111111111111111111",
+      createdAt: new Date("2026-04-20T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-20T00:00:00.000Z"),
+    } as any);
+    prismaMock.roster.findFirst.mockResolvedValueOnce({
+      id: "roster-2",
+      guildId: "guild-1",
+      rosterType: "CWL",
+      rosterCategory: "signup",
+      title: "Target Roster",
+      clanTag: "#2QG2C08UP",
+      startsAt: new Date("2026-04-20T00:00:00.000Z"),
+      endsAt: null,
+      timezone: "America/Los_Angeles",
+      displayTimezone: "America/Los_Angeles",
+      maxMembers: 1,
+      maxAccountsPerUser: null,
+      minTownhall: null,
+      maxTownhall: null,
+      rosterRoleId: null,
+      allowMultiSignup: true,
+      sortBy: null,
+      importMembers: false,
+      lifecycleState: "OPEN",
+      postedChannelId: null,
+      postedMessageId: null,
+      postedMessageUrl: null,
+      postedAt: null,
+      createdByDiscordUserId: "111111111111111111",
+      updatedByDiscordUserId: "111111111111111111",
+      createdAt: new Date("2026-04-20T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-20T00:00:00.000Z"),
+    } as any);
+    prismaMock.rosterGroup.findMany.mockResolvedValueOnce([
+      {
+        id: "group-confirmed",
+        key: "confirmed",
+        name: "Confirmed",
+        description: "Primary roster members",
+        sortOrder: 0,
+      },
+    ] as any);
+    prismaMock.rosterSignup.findMany
+      .mockResolvedValueOnce([
+        {
+          id: "signup-1",
+          rosterId: "roster-1",
+          groupId: "group-confirmed",
+          playerTag: "#PQL0289",
+          playerName: "Alpha",
+          discordUserId: "111111111111111111",
+          group: {
+            id: "group-confirmed",
+            key: "confirmed",
+            name: "Confirmed",
+            description: "Primary roster members",
+            sortOrder: 0,
+          },
+        },
+      ] as any)
+      .mockResolvedValueOnce([
+        {
+          playerTag: "#ZZZ99999",
+          discordUserId: "222222222222222222",
+        },
+      ] as any)
+      .mockResolvedValueOnce([] as any);
+
+    const result = await rosterService.changeRosterSignups({
+      sourceRosterId: "roster-1",
+      targetRosterId: "roster-2",
+      playerTags: ["#PQL0289"],
+      updatedByDiscordUserId: "111111111111111111",
+    });
+
+    expect(result).toMatchObject({
+      outcome: "roster_full",
+      sourceRosterId: "roster-1",
+      targetRosterId: "roster-2",
+      requestedTags: ["#PQL0289"],
+      movedTags: [],
+      duplicateTags: [],
+      missingTags: [],
+      blockedTags: ["#PQL0289"],
+      blockedAccounts: [{ playerTag: "#PQL0289", playerName: "Alpha" }],
+    });
+    expect(prismaMock.rosterSignup.createMany).not.toHaveBeenCalled();
+    expect(prismaMock.rosterSignup.deleteMany).not.toHaveBeenCalled();
+  });
+
   it("builds roster ping previews for everyone, missing, and unregistered targets", async () => {
     const alphaTag = makeValidRosterPlayerTag(1);
     const bravoTag = makeValidRosterPlayerTag(2);

--- a/tests/roster.service.test.ts
+++ b/tests/roster.service.test.ts
@@ -2271,6 +2271,287 @@ describe("RosterService", () => {
     }
   });
 
+  it("moves roster signups to a different roster and preserves the resolved destination group per player", async () => {
+    prismaMock.roster.findUnique.mockResolvedValueOnce({
+      id: "roster-1",
+      guildId: "guild-1",
+      rosterType: "CWL",
+      rosterCategory: "signup",
+      title: "Source Roster",
+      clanTag: "#2QG2C08UP",
+      startsAt: new Date("2026-04-20T00:00:00.000Z"),
+      endsAt: null,
+      timezone: "America/Los_Angeles",
+      displayTimezone: "America/Los_Angeles",
+      maxMembers: null,
+      maxAccountsPerUser: null,
+      minTownhall: null,
+      maxTownhall: null,
+      rosterRoleId: null,
+      allowMultiSignup: true,
+      sortBy: null,
+      importMembers: false,
+      lifecycleState: "OPEN",
+      postedChannelId: null,
+      postedMessageId: null,
+      postedMessageUrl: null,
+      postedAt: null,
+      createdByDiscordUserId: "111111111111111111",
+      updatedByDiscordUserId: "111111111111111111",
+      createdAt: new Date("2026-04-20T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-20T00:00:00.000Z"),
+    } as any);
+    prismaMock.roster.findFirst.mockResolvedValueOnce({
+      id: "roster-2",
+      guildId: "guild-1",
+      rosterType: "CWL",
+      rosterCategory: "signup",
+      title: "Target Roster",
+      clanTag: "#2QG2C08UP",
+      startsAt: new Date("2026-04-20T00:00:00.000Z"),
+      endsAt: null,
+      timezone: "America/Los_Angeles",
+      displayTimezone: "America/Los_Angeles",
+      maxMembers: null,
+      maxAccountsPerUser: null,
+      minTownhall: null,
+      maxTownhall: null,
+      rosterRoleId: null,
+      allowMultiSignup: true,
+      sortBy: null,
+      importMembers: false,
+      lifecycleState: "OPEN",
+      postedChannelId: null,
+      postedMessageId: null,
+      postedMessageUrl: null,
+      postedAt: null,
+      createdByDiscordUserId: "111111111111111111",
+      updatedByDiscordUserId: "111111111111111111",
+      createdAt: new Date("2026-04-20T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-20T00:00:00.000Z"),
+    } as any);
+    prismaMock.rosterGroup.findMany.mockResolvedValueOnce([
+      {
+        id: "group-confirmed",
+        key: "confirmed",
+        name: "Confirmed",
+        description: "Primary roster members",
+        sortOrder: 0,
+      },
+      {
+        id: "group-substitute",
+        key: "substitute",
+        name: "Substitute",
+        description: "Reserve roster members",
+        sortOrder: 1,
+      },
+    ] as any);
+    prismaMock.rosterSignup.findMany
+      .mockResolvedValueOnce([
+        {
+          id: "signup-1",
+          rosterId: "roster-1",
+          groupId: "group-confirmed",
+          playerTag: "#PQL0289",
+          playerName: "Alpha",
+          discordUserId: "111111111111111111",
+          group: {
+            id: "group-confirmed",
+            key: "confirmed",
+            name: "Confirmed",
+            description: "Primary roster members",
+            sortOrder: 0,
+          },
+        },
+        {
+          id: "signup-2",
+          rosterId: "roster-1",
+          groupId: "group-confirmed",
+          playerTag: "#QGRJ2222",
+          playerName: "Bravo",
+          discordUserId: "222222222222222222",
+          group: {
+            id: "group-confirmed",
+            key: "confirmed",
+            name: "Confirmed",
+            description: "Primary roster members",
+            sortOrder: 0,
+          },
+        },
+        {
+          id: "signup-3",
+          rosterId: "roster-1",
+          groupId: "group-confirmed",
+          playerTag: "#CUV02898",
+          playerName: "Charlie",
+          discordUserId: "333333333333333333",
+          group: {
+            id: "group-confirmed",
+            key: "confirmed",
+            name: "Confirmed",
+            description: "Primary roster members",
+            sortOrder: 0,
+          },
+        },
+      ] as any)
+      .mockResolvedValueOnce([
+        {
+          playerTag: "#QGRJ2222",
+          discordUserId: "222222222222222222",
+        },
+      ] as any)
+      .mockResolvedValueOnce([] as any);
+    prismaMock.rosterSignup.createMany.mockResolvedValueOnce({ count: 2 });
+    prismaMock.rosterSignup.deleteMany.mockResolvedValueOnce({ count: 2 });
+
+    const result = await rosterService.changeRosterSignups({
+      sourceRosterId: "roster-1",
+      targetRosterId: "roster-2",
+      playerTags: ["#PQL0289", "#QGRJ2222", "#CUV02898"],
+      updatedByDiscordUserId: "111111111111111111",
+    });
+
+    expect(result).toMatchObject({
+      outcome: "changed",
+      sourceRosterId: "roster-1",
+      sourceRosterTitle: "Source Roster",
+      targetRosterId: "roster-2",
+      targetRosterTitle: "Target Roster",
+      requestedTags: ["#PQL0289", "#QGRJ2222", "#CUV02898"],
+      movedTags: ["#PQL0289", "#CUV02898"],
+      duplicateTags: ["#QGRJ2222"],
+      missingTags: [],
+    });
+    expect(result.movedAccounts).toEqual([
+      {
+        playerTag: "#PQL0289",
+        playerName: "Alpha",
+        targetGroupKey: "confirmed",
+        targetGroupName: "Confirmed",
+      },
+      {
+        playerTag: "#CUV02898",
+        playerName: "Charlie",
+        targetGroupKey: "confirmed",
+        targetGroupName: "Confirmed",
+      },
+    ]);
+    expect(prismaMock.rosterSignup.createMany).toHaveBeenCalledWith({
+      data: [
+        expect.objectContaining({
+          rosterId: "roster-2",
+          groupId: "group-confirmed",
+          playerTag: "#PQL0289",
+          playerName: "Alpha",
+          discordUserId: "111111111111111111",
+        }),
+        expect.objectContaining({
+          rosterId: "roster-2",
+          groupId: "group-confirmed",
+          playerTag: "#CUV02898",
+          playerName: "Charlie",
+          discordUserId: "333333333333333333",
+        }),
+      ],
+      skipDuplicates: false,
+    });
+    expect(prismaMock.rosterSignup.deleteMany).toHaveBeenCalledWith({
+      where: {
+        rosterId: "roster-1",
+        playerTag: { in: ["#PQL0289", "#CUV02898"] },
+      },
+    });
+  });
+
+  it("rejects change roster when the requested target group is missing from the destination roster", async () => {
+    prismaMock.roster.findUnique.mockResolvedValueOnce({
+      id: "roster-1",
+      guildId: "guild-1",
+      rosterType: "CWL",
+      rosterCategory: "signup",
+      title: "Source Roster",
+      clanTag: "#2QG2C08UP",
+      startsAt: new Date("2026-04-20T00:00:00.000Z"),
+      endsAt: null,
+      timezone: "America/Los_Angeles",
+      displayTimezone: "America/Los_Angeles",
+      maxMembers: null,
+      maxAccountsPerUser: null,
+      minTownhall: null,
+      maxTownhall: null,
+      rosterRoleId: null,
+      allowMultiSignup: true,
+      sortBy: null,
+      importMembers: false,
+      lifecycleState: "OPEN",
+      postedChannelId: null,
+      postedMessageId: null,
+      postedMessageUrl: null,
+      postedAt: null,
+      createdByDiscordUserId: "111111111111111111",
+      updatedByDiscordUserId: "111111111111111111",
+      createdAt: new Date("2026-04-20T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-20T00:00:00.000Z"),
+    } as any);
+    prismaMock.roster.findFirst.mockResolvedValueOnce({
+      id: "roster-2",
+      guildId: "guild-1",
+      rosterType: "CWL",
+      rosterCategory: "signup",
+      title: "Target Roster",
+      clanTag: "#2QG2C08UP",
+      startsAt: new Date("2026-04-20T00:00:00.000Z"),
+      endsAt: null,
+      timezone: "America/Los_Angeles",
+      displayTimezone: "America/Los_Angeles",
+      maxMembers: null,
+      maxAccountsPerUser: null,
+      minTownhall: null,
+      maxTownhall: null,
+      rosterRoleId: null,
+      allowMultiSignup: true,
+      sortBy: null,
+      importMembers: false,
+      lifecycleState: "OPEN",
+      postedChannelId: null,
+      postedMessageId: null,
+      postedMessageUrl: null,
+      postedAt: null,
+      createdByDiscordUserId: "111111111111111111",
+      updatedByDiscordUserId: "111111111111111111",
+      createdAt: new Date("2026-04-20T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-20T00:00:00.000Z"),
+    } as any);
+    prismaMock.rosterGroup.findMany.mockResolvedValueOnce([
+      {
+        id: "group-confirmed",
+        key: "confirmed",
+        name: "Confirmed",
+        description: "Primary roster members",
+        sortOrder: 0,
+      },
+    ] as any);
+
+    const result = await rosterService.changeRosterSignups({
+      sourceRosterId: "roster-1",
+      targetRosterId: "roster-2",
+      targetGroupKey: "substitute",
+      playerTags: ["#PQL0289"],
+      updatedByDiscordUserId: "111111111111111111",
+    });
+
+    expect(result).toMatchObject({
+      outcome: "target_group_not_found",
+      targetGroupKey: "substitute",
+      requestedTags: ["#PQL0289"],
+      movedTags: [],
+      duplicateTags: [],
+      missingTags: ["#PQL0289"],
+    });
+    expect(prismaMock.rosterSignup.createMany).not.toHaveBeenCalled();
+    expect(prismaMock.rosterSignup.deleteMany).not.toHaveBeenCalled();
+  });
+
   it("builds roster ping previews for everyone, missing, and unregistered targets", async () => {
     const alphaTag = makeValidRosterPlayerTag(1);
     const bravoTag = makeValidRosterPlayerTag(2);


### PR DESCRIPTION
- add target roster/group/user options to /roster manage
- move selected players between rosters with scoped autocomplete and validation