### PR TITLE
feat(fwa): use blue alert emoji for fwa base-swap

### DIFF
--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -302,6 +302,7 @@ type FwaBaseSwapAnnouncementState = {
   layoutLinks?: FwaBaseSwapLayoutLink[];
   phaseTimingLine?: string | null;
   alertEmoji?: string | null;
+  fwaAlertEmoji?: string | null;
   layoutBulletEmoji?: string | null;
   createdAtIso: string;
 };
@@ -310,6 +311,7 @@ const FWA_BASE_SWAP_TTL_MS = 48 * 60 * 60 * 1000;
 export const FWA_BASE_SWAP_ACK_EMOJI = "✅";
 const FWA_BASE_SWAP_LAYOUT_TYPE = "RISINGDAWN";
 const FWA_BASE_SWAP_ALERT_EMOJI_NAME = "alert";
+const FWA_BASE_SWAP_FWA_ALERT_EMOJI_NAME = "alert_blue";
 const FWA_BASE_SWAP_LAYOUT_BULLET_EMOJI_NAME = "arrow_arrow";
 export const FWA_BASE_SWAP_ALERT_FALLBACK_EMOJI = "\u26A0\uFE0F";
 export const FWA_BASE_SWAP_LAYOUT_BULLET_FALLBACK_EMOJI = "\u27A1\uFE0F";
@@ -352,6 +354,7 @@ type FwaBaseSwapSplitPostPayload = {
   layoutLinks?: FwaBaseSwapLayoutLink[];
   phaseTimingLine?: string | null;
   alertEmoji?: string | null;
+  fwaAlertEmoji?: string | null;
   layoutBulletEmoji?: string | null;
   mentionUserIds: string[];
   swapReminder: boolean;
@@ -361,6 +364,7 @@ type FwaBaseSwapSplitPostPayload = {
 
 type FwaBaseSwapResolvedInlineEmojis = {
   alertEmoji: string;
+  fwaAlertEmoji: string;
   layoutBulletEmoji: string;
 };
 
@@ -1288,6 +1292,7 @@ async function resolveFwaBaseSwapInlineEmojis(
 ): Promise<FwaBaseSwapResolvedInlineEmojis> {
   const fallback: FwaBaseSwapResolvedInlineEmojis = {
     alertEmoji: FWA_BASE_SWAP_ALERT_FALLBACK_EMOJI,
+    fwaAlertEmoji: FWA_BASE_SWAP_ALERT_FALLBACK_EMOJI,
     layoutBulletEmoji: FWA_BASE_SWAP_LAYOUT_BULLET_FALLBACK_EMOJI,
   };
   const inventoryResult =
@@ -1307,6 +1312,8 @@ async function resolveFwaBaseSwapInlineEmojis(
 
   return {
     alertEmoji: resolveByName(FWA_BASE_SWAP_ALERT_EMOJI_NAME) ?? fallback.alertEmoji,
+    fwaAlertEmoji:
+      resolveByName(FWA_BASE_SWAP_FWA_ALERT_EMOJI_NAME) ?? fallback.alertEmoji,
     layoutBulletEmoji:
       resolveByName(FWA_BASE_SWAP_LAYOUT_BULLET_EMOJI_NAME) ??
       fallback.layoutBulletEmoji,
@@ -1340,10 +1347,14 @@ function buildFwaBaseSwapAnnouncementLines(state: {
   layoutLinks?: FwaBaseSwapLayoutLink[];
   phaseTimingLine?: string | null;
   alertEmoji?: string | null;
+  fwaAlertEmoji?: string | null;
   layoutBulletEmoji?: string | null;
 }): string[] {
   const alertEmoji =
     String(state.alertEmoji ?? "").trim() || FWA_BASE_SWAP_ALERT_FALLBACK_EMOJI;
+  const fwaAlertEmoji =
+    String(state.fwaAlertEmoji ?? state.alertEmoji ?? "").trim() ||
+    FWA_BASE_SWAP_ALERT_FALLBACK_EMOJI;
   const layoutBulletEmoji =
     String(state.layoutBulletEmoji ?? "").trim() ||
     FWA_BASE_SWAP_LAYOUT_BULLET_FALLBACK_EMOJI;
@@ -1382,7 +1393,7 @@ function buildFwaBaseSwapAnnouncementLines(state: {
       entries: state.entries,
       section: "fwa_bases",
       headingLine: FWA_BASE_SWAP_FWA_ANNOUNCEMENT_HEADING.split("{emoji}").join(
-        alertEmoji,
+        fwaAlertEmoji,
       ),
       noteLine: FWA_BASE_SWAP_FWA_ANNOUNCEMENT_NOTE,
       separatorBefore: true,
@@ -1460,6 +1471,7 @@ function buildFwaBaseSwapRenderPlan(state: {
   layoutLinks?: FwaBaseSwapLayoutLink[];
   phaseTimingLine?: string | null;
   alertEmoji?: string | null;
+  fwaAlertEmoji?: string | null;
   layoutBulletEmoji?: string | null;
 }): FwaBaseSwapRenderPlan {
   const lines = buildFwaBaseSwapAnnouncementLines(state);
@@ -1484,6 +1496,7 @@ function renderFwaBaseSwapAnnouncement(
     layoutLinks?: FwaBaseSwapLayoutLink[];
     phaseTimingLine?: string | null;
     alertEmoji?: string | null;
+    fwaAlertEmoji?: string | null;
     layoutBulletEmoji?: string | null;
     renderVariant?: FwaBaseSwapRenderVariant;
   },
@@ -13094,6 +13107,7 @@ export const Fwa: Command = {
         layoutLinks,
         phaseTimingLine: baseSwapPhaseTimingLine,
         alertEmoji: inlineEmojis.alertEmoji,
+        fwaAlertEmoji: inlineEmojis.fwaAlertEmoji,
         layoutBulletEmoji: inlineEmojis.layoutBulletEmoji,
       });
       const mentionUserIds = buildFwaBaseSwapMentionUserIds(entries);
@@ -13120,6 +13134,7 @@ export const Fwa: Command = {
           layoutLinks,
           phaseTimingLine: baseSwapPhaseTimingLine,
           alertEmoji: inlineEmojis.alertEmoji,
+          fwaAlertEmoji: inlineEmojis.fwaAlertEmoji,
           layoutBulletEmoji: inlineEmojis.layoutBulletEmoji,
           mentionUserIds,
           swapReminder: Boolean(swapReminder),
@@ -13170,6 +13185,7 @@ export const Fwa: Command = {
               layoutLinks,
               phaseTimingLine: baseSwapPhaseTimingLine,
               alertEmoji: inlineEmojis.alertEmoji,
+              fwaAlertEmoji: inlineEmojis.fwaAlertEmoji,
               layoutBulletEmoji: inlineEmojis.layoutBulletEmoji,
               renderVariant: "single",
               swapReminder: Boolean(swapReminder),

--- a/src/services/TrackedMessageService.ts
+++ b/src/services/TrackedMessageService.ts
@@ -28,6 +28,7 @@ export type FwaBaseSwapTrackedMetadata = {
   renderVariant?: "single" | "split_part_1" | "split_part_2";
   phaseTimingLine?: string | null;
   alertEmoji?: string | null;
+  fwaAlertEmoji?: string | null;
   layoutBulletEmoji?: string | null;
   entries: Array<{
     position: number;
@@ -156,6 +157,7 @@ export function parseFwaBaseSwapMetadata(value: unknown): FwaBaseSwapTrackedMeta
     : undefined;
   const phaseTimingLineRaw = String(value.phaseTimingLine ?? "").trim();
   const alertEmojiRaw = String(value.alertEmoji ?? "").trim();
+  const fwaAlertEmojiRaw = String(value.fwaAlertEmoji ?? "").trim();
   const layoutBulletEmojiRaw = String(value.layoutBulletEmoji ?? "").trim();
   const rawRenderVariant = String(value.renderVariant ?? "").trim();
   const renderVariant: FwaBaseSwapTrackedMetadata["renderVariant"] =
@@ -169,6 +171,7 @@ export function parseFwaBaseSwapMetadata(value: unknown): FwaBaseSwapTrackedMeta
     renderVariant,
     phaseTimingLine: phaseTimingLineRaw || null,
     alertEmoji: alertEmojiRaw || null,
+    fwaAlertEmoji: fwaAlertEmojiRaw || null,
     layoutBulletEmoji: layoutBulletEmojiRaw || null,
     swapReminder,
     entries,

--- a/tests/fwaBaseSwap.layoutLinks.test.ts
+++ b/tests/fwaBaseSwap.layoutLinks.test.ts
@@ -685,9 +685,13 @@ describe("FWA base-swap layout links", () => {
       ],
       phaseTimingLine:
         "## Preparation Day ends <t:1740000000:F> (<t:1740000000:R>)",
+      alertEmoji: "<a:alert:10001>",
+      fwaAlertEmoji: "<a:alert_blue:10003>",
     });
 
-    expect(content).toContain("YOU HAVE AN ACTIVE FWA BASE");
+    expect(content).toContain(
+      "# <a:alert_blue:10003> YOU HAVE AN ACTIVE FWA BASE <a:alert_blue:10003>",
+    );
     expect(content).toContain(
       "These players currently have an active FWA base. Please swap to an active war base to increase our chances of beating the blacklisted clan!",
     );
@@ -695,6 +699,59 @@ describe("FWA base-swap layout links", () => {
     expect(content).toContain("Preparation Day ends <t:1740000000:F>");
     expect(content).toContain(
       `React with ${FWA_BASE_SWAP_ACK_EMOJI} once your base is fixed.`,
+    );
+  });
+
+  it("uses alert for war-bases and alert_blue for fwa-bases in mixed sections", () => {
+    const content = renderFwaBaseSwapAnnouncementForTest({
+      entries: [
+        buildEntry({
+          position: 1,
+          playerTag: "#AAA111",
+          playerName: "Alpha",
+          section: "war_bases",
+          discordUserId: "100",
+          townhallLevel: 18,
+        }),
+        buildEntry({
+          position: 2,
+          playerTag: "#BBB222",
+          playerName: "Bravo",
+          section: "fwa_bases",
+          discordUserId: "101",
+          townhallLevel: 17,
+        }),
+      ],
+      layoutLinks: [],
+      alertEmoji: "<a:alert:10001>",
+      fwaAlertEmoji: "<a:alert_blue:10003>",
+    });
+
+    expect(content).toContain(
+      "# <a:alert:10001> YOU HAVE AN ACTIVE WAR BASE <a:alert:10001>",
+    );
+    expect(content).toContain(
+      "# <a:alert_blue:10003> YOU HAVE AN ACTIVE FWA BASE <a:alert_blue:10003>",
+    );
+  });
+
+  it("falls back to the unicode alert glyph for fwa-bases when alert_blue is unavailable", () => {
+    const content = renderFwaBaseSwapAnnouncementForTest({
+      entries: [
+        buildEntry({
+          position: 1,
+          playerTag: "#AAA111",
+          playerName: "Alpha",
+          section: "fwa_bases",
+          discordUserId: "100",
+          townhallLevel: 18,
+        }),
+      ],
+      layoutLinks: [],
+    });
+
+    expect(content).toContain(
+      `# ${FWA_BASE_SWAP_ALERT_FALLBACK_EMOJI} YOU HAVE AN ACTIVE FWA BASE ${FWA_BASE_SWAP_ALERT_FALLBACK_EMOJI}`,
     );
   });
 

--- a/tests/trackedMessageMetadata.logic.test.ts
+++ b/tests/trackedMessageMetadata.logic.test.ts
@@ -64,6 +64,7 @@ describe("tracked message metadata parsing", () => {
       renderVariant: "single",
       phaseTimingLine: "## Battle Day ends <t:1740003600:F> (<t:1740003600:R>)",
       alertEmoji: "<a:alert:1>",
+      fwaAlertEmoji: null,
       layoutBulletEmoji: "<a:arrow_arrow:2>",
       swapReminder: true,
       entries: [
@@ -124,6 +125,7 @@ describe("tracked message metadata parsing", () => {
       renderVariant: "single",
       phaseTimingLine: null,
       alertEmoji: null,
+      fwaAlertEmoji: null,
       layoutBulletEmoji: null,
       swapReminder: false,
       entries: [


### PR DESCRIPTION
- resolve a separate alert_blue emoji for the fwa-bases heading
- keep war-bases and fallback alert rendering unchanged