### PR TITLE
fix(roster): bypass signup gates for manager edits

### DIFF
--- a/src/commands/Roster.ts
+++ b/src/commands/Roster.ts
@@ -2541,14 +2541,15 @@ async function handleRosterManageSubcommand(
       return;
     }
 
-    const result = await rosterService.changeRosterSignups({
-      sourceRosterId: roster.id,
-      targetRosterId: targetRoster.id,
-      targetGroupKey,
-      playerTags,
-      updatedByDiscordUserId: interaction.user.id,
-      cocService,
-    });
+      const result = await rosterService.changeRosterSignups({
+        sourceRosterId: roster.id,
+        targetRosterId: targetRoster.id,
+        targetGroupKey,
+        playerTags,
+        updatedByDiscordUserId: interaction.user.id,
+        bypassEligibility: true,
+        cocService,
+      });
 
     if (
       result.outcome === "changed" ||
@@ -2608,6 +2609,7 @@ async function handleRosterManageSubcommand(
         groupKey,
         playerTags,
         updatedByDiscordUserId: interaction.user.id,
+        bypassEligibility: true,
         cocService,
       });
       await syncRosterRolesForRoster(interaction.client, roster.id).catch(() => undefined);

--- a/src/services/RosterService.ts
+++ b/src/services/RosterService.ts
@@ -4527,7 +4527,9 @@ export class RosterService {
     playerTags?: string[] | null;
     updatedByDiscordUserId?: string | null;
     cocService?: CoCService | null;
+    bypassEligibility?: boolean;
   }): Promise<SignupLinkedAccountsResult> {
+    const bypassEligibility = input.bypassEligibility ?? false;
     const roster = await prisma.roster.findUnique({
       where: { id: input.rosterId },
       select: {
@@ -4637,14 +4639,14 @@ export class RosterService {
         ? await playerCurrentService.resolveCurrentPlayersForTags({
             playerTags: createdTags,
             cocService: input.cocService ?? null,
-            requireFields: isRosterTownHallGated(roster) ? ["townHall"] : ["playerName"],
+            requireFields: !bypassEligibility && townHallGated ? ["townHall"] : ["playerName"],
             refreshPolicy: "missing_or_stale",
             maxAcceptedAgeMs: PLAYER_CURRENT_SIGNUP_MAX_AGE_MS,
           })
         : new Map();
     const nameSources = createdTags.length > 0 ? await loadRosterSignupNameSourceMaps(createdTags) : null;
 
-    if (townHallGated && createdTags.length > 0) {
+    if (!bypassEligibility && townHallGated && createdTags.length > 0) {
       const minTownhall = normalizeRosterInt(roster.minTownhall);
       const maxTownhall = normalizeRosterInt(roster.maxTownhall);
       const blockedUnavailableTags: string[] = [];
@@ -4889,7 +4891,9 @@ export class RosterService {
     playerTags?: string[] | null;
     updatedByDiscordUserId?: string | null;
     cocService?: CoCService | null;
+    bypassEligibility?: boolean;
   }): Promise<ChangeRosterSignupsResult> {
+    const bypassEligibility = input.bypassEligibility ?? false;
     const requestedTags = normalizeRosterPlayerTags(Array.isArray(input.playerTags) ? input.playerTags : []);
     if (requestedTags.length <= 0) {
       return {
@@ -5150,7 +5154,7 @@ export class RosterService {
       }
 
       const conflictRows =
-        candidateTags.length > 0
+        !bypassEligibility && candidateTags.length > 0
           ? ((await tx.rosterSignup.findMany({
               where: {
                 playerTag: { in: candidateTags },
@@ -5170,7 +5174,7 @@ export class RosterService {
       const conflictTags = new Set(normalizeRosterPlayerTags(conflictRows.map((row) => row.playerTag)));
 
       const targetTownHallResolution =
-        isRosterTownHallGated(targetRoster) && candidateTags.length > 0
+        !bypassEligibility && isRosterTownHallGated(targetRoster) && candidateTags.length > 0
           ? await resolveRosterPlayerTownHallMap({
               rosterType: targetRoster.rosterType,
               clanTag: targetRoster.clanTag,
@@ -5258,44 +5262,46 @@ export class RosterService {
           } as const;
         }
 
-        const maxMembers = normalizeRosterInt(targetRoster.maxMembers);
-        if (maxMembers !== null && targetCount + movedTags.length + 1 > maxMembers) {
-          blockedRosterFullTags.push(tag);
-          blockedRosterFullAccounts.push(blockedAccount);
-          blockedOutcomeOrder.push("roster_full");
-          continue;
-        }
-
         const normalizedDiscordUserId = normalizeDiscordUserId(sourceSignup.discordUserId) ?? sourceSignup.discordUserId;
-        const effectiveMaxAccountsPerUser =
-          targetRoster.allowMultiSignup === false
-            ? 1
-            : normalizeRosterInt(targetRoster.maxAccountsPerUser);
-        if (effectiveMaxAccountsPerUser !== null) {
-          const ownedCount = targetOwnedCountByUser.get(normalizedDiscordUserId) ?? 0;
-          if (ownedCount + 1 > effectiveMaxAccountsPerUser) {
-            blockedAccountLimitTags.push(tag);
-            blockedAccountLimitAccounts.push(blockedAccount);
-            blockedOutcomeOrder.push("account_limit_exceeded");
+        if (!bypassEligibility) {
+          const maxMembers = normalizeRosterInt(targetRoster.maxMembers);
+          if (maxMembers !== null && targetCount + movedTags.length + 1 > maxMembers) {
+            blockedRosterFullTags.push(tag);
+            blockedRosterFullAccounts.push(blockedAccount);
+            blockedOutcomeOrder.push("roster_full");
             continue;
           }
-        }
 
-        if (targetTownHallResolution) {
-          const townHall = targetTownHallResolution.townHallByTag.get(tag) ?? null;
-          if (townHall === null) {
-            blockedUnavailableTags.push(tag);
-            blockedUnavailableAccounts.push(blockedAccount);
-            blockedOutcomeOrder.push("townhall_unavailable");
-            continue;
+          const effectiveMaxAccountsPerUser =
+            targetRoster.allowMultiSignup === false
+              ? 1
+              : normalizeRosterInt(targetRoster.maxAccountsPerUser);
+          if (effectiveMaxAccountsPerUser !== null) {
+            const ownedCount = targetOwnedCountByUser.get(normalizedDiscordUserId) ?? 0;
+            if (ownedCount + 1 > effectiveMaxAccountsPerUser) {
+              blockedAccountLimitTags.push(tag);
+              blockedAccountLimitAccounts.push(blockedAccount);
+              blockedOutcomeOrder.push("account_limit_exceeded");
+              continue;
+            }
           }
-          const minTownhall = normalizeRosterInt(targetRoster.minTownhall);
-          const maxTownhall = normalizeRosterInt(targetRoster.maxTownhall);
-          if ((minTownhall !== null && townHall < minTownhall) || (maxTownhall !== null && townHall > maxTownhall)) {
-            blockedOutOfRangeTags.push(tag);
-            blockedOutOfRangeAccounts.push(blockedAccount);
-            blockedOutcomeOrder.push("townhall_out_of_range");
-            continue;
+
+          if (targetTownHallResolution) {
+            const townHall = targetTownHallResolution.townHallByTag.get(tag) ?? null;
+            if (townHall === null) {
+              blockedUnavailableTags.push(tag);
+              blockedUnavailableAccounts.push(blockedAccount);
+              blockedOutcomeOrder.push("townhall_unavailable");
+              continue;
+            }
+            const minTownhall = normalizeRosterInt(targetRoster.minTownhall);
+            const maxTownhall = normalizeRosterInt(targetRoster.maxTownhall);
+            if ((minTownhall !== null && townHall < minTownhall) || (maxTownhall !== null && townHall > maxTownhall)) {
+              blockedOutOfRangeTags.push(tag);
+              blockedOutOfRangeAccounts.push(blockedAccount);
+              blockedOutcomeOrder.push("townhall_out_of_range");
+              continue;
+            }
           }
         }
 
@@ -5966,6 +5972,7 @@ export class RosterService {
           playerTags: session.selectedTags,
           updatedByDiscordUserId: session.ownerDiscordUserId,
           cocService: input.cocService ?? null,
+          bypassEligibility: true,
         });
         deleteRosterSelectionSession(session.sessionId);
         return { outcome: "add_user", result };

--- a/tests/roster.command.test.ts
+++ b/tests/roster.command.test.ts
@@ -734,6 +734,7 @@ describe("/roster command", () => {
         rosterId: "roster-1",
         groupKey: "confirmed",
         playerTags: ["#PQL0289", "#QGRJ2222"],
+        bypassEligibility: true,
       }),
     );
     expect(String(addInteraction.editReply.mock.calls.at(-1)?.[0] ?? "")).toContain("Signed up #PQL0289, #QGRJ2222");
@@ -832,6 +833,7 @@ describe("/roster command", () => {
         targetRosterId: "roster-2",
         targetGroupKey: "substitute",
         playerTags: ["#PQL0289", "#QGRJ2222"],
+        bypassEligibility: true,
       }),
     );
     expect(String(changeInteraction.editReply.mock.calls.at(-1)?.[0] ?? "")).toContain(

--- a/tests/roster.service.test.ts
+++ b/tests/roster.service.test.ts
@@ -3134,6 +3134,7 @@ describe("RosterService", () => {
           rosterId: "roster-1",
           groupKey: "confirmed",
           playerTags: [makeValidRosterPlayerTag(0), makeValidRosterPlayerTag(1), makeValidRosterPlayerTag(75)],
+          bypassEligibility: true,
         }),
       );
     } finally {
@@ -3816,6 +3817,141 @@ describe("RosterService", () => {
     expect(prismaMock.rosterSignup.deleteMany).not.toHaveBeenCalled();
   });
 
+  it("bypasses roster limit and town hall checks when managers change roster entries", async () => {
+    prismaMock.roster.findUnique.mockResolvedValueOnce({
+      id: "roster-1",
+      guildId: "guild-1",
+      rosterType: "CWL",
+      rosterCategory: "signup",
+      title: "Source Roster",
+      clanTag: "#2QG2C08UP",
+      startsAt: new Date("2026-04-20T00:00:00.000Z"),
+      endsAt: null,
+      timezone: "America/Los_Angeles",
+      displayTimezone: "America/Los_Angeles",
+      maxMembers: null,
+      maxAccountsPerUser: null,
+      minTownhall: null,
+      maxTownhall: null,
+      rosterRoleId: null,
+      allowMultiSignup: true,
+      sortBy: null,
+      importMembers: false,
+      lifecycleState: "CLOSED",
+      postedChannelId: null,
+      postedMessageId: null,
+      postedMessageUrl: null,
+      postedAt: null,
+      createdByDiscordUserId: "111111111111111111",
+      updatedByDiscordUserId: "111111111111111111",
+      createdAt: new Date("2026-04-20T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-20T00:00:00.000Z"),
+    } as any);
+    prismaMock.roster.findFirst.mockResolvedValueOnce({
+      id: "roster-2",
+      guildId: "guild-1",
+      rosterType: "CWL",
+      rosterCategory: "signup",
+      title: "Target Roster",
+      clanTag: "#2QG2C08UP",
+      startsAt: new Date("2026-04-20T00:00:00.000Z"),
+      endsAt: null,
+      timezone: "America/Los_Angeles",
+      displayTimezone: "America/Los_Angeles",
+      maxMembers: 1,
+      maxAccountsPerUser: 1,
+      minTownhall: 15,
+      maxTownhall: 15,
+      rosterRoleId: null,
+      allowMultiSignup: true,
+      sortBy: null,
+      importMembers: false,
+      lifecycleState: "CLOSED",
+      postedChannelId: null,
+      postedMessageId: null,
+      postedMessageUrl: null,
+      postedAt: null,
+      createdByDiscordUserId: "111111111111111111",
+      updatedByDiscordUserId: "111111111111111111",
+      createdAt: new Date("2026-04-20T00:00:00.000Z"),
+      updatedAt: new Date("2026-04-20T00:00:00.000Z"),
+    } as any);
+    prismaMock.rosterGroup.findMany.mockResolvedValueOnce([
+      {
+        id: "group-confirmed",
+        key: "confirmed",
+        name: "Confirmed",
+        description: "Primary roster members",
+        sortOrder: 0,
+      },
+    ] as any);
+    prismaMock.rosterSignup.findMany
+      .mockResolvedValueOnce([
+        {
+          id: "signup-1",
+          rosterId: "roster-1",
+          groupId: "group-confirmed",
+          playerTag: "#PQL0289",
+          playerName: "Alpha",
+          discordUserId: "111111111111111111",
+          group: {
+            id: "group-confirmed",
+            key: "confirmed",
+            name: "Confirmed",
+            description: "Primary roster members",
+            sortOrder: 0,
+          },
+        },
+      ] as any)
+      .mockResolvedValueOnce([
+        {
+          playerTag: "#ZZZ99999",
+          discordUserId: "111111111111111111",
+        },
+      ] as any);
+    prismaMock.rosterSignup.createMany.mockResolvedValue({ count: 1 });
+    prismaMock.rosterSignup.deleteMany.mockResolvedValue({ count: 1 });
+
+    const result = await rosterService.changeRosterSignups({
+      sourceRosterId: "roster-1",
+      targetRosterId: "roster-2",
+      playerTags: ["#PQL0289"],
+      updatedByDiscordUserId: "111111111111111111",
+      bypassEligibility: true,
+    });
+
+    expect(result).toMatchObject({
+      outcome: "changed",
+      sourceRosterId: "roster-1",
+      targetRosterId: "roster-2",
+      targetGroupKey: null,
+      requestedTags: ["#PQL0289"],
+      movedTags: ["#PQL0289"],
+      duplicateTags: [],
+      missingTags: [],
+      blockedTags: [],
+      blockedAccounts: [],
+    });
+    expect(prismaMock.rosterSignup.createMany).toHaveBeenCalledWith({
+      data: [
+        expect.objectContaining({
+          rosterId: "roster-2",
+          groupId: "group-confirmed",
+          playerTag: "#PQL0289",
+          playerName: "Alpha",
+          discordUserId: "111111111111111111",
+        }),
+      ],
+      skipDuplicates: false,
+    });
+    expect(prismaMock.rosterSignup.deleteMany).toHaveBeenCalledWith({
+      where: {
+        rosterId: "roster-1",
+        playerTag: { in: ["#PQL0289"] },
+      },
+    });
+  });
+
   it("builds roster ping previews for everyone, missing, and unregistered targets", async () => {
     const alphaTag = makeValidRosterPlayerTag(1);
     const bravoTag = makeValidRosterPlayerTag(2);
@@ -4278,6 +4414,10 @@ describe("RosterService", () => {
         endsAt: null,
         timezone: "America/Los_Angeles",
         displayTimezone: "America/Los_Angeles",
+        maxMembers: 1,
+        maxAccountsPerUser: 1,
+        minTownhall: 15,
+        maxTownhall: 15,
         lifecycleState,
         postedChannelId: null,
         postedMessageId: null,
@@ -4300,6 +4440,7 @@ describe("RosterService", () => {
           playerName: "Bravo",
         },
       ]);
+      playerCurrentServiceMock.resolveCurrentPlayersForTags.mockResolvedValue(new Map());
       prismaMock.rosterSignup.findMany
         .mockResolvedValueOnce([]) // add existing rows
         .mockResolvedValueOnce([
@@ -4333,6 +4474,7 @@ describe("RosterService", () => {
         groupKey: "confirmed",
         playerTags: ["#PQL0289", "#QGRJ2222"],
         updatedByDiscordUserId: "999999999999999999",
+        bypassEligibility: true,
       });
       const moved = await rosterService.moveRosterSignups({
         rosterId: "roster-1",


### PR DESCRIPTION
- pass explicit bypass eligibility through roster manage add and change flows
- keep public signup validation unchanged while preserving archived roster protection
- add regressions for closed/restricted manager edits and command routing