### PR TITLE
fix(roster): refresh stale signup player current data

### DIFF
--- a/src/services/PlayerCurrentService.ts
+++ b/src/services/PlayerCurrentService.ts
@@ -24,6 +24,10 @@ export type PlayerCurrentResolutionSource =
   | "live_refresh"
   | "missing";
 
+export type PlayerCurrentRefreshPolicy = "missing_only" | "missing_or_stale";
+
+export const PLAYER_CURRENT_SIGNUP_MAX_AGE_MS = 6 * 60 * 60 * 1000;
+
 export type PlayerCurrentLike = {
   playerTag: string;
   playerName: string | null;
@@ -325,6 +329,35 @@ function normalizeFields(input: string[]): string[] {
   return [...new Set(input.map((tag) => normalizePlayerTag(tag)).filter(Boolean))];
 }
 
+function isPlayerCurrentStaleForSignup(
+  record: PlayerCurrentLike | null | undefined,
+  now: Date,
+  maxAcceptedAgeMs: number,
+): boolean {
+  if (!record?.lastFetchedAt) {
+    return true;
+  }
+  return now.getTime() - record.lastFetchedAt.getTime() >= maxAcceptedAgeMs;
+}
+
+function shouldLiveRefreshForRequiredFields(input: {
+  currentRecord: PlayerCurrentLike | null | undefined;
+  resolvedRecord: PlayerCurrentLike;
+  requireFields: PlayerCurrentResolutionField[];
+  refreshPolicy: PlayerCurrentRefreshPolicy;
+  now: Date;
+  maxAcceptedAgeMs: number;
+}): boolean {
+  const hasMissingRequiredField = input.requireFields.some((field) => isFieldMissing(input.resolvedRecord, field));
+  if (hasMissingRequiredField) {
+    return true;
+  }
+  if (input.refreshPolicy !== "missing_or_stale") {
+    return false;
+  }
+  return isPlayerCurrentStaleForSignup(input.currentRecord, input.now, input.maxAcceptedAgeMs);
+}
+
 export class PlayerCurrentService {
   async listPlayerCurrentByTags(tags: string[]): Promise<Map<string, PlayerCurrentLike>> {
     const normalizedTags = normalizeFields(tags);
@@ -381,6 +414,8 @@ export class PlayerCurrentService {
     playerTags: string[];
     cocService?: CoCService | null;
     requireFields?: PlayerCurrentResolutionField[];
+    refreshPolicy?: PlayerCurrentRefreshPolicy;
+    maxAcceptedAgeMs?: number;
   }): Promise<Map<string, PlayerCurrentLike>> {
     const normalizedTags = normalizeFields(input.playerTags);
     if (normalizedTags.length <= 0) {
@@ -388,6 +423,8 @@ export class PlayerCurrentService {
     }
 
     const requireFields = input.requireFields && input.requireFields.length > 0 ? [...new Set(input.requireFields)] : DEFAULT_REQUIRE_FIELDS;
+    const refreshPolicy: PlayerCurrentRefreshPolicy = input.refreshPolicy ?? "missing_only";
+    const maxAcceptedAgeMs = Math.max(1, Math.trunc(Number(input.maxAcceptedAgeMs ?? PLAYER_CURRENT_SIGNUP_MAX_AGE_MS) || PLAYER_CURRENT_SIGNUP_MAX_AGE_MS));
     const now = new Date();
 
     const [playerCurrentRows, fwaRows, snapshotRows] = await Promise.all([
@@ -480,7 +517,14 @@ export class PlayerCurrentService {
     }
 
     const liveCandidates = normalizedTags.filter((playerTag) =>
-      requireFields.some((field) => isFieldMissing(resolved.get(playerTag) ?? createMissingPlayerCurrent({ playerTag }), field)),
+      shouldLiveRefreshForRequiredFields({
+        currentRecord: playerCurrentRows.get(playerTag) ?? null,
+        resolvedRecord: resolved.get(playerTag) ?? createMissingPlayerCurrent({ playerTag }),
+        requireFields,
+        refreshPolicy,
+        now,
+        maxAcceptedAgeMs,
+      }),
     );
 
     const cocService = input.cocService ?? null;
@@ -555,6 +599,10 @@ export class PlayerCurrentService {
       source: input.source ?? "live_refresh",
       liveRefreshInvoked: true,
     };
+  }
+
+  isPlayerCurrentStaleForSignup(record: PlayerCurrentLike | null | undefined, now = new Date(), maxAcceptedAgeMs = PLAYER_CURRENT_SIGNUP_MAX_AGE_MS): boolean {
+    return isPlayerCurrentStaleForSignup(record, now, maxAcceptedAgeMs);
   }
 }
 

--- a/src/services/RosterService.ts
+++ b/src/services/RosterService.ts
@@ -30,7 +30,10 @@ import {
   resolveRosterCurrentWeightRecords,
   type RosterWeightSource,
 } from "./RosterWeightService";
-import { playerCurrentService } from "./PlayerCurrentService";
+import {
+  PLAYER_CURRENT_SIGNUP_MAX_AGE_MS,
+  playerCurrentService,
+} from "./PlayerCurrentService";
 import { todoSnapshotService } from "./TodoSnapshotService";
 import { normalizeSyncTimeZone } from "./syncTimeZone";
 
@@ -2014,9 +2017,15 @@ async function loadRosterSelectionOptions(input: {
           playerTags: linkedTags,
           cocService: input.cocService ?? null,
           requireFields: ["townHall"],
+          refreshPolicy: "missing_or_stale",
+          maxAcceptedAgeMs: PLAYER_CURRENT_SIGNUP_MAX_AGE_MS,
         })
       : null;
-
+    const filteredOutReasons = {
+      unknown: 0,
+      belowMin: 0,
+      aboveMax: 0,
+    };
     const signupOptions = linkedAccounts.filter((account) => {
       if (!townHallGated) {
         return true;
@@ -2024,19 +2033,24 @@ async function loadRosterSelectionOptions(input: {
 
       const townHall = normalizeRosterInt(resolvedPlayersByTag?.get(account.playerTag)?.townHall ?? null);
       if (townHall === null) {
+        filteredOutReasons.unknown += 1;
         return false;
       }
       if (minTownhall !== null && townHall < minTownhall) {
+        filteredOutReasons.belowMin += 1;
         return false;
       }
       if (maxTownhall !== null && townHall > maxTownhall) {
+        filteredOutReasons.aboveMax += 1;
         return false;
       }
       return true;
     });
     const emptyStateMessage =
       townHallGated && linkedAccounts.length > 0 && signupOptions.length <= 0
-        ? "No linked accounts met this roster's town hall requirements."
+        ? filteredOutReasons.unknown > 0
+          ? "Town hall could not be determined for your linked accounts right now."
+          : "No linked accounts met this roster's town hall requirements."
         : null;
     return {
       outcome: "ready",
@@ -5827,6 +5841,8 @@ export class RosterService {
           playerTags: createdCandidates,
           cocService: input.cocService ?? null,
           requireFields: ["townHall"],
+          refreshPolicy: "missing_or_stale",
+          maxAcceptedAgeMs: PLAYER_CURRENT_SIGNUP_MAX_AGE_MS,
         });
         const minTownhall = normalizeRosterInt(roster.minTownhall);
         const maxTownhall = normalizeRosterInt(roster.maxTownhall);

--- a/tests/playerCurrent.service.test.ts
+++ b/tests/playerCurrent.service.test.ts
@@ -43,6 +43,25 @@ function makeCurrentRow(overrides: Record<string, unknown> = {}): Record<string,
   };
 }
 
+function makeLivePlayer(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    name: "Live Player",
+    townHallLevel: 16,
+    clan: {
+      tag: "#2QG2C08UP",
+      name: "Live Clan",
+    },
+    trophies: 6100,
+    builderBaseTrophies: 4200,
+    warStars: 101,
+    expLevel: 201,
+    role: "member",
+    league: { name: "Legend League" },
+    achievements: [{ name: "Friend in Need", value: 1 }],
+    ...overrides,
+  };
+}
+
 describe("PlayerCurrentService", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
@@ -135,18 +154,7 @@ describe("PlayerCurrentService", () => {
     prismaMock.fwaPlayerCatalog.findMany.mockResolvedValueOnce([]);
     (todoSnapshotService.listSnapshotsByPlayerTags as any).mockResolvedValueOnce([]);
     const cocService = {
-      getPlayerRaw: vi.fn().mockResolvedValue({
-        name: "Live Player",
-        townHallLevel: 16,
-        clan: null,
-        trophies: 6100,
-        builderBaseTrophies: 4200,
-        warStars: 101,
-        expLevel: 201,
-        role: "member",
-        league: { name: "Legend League" },
-        achievements: [{ name: "Friend in Need", value: 1 }],
-      }),
+      getPlayerRaw: vi.fn().mockResolvedValue(makeLivePlayer({ clan: null })),
     } as any;
 
     const resolved = await playerCurrentService.resolveCurrentPlayersForTags({
@@ -182,5 +190,114 @@ describe("PlayerCurrentService", () => {
         }),
       }),
     );
+  });
+
+  it("refreshes stale signup-path player current data even when town hall is already populated", async () => {
+    prismaMock.playerCurrent.findMany.mockResolvedValueOnce([
+      makeCurrentRow({
+        playerTag: "#PQL0289",
+        playerName: "Cached Player",
+        townHall: 14,
+        lastFetchedAt: new Date(Date.now() - (7 * 60 * 60 * 1000)),
+      }),
+    ]);
+    prismaMock.fwaPlayerCatalog.findMany.mockResolvedValueOnce([]);
+    (todoSnapshotService.listSnapshotsByPlayerTags as any).mockResolvedValueOnce([]);
+    const cocService = {
+      getPlayerRaw: vi.fn().mockResolvedValue(makeLivePlayer({ townHallLevel: 15 })),
+    } as any;
+
+    const resolved = await playerCurrentService.resolveCurrentPlayersForTags({
+      playerTags: ["#PQL0289"],
+      cocService,
+      requireFields: ["townHall"],
+      refreshPolicy: "missing_or_stale",
+      maxAcceptedAgeMs: 6 * 60 * 60 * 1000,
+    });
+
+    expect(cocService.getPlayerRaw).toHaveBeenCalledWith("#PQL0289");
+    expect(resolved.get("#PQL0289")).toMatchObject({
+      playerTag: "#PQL0289",
+      playerName: "Live Player",
+      townHall: 15,
+      source: "live_refresh",
+      liveRefreshInvoked: true,
+    });
+    expect(prismaMock.playerCurrent.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { playerTag: "#PQL0289" },
+        create: expect.objectContaining({
+          playerTag: "#PQL0289",
+          townHall: 15,
+          lastSource: "live_refresh",
+        }),
+      }),
+    );
+  });
+
+  it("keeps fresh signup-path player current data cached when town hall is already populated", async () => {
+    prismaMock.playerCurrent.findMany.mockResolvedValueOnce([
+      makeCurrentRow({
+        playerTag: "#QGRJ2222",
+        playerName: "Cached Player",
+        townHall: 14,
+        lastFetchedAt: new Date(Date.now() - (2 * 60 * 60 * 1000)),
+      }),
+    ]);
+    prismaMock.fwaPlayerCatalog.findMany.mockResolvedValueOnce([]);
+    (todoSnapshotService.listSnapshotsByPlayerTags as any).mockResolvedValueOnce([]);
+    const cocService = {
+      getPlayerRaw: vi.fn().mockResolvedValue(makeLivePlayer({ townHallLevel: 15 })),
+    } as any;
+
+    const resolved = await playerCurrentService.resolveCurrentPlayersForTags({
+      playerTags: ["#QGRJ2222"],
+      cocService,
+      requireFields: ["townHall"],
+      refreshPolicy: "missing_or_stale",
+      maxAcceptedAgeMs: 6 * 60 * 60 * 1000,
+    });
+
+    expect(cocService.getPlayerRaw).not.toHaveBeenCalled();
+    expect(resolved.get("#QGRJ2222")).toMatchObject({
+      playerTag: "#QGRJ2222",
+      playerName: "Cached Player",
+      townHall: 14,
+      source: "player_current",
+      liveRefreshInvoked: false,
+    });
+  });
+
+  it("treats missing lastFetchedAt as stale for signup refresh", async () => {
+    prismaMock.playerCurrent.findMany.mockResolvedValueOnce([
+      makeCurrentRow({
+        playerTag: "#298CG8UJG",
+        playerName: "Cached Player",
+        townHall: 14,
+        lastFetchedAt: null,
+      }),
+    ]);
+    prismaMock.fwaPlayerCatalog.findMany.mockResolvedValueOnce([]);
+    (todoSnapshotService.listSnapshotsByPlayerTags as any).mockResolvedValueOnce([]);
+    const cocService = {
+      getPlayerRaw: vi.fn().mockResolvedValue(makeLivePlayer({ townHallLevel: 15 })),
+    } as any;
+
+    const resolved = await playerCurrentService.resolveCurrentPlayersForTags({
+      playerTags: ["#298CG8UJG"],
+      cocService,
+      requireFields: ["townHall"],
+      refreshPolicy: "missing_or_stale",
+      maxAcceptedAgeMs: 6 * 60 * 60 * 1000,
+    });
+
+    expect(cocService.getPlayerRaw).toHaveBeenCalledWith("#298CG8UJG");
+    expect(resolved.get("#298CG8UJG")).toMatchObject({
+      playerTag: "#298CG8UJG",
+      playerName: "Live Player",
+      townHall: 15,
+      source: "live_refresh",
+      liveRefreshInvoked: true,
+    });
   });
 });

--- a/tests/roster.service.test.ts
+++ b/tests/roster.service.test.ts
@@ -223,7 +223,7 @@ import {
   rosterService,
 } from "../src/services/RosterService";
 import { resolveCurrentCwlSeasonKey } from "../src/services/CwlRegistryService";
-import { playerCurrentService } from "../src/services/PlayerCurrentService";
+import { PLAYER_CURRENT_SIGNUP_MAX_AGE_MS } from "../src/services/PlayerCurrentService";
 
 describe("RosterService", () => {
   function mockConflictLookupForLifecycleState(
@@ -580,6 +580,8 @@ describe("RosterService", () => {
       playerTags: ["#PQL0289", "#QGRJ2222"],
       cocService: null,
       requireFields: ["townHall"],
+      refreshPolicy: "missing_or_stale",
+      maxAcceptedAgeMs: PLAYER_CURRENT_SIGNUP_MAX_AGE_MS,
     });
   });
 
@@ -637,6 +639,8 @@ describe("RosterService", () => {
       playerTags: ["#PQL0289"],
       cocService: null,
       requireFields: ["townHall"],
+      refreshPolicy: "missing_or_stale",
+      maxAcceptedAgeMs: PLAYER_CURRENT_SIGNUP_MAX_AGE_MS,
     });
   });
 
@@ -694,6 +698,8 @@ describe("RosterService", () => {
       playerTags: ["#PQL0289"],
       cocService: null,
       requireFields: ["townHall"],
+      refreshPolicy: "missing_or_stale",
+      maxAcceptedAgeMs: PLAYER_CURRENT_SIGNUP_MAX_AGE_MS,
     });
   });
 
@@ -754,6 +760,8 @@ describe("RosterService", () => {
       playerTags: ["#PQL0289"],
       cocService: null,
       requireFields: ["townHall"],
+      refreshPolicy: "missing_or_stale",
+      maxAcceptedAgeMs: PLAYER_CURRENT_SIGNUP_MAX_AGE_MS,
     });
   });
 
@@ -817,11 +825,15 @@ describe("RosterService", () => {
       playerTags: ["#PQL0289"],
       cocService: null,
       requireFields: ["townHall"],
+      refreshPolicy: "missing_or_stale",
+      maxAcceptedAgeMs: PLAYER_CURRENT_SIGNUP_MAX_AGE_MS,
     });
     expect(playerCurrentServiceMock.resolveCurrentPlayersForTags).toHaveBeenNthCalledWith(2, {
       playerTags: ["#PQL0289"],
       cocService: null,
       requireFields: ["townHall"],
+      refreshPolicy: "missing_or_stale",
+      maxAcceptedAgeMs: PLAYER_CURRENT_SIGNUP_MAX_AGE_MS,
     });
   });
 
@@ -876,6 +888,8 @@ describe("RosterService", () => {
       playerTags: ["#298CG8UJG"],
       cocService: expect.objectContaining({ getPlayerRaw: expect.any(Function) }),
       requireFields: ["townHall"],
+      refreshPolicy: "missing_or_stale",
+      maxAcceptedAgeMs: PLAYER_CURRENT_SIGNUP_MAX_AGE_MS,
     });
   });
 
@@ -2154,6 +2168,114 @@ describe("RosterService", () => {
     expect(optionValues).toContain("#QGRJ2222");
     expect(optionValues).not.toContain("#PQL0289");
     expect(optionValues).not.toContain("#2QG2C08UP");
+  });
+
+  it("explains when TH-gated signup accounts are hidden because town hall could not be determined", async () => {
+    playerLinkServiceMock.listPlayerLinksForDiscordUser.mockResolvedValue([
+      { playerTag: "#PQL0289", linkedName: "Low TH", linkedAt: new Date("2026-04-20T00:00:00.000Z") },
+      { playerTag: "#2QG2C08UP", linkedName: "Unknown TH", linkedAt: new Date("2026-04-20T00:00:00.000Z") },
+    ]);
+    playerCurrentServiceMock.resolveCurrentPlayersForTags.mockResolvedValue(
+      new Map([
+        ["#PQL0289", makeResolvedPlayerCurrent("#PQL0289", null)],
+        ["#2QG2C08UP", makeResolvedPlayerCurrent("#2QG2C08UP", null)],
+      ]),
+    );
+    prismaMock.roster.findUnique.mockResolvedValueOnce({
+      id: "roster-1",
+      guildId: "guild-1",
+      rosterType: "CWL",
+      rosterCategory: "signup",
+      title: "CWL Alpha Signup",
+      clanTag: "#2QG2C08UP",
+      startsAt: new Date("2026-04-20T00:00:00.000Z"),
+      endsAt: null,
+      timezone: "America/Los_Angeles",
+      displayTimezone: "America/Los_Angeles",
+      lifecycleState: "OPEN",
+      postedChannelId: null,
+      postedMessageId: null,
+      postedMessageUrl: null,
+      postedAt: null,
+      createdByDiscordUserId: "111111111111111111",
+      updatedByDiscordUserId: "111111111111111111",
+      createdAt: new Date("2026-04-20T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-20T00:00:00.000Z"),
+      minTownhall: 13,
+      maxTownhall: 15,
+      allowMultiSignup: true,
+    } as any);
+    prismaMock.rosterSignup.findMany.mockResolvedValueOnce([] as any);
+
+    const result = await rosterService.createRosterSignupSelectionPanel({
+      rosterId: "roster-1",
+      discordUserId: "111111111111111111",
+      groupKey: "confirmed",
+    });
+
+    expect(result).toMatchObject({ outcome: "ready" });
+    if (result.outcome !== "ready") return;
+    const description = result.panel.embed.toJSON().description ?? "";
+    expect(description).toContain("Town hall could not be determined for your linked accounts right now.");
+    const accountMenu = result.panel.components
+      .map((row) => row.toJSON?.() as any)
+      .flatMap((rowJson) => (Array.isArray(rowJson?.components) ? rowJson.components : []))
+      .find((component: any) => String(component?.custom_id ?? component?.customId ?? component?.data?.custom_id ?? component?.data?.customId ?? "").startsWith("roster-selection:account:"));
+    expect((accountMenu?.options ?? []).map((option: any) => option.value)).toEqual(["none"]);
+  });
+
+  it("explains when TH-gated signup accounts are all outside the roster town hall range", async () => {
+    playerLinkServiceMock.listPlayerLinksForDiscordUser.mockResolvedValue([
+      { playerTag: "#PQL0289", linkedName: "Low TH", linkedAt: new Date("2026-04-20T00:00:00.000Z") },
+      { playerTag: "#QGRJ2222", linkedName: "High TH", linkedAt: new Date("2026-04-20T00:00:00.000Z") },
+    ]);
+    playerCurrentServiceMock.resolveCurrentPlayersForTags.mockResolvedValue(
+      new Map([
+        ["#PQL0289", makeResolvedPlayerCurrent("#PQL0289", 12)],
+        ["#QGRJ2222", makeResolvedPlayerCurrent("#QGRJ2222", 16)],
+      ]),
+    );
+    prismaMock.roster.findUnique.mockResolvedValueOnce({
+      id: "roster-1",
+      guildId: "guild-1",
+      rosterType: "CWL",
+      rosterCategory: "signup",
+      title: "CWL Alpha Signup",
+      clanTag: "#2QG2C08UP",
+      startsAt: new Date("2026-04-20T00:00:00.000Z"),
+      endsAt: null,
+      timezone: "America/Los_Angeles",
+      displayTimezone: "America/Los_Angeles",
+      lifecycleState: "OPEN",
+      postedChannelId: null,
+      postedMessageId: null,
+      postedMessageUrl: null,
+      postedAt: null,
+      createdByDiscordUserId: "111111111111111111",
+      updatedByDiscordUserId: "111111111111111111",
+      createdAt: new Date("2026-04-20T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-20T00:00:00.000Z"),
+      minTownhall: 13,
+      maxTownhall: 15,
+      allowMultiSignup: true,
+    } as any);
+    prismaMock.rosterSignup.findMany.mockResolvedValueOnce([] as any);
+
+    const result = await rosterService.createRosterSignupSelectionPanel({
+      rosterId: "roster-1",
+      discordUserId: "111111111111111111",
+      groupKey: "confirmed",
+    });
+
+    expect(result).toMatchObject({ outcome: "ready" });
+    if (result.outcome !== "ready") return;
+    const description = result.panel.embed.toJSON().description ?? "";
+    expect(description).toContain("No linked accounts met this roster's town hall requirements.");
+    const accountMenu = result.panel.components
+      .map((row) => row.toJSON?.() as any)
+      .flatMap((rowJson) => (Array.isArray(rowJson?.components) ? rowJson.components : []))
+      .find((component: any) => String(component?.custom_id ?? component?.customId ?? component?.data?.custom_id ?? component?.data?.customId ?? "").startsWith("roster-selection:account:"));
+    expect((accountMenu?.options ?? []).map((option: any) => option.value)).toEqual(["none"]);
   });
 
   it("builds the manager add-user panel with chunked linked-player menus and a disabled confirm button until required selections exist", async () => {


### PR DESCRIPTION
- add signup-only freshness policy to PlayerCurrent resolution
- keep signup picker and confirm aligned while improving empty-state messaging