### PR TITLE
fix(roster): persist repaired signup names on refresh

### DIFF
--- a/src/services/RosterService.ts
+++ b/src/services/RosterService.ts
@@ -870,6 +870,11 @@ function isTagLikeRosterPlayerName(input: string | null | undefined): boolean {
   return Boolean(normalizePlayerTag(normalized));
 }
 
+function isUsableRosterPlayerName(input: string | null | undefined): boolean {
+  const normalized = normalizeRosterText(input ?? null);
+  return normalized !== null && !isTagLikeRosterPlayerName(normalized);
+}
+
 function resolveBestRosterPlayerName(input: {
   playerTag: string;
   rosterPlayerName?: string | null;
@@ -3764,11 +3769,15 @@ export class RosterService {
 
     if (playerTags.length > 0) {
       const nameSources = await loadRosterSignupNameSourceMaps(playerTags);
-      const nameUpdates = rosteredSignups.filter((signup) => normalizeRosterText(signup.playerName ?? null) === null);
-      await Promise.all(
-        nameUpdates.map((signup) => {
+      const nameUpdates = rosteredSignups.filter((signup) => !isUsableRosterPlayerName(signup.playerName ?? null));
+      const repairedNameUpdates = await Promise.all(
+        nameUpdates.map(async (signup) => {
           const playerTag = normalizePlayerTag(signup.playerTag);
-          if (!playerTag) return Promise.resolve();
+          if (!playerTag) {
+            return { playerTag: null, playerName: null, updatedCount: 0 };
+          }
+
+          const currentPlayerName = normalizeRosterText(signup.playerName ?? null);
           const playerName = resolveBestRosterPlayerName({
             playerTag,
             playerCurrentName: nameSources.playerCurrentNameByTag.get(playerTag) ?? null,
@@ -3776,21 +3785,37 @@ export class RosterService {
             snapshotPlayerName: nameSources.snapshotByTag.get(playerTag)?.playerName ?? null,
             playerLinkPlayerName: nameSources.linkByTag.get(playerTag)?.playerName ?? null,
           });
-          if (playerName === normalizeRosterText(signup.playerName ?? null)) {
-            return Promise.resolve();
+          if (!isUsableRosterPlayerName(playerName)) {
+            console.info(
+              `[roster] stage=signup_name_refresh roster_id=${roster.id} player_tag=${playerTag} current_name=${currentPlayerName ?? ""} repair_name=none updated_count=0`,
+            );
+            return { playerTag, playerName: null, updatedCount: 0 };
           }
-          return prisma.rosterSignup.updateMany({
+
+          const updateResult = await prisma.rosterSignup.updateMany({
             where: {
               rosterId: roster.id,
               playerTag,
-              OR: [{ playerName: null }, { playerName: "" }],
+              ...(signup.playerName === null || signup.playerName === ""
+                ? { OR: [{ playerName: null }, { playerName: "" }] }
+                : { playerName: signup.playerName }),
             },
             data: {
               playerName,
             },
-          }).then(() => undefined);
+          });
+
+          console.info(
+            `[roster] stage=signup_name_refresh roster_id=${roster.id} player_tag=${playerTag} current_name=${currentPlayerName ?? ""} repair_name=${playerName} updated_count=${updateResult.count}`,
+          );
+          return { playerTag, playerName, updatedCount: updateResult.count };
         }),
       );
+
+      const repairedNameCount = repairedNameUpdates.reduce((count, row) => count + (row.updatedCount ?? 0), 0);
+      if (repairedNameCount > 0) {
+        console.info(`[roster] stage=signup_name_refresh_complete roster_id=${roster.id} repaired_count=${repairedNameCount}`);
+      }
 
       if (discordClient) {
         await backfillMissingDiscordUsernamesForClanMembers({

--- a/tests/roster.service.test.ts
+++ b/tests/roster.service.test.ts
@@ -2150,6 +2150,7 @@ describe("RosterService", () => {
         },
       },
     ] as any);
+    prismaMock.rosterSignup.updateMany.mockResolvedValue({ count: 1 } as any);
     prismaMock.fwaPlayerCatalog.findMany.mockResolvedValue([
       { playerTag: rosterPlayerTag, latestName: "DJ13" },
     ] as any);
@@ -2172,10 +2173,76 @@ describe("RosterService", () => {
 
     const hydrated = await rosterService.refreshRosterBoardSourceData("roster-1", cocServiceMock as any, null);
     expect(hydrated).toBe(true);
+    expect(prismaMock.rosterSignup.updateMany).toHaveBeenCalledWith({
+      where: {
+        rosterId: "roster-1",
+        playerTag: rosterPlayerTag,
+        OR: [{ playerName: null }, { playerName: "" }],
+      },
+      data: {
+        playerName: "DJ13",
+      },
+    });
     const payload = await rosterService.buildRosterSignupPayload("roster-1", cocServiceMock as any);
 
     expect(payload).toBeTruthy();
     expect(String(payload?.embed.toJSON().description ?? "")).toContain("DJ13");
+  });
+
+  it("repairs missing signup names from the snapshot owner during roster refresh", async () => {
+    const rosterPlayerTag = makeValidRosterPlayerTag(2);
+    prismaMock.rosterSignup.findMany.mockResolvedValue([
+      {
+        id: "signup-1",
+        rosterId: "roster-1",
+        groupId: "group-confirmed",
+        playerTag: rosterPlayerTag,
+        playerName: null,
+        discordUserId: "111111111111111111",
+        signedUpAt: new Date("2026-04-20T00:00:00.000Z"),
+        createdAt: new Date("2026-04-20T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-20T00:00:00.000Z"),
+        group: {
+          id: "group-confirmed",
+          key: "confirmed",
+          name: "Confirmed",
+          description: "Primary roster members",
+          sortOrder: 0,
+        },
+      },
+    ] as any);
+    prismaMock.rosterSignup.updateMany.mockResolvedValue({ count: 1 } as any);
+    prismaMock.fwaPlayerCatalog.findMany.mockResolvedValue([] as any);
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      {
+        playerTag: rosterPlayerTag,
+        playerName: null,
+        discordUsername: null,
+        discordUserId: "111111111111111111",
+      },
+    ] as any);
+    todoSnapshotServiceMock.listSnapshotsByPlayerTags.mockResolvedValue([
+      {
+        playerTag: rosterPlayerTag,
+        playerName: "naruto uzumaki",
+        clanTag: "#2QG2C08UP",
+        clanName: "CWL Alpha",
+      },
+    ] as any);
+
+    const hydrated = await rosterService.refreshRosterBoardSourceData("roster-1", null, null);
+
+    expect(hydrated).toBe(true);
+    expect(prismaMock.rosterSignup.updateMany).toHaveBeenCalledWith({
+      where: {
+        rosterId: "roster-1",
+        playerTag: rosterPlayerTag,
+        OR: [{ playerName: null }, { playerName: "" }],
+      },
+      data: {
+        playerName: "naruto uzumaki",
+      },
+    });
   });
 
   it("does not overwrite an existing signup name during roster refresh", async () => {
@@ -2223,6 +2290,63 @@ describe("RosterService", () => {
     await rosterService.refreshRosterBoardSourceData("roster-1", null, null);
 
     expect(prismaMock.rosterSignup.updateMany).not.toHaveBeenCalled();
+  });
+
+  it("repairs tag-like signup names during roster refresh when a better source exists", async () => {
+    const rosterPlayerTag = "#PQL0289";
+    prismaMock.rosterSignup.findMany.mockResolvedValue([
+      {
+        id: "signup-1",
+        rosterId: "roster-1",
+        groupId: "group-confirmed",
+        playerTag: rosterPlayerTag,
+        playerName: rosterPlayerTag,
+        discordUserId: "111111111111111111",
+        signedUpAt: new Date("2026-04-20T00:00:00.000Z"),
+        createdAt: new Date("2026-04-20T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-20T00:00:00.000Z"),
+        group: {
+          id: "group-confirmed",
+          key: "confirmed",
+          name: "Confirmed",
+          description: "Primary roster members",
+          sortOrder: 0,
+        },
+      },
+    ] as any);
+    prismaMock.rosterSignup.updateMany.mockResolvedValue({ count: 1 } as any);
+    prismaMock.fwaPlayerCatalog.findMany.mockResolvedValue([
+      { playerTag: rosterPlayerTag, latestName: "DJ13" },
+    ] as any);
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      {
+        playerTag: rosterPlayerTag,
+        playerName: null,
+        discordUsername: null,
+        discordUserId: "111111111111111111",
+      },
+    ] as any);
+    todoSnapshotServiceMock.listSnapshotsByPlayerTags.mockResolvedValue([
+      {
+        playerTag: rosterPlayerTag,
+        playerName: null,
+        clanTag: "#2QG2C08UP",
+        clanName: "CWL Alpha",
+      },
+    ] as any);
+
+    await rosterService.refreshRosterBoardSourceData("roster-1", null, null);
+
+    expect(prismaMock.rosterSignup.updateMany).toHaveBeenCalledWith({
+      where: {
+        rosterId: "roster-1",
+        playerTag: rosterPlayerTag,
+        playerName: rosterPlayerTag,
+      },
+      data: {
+        playerName: "DJ13",
+      },
+    });
   });
 
   it("backfills missing discord usernames during roster refresh when Discord can resolve them", async () => {


### PR DESCRIPTION
- repair null and tag-like signup rows from upstream name sources
- log per-row refresh repairs for easier diagnosis