### PR TITLE
fix(roster): refresh board hydration before rerendering

### DIFF
--- a/src/services/RosterService.ts
+++ b/src/services/RosterService.ts
@@ -24,6 +24,7 @@ import {
   resolveCurrentCwlSeasonKey,
 } from "./CwlRegistryService";
 import { cwlStateService } from "./CwlStateService";
+import { FwaClanMembersSyncService } from "./fwa-feeds/FwaClanMembersSyncService";
 import {
   formatRosterWeightAge,
   resolveRosterCurrentWeightRecords,
@@ -71,6 +72,8 @@ const ROSTER_CONFLICT_LIFECYCLE_STATES: readonly RosterLifecycleState[] = [
   ROSTER_LIFECYCLE_STATE.OPEN,
   ROSTER_LIFECYCLE_STATE.CLOSED,
 ];
+
+const fwaClanMembersSyncService = new FwaClanMembersSyncService();
 
 export type RosterGroupSeed = {
   key: string;
@@ -3500,6 +3503,13 @@ export class RosterService {
     cocService?: CoCService | null,
     options?: RosterSignupPayloadBuildOptions,
   ): Promise<RosterSignupPayload | null> {
+    const hydrated = await this.refreshRosterBoardSourceData(rosterId, cocService ?? null);
+    if (!hydrated) return null;
+    return this.buildRosterSignupPayload(rosterId, cocService ?? null, options);
+  }
+
+  /** Purpose: refresh the live/persisted board owners for one roster before rerendering its post. */
+  async refreshRosterBoardSourceData(rosterId: string, cocService?: CoCService | null): Promise<boolean> {
     const roster = await prisma.roster.findUnique({
       where: { id: rosterId },
       select: {
@@ -3508,17 +3518,28 @@ export class RosterService {
         clanTag: true,
       },
     });
-    if (!roster) return null;
+    if (!roster) return false;
 
-    if (cocService) {
-      const rosteredTags = await prisma.rosterSignup.findMany({
-        where: { rosterId: roster.id },
-        select: { playerTag: true },
+    const rosteredTags = await prisma.rosterSignup.findMany({
+      where: { rosterId: roster.id },
+      select: { playerTag: true },
+    });
+    const playerTags = [...new Set(rosteredTags.map((row) => normalizePlayerTag(row.playerTag)).filter(Boolean))];
+    if (cocService && playerTags.length > 0) {
+      await todoSnapshotService.refreshSnapshotsForPlayerTags({
+        playerTags,
+        cocService,
       });
-      const playerTags = [...new Set(rosteredTags.map((row) => normalizePlayerTag(row.playerTag)).filter(Boolean))];
-      if (playerTags.length > 0) {
-        await todoSnapshotService.refreshSnapshotsForPlayerTags({
-          playerTags,
+    }
+
+    if (cocService && roster.clanTag) {
+      if (roster.rosterType === "CWL") {
+        await cwlStateService.refreshTrackedCwlStateForClan({
+          cocService,
+          clanTag: roster.clanTag,
+        });
+      } else if (roster.rosterType === "FWA") {
+        await fwaClanMembersSyncService.refreshCurrentClanMembersForClanTags([roster.clanTag], {
           cocService,
         });
       }
@@ -3536,7 +3557,7 @@ export class RosterService {
       });
     }
 
-    return this.buildRosterSignupPayload(rosterId, cocService ?? null, options);
+    return true;
   }
 
   async getRosterView(

--- a/tests/roster.command.test.ts
+++ b/tests/roster.command.test.ts
@@ -919,6 +919,81 @@ describe("/roster command", () => {
     expect(setWeightButton?.custom_id).toBe("roster-manage-weight:open:roster-1:#PQL0289");
   });
 
+  it("refreshes the posted roster after manager add before returning the add summary", async () => {
+    (rosterService.findGuildRosterById as any).mockResolvedValue({
+      id: "roster-1",
+      guildId: "guild-1",
+      rosterType: "CWL",
+      rosterCategory: "signup",
+      title: "CWL Alpha Signup",
+      clanTag: "#2QG2C08UP",
+      startsAt: new Date("2026-04-20T00:00:00.000Z"),
+      endsAt: null,
+      timezone: "America/Los_Angeles",
+      displayTimezone: "America/Los_Angeles",
+      lifecycleState: "OPEN",
+      postedChannelId: "channel-1",
+      postedMessageId: "message-1",
+      postedMessageUrl: "https://discord.com/channels/guild-1/channel-1/message-1",
+      postedAt: null,
+      createdByDiscordUserId: "111111111111111111",
+      updatedByDiscordUserId: "111111111111111111",
+      createdAt: new Date("2026-04-20T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-20T00:00:00.000Z"),
+    });
+    (rosterService.getRosterView as any).mockResolvedValue({
+      roster: {
+        id: "roster-1",
+        postedChannelId: "channel-1",
+        postedMessageId: "message-1",
+      },
+      groups: [],
+      signups: [],
+      totalSignupCount: 0,
+    });
+    (rosterService.addRosterSignupsForManager as any).mockResolvedValue({
+      outcome: "created",
+      rosterId: "roster-1",
+      groupKey: "confirmed",
+      groupName: "Confirmed",
+      requestedTags: ["#PQL0289"],
+      linkedTags: ["#PQL0289"],
+      createdTags: ["#PQL0289"],
+      createdAccounts: [{ playerTag: "#PQL0289", playerName: "Alpha" }],
+      duplicateTags: [],
+      missingLinkedTags: [],
+    });
+    const editedMessage = { edit: vi.fn().mockResolvedValue(undefined) };
+    const rosterChannel = {
+      isTextBased: () => true,
+      messages: {
+        fetch: vi.fn().mockResolvedValue(editedMessage),
+      },
+    };
+    const interaction = makeInteraction({
+      subcommand: "manage",
+      roster: "roster-1",
+      action: "add",
+      group: "confirmed",
+      players: "#PQL0289",
+    }) as any;
+    interaction.client.channels.fetch = vi.fn().mockResolvedValue(rosterChannel);
+
+    await Roster.run({} as any, interaction as any);
+
+    expect(rosterService.refreshRosterSignupPayload).toHaveBeenCalledWith(
+      "roster-1",
+      null,
+      expect.objectContaining({
+        refreshButtonDisabled: false,
+      }),
+    );
+    expect(editedMessage.edit).toHaveBeenCalled();
+    expect(String(interaction.editReply.mock.calls.at(-1)?.[0] ?? "")).toContain(
+      "Signed up #PQL0289",
+    );
+  });
+
   it("rejects roster manage set_weight when the selected player is not on the roster", async () => {
     (rosterService.findGuildRosterById as any).mockResolvedValue({
       id: "roster-1",
@@ -1321,8 +1396,8 @@ describe("/roster command", () => {
         id: "roster-1",
         title: "CWL Alpha Signup",
         clanTag: "#2QG2C08UP",
-        postedChannelId: null,
-        postedMessageId: null,
+        postedChannelId: "channel-1",
+        postedMessageId: "message-1",
         rosterRoleId: null,
       },
       clanDisplayName: "CWL Alpha",
@@ -1330,6 +1405,15 @@ describe("/roster command", () => {
       signups: [],
       totalSignupCount: 0,
     });
+    const editedMessage = {
+      edit: vi.fn().mockResolvedValue(undefined),
+    };
+    const rosterChannel = {
+      isTextBased: () => true,
+      messages: {
+        fetch: vi.fn().mockResolvedValue(editedMessage),
+      },
+    };
 
     const interaction = {
       customId,
@@ -1344,7 +1428,7 @@ describe("/roster command", () => {
       followUp: vi.fn().mockResolvedValue(undefined),
       client: {
         channels: {
-          fetch: vi.fn().mockResolvedValue(null),
+          fetch: vi.fn().mockResolvedValue(rosterChannel),
         },
       },
     } as any;
@@ -1356,6 +1440,13 @@ describe("/roster command", () => {
       discordUserId: "111111111111111111",
       cocService: null,
     });
+    expect(rosterService.refreshRosterSignupPayload).toHaveBeenCalledWith(
+      "roster-1",
+      null,
+      expect.objectContaining({
+        refreshButtonDisabled: false,
+      }),
+    );
     expect(String(interaction.editReply.mock.calls.at(-1)?.[0]?.content ?? "")).toBe(expectedContent);
   });
 

--- a/tests/roster.service.test.ts
+++ b/tests/roster.service.test.ts
@@ -56,10 +56,16 @@ const playerLinkServiceMock = vi.hoisted(() => ({
 const cwlStateServiceMock = vi.hoisted(() => ({
   listSeasonRosterForClan: vi.fn(),
   getCurrentRoundForClan: vi.fn(),
+  refreshTrackedCwlStateForClan: vi.fn(),
 }));
 
 const cocServiceMock = vi.hoisted(() => ({
   getClan: vi.fn(),
+  getPlayerRaw: vi.fn(),
+}));
+
+const fwaClanMembersSyncServiceMock = vi.hoisted(() => ({
+  refreshCurrentClanMembersForClanTags: vi.fn(),
 }));
 
 const todoSnapshotServiceMock = vi.hoisted(() => ({
@@ -141,6 +147,18 @@ vi.mock("../src/services/TodoSnapshotService", async () => {
   return {
     ...actual,
     todoSnapshotService: todoSnapshotServiceMock,
+  };
+});
+
+vi.mock("../src/services/fwa-feeds/FwaClanMembersSyncService", async () => {
+  const actual = await vi.importActual<typeof import("../src/services/fwa-feeds/FwaClanMembersSyncService")>(
+    "../src/services/fwa-feeds/FwaClanMembersSyncService",
+  );
+  return {
+    ...actual,
+    FwaClanMembersSyncService: class {
+      refreshCurrentClanMembersForClanTags = fwaClanMembersSyncServiceMock.refreshCurrentClanMembersForClanTags;
+    },
   };
 });
 
@@ -300,11 +318,26 @@ describe("RosterService", () => {
     playerLinkServiceMock.listPlayerLinksForDiscordUser.mockResolvedValue([]);
     cwlStateServiceMock.listSeasonRosterForClan.mockResolvedValue([]);
     cwlStateServiceMock.getCurrentRoundForClan.mockResolvedValue(null);
+    cwlStateServiceMock.refreshTrackedCwlStateForClan.mockResolvedValue({
+      season: resolveCurrentCwlSeasonKey(),
+      trackedClanCount: 1,
+      refreshedClanCount: 1,
+      currentRoundCount: 1,
+      currentMemberCount: 1,
+      historyRoundCount: 1,
+      historyMemberCount: 1,
+    });
     todoSnapshotServiceMock.listSnapshotsByPlayerTags.mockResolvedValue([]);
     todoSnapshotServiceMock.listSnapshotsByClanTag.mockResolvedValue([]);
     todoSnapshotServiceMock.refreshSnapshotsForPlayerTags.mockResolvedValue({
       playerCount: 0,
       updatedCount: 0,
+    });
+    fwaClanMembersSyncServiceMock.refreshCurrentClanMembersForClanTags.mockResolvedValue({
+      clanCount: 1,
+      rowCount: 1,
+      changedRowCount: 1,
+      failedClans: [],
     });
     cocServiceMock.getClan.mockReset();
     cocServiceMock.getClan.mockResolvedValue({
@@ -961,7 +994,7 @@ describe("RosterService", () => {
   });
 
   it("renders grouped signup entries and shows the compact roster board header", async () => {
-    prismaMock.rosterSignup.findMany.mockResolvedValue([
+    prismaMock.rosterSignup.findMany.mockResolvedValueOnce([
       {
         id: "signup-1",
         rosterId: "roster-1",
@@ -1675,19 +1708,31 @@ describe("RosterService", () => {
         townHall: 15,
       },
     ] as any);
-    todoSnapshotServiceMock.refreshSnapshotsForPlayerTags.mockResolvedValue({
-      playerCount: 1,
-      updatedCount: 1,
+    todoSnapshotServiceMock.refreshSnapshotsForPlayerTags.mockImplementation(async ({ cocService }) => {
+      await cocService?.getPlayerRaw("#PQL0289", { suppressTelemetry: true });
+      return {
+        playerCount: 1,
+        updatedCount: 1,
+      };
     });
+    const refreshRosterBoardSourceDataSpy = vi.spyOn(
+      rosterService,
+      "refreshRosterBoardSourceData",
+    );
 
     const payload = await rosterService.refreshRosterSignupPayload("roster-1", cocServiceMock as any);
 
+    expect(refreshRosterBoardSourceDataSpy).toHaveBeenCalledWith("roster-1", cocServiceMock);
     expect(todoSnapshotServiceMock.refreshSnapshotsForPlayerTags).toHaveBeenCalledWith(
       expect.objectContaining({
         playerTags: ["#PQL0289"],
         cocService: cocServiceMock,
       }),
     );
+    expect(cwlStateServiceMock.refreshTrackedCwlStateForClan).toHaveBeenCalledWith({
+      cocService: cocServiceMock,
+      clanTag: "#2QG2C08UP",
+    });
     expect(cocServiceMock.getClan).toHaveBeenCalledWith("#2QG2C08UP");
     expect(prismaMock.cwlTrackedClan.updateMany).toHaveBeenCalledWith({
       where: {
@@ -1752,22 +1797,18 @@ describe("RosterService", () => {
         townHall: null,
       },
     ] as any);
+    const refreshRosterBoardSourceDataSpy = vi
+      .spyOn(rosterService, "refreshRosterBoardSourceData")
+      .mockResolvedValue(true);
     const cocService = {
       getPlayerRaw: vi.fn().mockResolvedValue({
         townHallLevel: 15,
         clan: { tag: "#2QG2C08UP" },
       }),
     } as any;
-
     const payload = await rosterService.refreshRosterSignupPayload("roster-1", cocService);
 
-    expect(todoSnapshotServiceMock.refreshSnapshotsForPlayerTags).toHaveBeenCalledWith({
-      playerTags: ["#298CG8UJG"],
-      cocService,
-    });
-    expect(cocService.getPlayerRaw).toHaveBeenCalledWith("#298CG8UJG", {
-      suppressTelemetry: true,
-    });
+    expect(refreshRosterBoardSourceDataSpy).toHaveBeenCalledWith("roster-1", cocService);
     expect(payload).toBeTruthy();
     const description = String(payload?.embed.toJSON().description ?? "");
     expect(description).toContain("`15 Player 298");
@@ -2346,61 +2387,68 @@ describe("RosterService", () => {
         sortOrder: 1,
       },
     ] as any);
-    prismaMock.rosterSignup.findMany
-      .mockResolvedValueOnce([
-        {
-          id: "signup-1",
-          rosterId: "roster-1",
-          groupId: "group-confirmed",
-          playerTag: "#PQL0289",
-          playerName: "Alpha",
-          discordUserId: "111111111111111111",
-          group: {
-            id: "group-confirmed",
-            key: "confirmed",
-            name: "Confirmed",
-            description: "Primary roster members",
-            sortOrder: 0,
+    let rosterSignupFindManyCall = 0;
+    prismaMock.rosterSignup.findMany.mockImplementation(async () => {
+      rosterSignupFindManyCall += 1;
+      if (rosterSignupFindManyCall === 1) {
+        return [
+          {
+            id: "signup-1",
+            rosterId: "roster-1",
+            groupId: "group-confirmed",
+            playerTag: "#PQL0289",
+            playerName: "Alpha",
+            discordUserId: "111111111111111111",
+            group: {
+              id: "group-confirmed",
+              key: "confirmed",
+              name: "Confirmed",
+              description: "Primary roster members",
+              sortOrder: 0,
+            },
           },
-        },
-        {
-          id: "signup-2",
-          rosterId: "roster-1",
-          groupId: "group-confirmed",
-          playerTag: "#QGRJ2222",
-          playerName: "Bravo",
-          discordUserId: "222222222222222222",
-          group: {
-            id: "group-confirmed",
-            key: "confirmed",
-            name: "Confirmed",
-            description: "Primary roster members",
-            sortOrder: 0,
+          {
+            id: "signup-2",
+            rosterId: "roster-1",
+            groupId: "group-confirmed",
+            playerTag: "#QGRJ2222",
+            playerName: "Bravo",
+            discordUserId: "222222222222222222",
+            group: {
+              id: "group-confirmed",
+              key: "confirmed",
+              name: "Confirmed",
+              description: "Primary roster members",
+              sortOrder: 0,
+            },
           },
-        },
-        {
-          id: "signup-3",
-          rosterId: "roster-1",
-          groupId: "group-confirmed",
-          playerTag: "#CUV02898",
-          playerName: "Charlie",
-          discordUserId: "333333333333333333",
-          group: {
-            id: "group-confirmed",
-            key: "confirmed",
-            name: "Confirmed",
-            description: "Primary roster members",
-            sortOrder: 0,
+          {
+            id: "signup-3",
+            rosterId: "roster-1",
+            groupId: "group-confirmed",
+            playerTag: "#CUV02898",
+            playerName: "Charlie",
+            discordUserId: "333333333333333333",
+            group: {
+              id: "group-confirmed",
+              key: "confirmed",
+              name: "Confirmed",
+              description: "Primary roster members",
+              sortOrder: 0,
+            },
           },
-        },
-      ] as any)
-      .mockResolvedValueOnce([
-        {
-          playerTag: "#QGRJ2222",
-          discordUserId: "222222222222222222",
-        },
-      ] as any)
-      .mockResolvedValueOnce([] as any);
+        ] as any;
+      }
+      if (rosterSignupFindManyCall === 2) {
+        return [
+          {
+            playerTag: "#QGRJ2222",
+            discordUserId: "222222222222222222",
+          },
+        ] as any;
+      }
+      return [] as any;
+    });
     prismaMock.rosterSignup.createMany.mockResolvedValueOnce({ count: 2 });
     prismaMock.rosterSignup.deleteMany.mockResolvedValueOnce({ count: 2 });
 


### PR DESCRIPTION
- add a shared roster board hydration helper for post refreshes
- refresh live roster sources before rebuilding posted roster payloads