### PR TITLE
feat(roster): render town hall icons in user signup list

### DIFF
--- a/src/commands/Roster.ts
+++ b/src/commands/Roster.ts
@@ -22,6 +22,7 @@ import { prisma } from "../prisma";
 import { CoCService } from "../services/CoCService";
 import { CommandPermissionService } from "../services/CommandPermissionService";
 import { resolveCurrentCwlSeasonKey } from "../services/CwlRegistryService";
+import { emojiResolverService } from "../services/emoji/EmojiResolverService";
 import {
   listPlayerLinksForDiscordUser,
   normalizeClanTag,
@@ -52,6 +53,7 @@ import {
   parseRosterManageRosterSelectMenuCustomId,
   getRosterManageSession,
   buildRosterSignupRoleRequirementLines,
+  formatRosterTownhallIconsValue,
   rosterService,
   type RosterRecord,
   type RosterSignupViewRecord,
@@ -517,9 +519,11 @@ function buildRosterSignupUserGroupHeading(group: {
 function buildRosterSignupUserAccountLine(account: {
   playerTag: string;
   playerName: string | null;
+  townHall: number | null;
 }): string {
   const playerName = normalizeRosterMutationLabel(account.playerName, "");
-  return playerName ? `  - ${playerName} \`${account.playerTag}\`` : `  - \`${account.playerTag}\``;
+  const townHall = formatRosterTownhallIconsValue(account.townHall) ?? "TH?";
+  return playerName ? `${townHall} ${playerName} \`${account.playerTag}\`` : `${townHall} \`${account.playerTag}\``;
 }
 
 export function paginateRosterSignupUserBlocks(blocks: string[]): string[] {
@@ -554,28 +558,38 @@ export function paginateRosterSignupUserBlocks(blocks: string[]): string[] {
 
 async function buildRosterSignupUserEmbeds(input: {
   discordUserId: string;
+  client: Client;
   sections: Awaited<ReturnType<typeof rosterService.listRosterSignupsForDiscordUser>>["sections"];
 }): Promise<EmbedBuilder[]> {
-  const blocks = input.sections.map((section) => {
-    const clanTag = normalizeClanTag(section.roster.clanTag ?? "") || null;
-    const clanName = section.clanName ?? null;
-    const lines: string[] = [buildRosterSignupUserSectionTitle(section.roster.title, clanName, clanTag)];
+  const blocks = [
+    `User: <@${input.discordUserId}>`,
+    ...input.sections.map((section) => {
+      const clanTag = normalizeClanTag(section.roster.clanTag ?? "") || null;
+      const clanName = section.clanName ?? null;
+      const lines: string[] = [buildRosterSignupUserSectionTitle(section.roster.title, clanName, clanTag)];
 
-    for (const group of section.groups) {
-      lines.push(buildRosterSignupUserGroupHeading(group));
-      for (const signup of group.signups) {
-        lines.push(buildRosterSignupUserAccountLine(signup));
+      for (const group of section.groups) {
+        lines.push(buildRosterSignupUserGroupHeading(group));
+        for (const signup of group.signups) {
+          lines.push(buildRosterSignupUserAccountLine(signup));
+        }
       }
-    }
 
-    return lines.join("\n");
-  });
+      return lines.join("\n");
+    }),
+  ];
   const pages = paginateRosterSignupUserBlocks(blocks);
-  return pages.map(
+  const renderedPages = await Promise.all(
+    pages.map(async (description) => {
+      const rendered = await emojiResolverService.replaceShortcodes(input.client, description).catch(() => description);
+      return rendered.replace(/:th(\d+):/gi, (_match, level: string) => `TH${level}`);
+    }),
+  );
+  return renderedPages.map(
     (description, index) =>
       new EmbedBuilder()
         .setColor(0xfee75c)
-        .setTitle(`Roster Signups for <@${input.discordUserId}>`)
+        .setTitle("Roster Signups")
         .setDescription(description)
         .setFooter({ text: `Page ${index + 1}/${pages.length}` }),
   );
@@ -2676,6 +2690,7 @@ async function handleRosterListSubcommand(interaction: ChatInputCommandInteracti
     });
     const embeds = await buildRosterSignupUserEmbeds({
       discordUserId: selectedUser.id,
+      client: interaction.client,
       sections: result.sections,
     });
     if (result.signupCount <= 0) {

--- a/src/services/RosterService.ts
+++ b/src/services/RosterService.ts
@@ -343,6 +343,7 @@ export type RosterSummaryRecord = RosterRecord & {
 export type RosterUserSignupListSignupRecord = {
   playerTag: string;
   playerName: string | null;
+  townHall: number | null;
   signedUpAt: Date;
 };
 
@@ -1580,7 +1581,7 @@ export async function listRosterSignupsForDiscordUser(input: {
     };
   }
 
-  const currentRosterSignups = await prisma.rosterSignup.findMany({
+  const currentRosterSignups = (await prisma.rosterSignup.findMany({
     where: {
       playerTag: { in: linkedTags },
       roster: {
@@ -1611,23 +1612,7 @@ export async function listRosterSignupsForDiscordUser(input: {
         },
       },
     },
-  });
-
-  if (currentRosterSignups.length <= 0) {
-    return {
-      discordUserId,
-      linkedAccountCount: linkedAccounts.length,
-      signupCount: 0,
-      sections: [],
-    };
-  }
-
-  const clanNameByTag = await resolveRosterClanNameMap(
-    currentRosterSignups.map((row) => normalizeClanTag((row as { roster: { clanTag: string | null } }).roster.clanTag ?? "")).filter(Boolean),
-  );
-
-  const sectionByRosterId = new Map<string, RosterUserSignupListSectionRecord>();
-  for (const row of currentRosterSignups as Array<{
+  })) as Array<{
     rosterId: string;
     playerTag: string;
     playerName: string | null;
@@ -1640,7 +1625,28 @@ export async function listRosterSignupsForDiscordUser(input: {
       description: string | null;
       sortOrder: number;
     } | null;
-  }>) {
+  }>;
+
+  if (currentRosterSignups.length <= 0) {
+    return {
+      discordUserId,
+      linkedAccountCount: linkedAccounts.length,
+      signupCount: 0,
+      sections: [],
+    };
+  }
+
+  const townHallByTag = await loadRosterDisplayTownHallMap({
+    clanTag: null,
+    playerTags: currentRosterSignups.map((row) => row.playerTag),
+  });
+
+  const clanNameByTag = await resolveRosterClanNameMap(
+    currentRosterSignups.map((row) => normalizeClanTag(row.roster.clanTag ?? "")).filter(Boolean),
+  );
+
+  const sectionByRosterId = new Map<string, RosterUserSignupListSectionRecord>();
+  for (const row of currentRosterSignups) {
     const roster = mapRosterRecord(row.roster);
     let section = sectionByRosterId.get(roster.id);
     if (!section) {
@@ -1681,6 +1687,7 @@ export async function listRosterSignupsForDiscordUser(input: {
     group.signups.push({
       playerTag: normalizePlayerTag(row.playerTag),
       playerName: normalizeRosterText(row.playerName ?? null),
+      townHall: townHallByTag.get(normalizePlayerTag(row.playerTag)) ?? null,
       signedUpAt: row.signedUpAt,
     });
   }
@@ -3723,7 +3730,7 @@ function getRosterDisplayColumnHeader(column: RosterDisplayColumn): string {
   return ROSTER_BOARD_COLUMN_HEADERS[column];
 }
 
-function formatRosterTownhallIconsValue(townHall: number | null | undefined): string | null {
+export function formatRosterTownhallIconsValue(townHall: number | null | undefined): string | null {
   if (townHall === null || townHall === undefined || !Number.isFinite(townHall)) {
     return null;
   }

--- a/tests/roster.command.test.ts
+++ b/tests/roster.command.test.ts
@@ -752,6 +752,7 @@ describe("/roster command", () => {
                 {
                   playerTag: "#GGYLPVCUQ",
                   playerName: "Charmander",
+                  townHall: 18,
                   signedUpAt: new Date("2026-04-20T10:00:00.000Z"),
                 },
               ],
@@ -766,6 +767,7 @@ describe("/roster command", () => {
                 {
                   playerTag: "#YJCLLYU8C",
                   playerName: "Bulbasaur",
+                  townHall: 17,
                   signedUpAt: new Date("2026-04-20T11:00:00.000Z"),
                 },
               ],
@@ -818,6 +820,7 @@ describe("/roster command", () => {
                 {
                   playerTag: makeValidRosterPlayerTag(1),
                   playerName: "Pikachu",
+                  townHall: null,
                   signedUpAt: new Date("2026-04-22T10:00:00.000Z"),
                 },
               ],
@@ -844,17 +847,18 @@ describe("/roster command", () => {
     expect(Array.isArray(payload?.embeds)).toBe(true);
     expect(payload.embeds).toHaveLength(1);
     const firstEmbed = payload.embeds[0]?.toJSON?.() ?? payload.embeds[0];
-    expect(String(firstEmbed?.title ?? "")).toBe("Roster Signups for <@222222222222222222>");
+    expect(String(firstEmbed?.title ?? "")).toBe("Roster Signups");
+    expect(String(firstEmbed?.description ?? "")).toContain("User: <@222222222222222222>");
     expect(String(firstEmbed?.description ?? "")).toContain(
       "Masters 2 [C] | TH17 ([Serenity](<https://cc.fwafarm.com/cc_n/clan.php?tag=2P0J0YL8>))",
     );
     expect(String(firstEmbed?.description ?? "")).toContain("Confirmed");
-    expect(String(firstEmbed?.description ?? "")).toContain("  - Charmander `#GGYLPVCUQ`");
+    expect(String(firstEmbed?.description ?? "")).toContain("TH18 Charmander `#GGYLPVCUQ`");
     expect(String(firstEmbed?.description ?? "")).toContain("Substitute");
-    expect(String(firstEmbed?.description ?? "")).toContain("  - Bulbasaur `#YJCLLYU8C`");
+    expect(String(firstEmbed?.description ?? "")).toContain("TH17 Bulbasaur `#YJCLLYU8C`");
     expect(String(firstEmbed?.description ?? "")).toContain("FWA Beta Signup (Beta Force)");
     expect(String(firstEmbed?.description ?? "")).toContain("Ungrouped");
-    expect(String(firstEmbed?.description ?? "")).toContain(`  - Pikachu \`${makeValidRosterPlayerTag(1)}\``);
+    expect(String(firstEmbed?.description ?? "")).toContain(`TH? Pikachu \`${makeValidRosterPlayerTag(1)}\``);
   });
 
   it("shows an empty state when the selected user has no linked roster signups", async () => {
@@ -881,12 +885,12 @@ describe("/roster command", () => {
     const largeRosterBlock = [
       "Masters 2 [C] | TH17 ([Serenity](<https://cc.fwafarm.com/cc_n/clan.php?tag=2P0J0YL8>))",
       "Confirmed",
-      ...Array.from({ length: 157 }, (_, index) => `  - Player ${index + 1} \`${makeValidRosterPlayerTag(index)}\``),
+      ...Array.from({ length: 157 }, (_, index) => `TH18 Player ${index + 1} \`${makeValidRosterPlayerTag(index)}\``),
     ].join("\n");
     const secondRosterBlock = [
       "FWA Beta Signup (Beta Force)",
       "Ungrouped",
-      `  - Pikachu \`${makeValidRosterPlayerTag(1)}\``,
+      `TH? Pikachu \`${makeValidRosterPlayerTag(1)}\``,
     ].join("\n");
 
     const pages = paginateRosterSignupUserBlocks([largeRosterBlock, secondRosterBlock]);

--- a/tests/roster.service.test.ts
+++ b/tests/roster.service.test.ts
@@ -5614,6 +5614,13 @@ describe("RosterService", () => {
     prismaMock.trackedClan.findMany.mockResolvedValue([{ tag: "#2P0J0YL8", name: "Serenity" }]);
     prismaMock.raidTrackedClan.findMany.mockResolvedValue([]);
     prismaMock.cwlTrackedClan.findMany.mockResolvedValue([]);
+    playerCurrentServiceMock.listPlayerCurrentByTags.mockResolvedValue(
+      makePlayerCurrentMap([
+        ["#GGYLPVCUQ", 18],
+        ["#YJCLLYU8C", 17],
+        ["#PQL0002", null],
+      ]),
+    );
 
     const rosterOne = {
       id: "roster-1",
@@ -5690,6 +5697,7 @@ describe("RosterService", () => {
           groupId: "group-confirmed",
           playerTag: "#GGYLPVCUQ",
           playerName: "Charmander",
+          townHall: 18,
           signedUpAt: new Date("2026-04-20T10:00:00.000Z"),
           roster: rosterOne,
           group: {
@@ -5706,6 +5714,7 @@ describe("RosterService", () => {
           groupId: "group-substitute",
           playerTag: "#YJCLLYU8C",
           playerName: "Bulbasaur",
+          townHall: 17,
           signedUpAt: new Date("2026-04-20T11:00:00.000Z"),
           roster: rosterOne,
           group: {
@@ -5722,6 +5731,7 @@ describe("RosterService", () => {
           groupId: null,
           playerTag: "#PQL0002",
           playerName: null,
+          townHall: null,
           signedUpAt: new Date("2026-04-22T10:00:00.000Z"),
           roster: rosterTwo,
           group: null,
@@ -5765,9 +5775,12 @@ describe("RosterService", () => {
     });
     expect(result.sections[0].groups.map((group) => group.name)).toEqual(["Confirmed", "Substitute"]);
     expect(result.sections[0].groups[0].signups.map((signup) => signup.playerTag)).toEqual(["#GGYLPVCUQ"]);
+    expect(result.sections[0].groups[0].signups[0]?.townHall).toBe(18);
     expect(result.sections[0].groups[1].signups.map((signup) => signup.playerTag)).toEqual(["#YJCLLYU8C"]);
+    expect(result.sections[0].groups[1].signups[0]?.townHall).toBe(17);
     expect(result.sections[1].groups.map((group) => group.name)).toEqual(["Ungrouped"]);
     expect(result.sections[1].groups[0].signups.map((signup) => signup.playerTag)).toEqual(["#PQL0002"]);
+    expect(result.sections[1].groups[0].signups[0]?.townHall).toBeNull();
     expect(prismaMock.rosterSignup.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
         where: expect.objectContaining({


### PR DESCRIPTION
- move the selected user mention into the embed body
- replace markdown bullets with per-account town hall icons