### PR TITLE
fix(roster): filter signup accounts and defer confirm replies

### DIFF
--- a/src/commands/Cwl.ts
+++ b/src/commands/Cwl.ts
@@ -3074,86 +3074,76 @@ export async function handleRosterSelectionActionButtonInteraction(
     return;
   }
 
+  const deferred = await interaction.deferUpdate().then(() => true).catch(() => false);
+  const sendSelectionResponse = async (content: string): Promise<void> => {
+    if (deferred) {
+      await interaction
+        .editReply({
+          content,
+          embeds: [],
+          components: [],
+        })
+        .catch(() => undefined);
+      return;
+    }
+
+    await interaction
+      .reply({
+        content,
+        ephemeral: true,
+      })
+      .catch(() => undefined);
+  };
+
   const result = await rosterService.confirmRosterSelectionPanel({
     sessionId: parsed.sessionId,
     discordUserId: interaction.user.id,
     cocService: cocService ?? null,
   });
   if (result.outcome === "session_not_found") {
-    await interaction.reply({
-      content: "That roster selection has expired. Please start again.",
-      ephemeral: true,
-    });
+    await sendSelectionResponse("That roster selection has expired. Please start again.");
     return;
   }
   if (result.outcome === "forbidden") {
-    await interaction.reply({
-      content: "Only the original requester can use this roster selection.",
-      ephemeral: true,
-    });
+    await sendSelectionResponse("Only the original requester can use this roster selection.");
     return;
   }
 
   if (result.outcome === "missing_user") {
-    await interaction.reply({
-      content: "Select a Discord user first.",
-      ephemeral: true,
-    });
+    await sendSelectionResponse("Select a Discord user first.");
     return;
   }
   if (result.outcome === "missing_players") {
-    await interaction.reply({
-      content: "Select at least one linked player.",
-      ephemeral: true,
-    });
+    await sendSelectionResponse("Select at least one linked player.");
     return;
   }
   if (result.outcome === "missing_group") {
-    await interaction.reply({
-      content: "Select a roster group first.",
-      ephemeral: true,
-    });
+    await sendSelectionResponse("Select a roster group first.");
     return;
   }
 
   if (result.outcome === "add_user") {
     await syncRosterRoleAssignments(interaction.client, result.result.rosterId).catch(() => undefined);
     await refreshRosterSignupPost(interaction, result.result.rosterId, cocService).catch(() => undefined);
-    await interaction.update({
-      content: formatRosterSignupResultSummary(result.result),
-      embeds: [],
-      components: [],
-    });
+    await sendSelectionResponse(formatRosterSignupResultSummary(result.result));
     return;
   }
 
   if (result.outcome === "remove_user") {
     await refreshRosterSignupPost(interaction, result.result.rosterId, cocService).catch(() => undefined);
-    await interaction.update({
-      content: formatRosterRemoveResultSummary(result.result),
-      embeds: [],
-      components: [],
-    });
+    await sendSelectionResponse(formatRosterRemoveResultSummary(result.result));
     return;
   }
 
   if (result.outcome === "signup") {
     await syncRosterRoleAssignments(interaction.client, result.result.rosterId).catch(() => undefined);
     await refreshRosterSignupPost(interaction, result.result.rosterId, cocService).catch(() => undefined);
-    await interaction.update({
-      content: formatRosterSignupResultSummary(result.result),
-      embeds: [],
-      components: [],
-    });
+    await sendSelectionResponse(formatRosterSignupResultSummary(result.result));
     return;
   }
 
   await refreshRosterSignupPost(interaction, result.result.rosterId, cocService).catch(() => undefined);
-  await interaction.update({
-    content: formatRosterRemoveResultSummary(result.result),
-    embeds: [],
-    components: [],
-  });
+  await sendSelectionResponse(formatRosterRemoveResultSummary(result.result));
 }
 
 export const Cwl: Command = {

--- a/src/services/RosterService.ts
+++ b/src/services/RosterService.ts
@@ -1994,13 +1994,45 @@ async function loadRosterSelectionOptions(input: {
       select: { playerTag: true },
     });
     const existingTags = new Set(existing.map((row) => normalizePlayerTag(row.playerTag)).filter(Boolean));
+    const minTownhall = normalizeRosterInt(roster.minTownhall);
+    const maxTownhall = normalizeRosterInt(roster.maxTownhall);
+    const townHallGated = minTownhall !== null || maxTownhall !== null;
+    const townHallByTag = townHallGated
+      ? (
+          await resolveRosterPlayerTownHallMap({
+            rosterType: roster.rosterType,
+            clanTag: roster.clanTag,
+            playerTags: linkedTags,
+            allowLiveFetch: false,
+            cocService: null,
+          })
+        ).townHallByTag
+      : null;
+
+    const signupOptions = linkedAccounts.filter((account) => {
+      if (!townHallGated) {
+        return true;
+      }
+
+      const townHall = townHallByTag?.get(account.playerTag) ?? null;
+      if (townHall === null) {
+        return false;
+      }
+      if (minTownhall !== null && townHall < minTownhall) {
+        return false;
+      }
+      if (maxTownhall !== null && townHall > maxTownhall) {
+        return false;
+      }
+      return true;
+    });
     return {
       outcome: "ready",
       roster: mappedRoster,
       group: selectedGroup,
       groups,
       selectedGroupKey: selectedGroup?.key ?? null,
-      options: linkedAccounts.map((account) => ({
+      options: signupOptions.map((account) => ({
         value: account.playerTag,
         label: account.linkedName ?? account.playerTag,
         description: `${account.playerTag}${existingTags.has(account.playerTag) ? " | already signed up" : " | available"}`,

--- a/tests/cwl.command.test.ts
+++ b/tests/cwl.command.test.ts
@@ -557,6 +557,8 @@ describe("/cwl command", () => {
     const confirmInteraction = {
       customId: "roster-selection:action:confirm:session-2",
       user: { id: "111111111111111111" },
+      deferUpdate: vi.fn().mockResolvedValue(undefined),
+      editReply: vi.fn().mockResolvedValue(undefined),
       update: vi.fn().mockResolvedValue(undefined),
       reply: vi.fn().mockResolvedValue(undefined),
       client: {
@@ -571,13 +573,18 @@ describe("/cwl command", () => {
       discordUserId: "111111111111111111",
       cocService: null,
     });
-    expect(confirmInteraction.update).toHaveBeenCalledWith(
+    expect(confirmInteraction.deferUpdate).toHaveBeenCalledTimes(1);
+    expect(confirmInteraction.deferUpdate.mock.invocationCallOrder[0]).toBeLessThan(
+      (rosterService.confirmRosterSelectionPanel as any).mock.invocationCallOrder[0],
+    );
+    expect(confirmInteraction.editReply).toHaveBeenCalledWith(
       expect.objectContaining({
         content: expect.stringContaining("Signed up #P1, #P2"),
         embeds: [],
         components: [],
       }),
     );
+    expect(confirmInteraction.update).not.toHaveBeenCalled();
 
     const removeInteraction = {
       customId: "roster-post-action:optout:roster-1",
@@ -621,6 +628,8 @@ describe("/cwl command", () => {
     const confirmInteraction = {
       customId: "roster-selection:action:confirm:session-2",
       user: { id: "111111111111111111" },
+      deferUpdate: vi.fn().mockResolvedValue(undefined),
+      editReply: vi.fn().mockResolvedValue(undefined),
       update: vi.fn().mockResolvedValue(undefined),
       reply: vi.fn().mockResolvedValue(undefined),
       client: {
@@ -632,13 +641,58 @@ describe("/cwl command", () => {
 
     await handleRosterSelectionActionButtonInteraction(confirmInteraction as any);
 
-    expect(confirmInteraction.update).toHaveBeenCalledWith(
+    expect(confirmInteraction.deferUpdate).toHaveBeenCalledTimes(1);
+    expect(confirmInteraction.editReply).toHaveBeenCalledWith(
       expect.objectContaining({
         content: expect.stringContaining("Town hall data is unavailable for: Alpha `#P1`, `#P2`."),
         embeds: [],
         components: [],
       }),
     );
+    expect(confirmInteraction.update).not.toHaveBeenCalled();
+  });
+
+  it("defers and edits the roster selection when confirming self-service removal", async () => {
+    (rosterService.confirmRosterSelectionPanel as any).mockResolvedValue({
+      outcome: "remove_user",
+      result: {
+        outcome: "removed" as const,
+        rosterId: "roster-1",
+        removedTags: ["#P1", "#P2"],
+        removedAccounts: [
+          { playerTag: "#P1", playerName: "Alpha" },
+          { playerTag: "#P2", playerName: "Bravo" },
+        ],
+        ignoredTags: [],
+        notOwnedTags: [],
+      },
+    });
+
+    const confirmInteraction = {
+      customId: "roster-selection:action:confirm:session-3",
+      user: { id: "111111111111111111" },
+      deferUpdate: vi.fn().mockResolvedValue(undefined),
+      editReply: vi.fn().mockResolvedValue(undefined),
+      update: vi.fn().mockResolvedValue(undefined),
+      reply: vi.fn().mockResolvedValue(undefined),
+      client: {
+        channels: {
+          fetch: vi.fn().mockResolvedValue(null),
+        },
+      },
+    };
+
+    await handleRosterSelectionActionButtonInteraction(confirmInteraction as any);
+
+    expect(confirmInteraction.deferUpdate).toHaveBeenCalledTimes(1);
+    expect(confirmInteraction.editReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining("Removed #P1, #P2"),
+        embeds: [],
+        components: [],
+      }),
+    );
+    expect(confirmInteraction.update).not.toHaveBeenCalled();
   });
 
   it("renders a manager readiness report for /cwl roster report", async () => {

--- a/tests/roster.service.test.ts
+++ b/tests/roster.service.test.ts
@@ -2075,6 +2075,63 @@ describe("RosterService", () => {
     expect(payload.selectedTags).toEqual([]);
   });
 
+  it("filters TH-gated signup selection options to only viable linked accounts", async () => {
+    playerLinkServiceMock.listPlayerLinksForDiscordUser.mockResolvedValue([
+      { playerTag: "#PQL0289", linkedName: "Low TH", linkedAt: new Date("2026-04-20T00:00:00.000Z") },
+      { playerTag: "#QGRJ2222", linkedName: "Eligible TH", linkedAt: new Date("2026-04-20T00:00:00.000Z") },
+      { playerTag: "#2QG2C08UP", linkedName: "Unknown TH", linkedAt: new Date("2026-04-20T00:00:00.000Z") },
+    ]);
+    prismaMock.roster.findUnique.mockResolvedValueOnce({
+      id: "roster-1",
+      guildId: "guild-1",
+      rosterType: "CWL",
+      rosterCategory: "signup",
+      title: "CWL Alpha Signup",
+      clanTag: "#2QG2C08UP",
+      startsAt: new Date("2026-04-20T00:00:00.000Z"),
+      endsAt: null,
+      timezone: "America/Los_Angeles",
+      displayTimezone: "America/Los_Angeles",
+      lifecycleState: "OPEN",
+      postedChannelId: null,
+      postedMessageId: null,
+      postedMessageUrl: null,
+      postedAt: null,
+      createdByDiscordUserId: "111111111111111111",
+      updatedByDiscordUserId: "111111111111111111",
+      createdAt: new Date("2026-04-20T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-20T00:00:00.000Z"),
+      minTownhall: 13,
+      maxTownhall: 15,
+      allowMultiSignup: true,
+    } as any);
+    prismaMock.rosterSignup.findMany.mockResolvedValueOnce([] as any);
+    todoSnapshotServiceMock.listSnapshotsByPlayerTags.mockResolvedValueOnce([
+      { playerTag: "#PQL0289", townHall: 12 },
+      { playerTag: "#QGRJ2222", townHall: 13 },
+    ] as any);
+
+    const result = await rosterService.createRosterSignupSelectionPanel({
+      rosterId: "roster-1",
+      discordUserId: "111111111111111111",
+      groupKey: "confirmed",
+    });
+
+    expect(result).toMatchObject({ outcome: "ready" });
+    if (result.outcome !== "ready") return;
+    const optionValues = result.panel.components.flatMap((row) => {
+      const rowJson = row.toJSON?.() as any;
+      return Array.isArray(rowJson?.components)
+        ? rowJson.components.flatMap((component: any) =>
+            Array.isArray(component.options) ? component.options.map((option: any) => option.value) : [],
+          )
+        : [];
+    });
+    expect(optionValues).toContain("#QGRJ2222");
+    expect(optionValues).not.toContain("#PQL0289");
+    expect(optionValues).not.toContain("#2QG2C08UP");
+  });
+
   it("builds the manager add-user panel with chunked linked-player menus and a disabled confirm button until required selections exist", async () => {
     playerLinkServiceMock.listPlayerLinksForDiscordUser.mockResolvedValueOnce(
       Array.from({ length: 30 }, (_, index) => {


### PR DESCRIPTION
- hide TH-ineligible linked accounts from roster signup selection panels
- defer signup/remove confirm interactions before roster mutation and refresh work