### PR TITLE
fix(roster): use live clan membership for unregistered members

### DIFF
--- a/src/commands/Cwl.ts
+++ b/src/commands/Cwl.ts
@@ -2338,7 +2338,10 @@ export async function handleRosterManagerSubcommand(
 
   if (subcommand === "report" || subcommand === "readiness") {
     // Report and readiness intentionally share the same manager-facing roster view in Phase 2.
-    const reportText = await rosterService.buildRosterManagerReadinessText({ rosterId: roster.id });
+    const reportText = await rosterService.buildRosterManagerReadinessText({
+      rosterId: roster.id,
+      cocService,
+    });
     if (!reportText) {
       await interaction.editReply("Failed to build the roster readiness report.");
       return;

--- a/src/commands/Roster.ts
+++ b/src/commands/Roster.ts
@@ -1392,6 +1392,7 @@ export async function handleRosterPostSettingsMenuInteraction(
   if (choice === "unregistered_members" || choice === "missing_members") {
     const readiness = await rosterService.buildRosterManagerReadinessView({
       rosterId: roster.id,
+      cocService,
     });
     const lines = !readiness
       ? ["That roster is no longer available."]
@@ -2289,7 +2290,10 @@ async function handleRosterPostSubcommand(
   );
 }
 
-async function handleRosterReportSubcommand(interaction: ChatInputCommandInteraction): Promise<void> {
+async function handleRosterReportSubcommand(
+  interaction: ChatInputCommandInteraction,
+  cocService: CoCService,
+): Promise<void> {
   if (!interaction.inGuild() || !interaction.guildId) {
     await interaction.editReply("This command can only be used in a server.");
     return;
@@ -2300,7 +2304,10 @@ async function handleRosterReportSubcommand(interaction: ChatInputCommandInterac
     return;
   }
 
-  const reportText = await rosterService.buildRosterManagerReadinessText({ rosterId: roster.id });
+  const reportText = await rosterService.buildRosterManagerReadinessText({
+    rosterId: roster.id,
+    cocService,
+  });
   if (!reportText) {
     await interaction.editReply("Failed to build the roster readiness report.");
     return;
@@ -2311,11 +2318,17 @@ async function handleRosterReportSubcommand(interaction: ChatInputCommandInterac
   });
 }
 
-async function handleRosterReadinessSubcommand(interaction: ChatInputCommandInteraction): Promise<void> {
-  await handleRosterReportSubcommand(interaction);
+async function handleRosterReadinessSubcommand(
+  interaction: ChatInputCommandInteraction,
+  cocService: CoCService,
+): Promise<void> {
+  await handleRosterReportSubcommand(interaction, cocService);
 }
 
-async function handleRosterPingSubcommand(interaction: ChatInputCommandInteraction): Promise<void> {
+async function handleRosterPingSubcommand(
+  interaction: ChatInputCommandInteraction,
+  cocService: CoCService,
+): Promise<void> {
   if (!interaction.inGuild() || !interaction.guildId) {
     await interaction.editReply("This command can only be used in a server.");
     return;
@@ -2340,6 +2353,7 @@ async function handleRosterPingSubcommand(interaction: ChatInputCommandInteracti
     pingOption,
     groupKey,
     message,
+    cocService,
   });
 
   if (panel.outcome === "roster_not_found") {
@@ -3626,7 +3640,7 @@ export const Roster: Command = {
         return;
       }
       if (subcommand === "ping") {
-        await handleRosterPingSubcommand(interaction);
+        await handleRosterPingSubcommand(interaction, cocService);
         return;
       }
       if (subcommand === "manage") {
@@ -3642,11 +3656,11 @@ export const Roster: Command = {
         return;
       }
       if (subcommand === "report") {
-        await handleRosterReportSubcommand(interaction);
+        await handleRosterReportSubcommand(interaction, cocService);
         return;
       }
       if (subcommand === "readiness") {
-        await handleRosterReadinessSubcommand(interaction);
+        await handleRosterReadinessSubcommand(interaction, cocService);
         return;
       }
       if (subcommand === "refresh") {

--- a/src/services/RosterService.ts
+++ b/src/services/RosterService.ts
@@ -2381,32 +2381,50 @@ function buildRosterManagerMemberLine(entry: RosterManagerTrackedClanMemberRecor
   return `- ${entry.playerName} \`${entry.playerTag}\`${discordLabel}`;
 }
 
-async function loadCurrentCwlRosterManagerMembers(clanTag: string): Promise<Array<{
+async function loadCurrentCwlRosterManagerMembers(
+  clanTag: string,
+  cocService?: CoCService | null,
+): Promise<Array<{
   playerTag: string;
   playerName: string;
   townHall: number | null;
 }>> {
-  const currentClanRows = await todoSnapshotService.listSnapshotsByClanTag({
-    clanTag,
-    source: "clanTag",
-  });
-  if (currentClanRows.length <= 0) {
+  if (!cocService) {
     return [];
   }
 
-  return currentClanRows.map((member) => ({
-    playerTag: member.playerTag,
-    playerName: member.playerName,
-    townHall: member.townHall,
-  }));
+  const clan = await cocService.getClan(clanTag).catch(() => null);
+  const currentClanRows = (Array.isArray(clan?.members) ? clan.members : []) as Array<{
+    tag?: unknown;
+    name?: unknown;
+  }>;
+  const liveMembers: Array<{
+    playerTag: string;
+    playerName: string;
+    townHall: number | null;
+  }> = currentClanRows.flatMap((member: { tag?: unknown; name?: unknown }) => {
+      const playerTag = normalizePlayerTag(String(member?.tag ?? ""));
+      if (!playerTag) return [];
+      return [
+        {
+          playerTag,
+          playerName: normalizeRosterText(String(member?.name ?? "")) ?? playerTag,
+          townHall: null,
+        },
+      ];
+    });
+  return liveMembers;
 }
 
-async function loadRosterManagerTrackedClanMembers(roster: RosterRecord): Promise<RosterManagerTrackedClanMemberRecord[]> {
+async function loadRosterManagerTrackedClanMembers(
+  roster: RosterRecord,
+  cocService?: CoCService | null,
+): Promise<RosterManagerTrackedClanMemberRecord[]> {
   const trackedClanTag = normalizeClanTag(roster.clanTag ?? "");
   if (!trackedClanTag) return [];
 
   const rawMembers =
-    roster.rosterType === "FWA"
+      roster.rosterType === "FWA"
       ? await prisma.fwaClanMemberCurrent.findMany({
           where: { clanTag: trackedClanTag },
           orderBy: [{ playerName: "asc" }, { playerTag: "asc" }],
@@ -2417,7 +2435,7 @@ async function loadRosterManagerTrackedClanMembers(roster: RosterRecord): Promis
           },
         })
       : roster.rosterType === "CWL"
-        ? await loadCurrentCwlRosterManagerMembers(trackedClanTag)
+        ? await loadCurrentCwlRosterManagerMembers(trackedClanTag, cocService)
         : [];
 
   if (rawMembers.length <= 0) {
@@ -2493,6 +2511,7 @@ async function loadRosterPingTargets(input: {
   rosterId: string;
   pingOption: RosterPingOption;
   groupKey: string | null;
+  cocService?: CoCService | null;
 }): Promise<
   | {
       outcome: "ready";
@@ -2519,7 +2538,7 @@ async function loadRosterPingTargets(input: {
   }
 
   const [trackedClanRoster, signupLinks] = await Promise.all([
-    loadRosterManagerTrackedClanMembers(view.roster),
+    loadRosterManagerTrackedClanMembers(view.roster, input.cocService ?? null),
     listPlayerLinksForClanMembers({
       memberTagsInOrder: view.signups.map((signup) => signup.playerTag),
     }),
@@ -5111,11 +5130,12 @@ export class RosterService {
 
   async buildRosterManagerReadinessView(input: {
     rosterId: string;
+    cocService?: CoCService | null;
   }): Promise<RosterManagerReadinessView | null> {
     const view = await loadRosterView(input.rosterId);
     if (!view) return null;
 
-    const trackedClanRoster = await loadRosterManagerTrackedClanMembers(view.roster);
+    const trackedClanRoster = await loadRosterManagerTrackedClanMembers(view.roster, input.cocService ?? null);
     const trackedTagSet = new Set(trackedClanRoster.map((entry) => normalizePlayerTag(entry.playerTag)).filter(Boolean));
     const signupsByTag = new Map(view.signups.map((signup) => [normalizePlayerTag(signup.playerTag), signup] as const));
     const signedUpButUntracked = view.signups.filter((signup) => {
@@ -5138,6 +5158,7 @@ export class RosterService {
 
   async buildRosterManagerReadinessText(input: {
     rosterId: string;
+    cocService?: CoCService | null;
   }): Promise<string | null> {
     const view = await this.buildRosterManagerReadinessView(input);
     if (!view) return null;
@@ -5281,6 +5302,7 @@ export class RosterService {
     pingOption?: string | null;
     groupKey?: string | null;
     message?: string | null;
+    cocService?: CoCService | null;
   }): Promise<RosterPingOpenResult> {
     const pingOption = normalizeRosterPingOption(input.pingOption) ?? "everyone";
     const selectedGroupKey = input.groupKey ? normalizeRosterGroupKey(input.groupKey) : null;
@@ -5288,6 +5310,7 @@ export class RosterService {
       rosterId: input.rosterId,
       pingOption,
       groupKey: selectedGroupKey,
+      cocService: input.cocService ?? null,
     });
     if (loaded.outcome !== "ready") {
       return loaded;

--- a/tests/cwl.command.test.ts
+++ b/tests/cwl.command.test.ts
@@ -666,6 +666,7 @@ describe("/cwl command", () => {
     (rosterService.buildRosterManagerReadinessText as any).mockResolvedValue(
       "CWL Alpha Signup\nUnregistered members:\n- Bravo `#QGRJ2222` <@222222222222222222>",
     );
+    const cocService = {} as any;
 
     const interaction = makeInteraction({
       group: "roster",
@@ -675,7 +676,7 @@ describe("/cwl command", () => {
     interaction.inGuild = () => true;
     interaction.guildId = "guild-1";
 
-    await Cwl.run({} as any, interaction as any, {} as any);
+    await Cwl.run({} as any, interaction as any, cocService);
 
     expect(rosterService.findCwlRosterForClan).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -685,6 +686,7 @@ describe("/cwl command", () => {
     );
     expect(rosterService.buildRosterManagerReadinessText).toHaveBeenCalledWith({
       rosterId: "roster-1",
+      cocService,
     });
     expect(getEditedDescription(interaction)).toContain("Unregistered members:");
   });

--- a/tests/roster.command.test.ts
+++ b/tests/roster.command.test.ts
@@ -1399,7 +1399,8 @@ describe("/roster command", () => {
       group: "confirmed",
     }) as any;
 
-    await Roster.run({} as any, interaction as any);
+    const cocService = {} as any;
+    await Roster.run({} as any, interaction as any, cocService);
 
     expect(rosterService.createRosterPingSelectionPanel).toHaveBeenCalledWith({
       rosterId: "roster-1",
@@ -1407,6 +1408,7 @@ describe("/roster command", () => {
       pingOption: "everyone",
       groupKey: "confirmed",
       message: "Good luck tonight!",
+      cocService,
     });
     expect(interaction.editReply).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -2608,13 +2610,14 @@ describe("/roster command", () => {
       (rosterService.buildRosterManagerReadinessText as any).mockResolvedValue(
         "CWL Alpha Signup\nUnregistered members:\n- Bravo `#QGRJ2222` <@222222222222222222>",
       );
+      const cocService = {} as any;
 
       const interaction = makeInteraction({
         subcommand,
         roster: "roster-1",
       }) as any;
 
-      await Roster.run({} as any, interaction as any);
+      await Roster.run({} as any, interaction as any, cocService);
 
       expect(rosterService.findGuildRosterById).toHaveBeenCalledWith({
         guildId: "guild-1",
@@ -2622,6 +2625,7 @@ describe("/roster command", () => {
       });
       expect(rosterService.buildRosterManagerReadinessText).toHaveBeenCalledWith({
         rosterId: "roster-1",
+        cocService,
       });
       expect(getEditedDescription(interaction)).toContain("Unregistered members:");
     },

--- a/tests/roster.service.test.ts
+++ b/tests/roster.service.test.ts
@@ -2845,6 +2845,13 @@ describe("RosterService", () => {
         },
       },
     ] as any);
+    cocServiceMock.getClan.mockResolvedValue({
+      name: "CWL Alpha",
+      members: [
+        { tag: alphaTag, name: "Alpha" },
+        { tag: deltaTag, name: "Delta" },
+      ],
+    } as any);
     prismaMock.playerLink.findMany.mockImplementation(async (args: any) => {
       const select = args?.select ?? {};
       const tagList = (args?.where?.playerTag?.in ?? []) as string[];
@@ -2908,17 +2915,20 @@ describe("RosterService", () => {
       pingOption: "everyone",
       groupKey: "confirmed",
       message: "Good luck tonight!",
+      cocService: cocServiceMock as any,
     });
     const missing = await rosterService.createRosterPingSelectionPanel({
       rosterId: "roster-1",
       discordUserId: "111111111111111111",
       pingOption: "missing",
+      cocService: cocServiceMock as any,
     });
     const unregistered = await rosterService.createRosterPingSelectionPanel({
       rosterId: "roster-1",
       discordUserId: "111111111111111111",
       pingOption: "unregistered",
       groupKey: "confirmed",
+      cocService: cocServiceMock as any,
     });
 
     expect(everyone).toMatchObject({ outcome: "ready" });
@@ -3501,6 +3511,13 @@ describe("RosterService", () => {
         sortOrder: 1,
       },
     ]);
+    cocServiceMock.getClan.mockResolvedValue({
+      name: "Rising Crowns",
+      members: [
+        { tag: "#PQL0289", name: "Alpha" },
+        { tag: "#QGRJ2222", name: "Bravo" },
+      ],
+    } as any);
     todoSnapshotServiceMock.listSnapshotsByClanTag.mockResolvedValue([
       {
         playerTag: "#PQL0289",
@@ -3512,9 +3529,9 @@ describe("RosterService", () => {
         cwlClanName: "Rising Crowns",
       },
       {
-        playerTag: "#QGRJ2222",
-        playerName: "Bravo",
-        townHall: 15,
+        playerTag: "#OLD1111",
+        playerName: "OldTimer",
+        townHall: 14,
         clanTag: "#2QG2C08UP",
         clanName: "Rising Crowns",
         cwlClanTag: "#2QG2C08UP",
@@ -3526,11 +3543,6 @@ describe("RosterService", () => {
         playerTag: "#PQL0289",
         playerName: "Alpha",
         townHall: 16,
-      },
-      {
-        playerTag: "#QGRJ2222",
-        playerName: "Bravo",
-        townHall: 15,
       },
       {
         playerTag: "#OLD1111",
@@ -3551,7 +3563,10 @@ describe("RosterService", () => {
       },
     ] as any);
 
-    const report = await rosterService.buildRosterManagerReadinessText({ rosterId: "roster-1" });
+    const report = await rosterService.buildRosterManagerReadinessText({
+      rosterId: "roster-1",
+      cocService: cocServiceMock as any,
+    });
 
     expect(report).toContain("CWL Alpha Signup");
     expect(report).toContain("Current clan members:");
@@ -3561,10 +3576,7 @@ describe("RosterService", () => {
     expect(report).toContain("Out-of-clan signups:");
     expect(report).toContain("- Outlier `#ZZZZ1111` <@333333333333333333>");
     expect(report).not.toContain("#OLD1111");
-    expect(todoSnapshotServiceMock.listSnapshotsByClanTag).toHaveBeenCalledWith({
-      clanTag: "#2QG2C08UP",
-      source: "clanTag",
-    });
+    expect(cocServiceMock.getClan).toHaveBeenCalledWith("#2QG2C08UP");
   });
 
   it("builds a manager readiness view from the current FWA clan membership table", async () => {
@@ -3645,7 +3657,10 @@ describe("RosterService", () => {
       },
     ] as any);
 
-    const report = await rosterService.buildRosterManagerReadinessText({ rosterId: "roster-2" });
+    const report = await rosterService.buildRosterManagerReadinessText({
+      rosterId: "roster-2",
+      cocService: cocServiceMock as any,
+    });
 
     expect(report).toContain("FWA Alpha Signup");
     expect(report).toContain("Current clan members:");


### PR DESCRIPTION
- source unregistered members from live clan membership only
- preserve missing members behavior with the current clan view