### PR TITLE
feat(cwl): format members with th icons and roster warnings

### DIFF
--- a/src/services/CwlRotationService.ts
+++ b/src/services/CwlRotationService.ts
@@ -561,6 +561,174 @@ async function loadCwlRotationExportClanNameMap(input: {
   return clanNameByClanTag;
 }
 
+type CwlRotationExportRosterRecord = {
+  id: string;
+  clanTag: string | null;
+  title: string;
+  lifecycleState: string;
+  postedAt: Date | null;
+  updatedAt: Date;
+  createdAt: Date;
+};
+
+async function loadCwlRotationExportRosterDetailsMap(input: {
+  season: string;
+  plans: Array<{
+    id: string;
+    clanTag: string;
+    metadata: Record<string, unknown> | null;
+  }>;
+}): Promise<Map<string, { rosterTitle: string; rosterShortName: string | null }>> {
+  const rosterIdByPlanId = new Map<string, string>();
+  const clanTags = new Set<string>();
+  for (const plan of input.plans) {
+    const planMetadata = toRecordValue(plan.metadata);
+    const rosterId = sanitizeDisplayText(String(planMetadata?.rosterId ?? "")) || null;
+    if (rosterId) {
+      rosterIdByPlanId.set(plan.id, rosterId);
+    }
+    const clanTag = normalizeClanTag(plan.clanTag);
+    if (clanTag) {
+      clanTags.add(clanTag);
+    }
+  }
+
+  const rosterIds = [...new Set(rosterIdByPlanId.values())];
+  const rosterFilter: Prisma.RosterWhereInput[] = [];
+  if (rosterIds.length > 0) {
+    rosterFilter.push({ id: { in: rosterIds } });
+  }
+  if (clanTags.size > 0) {
+    rosterFilter.push({ clanTag: { in: [...clanTags] } });
+  }
+
+  const resolvedByPlanId = new Map<string, { rosterTitle: string; rosterShortName: string | null }>();
+  if (rosterFilter.length <= 0) {
+    return resolvedByPlanId;
+  }
+
+  const rosterRows = (await prisma.roster.findMany({
+    where: {
+      rosterType: "CWL",
+      rosterCategory: "signup",
+      OR: rosterFilter,
+    },
+    select: {
+      id: true,
+      clanTag: true,
+      title: true,
+      lifecycleState: true,
+      postedAt: true,
+      updatedAt: true,
+      createdAt: true,
+    },
+  })) as CwlRotationExportRosterRecord[];
+
+  const rosterById = new Map<string, CwlRotationExportRosterRecord>();
+  const rosterByClanTag = new Map<string, CwlRotationExportRosterRecord[]>();
+  for (const roster of rosterRows) {
+    rosterById.set(roster.id, roster);
+    const clanTag = normalizeClanTag(roster.clanTag ?? "");
+    if (!clanTag) continue;
+    const existing = rosterByClanTag.get(clanTag) ?? [];
+    existing.push(roster);
+    rosterByClanTag.set(clanTag, existing);
+  }
+
+  for (const plan of input.plans) {
+    const planMetadata = toRecordValue(plan.metadata);
+    const explicitRosterTitle = sanitizeDisplayText(String(planMetadata?.rosterTitle ?? ""));
+    if (explicitRosterTitle) {
+      resolvedByPlanId.set(plan.id, {
+        rosterTitle: explicitRosterTitle,
+        rosterShortName:
+          sanitizeDisplayText(String(planMetadata?.rosterShortName ?? "")) ||
+          buildCwlRosterRotationShortName(explicitRosterTitle),
+      });
+      continue;
+    }
+
+    const explicitRosterId = sanitizeDisplayText(String(planMetadata?.rosterId ?? ""));
+    const explicitRoster = explicitRosterId ? rosterById.get(explicitRosterId) ?? null : null;
+    const clanTag = normalizeClanTag(plan.clanTag);
+    const clanRosters = clanTag ? rosterByClanTag.get(clanTag) ?? [] : [];
+    const resolvedRoster =
+      explicitRoster ??
+      pickCwlRotationExportRosterCandidate(clanRosters, input.season) ??
+      null;
+
+    if (!resolvedRoster) continue;
+
+    const rosterTitle = sanitizeDisplayText(resolvedRoster.title);
+    if (!rosterTitle) continue;
+    resolvedByPlanId.set(plan.id, {
+      rosterTitle,
+      rosterShortName:
+        sanitizeDisplayText(String(planMetadata?.rosterShortName ?? "")) ||
+        buildCwlRosterRotationShortName(rosterTitle),
+    });
+  }
+
+  return resolvedByPlanId;
+}
+
+function pickCwlRotationExportRosterCandidate(
+  rosterRows: CwlRotationExportRosterRecord[],
+  season: string,
+): CwlRotationExportRosterRecord | null {
+  if (rosterRows.length <= 0) {
+    return null;
+  }
+  return [...rosterRows].sort((left, right) => {
+    const leftLifecycleScore = scoreCwlRotationExportRosterLifecycle(left.lifecycleState);
+    const rightLifecycleScore = scoreCwlRotationExportRosterLifecycle(right.lifecycleState);
+    if (leftLifecycleScore !== rightLifecycleScore) {
+      return rightLifecycleScore - leftLifecycleScore;
+    }
+
+    const leftSeasonScore = scoreCwlRotationExportRosterSeasonMatch(left.title, season);
+    const rightSeasonScore = scoreCwlRotationExportRosterSeasonMatch(right.title, season);
+    if (leftSeasonScore !== rightSeasonScore) {
+      return rightSeasonScore - leftSeasonScore;
+    }
+
+    const leftPostedAt = left.postedAt?.getTime() ?? 0;
+    const rightPostedAt = right.postedAt?.getTime() ?? 0;
+    if (leftPostedAt !== rightPostedAt) {
+      return rightPostedAt - leftPostedAt;
+    }
+
+    const leftUpdatedAt = left.updatedAt.getTime();
+    const rightUpdatedAt = right.updatedAt.getTime();
+    if (leftUpdatedAt !== rightUpdatedAt) {
+      return rightUpdatedAt - leftUpdatedAt;
+    }
+
+    const leftCreatedAt = left.createdAt.getTime();
+    const rightCreatedAt = right.createdAt.getTime();
+    if (leftCreatedAt !== rightCreatedAt) {
+      return rightCreatedAt - leftCreatedAt;
+    }
+
+    return left.id.localeCompare(right.id);
+  })[0] ?? null;
+}
+
+function scoreCwlRotationExportRosterLifecycle(lifecycleState: string): number {
+  const normalized = sanitizeDisplayText(lifecycleState).toUpperCase();
+  if (normalized === ROSTER_LIFECYCLE_STATE.OPEN) return 3;
+  if (normalized === ROSTER_LIFECYCLE_STATE.CLOSED) return 2;
+  if (normalized === ROSTER_LIFECYCLE_STATE.ACTIVE) return 1;
+  return 0;
+}
+
+function scoreCwlRotationExportRosterSeasonMatch(title: string, season: string): number {
+  const normalizedTitle = sanitizeDisplayText(title).toLowerCase();
+  const normalizedSeason = sanitizeDisplayText(season).toLowerCase();
+  if (!normalizedTitle || !normalizedSeason) return 0;
+  return normalizedTitle.includes(normalizedSeason) ? 1 : 0;
+}
+
 function buildRosterRowsForMetadata(roster: CwlSeasonRosterEntry[]): Array<{
   playerTag: string;
   playerName: string;
@@ -1382,6 +1550,14 @@ export class CwlRotationService {
         .map((plan) => normalizeClanTag(plan.clanTag))
         .filter((clanTag): clanTag is string => Boolean(clanTag)),
     });
+    const rosterDetailsByPlanId = await loadCwlRotationExportRosterDetailsMap({
+      season,
+      plans: [...uniquePlans.values()].map((plan) => ({
+        id: plan.id,
+        clanTag: plan.clanTag,
+        metadata: plan.metadata,
+      })),
+    });
     const exports: CwlRotationPlanExport[] = [];
     for (const plan of uniquePlans.values()) {
       const days = await loadPlanDaysWithMembers(plan.id);
@@ -1390,12 +1566,16 @@ export class CwlRotationService {
         Array.isArray(planMetadata?.rosterRows) ? planMetadata.rosterRows : [],
       );
       const normalizedClanTag = normalizeClanTag(plan.clanTag) || plan.clanTag;
+      const resolvedRosterDetails = rosterDetailsByPlanId.get(plan.id) ?? null;
       const clanName =
         sanitizeDisplayText(String(planMetadata?.clanName ?? "")) ||
         clanNameByClanTag.get(normalizedClanTag) ||
         normalizedClanTag ||
         null;
-      const rosterTitle = sanitizeDisplayText(String(planMetadata?.rosterTitle ?? "")) || null;
+      const rosterTitle =
+        sanitizeDisplayText(String(planMetadata?.rosterTitle ?? "")) ||
+        resolvedRosterDetails?.rosterTitle ||
+        null;
       const rosterShortName =
         sanitizeDisplayText(String(planMetadata?.rosterShortName ?? "")) ||
         buildCwlRosterRotationShortName(rosterTitle) ||

--- a/src/services/CwlRotationService.ts
+++ b/src/services/CwlRotationService.ts
@@ -576,7 +576,7 @@ async function loadCwlRotationExportRosterDetailsMap(input: {
   plans: Array<{
     id: string;
     clanTag: string;
-    metadata: Record<string, unknown> | null;
+    metadata: Prisma.JsonValue;
   }>;
 }): Promise<Map<string, { rosterTitle: string; rosterShortName: string | null }>> {
   const rosterIdByPlanId = new Map<string, string>();

--- a/tests/cwlRotation.service.test.ts
+++ b/tests/cwlRotation.service.test.ts
@@ -35,6 +35,9 @@ const prismaMock = vi.hoisted(() => ({
     findFirst: vi.fn(),
     findMany: vi.fn(),
   },
+  roster: {
+    findMany: vi.fn(),
+  },
   fwaClanMemberCurrent: {
     findMany: vi.fn(),
   },
@@ -65,6 +68,7 @@ describe("CwlRotationService", () => {
     prismaMock.currentCwlPrepSnapshot.findMany.mockResolvedValue([]);
     prismaMock.cwlRotationPlan.findFirst.mockResolvedValue(null);
     prismaMock.cwlRotationPlan.findMany.mockResolvedValue([]);
+    prismaMock.roster.findMany.mockResolvedValue([]);
     prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue([]);
     prismaMock.cwlRotationPlanDay.findMany.mockResolvedValue([]);
     txMock.cwlRotationPlan.updateMany.mockResolvedValue({ count: 0 });
@@ -727,6 +731,132 @@ describe("CwlRotationService", () => {
         clanDisplayName: "Rising Thrones",
         rosterTitle: "Masters 1 [A] | 175k+ WW",
         rosterShortName: "M1 [A]",
+      }),
+    );
+  });
+
+  it("resolves a matching CWL roster title for clan-created export plans without roster metadata", async () => {
+    prismaMock.cwlRotationPlan.findMany.mockResolvedValue([
+      {
+        id: "plan-manual-1",
+        clanTag: "#2QG2C08UP",
+        season: "2026-04",
+        version: 4,
+        isActive: true,
+        rosterSize: 2,
+        generatedFromRoundDay: null,
+        excludedPlayerTags: [],
+        warningSummary: null,
+        metadata: {
+          source: "manual",
+          clanName: "Rising Thrones",
+        },
+        createdAt: new Date("2026-04-20T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-20T00:00:00.000Z"),
+      } as any,
+    ]);
+    prismaMock.cwlRotationPlanDay.findMany.mockResolvedValue([
+      {
+        id: 1,
+        planId: "plan-manual-1",
+        roundDay: 1,
+        lineupSize: 2,
+        locked: false,
+        metadata: {},
+        createdAt: new Date("2026-04-20T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-20T00:00:00.000Z"),
+        members: [
+          {
+            id: 11,
+            planDayId: 1,
+            playerTag: "#PYLQ0289",
+            playerName: "Alpha",
+            assignmentOrder: 0,
+            manualOverride: false,
+            createdAt: new Date("2026-04-20T00:00:00.000Z"),
+            updatedAt: new Date("2026-04-20T00:00:00.000Z"),
+          } as any,
+        ],
+      } as any,
+    ]);
+    prismaMock.cwlTrackedClan.findMany.mockResolvedValue([{ tag: "#2QG2C08UP", name: "Rising Thrones" } as any]);
+    prismaMock.roster.findMany.mockResolvedValue([
+      {
+        id: "roster-1",
+        clanTag: "#2QG2C08UP",
+        title: "Masters 1 [A] | 175k+ WW",
+        lifecycleState: "OPEN",
+        postedAt: new Date("2026-04-19T00:00:00.000Z"),
+        createdAt: new Date("2026-04-19T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-19T00:00:00.000Z"),
+      } as any,
+    ]);
+    prismaMock.currentCwlPrepSnapshot.findMany.mockResolvedValue([]);
+    prismaMock.cwlRoundHistory.findMany.mockResolvedValue([]);
+
+    const exports = await cwlRotationService.listActivePlanExports({ season: "2026-04" });
+
+    expect(exports).toHaveLength(1);
+    expect(exports[0]).toEqual(
+      expect.objectContaining({
+        clanTag: "#2QG2C08UP",
+        clanName: "Rising Thrones",
+        clanDisplayName: "Rising Thrones",
+        rosterTitle: "Masters 1 [A] | 175k+ WW",
+        rosterShortName: "M1 [A]",
+        sourceLabel: "manual",
+      }),
+    );
+  });
+
+  it("falls back safely when no matching CWL roster can be resolved for export plans", async () => {
+    prismaMock.cwlRotationPlan.findMany.mockResolvedValue([
+      {
+        id: "plan-manual-2",
+        clanTag: "#2QG2C08UP",
+        season: "2026-04",
+        version: 4,
+        isActive: true,
+        rosterSize: 2,
+        generatedFromRoundDay: null,
+        excludedPlayerTags: [],
+        warningSummary: null,
+        metadata: {
+          source: "manual",
+        },
+        createdAt: new Date("2026-04-20T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-20T00:00:00.000Z"),
+      } as any,
+    ]);
+    prismaMock.cwlRotationPlanDay.findMany.mockResolvedValue([
+      {
+        id: 1,
+        planId: "plan-manual-2",
+        roundDay: 1,
+        lineupSize: 2,
+        locked: false,
+        metadata: {},
+        createdAt: new Date("2026-04-20T00:00:00.000Z"),
+        updatedAt: new Date("2026-04-20T00:00:00.000Z"),
+        members: [],
+      } as any,
+    ]);
+    prismaMock.cwlTrackedClan.findMany.mockResolvedValue([{ tag: "#2QG2C08UP", name: "Rising Thrones" } as any]);
+    prismaMock.roster.findMany.mockResolvedValue([]);
+    prismaMock.currentCwlPrepSnapshot.findMany.mockResolvedValue([]);
+    prismaMock.cwlRoundHistory.findMany.mockResolvedValue([]);
+
+    const exports = await cwlRotationService.listActivePlanExports({ season: "2026-04" });
+
+    expect(exports).toHaveLength(1);
+    expect(exports[0]).toEqual(
+      expect.objectContaining({
+        clanTag: "#2QG2C08UP",
+        clanName: "Rising Thrones",
+        clanDisplayName: "Rising Thrones",
+        rosterTitle: null,
+        rosterShortName: null,
+        sourceLabel: "manual",
       }),
     );
   });


### PR DESCRIPTION
- prepend cwl members with town hall emoji bullets and attacks-only status
- flag members missing from the corresponding signup roster in the same season feat(cwl): resolve roster metadata for rotation exports

- resolve matching CWL roster titles for clan-created active plans
- preserve manual fallback when no matching roster exists