### PR TITLE
fix(roster): persist live town hall without clan tag

### DIFF
--- a/src/services/TodoSnapshotService.ts
+++ b/src/services/TodoSnapshotService.ts
@@ -1783,9 +1783,8 @@ async function loadLiveClanTagsByPlayerTag(input: {
   }
 
   return new Map(
-    entries.filter(
-      (entry): entry is [string, { clanTag: string; townHall: number | null }] =>
-        Boolean(entry[0] && entry[1].clanTag),
+    entries.filter((entry): entry is [string, { clanTag: string; townHall: number | null }] =>
+      Boolean(entry[0]),
     ),
   );
 }

--- a/tests/roster.service.test.ts
+++ b/tests/roster.service.test.ts
@@ -1931,6 +1931,68 @@ describe("RosterService", () => {
     expect(description).not.toContain("`- Player 298");
   });
 
+  it("keeps a refreshed town hall visible on the roster board even when the live player is clanless", async () => {
+    prismaMock.rosterSignup.findMany.mockResolvedValue([
+      {
+        id: "signup-1",
+        rosterId: "roster-1",
+        groupId: "group-confirmed",
+        playerTag: "#298CG8UJG",
+        playerName: "Player 298",
+        discordUserId: "111111111111111111",
+        signedUpAt: new Date("2026-04-20T00:00:00.000Z"),
+        createdAt: new Date("2026-04-20T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-20T00:00:00.000Z"),
+        group: {
+          id: "group-confirmed",
+          key: "confirmed",
+          name: "Confirmed",
+          description: "Primary roster members",
+          sortOrder: 0,
+        },
+      },
+    ] as any);
+    todoSnapshotServiceMock.refreshSnapshotsForPlayerTags.mockImplementation(async ({ cocService }) => {
+      await cocService?.getPlayerRaw("#298CG8UJG", { suppressTelemetry: true });
+      return {
+        playerCount: 1,
+        updatedCount: 1,
+      };
+    });
+    todoSnapshotServiceMock.listSnapshotsByPlayerTags.mockResolvedValue([
+      {
+        playerTag: "#298CG8UJG",
+        townHall: 15,
+        clanTag: null,
+        clanName: null,
+        cwlClanTag: null,
+        cwlClanName: null,
+      },
+    ] as any);
+    cwlStateServiceMock.listSeasonRosterForClan.mockResolvedValue([
+      {
+        playerTag: "#298CG8UJG",
+        playerName: "Player 298",
+        townHall: null,
+      },
+    ] as any);
+    const refreshRosterBoardSourceDataSpy = vi
+      .spyOn(rosterService, "refreshRosterBoardSourceData")
+      .mockResolvedValue(true);
+    const cocService = {
+      getPlayerRaw: vi.fn().mockResolvedValue({
+        townHallLevel: 15,
+      }),
+    } as any;
+    const payload = await rosterService.refreshRosterSignupPayload("roster-1", cocService);
+
+    expect(refreshRosterBoardSourceDataSpy).toHaveBeenCalledWith("roster-1", cocService);
+    expect(payload).toBeTruthy();
+    const description = String(payload?.embed.toJSON().description ?? "");
+    expect(description).toContain("`15 Player 298");
+    expect(description).not.toContain("`- Player 298");
+  });
+
   it("falls back cleanly when no persisted CWL league label is available", async () => {
     prismaMock.cwlTrackedClan.findFirst.mockResolvedValue({
       name: "CWL Alpha",

--- a/tests/todoSnapshot.service.test.ts
+++ b/tests/todoSnapshot.service.test.ts
@@ -316,6 +316,56 @@ describe("TodoSnapshotService", () => {
     );
   });
 
+  it("persists live town hall even when the fetched player has no clan tag", async () => {
+    prismaMock.todoPlayerSnapshot.findMany.mockResolvedValue([
+      buildSnapshotRow({
+        playerTag: "#298CG8UJG",
+        townHall: null,
+        clanTag: null,
+        clanName: null,
+        cwlClanTag: null,
+        cwlClanName: null,
+      }),
+    ]);
+    prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue([]);
+    prismaMock.fwaWarMemberCurrent.findMany.mockResolvedValue([]);
+    prismaMock.currentWar.findMany.mockResolvedValue([]);
+    prismaMock.trackedClan.findMany.mockResolvedValue([]);
+    prismaMock.raidTrackedClan.findMany.mockResolvedValue([]);
+    prismaMock.cwlTrackedClan.findMany.mockResolvedValue([]);
+    prismaMock.currentCwlRound.findMany.mockResolvedValue([]);
+    prismaMock.cwlRoundMemberCurrent.findMany.mockResolvedValue([]);
+    prismaMock.cwlRoundMemberHistory.findMany.mockResolvedValue([]);
+    prismaMock.cwlPlayerClanSeason.findMany.mockResolvedValue([]);
+    const cocService = {
+      getPlayerRaw: vi.fn().mockResolvedValue({
+        tag: "#298CG8UJG",
+        townHallLevel: 15,
+      }),
+    };
+
+    const result = await todoSnapshotService.refreshSnapshotsForPlayerTags({
+      playerTags: ["#298CG8UJG"],
+      cocService: cocService as any,
+      nowMs: Date.UTC(2026, 2, 26, 0, 0, 0, 0),
+    });
+
+    expect(result.playerCount).toBe(1);
+    expect(result.updatedCount).toBe(1);
+    expect(cocService.getPlayerRaw).toHaveBeenCalledWith("#298CG8UJG", {
+      suppressTelemetry: true,
+    });
+    expect(prismaMock.todoPlayerSnapshot.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        update: expect.objectContaining({
+          townHall: 15,
+          clanTag: null,
+          clanName: null,
+        }),
+      }),
+    );
+  });
+
   it("hydrates one live non-tracked CWL clan once and fans out the snapshot to multiple linked players", async () => {
     prismaMock.cwlTrackedClan.findMany.mockResolvedValue([]);
     prismaMock.currentCwlRound.findMany.mockResolvedValue([]);


### PR DESCRIPTION
- keep clanless live player refresh rows so town hall can persist
- add snapshot and roster regressions for empty-clan live fetches