### PR TITLE
fix(roster): ack customize select menus before slow work

### DIFF
--- a/src/commands/Roster.ts
+++ b/src/commands/Roster.ts
@@ -1935,24 +1935,35 @@ export async function handleRosterPostCustomizeMenuInteraction(
     return;
   }
 
-  if (!(await canUseRosterPostTarget(interaction, "roster:manage"))) {
+  const parsed = parseRosterPostCustomizeMenuCustomId(interaction.customId);
+  if (!parsed) {
+    return;
+  }
+
+  const deferred = await interaction.deferUpdate().then(() => true).catch(() => false);
+
+  const sendCustomizeError = async (content: string): Promise<void> => {
+    if (deferred || interaction.replied) {
+      await interaction.followUp({
+        content,
+        ephemeral: true,
+      }).catch(() => undefined);
+      return;
+    }
+
     await interaction.reply({
-      content: "You don't have permission to manage this roster.",
+      content,
       ephemeral: true,
-    });
+    }).catch(() => undefined);
+  };
+
+  if (!(await canUseRosterPostTarget(interaction, "roster:manage"))) {
+    await sendCustomizeError("You don't have permission to manage this roster.");
     return;
   }
 
   if (!interaction.inGuild() || !interaction.guildId) {
-    await interaction.reply({
-      content: "This command can only be used in a server.",
-      ephemeral: true,
-    });
-    return;
-  }
-
-  const parsed = parseRosterPostCustomizeMenuCustomId(interaction.customId);
-  if (!parsed) {
+    await sendCustomizeError("This command can only be used in a server.");
     return;
   }
 
@@ -1961,24 +1972,16 @@ export async function handleRosterPostCustomizeMenuInteraction(
     rosterId: parsed.rosterId,
   });
   if (!roster) {
-    await interaction.reply({
-      content: "That roster is no longer available.",
-      ephemeral: true,
-    });
+    await sendCustomizeError("That roster is no longer available.");
     return;
   }
 
   if (parsed.kind === "columns") {
     const selectedColumns = normalizeRosterCustomizeColumns(interaction.values) ?? [];
     if (selectedColumns.length <= 0) {
-      await interaction.reply({
-        content: "Choose at least one column to customize.",
-        ephemeral: true,
-      });
+      await sendCustomizeError("Choose at least one column to customize.");
       return;
     }
-
-    await interaction.deferUpdate().catch(() => undefined);
 
     const updated = await rosterService.updateRoster({
       rosterId: roster.id,
@@ -2013,8 +2016,6 @@ export async function handleRosterPostCustomizeMenuInteraction(
     return;
   }
 
-  await interaction.deferUpdate().catch(() => undefined);
-
   const normalizedSortBy = normalizeRosterCustomizeSortByChoice(interaction.values[0] ?? "");
   const updated = await rosterService.updateRoster({
     rosterId: roster.id,
@@ -2023,11 +2024,7 @@ export async function handleRosterPostCustomizeMenuInteraction(
   });
 
   if (!updated) {
-    await interaction.editReply({
-      content: "That roster is no longer available.",
-      embeds: [],
-      components: [],
-    });
+    await sendCustomizeError("That roster is no longer available.");
     return;
   }
 

--- a/src/listeners/interactionCreate.ts
+++ b/src/listeners/interactionCreate.ts
@@ -203,6 +203,26 @@ function getInteractionSubcommandPath(interaction: ChatInputCommandInteraction):
   return "";
 }
 
+async function respondBestEffortToRosterCustomizeFailure(
+  interaction: StringSelectMenuInteraction,
+): Promise<void> {
+  const payload = {
+    ephemeral: true,
+    content: "Failed to update roster customization.",
+  };
+
+  try {
+    if (interaction.deferred || interaction.replied) {
+      await interaction.followUp(payload);
+      return;
+    }
+
+    await interaction.reply(payload);
+  } catch (responseError) {
+    console.warn(`Roster customize fallback response failed: ${formatError(responseError)}`);
+  }
+}
+
 function buildGlobalPostButton(userId: string): ActionRowBuilder<ButtonBuilder> {
   return new ActionRowBuilder<ButtonBuilder>().addComponents(
     new ButtonBuilder()
@@ -463,12 +483,7 @@ const handleSelectMenuInteraction = async (
       await handleRosterPostCustomizeMenuInteraction(interaction, cocService);
     } catch (err) {
       console.error(`Roster customize menu failed: ${formatError(err)}`);
-      if (!interaction.replied && !interaction.deferred) {
-        await interaction.reply({
-          ephemeral: true,
-          content: "Failed to update roster customization.",
-        });
-      }
+      await respondBestEffortToRosterCustomizeFailure(interaction);
     }
     return;
   }

--- a/tests/interactionCreate.rosterCustomize.test.ts
+++ b/tests/interactionCreate.rosterCustomize.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Client } from "discord.js";
+
+vi.mock("../src/commands/Roster", async () => {
+  const actual = await vi.importActual<typeof import("../src/commands/Roster")>(
+    "../src/commands/Roster",
+  );
+  return {
+    ...actual,
+    handleRosterPostCustomizeMenuInteraction: vi.fn(async () => {
+      throw new Error("boom");
+    }),
+  };
+});
+
+type ListenerHandler = (interaction: unknown) => Promise<void>;
+
+async function loadInteractionHandler(): Promise<ListenerHandler> {
+  const { default: registerInteractionCreate } = await import("../src/listeners/interactionCreate");
+  const handlers = new Map<string, ListenerHandler>();
+  const client = {
+    on: vi.fn((event: string, callback: ListenerHandler) => {
+      handlers.set(event, callback);
+    }),
+  } as unknown as Client;
+
+  registerInteractionCreate(client, {} as any);
+  const handler = handlers.get("interactionCreate");
+  if (!handler) {
+    throw new Error("interactionCreate listener was not registered");
+  }
+  return handler;
+}
+
+function makeRosterCustomizeInteraction() {
+  return {
+    customId: "roster-post-customize:columns:roster-1",
+    values: ["player_name"],
+    deferred: false,
+    replied: false,
+    isAutocomplete: () => false,
+    isButton: () => false,
+    isChatInputCommand: () => false,
+    isModalSubmit: () => false,
+    isStringSelectMenu: () => true,
+    isUserSelectMenu: () => false,
+    inGuild: () => true,
+    guildId: "guild-1",
+    user: { id: "user-1", tag: "tester#0001" },
+    memberPermissions: {
+      has: () => true,
+    },
+    reply: vi.fn().mockRejectedValue(Object.assign(new Error("Unknown interaction"), { code: 10062 })),
+    followUp: vi.fn().mockResolvedValue(undefined),
+    editReply: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe("interactionCreate roster customize fallback", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it("swallows fallback reply failures when the roster customize interaction already expired", async () => {
+    const handler = await loadInteractionHandler();
+    const interaction = makeRosterCustomizeInteraction();
+
+    await expect(handler(interaction as any)).resolves.toBeUndefined();
+
+    expect(interaction.reply).toHaveBeenCalled();
+    expect(interaction.followUp).not.toHaveBeenCalled();
+  }, 30000);
+});

--- a/tests/roster.command.test.ts
+++ b/tests/roster.command.test.ts
@@ -1827,6 +1827,7 @@ describe("/roster command", () => {
       deferUpdate: vi.fn().mockResolvedValue(undefined),
       editReply: vi.fn().mockResolvedValue(undefined),
       reply: vi.fn().mockResolvedValue(undefined),
+      followUp: vi.fn().mockResolvedValue(undefined),
       client: {
         channels: {
           fetch: vi.fn().mockResolvedValue(rosterChannel),
@@ -1845,6 +1846,9 @@ describe("/roster command", () => {
     );
     expect(rosterService.refreshRosterSignupPayload).toHaveBeenCalledWith("roster-1", expect.anything(), expect.anything());
     expect(interaction.deferUpdate).toHaveBeenCalled();
+    expect(interaction.deferUpdate.mock.invocationCallOrder[0]).toBeLessThan(
+      (rosterService.findGuildRosterById as any).mock.invocationCallOrder[0],
+    );
     expect(interaction.editReply).toHaveBeenCalledWith(
       expect.objectContaining({
         embeds: [expect.any(EmbedBuilder)],
@@ -1947,6 +1951,7 @@ describe("/roster command", () => {
       deferUpdate: vi.fn().mockResolvedValue(undefined),
       editReply: vi.fn().mockResolvedValue(undefined),
       reply: vi.fn().mockResolvedValue(undefined),
+      followUp: vi.fn().mockResolvedValue(undefined),
       client: {
         channels: {
           fetch: vi.fn().mockResolvedValue(rosterChannel),
@@ -1964,6 +1969,10 @@ describe("/roster command", () => {
       }),
     );
     expect(rosterService.refreshRosterSignupPayload).toHaveBeenCalledWith("roster-1", expect.anything(), expect.anything());
+    expect(interaction.deferUpdate).toHaveBeenCalled();
+    expect(interaction.deferUpdate.mock.invocationCallOrder[0]).toBeLessThan(
+      (rosterService.findGuildRosterById as any).mock.invocationCallOrder[0],
+    );
     expect(interaction.editReply).toHaveBeenCalledWith(
       expect.objectContaining({
         embeds: [expect.any(EmbedBuilder)],
@@ -2011,6 +2020,65 @@ describe("/roster command", () => {
     const optionValues = menu?.options?.map((option: any) => option.value) ?? [];
     expect(optionValues).toContain("open_roster");
     expect(optionValues).not.toContain("close_roster");
+  });
+
+  it("acks before rejecting invalid roster customize column selections", async () => {
+    (rosterService.findGuildRosterById as any).mockResolvedValue({
+      id: "roster-1",
+      guildId: "guild-1",
+      rosterType: "CWL",
+      rosterCategory: "signup",
+      title: "CWL Alpha Signup",
+      clanTag: "#2QG2C08UP",
+      startsAt: new Date("2026-04-20T00:00:00.000Z"),
+      endsAt: null,
+      timezone: "America/Los_Angeles",
+      displayTimezone: "America/Los_Angeles",
+      sortBy: null,
+      displayColumns: null,
+      lifecycleState: "OPEN",
+      postedChannelId: "channel-1",
+      postedMessageId: "message-1",
+      postedMessageUrl: "https://discord.com/channels/guild-1/channel-1/message-1",
+      postedAt: null,
+      createdByDiscordUserId: "111111111111111111",
+      updatedByDiscordUserId: "111111111111111111",
+      createdAt: new Date("2026-04-20T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-20T00:00:00.000Z"),
+    });
+    const deferUpdate = vi.fn().mockResolvedValue(undefined);
+    const followUp = vi.fn().mockResolvedValue(undefined);
+    const interaction = {
+      customId: "roster-post-customize:columns:roster-1",
+      values: [],
+      user: { id: "111111111111111111" },
+      guildId: "guild-1",
+      inGuild: () => true,
+      memberPermissions: {
+        has: vi.fn().mockReturnValue(true),
+      },
+      deferUpdate,
+      editReply: vi.fn().mockResolvedValue(undefined),
+      reply: vi.fn().mockResolvedValue(undefined),
+      followUp,
+      client: {
+        channels: {
+          fetch: vi.fn().mockResolvedValue(null),
+        },
+      },
+    } as any;
+
+    await handleRosterPostCustomizeMenuInteraction(interaction, {} as any);
+
+    expect(deferUpdate).toHaveBeenCalledTimes(1);
+    expect(interaction.reply).not.toHaveBeenCalled();
+    expect(followUp).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ephemeral: true,
+        content: "Choose at least one column to customize.",
+      }),
+    );
+    expect(rosterService.updateRoster).not.toHaveBeenCalled();
   });
 
   it("refreshes the posted roster from the service-owned current-clan refresh path", async () => {


### PR DESCRIPTION
- defer roster customize select menus before roster lookup and rebuild work
- make customize error fallbacks best-effort so expired interactions do not crash the bot