### PR TITLE
feat(cwl): refine roster-aware rotation flows

### DIFF
--- a/src/commands/Cwl.ts
+++ b/src/commands/Cwl.ts
@@ -149,6 +149,100 @@ async function resolveCwlRosterSignupTagSet(input: {
   );
 }
 
+function normalizeClanMemberRole(input: unknown): "leader" | "coleader" | null {
+  const normalized = String(input ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z]/g, "");
+  if (normalized === "leader") return "leader";
+  if (normalized === "coleader") return "coleader";
+  return null;
+}
+
+function compareCwlMembersListEntries(
+  left: {
+    playerTag: string;
+    playerName: string;
+    townHall: number | null;
+    currentWeight?: number | null;
+  },
+  right: {
+    playerTag: string;
+    playerName: string;
+    townHall: number | null;
+    currentWeight?: number | null;
+  },
+  rosterSignupTagSet: Set<string> | null,
+): number {
+  const leftInRoster = rosterSignupTagSet?.has(normalizePlayerTag(left.playerTag) ?? "") ?? false;
+  const rightInRoster = rosterSignupTagSet?.has(normalizePlayerTag(right.playerTag) ?? "") ?? false;
+  if (leftInRoster !== rightInRoster) {
+    return leftInRoster ? -1 : 1;
+  }
+
+  const leftHasWeight = left.currentWeight !== null && Number.isFinite(left.currentWeight);
+  const rightHasWeight = right.currentWeight !== null && Number.isFinite(right.currentWeight);
+  if (leftHasWeight !== rightHasWeight) {
+    return leftHasWeight ? -1 : 1;
+  }
+  if (leftHasWeight && rightHasWeight && left.currentWeight !== right.currentWeight) {
+    return (right.currentWeight ?? -1) - (left.currentWeight ?? -1);
+  }
+
+  const leftTownHall = left.townHall ?? -1;
+  const rightTownHall = right.townHall ?? -1;
+  if (leftTownHall !== rightTownHall) {
+    return rightTownHall - leftTownHall;
+  }
+
+  const byName = left.playerName.localeCompare(right.playerName, undefined, { sensitivity: "base" });
+  if (byName !== 0) return byName;
+  return left.playerTag.localeCompare(right.playerTag);
+}
+
+function formatCwlMembersRoleBadge(role: string | null | undefined): string {
+  const normalized = normalizeClanMemberRole(role);
+  return normalized ? "👑" : "";
+}
+
+function buildCwlRotationRosterTagSet(plan: CwlRotationPlanExport): Set<string> {
+  const rosterRowsValue = (plan.metadata as { rosterRows?: unknown } | null)?.rosterRows;
+  if (!Array.isArray(rosterRowsValue)) {
+    return new Set();
+  }
+
+  return new Set(
+    rosterRowsValue
+      .map((row) => {
+        if (!row || typeof row !== "object" || Array.isArray(row)) return null;
+        const record = row as { playerTag?: unknown };
+        return normalizePlayerTag(String(record.playerTag ?? ""));
+      })
+      .filter((tag): tag is string => Boolean(tag)),
+  );
+}
+
+function buildCwlRotationLeaderNames(
+  entries: Awaited<ReturnType<typeof cwlStateService.listSeasonRosterForClan>>,
+): string[] {
+  const leaders = entries
+    .map((entry) => ({
+      name: entry.playerName,
+      tag: entry.playerTag,
+      role: normalizeClanMemberRole(entry.role),
+    }))
+    .filter((entry) => entry.role !== null)
+    .sort((left, right) => {
+      const leftRank = left.role === "leader" ? 0 : 1;
+      const rightRank = right.role === "leader" ? 0 : 1;
+      if (leftRank !== rightRank) return leftRank - rightRank;
+      const byName = left.name.localeCompare(right.name, undefined, { sensitivity: "base" });
+      if (byName !== 0) return byName;
+      return left.tag.localeCompare(right.tag);
+    });
+  return leaders.map((entry) => entry.name);
+}
+
 function renderTownHallIcon(
   townHall: number | null | undefined,
   townHallEmojiByLevel: Map<number, string>,
@@ -463,12 +557,15 @@ function renderMembersListLines(input: {
   townHallEmojiByLevel: Map<number, string>;
   rosterSignupTagSet: Set<string> | null;
 }) {
+  const sortedEntries = [...input.entries].sort((left, right) =>
+    compareCwlMembersListEntries(left, right, input.rosterSignupTagSet),
+  );
   const lines: string[] = [
     `Season: ${input.season}`,
     `Clan: ${input.clanName ? `${input.clanName} (${input.clanTag})` : input.clanTag}`,
     "",
   ];
-  for (const entry of input.entries) {
+  for (const entry of sortedEntries) {
     const normalizedPlayerTag = normalizePlayerTag(entry.playerTag);
     const linkLabel = entry.linkedDiscordUserId
       ? `<@${entry.linkedDiscordUserId}>`
@@ -482,10 +579,11 @@ function renderMembersListLines(input: {
       input.rosterSignupTagSet && normalizedPlayerTag && !input.rosterSignupTagSet.has(normalizedPlayerTag)
         ? " :warning:"
         : "";
+    const badgeParts = [formatCwlMembersRoleBadge(entry.role), rosterWarning ? ":warning:" : ""].filter(Boolean);
     lines.push(
       `${renderTownHallIcon(entry.townHall, input.townHallEmojiByLevel)} ${entry.playerName} \`${
         entry.playerTag
-      }\`${rosterWarning} - days ${entry.daysParticipated} - ${linkLabel} - ${currentLabel}`,
+      }\`${badgeParts.length > 0 ? ` ${badgeParts.join(" ")}` : ""} - days ${entry.daysParticipated} - ${linkLabel} - ${currentLabel}`,
     );
   }
   if (input.entries.length <= 0) {
@@ -510,7 +608,13 @@ function buildCwlRotationMergedRosterLines(input: {
     playerName: string;
   }>;
   actualAvailable: boolean;
-}): string[] {
+  rosterTagSet: Set<string>;
+  excludedTagSet: Set<string>;
+}): {
+  lines: string[];
+  hasMismatchWarning: boolean;
+  hasBlockedWarning: boolean;
+} {
   const actualTagSet = new Set(
     input.actualPlayerRows.map((member) => normalizePlayerTag(member.playerTag)).filter(Boolean),
   );
@@ -530,12 +634,16 @@ function buildCwlRotationMergedRosterLines(input: {
     }));
 
   if (!input.actualAvailable) {
-    return [
+    return {
+      lines: [
       "Actual lineup unavailable",
       ...plannedBenchMembers.map(
         (member) => `:x: ${member.playerName} (${member.playerTag}) | War count: ${member.warCount}`,
       ),
-    ];
+      ],
+      hasMismatchWarning: false,
+      hasBlockedWarning: false,
+    };
   }
 
   const expectedMembers = input.plannedMembers.filter((member) => !member.subbedOut);
@@ -563,6 +671,9 @@ function buildCwlRotationMergedRosterLines(input: {
   });
 
   const lines: string[] = [];
+  let hasMismatchWarning = false;
+  let hasBlockedWarning = false;
+  const hasRosterTagSet = input.rosterTagSet.size > 0;
   let missingExpectedIndex = 0;
   for (const actual of actualRows) {
     if (actual.normalizedTag && expectedByTag.has(actual.normalizedTag)) {
@@ -570,15 +681,27 @@ function buildCwlRotationMergedRosterLines(input: {
       continue;
     }
 
+    const isBlocked =
+      Boolean(actual.normalizedTag) &&
+      (input.excludedTagSet.has(actual.normalizedTag) ||
+        (hasRosterTagSet && !input.rosterTagSet.has(actual.normalizedTag)));
+    if (isBlocked) {
+      hasBlockedWarning = true;
+      lines.push(`⛔️ ${actual.playerName} (${actual.playerTag}) | War count: ${actual.warCount}`);
+      continue;
+    }
+
     const expected = missingExpectedRows[missingExpectedIndex] ?? null;
     if (expected) {
       missingExpectedIndex += 1;
+      hasMismatchWarning = true;
       lines.push(
         `:warning: ${actual.playerName} (${actual.playerTag}) | War count: ${actual.warCount} - Expected ${expected.playerName} (${expected.playerTag})`,
       );
       continue;
     }
 
+    hasMismatchWarning = true;
     lines.push(`:warning: ${actual.playerName} (${actual.playerTag}) | War count: ${actual.warCount}`);
   }
 
@@ -602,7 +725,11 @@ function buildCwlRotationMergedRosterLines(input: {
     lines.push("No actual lineup members.");
   }
 
-  return lines;
+  return {
+    lines,
+    hasMismatchWarning,
+    hasBlockedWarning,
+  };
 }
 
 function pruneExpiredCwlRotationImportSessions(nowMs = Date.now()): void {
@@ -1461,6 +1588,7 @@ function buildCwlRotationShowPageLines(input: {
   pageIndex: number;
   pageCount: number;
   battleDayStartAt: Date | null;
+  leaderNames: string[];
   warCountByPlayerTag: Map<string, number>;
   validation: {
     actualAvailable: boolean;
@@ -1475,6 +1603,10 @@ function buildCwlRotationShowPageLines(input: {
     days: input.plan.days,
     day: input.day,
   });
+  const rosterTagSet = buildCwlRotationRosterTagSet(input.plan);
+  const excludedTagSet = new Set(
+    input.plan.excludedPlayerTags.map((tag) => normalizePlayerTag(tag)).filter((tag): tag is string => Boolean(tag)),
+  );
   const lines: string[] = [
     `Season: ${input.plan.season}`,
     `Clan: ${input.plan.clanName || input.plan.clanTag}`,
@@ -1484,29 +1616,40 @@ function buildCwlRotationShowPageLines(input: {
   if (input.plan.excludedPlayerTags.length > 0) {
     lines.push(`Excluded: ${input.plan.excludedPlayerTags.join(", ")}`);
   }
+  lines.push(`Leaders/Co-leaders: ${input.leaderNames.length > 0 ? input.leaderNames.join(", ") : "unknown"}`);
   lines.push(`Page: ${input.pageIndex + 1} / ${input.pageCount}`);
   lines.push("");
   lines.push(`Day ${input.day.roundDay}`);
   lines.push("");
   if (!input.validation || !input.validation.actualAvailable) {
     lines.push("Actual lineup unavailable");
-    lines.push(
-      ...buildCwlRotationMergedRosterLines({
-        warCountByPlayerTag: input.warCountByPlayerTag,
-        plannedMembers: visibleDayRows,
-        actualPlayerRows: [],
-        actualAvailable: false,
-      }).slice(1),
-    );
+    const merged = buildCwlRotationMergedRosterLines({
+      warCountByPlayerTag: input.warCountByPlayerTag,
+      plannedMembers: visibleDayRows,
+      actualPlayerRows: [],
+      actualAvailable: false,
+      rosterTagSet,
+      excludedTagSet,
+    });
+    lines.push(...merged.lines.slice(1));
   } else {
-    lines.push(
-      ...buildCwlRotationMergedRosterLines({
-        warCountByPlayerTag: input.warCountByPlayerTag,
-        plannedMembers: visibleDayRows,
-        actualPlayerRows: input.validation.actualPlayerRows,
-        actualAvailable: input.validation.actualAvailable,
-      }),
-    );
+    const merged = buildCwlRotationMergedRosterLines({
+      warCountByPlayerTag: input.warCountByPlayerTag,
+      plannedMembers: visibleDayRows,
+      actualPlayerRows: input.validation.actualPlayerRows,
+      actualAvailable: input.validation.actualAvailable,
+      rosterTagSet,
+      excludedTagSet,
+    });
+    if (merged.hasMismatchWarning) {
+      lines.push(
+        "⚠️ Unexpected lineup mismatch: actual player is in where another planned player was expected.",
+      );
+    }
+    if (merged.hasBlockedWarning) {
+      lines.push("⛔️ Not on roster / excluded from rotation.");
+    }
+    lines.push(...merged.lines);
   }
 
   return lines;
@@ -1518,6 +1661,7 @@ function buildCwlRotationShowPageEmbed(input: {
   pageIndex: number;
   pageCount: number;
   battleDayStartAt: Date | null;
+  leaderNames: string[];
   warCountByPlayerTag: Map<string, number>;
   validation: {
     actualAvailable: boolean;
@@ -1538,6 +1682,7 @@ function buildCwlRotationShowPageEmbed(input: {
             pageIndex: input.pageIndex,
             pageCount: input.pageCount,
             battleDayStartAt: input.battleDayStartAt,
+            leaderNames: input.leaderNames,
             warCountByPlayerTag: input.warCountByPlayerTag,
             validation: input.validation,
           }),
@@ -1679,6 +1824,11 @@ async function loadCwlRotationShowClanPayload(input: {
       throughRoundDay: selectedDay.roundDay,
     }),
   ]);
+  const seasonRosterEntries = await cwlStateService.listSeasonRosterForClan({
+    clanTag: planView.clanTag,
+    season: planView.season,
+  });
+  const leaderNames = buildCwlRotationLeaderNames(seasonRosterEntries);
 
   return {
     payload: await buildCwlRotationShowClanPayload({
@@ -1689,10 +1839,11 @@ async function loadCwlRotationShowClanPayload(input: {
       pageIndex,
       pageCount: relevantDays.length,
       battleDayStartAt,
+      leaderNames,
       warCountByPlayerTag,
       validation: validation
         ? {
-            actualAvailable: validation.actualAvailable,
+          actualAvailable: validation.actualAvailable,
             complete: validation.complete,
             missingExpectedPlayerTags: validation.missingExpectedPlayerTags,
             extraActualPlayerTags: validation.extraActualPlayerTags,
@@ -1718,6 +1869,7 @@ async function buildCwlRotationShowClanPayload(input: {
   pageIndex: number;
   pageCount: number;
   battleDayStartAt: Date | null;
+  leaderNames: string[];
   warCountByPlayerTag: Map<string, number>;
   validation: {
     actualAvailable: boolean;
@@ -1737,6 +1889,7 @@ async function buildCwlRotationShowClanPayload(input: {
       pageIndex: input.pageIndex,
       pageCount: input.pageCount,
       battleDayStartAt: input.battleDayStartAt,
+      leaderNames: input.leaderNames,
       warCountByPlayerTag: input.warCountByPlayerTag,
       validation: input.validation,
     }),
@@ -2256,6 +2409,7 @@ async function handleRotationCreateSubcommand(interaction: ChatInputCommandInter
         excludeTagsRaw: exclude,
         lineupSize: size,
         overwrite,
+        guildId: interaction.guildId ?? null,
       });
 
   if (result.outcome === "not_tracked") {

--- a/src/services/CwlRotationService.ts
+++ b/src/services/CwlRotationService.ts
@@ -13,6 +13,19 @@ type CwlRotationPlanPlayerRow = {
   manualOverride?: boolean;
 };
 
+type CwlRotationSeedRosterEntry = CwlSeasonRosterEntry & {
+  weight: number | null;
+  sourcePosition: number | null;
+};
+
+type CwlRotationMetadataRosterRow = {
+  playerTag: string;
+  playerName: string;
+  townHall: number | null;
+  weight: number | null;
+  sourcePosition: number | null;
+};
+
 type CwlRotationPlanDayWriteInput = {
   roundDay: number;
   lineupSize: number;
@@ -39,6 +52,9 @@ export type CwlRotationPlanExportDayRow = {
   playerName: string;
   subbedOut: boolean;
   assignmentOrder: number;
+  townHall: number | null;
+  weight: number | null;
+  sourcePosition: number | null;
 };
 
 export type CwlRotationPlanExportDay = {
@@ -289,8 +305,8 @@ function normalizeClanMemberRole(input: unknown): "leader" | "coleader" | null {
 const fwaClanMembersSyncService = new FwaClanMembersSyncService();
 
 function compareRosterEntries(
-  a: CwlSeasonRosterEntry,
-  b: CwlSeasonRosterEntry,
+  a: CwlRotationSeedRosterEntry,
+  b: CwlRotationSeedRosterEntry,
   stableIndexByTag: Map<string, number>,
   totalCountByTag: Map<string, number>,
 ): number {
@@ -308,9 +324,9 @@ function compareRosterEntries(
 }
 
 function buildStableRosterOrder(input: {
-  roster: CwlSeasonRosterEntry[];
+  roster: CwlRotationSeedRosterEntry[];
   currentLineupTags: string[];
-}): CwlSeasonRosterEntry[] {
+}): CwlRotationSeedRosterEntry[] {
   const currentTagSet = new Set(input.currentLineupTags);
   const currentByTag = new Map(input.currentLineupTags.map((tag, index) => [tag, index]));
   const currentEntries = input.roster
@@ -336,12 +352,12 @@ function buildStableRosterOrder(input: {
 }
 
 function buildPlanDays(input: {
-  roster: CwlSeasonRosterEntry[];
+  roster: CwlRotationSeedRosterEntry[];
   lineupSize: number;
   currentRoundDay: number;
   currentLineupTags: string[];
   seedRoundAlreadyCountedInParticipation?: boolean;
-}): Array<{ roundDay: number; members: CwlSeasonRosterEntry[] }> {
+}): Array<{ roundDay: number; members: CwlRotationSeedRosterEntry[] }> {
   const stableRoster = buildStableRosterOrder({
     roster: input.roster,
     currentLineupTags: input.currentLineupTags,
@@ -353,12 +369,19 @@ function buildPlanDays(input: {
     stableRoster.map((entry) => [entry.playerTag, Math.max(0, entry.daysParticipated)]),
   );
   const rosterByTag = new Map(stableRoster.map((entry) => [entry.playerTag, entry]));
-  const days: Array<{ roundDay: number; members: CwlSeasonRosterEntry[] }> = [];
+  const days: Array<{ roundDay: number; members: CwlRotationSeedRosterEntry[] }> = [];
 
   const currentDayMembers = input.currentLineupTags
     .map((tag) => rosterByTag.get(tag))
-    .filter((entry): entry is CwlSeasonRosterEntry => Boolean(entry))
+    .filter((entry): entry is CwlRotationSeedRosterEntry => Boolean(entry))
     .slice(0, input.lineupSize);
+  if (currentDayMembers.length < input.lineupSize) {
+    const currentTagSet = new Set(currentDayMembers.map((member) => member.playerTag));
+    const remainingCandidates = [...stableRoster]
+      .filter((entry) => !currentTagSet.has(entry.playerTag))
+      .sort((a, b) => compareRosterEntries(a, b, stableIndexByTag, totalCountByTag));
+    currentDayMembers.push(...remainingCandidates.slice(0, input.lineupSize - currentDayMembers.length));
+  }
   if (!input.seedRoundAlreadyCountedInParticipation) {
     for (const member of currentDayMembers) {
       totalCountByTag.set(member.playerTag, (totalCountByTag.get(member.playerTag) ?? 0) + 1);
@@ -391,8 +414,8 @@ function buildPlanDays(input: {
 }
 
 function buildCoverageWarnings(input: {
-  roster: CwlSeasonRosterEntry[];
-  planDays: Array<{ roundDay: number; members: CwlSeasonRosterEntry[] }>;
+  roster: CwlRotationSeedRosterEntry[];
+  planDays: Array<{ roundDay: number; members: CwlRotationSeedRosterEntry[] }>;
   currentRoundDay: number;
   seedRoundAlreadyCountedInParticipation?: boolean;
 }): string[] {
@@ -748,13 +771,13 @@ function scoreCwlRotationExportRosterSeasonMatch(title: string, season: string):
   return normalizedTitle.includes(normalizedSeason) ? 1 : 0;
 }
 
-function buildRosterRowsForMetadata(roster: CwlSeasonRosterEntry[]): Array<{
-  playerTag: string;
-  playerName: string;
-}> {
+function buildRosterRowsForMetadata(roster: CwlRotationSeedRosterEntry[]): CwlRotationMetadataRosterRow[] {
   return roster.map((entry) => ({
     playerTag: entry.playerTag,
     playerName: entry.playerName,
+    townHall: entry.townHall ?? null,
+    weight: entry.weight ?? null,
+    sourcePosition: entry.sourcePosition ?? null,
   }));
 }
 
@@ -803,10 +826,7 @@ function toRecordValue(value: unknown): Record<string, unknown> | null {
   return value as Record<string, unknown>;
 }
 
-function normalizeRosterRows(value: unknown): Array<{
-  playerTag: string;
-  playerName: string;
-}> {
+function normalizeRosterRows(value: unknown): CwlRotationMetadataRosterRow[] {
   if (!Array.isArray(value)) return [];
   const rows = value
     .map((row) => {
@@ -815,12 +835,20 @@ function normalizeRosterRows(value: unknown): Array<{
       const playerTag = normalizePlayerTag(String(record.playerTag ?? ""));
       if (!playerTag) return null;
       const playerName = sanitizeDisplayText(record.playerName);
+      const townHall = Number.isFinite(Number(record.townHall)) ? Math.trunc(Number(record.townHall)) : null;
+      const weight = Number.isFinite(Number(record.weight)) ? Math.trunc(Number(record.weight)) : null;
+      const sourcePosition = Number.isFinite(Number(record.sourcePosition))
+        ? Math.trunc(Number(record.sourcePosition))
+        : null;
       return {
         playerTag,
         playerName: playerName || playerTag,
+        townHall,
+        weight,
+        sourcePosition,
       };
     })
-    .filter((row): row is { playerTag: string; playerName: string } => Boolean(row));
+    .filter((row): row is CwlRotationMetadataRosterRow => Boolean(row));
   return [...new Map(rows.map((row) => [row.playerTag, row])).values()];
 }
 
@@ -833,6 +861,11 @@ function normalizeExportRows(value: unknown): CwlRotationPlanExportDayRow[] {
       const playerTag = normalizePlayerTag(String(record.playerTag ?? ""));
       if (!playerTag) return null;
       const playerName = sanitizeDisplayText(record.playerName) || playerTag;
+      const townHall = Number.isFinite(Number(record.townHall)) ? Math.trunc(Number(record.townHall)) : null;
+      const weight = Number.isFinite(Number(record.weight)) ? Math.trunc(Number(record.weight)) : null;
+      const sourcePosition = Number.isFinite(Number(record.sourcePosition))
+        ? Math.trunc(Number(record.sourcePosition))
+        : null;
       const subbedOut =
         typeof record.subbedOut === "boolean"
           ? record.subbedOut
@@ -848,6 +881,9 @@ function normalizeExportRows(value: unknown): CwlRotationPlanExportDayRow[] {
         playerName,
         subbedOut,
         assignmentOrder,
+        townHall,
+        weight,
+        sourcePosition,
       };
     })
     .filter((row): row is CwlRotationPlanExportDayRow => Boolean(row));
@@ -859,10 +895,16 @@ function buildExportRowsFromMembersAndRoster(input: {
     playerName: string;
     assignmentOrder: number;
     manualOverride?: boolean;
+    townHall?: number | null;
+    weight?: number | null;
+    sourcePosition?: number | null;
   }>;
   rosterRows: Array<{
     playerTag: string;
     playerName: string;
+    townHall?: number | null;
+    weight?: number | null;
+    sourcePosition?: number | null;
   }>;
 }): CwlRotationPlanExportDayRow[] {
   const activeMemberByTag = new Map(
@@ -878,6 +920,9 @@ function buildExportRowsFromMembersAndRoster(input: {
       playerName: rosterRow.playerName,
       subbedOut: !activeMember,
       assignmentOrder: activeMember?.assignmentOrder ?? rows.length,
+      townHall: rosterRow.townHall ?? activeMember?.townHall ?? null,
+      weight: rosterRow.weight ?? activeMember?.weight ?? null,
+      sourcePosition: rosterRow.sourcePosition ?? activeMember?.sourcePosition ?? null,
     });
     seenTags.add(rosterRow.playerTag);
   }
@@ -889,6 +934,9 @@ function buildExportRowsFromMembersAndRoster(input: {
       playerName: member.playerName,
       subbedOut: false,
       assignmentOrder: member.assignmentOrder,
+      townHall: member.townHall ?? null,
+      weight: member.weight ?? null,
+      sourcePosition: member.sourcePosition ?? null,
     });
   }
 
@@ -1010,6 +1058,7 @@ export class CwlRotationService {
     excludeTagsRaw?: string | null;
     lineupSize?: number | null;
     overwrite?: boolean;
+    guildId?: string | null;
     season?: string;
   }): Promise<CreateCwlRotationPlanResult> {
     const season = input.season ?? resolveCurrentCwlSeasonKey();
@@ -1070,14 +1119,54 @@ export class CwlRotationService {
       .map((value) => normalizePlayerTag(value))
       .filter(Boolean);
     const excludeTags = [...new Set(rawExcludeTags)];
-    const roster = await cwlStateService.listSeasonRosterForClan({ clanTag, season });
-    const rosterByTag = new Map(roster.map((entry) => [entry.playerTag, entry]));
-    const invalidTags = excludeTags.filter((tag) => !rosterByTag.has(tag));
+    const [seasonRoster, correspondingRoster] = await Promise.all([
+      cwlStateService.listSeasonRosterForClan({ clanTag, season }),
+      input.guildId
+        ? (async () => {
+            const roster = await rosterService.findCwlRosterForClan({
+              guildId: input.guildId ?? "",
+              clanTag,
+              season,
+            });
+            if (!roster) return null;
+            return rosterService.getRosterView(roster.id);
+          })()
+        : Promise.resolve(null),
+    ]);
+    const seasonRosterByTag = new Map(seasonRoster.map((entry) => [entry.playerTag, entry]));
+    const invalidTags = excludeTags.filter((tag) => !seasonRosterByTag.has(tag));
     if (invalidTags.length > 0) {
       return { outcome: "invalid_excludes", season, clanTag, invalidTags };
     }
 
-    const includedRoster = roster.filter((entry) => !excludeTags.includes(entry.playerTag));
+    const rosterSignups = correspondingRoster?.signups ?? [];
+    const rosterSignupByTag = new Map(
+      rosterSignups
+        .map((signup) => {
+          const playerTag = normalizePlayerTag(signup.playerTag);
+          return playerTag ? ([playerTag, signup] as const) : null;
+        })
+        .filter((entry): entry is readonly [string, (typeof rosterSignups)[number]] => Boolean(entry)),
+    );
+    const eligibleRosterEntriesBase = correspondingRoster
+      ? seasonRoster
+          .filter((entry) => rosterSignupByTag.has(entry.playerTag))
+          .map((entry, index) => {
+            const signup = rosterSignupByTag.get(entry.playerTag) ?? null;
+            return {
+              ...entry,
+              weight: signup?.weight ?? entry.currentWeight ?? null,
+              sourcePosition: index,
+            };
+          })
+      : seasonRoster.map((entry, index) => ({
+          ...entry,
+          weight: entry.currentWeight ?? null,
+          sourcePosition: index,
+        }));
+    const eligibleRosterEntries = eligibleRosterEntriesBase.filter(
+      (entry) => !excludeTags.includes(entry.playerTag),
+    );
     const currentLineupTags = currentRound.members
       .filter((member) => member.subbedIn)
       .map((member) => member.playerTag);
@@ -1085,42 +1174,43 @@ export class CwlRotationService {
       currentLineupTags.length > 0
         ? currentLineupTags
         : currentRound.members.map((member) => member.playerTag).filter(Boolean);
+    const eligibleLineupTags = currentLineupSeedTags.filter((tag) =>
+      eligibleRosterEntries.some((entry) => entry.playerTag === tag),
+    );
     const lineupSize = explicitLineupSize ?? Math.max(0, currentLineupSeedTags.length);
     const seedRoundAlreadyCountedInParticipation = hasOverlapPreparation;
-    if (explicitLineupSize !== null && currentLineupSeedTags.length < lineupSize) {
+    if (eligibleRosterEntries.length < lineupSize) {
       return {
         outcome: "not_enough_players",
         season,
         clanTag,
         lineupSize,
-        availablePlayers: currentLineupSeedTags.length,
-      };
-    }
-    if (includedRoster.length < lineupSize) {
-      return {
-        outcome: "not_enough_players",
-        season,
-        clanTag,
-        lineupSize,
-        availablePlayers: includedRoster.length,
+        availablePlayers: eligibleRosterEntries.length,
       };
     }
 
     const version = (existingActivePlan?.version ?? 0) + 1;
+    const sourceOrderedRoster = buildStableRosterOrder({
+      roster: eligibleRosterEntries,
+      currentLineupTags: eligibleLineupTags,
+    }).map((entry, index) => ({
+      ...entry,
+      sourcePosition: index,
+    }));
     const planDays = buildPlanDays({
-      roster: includedRoster,
+      roster: sourceOrderedRoster,
       lineupSize,
       currentRoundDay: currentRound.roundDay,
-      currentLineupTags: currentLineupSeedTags,
+      currentLineupTags: eligibleLineupTags,
       seedRoundAlreadyCountedInParticipation,
     });
     const warnings = buildCoverageWarnings({
-      roster: includedRoster,
+      roster: sourceOrderedRoster,
       planDays,
       currentRoundDay: currentRound.roundDay,
       seedRoundAlreadyCountedInParticipation,
     });
-    const rosterRows = buildRosterRowsForMetadata(includedRoster);
+    const rosterRows = buildRosterRowsForMetadata(sourceOrderedRoster);
 
     await prisma.$transaction(async (tx) => {
       await persistRotationPlanVersion(tx, {
@@ -1137,7 +1227,7 @@ export class CwlRotationService {
           clanName: currentRound.clanName,
           createdFromRoundState: currentRound.roundState,
           hasOverlapPreparation,
-          currentLineupTags,
+          currentLineupTags: eligibleLineupTags,
           rosterRows,
         } as Prisma.InputJsonValue,
         days: planDays.map((day) => ({
@@ -1149,6 +1239,7 @@ export class CwlRotationService {
           metadata: {
             source: "manual",
             generatedFromRoundDay: currentRound.roundDay,
+            rosterRows: buildRosterRowsForMetadata(day.members),
           } as Prisma.InputJsonValue,
           members: day.members.map((member, index) => ({
             playerTag: member.playerTag,
@@ -1354,12 +1445,14 @@ export class CwlRotationService {
         availablePlayers: dedupedConfirmedSignups.length,
       };
     }
-    const rosterEntries = dedupedConfirmedSignups.map<CwlSeasonRosterEntry>((signup) => ({
+    const rosterEntries = dedupedConfirmedSignups.map<CwlRotationSeedRosterEntry>((signup, index) => ({
       season,
       clanTag,
       playerTag: signup.playerTag,
       playerName: signup.playerName,
       townHall: signup.townHall,
+      weight: signup.weight,
+      sourcePosition: index,
       linkedDiscordUserId: null,
       linkedDiscordUsername: null,
       daysParticipated: 0,

--- a/src/services/CwlRotationService.ts
+++ b/src/services/CwlRotationService.ts
@@ -1148,21 +1148,33 @@ export class CwlRotationService {
         })
         .filter((entry): entry is readonly [string, (typeof rosterSignups)[number]] => Boolean(entry)),
     );
+    const liveSourcePositionByTag = new Map(
+      currentRound.members
+        .map((member) => {
+          const playerTag = normalizePlayerTag(member.playerTag);
+          if (!playerTag) return null;
+          const sourcePosition = Number.isFinite(Number(member.mapPosition))
+            ? Math.trunc(Number(member.mapPosition))
+            : null;
+          return [playerTag, sourcePosition] as const;
+        })
+        .filter((entry): entry is readonly [string, number | null] => Boolean(entry)),
+    );
     const eligibleRosterEntriesBase = correspondingRoster
       ? seasonRoster
           .filter((entry) => rosterSignupByTag.has(entry.playerTag))
-          .map((entry, index) => {
+          .map((entry) => {
             const signup = rosterSignupByTag.get(entry.playerTag) ?? null;
             return {
               ...entry,
               weight: signup?.weight ?? entry.currentWeight ?? null,
-              sourcePosition: index,
+              sourcePosition: liveSourcePositionByTag.get(entry.playerTag) ?? null,
             };
           })
-      : seasonRoster.map((entry, index) => ({
+      : seasonRoster.map((entry) => ({
           ...entry,
           weight: entry.currentWeight ?? null,
-          sourcePosition: index,
+          sourcePosition: liveSourcePositionByTag.get(entry.playerTag) ?? null,
         }));
     const eligibleRosterEntries = eligibleRosterEntriesBase.filter(
       (entry) => !excludeTags.includes(entry.playerTag),
@@ -1193,10 +1205,7 @@ export class CwlRotationService {
     const sourceOrderedRoster = buildStableRosterOrder({
       roster: eligibleRosterEntries,
       currentLineupTags: eligibleLineupTags,
-    }).map((entry, index) => ({
-      ...entry,
-      sourcePosition: index,
-    }));
+    });
     const planDays = buildPlanDays({
       roster: sourceOrderedRoster,
       lineupSize,

--- a/src/services/CwlRotationSheetService.ts
+++ b/src/services/CwlRotationSheetService.ts
@@ -753,31 +753,39 @@ function buildExportTabValues(plan: CwlRotationPlanExport): string[][] {
       playerTag: string;
       playerName: string;
       assignmentOrder: number;
+      sourcePosition: number | null;
+      weight: number | null;
+      townHall: number | null;
       dayMap: Map<number, boolean>;
     }
   >();
 
+  const sortMode = resolveCwlRotationExportSortMode(plan);
   for (const day of plan.days) {
     for (const row of day.rows) {
       const existing = playerRows.get(row.playerTag) ?? {
         playerTag: row.playerTag,
         playerName: row.playerName,
         assignmentOrder: playerRows.size,
+        sourcePosition: row.sourcePosition ?? null,
+        weight: row.weight ?? null,
+        townHall: row.townHall ?? null,
         dayMap: new Map<number, boolean>(),
       };
       existing.playerName = existing.playerName || row.playerName;
       existing.assignmentOrder = Math.min(existing.assignmentOrder, row.assignmentOrder);
+      existing.sourcePosition =
+        existing.sourcePosition !== null ? existing.sourcePosition : row.sourcePosition ?? null;
+      existing.weight = existing.weight !== null ? existing.weight : row.weight ?? null;
+      existing.townHall = existing.townHall !== null ? existing.townHall : row.townHall ?? null;
       existing.dayMap.set(day.roundDay, !row.subbedOut);
       playerRows.set(row.playerTag, existing);
     }
   }
 
-  const orderedPlayers = [...playerRows.values()].sort((a, b) => {
-    if (a.assignmentOrder !== b.assignmentOrder) return a.assignmentOrder - b.assignmentOrder;
-    const byName = a.playerName.localeCompare(b.playerName, undefined, { sensitivity: "base" });
-    if (byName !== 0) return byName;
-    return a.playerTag.localeCompare(b.playerTag);
-  });
+  const orderedPlayers = [...playerRows.values()].sort((a, b) =>
+    compareCwlRotationExportPlayerRows(a, b, sortMode),
+  );
 
   for (const player of orderedPlayers) {
     const totalWars = [...player.dayMap.values()].filter(Boolean).length;
@@ -796,6 +804,84 @@ function buildExportTabValues(plan: CwlRotationPlanExport): string[][] {
     values.pop();
   }
   return values;
+}
+
+type CwlRotationExportSortMode = "live" | "roster" | "import" | "fallback";
+
+function resolveCwlRotationExportSortMode(plan: CwlRotationPlanExport): CwlRotationExportSortMode {
+  const metadata = plan.metadata;
+  const source = sanitizeCwlRotationExportTabText(String(metadata?.source ?? plan.sourceLabel ?? "")).toLowerCase();
+  if (source === "sheet-import") {
+    return "import";
+  }
+  if (plan.rosterId || metadata?.rosterId || source.startsWith("cwl roster")) {
+    return "roster";
+  }
+  if (source === "manual" || source.length > 0) {
+    return "live";
+  }
+  return "fallback";
+}
+
+function compareCwlRotationExportPlayerRows(
+  a: {
+    playerTag: string;
+    playerName: string;
+    assignmentOrder: number;
+    sourcePosition: number | null;
+    weight: number | null;
+    townHall: number | null;
+  },
+  b: {
+    playerTag: string;
+    playerName: string;
+    assignmentOrder: number;
+    sourcePosition: number | null;
+    weight: number | null;
+    townHall: number | null;
+  },
+  sortMode: CwlRotationExportSortMode,
+): number {
+  if (sortMode === "roster") {
+    const aHasWeight = a.weight !== null;
+    const bHasWeight = b.weight !== null;
+    if (aHasWeight !== bHasWeight) {
+      return aHasWeight ? -1 : 1;
+    }
+    if (aHasWeight && bHasWeight && a.weight !== b.weight) {
+      return (b.weight ?? -1) - (a.weight ?? -1);
+    }
+    if (!aHasWeight && !bHasWeight) {
+      const byTag = a.playerTag.localeCompare(b.playerTag);
+      if (byTag !== 0) return byTag;
+    }
+    const aTownHall = a.townHall ?? -1;
+    const bTownHall = b.townHall ?? -1;
+    if (aTownHall !== bTownHall) {
+      return bTownHall - aTownHall;
+    }
+    const byName = a.playerName.localeCompare(b.playerName, undefined, { sensitivity: "base" });
+    if (byName !== 0) return byName;
+    return a.playerTag.localeCompare(b.playerTag);
+  }
+
+  if (sortMode === "live") {
+    const aHasSource = a.sourcePosition !== null;
+    const bHasSource = b.sourcePosition !== null;
+    if (aHasSource !== bHasSource) {
+      return aHasSource ? -1 : 1;
+    }
+    if (aHasSource && bHasSource && a.sourcePosition !== b.sourcePosition) {
+      return (a.sourcePosition ?? 0) - (b.sourcePosition ?? 0);
+    }
+  }
+
+  if (a.assignmentOrder !== b.assignmentOrder) {
+    return a.assignmentOrder - b.assignmentOrder;
+  }
+  const byName = a.playerName.localeCompare(b.playerName, undefined, { sensitivity: "base" });
+  if (byName !== 0) return byName;
+  return a.playerTag.localeCompare(b.playerTag);
 }
 
 async function loadActiveRotationPlanVersion(input: {

--- a/src/services/CwlStateService.ts
+++ b/src/services/CwlStateService.ts
@@ -77,6 +77,8 @@ export type CwlSeasonRosterEntry = {
   playerTag: string;
   playerName: string;
   townHall: number | null;
+  currentWeight?: number | null;
+  role?: string | null;
   linkedDiscordUserId: string | null;
   linkedDiscordUsername: string | null;
   daysParticipated: number;
@@ -1992,7 +1994,7 @@ export class CwlStateService {
       orderBy: [{ lastRoundDay: "asc" }, { playerName: "asc" }, { playerTag: "asc" }],
     });
     const rosterTags = rosterRows.map((row) => row.playerTag);
-    const [currentRound, currentMembers, playerLinks] = await Promise.all([
+    const [currentRound, currentMembers, playerLinks, playerCurrents] = await Promise.all([
       prisma.currentCwlRound.findUnique({
         where: { season_clanTag: { season, clanTag } },
       }),
@@ -2010,13 +2012,27 @@ export class CwlStateService {
           discordUsername: true,
         },
       }),
+      prisma.playerCurrent.findMany({
+        where: {
+          playerTag: { in: rosterTags },
+        },
+        select: {
+          playerTag: true,
+          currentWeight: true,
+          role: true,
+        },
+      }),
     ]);
 
     const currentMemberByTag = new Map(currentMembers.map((member) => [member.playerTag, member]));
     const playerLinkByTag = new Map(playerLinks.map((row) => [row.playerTag, row]));
+    const playerCurrentByTag = new Map(
+      playerCurrents.map((row) => [row.playerTag, row]),
+    );
     return rosterRows.map((row) => {
       const currentMember = currentMemberByTag.get(row.playerTag) ?? null;
       const playerLink = playerLinkByTag.get(row.playerTag) ?? null;
+      const playerCurrent = playerCurrentByTag.get(row.playerTag) ?? null;
       return {
         season: row.season,
         clanTag: row.cwlClanTag,
@@ -2027,6 +2043,8 @@ export class CwlStateService {
           sanitizeCwlName(currentMember?.playerName) ??
           row.playerTag,
         townHall: currentMember?.townHall ?? row.townHall,
+        currentWeight: playerCurrent?.currentWeight ?? null,
+        role: playerCurrent?.role ?? null,
         linkedDiscordUserId: playerLink?.discordUserId ?? null,
         linkedDiscordUsername: playerLink?.discordUsername ?? null,
         daysParticipated: Math.max(0, Math.trunc(Number(row.daysParticipated ?? 0) || 0)),

--- a/tests/cwl.command.test.ts
+++ b/tests/cwl.command.test.ts
@@ -12,6 +12,12 @@ const prismaMock = vi.hoisted(() => ({
     findMany: vi.fn(),
     findFirst: vi.fn(),
   },
+  cwlPlayerClanSeason: {
+    findMany: vi.fn(),
+  },
+  playerCurrent: {
+    findMany: vi.fn(),
+  },
 }));
 
 vi.mock("../src/prisma", () => ({
@@ -333,6 +339,9 @@ describe("/cwl command", () => {
     vi.spyOn(cwlRotationService, "validatePlanDay");
     vi.spyOn(cwlStateService, "getBattleDayStartForClanDay").mockResolvedValue(null);
     vi.spyOn(cwlStateService, "getParticipationCountsForClanDay").mockResolvedValue(new Map());
+    prismaMock.cwlPlayerClanSeason.findMany.mockResolvedValue([]);
+    prismaMock.playerCurrent.findMany.mockResolvedValue([]);
+    vi.spyOn(cwlStateService, "listSeasonRosterForClan").mockResolvedValue([] as any);
     vi.spyOn(emojiResolverService, "fetchApplicationEmojiInventory").mockResolvedValue(makeCwlEmojiInventory());
   });
 
@@ -1225,6 +1234,7 @@ describe("/cwl command", () => {
       excludeTagsRaw: "#P9",
       lineupSize: 15,
       overwrite: true,
+      guildId: "guild-1",
     });
     expect(getDescription(interaction)).toContain("Created CWL rotation plan for #2QG2C08UP.");
     expect(getDescription(interaction)).toContain("Version: 2");
@@ -1253,6 +1263,7 @@ describe("/cwl command", () => {
       excludeTagsRaw: null,
       lineupSize: null,
       overwrite: false,
+      guildId: "guild-1",
     });
     expect(String(interaction.editReply.mock.calls.at(-1)?.[0] ?? "")).toBe(
       "A CWL rotation plan already exists for #2QG2C08UP this season. Use overwrite:true to replace version 4.",
@@ -1280,6 +1291,7 @@ describe("/cwl command", () => {
       excludeTagsRaw: null,
       lineupSize: 20,
       overwrite: false,
+      guildId: "guild-1",
     });
     expect(String(interaction.editReply.mock.calls.at(-1)?.[0] ?? "")).toBe(
       "CWL rotation lineup size must be 15 or 30.",

--- a/tests/cwlRotation.service.test.ts
+++ b/tests/cwlRotation.service.test.ts
@@ -1541,6 +1541,135 @@ describe("CwlRotationService", () => {
     );
   });
 
+  it("persists live CWL source positions from the current lineup map order", async () => {
+    vi.spyOn(cwlStateService, "getCurrentRoundForClan").mockResolvedValue({
+      season: "2026-04",
+      clanTag: "#2QG2C08UP",
+      clanName: "CWL Alpha",
+      roundDay: 2,
+      roundState: "preparation",
+      opponentTag: "#OPP1",
+      opponentName: "Opponent One",
+      teamSize: 15,
+      attacksPerMember: 1,
+      preparationStartTime: new Date("2026-04-02T12:00:00.000Z"),
+      startTime: new Date("2026-04-03T12:00:00.000Z"),
+      endTime: new Date("2026-04-04T12:00:00.000Z"),
+      sourceUpdatedAt: new Date("2026-04-02T00:00:00.000Z"),
+      members: [
+        {
+          season: "2026-04",
+          clanTag: "#2QG2C08UP",
+          playerTag: "#PYLQ0289",
+          roundDay: 2,
+          playerName: "Alpha",
+          mapPosition: 10,
+          townHall: 16,
+          attacksUsed: 0,
+          attacksAvailable: 0,
+          stars: 0,
+          destruction: 0,
+          subbedIn: true,
+          subbedOut: false,
+        },
+        {
+          season: "2026-04",
+          clanTag: "#2QG2C08UP",
+          playerTag: "#QGRJ2222",
+          roundDay: 2,
+          playerName: "Bravo",
+          mapPosition: 20,
+          townHall: 15,
+          attacksUsed: 0,
+          attacksAvailable: 0,
+          stars: 0,
+          destruction: 0,
+          subbedIn: true,
+          subbedOut: false,
+        },
+        {
+          season: "2026-04",
+          clanTag: "#2QG2C08UP",
+          playerTag: "#CUV9082",
+          roundDay: 2,
+          playerName: "Charlie",
+          mapPosition: 30,
+          townHall: 15,
+          attacksUsed: 0,
+          attacksAvailable: 0,
+          stars: 0,
+          destruction: 0,
+          subbedIn: true,
+          subbedOut: false,
+        },
+      ],
+    });
+    vi.spyOn(cwlStateService, "listSeasonRosterForClan").mockResolvedValue([
+      {
+        season: "2026-04",
+        clanTag: "#2QG2C08UP",
+        playerTag: "#PYLQ0289",
+        playerName: "Alpha",
+        townHall: 16,
+        linkedDiscordUserId: null,
+        linkedDiscordUsername: null,
+        daysParticipated: 0,
+        currentRound: null,
+      },
+      {
+        season: "2026-04",
+        clanTag: "#2QG2C08UP",
+        playerTag: "#QGRJ2222",
+        playerName: "Bravo",
+        townHall: 15,
+        linkedDiscordUserId: null,
+        linkedDiscordUsername: null,
+        daysParticipated: 0,
+        currentRound: null,
+      },
+      {
+        season: "2026-04",
+        clanTag: "#2QG2C08UP",
+        playerTag: "#CUV9082",
+        playerName: "Charlie",
+        townHall: 15,
+        linkedDiscordUserId: null,
+        linkedDiscordUsername: null,
+        daysParticipated: 0,
+        currentRound: null,
+      },
+    ]);
+
+    const result = await cwlRotationService.createPlan({
+      clanTag: "#2QG2C08UP",
+      season: "2026-04",
+    });
+
+    expect(result.outcome).toBe("created");
+    expect(txMock.cwlRotationPlan.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          metadata: expect.objectContaining({
+            rosterRows: [
+              expect.objectContaining({
+                playerTag: "#PYLQ0289",
+                sourcePosition: 10,
+              }),
+              expect.objectContaining({
+                playerTag: "#QGRJ2222",
+                sourcePosition: 20,
+              }),
+              expect.objectContaining({
+                playerTag: "#CUV9082",
+                sourcePosition: 30,
+              }),
+            ],
+          }),
+        }),
+      }),
+    );
+  });
+
   it("prefers the prep snapshot day in overview during overlap", async () => {
     prismaMock.cwlRotationPlan.findMany.mockResolvedValue([
       {

--- a/tests/cwlRotationSheet.service.test.ts
+++ b/tests/cwlRotationSheet.service.test.ts
@@ -695,6 +695,99 @@ describe("CwlRotationSheetService", () => {
     });
   });
 
+  it("keeps live/manual export rows ordered by stored source position rather than assignment order", async () => {
+    vi.spyOn(cwlRotationService, "listActivePlanExports").mockResolvedValue([
+      {
+        season: "2026-04",
+        clanTag: "#2QG2C08UP",
+        clanName: "Rising Thrones",
+        rosterId: null,
+        rosterTitle: null,
+        rosterShortName: null,
+        clanDisplayName: "Rising Thrones",
+        sourceLabel: "manual",
+        version: 5,
+        rosterSize: 3,
+        generatedFromRoundDay: 2,
+        excludedPlayerTags: [],
+        warningSummary: null,
+        metadata: { source: "manual" },
+        days: [
+          {
+            roundDay: 1,
+            lineupSize: 3,
+            locked: false,
+            metadata: { source: "manual" },
+            rows: [
+              {
+                playerTag: "#PYLQ0289",
+                playerName: "Alpha",
+                subbedOut: false,
+                assignmentOrder: 2,
+                sourcePosition: 30,
+              },
+              {
+                playerTag: "#QGRJ2222",
+                playerName: "Bravo",
+                subbedOut: false,
+                assignmentOrder: 0,
+                sourcePosition: 10,
+              },
+              {
+                playerTag: "#CUV9082",
+                playerName: "Charlie",
+                subbedOut: false,
+                assignmentOrder: 1,
+                sourcePosition: 20,
+              },
+            ],
+          },
+        ],
+      },
+    ]);
+    const createSpreadsheet = vi
+      .spyOn(GoogleSheetsService.prototype, "createSpreadsheet")
+      .mockResolvedValue({
+        spreadsheetId: "sheet-live",
+        spreadsheetUrl: "https://docs.google.com/spreadsheets/d/sheet-live/edit?usp=sharing",
+      });
+    const writeTabs = vi
+      .spyOn(GoogleSheetsService.prototype, "writeSpreadsheetTabs")
+      .mockResolvedValue(undefined);
+    const publicSpy = vi
+      .spyOn(GoogleSheetsService.prototype, "makeSpreadsheetPublic")
+      .mockResolvedValue(undefined);
+
+    const result = await cwlRotationSheetService.exportActivePlans({
+      season: "2026-04",
+    });
+
+    expect(createSpreadsheet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tabNames: ["manual | Rising Thrones"],
+      }),
+    );
+    const exportedTabValues = (writeTabs.mock.calls[0]?.[0] as any)?.tabs?.[0]?.values as string[][] | undefined;
+    expect(exportedTabValues).toEqual([
+      ["Season: 2026-04"],
+      ["Roster: manual"],
+      ["Clan: Rising Thrones"],
+      ["Clan Tag: #2QG2C08UP"],
+      [],
+      ["Member", "Player Tag", "Total Wars", "Day 1", "Day 2", "Day 3", "Day 4", "Day 5", "Day 6", "Day 7"],
+      ["Bravo", "#QGRJ2222", "1", "IN", "OUT", "OUT", "OUT", "OUT", "OUT", "OUT"],
+      ["Charlie", "#CUV9082", "1", "IN", "OUT", "OUT", "OUT", "OUT", "OUT", "OUT"],
+      ["Alpha", "#PYLQ0289", "1", "IN", "OUT", "OUT", "OUT", "OUT", "OUT", "OUT"],
+    ]);
+    expect(result).toEqual({
+      spreadsheetId: "sheet-live",
+      spreadsheetUrl: "https://docs.google.com/spreadsheets/d/sheet-live/edit?usp=sharing",
+      tabCount: 1,
+      reused: false,
+    });
+    expect(publicSpy).toHaveBeenCalledWith("sheet-live");
+  });
+
   it("reuses the same-season export link when the export fingerprint has not changed", async () => {
     vi.spyOn(cwlRotationService, "listActivePlanExports").mockResolvedValue([
       {

--- a/tests/cwlState.service.test.ts
+++ b/tests/cwlState.service.test.ts
@@ -47,6 +47,9 @@ const prismaMock = vi.hoisted(() => ({
   cwlPlayerClanSeason: {
     findMany: vi.fn(),
   },
+  playerCurrent: {
+    findMany: vi.fn(),
+  },
   playerLink: {
     findMany: vi.fn(),
   },
@@ -70,6 +73,7 @@ describe("CwlStateService", () => {
     prismaMock.cwlRoundHistory.findUnique.mockResolvedValue(null);
     prismaMock.cwlRoundMemberHistory.findMany.mockResolvedValue([]);
     prismaMock.cwlPlayerClanSeason.findMany.mockResolvedValue([]);
+    prismaMock.playerCurrent.findMany.mockResolvedValue([]);
     prismaMock.playerLink.findMany.mockResolvedValue([]);
 
     txMock.currentCwlRound.upsert.mockResolvedValue(undefined);
@@ -1064,6 +1068,13 @@ describe("CwlStateService", () => {
         lastRoundDay: 1,
       },
     ]);
+    prismaMock.playerCurrent.findMany.mockResolvedValue([
+      {
+        playerTag: "#PYLQ0289",
+        currentWeight: 177,
+        role: "leader",
+      },
+    ]);
     prismaMock.currentCwlRound.findUnique.mockResolvedValue({
       season: "2026-04",
       clanTag: "#2QG2C08UP",
@@ -1120,6 +1131,8 @@ describe("CwlStateService", () => {
           linkedDiscordUserId: "111111111111111111",
           linkedDiscordUsername: "alpha-user",
           daysParticipated: 2,
+          currentWeight: 177,
+          role: "leader",
           currentRound: expect.objectContaining({
             roundDay: 3,
             inCurrentLineup: true,


### PR DESCRIPTION
- seed current CWL rotations from the corresponding roster and respect excludes
- sort members and exports by roster/weight/source position, with clearer show warnings