### PR TITLE
fix(roster): use in-game clan profile links in roster list

### DIFF
--- a/src/commands/Roster.ts
+++ b/src/commands/Roster.ts
@@ -18,6 +18,7 @@ import {
 } from "discord.js";
 import { Command } from "../Command";
 import { formatError } from "../helper/formatError";
+import { buildClanProfileMarkdownLink } from "../helper/clanProfileLink";
 import { prisma } from "../prisma";
 import { CoCService } from "../services/CoCService";
 import { CommandPermissionService } from "../services/CommandPermissionService";
@@ -479,12 +480,8 @@ function buildRosterSignupUserClanLine(clanName: string | null, clanTag: string 
     .replace(/\s+/g, " ")
     .trim();
   const normalizedClanTag = normalizeClanTag(clanTag ?? "");
-  if (normalizedClanName && normalizedClanTag) {
-    const encodedTag = normalizedClanTag.replace(/^#/, "");
-    return `[${normalizedClanName}](<https://cc.fwafarm.com/cc_n/clan.php?tag=${encodedTag}>)`;
-  }
   if (normalizedClanName) {
-    return normalizedClanName;
+    return normalizedClanTag ? buildClanProfileMarkdownLink(normalizedClanName, normalizedClanTag) : normalizedClanName;
   }
   if (normalizedClanTag) {
     return normalizedClanTag;

--- a/src/helper/clanProfileLink.ts
+++ b/src/helper/clanProfileLink.ts
@@ -16,5 +16,5 @@ export function buildClanProfileMarkdownLink(
   const label = sanitizeDisplayText(clanName) || normalizedClanTag || "Unknown Clan";
   if (!normalizedClanTag) return label;
   const encodedTag = normalizedClanTag.replace(/^#/, "");
-  return `[${label}](<https://link.clashofclans.com/en?action=OpenClanProfile&tag=${encodedTag}>)`;
+  return `[${label}](<https://link.clashofclans.com/en/?action=OpenClanProfile&tag=${encodedTag}>)`;
 }

--- a/src/services/RosterService.ts
+++ b/src/services/RosterService.ts
@@ -2367,7 +2367,7 @@ function buildRosterManageClanLabel(roster: { clanTag: string | null }, clanName
     return clanName ? clanName : "-";
   }
   if (clanName) {
-    return `[${clanName}](<https://cc.fwafarm.com/cc_n/clan.php?tag=${encodeURIComponent(tag.replace(/^#/, ""))}>)`;
+    return `[${clanName}](<https://link.clashofclans.com/en/?action=OpenClanProfile&tag=${encodeURIComponent(tag.replace(/^#/, ""))}>)`;
   }
   return `\`${tag}\``;
 }
@@ -3496,7 +3496,7 @@ function buildRosterReportClanLine(view: RosterManagerReadinessView): string {
   }
   const clanName = normalizeRosterText(view.signupView.clanDisplayName ?? null) ?? "Unknown Clan";
   const encodedTag = clanTag.replace(/^#/, "");
-  return `Clan: ${clanName} \`${clanTag}\` ([Open in-game](<https://link.clashofclans.com/en?action=OpenClanProfile&tag=${encodedTag}>))`;
+  return `Clan: ${clanName} \`${clanTag}\` ([Open in-game](<https://link.clashofclans.com/en/?action=OpenClanProfile&tag=${encodedTag}>))`;
 }
 
 function buildRosterManagerReportLines(view: RosterManagerReadinessView): string[] {
@@ -3722,7 +3722,7 @@ export function buildClanProfileMarkdownLink(clanName: string | null, clanTag: s
   const label = sanitizeRosterBoardText(clanName) || normalizedClanTag || "Unknown Clan";
   if (!normalizedClanTag) return label;
   const encodedTag = normalizedClanTag.replace(/^#/, "");
-  return `[${label}](https://link.clashofclans.com/en?action=OpenClanProfile&tag=${encodedTag})`;
+  return `[${label}](https://link.clashofclans.com/en/?action=OpenClanProfile&tag=${encodedTag})`;
 }
 
 function getRosterDisplayColumnHeader(column: RosterDisplayColumn): string {

--- a/tests/raidTrackedClan.service.test.ts
+++ b/tests/raidTrackedClan.service.test.ts
@@ -149,7 +149,7 @@ describe("RaidTrackedClanService", () => {
       },
     ]);
     expect(lines[0]).toBe(
-      "### 🔓 [Vanilla | 3331](<https://link.clashofclans.com/en?action=OpenClanProfile&tag=2RVGJYLC0>) `2RVGJYLC0`",
+      "### 🔓 [Vanilla | 3331](<https://link.clashofclans.com/en/?action=OpenClanProfile&tag=2RVGJYLC0>) `2RVGJYLC0`",
     );
     expect(getRaidTrackedClanJoinTypeEmoji("inviteOnly")).toBe("🔒");
     expect(getRaidTrackedClanJoinTypeEmoji("closed")).toBe("🔒");

--- a/tests/roster.command.test.ts
+++ b/tests/roster.command.test.ts
@@ -852,7 +852,7 @@ describe("/roster command", () => {
     expect(String(firstEmbed?.title ?? "")).toBe("Roster Signups");
     expect(String(firstEmbed?.description ?? "")).toContain("User: <@222222222222222222>");
     expect(String(firstEmbed?.description ?? "")).toContain(
-      "Masters 2 [C] | TH17 ([Serenity](<https://cc.fwafarm.com/cc_n/clan.php?tag=2P0J0YL8>))",
+      "Masters 2 [C] | TH17 ([Serenity](<https://link.clashofclans.com/en/?action=OpenClanProfile&tag=2P0J0YL8>))",
     );
     expect(String(firstEmbed?.description ?? "")).toContain("Confirmed");
     expect(String(firstEmbed?.description ?? "")).toContain("<:th18:1018> Charmander `#GGYLPVCUQ`");
@@ -964,7 +964,7 @@ describe("/roster command", () => {
 
   it("keeps roster sections atomic across list pagination when a section is large", async () => {
     const largeRosterBlock = [
-      "Masters 2 [C] | TH17 ([Serenity](<https://cc.fwafarm.com/cc_n/clan.php?tag=2P0J0YL8>))",
+      "Masters 2 [C] | TH17 ([Serenity](<https://link.clashofclans.com/en/?action=OpenClanProfile&tag=2P0J0YL8>))",
       "Confirmed",
       ...Array.from({ length: 157 }, (_, index) => `TH18 Player ${index + 1} \`${makeValidRosterPlayerTag(index)}\``),
     ].join("\n");
@@ -3354,7 +3354,7 @@ describe("/roster command", () => {
       updatedAt: new Date("2026-04-20T00:00:00.000Z"),
     });
     (rosterService.buildRosterManagerReadinessText as any).mockResolvedValue(
-      "State: Open\nClan: CWL Alpha `#2QG2C08UP` ([Open in-game](<https://link.clashofclans.com/en?action=OpenClanProfile&tag=2QG2C08UP>))\n**Groups**\n**Confirmed** (1)\n- <:th15:1001> Alpha <:yes:901>",
+      "State: Open\nClan: CWL Alpha `#2QG2C08UP` ([Open in-game](<https://link.clashofclans.com/en/?action=OpenClanProfile&tag=2QG2C08UP>))\n**Groups**\n**Confirmed** (1)\n- <:th15:1001> Alpha <:yes:901>",
     );
     const cocService = {} as any;
 

--- a/tests/roster.service.test.ts
+++ b/tests/roster.service.test.ts
@@ -1559,7 +1559,7 @@ describe("RosterService", () => {
     expect(substituteRow).toBeTruthy();
     expect(embedTitle).toBe("Rising Crowns");
     expect(description).toContain(
-      "**[CWL Alpha Signup](https://link.clashofclans.com/en?action=OpenClanProfile&tag=2QG2C08UP)** Champion League II",
+      "**[CWL Alpha Signup](https://link.clashofclans.com/en/?action=OpenClanProfile&tag=2QG2C08UP)** Champion League II",
     );
     expect(description).toContain("**Confirmed - 1**");
     expect(description).toContain("**Substitute - 1**");
@@ -2557,7 +2557,7 @@ describe("RosterService", () => {
     expect(payload).toBeTruthy();
     expect(String(payload?.embed.toJSON().title ?? "")).toBe("CWL Alpha");
     expect(String(payload?.embed.toJSON().description ?? "")).toContain(
-      "**[CWL Alpha Signup](https://link.clashofclans.com/en?action=OpenClanProfile&tag=2QG2C08UP)** Champion League II",
+      "**[CWL Alpha Signup](https://link.clashofclans.com/en/?action=OpenClanProfile&tag=2QG2C08UP)** Champion League II",
     );
   });
 
@@ -3111,7 +3111,7 @@ describe("RosterService", () => {
     prismaMock.rosterSignup.count.mockResolvedValueOnce(0);
     const payload = await rosterService.buildRosterSignupPayload("roster-1");
     expect(String(payload?.embed.toJSON().description ?? "")).toContain(
-      "**[CWL Alpha Signup](https://link.clashofclans.com/en?action=OpenClanProfile&tag=2QG2C08UP)** CWL",
+      "**[CWL Alpha Signup](https://link.clashofclans.com/en/?action=OpenClanProfile&tag=2QG2C08UP)** CWL",
     );
   });
 
@@ -5290,7 +5290,7 @@ describe("RosterService", () => {
       emojiClient: makeRosterEmojiClient(),
     });
 
-    expect(report).toContain("Clan: Rising Crowns `#2QG2C08UP` ([Open in-game](<https://link.clashofclans.com/en?action=OpenClanProfile&tag=2QG2C08UP>))");
+    expect(report).toContain("Clan: Rising Crowns `#2QG2C08UP` ([Open in-game](<https://link.clashofclans.com/en/?action=OpenClanProfile&tag=2QG2C08UP>))");
     expect(report).toContain("**Groups**");
     expect(report).toContain("**Confirmed** (1)");
     expect(report).toContain("- <:th16:116> Alpha <:yes:901>");
@@ -5397,7 +5397,7 @@ describe("RosterService", () => {
       emojiClient: makeRosterEmojiClient(),
     });
 
-    expect(report).toContain("Clan: Unknown Clan `#2QG2C08UP` ([Open in-game](<https://link.clashofclans.com/en?action=OpenClanProfile&tag=2QG2C08UP>))");
+    expect(report).toContain("Clan: Unknown Clan `#2QG2C08UP` ([Open in-game](<https://link.clashofclans.com/en/?action=OpenClanProfile&tag=2QG2C08UP>))");
     expect(report).toContain("**Groups**");
     expect(report).toContain("**Confirmed** (1)");
     expect(report).not.toContain("#OLD1111");

--- a/tests/trackedClan.command.test.ts
+++ b/tests/trackedClan.command.test.ts
@@ -386,7 +386,7 @@ describe("/tracked-clan command behavior", () => {
 
     const description = getFirstEmbedDescription(interaction);
     expect(description).toContain(
-      "**[Alpha Clan](<https://link.clashofclans.com/en?action=OpenClanProfile&tag=2QG2C08UP>)** `#2QG2C08UP`",
+      "**[Alpha Clan](<https://link.clashofclans.com/en/?action=OpenClanProfile&tag=2QG2C08UP>)** `#2QG2C08UP`",
     );
     expect(description).toContain("shortName: AC");
     expect(prismaMock.cwlTrackedClan.findMany).not.toHaveBeenCalled();
@@ -412,7 +412,7 @@ describe("/tracked-clan command behavior", () => {
 
     const description = getFirstEmbedDescription(interaction);
     expect(description).toContain(
-      "**[CWL Alpha](<https://link.clashofclans.com/en?action=OpenClanProfile&tag=PYLQ0289>)** `#PYLQ0289`",
+      "**[CWL Alpha](<https://link.clashofclans.com/en/?action=OpenClanProfile&tag=PYLQ0289>)** `#PYLQ0289`",
     );
     expect(description).toContain("registry: CWL seasonal");
     expect(prismaMock.trackedClan.findMany).not.toHaveBeenCalled();
@@ -467,13 +467,13 @@ describe("/tracked-clan command behavior", () => {
     expect(description).toContain("**CWL**");
     expect(description).toContain("**RAIDS**");
     expect(description).toContain(
-      "- [Alpha Clan](<https://link.clashofclans.com/en?action=OpenClanProfile&tag=2QG2C08UP>) `#2QG2C08UP`",
+      "- [Alpha Clan](<https://link.clashofclans.com/en/?action=OpenClanProfile&tag=2QG2C08UP>) `#2QG2C08UP`",
     );
     expect(description).toContain(
-      "- [CWL Alpha](<https://link.clashofclans.com/en?action=OpenClanProfile&tag=PYLQ0289>) `#PYLQ0289`",
+      "- [CWL Alpha](<https://link.clashofclans.com/en/?action=OpenClanProfile&tag=PYLQ0289>) `#PYLQ0289`",
     );
     expect(description).toContain(
-      "- 🔓 [Vanilla | 3331](<https://link.clashofclans.com/en?action=OpenClanProfile&tag=2RVGJYLC0>) `2RVGJYLC0`",
+      "- 🔓 [Vanilla | 3331](<https://link.clashofclans.com/en/?action=OpenClanProfile&tag=2RVGJYLC0>) `2RVGJYLC0`",
     );
     expect(payload?.components).toEqual([]);
     expect(prismaMock.trackedClan.findMany).toHaveBeenCalledTimes(1);
@@ -506,7 +506,7 @@ describe("/tracked-clan command behavior", () => {
 
     const description = getFirstEmbedDescription(interaction);
     expect(description).toContain(
-      "**[#2QG2C08UP](<https://link.clashofclans.com/en?action=OpenClanProfile&tag=2QG2C08UP>)**",
+      "**[#2QG2C08UP](<https://link.clashofclans.com/en/?action=OpenClanProfile&tag=2QG2C08UP>)**",
     );
     expect(description).not.toContain("undefined");
     expect(description).not.toContain("null");


### PR DESCRIPTION
- route roster list clan aliases through the shared clan profile helper
- normalize roster clan link URLs to the canonical in-game profile format