### PR TITLE
fix(roster): scope manage autocomplete by selected user

### DIFF
--- a/src/commands/Roster.ts
+++ b/src/commands/Roster.ts
@@ -3235,12 +3235,11 @@ async function autocompleteRosterManagePlayers(interaction: AutocompleteInteract
     action === "change_roster" && targetRosterView
       ? new Set(targetRosterView.signups.map((signup) => normalizePlayerTag(signup.playerTag)).filter(Boolean))
       : new Set<string>();
+  const addUserId = selectedUserId ?? interaction.user.id;
 
   const choices =
     action === "add"
-      ? (
-          await listPlayerLinksForDiscordUser({ discordUserId: interaction.user.id })
-        )
+      ? (await listPlayerLinksForDiscordUser({ discordUserId: addUserId }))
           .filter((link) => !existingTags.has(normalizePlayerTag(link.playerTag)))
           .map((link) => {
             const value = normalizePlayerTag(link.playerTag);

--- a/tests/roster.command.test.ts
+++ b/tests/roster.command.test.ts
@@ -3166,6 +3166,26 @@ describe("/roster command", () => {
       { name: "Delta (#VJQ28888)", value: "#VJQ28888" },
     ]);
 
+    const selectedUserAddInteraction = makeAutocompleteInteraction({
+      focusedName: "players",
+      focusedValue: "del",
+      subcommand: "manage",
+      roster: "roster-1",
+      action: "add",
+      userId: "222222222222222222",
+    }) as any;
+    vi.spyOn(playerLinkService, "listPlayerLinksForDiscordUser").mockResolvedValueOnce([
+      { playerTag: "#VJQ28888", linkedAt: new Date("2026-04-03T00:00:00.000Z"), linkedName: "Delta" },
+      { playerTag: "#PYLQ0289", linkedAt: new Date("2026-04-01T00:00:00.000Z"), linkedName: "Alpha Prime" },
+    ] as any);
+    await Roster.autocomplete(selectedUserAddInteraction);
+    expect(playerLinkService.listPlayerLinksForDiscordUser).toHaveBeenCalledWith({
+      discordUserId: "222222222222222222",
+    });
+    expect(selectedUserAddInteraction.respond).toHaveBeenCalledWith([
+      { name: "Delta (#VJQ28888)", value: "#VJQ28888" },
+    ]);
+
     const changeTargetInteraction = makeAutocompleteInteraction({
       focusedName: "target_roster",
       focusedValue: "",


### PR DESCRIPTION
- use the autocomplete-selected user for roster manage add lookups
- add a regression for the selected-user and fallback paths