### PR TITLE
feat(accounts): use playercurrent for account rows

### DIFF
--- a/src/commands/Accounts.ts
+++ b/src/commands/Accounts.ts
@@ -99,6 +99,11 @@ function buildClanHeadingMarkdown(group: Pick<ClanGroup, "clanName" | "clanTag">
   return clanTag ? buildClanProfileMarkdownLink(label, clanTag) : label;
 }
 
+function isConfirmedClanlessSource(source: string | null | undefined): boolean {
+  const normalized = sanitizeDisplayText(source)?.toLowerCase() ?? null;
+  return normalized === "accounts-refresh" || normalized === "live_refresh";
+}
+
 function resolveAccountClanState(input: {
   playerCurrent: PlayerCurrentSnapshot | null;
   playerActivity: { clanTag: string | null; clanName: string | null } | null;
@@ -106,7 +111,7 @@ function resolveAccountClanState(input: {
   const currentClanTag = sanitizeDisplayText(input.playerCurrent?.currentClanTag);
   const activityClanTag = sanitizeDisplayText(input.playerActivity?.clanTag);
   if (currentClanTag || activityClanTag) return "known";
-  if (input.playerCurrent || input.playerActivity) return "no_clan";
+  if (isConfirmedClanlessSource(input.playerCurrent?.lastSource)) return "no_clan";
   return "unknown";
 }
 

--- a/src/commands/Accounts.ts
+++ b/src/commands/Accounts.ts
@@ -11,6 +11,7 @@ import {
 } from "discord.js";
 import { Command } from "../Command";
 import { prisma } from "../prisma";
+import { playerCurrentService } from "../services/PlayerCurrentService";
 import { listPlayerLinksForDiscordUser } from "../services/PlayerLinkService";
 
 type AccountRow = {
@@ -19,12 +20,14 @@ type AccountRow = {
   clanTag: string | null;
   clanName: string | null;
   clanRole: "leader" | "coleader" | null;
+  clanState: "known" | "no_clan" | "unknown";
 };
 
 type ClanGroup = {
   key: string;
   clanTag: string | null;
   clanName: string | null;
+  clanState: "known" | "no_clan" | "unknown";
   entries: AccountRow[];
 };
 
@@ -38,6 +41,12 @@ type AccountAutocompleteChoice = {
   name: string;
   value: string;
 };
+
+type PlayerCurrentSnapshot = Awaited<
+  ReturnType<typeof playerCurrentService.listPlayerCurrentByTags>
+> extends Map<string, infer T>
+  ? T
+  : never;
 
 const MAX_ACCOUNTS_PER_PAGE = 18;
 
@@ -88,6 +97,17 @@ function buildClanHeadingMarkdown(group: Pick<ClanGroup, "clanName" | "clanTag">
   const label = buildClanHeadingLabel(group);
   const clanTag = normalizeTag(group.clanTag ?? "");
   return clanTag ? buildClanProfileMarkdownLink(label, clanTag) : label;
+}
+
+function resolveAccountClanState(input: {
+  playerCurrent: PlayerCurrentSnapshot | null;
+  playerActivity: { clanTag: string | null; clanName: string | null } | null;
+}): "known" | "no_clan" | "unknown" {
+  const currentClanTag = sanitizeDisplayText(input.playerCurrent?.currentClanTag);
+  const activityClanTag = sanitizeDisplayText(input.playerActivity?.clanTag);
+  if (currentClanTag || activityClanTag) return "known";
+  if (input.playerCurrent || input.playerActivity) return "no_clan";
+  return "unknown";
 }
 
 function buildAccountsTagAutocompleteChoices(
@@ -168,33 +188,27 @@ function buildAccountsTagAutocompleteChoices(
 }
 
 async function buildAccountsRows(input: {
-  cocService: unknown;
   guildId: string;
   linkedNameByTag: Map<string, string>;
   tags: string[];
 }): Promise<AccountRow[]> {
+  const playerCurrentByTag = await playerCurrentService.listPlayerCurrentByTags(
+    input.tags,
+  );
   const activity = await prisma.playerActivity.findMany({
     where: { guildId: input.guildId, tag: { in: input.tags } },
     select: { tag: true, name: true, clanTag: true, clanName: true },
   });
   const activityByTag = new Map(activity.map((a) => [normalizeTag(a.tag), a]));
-  const coc = input.cocService as { getPlayerRaw?: (tag: string) => Promise<any> } | null;
-  const livePlayerByTag = new Map<string, any | null>();
-  const getPlayerRaw = coc?.getPlayerRaw ?? null;
-  if (getPlayerRaw) {
-    const liveRows = await Promise.all(
-      input.tags.map(async (tag) => [tag, await getPlayerRaw(tag).catch(() => null)] as const),
-    );
-    for (const [tag, player] of liveRows) {
-      livePlayerByTag.set(tag, player);
-    }
-  }
   const candidateClanTags = [...new Set([
+    ...input.tags
+      .map((tag) => {
+        const current = playerCurrentByTag.get(tag) ?? null;
+        return current?.currentClanTag ? normalizeTag(current.currentClanTag) : "";
+      })
+      .filter(Boolean),
     ...activity
       .map((row) => (row.clanTag ? normalizeTag(row.clanTag) : ""))
-      .filter(Boolean),
-    ...[...livePlayerByTag.values()]
-      .map((player) => (player?.clan?.tag ? normalizeTag(player.clan.tag) : ""))
       .filter(Boolean),
   ])];
   const trackedClanRows =
@@ -212,28 +226,68 @@ async function buildAccountsRows(input: {
   );
 
   return input.tags.map((tag) => {
+    const playerCurrent = playerCurrentByTag.get(tag) ?? null;
+    const fallback = activityByTag.get(tag) ?? null;
     const linkedName = input.linkedNameByTag.get(tag) ?? null;
-    const fallback = activityByTag.get(tag);
-    const livePlayer = livePlayerByTag.get(tag) ?? null;
-    const liveClanTag = livePlayer?.clan?.tag ? normalizeTag(livePlayer.clan.tag) : null;
+    const currentClanTag = playerCurrent?.currentClanTag
+      ? normalizeTag(playerCurrent.currentClanTag)
+      : null;
     const fallbackClanTag = fallback?.clanTag ? normalizeTag(fallback.clanTag) : null;
-    const clanTag = liveClanTag ?? fallbackClanTag ?? null;
-    const activityName = sanitizeDisplayText(fallback?.name);
-    const liveName = sanitizeDisplayText(livePlayer?.name);
-    const liveClanName = sanitizeDisplayText(livePlayer?.clan?.name);
+    const clanTag = currentClanTag ?? fallbackClanTag ?? null;
+    const currentClanName = sanitizeDisplayText(playerCurrent?.currentClanName);
+    const fallbackClanName = sanitizeDisplayText(fallback?.clanName);
     const clanName =
-      liveClanName ??
-      sanitizeDisplayText(fallback?.clanName) ??
+      currentClanName ??
+      fallbackClanName ??
       (clanTag ? trackedClanNameByTag.get(clanTag) ?? null : null);
+    const clanState = resolveAccountClanState({
+      playerCurrent,
+      playerActivity: fallback
+        ? {
+            clanTag: fallback.clanTag ?? null,
+            clanName: fallback.clanName ?? null,
+          }
+        : null,
+    });
 
     return {
       tag,
-      name: linkedName ?? activityName ?? liveName ?? tag,
-      clanTag,
-      clanName,
-      clanRole: normalizeClanMemberRole(livePlayer?.role),
+      name:
+        sanitizeDisplayText(playerCurrent?.playerName) ??
+        linkedName ??
+        sanitizeDisplayText(fallback?.name) ??
+        tag,
+      clanTag: clanState === "known" ? clanTag : null,
+      clanName: clanState === "known" ? clanName : null,
+      clanRole: normalizeClanMemberRole(playerCurrent?.role),
+      clanState,
     };
   });
+}
+
+async function refreshAccountsPlayerCurrentData(input: {
+  cocService: unknown;
+  tags: string[];
+}): Promise<void> {
+  const coc = input.cocService as { getPlayerRaw?: (tag: string) => Promise<any> } | null;
+  const getPlayerRaw = coc?.getPlayerRaw ?? null;
+  if (!getPlayerRaw) return;
+
+  const existingByTag = await playerCurrentService.listPlayerCurrentByTags(input.tags);
+  await Promise.all(
+    input.tags.map(async (tag) => {
+      const livePlayer = await getPlayerRaw(tag).catch(() => null);
+      if (!livePlayer) return;
+      await playerCurrentService
+        .upsertPlayerCurrentFromLivePlayer({
+          playerTag: tag,
+          livePlayer,
+          existing: existingByTag.get(tag) ?? null,
+          source: "accounts-refresh",
+        })
+        .catch(() => undefined);
+    }),
+  );
 }
 
 function buildGroups(rows: AccountRow[]): ClanGroup[] {
@@ -242,7 +296,8 @@ function buildGroups(rows: AccountRow[]): ClanGroup[] {
   for (const row of rows) {
     const clanName = sanitizeDisplayText(row.clanName);
     const clanTag = row.clanTag ? normalizeTag(row.clanTag) : null;
-    const key = clanTag ?? "__NO_CLAN__";
+    const key =
+      clanTag ?? (row.clanState === "unknown" ? "__UNKNOWN_CLAN__" : "__NO_CLAN__");
 
     const bucket = grouped.get(key);
     if (!bucket) {
@@ -250,18 +305,27 @@ function buildGroups(rows: AccountRow[]): ClanGroup[] {
         key,
         clanTag,
         clanName,
+        clanState: row.clanState,
         entries: [row],
       });
     } else {
       if (clanName && !bucket.clanName) bucket.clanName = clanName;
+      if (bucket.clanState === "unknown" && row.clanState !== "unknown") {
+        bucket.clanState = row.clanState;
+      }
       bucket.entries.push(row);
     }
   }
 
   const groups: ClanGroup[] = [...grouped.entries()]
     .sort((a, b) => {
-      if (a[0] === "__NO_CLAN__") return 1;
-      if (b[0] === "__NO_CLAN__") return -1;
+      const rank = (group: ClanGroup) => {
+        if (group.clanState === "unknown") return 1;
+        if (group.clanState === "no_clan") return 2;
+        return 0;
+      };
+      const rankDelta = rank(a[1]) - rank(b[1]);
+      if (rankDelta !== 0) return rankDelta;
       return buildClanHeadingLabel(a[1]).localeCompare(buildClanHeadingLabel(b[1]), undefined, {
         sensitivity: "base",
       });
@@ -282,7 +346,15 @@ function buildPages(groups: ClanGroup[]): string[] {
 
   for (const group of groups) {
     const groupLines: string[] = [];
-    groupLines.push(`**${group.clanTag ? buildClanHeadingMarkdown(group) : "No Clan"}**`);
+    groupLines.push(
+      `**${
+        group.clanState === "known" && group.clanTag
+          ? buildClanHeadingMarkdown(group)
+          : group.clanState === "unknown"
+            ? "Unknown Clan"
+            : "No Clan"
+      }**`,
+    );
     for (const entry of group.entries) {
       const marker = entry.clanRole === "coleader" ? ":crown:" : "-";
       groupLines.push(`${marker} ${entry.name} \`${entry.tag}\``);
@@ -452,7 +524,6 @@ export const Accounts: Command = {
         .filter((entry): entry is [string, string] => Boolean(entry[0] && entry[1]))
     );
     const rows = await buildAccountsRows({
-      cocService,
       guildId,
       linkedNameByTag,
       tags: uniqueTags,
@@ -492,8 +563,11 @@ export const Accounts: Command = {
             components: buildAccountsControlsRow(prefix, page, embeds.length, true),
           });
           try {
-            const refreshedRows = await buildAccountsRows({
+            await refreshAccountsPlayerCurrentData({
               cocService,
+              tags: uniqueTags,
+            });
+            const refreshedRows = await buildAccountsRows({
               guildId,
               linkedNameByTag,
               tags: uniqueTags,

--- a/src/services/PlayerCurrentService.ts
+++ b/src/services/PlayerCurrentService.ts
@@ -22,6 +22,7 @@ export type PlayerCurrentResolutionSource =
   | "fwa_player_catalog"
   | "todo_snapshot"
   | "live_refresh"
+  | "accounts-refresh"
   | "missing";
 
 export type PlayerCurrentRefreshPolicy = "missing_only" | "missing_or_stale";
@@ -585,6 +586,8 @@ export class PlayerCurrentService {
 
     const state = input.existing ? { ...input.existing } : createMissingPlayerCurrent({ playerTag });
     applyLivePlayer(state, input.livePlayer, input.now ?? new Date());
+    const source = input.source ?? "live_refresh";
+    state.lastSource = source;
     const data = buildPersistData(state);
     await prisma.playerCurrent.upsert({
       where: { playerTag },
@@ -596,7 +599,7 @@ export class PlayerCurrentService {
     });
     return {
       ...state,
-      source: input.source ?? "live_refresh",
+      source,
       liveRefreshInvoked: true,
     };
   }

--- a/tests/accounts.command.test.ts
+++ b/tests/accounts.command.test.ts
@@ -225,6 +225,33 @@ describe("/accounts command", () => {
     expect(getEmbedDescription(interaction)).toContain("- #CUV9082 `#CUV9082`");
   });
 
+  it("renders Unknown Clan when PlayerCurrent only has catalog hydration data", async () => {
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      {
+        playerTag: "#CUV9082",
+        playerName: "",
+        createdAt: new Date("2026-03-01T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.playerCurrent.findMany.mockResolvedValue([
+      makePlayerCurrentRow({
+        playerTag: "#CUV9082",
+        playerName: "Catalog Alpha",
+        currentClanTag: null,
+        currentClanName: null,
+        lastSource: "fwa_player_catalog",
+      }),
+    ]);
+    prismaMock.playerActivity.findMany.mockResolvedValue([]);
+    const interaction = makeInteraction();
+
+    await Accounts.run({} as any, interaction as any, makeCocService() as any);
+
+    const description = getEmbedDescription(interaction);
+    expect(description).toContain("**Unknown Clan**");
+    expect(description).toContain("Catalog Alpha");
+  });
+
   it("renders No Clan when PlayerCurrent confirms the player is clanless", async () => {
     prismaMock.playerLink.findMany.mockResolvedValue([
       {

--- a/tests/accounts.command.test.ts
+++ b/tests/accounts.command.test.ts
@@ -2,6 +2,10 @@ import { ApplicationCommandOptionType } from "discord.js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const prismaMock = vi.hoisted(() => ({
+  playerCurrent: {
+    findMany: vi.fn(),
+    upsert: vi.fn(),
+  },
   playerLink: {
     findUnique: vi.fn(),
     findMany: vi.fn(),
@@ -85,6 +89,32 @@ function makeCocService(playersByTag: Record<string, any> = {}) {
   };
 }
 
+function makePlayerCurrentRow(overrides: Record<string, any> = {}) {
+  return {
+    playerTag: "#PYLQ0289",
+    playerName: "Current Alpha",
+    townHall: 16,
+    currentClanTag: "#PQL0289",
+    currentClanName: "Current Clan",
+    trophies: 6000,
+    builderTrophies: 4000,
+    warStars: 100,
+    expLevel: 200,
+    role: "leader",
+    leagueName: "Legend League",
+    currentWeight: null,
+    currentWeightSource: null,
+    currentWeightMeasuredAt: null,
+    achievementsJson: null,
+    lastSeenAt: new Date("2026-04-20T00:00:00.000Z"),
+    lastFetchedAt: new Date("2026-04-20T00:00:00.000Z"),
+    lastSource: "accounts-refresh",
+    createdAt: new Date("2026-04-20T00:00:00.000Z"),
+    updatedAt: new Date("2026-04-20T00:00:00.000Z"),
+    ...overrides,
+  };
+}
+
 function getEmbedDescription(interaction: any): string {
   const payload = [...interaction.editReply.mock.calls].reverse().find(
     (call: unknown[]) => call[0] && typeof call[0] === "object" && Array.isArray(call[0].embeds)
@@ -96,6 +126,8 @@ describe("/accounts command", () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
+    prismaMock.playerCurrent.findMany.mockResolvedValue([]);
+    prismaMock.playerCurrent.upsert.mockResolvedValue({} as never);
     prismaMock.playerLink.findUnique.mockResolvedValue(null);
     prismaMock.playerLink.findMany.mockResolvedValue([]);
     prismaMock.playerLink.updateMany.mockResolvedValue({ count: 0 });
@@ -172,7 +204,7 @@ describe("/accounts command", () => {
     expect(getEmbedDescription(interaction)).toContain("- Activity Bravo `#QGRJ2222`");
   });
 
-  it("falls back to raw tag when neither local name source exists", async () => {
+  it("renders Unknown Clan when neither PlayerCurrent nor PlayerActivity has clan data", async () => {
     prismaMock.playerLink.findMany.mockResolvedValue([
       {
         playerTag: "#CUV9082",
@@ -181,6 +213,7 @@ describe("/accounts command", () => {
       },
     ]);
     prismaMock.playerActivity.findMany.mockResolvedValue([]);
+    prismaMock.playerCurrent.findMany.mockResolvedValue([]);
     const cocService = makeCocService({
       "#CUV9082": null,
     });
@@ -188,8 +221,34 @@ describe("/accounts command", () => {
 
     await Accounts.run({} as any, interaction as any, cocService as any);
 
-    expect(getEmbedDescription(interaction)).toContain("**No Clan**");
+    expect(getEmbedDescription(interaction)).toContain("**Unknown Clan**");
     expect(getEmbedDescription(interaction)).toContain("- #CUV9082 `#CUV9082`");
+  });
+
+  it("renders No Clan when PlayerCurrent confirms the player is clanless", async () => {
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      {
+        playerTag: "#CUV9082",
+        playerName: "",
+        createdAt: new Date("2026-03-01T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.playerCurrent.findMany.mockResolvedValue([
+      makePlayerCurrentRow({
+        playerTag: "#CUV9082",
+        playerName: "Clanless Current",
+        currentClanTag: null,
+        currentClanName: null,
+        lastSource: "accounts-refresh",
+      }),
+    ]);
+    prismaMock.playerActivity.findMany.mockResolvedValue([]);
+    const interaction = makeInteraction();
+
+    await Accounts.run({} as any, interaction as any, makeCocService() as any);
+
+    expect(getEmbedDescription(interaction)).toContain("**No Clan**");
+    expect(getEmbedDescription(interaction)).toContain("Clanless Current");
   });
 
   it("groups untracked clans under their current clan heading and renders co-leader crowns", async () => {
@@ -205,26 +264,27 @@ describe("/accounts command", () => {
         createdAt: new Date("2026-03-02T00:00:00.000Z"),
       },
     ]);
-    prismaMock.playerActivity.findMany.mockResolvedValue([
-      { tag: "#PYLQ0289", name: "Alpha", clanTag: "#UNTRK1", clanName: "Untracked Clan" },
-      { tag: "#QGRJ2222", name: "Bravo", clanTag: "#UNTRK1", clanName: "Untracked Clan" },
-    ]);
-    prismaMock.trackedClan.findMany.mockResolvedValue([]);
-    const cocService = makeCocService({
-      "#PYLQ0289": {
-        name: "Alpha",
-        clan: { tag: "#UNTRK1", name: "Untracked Clan" },
-        role: "coLeader",
-      },
-      "#QGRJ2222": {
-        name: "Bravo",
-        clan: { tag: "#UNTRK1", name: "Untracked Clan" },
+    prismaMock.playerCurrent.findMany.mockResolvedValue([
+      makePlayerCurrentRow({
+        playerTag: "#PYLQ0289",
+        playerName: "Alpha",
+        currentClanTag: "#UNTRK1",
+        currentClanName: "Untracked Clan",
+        role: "coleader",
+      }),
+      makePlayerCurrentRow({
+        playerTag: "#QGRJ2222",
+        playerName: "Bravo",
+        currentClanTag: "#UNTRK1",
+        currentClanName: "Untracked Clan",
         role: "member",
-      },
-    });
+      }),
+    ]);
+    prismaMock.playerActivity.findMany.mockResolvedValue([]);
+    prismaMock.trackedClan.findMany.mockResolvedValue([]);
     const interaction = makeInteraction();
 
-    await Accounts.run({} as any, interaction as any, cocService as any);
+    await Accounts.run({} as any, interaction as any, makeCocService() as any);
 
     const description = getEmbedDescription(interaction);
     expect(description).toContain(
@@ -242,14 +302,38 @@ describe("/accounts command", () => {
         discordUserId: "111111111111111111",
       },
     ]);
-    prismaMock.playerActivity.findMany.mockResolvedValue([
-      { tag: "#PYLQ0289", name: "Linked Alpha", clanTag: "#OLDTAG", clanName: "Old Clan" },
-    ]);
+    prismaMock.playerCurrent.findMany
+      .mockResolvedValueOnce([
+        makePlayerCurrentRow({
+          playerTag: "#PYLQ0289",
+          playerName: "Linked Alpha",
+          currentClanTag: "#PQL0289",
+          currentClanName: "Old Clan",
+        }),
+      ])
+      .mockResolvedValueOnce([
+        makePlayerCurrentRow({
+          playerTag: "#PYLQ0289",
+          playerName: "Linked Alpha",
+          currentClanTag: "#PQL0289",
+          currentClanName: "Old Clan",
+        }),
+      ])
+      .mockResolvedValueOnce([
+        makePlayerCurrentRow({
+          playerTag: "#PYLQ0289",
+          playerName: "Linked Alpha",
+          currentClanTag: "#GRJ0289",
+          currentClanName: "New Clan",
+          lastSource: "accounts-refresh",
+        }),
+      ]);
+    prismaMock.playerActivity.findMany.mockResolvedValue([]);
     prismaMock.trackedClan.findMany.mockResolvedValue([]);
     const cocService = makeCocService({
       "#PYLQ0289": {
         name: "Linked Alpha",
-        clan: { tag: "#OLDTAG", name: "Old Clan" },
+        clan: { tag: "#PQL0289", name: "Old Clan" },
         role: "member",
       },
     });
@@ -262,11 +346,11 @@ describe("/accounts command", () => {
     expect(initialControls.map((button: any) => button.label)).toContain("Refresh");
 
     prismaMock.playerActivity.findMany.mockResolvedValue([
-      { tag: "#PYLQ0289", name: "Linked Alpha", clanTag: "#NEWTAG", clanName: "New Clan" },
+      { tag: "#PYLQ0289", name: "Linked Alpha", clanTag: "#GRJ0289", clanName: "New Clan" },
     ]);
     cocService.getPlayerRaw.mockResolvedValueOnce({
       name: "Linked Alpha",
-      clan: { tag: "#NEWTAG", name: "New Clan" },
+      clan: { tag: "#GRJ0289", name: "New Clan" },
       role: "member",
     });
 
@@ -283,7 +367,17 @@ describe("/accounts command", () => {
 
     const refreshedDescription = getEmbedDescription(interaction);
     expect(refreshedDescription).toContain(
-      "**[New Clan](https://link.clashofclans.com/en?action=OpenClanProfile&tag=NEWTAG)**",
+      "**[New Clan](https://link.clashofclans.com/en?action=OpenClanProfile&tag=GRJ0289)**",
+    );
+    expect(prismaMock.playerCurrent.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { playerTag: "#PYLQ0289" },
+        update: expect.objectContaining({
+          currentClanTag: "#GRJ0289",
+          currentClanName: "New Clan",
+          lastSource: "accounts-refresh",
+        }),
+      }),
     );
   });
 
@@ -312,6 +406,37 @@ describe("/accounts command", () => {
     });
   });
 
+  it("renders improved PlayerCurrent data when tag lookup resolves a linked Discord user", async () => {
+    prismaMock.playerLink.findUnique.mockResolvedValue({
+      discordUserId: "222222222222222222",
+    });
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      {
+        playerTag: "#PYLQ0289",
+        playerName: "Linked Alpha",
+        createdAt: new Date("2026-03-01T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.playerCurrent.findMany.mockResolvedValue([
+      makePlayerCurrentRow({
+        playerTag: "#PYLQ0289",
+        playerName: "Current Alpha",
+        currentClanTag: "#PQL0289",
+        currentClanName: "Current Clan",
+      }),
+    ]);
+    prismaMock.playerActivity.findMany.mockResolvedValue([]);
+    const interaction = makeInteraction({ tag: "#PYLQ0289" });
+
+    await Accounts.run({} as any, interaction as any, makeCocService() as any);
+
+    const description = getEmbedDescription(interaction);
+    expect(description).toContain("Current Alpha");
+    expect(description).toContain(
+      "**[Current Clan](https://link.clashofclans.com/en?action=OpenClanProfile&tag=PQL0289)**",
+    );
+  });
+
   it("defaults to the caller's Discord account when discord-id is omitted", async () => {
     prismaMock.playerLink.findMany.mockResolvedValue([
       {
@@ -333,6 +458,36 @@ describe("/accounts command", () => {
         createdAt: true,
       },
     });
+  });
+
+  it("renders improved PlayerCurrent data when /accounts discord-id is used", async () => {
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      {
+        playerTag: "#PYLQ0289",
+        playerName: "Linked Alpha",
+        createdAt: new Date("2026-03-01T00:00:00.000Z"),
+      },
+    ]);
+    prismaMock.playerCurrent.findMany.mockResolvedValue([
+      makePlayerCurrentRow({
+        playerTag: "#PYLQ0289",
+        playerName: "Discord Alpha",
+        currentClanTag: "#GRJ0289",
+        currentClanName: "Discord Clan",
+      }),
+    ]);
+    prismaMock.playerActivity.findMany.mockResolvedValue([]);
+    const interaction = makeInteraction({
+      discordUserId: "222222222222222222",
+    });
+
+    await Accounts.run({} as any, interaction as any, makeCocService() as any);
+
+    const description = getEmbedDescription(interaction);
+    expect(description).toContain("Discord Alpha");
+    expect(description).toContain(
+      "**[Discord Clan](https://link.clashofclans.com/en?action=OpenClanProfile&tag=GRJ0289)**",
+    );
   });
 
   it("autocompletes player tags from PlayerLink and ignores tracked clans", async () => {


### PR DESCRIPTION
- prefer persisted PlayerCurrent data for display names and clan grouping
- refresh linked accounts into PlayerCurrent before rerendering
- preserve unknown vs no-clan states and add coverage