### PR TITLE
feat(roster): add player current cache for signup hydration

### DIFF
--- a/prisma/migrations/20260423000000_add_player_current/migration.sql
+++ b/prisma/migrations/20260423000000_add_player_current/migration.sql
@@ -1,0 +1,29 @@
+CREATE TABLE "PlayerCurrent" (
+    "playerTag" TEXT NOT NULL,
+    "playerName" TEXT,
+    "townHall" INTEGER,
+    "currentClanTag" TEXT,
+    "currentClanName" TEXT,
+    "trophies" INTEGER,
+    "builderTrophies" INTEGER,
+    "warStars" INTEGER,
+    "expLevel" INTEGER,
+    "role" TEXT,
+    "leagueName" TEXT,
+    "currentWeight" INTEGER,
+    "currentWeightSource" TEXT,
+    "currentWeightMeasuredAt" TIMESTAMP(3),
+    "achievementsJson" JSONB,
+    "lastSeenAt" TIMESTAMP(3),
+    "lastFetchedAt" TIMESTAMP(3),
+    "lastSource" TEXT,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "PlayerCurrent_pkey" PRIMARY KEY ("playerTag")
+);
+
+CREATE INDEX "PlayerCurrent_currentClanTag_idx" ON "PlayerCurrent"("currentClanTag");
+CREATE INDEX "PlayerCurrent_updatedAt_idx" ON "PlayerCurrent"("updatedAt");
+CREATE INDEX "PlayerCurrent_lastFetchedAt_idx" ON "PlayerCurrent"("lastFetchedAt");
+CREATE INDEX "PlayerCurrent_currentWeightMeasuredAt_idx" ON "PlayerCurrent"("currentWeightMeasuredAt");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -82,6 +82,34 @@ model PlayerLink {
   @@index([discordUserId])
 }
 
+model PlayerCurrent {
+  playerTag               String   @id
+  playerName              String?
+  townHall                Int?
+  currentClanTag          String?
+  currentClanName         String?
+  trophies                Int?
+  builderTrophies         Int?
+  warStars                Int?
+  expLevel                Int?
+  role                    String?
+  leagueName              String?
+  currentWeight           Int?
+  currentWeightSource     String?
+  currentWeightMeasuredAt DateTime?
+  achievementsJson        Json?
+  lastSeenAt              DateTime?
+  lastFetchedAt           DateTime?
+  lastSource              String?
+  createdAt               DateTime @default(now())
+  updatedAt               DateTime @updatedAt
+
+  @@index([currentClanTag])
+  @@index([updatedAt])
+  @@index([lastFetchedAt])
+  @@index([currentWeightMeasuredAt])
+}
+
 model DumpLink {
   guildId               String   @id
   link                  String

--- a/src/commands/Cwl.ts
+++ b/src/commands/Cwl.ts
@@ -2913,43 +2913,62 @@ export async function handleCwlRotationShowSelectMenuInteraction(
 
 export async function handleRosterSignupButtonInteraction(
   interaction: ButtonInteraction,
+  cocService?: CoCService | null,
 ): Promise<void> {
   const parsed = parseRosterSignupButtonCustomId(interaction.customId);
   if (!parsed) return;
 
+  const deferred = await interaction.deferReply({ ephemeral: true }).then(() => true).catch(() => false);
+  const sendSignupResponse = async (payload: { content?: string; embeds?: any[]; components?: any[] }): Promise<void> => {
+    if (deferred) {
+      await interaction
+        .editReply({
+          ...payload,
+          embeds: payload.embeds ?? [],
+          components: payload.components ?? [],
+        })
+        .catch(() => undefined);
+      return;
+    }
+
+    await interaction
+      .reply({
+        ...payload,
+        ephemeral: true,
+      })
+      .catch(() => undefined);
+  };
+
   const result = await rosterService.createRosterSignupSelectionPanel({
     rosterId: parsed.rosterId,
     discordUserId: interaction.user.id,
+    cocService: cocService ?? null,
   });
 
   if (result.outcome === "roster_not_found") {
-    await interaction.reply({
+    await sendSignupResponse({
       content: "That roster is no longer available.",
-      ephemeral: true,
     });
     return;
   }
 
   if (result.outcome === "roster_closed") {
-    await interaction.reply({
+    await sendSignupResponse({
       content: "Signups are closed for that roster.",
-      ephemeral: true,
     });
     return;
   }
 
   if (result.outcome === "group_not_found") {
-    await interaction.reply({
+    await sendSignupResponse({
       content: "That roster group is no longer available.",
-      ephemeral: true,
     });
     return;
   }
 
   if (result.outcome === "no_linked_accounts") {
-    await interaction.reply({
+    await sendSignupResponse({
       content: "No linked player accounts were found for your Discord user.",
-      ephemeral: true,
     });
     return;
   }
@@ -2958,10 +2977,9 @@ export async function handleRosterSignupButtonInteraction(
     return;
   }
 
-  await interaction.reply({
+  await sendSignupResponse({
     embeds: [result.panel.embed],
     components: result.panel.components,
-    ephemeral: true,
   });
 }
 

--- a/src/listeners/interactionCreate.ts
+++ b/src/listeners/interactionCreate.ts
@@ -722,7 +722,7 @@ const handleButtonInteraction = async (
 
   if (isRosterSignupButtonCustomId(interaction.customId)) {
     try {
-      await handleRosterSignupButtonInteraction(interaction);
+      await handleRosterSignupButtonInteraction(interaction, cocService);
     } catch (err) {
       console.error(`CWL roster signup button failed: ${formatError(err)}`);
       if (!interaction.replied && !interaction.deferred) {

--- a/src/services/PlayerCurrentService.ts
+++ b/src/services/PlayerCurrentService.ts
@@ -1,0 +1,562 @@
+import { Prisma } from "@prisma/client";
+import { prisma } from "../prisma";
+import { CoCService } from "./CoCService";
+import { normalizeClanTag, normalizePlayerTag } from "./PlayerLinkService";
+import { todoSnapshotService } from "./TodoSnapshotService";
+
+export type PlayerCurrentResolutionField =
+  | "playerName"
+  | "townHall"
+  | "currentClanTag"
+  | "currentClanName"
+  | "trophies"
+  | "builderTrophies"
+  | "warStars"
+  | "expLevel"
+  | "role"
+  | "leagueName"
+  | "currentWeight";
+
+export type PlayerCurrentResolutionSource =
+  | "player_current"
+  | "fwa_player_catalog"
+  | "todo_snapshot"
+  | "live_refresh"
+  | "missing";
+
+export type PlayerCurrentLike = {
+  playerTag: string;
+  playerName: string | null;
+  townHall: number | null;
+  currentClanTag: string | null;
+  currentClanName: string | null;
+  trophies: number | null;
+  builderTrophies: number | null;
+  warStars: number | null;
+  expLevel: number | null;
+  role: string | null;
+  leagueName: string | null;
+  currentWeight: number | null;
+  currentWeightSource: string | null;
+  currentWeightMeasuredAt: Date | null;
+  achievementsJson: Prisma.JsonValue | null;
+  lastSeenAt: Date | null;
+  lastFetchedAt: Date | null;
+  lastSource: string | null;
+  createdAt: Date | null;
+  updatedAt: Date | null;
+  source: PlayerCurrentResolutionSource;
+  liveRefreshInvoked: boolean;
+};
+
+type PlayerCurrentRow = {
+  playerTag: string;
+  playerName: string | null;
+  townHall: number | null;
+  currentClanTag: string | null;
+  currentClanName: string | null;
+  trophies: number | null;
+  builderTrophies: number | null;
+  warStars: number | null;
+  expLevel: number | null;
+  role: string | null;
+  leagueName: string | null;
+  currentWeight: number | null;
+  currentWeightSource: string | null;
+  currentWeightMeasuredAt: Date | null;
+  achievementsJson: Prisma.JsonValue | null;
+  lastSeenAt: Date | null;
+  lastFetchedAt: Date | null;
+  lastSource: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+type FwaPlayerCatalogRow = {
+  playerTag: string;
+  latestName: string;
+  latestTownHall: number | null;
+  latestKnownWeight: number | null;
+  firstSeenAt: Date;
+  lastSeenAt: Date;
+  lastSyncedAt: Date;
+};
+
+type TodoSnapshotRow = {
+  playerTag: string;
+  playerName: string;
+  townHall: number | null;
+  clanTag: string | null;
+  clanName: string | null;
+  updatedAt: Date;
+  lastUpdatedAt?: Date | null;
+};
+
+const DEFAULT_REQUIRE_FIELDS: PlayerCurrentResolutionField[] = ["townHall"];
+
+function normalizeText(input: unknown): string | null {
+  const normalized = String(input ?? "").replace(/\s+/g, " ").trim();
+  return normalized ? normalized : null;
+}
+
+function normalizeNumber(input: unknown): number | null {
+  if (input === null || input === undefined || input === "") return null;
+  const parsed = Math.trunc(Number(input));
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function createMissingPlayerCurrent(input: { playerTag: string }): PlayerCurrentLike {
+  return {
+    playerTag: input.playerTag,
+    playerName: null,
+    townHall: null,
+    currentClanTag: null,
+    currentClanName: null,
+    trophies: null,
+    builderTrophies: null,
+    warStars: null,
+    expLevel: null,
+    role: null,
+    leagueName: null,
+    currentWeight: null,
+    currentWeightSource: null,
+    currentWeightMeasuredAt: null,
+    achievementsJson: null,
+    lastSeenAt: null,
+    lastFetchedAt: null,
+    lastSource: null,
+    createdAt: null,
+    updatedAt: null,
+    source: "missing",
+    liveRefreshInvoked: false,
+  };
+}
+
+function toPlayerCurrentLike(row: PlayerCurrentRow): PlayerCurrentLike {
+  return {
+    playerTag: row.playerTag,
+    playerName: row.playerName,
+    townHall: row.townHall,
+    currentClanTag: row.currentClanTag,
+    currentClanName: row.currentClanName,
+    trophies: row.trophies,
+    builderTrophies: row.builderTrophies,
+    warStars: row.warStars,
+    expLevel: row.expLevel,
+    role: row.role,
+    leagueName: row.leagueName,
+    currentWeight: row.currentWeight,
+    currentWeightSource: row.currentWeightSource,
+    currentWeightMeasuredAt: row.currentWeightMeasuredAt,
+    achievementsJson: row.achievementsJson,
+    lastSeenAt: row.lastSeenAt,
+    lastFetchedAt: row.lastFetchedAt,
+    lastSource: row.lastSource,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+    source: "player_current",
+    liveRefreshInvoked: false,
+  };
+}
+
+function applyMissingFields(
+  target: PlayerCurrentLike,
+  source: Partial<PlayerCurrentLike>,
+  sourceLabel: PlayerCurrentResolutionSource,
+): void {
+  const playerName = source.playerName ?? null;
+  const townHall = source.townHall ?? null;
+  const currentClanTag = source.currentClanTag ?? null;
+  const currentClanName = source.currentClanName ?? null;
+  const trophies = source.trophies ?? null;
+  const builderTrophies = source.builderTrophies ?? null;
+  const warStars = source.warStars ?? null;
+  const expLevel = source.expLevel ?? null;
+  const role = source.role ?? null;
+  const leagueName = source.leagueName ?? null;
+  const currentWeight = source.currentWeight ?? null;
+  const currentWeightSource = source.currentWeightSource ?? null;
+  const currentWeightMeasuredAt = source.currentWeightMeasuredAt ?? null;
+  const achievementsJson = source.achievementsJson ?? null;
+  const lastSeenAt = source.lastSeenAt ?? null;
+  const lastFetchedAt = source.lastFetchedAt ?? null;
+  const lastSource = source.lastSource ?? null;
+
+  if (target.playerName === null && playerName !== null) target.playerName = playerName;
+  if (target.townHall === null && townHall !== null) target.townHall = townHall;
+  if (target.currentClanTag === null && currentClanTag !== null) target.currentClanTag = currentClanTag;
+  if (target.currentClanName === null && currentClanName !== null) target.currentClanName = currentClanName;
+  if (target.trophies === null && trophies !== null) target.trophies = trophies;
+  if (target.builderTrophies === null && builderTrophies !== null) target.builderTrophies = builderTrophies;
+  if (target.warStars === null && warStars !== null) target.warStars = warStars;
+  if (target.expLevel === null && expLevel !== null) target.expLevel = expLevel;
+  if (target.role === null && role !== null) target.role = role;
+  if (target.leagueName === null && leagueName !== null) target.leagueName = leagueName;
+  if (target.currentWeight === null && currentWeight !== null) target.currentWeight = currentWeight;
+  if (target.currentWeightSource === null && currentWeightSource !== null) target.currentWeightSource = currentWeightSource;
+  if (target.currentWeightMeasuredAt === null && currentWeightMeasuredAt !== null) target.currentWeightMeasuredAt = currentWeightMeasuredAt;
+  if (target.achievementsJson === null && achievementsJson !== null) target.achievementsJson = achievementsJson;
+  if (target.lastSeenAt === null && lastSeenAt !== null) target.lastSeenAt = lastSeenAt;
+  if (target.lastFetchedAt === null && lastFetchedAt !== null) target.lastFetchedAt = lastFetchedAt;
+  if (target.lastSource === null && lastSource !== null) target.lastSource = lastSource;
+  if (target.source === "missing" && sourceLabel !== "missing") {
+    target.source = sourceLabel;
+  }
+}
+
+function applyLivePlayer(target: PlayerCurrentLike, livePlayer: any, now: Date): void {
+  target.playerName = normalizeText(livePlayer?.name ?? null) ?? target.playerName;
+  const liveTownHall = normalizeNumber(livePlayer?.townHallLevel ?? livePlayer?.townHall ?? null);
+  if (liveTownHall !== null) {
+    target.townHall = liveTownHall;
+  }
+
+  const clanTag = normalizeClanTag(String(livePlayer?.clan?.tag ?? ""));
+  target.currentClanTag = clanTag || null;
+  target.currentClanName = normalizeText(livePlayer?.clan?.name ?? null);
+  target.trophies = normalizeNumber(livePlayer?.trophies ?? null) ?? target.trophies;
+  target.builderTrophies = normalizeNumber(livePlayer?.builderBaseTrophies ?? livePlayer?.versusTrophies ?? null) ?? target.builderTrophies;
+  target.warStars = normalizeNumber(livePlayer?.warStars ?? null) ?? target.warStars;
+  target.expLevel = normalizeNumber(livePlayer?.expLevel ?? null) ?? target.expLevel;
+  target.role = normalizeText(livePlayer?.role ?? null) ?? target.role;
+  target.leagueName = normalizeText(livePlayer?.league?.name ?? null) ?? target.leagueName;
+  target.achievementsJson = Array.isArray(livePlayer?.achievements) ? (livePlayer.achievements as Prisma.JsonValue) : target.achievementsJson;
+  target.lastSeenAt = now;
+  target.lastFetchedAt = now;
+  target.lastSource = "live_refresh";
+  target.source = "live_refresh";
+  target.liveRefreshInvoked = true;
+}
+
+function isFieldMissing(record: PlayerCurrentLike, field: PlayerCurrentResolutionField): boolean {
+  switch (field) {
+    case "playerName":
+      return record.playerName === null;
+    case "townHall":
+      return record.townHall === null;
+    case "currentClanTag":
+      return record.currentClanTag === null;
+    case "currentClanName":
+      return record.currentClanName === null;
+    case "trophies":
+      return record.trophies === null;
+    case "builderTrophies":
+      return record.builderTrophies === null;
+    case "warStars":
+      return record.warStars === null;
+    case "expLevel":
+      return record.expLevel === null;
+    case "role":
+      return record.role === null;
+    case "leagueName":
+      return record.leagueName === null;
+    case "currentWeight":
+      return record.currentWeight === null;
+    default:
+      return true;
+  }
+}
+
+function hasUsefulPersistableData(record: PlayerCurrentLike): boolean {
+  return [
+    record.playerName,
+    record.townHall,
+    record.currentClanTag,
+    record.currentClanName,
+    record.trophies,
+    record.builderTrophies,
+    record.warStars,
+    record.expLevel,
+    record.role,
+    record.leagueName,
+    record.currentWeight,
+    record.currentWeightSource,
+    record.currentWeightMeasuredAt,
+    record.achievementsJson,
+    record.lastSeenAt,
+    record.lastFetchedAt,
+    record.lastSource,
+  ].some((value) => value !== null && value !== undefined && value !== "");
+}
+
+function buildPersistData(record: PlayerCurrentLike): {
+  playerTag: string;
+  playerName: string | null;
+  townHall: number | null;
+  currentClanTag: string | null;
+  currentClanName: string | null;
+  trophies: number | null;
+  builderTrophies: number | null;
+  warStars: number | null;
+  expLevel: number | null;
+  role: string | null;
+  leagueName: string | null;
+  currentWeight: number | null;
+  currentWeightSource: string | null;
+  currentWeightMeasuredAt: Date | null;
+  achievementsJson?: Prisma.InputJsonValue | Prisma.NullableJsonNullValueInput;
+  lastSeenAt: Date | null;
+  lastFetchedAt: Date | null;
+  lastSource: string | null;
+} {
+  return {
+    playerTag: record.playerTag,
+    playerName: record.playerName,
+    townHall: record.townHall,
+    currentClanTag: record.currentClanTag,
+    currentClanName: record.currentClanName,
+    trophies: record.trophies,
+    builderTrophies: record.builderTrophies,
+    warStars: record.warStars,
+    expLevel: record.expLevel,
+    role: record.role,
+    leagueName: record.leagueName,
+    currentWeight: record.currentWeight,
+    currentWeightSource: record.currentWeightSource,
+    currentWeightMeasuredAt: record.currentWeightMeasuredAt,
+    achievementsJson: record.achievementsJson === null ? undefined : (record.achievementsJson as Prisma.InputJsonValue),
+    lastSeenAt: record.lastSeenAt,
+    lastFetchedAt: record.lastFetchedAt,
+    lastSource: record.lastSource,
+  };
+}
+
+function normalizeFields(input: string[]): string[] {
+  return [...new Set(input.map((tag) => normalizePlayerTag(tag)).filter(Boolean))];
+}
+
+export class PlayerCurrentService {
+  async listPlayerCurrentByTags(tags: string[]): Promise<Map<string, PlayerCurrentLike>> {
+    const normalizedTags = normalizeFields(tags);
+    if (normalizedTags.length <= 0) {
+      return new Map();
+    }
+
+    const rows = await prisma.playerCurrent.findMany({
+      where: {
+        playerTag: { in: normalizedTags },
+      },
+      select: {
+        playerTag: true,
+        playerName: true,
+        townHall: true,
+        currentClanTag: true,
+        currentClanName: true,
+        trophies: true,
+        builderTrophies: true,
+        warStars: true,
+        expLevel: true,
+        role: true,
+        leagueName: true,
+        currentWeight: true,
+        currentWeightSource: true,
+        currentWeightMeasuredAt: true,
+        achievementsJson: true,
+        lastSeenAt: true,
+        lastFetchedAt: true,
+        lastSource: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+
+    const result = new Map<string, PlayerCurrentLike>();
+    for (const row of rows) {
+      const playerTag = normalizePlayerTag(row.playerTag);
+      if (!playerTag) continue;
+      result.set(playerTag, toPlayerCurrentLike(row as PlayerCurrentRow));
+    }
+    return result;
+  }
+
+  async hydrateMissingCurrentPlayersForTags(input: {
+    playerTags: string[];
+    cocService?: CoCService | null;
+    requireFields?: PlayerCurrentResolutionField[];
+  }): Promise<Map<string, PlayerCurrentLike>> {
+    return this.resolveCurrentPlayersForTags(input);
+  }
+
+  async resolveCurrentPlayersForTags(input: {
+    playerTags: string[];
+    cocService?: CoCService | null;
+    requireFields?: PlayerCurrentResolutionField[];
+  }): Promise<Map<string, PlayerCurrentLike>> {
+    const normalizedTags = normalizeFields(input.playerTags);
+    if (normalizedTags.length <= 0) {
+      return new Map();
+    }
+
+    const requireFields = input.requireFields && input.requireFields.length > 0 ? [...new Set(input.requireFields)] : DEFAULT_REQUIRE_FIELDS;
+    const now = new Date();
+
+    const [playerCurrentRows, fwaRows, snapshotRows] = await Promise.all([
+      this.listPlayerCurrentByTags(normalizedTags),
+      prisma.fwaPlayerCatalog.findMany({
+        where: { playerTag: { in: normalizedTags } },
+        select: {
+          playerTag: true,
+          latestName: true,
+          latestTownHall: true,
+          latestKnownWeight: true,
+          firstSeenAt: true,
+          lastSeenAt: true,
+          lastSyncedAt: true,
+        },
+      }),
+      todoSnapshotService.listSnapshotsByPlayerTags({
+        playerTags: normalizedTags,
+      }),
+    ]);
+
+    const fwaByTag = new Map<string, FwaPlayerCatalogRow>();
+    for (const row of fwaRows) {
+      const playerTag = normalizePlayerTag(row.playerTag);
+      if (!playerTag) continue;
+      fwaByTag.set(playerTag, {
+        playerTag,
+        latestName: normalizeText(row.latestName) ?? row.latestName,
+        latestTownHall: normalizeNumber(row.latestTownHall),
+        latestKnownWeight: normalizeNumber(row.latestKnownWeight),
+        firstSeenAt: row.firstSeenAt,
+        lastSeenAt: row.lastSeenAt,
+        lastSyncedAt: row.lastSyncedAt,
+      });
+    }
+
+    const snapshotByTag = new Map<string, TodoSnapshotRow>();
+    for (const row of snapshotRows as Array<{ playerTag: string; playerName: string; townHall?: unknown; clanTag?: string | null; clanName?: string | null; updatedAt?: Date; lastUpdatedAt?: Date | null }>) {
+      const playerTag = normalizePlayerTag(row.playerTag);
+      if (!playerTag) continue;
+      snapshotByTag.set(playerTag, {
+        playerTag,
+        playerName: normalizeText(row.playerName) ?? row.playerName,
+        townHall: normalizeNumber(row.townHall ?? null),
+        clanTag: normalizeClanTag(String(row.clanTag ?? "")) || null,
+        clanName: normalizeText(row.clanName ?? null),
+        updatedAt: row.updatedAt ?? new Date(),
+        lastUpdatedAt: row.lastUpdatedAt ?? row.updatedAt ?? null,
+      });
+    }
+
+    const resolved = new Map<string, PlayerCurrentLike>();
+    for (const playerTag of normalizedTags) {
+      const current = playerCurrentRows.get(playerTag) ?? null;
+      const state = current ? { ...current } : createMissingPlayerCurrent({ playerTag });
+      const fwa = fwaByTag.get(playerTag) ?? null;
+      if (fwa) {
+        applyMissingFields(
+          state,
+          {
+            playerName: fwa.latestName,
+            townHall: fwa.latestTownHall,
+            currentWeight: fwa.latestKnownWeight,
+            currentWeightSource: fwa.latestKnownWeight !== null ? "FWA" : null,
+            currentWeightMeasuredAt: fwa.lastSyncedAt,
+            lastSeenAt: fwa.lastSeenAt,
+            lastFetchedAt: fwa.lastSyncedAt,
+            lastSource: "fwa_player_catalog",
+          },
+          "fwa_player_catalog",
+        );
+      }
+      const snapshot = snapshotByTag.get(playerTag) ?? null;
+      if (snapshot) {
+        applyMissingFields(
+          state,
+          {
+            playerName: snapshot.playerName,
+            townHall: snapshot.townHall,
+            currentClanTag: snapshot.clanTag,
+            currentClanName: snapshot.clanName,
+            lastSeenAt: snapshot.updatedAt,
+            lastFetchedAt: snapshot.lastUpdatedAt ?? snapshot.updatedAt,
+            lastSource: "todo_snapshot",
+          },
+          "todo_snapshot",
+        );
+      }
+      resolved.set(playerTag, state);
+    }
+
+    const liveCandidates = normalizedTags.filter((playerTag) =>
+      requireFields.some((field) => isFieldMissing(resolved.get(playerTag) ?? createMissingPlayerCurrent({ playerTag }), field)),
+    );
+
+    const cocService = input.cocService ?? null;
+    if (cocService && typeof cocService.getPlayerRaw === "function" && liveCandidates.length > 0) {
+      const liveRows = await Promise.all(
+        liveCandidates.map(async (playerTag) => {
+          const livePlayer = await cocService.getPlayerRaw(playerTag).catch(() => null);
+          return [playerTag, livePlayer] as const;
+        }),
+      );
+      for (const [playerTag, livePlayer] of liveRows) {
+        if (!livePlayer) continue;
+        const state = resolved.get(playerTag) ?? createMissingPlayerCurrent({ playerTag });
+        applyLivePlayer(state, livePlayer, now);
+        resolved.set(playerTag, state);
+      }
+    }
+
+    const persistableRows: Array<ReturnType<typeof buildPersistData>> = [];
+    for (const playerTag of normalizedTags) {
+      const state = resolved.get(playerTag) ?? createMissingPlayerCurrent({ playerTag });
+      resolved.set(playerTag, state);
+
+      if (hasUsefulPersistableData(state)) {
+        persistableRows.push(buildPersistData(state));
+      }
+    }
+
+    if (persistableRows.length > 0) {
+      await Promise.all(
+        persistableRows.map((data) =>
+          prisma.playerCurrent.upsert({
+            where: { playerTag: data.playerTag },
+            create: data,
+            update: (() => {
+              const { playerTag: _playerTag, ...updateData } = data;
+              return updateData;
+            })(),
+          }),
+        ),
+      );
+    }
+
+    return resolved;
+  }
+
+  async upsertPlayerCurrentFromLivePlayer(input: {
+    playerTag: string;
+    livePlayer: unknown;
+    existing?: PlayerCurrentLike | null;
+    source?: PlayerCurrentResolutionSource;
+    now?: Date;
+  }): Promise<PlayerCurrentLike | null> {
+    const playerTag = normalizePlayerTag(input.playerTag);
+    if (!playerTag || !input.livePlayer) {
+      return null;
+    }
+
+    const state = input.existing ? { ...input.existing } : createMissingPlayerCurrent({ playerTag });
+    applyLivePlayer(state, input.livePlayer, input.now ?? new Date());
+    const data = buildPersistData(state);
+    await prisma.playerCurrent.upsert({
+      where: { playerTag },
+      create: data,
+      update: (() => {
+        const { playerTag: _playerTag, ...updateData } = data;
+        return updateData;
+      })(),
+    });
+    return {
+      ...state,
+      source: input.source ?? "live_refresh",
+      liveRefreshInvoked: true,
+    };
+  }
+}
+
+/** Purpose: provide one singleton current-player resolver for roster signup paths. */
+export const playerCurrentService = new PlayerCurrentService();

--- a/src/services/RosterService.ts
+++ b/src/services/RosterService.ts
@@ -30,6 +30,7 @@ import {
   resolveRosterCurrentWeightRecords,
   type RosterWeightSource,
 } from "./RosterWeightService";
+import { playerCurrentService } from "./PlayerCurrentService";
 import { todoSnapshotService } from "./TodoSnapshotService";
 import { normalizeSyncTimeZone } from "./syncTimeZone";
 
@@ -226,6 +227,7 @@ type RosterSelectionSignupLoadReadyResult = {
   groups: RosterGroupRecord[];
   selectedGroupKey: string | null;
   options: RosterSelectionOption[];
+  emptyStateMessage: string | null;
 };
 
 type RosterSelectionRemoveLoadReadyResult = {
@@ -1322,6 +1324,7 @@ type RosterSelectionSession = {
   selectedDiscordUserLabel: string | null;
   groupPickerVisible: boolean;
   playerPageWindowStart: number;
+  emptyStateMessage: string | null;
 };
 
 const rosterSelectionSessions = new Map<string, RosterSelectionSession>();
@@ -1405,6 +1408,7 @@ function buildRosterSelectionDescription(input: {
   groupName: string | null;
   selectedTags: string[];
   options: RosterSelectionOption[];
+  emptyStateMessage?: string | null;
 }): string[] {
   const lines: string[] = [];
   if (input.mode === "signup") {
@@ -1423,6 +1427,10 @@ function buildRosterSelectionDescription(input: {
     lines.push(
       ...selectedLines.map((option) => `- ${option.label}${option.description ? ` - ${option.description}` : ""}`),
     );
+  }
+  if (input.emptyStateMessage) {
+    lines.push("");
+    lines.push(input.emptyStateMessage);
   }
   return lines;
 }
@@ -1747,6 +1755,7 @@ function buildRosterSelectionPayload(session: RosterSelectionSession): RosterSel
         groupName: session.groupName,
         selectedTags,
         options: visibleOptions,
+        emptyStateMessage: session.emptyStateMessage,
       }).join("\n"),
     );
 
@@ -1934,18 +1943,21 @@ async function loadRosterSelectionOptions(input: {
   discordUserId: string;
   mode: "signup";
   groupKey?: string | null;
+  cocService?: CoCService | null;
 }): Promise<RosterSelectionSignupLoadResult>;
 async function loadRosterSelectionOptions(input: {
   rosterId: string;
   discordUserId: string;
   mode: "remove";
   groupKey?: string | null;
+  cocService?: CoCService | null;
 }): Promise<RosterSelectionRemoveLoadResult>;
 async function loadRosterSelectionOptions(input: {
   rosterId: string;
   discordUserId: string;
   mode: RosterSelectionMode;
   groupKey?: string | null;
+  cocService?: CoCService | null;
 }): Promise<RosterSelectionSignupLoadResult | RosterSelectionRemoveLoadResult> {
   const roster = await prisma.roster.findUnique({
     where: { id: input.rosterId },
@@ -1997,16 +2009,12 @@ async function loadRosterSelectionOptions(input: {
     const minTownhall = normalizeRosterInt(roster.minTownhall);
     const maxTownhall = normalizeRosterInt(roster.maxTownhall);
     const townHallGated = minTownhall !== null || maxTownhall !== null;
-    const townHallByTag = townHallGated
-      ? (
-          await resolveRosterPlayerTownHallMap({
-            rosterType: roster.rosterType,
-            clanTag: roster.clanTag,
-            playerTags: linkedTags,
-            allowLiveFetch: false,
-            cocService: null,
-          })
-        ).townHallByTag
+    const resolvedPlayersByTag = townHallGated
+      ? await playerCurrentService.resolveCurrentPlayersForTags({
+          playerTags: linkedTags,
+          cocService: input.cocService ?? null,
+          requireFields: ["townHall"],
+        })
       : null;
 
     const signupOptions = linkedAccounts.filter((account) => {
@@ -2014,7 +2022,7 @@ async function loadRosterSelectionOptions(input: {
         return true;
       }
 
-      const townHall = townHallByTag?.get(account.playerTag) ?? null;
+      const townHall = normalizeRosterInt(resolvedPlayersByTag?.get(account.playerTag)?.townHall ?? null);
       if (townHall === null) {
         return false;
       }
@@ -2026,6 +2034,10 @@ async function loadRosterSelectionOptions(input: {
       }
       return true;
     });
+    const emptyStateMessage =
+      townHallGated && linkedAccounts.length > 0 && signupOptions.length <= 0
+        ? "No linked accounts met this roster's town hall requirements."
+        : null;
     return {
       outcome: "ready",
       roster: mappedRoster,
@@ -2037,6 +2049,7 @@ async function loadRosterSelectionOptions(input: {
         label: account.linkedName ?? account.playerTag,
         description: `${account.playerTag}${existingTags.has(account.playerTag) ? " | already signed up" : " | available"}`,
       })),
+      emptyStateMessage,
     };
   }
 
@@ -5256,12 +5269,14 @@ export class RosterService {
     rosterId: string;
     discordUserId: string;
     groupKey?: string | null;
+    cocService?: CoCService | null;
   }): Promise<RosterSelectionOpenResult> {
     const loaded = await loadRosterSelectionOptions({
       rosterId: input.rosterId,
       discordUserId: input.discordUserId,
       mode: "signup",
       groupKey: input.groupKey,
+      cocService: input.cocService ?? null,
     });
     if (loaded.outcome !== "ready") {
       return loaded;
@@ -5296,6 +5311,7 @@ export class RosterService {
       selectedDiscordUserLabel: null,
       groupPickerVisible: false,
       playerPageWindowStart: 0,
+      emptyStateMessage: loaded.emptyStateMessage,
     });
     return {
       outcome: "ready",
@@ -5331,6 +5347,7 @@ export class RosterService {
       selectedDiscordUserLabel: null,
       groupPickerVisible: false,
       playerPageWindowStart: 0,
+      emptyStateMessage: null,
     });
     return {
       outcome: "ready",
@@ -5376,6 +5393,7 @@ export class RosterService {
       selectedDiscordUserLabel: null,
       groupPickerVisible: false,
       playerPageWindowStart: 0,
+      emptyStateMessage: null,
     });
     return {
       outcome: "ready",
@@ -5805,12 +5823,10 @@ export class RosterService {
       }
 
       if (isRosterTownHallGated(roster)) {
-        const playerTownHallResolution = await resolveRosterPlayerTownHallMap({
-          rosterType: roster.rosterType,
-          clanTag: roster.clanTag,
+        const playerCurrentByTag = await playerCurrentService.resolveCurrentPlayersForTags({
           playerTags: createdCandidates,
-          allowLiveFetch: true,
           cocService: input.cocService ?? null,
+          requireFields: ["townHall"],
         });
         const minTownhall = normalizeRosterInt(roster.minTownhall);
         const maxTownhall = normalizeRosterInt(roster.maxTownhall);
@@ -5824,7 +5840,7 @@ export class RosterService {
             playerTag: tag,
             playerName: normalizeRosterText(linked?.linkedName ?? null),
           };
-          const townHall = playerTownHallResolution.townHallByTag.get(tag) ?? null;
+          const townHall = normalizeRosterInt(playerCurrentByTag.get(tag)?.townHall ?? null);
           if (townHall === null) {
             blockedUnavailableTags.push(tag);
             blockedUnavailableAccounts.push(blockedAccount);
@@ -5835,17 +5851,6 @@ export class RosterService {
             blockedOutOfRangeAccounts.push(blockedAccount);
           }
         }
-        logRosterTownHallResolutionDiagnostics({
-          rosterId: roster.id,
-          rosterType: roster.rosterType,
-          clanTag: roster.clanTag,
-          requestedTags,
-          linkedTags: selectedTags,
-          resolution: playerTownHallResolution,
-          blockedUnavailableTags,
-          blockedOutOfRangeTags,
-          cocServicePresent: Boolean(input.cocService),
-        });
         if (blockedUnavailableTags.length > 0) {
           return {
             outcome: "townhall_unavailable",

--- a/tests/cwl.command.test.ts
+++ b/tests/cwl.command.test.ts
@@ -463,6 +463,8 @@ describe("/cwl command", () => {
     const interaction = {
       customId: "roster-post-action:signup:roster-1",
       user: { id: "111111111111111111" },
+      deferReply: vi.fn().mockResolvedValue(undefined),
+      editReply: vi.fn().mockResolvedValue(undefined),
       reply: vi.fn().mockResolvedValue(undefined),
     };
 
@@ -471,14 +473,15 @@ describe("/cwl command", () => {
     expect(rosterService.createRosterSignupSelectionPanel).toHaveBeenCalledWith({
       rosterId: "roster-1",
       discordUserId: "111111111111111111",
+      cocService: null,
     });
-    expect(interaction.reply).toHaveBeenCalledWith(
+    expect(interaction.deferReply).toHaveBeenCalledWith({ ephemeral: true });
+    expect(interaction.editReply).toHaveBeenCalledWith(
       expect.objectContaining({
-        ephemeral: true,
         embeds: [expect.any(EmbedBuilder)],
       }),
     );
-    const payload = interaction.reply.mock.calls[0]?.[0] as any;
+    const payload = interaction.editReply.mock.calls[0]?.[0] as any;
     expect(getPayloadComponentCustomIds(payload)).toEqual(
       expect.arrayContaining([
         "roster-selection:group:session-1",

--- a/tests/playerCurrent.service.test.ts
+++ b/tests/playerCurrent.service.test.ts
@@ -1,0 +1,186 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const prismaMock = vi.hoisted(() => ({
+  playerCurrent: {
+    findMany: vi.fn(),
+    upsert: vi.fn(),
+  },
+  fwaPlayerCatalog: {
+    findMany: vi.fn(),
+  },
+}));
+
+vi.mock("../src/prisma", () => ({
+  prisma: prismaMock,
+}));
+
+import { playerCurrentService } from "../src/services/PlayerCurrentService";
+import { todoSnapshotService } from "../src/services/TodoSnapshotService";
+
+function makeCurrentRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    playerTag: "#PQL0289",
+    playerName: "Primary",
+    townHall: 15,
+    currentClanTag: "#PRIMARY",
+    currentClanName: "Primary Clan",
+    trophies: 6000,
+    builderTrophies: 4000,
+    warStars: 100,
+    expLevel: 200,
+    role: "leader",
+    leagueName: "Legend League",
+    currentWeight: 123,
+    currentWeightSource: "primary",
+    currentWeightMeasuredAt: new Date("2026-04-20T00:00:00.000Z"),
+    achievementsJson: null,
+    lastSeenAt: new Date("2026-04-20T00:00:00.000Z"),
+    lastFetchedAt: new Date("2026-04-20T00:00:00.000Z"),
+    lastSource: "player_current",
+    createdAt: new Date("2026-04-20T00:00:00.000Z"),
+    updatedAt: new Date("2026-04-20T00:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+describe("PlayerCurrentService", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.clearAllMocks();
+    prismaMock.playerCurrent.findMany.mockResolvedValue([]);
+    prismaMock.playerCurrent.upsert.mockResolvedValue({} as never);
+    prismaMock.fwaPlayerCatalog.findMany.mockResolvedValue([]);
+    vi.spyOn(todoSnapshotService, "listSnapshotsByPlayerTags").mockResolvedValue([] as never);
+  });
+
+  it("prefers PlayerCurrent over fallback sources and skips live fetch when town hall is already present", async () => {
+    prismaMock.playerCurrent.findMany.mockResolvedValueOnce([
+      makeCurrentRow({ playerTag: "#PQL0289", playerName: "Primary", townHall: 16 }),
+    ]);
+    prismaMock.fwaPlayerCatalog.findMany.mockResolvedValueOnce([
+      { playerTag: "#PQL0289", latestName: "Fallback", latestTownHall: 14, latestKnownWeight: 111, firstSeenAt: new Date(), lastSeenAt: new Date(), lastSyncedAt: new Date() },
+    ]);
+    (todoSnapshotService.listSnapshotsByPlayerTags as any).mockResolvedValueOnce([
+      { playerTag: "#PQL0289", playerName: "Snapshot", townHall: 12, clanTag: "#SNAP", clanName: "Snapshot Clan", updatedAt: new Date(), lastUpdatedAt: new Date() },
+    ]);
+
+    const cocService = { getPlayerRaw: vi.fn() } as any;
+    const resolved = await playerCurrentService.resolveCurrentPlayersForTags({
+      playerTags: ["#PQL0289"],
+      cocService,
+      requireFields: ["townHall"],
+    });
+
+    expect(resolved.get("#PQL0289")).toMatchObject({
+      playerTag: "#PQL0289",
+      playerName: "Primary",
+      townHall: 16,
+      currentClanTag: "#PRIMARY",
+      currentClanName: "Primary Clan",
+      source: "player_current",
+    });
+    expect(cocService.getPlayerRaw).not.toHaveBeenCalled();
+  });
+
+  it("falls back to FwaPlayerCatalog before TodoPlayerSnapshot for missing town hall", async () => {
+    prismaMock.playerCurrent.findMany.mockResolvedValueOnce([]);
+    prismaMock.fwaPlayerCatalog.findMany.mockResolvedValueOnce([
+      { playerTag: "#QGRJ2222", latestName: "FWA Player", latestTownHall: 14, latestKnownWeight: 222, firstSeenAt: new Date(), lastSeenAt: new Date(), lastSyncedAt: new Date() },
+    ]);
+    (todoSnapshotService.listSnapshotsByPlayerTags as any).mockResolvedValueOnce([
+      { playerTag: "#QGRJ2222", playerName: "Snapshot Player", townHall: 12, clanTag: "#SNAP", clanName: "Snapshot Clan", updatedAt: new Date(), lastUpdatedAt: new Date() },
+    ]);
+
+    const resolved = await playerCurrentService.resolveCurrentPlayersForTags({
+      playerTags: ["#QGRJ2222"],
+      requireFields: ["townHall"],
+    });
+
+    expect(resolved.get("#QGRJ2222")).toMatchObject({
+      playerTag: "#QGRJ2222",
+      playerName: "FWA Player",
+      townHall: 14,
+      currentWeight: 222,
+      source: "fwa_player_catalog",
+    });
+  });
+
+  it("falls back to TodoPlayerSnapshot before live fetch when persisted current-player data is still missing town hall", async () => {
+    prismaMock.playerCurrent.findMany.mockResolvedValueOnce([]);
+    prismaMock.fwaPlayerCatalog.findMany.mockResolvedValueOnce([]);
+    (todoSnapshotService.listSnapshotsByPlayerTags as any).mockResolvedValueOnce([
+      { playerTag: "#298CG8UJG", playerName: "Snapshot Player", townHall: 13, clanTag: "#2QG2C08UP", clanName: "Snapshot Clan", updatedAt: new Date(), lastUpdatedAt: new Date() },
+    ]);
+    const cocService = { getPlayerRaw: vi.fn() } as any;
+
+    const resolved = await playerCurrentService.resolveCurrentPlayersForTags({
+      playerTags: ["#298CG8UJG"],
+      cocService,
+      requireFields: ["townHall"],
+    });
+
+    expect(resolved.get("#298CG8UJG")).toMatchObject({
+      playerTag: "#298CG8UJG",
+      playerName: "Snapshot Player",
+      townHall: 13,
+      currentClanTag: "#2QG2C08UP",
+      currentClanName: "Snapshot Clan",
+      source: "todo_snapshot",
+    });
+    expect(cocService.getPlayerRaw).not.toHaveBeenCalled();
+  });
+
+  it("persists live town hall even when the live player has no clan tag", async () => {
+    prismaMock.playerCurrent.findMany.mockResolvedValueOnce([]);
+    prismaMock.fwaPlayerCatalog.findMany.mockResolvedValueOnce([]);
+    (todoSnapshotService.listSnapshotsByPlayerTags as any).mockResolvedValueOnce([]);
+    const cocService = {
+      getPlayerRaw: vi.fn().mockResolvedValue({
+        name: "Live Player",
+        townHallLevel: 16,
+        clan: null,
+        trophies: 6100,
+        builderBaseTrophies: 4200,
+        warStars: 101,
+        expLevel: 201,
+        role: "member",
+        league: { name: "Legend League" },
+        achievements: [{ name: "Friend in Need", value: 1 }],
+      }),
+    } as any;
+
+    const resolved = await playerCurrentService.resolveCurrentPlayersForTags({
+      playerTags: ["#G99CVLG9Y"],
+      cocService,
+      requireFields: ["townHall"],
+    });
+
+    expect(cocService.getPlayerRaw).toHaveBeenCalledWith("#G99CVLG9Y");
+    expect(resolved.get("#G99CVLG9Y")).toMatchObject({
+      playerTag: "#G99CVLG9Y",
+      playerName: "Live Player",
+      townHall: 16,
+      currentClanTag: null,
+      currentClanName: null,
+      trophies: 6100,
+      builderTrophies: 4200,
+      warStars: 101,
+      expLevel: 201,
+      role: "member",
+      leagueName: "Legend League",
+      source: "live_refresh",
+      liveRefreshInvoked: true,
+    });
+    expect(prismaMock.playerCurrent.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { playerTag: "#G99CVLG9Y" },
+        create: expect.objectContaining({
+          playerTag: "#G99CVLG9Y",
+          townHall: 16,
+          currentClanTag: null,
+          currentClanName: null,
+        }),
+      }),
+    );
+  });
+});

--- a/tests/roster.service.test.ts
+++ b/tests/roster.service.test.ts
@@ -25,6 +25,10 @@ const prismaMock = vi.hoisted(() => ({
   playerLink: {
     findMany: vi.fn(),
   },
+  playerCurrent: {
+    findMany: vi.fn(),
+    upsert: vi.fn(),
+  },
   fwaClanMemberCurrent: {
     findMany: vi.fn(),
   },
@@ -72,6 +76,13 @@ const todoSnapshotServiceMock = vi.hoisted(() => ({
   listSnapshotsByPlayerTags: vi.fn(),
   listSnapshotsByClanTag: vi.fn(),
   refreshSnapshotsForPlayerTags: vi.fn(),
+}));
+
+const playerCurrentServiceMock = vi.hoisted(() => ({
+  resolveCurrentPlayersForTags: vi.fn(),
+  hydrateMissingCurrentPlayersForTags: vi.fn(),
+  listPlayerCurrentByTags: vi.fn(),
+  upsertPlayerCurrentFromLivePlayer: vi.fn(),
 }));
 
 function makeRosterEmojiClient(options?: { missing?: string[] }) {
@@ -124,6 +135,33 @@ function makeValidRosterPlayerTag(index: number): string {
   return `#PQL${digits.map((digit) => alphabet[digit] ?? "0").join("")}`;
 }
 
+function makeResolvedPlayerCurrent(playerTag: string, townHall: number | null): any {
+  return {
+    playerTag,
+    playerName: null,
+    townHall,
+    currentClanTag: null,
+    currentClanName: null,
+    trophies: null,
+    builderTrophies: null,
+    warStars: null,
+    expLevel: null,
+    role: null,
+    leagueName: null,
+    currentWeight: null,
+    currentWeightSource: null,
+    currentWeightMeasuredAt: null,
+    achievementsJson: null,
+    lastSeenAt: null,
+    lastFetchedAt: null,
+    lastSource: null,
+    createdAt: null,
+    updatedAt: null,
+    source: townHall === null ? "missing" : "player_current",
+    liveRefreshInvoked: false,
+  };
+}
+
 vi.mock("../src/prisma", () => ({
   prisma: prismaMock,
 }));
@@ -158,6 +196,16 @@ vi.mock("../src/services/TodoSnapshotService", async () => {
   };
 });
 
+vi.mock("../src/services/PlayerCurrentService", async () => {
+  const actual = await vi.importActual<typeof import("../src/services/PlayerCurrentService")>(
+    "../src/services/PlayerCurrentService",
+  );
+  return {
+    ...actual,
+    playerCurrentService: playerCurrentServiceMock,
+  };
+});
+
 vi.mock("../src/services/fwa-feeds/FwaClanMembersSyncService", async () => {
   const actual = await vi.importActual<typeof import("../src/services/fwa-feeds/FwaClanMembersSyncService")>(
     "../src/services/fwa-feeds/FwaClanMembersSyncService",
@@ -175,6 +223,7 @@ import {
   rosterService,
 } from "../src/services/RosterService";
 import { resolveCurrentCwlSeasonKey } from "../src/services/CwlRegistryService";
+import { playerCurrentService } from "../src/services/PlayerCurrentService";
 
 describe("RosterService", () => {
   function mockConflictLookupForLifecycleState(
@@ -305,6 +354,8 @@ describe("RosterService", () => {
     prismaMock.rosterSignup.updateMany.mockResolvedValue({ count: 0 });
     prismaMock.rosterSignup.deleteMany.mockResolvedValue({ count: 0 });
     prismaMock.playerLink.findMany.mockResolvedValue([]);
+    prismaMock.playerCurrent.findMany.mockResolvedValue([]);
+    prismaMock.playerCurrent.upsert.mockResolvedValue({} as never);
     prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue([]);
     prismaMock.fwaPlayerCatalog.findMany.mockResolvedValue([]);
     prismaMock.externalPlayerWeightCurrent.findMany.mockResolvedValue([]);
@@ -341,6 +392,10 @@ describe("RosterService", () => {
       playerCount: 0,
       updatedCount: 0,
     });
+    playerCurrentServiceMock.listPlayerCurrentByTags.mockResolvedValue(new Map());
+    playerCurrentServiceMock.resolveCurrentPlayersForTags.mockResolvedValue(new Map());
+    playerCurrentServiceMock.hydrateMissingCurrentPlayersForTags.mockResolvedValue(new Map());
+    playerCurrentServiceMock.upsertPlayerCurrentFromLivePlayer.mockResolvedValue(null);
     fwaClanMembersSyncServiceMock.refreshCurrentClanMembersForClanTags.mockResolvedValue({
       clanCount: 1,
       rowCount: 1,
@@ -471,6 +526,12 @@ describe("RosterService", () => {
       { playerTag: "#PQL0289", linkedName: "Alpha", linkedAt: new Date("2026-04-20T00:00:00.000Z") },
       { playerTag: "#QGRJ2222", linkedName: "Bravo", linkedAt: new Date("2026-04-20T00:00:00.000Z") },
     ]);
+    playerCurrentServiceMock.resolveCurrentPlayersForTags.mockResolvedValue(
+      new Map([
+        ["#PQL0289", makeResolvedPlayerCurrent("#PQL0289", null)],
+        ["#QGRJ2222", makeResolvedPlayerCurrent("#QGRJ2222", null)],
+      ]),
+    );
     prismaMock.roster.findUnique.mockResolvedValueOnce({
       id: "roster-1",
       guildId: "guild-1",
@@ -515,15 +576,20 @@ describe("RosterService", () => {
         { playerTag: "#QGRJ2222", playerName: "Bravo" },
       ],
     });
-    expect(cwlStateServiceMock.listSeasonRosterForClan).toHaveBeenCalledWith({
-      clanTag: "#2QG2C08UP",
+    expect(playerCurrentServiceMock.resolveCurrentPlayersForTags).toHaveBeenCalledWith({
+      playerTags: ["#PQL0289", "#QGRJ2222"],
+      cocService: null,
+      requireFields: ["townHall"],
     });
   });
 
-  it("uses the CWL season roster town hall before snapshot fallback when available", async () => {
+  it("prefers resolved current-player town hall when available for signup eligibility", async () => {
     playerLinkServiceMock.listPlayerLinksForDiscordUser.mockResolvedValue([
       { playerTag: "#PQL0289", linkedName: "Alpha", linkedAt: new Date("2026-04-20T00:00:00.000Z") },
     ]);
+    playerCurrentServiceMock.resolveCurrentPlayersForTags.mockResolvedValue(
+      new Map([["#PQL0289", makeResolvedPlayerCurrent("#PQL0289", 16)]]),
+    );
     prismaMock.roster.findUnique.mockResolvedValueOnce({
       id: "roster-1",
       guildId: "guild-1",
@@ -567,13 +633,20 @@ describe("RosterService", () => {
       outcome: "created",
       createdTags: ["#PQL0289"],
     });
-    expect(todoSnapshotServiceMock.listSnapshotsByPlayerTags).not.toHaveBeenCalled();
+    expect(playerCurrentServiceMock.resolveCurrentPlayersForTags).toHaveBeenCalledWith({
+      playerTags: ["#PQL0289"],
+      cocService: null,
+      requireFields: ["townHall"],
+    });
   });
 
-  it("uses the FWA catalog town hall before snapshot fallback when available", async () => {
+  it("uses persisted fallback data when the current-player cache is missing town hall", async () => {
     playerLinkServiceMock.listPlayerLinksForDiscordUser.mockResolvedValue([
       { playerTag: "#PQL0289", linkedName: "Alpha", linkedAt: new Date("2026-04-20T00:00:00.000Z") },
     ]);
+    playerCurrentServiceMock.resolveCurrentPlayersForTags.mockResolvedValue(
+      new Map([["#PQL0289", makeResolvedPlayerCurrent("#PQL0289", 15)]]),
+    );
     prismaMock.roster.findUnique.mockResolvedValueOnce({
       id: "roster-1",
       guildId: "guild-1",
@@ -617,13 +690,20 @@ describe("RosterService", () => {
       outcome: "created",
       createdTags: ["#PQL0289"],
     });
-    expect(todoSnapshotServiceMock.listSnapshotsByPlayerTags).not.toHaveBeenCalled();
+    expect(playerCurrentServiceMock.resolveCurrentPlayersForTags).toHaveBeenCalledWith({
+      playerTags: ["#PQL0289"],
+      cocService: null,
+      requireFields: ["townHall"],
+    });
   });
 
-  it("falls back to persisted player snapshots when the primary roster source misses town hall", async () => {
+  it("keeps signup blocked when the resolved town hall is still unavailable", async () => {
     playerLinkServiceMock.listPlayerLinksForDiscordUser.mockResolvedValue([
       { playerTag: "#PQL0289", linkedName: "Alpha", linkedAt: new Date("2026-04-20T00:00:00.000Z") },
     ]);
+    playerCurrentServiceMock.resolveCurrentPlayersForTags.mockResolvedValue(
+      new Map([["#PQL0289", makeResolvedPlayerCurrent("#PQL0289", null)]]),
+    );
     prismaMock.roster.findUnique.mockResolvedValueOnce({
       id: "roster-1",
       guildId: "guild-1",
@@ -667,18 +747,23 @@ describe("RosterService", () => {
     });
 
     expect(result).toMatchObject({
-      outcome: "created",
-      createdTags: ["#PQL0289"],
+      outcome: "townhall_unavailable",
+      blockedTags: ["#PQL0289"],
     });
-    expect(todoSnapshotServiceMock.listSnapshotsByPlayerTags).toHaveBeenCalledWith({
+    expect(playerCurrentServiceMock.resolveCurrentPlayersForTags).toHaveBeenCalledWith({
       playerTags: ["#PQL0289"],
+      cocService: null,
+      requireFields: ["townHall"],
     });
   });
 
-  it("uses a live player refresh for only the still-missing tags and reuses the persisted snapshot on later checks", async () => {
+  it("reuses resolved current-player data on repeated signup checks for the same roster", async () => {
     playerLinkServiceMock.listPlayerLinksForDiscordUser.mockResolvedValue([
       { playerTag: "#PQL0289", linkedName: "Alpha", linkedAt: new Date("2026-04-20T00:00:00.000Z") },
     ]);
+    playerCurrentServiceMock.resolveCurrentPlayersForTags
+      .mockResolvedValueOnce(new Map([["#PQL0289", makeResolvedPlayerCurrent("#PQL0289", 15)]]))
+      .mockResolvedValueOnce(new Map([["#PQL0289", makeResolvedPlayerCurrent("#PQL0289", 14)]]));
     prismaMock.roster.findUnique.mockResolvedValue({
       id: "roster-1",
       guildId: "guild-1",
@@ -708,30 +793,15 @@ describe("RosterService", () => {
       createdAt: new Date("2026-04-20T00:00:00.000Z"),
       updatedAt: new Date("2026-04-20T00:00:00.000Z"),
     } as any);
-    cwlStateServiceMock.listSeasonRosterForClan.mockResolvedValue([
-      { playerTag: "#PQL0289", playerName: "Alpha", townHall: null },
-    ]);
-    todoSnapshotServiceMock.listSnapshotsByPlayerTags
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([{ playerTag: "#PQL0289", townHall: 14 }])
-      .mockResolvedValueOnce([{ playerTag: "#PQL0289", townHall: 14 }]);
-    todoSnapshotServiceMock.refreshSnapshotsForPlayerTags.mockResolvedValue({
-      playerCount: 1,
-      updatedCount: 1,
-    });
-    const cocService = { getPlayerRaw: vi.fn() } as any;
-
     const first = await rosterService.signupLinkedAccounts({
       rosterId: "roster-1",
       groupKey: "confirmed",
       discordUserId: "111111111111111111",
-      cocService,
     });
     const second = await rosterService.signupLinkedAccounts({
       rosterId: "roster-1",
       groupKey: "confirmed",
       discordUserId: "111111111111111111",
-      cocService,
     });
 
     expect(first).toMatchObject({
@@ -742,17 +812,26 @@ describe("RosterService", () => {
       outcome: "created",
       createdTags: ["#PQL0289"],
     });
-    expect(todoSnapshotServiceMock.refreshSnapshotsForPlayerTags).toHaveBeenCalledTimes(1);
-    expect(todoSnapshotServiceMock.refreshSnapshotsForPlayerTags).toHaveBeenCalledWith({
+    expect(playerCurrentServiceMock.resolveCurrentPlayersForTags).toHaveBeenCalledTimes(2);
+    expect(playerCurrentServiceMock.resolveCurrentPlayersForTags).toHaveBeenNthCalledWith(1, {
       playerTags: ["#PQL0289"],
-      cocService,
+      cocService: null,
+      requireFields: ["townHall"],
+    });
+    expect(playerCurrentServiceMock.resolveCurrentPlayersForTags).toHaveBeenNthCalledWith(2, {
+      playerTags: ["#PQL0289"],
+      cocService: null,
+      requireFields: ["townHall"],
     });
   });
 
-  it("logs town hall source diagnostics and reuses live refresh data when refreshed snapshots are still invisible", async () => {
+  it("uses live current-player hydration when the cached town hall is still missing", async () => {
     playerLinkServiceMock.listPlayerLinksForDiscordUser.mockResolvedValue([
       { playerTag: "#298CG8UJG", linkedName: "Player 298", linkedAt: new Date("2026-04-20T00:00:00.000Z") },
     ]);
+    playerCurrentServiceMock.resolveCurrentPlayersForTags.mockResolvedValue(
+      new Map([["#298CG8UJG", makeResolvedPlayerCurrent("#298CG8UJG", 15)]]),
+    );
     prismaMock.roster.findUnique.mockResolvedValueOnce({
       id: "roster-1",
       guildId: "guild-1",
@@ -782,82 +861,31 @@ describe("RosterService", () => {
       createdAt: new Date("2026-04-20T00:00:00.000Z"),
       updatedAt: new Date("2026-04-20T00:00:00.000Z"),
     } as any);
-    cwlStateServiceMock.listSeasonRosterForClan.mockResolvedValue([
-      { playerTag: "#298CG8UJG", playerName: "Player 298", townHall: null },
-    ]);
-    todoSnapshotServiceMock.listSnapshotsByPlayerTags
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([]);
-    todoSnapshotServiceMock.refreshSnapshotsForPlayerTags.mockImplementation(async ({ cocService }) => {
-      await cocService?.getPlayerRaw("#298CG8UJG", { suppressTelemetry: true });
-      return {
-        playerCount: 1,
-        updatedCount: 1,
-      };
+    const result = await rosterService.signupLinkedAccounts({
+      rosterId: "roster-1",
+      groupKey: "confirmed",
+      discordUserId: "111111111111111111",
+      cocService: { getPlayerRaw: vi.fn() } as any,
     });
-    const cocService = {
-      getPlayerRaw: vi.fn().mockResolvedValue({
-        townHallLevel: 15,
-        clan: { tag: "#2QG2C08UP" },
-      }),
-    } as any;
-    const consoleInfoSpy = vi.spyOn(console, "info").mockImplementation(() => undefined);
 
-    try {
-      const result = await rosterService.signupLinkedAccounts({
-        rosterId: "roster-1",
-        groupKey: "confirmed",
-        discordUserId: "111111111111111111",
-        cocService,
-      });
-
-      expect(result).toMatchObject({
-        outcome: "created",
-        createdTags: ["#298CG8UJG"],
-      });
-      expect(cocService.getPlayerRaw).toHaveBeenCalledWith("#298CG8UJG", {
-        suppressTelemetry: true,
-      });
-      expect(todoSnapshotServiceMock.refreshSnapshotsForPlayerTags).toHaveBeenCalledWith({
-        playerTags: ["#298CG8UJG"],
-        cocService,
-      });
-
-      const lastCall = consoleInfoSpy.mock.calls[consoleInfoSpy.mock.calls.length - 1] ?? [];
-      const logLine = String(lastCall[0] ?? "");
-      expect(logLine).toContain("[roster-townhall] ");
-      const payload = JSON.parse(logLine.replace(/^\[roster-townhall\]\s*/, ""));
-      expect(payload).toMatchObject({
-        roster_id: "roster-1",
-        roster_type: "CWL",
-        roster_clan_tag: "#2QG2C08UP",
-        requested_player_tags: ["#298CG8UJG"],
-        linked_tags: ["#298CG8UJG"],
-        coc_service_present: true,
-        live_refresh_invoked: true,
-        blocked_unavailable_tags: [],
-        blocked_out_of_range_tags: [],
-        blocked_tags: [],
-      });
-      expect(payload.resolution).toEqual([
-        expect.objectContaining({
-          player_tag: "#298CG8UJG",
-          source: "live_refresh",
-          town_hall: 15,
-          primary_source_hit: false,
-          snapshot_hit: false,
-          live_refresh_invoked: true,
-        }),
-      ]);
-    } finally {
-      consoleInfoSpy.mockRestore();
-    }
+    expect(result).toMatchObject({
+      outcome: "created",
+      createdTags: ["#298CG8UJG"],
+    });
+    expect(playerCurrentServiceMock.resolveCurrentPlayersForTags).toHaveBeenCalledWith({
+      playerTags: ["#298CG8UJG"],
+      cocService: expect.objectContaining({ getPlayerRaw: expect.any(Function) }),
+      requireFields: ["townHall"],
+    });
   });
 
   it("still blocks when the recovered town hall is out of range", async () => {
     playerLinkServiceMock.listPlayerLinksForDiscordUser.mockResolvedValue([
       { playerTag: "#PQL0289", linkedName: "Alpha", linkedAt: new Date("2026-04-20T00:00:00.000Z") },
     ]);
+    playerCurrentServiceMock.resolveCurrentPlayersForTags.mockResolvedValue(
+      new Map([["#PQL0289", makeResolvedPlayerCurrent("#PQL0289", 13)]]),
+    );
     prismaMock.roster.findUnique.mockResolvedValueOnce({
       id: "roster-1",
       guildId: "guild-1",
@@ -887,17 +915,6 @@ describe("RosterService", () => {
       createdAt: new Date("2026-04-20T00:00:00.000Z"),
       updatedAt: new Date("2026-04-20T00:00:00.000Z"),
     } as any);
-    cwlStateServiceMock.listSeasonRosterForClan.mockResolvedValue([
-      { playerTag: "#PQL0289", playerName: "Alpha", townHall: null },
-    ]);
-    todoSnapshotServiceMock.listSnapshotsByPlayerTags
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([{ playerTag: "#PQL0289", townHall: 13 }]);
-    todoSnapshotServiceMock.refreshSnapshotsForPlayerTags.mockResolvedValue({
-      playerCount: 1,
-      updatedCount: 1,
-    });
-
     const result = await rosterService.signupLinkedAccounts({
       rosterId: "roster-1",
       groupKey: "confirmed",
@@ -2081,6 +2098,13 @@ describe("RosterService", () => {
       { playerTag: "#QGRJ2222", linkedName: "Eligible TH", linkedAt: new Date("2026-04-20T00:00:00.000Z") },
       { playerTag: "#2QG2C08UP", linkedName: "Unknown TH", linkedAt: new Date("2026-04-20T00:00:00.000Z") },
     ]);
+    playerCurrentServiceMock.resolveCurrentPlayersForTags.mockResolvedValue(
+      new Map([
+        ["#PQL0289", makeResolvedPlayerCurrent("#PQL0289", 12)],
+        ["#QGRJ2222", makeResolvedPlayerCurrent("#QGRJ2222", 13)],
+        ["#2QG2C08UP", makeResolvedPlayerCurrent("#2QG2C08UP", null)],
+      ]),
+    );
     prismaMock.roster.findUnique.mockResolvedValueOnce({
       id: "roster-1",
       guildId: "guild-1",


### PR DESCRIPTION
- add PlayerCurrent schema/service and live write-back for signup resolution
- route posted signup option-building and confirm-time TH checks through PlayerCurrent precedence