### PR TITLE
fix(roster): refresh stale signup player current data

### DIFF
--- a/src/services/RosterService.ts
+++ b/src/services/RosterService.ts
@@ -15,6 +15,7 @@ import { emojiResolverService } from "./emoji/EmojiResolverService";
 import {
   listPlayerLinksForClanMembers,
   listPlayerLinksForDiscordUser,
+  backfillMissingDiscordUsernamesForClanMembers,
   normalizeClanTag,
   normalizeDiscordUserId,
   normalizePlayerTag,
@@ -859,6 +860,42 @@ function normalizeRosterText(input: string | null | undefined): string | null {
     .replace(/\s+/g, " ")
     .trim();
   return normalized.length > 0 ? normalized : null;
+}
+
+function isTagLikeRosterPlayerName(input: string | null | undefined): boolean {
+  const normalized = normalizeRosterText(input ?? null);
+  if (!normalized) {
+    return false;
+  }
+  return Boolean(normalizePlayerTag(normalized));
+}
+
+function resolveBestRosterPlayerName(input: {
+  playerTag: string;
+  rosterPlayerName?: string | null;
+  playerCurrentName?: string | null;
+  fwaPlayerName?: string | null;
+  snapshotPlayerName?: string | null;
+  playerLinkPlayerName?: string | null;
+}): string {
+  const candidates = [
+    input.rosterPlayerName,
+    input.playerCurrentName,
+    input.fwaPlayerName,
+    input.snapshotPlayerName,
+    input.playerLinkPlayerName,
+  ];
+  for (const candidate of candidates) {
+    const normalized = normalizeRosterText(candidate ?? null);
+    if (!normalized) {
+      continue;
+    }
+    if (isTagLikeRosterPlayerName(normalized)) {
+      continue;
+    }
+    return normalized;
+  }
+  return normalizeRosterText(input.playerTag) ?? input.playerTag;
 }
 
 function normalizeRosterInt(input: unknown): number | null {
@@ -3019,6 +3056,101 @@ type RosterViewLoadOptions = {
   discordDisplayNamesByUserId?: Map<string, string | null>;
 };
 
+type RosterSignupNameSourceMaps = {
+  playerCurrentNameByTag: Map<string, string | null>;
+  fwaPlayerNameByTag: Map<string, string | null>;
+  snapshotByTag: Map<string, RosterSignupNameSourceSnapshotRow>;
+  linkByTag: Map<string, RosterSignupNameSourceLinkRow>;
+};
+
+type RosterSignupNameSourceSnapshotRow = {
+  playerTag: string;
+  playerName: string | null;
+  clanTag: string | null;
+  clanName: string | null;
+};
+
+type RosterSignupNameSourceLinkRow = {
+  playerTag: string;
+  playerName: string | null;
+  discordUsername: string | null;
+  discordUserId: string | null;
+};
+
+async function loadRosterSignupNameSourceMaps(playerTags: string[]): Promise<RosterSignupNameSourceMaps> {
+  const normalizedTags = [...new Set(playerTags.map((tag) => normalizePlayerTag(tag)).filter(Boolean))];
+  if (normalizedTags.length <= 0) {
+    return {
+      playerCurrentNameByTag: new Map(),
+      fwaPlayerNameByTag: new Map(),
+      snapshotByTag: new Map(),
+      linkByTag: new Map(),
+    };
+  }
+
+  const [currentRows, fwaRows, snapshotRows, linkRows] = await Promise.all([
+    playerCurrentService.listPlayerCurrentByTags(normalizedTags),
+    prisma.fwaPlayerCatalog.findMany({
+      where: { playerTag: { in: normalizedTags } },
+      select: {
+        playerTag: true,
+        latestName: true,
+      },
+    }),
+    todoSnapshotService.listSnapshotsByPlayerTags({
+      playerTags: normalizedTags,
+    }),
+    prisma.playerLink.findMany({
+      where: { playerTag: { in: normalizedTags } },
+      select: {
+        playerTag: true,
+        playerName: true,
+        discordUsername: true,
+        discordUserId: true,
+      },
+    }),
+  ]);
+
+  const playerCurrentNameByTag = new Map(
+    Array.from(currentRows.entries()).map(([playerTag, row]) => [playerTag, normalizeRosterText(row.playerName ?? null)] as const),
+  );
+  const fwaPlayerNameByTag = new Map<string, string | null>();
+  for (const row of fwaRows) {
+    const playerTag = normalizePlayerTag(row.playerTag);
+    if (!playerTag) continue;
+    fwaPlayerNameByTag.set(playerTag, normalizeRosterText(row.latestName ?? null));
+  }
+  const snapshotByTag = new Map<string, RosterSignupNameSourceSnapshotRow>();
+  for (const row of snapshotRows as RosterSignupNameSourceSnapshotRow[]) {
+    const playerTag = normalizePlayerTag(row.playerTag);
+    if (!playerTag) continue;
+    snapshotByTag.set(playerTag, {
+      playerTag,
+      playerName: normalizeRosterText(row.playerName ?? null),
+      clanTag: normalizeClanTag(String(row.clanTag ?? "")) || null,
+      clanName: normalizeRosterText(row.clanName ?? null),
+    });
+  }
+  const linkByTag = new Map<string, RosterSignupNameSourceLinkRow>();
+  for (const row of linkRows) {
+    const playerTag = normalizePlayerTag(row.playerTag);
+    if (!playerTag) continue;
+    linkByTag.set(playerTag, {
+      playerTag,
+      playerName: normalizeRosterText(row.playerName ?? null),
+      discordUsername: normalizeRosterText(row.discordUsername ?? null),
+      discordUserId: normalizeDiscordUserId(row.discordUserId),
+    });
+  }
+
+  return {
+    playerCurrentNameByTag,
+    fwaPlayerNameByTag,
+    snapshotByTag,
+    linkByTag,
+  };
+}
+
 async function loadRosterView(rosterId: string, options?: RosterViewLoadOptions): Promise<RosterSignupView | null> {
   const roster = await prisma.roster.findUnique({
     where: { id: rosterId },
@@ -3098,41 +3230,24 @@ async function loadRosterView(rosterId: string, options?: RosterViewLoadOptions)
     allowLiveFetch: false,
   });
   const townHallByTag = townHallResolution.townHallByTag;
-  const [snapshotRows, linkedPlayerRows, resolvedWeightRows] = await Promise.all([
-    todoSnapshotService.listSnapshotsByPlayerTags({
-      playerTags: signupTags,
-    }),
-    prisma.playerLink.findMany({
-      where: {
-        playerTag: { in: signupTags },
-      },
-      select: {
-        playerTag: true,
-        discordUsername: true,
-      },
-    }),
+  const [sourceMaps, resolvedWeightRows, currentClanSnapshotRows] = await Promise.all([
+    loadRosterSignupNameSourceMaps(signupTags),
     resolveRosterCurrentWeightRecords({
       playerTags: signupTags,
     }),
-  ]);
-  const currentClanRows =
     roster.clanTag
-      ? await todoSnapshotService.listSnapshotsByClanTag({
+      ? todoSnapshotService.listSnapshotsByClanTag({
           clanTag: roster.clanTag,
           source: "clanTag",
         })
-      : [];
-  const discordUsernameByTag = new Map(
-    linkedPlayerRows
-      .map((row) => [normalizePlayerTag(row.playerTag), normalizeRosterText(row.discordUsername ?? null)] as const)
-      .filter((entry): entry is readonly [string, string] => Boolean(entry[0])),
-  );
+      : Promise.resolve([]),
+  ]);
+  const snapshotRows = [...sourceMaps.snapshotByTag.values()];
   const discordDisplayNameByUserId = options?.discordDisplayNamesByUserId ?? new Map<string, string | null>();
-  const snapshotByTag = new Map(snapshotRows.map((row) => [normalizePlayerTag(row.playerTag), row] as const));
   const currentClanName =
-    currentClanRows.find((row) => normalizeRosterText(row.cwlClanName ?? row.clanName ?? null))
+    currentClanSnapshotRows.find((row) => normalizeRosterText(row.cwlClanName ?? row.clanName ?? null))
       ?.cwlClanName ??
-    currentClanRows.find((row) => normalizeRosterText(row.clanName ?? null))?.clanName ??
+    currentClanSnapshotRows.find((row) => normalizeRosterText(row.clanName ?? null))?.clanName ??
     snapshotRows.find((row) => normalizeRosterText(row.clanName ?? null))?.clanName ??
     null;
   const trackedClan =
@@ -3151,6 +3266,8 @@ async function loadRosterView(rosterId: string, options?: RosterViewLoadOptions)
   const signupsWithTownHall = signups.map((signup) => {
     const playerTag = normalizePlayerTag(signup.playerTag);
     const weightRecord = resolvedWeightRows.get(playerTag) ?? null;
+    const sourceRow = sourceMaps.snapshotByTag.get(playerTag) ?? null;
+    const linkRow = sourceMaps.linkByTag.get(playerTag) ?? null;
     return {
       ...signup,
       townHall: townHallByTag.get(playerTag) ?? null,
@@ -3159,9 +3276,17 @@ async function loadRosterView(rosterId: string, options?: RosterViewLoadOptions)
       weightSource: weightRecord?.weightSource ?? "Unknown",
       weightMeasuredAt: weightRecord?.weightMeasuredAt ?? null,
       discordDisplayName: discordDisplayNameByUserId.get(signup.discordUserId) ?? null,
-      discordUsername: discordUsernameByTag.get(playerTag) ?? null,
-      clanTag: snapshotByTag.get(playerTag)?.clanTag ?? null,
-      clanName: snapshotByTag.get(playerTag)?.clanName ?? null,
+      discordUsername: linkRow?.discordUsername ?? null,
+      playerName: resolveBestRosterPlayerName({
+        playerTag,
+        rosterPlayerName: signup.playerName ?? null,
+        playerCurrentName: sourceMaps.playerCurrentNameByTag.get(playerTag) ?? null,
+        fwaPlayerName: sourceMaps.fwaPlayerNameByTag.get(playerTag) ?? null,
+        snapshotPlayerName: sourceRow?.playerName ?? null,
+        playerLinkPlayerName: linkRow?.playerName ?? null,
+      }),
+      clanTag: sourceRow?.clanTag ?? null,
+      clanName: sourceRow?.clanName ?? null,
     };
   });
   const clanDisplayName =
@@ -3594,33 +3719,100 @@ export class RosterService {
     cocService?: CoCService | null,
     options?: RosterSignupPayloadBuildOptions,
   ): Promise<RosterSignupPayload | null> {
-    const hydrated = await this.refreshRosterBoardSourceData(rosterId, cocService ?? null);
+    const hydrated = await this.refreshRosterBoardSourceData(rosterId, cocService ?? null, options?.emojiClient ?? null);
     if (!hydrated) return null;
     return this.buildRosterSignupPayload(rosterId, cocService ?? null, options);
   }
 
   /** Purpose: refresh the live/persisted board owners for one roster before rerendering its post. */
-  async refreshRosterBoardSourceData(rosterId: string, cocService?: CoCService | null): Promise<boolean> {
+  async refreshRosterBoardSourceData(
+    rosterId: string,
+    cocService?: CoCService | null,
+    discordClient?: Client | null,
+  ): Promise<boolean> {
     const roster = await prisma.roster.findUnique({
       where: { id: rosterId },
       select: {
         id: true,
+        guildId: true,
         rosterType: true,
         clanTag: true,
       },
     });
     if (!roster) return false;
 
-    const rosteredTags = await prisma.rosterSignup.findMany({
+    const rosteredSignups = await prisma.rosterSignup.findMany({
       where: { rosterId: roster.id },
-      select: { playerTag: true },
+      select: { playerTag: true, playerName: true, discordUserId: true },
     });
-    const playerTags = [...new Set(rosteredTags.map((row) => normalizePlayerTag(row.playerTag)).filter(Boolean))];
+    const playerTags = [...new Set(rosteredSignups.map((row) => normalizePlayerTag(row.playerTag)).filter(Boolean))];
+    if (cocService && playerTags.length > 0) {
+      await playerCurrentService.resolveCurrentPlayersForTags({
+        playerTags,
+        cocService,
+        requireFields: ["playerName", "townHall"],
+        refreshPolicy: "missing_or_stale",
+        maxAcceptedAgeMs: PLAYER_CURRENT_SIGNUP_MAX_AGE_MS,
+      });
+    }
     if (cocService && playerTags.length > 0) {
       await todoSnapshotService.refreshSnapshotsForPlayerTags({
         playerTags,
         cocService,
       });
+    }
+
+    if (playerTags.length > 0) {
+      const nameSources = await loadRosterSignupNameSourceMaps(playerTags);
+      const nameUpdates = rosteredSignups.filter((signup) => normalizeRosterText(signup.playerName ?? null) === null);
+      await Promise.all(
+        nameUpdates.map((signup) => {
+          const playerTag = normalizePlayerTag(signup.playerTag);
+          if (!playerTag) return Promise.resolve();
+          const playerName = resolveBestRosterPlayerName({
+            playerTag,
+            playerCurrentName: nameSources.playerCurrentNameByTag.get(playerTag) ?? null,
+            fwaPlayerName: nameSources.fwaPlayerNameByTag.get(playerTag) ?? null,
+            snapshotPlayerName: nameSources.snapshotByTag.get(playerTag)?.playerName ?? null,
+            playerLinkPlayerName: nameSources.linkByTag.get(playerTag)?.playerName ?? null,
+          });
+          if (playerName === normalizeRosterText(signup.playerName ?? null)) {
+            return Promise.resolve();
+          }
+          return prisma.rosterSignup.updateMany({
+            where: {
+              rosterId: roster.id,
+              playerTag,
+              OR: [{ playerName: null }, { playerName: "" }],
+            },
+            data: {
+              playerName,
+            },
+          }).then(() => undefined);
+        }),
+      );
+
+      if (discordClient) {
+        await backfillMissingDiscordUsernamesForClanMembers({
+          memberTagsInOrder: playerTags,
+          resolveDiscordUsername: async (discordUserId) => {
+            const normalizedDiscordUserId = normalizeDiscordUserId(discordUserId);
+            if (!normalizedDiscordUserId) return null;
+            const guild = await discordClient.guilds.fetch(roster.guildId).catch(() => null);
+            const member = guild ? await guild.members.fetch(normalizedDiscordUserId).catch(() => null) : null;
+            const usernameFromMember = normalizeRosterText(member?.user?.username ?? null);
+            if (usernameFromMember) {
+              return usernameFromMember;
+            }
+            const user = await discordClient.users.fetch(normalizedDiscordUserId).catch(() => null);
+            return normalizeRosterText(user?.username ?? null);
+          },
+        }).catch((err) => {
+          console.error(
+            `[roster] stage=discord_username_refresh_failed roster_id=${roster.id} error=${String((err as Error)?.message ?? err)}`,
+          );
+        });
+      }
     }
 
     if (cocService && roster.clanTag) {
@@ -4337,15 +4529,19 @@ export class RosterService {
     const existingTags = new Set(existing.map((row) => normalizePlayerTag(row.playerTag)).filter(Boolean));
     const createdTags = linkedTags.filter((tag) => !existingTags.has(tag));
     const duplicateTags = linkedTags.filter((tag) => existingTags.has(tag));
+    const resolvedCurrentCandidates =
+      createdTags.length > 0
+        ? await playerCurrentService.resolveCurrentPlayersForTags({
+            playerTags: createdTags,
+            cocService: input.cocService ?? null,
+            requireFields: isRosterTownHallGated(roster) ? ["townHall"] : ["playerName"],
+            refreshPolicy: "missing_or_stale",
+            maxAcceptedAgeMs: PLAYER_CURRENT_SIGNUP_MAX_AGE_MS,
+          })
+        : new Map();
+    const nameSources = createdTags.length > 0 ? await loadRosterSignupNameSourceMaps(createdTags) : null;
 
     if (townHallGated && createdTags.length > 0) {
-      const playerTownHallResolution = await resolveRosterPlayerTownHallMap({
-        rosterType: roster.rosterType,
-        clanTag: roster.clanTag,
-        playerTags: createdTags,
-        allowLiveFetch: true,
-        cocService: input.cocService ?? null,
-      });
       const minTownhall = normalizeRosterInt(roster.minTownhall);
       const maxTownhall = normalizeRosterInt(roster.maxTownhall);
       const blockedUnavailableTags: string[] = [];
@@ -4353,12 +4549,17 @@ export class RosterService {
       const blockedOutOfRangeTags: string[] = [];
       const blockedOutOfRangeAccounts: RosterAccountIdentity[] = [];
       for (const tag of createdTags) {
-        const linked = linkedByTag.get(tag) ?? null;
         const blockedAccount = {
           playerTag: tag,
-          playerName: normalizeRosterText(linked?.playerName ?? null),
+          playerName: resolveBestRosterPlayerName({
+            playerTag: tag,
+            playerCurrentName: nameSources?.playerCurrentNameByTag.get(tag) ?? null,
+            fwaPlayerName: nameSources?.fwaPlayerNameByTag.get(tag) ?? null,
+            snapshotPlayerName: nameSources?.snapshotByTag.get(tag)?.playerName ?? null,
+            playerLinkPlayerName: nameSources?.linkByTag.get(tag)?.playerName ?? null,
+          }),
         };
-        const townHall = playerTownHallResolution.townHallByTag.get(tag) ?? null;
+        const townHall = normalizeRosterInt(resolvedCurrentCandidates.get(tag)?.townHall ?? null);
         if (townHall === null) {
           blockedUnavailableTags.push(tag);
           blockedUnavailableAccounts.push(blockedAccount);
@@ -4375,7 +4576,27 @@ export class RosterService {
         clanTag: roster.clanTag,
         requestedTags,
         linkedTags,
-        resolution: playerTownHallResolution,
+        resolution: {
+          townHallByTag: new Map(
+            createdTags
+              .map((tag) => [tag, normalizeRosterInt(resolvedCurrentCandidates.get(tag)?.townHall ?? null)] as const)
+              .filter((entry): entry is readonly [string, number] => entry[1] !== null),
+          ),
+          detailByTag: new Map(
+            createdTags.map((tag) => [
+              tag,
+              {
+                source: "live_refresh" as const,
+                townHall: normalizeRosterInt(resolvedCurrentCandidates.get(tag)?.townHall ?? null),
+                primarySourceHit: false,
+                snapshotSourceHit: false,
+                liveRefreshInvoked: Boolean(resolvedCurrentCandidates.get(tag)?.liveRefreshInvoked),
+              },
+            ] as const),
+          ),
+          liveRefreshInvoked: createdTags.some((tag) => Boolean(resolvedCurrentCandidates.get(tag)?.liveRefreshInvoked)),
+          missingTags: createdTags.filter((tag) => normalizeRosterInt(resolvedCurrentCandidates.get(tag)?.townHall ?? null) === null),
+        } as RosterTownHallResolution,
         blockedUnavailableTags,
         blockedOutOfRangeTags,
         cocServicePresent: Boolean(input.cocService),
@@ -4417,23 +4638,36 @@ export class RosterService {
     if (createdTags.length > 0) {
       await prisma.rosterSignup.createMany({
         data: createdTags.map((playerTag) => {
-          const linked = linkedByTag.get(playerTag) ?? null;
           return {
             rosterId: roster.id,
             groupId: group.id,
             playerTag,
-            playerName: linked?.playerName ?? null,
-            discordUserId: normalizeDiscordUserId(linked?.discordUserId) ?? input.updatedByDiscordUserId ?? "",
+            playerName: resolveBestRosterPlayerName({
+              playerTag,
+              playerCurrentName: nameSources?.playerCurrentNameByTag.get(playerTag) ?? null,
+              fwaPlayerName: nameSources?.fwaPlayerNameByTag.get(playerTag) ?? null,
+              snapshotPlayerName: nameSources?.snapshotByTag.get(playerTag)?.playerName ?? null,
+              playerLinkPlayerName: nameSources?.linkByTag.get(playerTag)?.playerName ?? null,
+            }),
+            discordUserId:
+              normalizeDiscordUserId(nameSources?.linkByTag.get(playerTag)?.discordUserId ?? null) ??
+              input.updatedByDiscordUserId ??
+              "",
           };
         }),
         skipDuplicates: true,
       });
     }
     const createdAccounts = createdTags.map((playerTag) => {
-      const linked = linkedByTag.get(playerTag) ?? null;
       return {
         playerTag,
-        playerName: normalizeRosterText(linked?.playerName ?? null),
+        playerName: resolveBestRosterPlayerName({
+          playerTag,
+          playerCurrentName: nameSources?.playerCurrentNameByTag.get(playerTag) ?? null,
+          fwaPlayerName: nameSources?.fwaPlayerNameByTag.get(playerTag) ?? null,
+          snapshotPlayerName: nameSources?.snapshotByTag.get(playerTag)?.playerName ?? null,
+          playerLinkPlayerName: nameSources?.linkByTag.get(playerTag)?.playerName ?? null,
+        }),
       };
     });
 
@@ -5783,6 +6017,17 @@ export class RosterService {
     const existingTags = new Set(existing.map((row) => normalizePlayerTag(row.playerTag)).filter(Boolean));
     const createdCandidates = selectedTags.filter((tag) => !existingTags.has(tag));
     const duplicateTags = selectedTags.filter((tag) => existingTags.has(tag));
+    const linkedNameSources = createdCandidates.length > 0 ? await loadRosterSignupNameSourceMaps(createdCandidates) : null;
+    const resolvedCurrentCandidates =
+      createdCandidates.length > 0
+        ? await playerCurrentService.resolveCurrentPlayersForTags({
+            playerTags: createdCandidates,
+            cocService: input.cocService ?? null,
+            requireFields: isRosterTownHallGated(roster) ? ["townHall"] : ["playerName"],
+            refreshPolicy: "missing_or_stale",
+            maxAcceptedAgeMs: PLAYER_CURRENT_SIGNUP_MAX_AGE_MS,
+          })
+        : new Map();
 
     const activeRosterSignups = await prisma.rosterSignup.count({
       where: {
@@ -5837,13 +6082,6 @@ export class RosterService {
       }
 
       if (isRosterTownHallGated(roster)) {
-        const playerCurrentByTag = await playerCurrentService.resolveCurrentPlayersForTags({
-          playerTags: createdCandidates,
-          cocService: input.cocService ?? null,
-          requireFields: ["townHall"],
-          refreshPolicy: "missing_or_stale",
-          maxAcceptedAgeMs: PLAYER_CURRENT_SIGNUP_MAX_AGE_MS,
-        });
         const minTownhall = normalizeRosterInt(roster.minTownhall);
         const maxTownhall = normalizeRosterInt(roster.maxTownhall);
         const blockedUnavailableTags: string[] = [];
@@ -5851,12 +6089,17 @@ export class RosterService {
         const blockedOutOfRangeTags: string[] = [];
         const blockedOutOfRangeAccounts: RosterAccountIdentity[] = [];
         for (const tag of createdCandidates) {
-          const linked = linkedByTag.get(tag) ?? null;
           const blockedAccount = {
             playerTag: tag,
-            playerName: normalizeRosterText(linked?.linkedName ?? null),
+            playerName: resolveBestRosterPlayerName({
+              playerTag: tag,
+              playerCurrentName: linkedNameSources?.playerCurrentNameByTag.get(tag) ?? null,
+              fwaPlayerName: linkedNameSources?.fwaPlayerNameByTag.get(tag) ?? null,
+              snapshotPlayerName: linkedNameSources?.snapshotByTag.get(tag)?.playerName ?? null,
+              playerLinkPlayerName: linkedNameSources?.linkByTag.get(tag)?.playerName ?? null,
+            }),
           };
-          const townHall = normalizeRosterInt(playerCurrentByTag.get(tag)?.townHall ?? null);
+          const townHall = normalizeRosterInt(resolvedCurrentCandidates.get(tag)?.townHall ?? null);
           if (townHall === null) {
             blockedUnavailableTags.push(tag);
             blockedUnavailableAccounts.push(blockedAccount);
@@ -5940,13 +6183,21 @@ export class RosterService {
     if (createdTags.length > 0) {
       await prisma.rosterSignup.createMany({
         data: createdTags.map((playerTag) => {
-          const linked = linkedByTag.get(playerTag) ?? null;
           return {
             rosterId: roster.id,
             groupId: group.id,
             playerTag,
-            playerName: linked?.linkedName ?? null,
-            discordUserId: normalizeDiscordUserId(input.discordUserId) ?? input.discordUserId,
+            playerName: resolveBestRosterPlayerName({
+              playerTag,
+              rosterPlayerName: null,
+              playerCurrentName: linkedNameSources?.playerCurrentNameByTag.get(playerTag) ?? null,
+              fwaPlayerName: linkedNameSources?.fwaPlayerNameByTag.get(playerTag) ?? null,
+              snapshotPlayerName: linkedNameSources?.snapshotByTag.get(playerTag)?.playerName ?? null,
+              playerLinkPlayerName: linkedNameSources?.linkByTag.get(playerTag)?.playerName ?? null,
+            }),
+            discordUserId:
+              normalizeDiscordUserId(linkedNameSources?.linkByTag.get(playerTag)?.discordUserId ?? null) ??
+              input.discordUserId,
           };
         }),
         skipDuplicates: true,
@@ -5962,10 +6213,16 @@ export class RosterService {
       linkedTags: selectedTags,
       createdTags,
       createdAccounts: createdTags.map((playerTag) => {
-        const linked = linkedByTag.get(playerTag) ?? null;
         return {
           playerTag,
-          playerName: normalizeRosterText(linked?.linkedName ?? null),
+          playerName: resolveBestRosterPlayerName({
+            playerTag,
+            rosterPlayerName: null,
+            playerCurrentName: linkedNameSources?.playerCurrentNameByTag.get(playerTag) ?? null,
+            fwaPlayerName: linkedNameSources?.fwaPlayerNameByTag.get(playerTag) ?? null,
+            snapshotPlayerName: linkedNameSources?.snapshotByTag.get(playerTag)?.playerName ?? null,
+            playerLinkPlayerName: linkedNameSources?.linkByTag.get(playerTag)?.playerName ?? null,
+          }),
         };
       }),
       duplicateTags,

--- a/tests/roster.service.test.ts
+++ b/tests/roster.service.test.ts
@@ -24,6 +24,7 @@ const prismaMock = vi.hoisted(() => ({
   },
   playerLink: {
     findMany: vi.fn(),
+    updateMany: vi.fn(),
   },
   playerCurrent: {
     findMany: vi.fn(),
@@ -248,6 +249,7 @@ describe("RosterService", () => {
   }
 
   beforeEach(() => {
+    vi.restoreAllMocks();
     vi.resetAllMocks();
     prismaMock.$transaction.mockImplementation(async (callback: (tx: typeof prismaMock) => Promise<unknown>) =>
       callback(prismaMock as any),
@@ -354,6 +356,7 @@ describe("RosterService", () => {
     prismaMock.rosterSignup.updateMany.mockResolvedValue({ count: 0 });
     prismaMock.rosterSignup.deleteMany.mockResolvedValue({ count: 0 });
     prismaMock.playerLink.findMany.mockResolvedValue([]);
+    prismaMock.playerLink.updateMany.mockResolvedValue({ count: 0 });
     prismaMock.playerCurrent.findMany.mockResolvedValue([]);
     prismaMock.playerCurrent.upsert.mockResolvedValue({} as never);
     prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue([]);
@@ -513,11 +516,110 @@ describe("RosterService", () => {
           rosterId: "roster-1",
           groupId: "group-confirmed",
           playerTag: "#QGRJ2222",
-          playerName: "Bravo",
+          playerName: "#QGRJ2222",
           discordUserId: "111111111111111111",
         }),
       ],
       skipDuplicates: true,
+    });
+  });
+
+  it("prefers player current, catalog, snapshot, and link names when writing roster signups", async () => {
+    const alphaTag = makeValidRosterPlayerTag(1);
+    const bravoTag = makeValidRosterPlayerTag(2);
+    const charlieTag = makeValidRosterPlayerTag(3);
+    const deltaTag = makeValidRosterPlayerTag(4);
+    playerLinkServiceMock.listPlayerLinksForDiscordUser.mockResolvedValue([
+      { playerTag: alphaTag, linkedName: null, linkedAt: new Date("2026-04-20T00:00:00.000Z") },
+      { playerTag: bravoTag, linkedName: null, linkedAt: new Date("2026-04-20T00:00:00.000Z") },
+      { playerTag: charlieTag, linkedName: null, linkedAt: new Date("2026-04-20T00:00:00.000Z") },
+      { playerTag: deltaTag, linkedName: null, linkedAt: new Date("2026-04-20T00:00:00.000Z") },
+    ]);
+    playerCurrentServiceMock.listPlayerCurrentByTags.mockResolvedValue(
+      new Map([
+        [alphaTag, { playerTag: alphaTag, playerName: "Current Alpha", townHall: 15 } as any],
+        [bravoTag, { playerTag: bravoTag, playerName: bravoTag, townHall: 14 } as any],
+        [charlieTag, { playerTag: charlieTag, playerName: null, townHall: 13 } as any],
+        [deltaTag, { playerTag: deltaTag, playerName: null, townHall: 12 } as any],
+      ]),
+    );
+    prismaMock.fwaPlayerCatalog.findMany.mockResolvedValue([
+      { playerTag: alphaTag, latestName: "Fallback Alpha" },
+      { playerTag: bravoTag, latestName: "Fallback Bravo" },
+    ] as any);
+    todoSnapshotServiceMock.listSnapshotsByPlayerTags.mockResolvedValue([
+      {
+        playerTag: charlieTag,
+        playerName: "Snapshot Charlie",
+        clanTag: null,
+        clanName: null,
+      },
+    ] as any);
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      {
+        playerTag: alphaTag,
+        playerName: "Link Alpha",
+        discordUsername: "alpha-user",
+        discordUserId: "111111111111111111",
+      },
+      {
+        playerTag: bravoTag,
+        playerName: "Link Bravo",
+        discordUsername: "bravo-user",
+        discordUserId: "111111111111111111",
+      },
+      {
+        playerTag: charlieTag,
+        playerName: "Link Charlie",
+        discordUsername: "charlie-user",
+        discordUserId: "111111111111111111",
+      },
+      {
+        playerTag: deltaTag,
+        playerName: "Link Delta",
+        discordUsername: "delta-user",
+        discordUserId: "111111111111111111",
+      },
+    ] as any);
+
+    const result = await rosterService.signupLinkedAccounts({
+      rosterId: "roster-1",
+      groupKey: "confirmed",
+      discordUserId: "111111111111111111",
+      playerTags: [alphaTag, bravoTag, charlieTag, deltaTag],
+    });
+
+    expect(result).toMatchObject({
+      outcome: "created",
+      createdTags: [alphaTag, bravoTag, charlieTag, deltaTag],
+      createdAccounts: [
+        { playerTag: alphaTag, playerName: "Current Alpha" },
+        { playerTag: bravoTag, playerName: "Fallback Bravo" },
+        { playerTag: charlieTag, playerName: "Snapshot Charlie" },
+        { playerTag: deltaTag, playerName: "Link Delta" },
+      ],
+    });
+    expect(prismaMock.rosterSignup.createMany).toHaveBeenCalledWith({
+      data: [
+        expect.objectContaining({ playerTag: alphaTag, playerName: "Current Alpha" }),
+        expect.objectContaining({ playerTag: bravoTag, playerName: "Fallback Bravo" }),
+        expect.objectContaining({ playerTag: charlieTag, playerName: "Snapshot Charlie" }),
+        expect.objectContaining({ playerTag: deltaTag, playerName: "Link Delta" }),
+      ],
+      skipDuplicates: true,
+    });
+    expect(playerCurrentServiceMock.listPlayerCurrentByTags).toHaveBeenCalledWith([
+      alphaTag,
+      bravoTag,
+      charlieTag,
+      deltaTag,
+    ]);
+    expect(playerCurrentServiceMock.resolveCurrentPlayersForTags).toHaveBeenCalledWith({
+      playerTags: [alphaTag, bravoTag, charlieTag, deltaTag],
+      cocService: null,
+      requireFields: ["playerName"],
+      refreshPolicy: "missing_or_stale",
+      maxAcceptedAgeMs: PLAYER_CURRENT_SIGNUP_MAX_AGE_MS,
     });
   });
 
@@ -572,8 +674,8 @@ describe("RosterService", () => {
       outcome: "townhall_unavailable",
       blockedTags: ["#PQL0289", "#QGRJ2222"],
       blockedAccounts: [
-        { playerTag: "#PQL0289", playerName: "Alpha" },
-        { playerTag: "#QGRJ2222", playerName: "Bravo" },
+        { playerTag: "#PQL0289", playerName: "#PQL0289" },
+        { playerTag: "#QGRJ2222", playerName: "#QGRJ2222" },
       ],
     });
     expect(playerCurrentServiceMock.resolveCurrentPlayersForTags).toHaveBeenCalledWith({
@@ -886,7 +988,7 @@ describe("RosterService", () => {
     });
     expect(playerCurrentServiceMock.resolveCurrentPlayersForTags).toHaveBeenCalledWith({
       playerTags: ["#298CG8UJG"],
-      cocService: expect.objectContaining({ getPlayerRaw: expect.any(Function) }),
+      cocService: { getPlayerRaw: expect.any(Function) } as any,
       requireFields: ["townHall"],
       refreshPolicy: "missing_or_stale",
       maxAcceptedAgeMs: PLAYER_CURRENT_SIGNUP_MAX_AGE_MS,
@@ -939,7 +1041,7 @@ describe("RosterService", () => {
     expect(result).toMatchObject({
       outcome: "townhall_out_of_range",
       blockedTags: ["#PQL0289"],
-      blockedAccounts: [{ playerTag: "#PQL0289", playerName: "Alpha" }],
+      blockedAccounts: [{ playerTag: "#PQL0289", playerName: "#PQL0289" }],
     });
   });
 
@@ -1871,7 +1973,7 @@ describe("RosterService", () => {
 
     const payload = await rosterService.refreshRosterSignupPayload("roster-1", cocServiceMock as any);
 
-    expect(refreshRosterBoardSourceDataSpy).toHaveBeenCalledWith("roster-1", cocServiceMock);
+    expect(refreshRosterBoardSourceDataSpy).toHaveBeenCalledWith("roster-1", cocServiceMock, null);
     expect(todoSnapshotServiceMock.refreshSnapshotsForPlayerTags).toHaveBeenCalledWith(
       expect.objectContaining({
         playerTags: ["#PQL0289"],
@@ -1957,7 +2059,7 @@ describe("RosterService", () => {
     } as any;
     const payload = await rosterService.refreshRosterSignupPayload("roster-1", cocService);
 
-    expect(refreshRosterBoardSourceDataSpy).toHaveBeenCalledWith("roster-1", cocService);
+    expect(refreshRosterBoardSourceDataSpy).toHaveBeenCalledWith("roster-1", cocService, null);
     expect(payload).toBeTruthy();
     const description = String(payload?.embed.toJSON().description ?? "");
     expect(description).toContain("`15 Player 298");
@@ -2019,11 +2121,178 @@ describe("RosterService", () => {
     } as any;
     const payload = await rosterService.refreshRosterSignupPayload("roster-1", cocService);
 
-    expect(refreshRosterBoardSourceDataSpy).toHaveBeenCalledWith("roster-1", cocService);
+    expect(refreshRosterBoardSourceDataSpy).toHaveBeenCalledWith("roster-1", cocService, null);
     expect(payload).toBeTruthy();
     const description = String(payload?.embed.toJSON().description ?? "");
     expect(description).toContain("`15 Player 298");
     expect(description).not.toContain("`- Player 298");
+  });
+
+  it("repairs missing signup names during roster refresh and renders the repaired value", async () => {
+    const rosterPlayerTag = makeValidRosterPlayerTag(1);
+    prismaMock.rosterSignup.findMany.mockResolvedValue([
+      {
+        id: "signup-1",
+        rosterId: "roster-1",
+        groupId: "group-confirmed",
+        playerTag: rosterPlayerTag,
+        playerName: null,
+        discordUserId: "111111111111111111",
+        signedUpAt: new Date("2026-04-20T00:00:00.000Z"),
+        createdAt: new Date("2026-04-20T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-20T00:00:00.000Z"),
+        group: {
+          id: "group-confirmed",
+          key: "confirmed",
+          name: "Confirmed",
+          description: "Primary roster members",
+          sortOrder: 0,
+        },
+      },
+    ] as any);
+    prismaMock.fwaPlayerCatalog.findMany.mockResolvedValue([
+      { playerTag: rosterPlayerTag, latestName: "DJ13" },
+    ] as any);
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      {
+        playerTag: rosterPlayerTag,
+        playerName: null,
+        discordUsername: null,
+        discordUserId: "111111111111111111",
+      },
+    ] as any);
+    todoSnapshotServiceMock.listSnapshotsByPlayerTags.mockResolvedValue([
+      {
+        playerTag: rosterPlayerTag,
+        playerName: null,
+        clanTag: "#2QG2C08UP",
+        clanName: "CWL Alpha",
+      },
+    ] as any);
+
+    const hydrated = await rosterService.refreshRosterBoardSourceData("roster-1", cocServiceMock as any, null);
+    expect(hydrated).toBe(true);
+    const payload = await rosterService.buildRosterSignupPayload("roster-1", cocServiceMock as any);
+
+    expect(payload).toBeTruthy();
+    expect(String(payload?.embed.toJSON().description ?? "")).toContain("DJ13");
+  });
+
+  it("does not overwrite an existing signup name during roster refresh", async () => {
+    const rosterPlayerTag = "#PQL0289";
+    prismaMock.rosterSignup.findMany.mockResolvedValue([
+      {
+        id: "signup-1",
+        rosterId: "roster-1",
+        groupId: "group-confirmed",
+        playerTag: rosterPlayerTag,
+        playerName: "Keep Me",
+        discordUserId: "111111111111111111",
+        signedUpAt: new Date("2026-04-20T00:00:00.000Z"),
+        createdAt: new Date("2026-04-20T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-20T00:00:00.000Z"),
+        group: {
+          id: "group-confirmed",
+          key: "confirmed",
+          name: "Confirmed",
+          description: "Primary roster members",
+          sortOrder: 0,
+        },
+      },
+    ] as any);
+    prismaMock.fwaPlayerCatalog.findMany.mockResolvedValue([
+      { playerTag: rosterPlayerTag, latestName: "DJ13" },
+    ] as any);
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      {
+        playerTag: rosterPlayerTag,
+        playerName: null,
+        discordUsername: null,
+        discordUserId: "111111111111111111",
+      },
+    ] as any);
+    todoSnapshotServiceMock.listSnapshotsByPlayerTags.mockResolvedValue([
+      {
+        playerTag: rosterPlayerTag,
+        playerName: null,
+        clanTag: "#2QG2C08UP",
+        clanName: "CWL Alpha",
+      },
+    ] as any);
+
+    await rosterService.refreshRosterBoardSourceData("roster-1", null, null);
+
+    expect(prismaMock.rosterSignup.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("backfills missing discord usernames during roster refresh when Discord can resolve them", async () => {
+    const rosterPlayerTag = makeValidRosterPlayerTag(1);
+    prismaMock.rosterSignup.findMany.mockResolvedValue([
+      {
+        id: "signup-1",
+        rosterId: "roster-1",
+        groupId: "group-confirmed",
+        playerTag: rosterPlayerTag,
+        playerName: "Keep Me",
+        discordUserId: "111111111111111111",
+        signedUpAt: new Date("2026-04-20T00:00:00.000Z"),
+        createdAt: new Date("2026-04-20T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-20T00:00:00.000Z"),
+        group: {
+          id: "group-confirmed",
+          key: "confirmed",
+          name: "Confirmed",
+          description: "Primary roster members",
+          sortOrder: 0,
+        },
+      },
+    ] as any);
+    prismaMock.playerLink.findMany.mockImplementation(async (args: any) => {
+      const hasBackfillFilter = Array.isArray(args?.where?.OR);
+      if (hasBackfillFilter) {
+        return [
+          {
+            playerTag: rosterPlayerTag,
+            discordUserId: "111111111111111111",
+            discordUsername: null,
+          },
+        ];
+      }
+      return [
+        {
+          playerTag: rosterPlayerTag,
+          playerName: null,
+          discordUsername: null,
+          discordUserId: "111111111111111111",
+        },
+      ];
+    });
+    const guildMembersFetch = vi.fn().mockResolvedValue({
+      user: {
+        username: "alpha-user",
+      },
+    });
+    const guildFetch = vi.fn().mockResolvedValue({
+      members: {
+        fetch: guildMembersFetch,
+      },
+    });
+    const usersFetch = vi.fn().mockResolvedValue({
+      username: "alpha-user",
+    });
+    const discordClient = {
+      guilds: {
+        fetch: guildFetch,
+      },
+      users: {
+        fetch: usersFetch,
+      },
+    } as any;
+
+    const hydrated = await rosterService.refreshRosterBoardSourceData("roster-1", cocServiceMock as any, discordClient);
+    expect(hydrated).toBe(true);
+    expect(guildFetch).toHaveBeenCalledWith("guild-1");
+    expect(guildMembersFetch).toHaveBeenCalledWith("111111111111111111");
   });
 
   it("falls back cleanly when no persisted CWL league label is available", async () => {
@@ -3582,14 +3851,14 @@ describe("RosterService", () => {
           rosterId: "roster-1",
           groupId: "group-confirmed",
           playerTag: "#PQL0289",
-          playerName: "Alpha",
+          playerName: "#PQL0289",
           discordUserId: "111111111111111111",
         }),
         expect.objectContaining({
           rosterId: "roster-1",
           groupId: "group-confirmed",
           playerTag: "#QGRJ2222",
-          playerName: "Bravo",
+          playerName: "#QGRJ2222",
           discordUserId: "111111111111111111",
         }),
       ],
@@ -4099,6 +4368,54 @@ describe("RosterService", () => {
     expect(report).toContain("**Groups**");
     expect(report).toContain("**Confirmed** (1)");
     expect(report).not.toContain("#OLD1111");
+  });
+
+  it("falls back to the player tag when all candidate names are tag-like or missing", async () => {
+    const rosterPlayerTag = "#PQL0289";
+    prismaMock.rosterSignup.findMany.mockResolvedValueOnce([
+      {
+        id: "signup-1",
+        rosterId: "roster-1",
+        groupId: "group-confirmed",
+        playerTag: rosterPlayerTag,
+        playerName: null,
+        discordUserId: "111111111111111111",
+        signedUpAt: new Date("2026-04-20T00:00:00.000Z"),
+        createdAt: new Date("2026-04-20T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-20T00:00:00.000Z"),
+        group: {
+          id: "group-confirmed",
+          key: "confirmed",
+          name: "Confirmed",
+          description: "Primary roster members",
+          sortOrder: 0,
+        },
+      },
+    ] as any);
+    prismaMock.fwaPlayerCatalog.findMany.mockResolvedValue([
+      { playerTag: rosterPlayerTag, latestName: rosterPlayerTag },
+    ] as any);
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      {
+        playerTag: rosterPlayerTag,
+        playerName: null,
+        discordUsername: null,
+        discordUserId: "111111111111111111",
+      },
+    ] as any);
+    todoSnapshotServiceMock.listSnapshotsByPlayerTags.mockResolvedValue([
+      {
+        playerTag: rosterPlayerTag,
+        playerName: null,
+        clanTag: "#2QG2C08UP",
+        clanName: "CWL Alpha",
+      },
+    ] as any);
+
+    const payload = await rosterService.buildRosterSignupPayload("roster-1", null);
+
+    expect(payload).toBeTruthy();
+    expect(String(payload?.embed.toJSON().description ?? "")).toContain(rosterPlayerTag);
   });
 
   it("renders closed rosters with disabled signup controls", async () => {


### PR DESCRIPTION
- add signup-only freshness policy to PlayerCurrent resolution
- keep signup picker and confirm aligned while improving empty-state messaging