### PR TITLE
fix(cwl): harden expired select-menu interactions

### DIFF
--- a/src/commands/Cwl.ts
+++ b/src/commands/Cwl.ts
@@ -3298,6 +3298,38 @@ export async function handleCwlRotationShowButtonInteraction(
   });
 }
 
+function getDiscordErrorCode(err: unknown): number | null {
+  const code = (err as { code?: number } | null | undefined)?.code;
+  return typeof code === "number" ? code : null;
+}
+
+async function respondBestEffortToCwlRotationShowFailure(
+  interaction: StringSelectMenuInteraction,
+  content: string,
+): Promise<void> {
+  const payload = {
+    ephemeral: true,
+    content,
+  };
+
+  try {
+    if (interaction.deferred || interaction.replied) {
+      await interaction.followUp(payload);
+      return;
+    }
+
+    await interaction.reply(payload);
+  } catch (responseError) {
+    const code = getDiscordErrorCode(responseError);
+    if (code === 10062) {
+      console.warn("CWL rotation show fallback response expired before response (10062).");
+      return;
+    }
+
+    console.error(`CWL rotation show fallback response failed: ${formatError(responseError)}`);
+  }
+}
+
 export async function handleCwlRotationShowSelectMenuInteraction(
   interaction: StringSelectMenuInteraction,
 ): Promise<void> {
@@ -3335,10 +3367,24 @@ export async function handleCwlRotationShowSelectMenuInteraction(
     return;
   }
 
-  await interaction.update({
-    embeds: [renderPayload.payload.embed],
-    components: renderPayload.payload.components,
-  });
+  try {
+    await interaction.update({
+      embeds: [renderPayload.payload.embed],
+      components: renderPayload.payload.components,
+    });
+  } catch (err) {
+    const code = getDiscordErrorCode(err);
+    if (code === 10062) {
+      console.warn("CWL rotation show select menu expired before update (10062).");
+      return;
+    }
+
+    console.error(`CWL rotation show select menu failed: ${formatError(err)}`);
+    await respondBestEffortToCwlRotationShowFailure(
+      interaction,
+      "Failed to update the CWL rotation show overview.",
+    );
+  }
 }
 
 export async function handleRosterSignupButtonInteraction(

--- a/src/listeners/interactionCreate.ts
+++ b/src/listeners/interactionCreate.ts
@@ -213,12 +213,22 @@ function getInteractionSubcommandPath(interaction: ChatInputCommandInteraction):
   return "";
 }
 
-async function respondBestEffortToRosterCustomizeFailure(
+async function handleBestEffortSelectMenuFailure(
   interaction: StringSelectMenuInteraction,
+  context: string,
+  fallbackContent: string,
+  err: unknown,
 ): Promise<void> {
+  const code = getDiscordErrorCode(err);
+  if (code === 10062) {
+    console.warn(`${context} expired before response (10062).`);
+    return;
+  }
+
+  console.error(`${context} failed: ${formatError(err)}`);
   const payload = {
     ephemeral: true,
-    content: "Failed to update roster customization.",
+    content: fallbackContent,
   };
 
   try {
@@ -229,7 +239,13 @@ async function respondBestEffortToRosterCustomizeFailure(
 
     await interaction.reply(payload);
   } catch (responseError) {
-    console.warn(`Roster customize fallback response failed: ${formatError(responseError)}`);
+    const responseCode = getDiscordErrorCode(responseError);
+    if (responseCode === 10062) {
+      console.warn(`${context} fallback response expired before response (10062).`);
+      return;
+    }
+
+    console.error(`${context} fallback response failed: ${formatError(responseError)}`);
   }
 }
 
@@ -417,13 +433,12 @@ const handleSelectMenuInteraction = async (
     try {
       await handleRosterSelectionMenuInteraction(interaction);
     } catch (err) {
-      console.error(`Roster selection menu failed: ${formatError(err)}`);
-      if (!interaction.replied && !interaction.deferred) {
-        await interaction.reply({
-          ephemeral: true,
-          content: "Failed to update roster selection.",
-        });
-      }
+      await handleBestEffortSelectMenuFailure(
+        interaction,
+        "Roster selection menu",
+        "Failed to update roster selection.",
+        err,
+      );
     }
     return;
   }
@@ -432,13 +447,12 @@ const handleSelectMenuInteraction = async (
     try {
       await handleRosterManageAccountSelectInteraction(interaction);
     } catch (err) {
-      console.error(`Roster manage account menu failed: ${formatError(err)}`);
-      if (!interaction.replied && !interaction.deferred) {
-        await interaction.reply({
-          ephemeral: true,
-          content: "Failed to update roster manage accounts.",
-        });
-      }
+      await handleBestEffortSelectMenuFailure(
+        interaction,
+        "Roster manage account menu",
+        "Failed to update roster manage accounts.",
+        err,
+      );
     }
     return;
   }
@@ -447,13 +461,12 @@ const handleSelectMenuInteraction = async (
     try {
       await handleRosterManageGroupSelectInteraction(interaction);
     } catch (err) {
-      console.error(`Roster manage group menu failed: ${formatError(err)}`);
-      if (!interaction.replied && !interaction.deferred) {
-        await interaction.reply({
-          ephemeral: true,
-          content: "Failed to update roster manage groups.",
-        });
-      }
+      await handleBestEffortSelectMenuFailure(
+        interaction,
+        "Roster manage group menu",
+        "Failed to update roster manage groups.",
+        err,
+      );
     }
     return;
   }
@@ -462,13 +475,12 @@ const handleSelectMenuInteraction = async (
     try {
       await handleRosterManageRosterSelectInteraction(interaction);
     } catch (err) {
-      console.error(`Roster manage roster menu failed: ${formatError(err)}`);
-      if (!interaction.replied && !interaction.deferred) {
-        await interaction.reply({
-          ephemeral: true,
-          content: "Failed to update roster manage target roster.",
-        });
-      }
+      await handleBestEffortSelectMenuFailure(
+        interaction,
+        "Roster manage roster menu",
+        "Failed to update roster manage target roster.",
+        err,
+      );
     }
     return;
   }
@@ -477,13 +489,12 @@ const handleSelectMenuInteraction = async (
     try {
       await handleRosterSelectionMenuInteraction(interaction);
     } catch (err) {
-      console.error(`Roster selection group menu failed: ${formatError(err)}`);
-      if (!interaction.replied && !interaction.deferred) {
-        await interaction.reply({
-          ephemeral: true,
-          content: "Failed to update roster selection.",
-        });
-      }
+      await handleBestEffortSelectMenuFailure(
+        interaction,
+        "Roster selection group menu",
+        "Failed to update roster selection.",
+        err,
+      );
     }
     return;
   }
@@ -492,13 +503,12 @@ const handleSelectMenuInteraction = async (
     try {
       await handleRosterPostSettingsPlayerSelectInteraction(interaction);
     } catch (err) {
-      console.error(`Roster settings player menu failed: ${formatError(err)}`);
-      if (!interaction.replied && !interaction.deferred) {
-        await interaction.reply({
-          ephemeral: true,
-          content: "Failed to update roster settings.",
-        });
-      }
+      await handleBestEffortSelectMenuFailure(
+        interaction,
+        "Roster settings player menu",
+        "Failed to update roster settings.",
+        err,
+      );
     }
     return;
   }
@@ -507,13 +517,12 @@ const handleSelectMenuInteraction = async (
     try {
       await handleRosterPostSettingsGroupSelectInteraction(interaction);
     } catch (err) {
-      console.error(`Roster settings group menu failed: ${formatError(err)}`);
-      if (!interaction.replied && !interaction.deferred) {
-        await interaction.reply({
-          ephemeral: true,
-          content: "Failed to update roster settings.",
-        });
-      }
+      await handleBestEffortSelectMenuFailure(
+        interaction,
+        "Roster settings group menu",
+        "Failed to update roster settings.",
+        err,
+      );
     }
     return;
   }
@@ -522,13 +531,12 @@ const handleSelectMenuInteraction = async (
     try {
       await handleRosterPostSettingsMenuInteraction(interaction, cocService);
     } catch (err) {
-      console.error(`Roster settings menu failed: ${formatError(err)}`);
-      if (!interaction.replied && !interaction.deferred) {
-        await interaction.reply({
-          ephemeral: true,
-          content: "Failed to update roster settings.",
-        });
-      }
+      await handleBestEffortSelectMenuFailure(
+        interaction,
+        "Roster settings menu",
+        "Failed to update roster settings.",
+        err,
+      );
     }
     return;
   }
@@ -537,8 +545,12 @@ const handleSelectMenuInteraction = async (
     try {
       await handleRosterPostCustomizeMenuInteraction(interaction, cocService);
     } catch (err) {
-      console.error(`Roster customize menu failed: ${formatError(err)}`);
-      await respondBestEffortToRosterCustomizeFailure(interaction);
+      await handleBestEffortSelectMenuFailure(
+        interaction,
+        "Roster customize menu",
+        "Failed to update roster customization.",
+        err,
+      );
     }
     return;
   }
@@ -547,13 +559,12 @@ const handleSelectMenuInteraction = async (
     try {
       await handleCwlRotationImportSelectMenuInteraction(interaction);
     } catch (err) {
-      console.error(`CWL rotation import select menu failed: ${formatError(err)}`);
-      if (!interaction.replied && !interaction.deferred) {
-        await interaction.reply({
-          ephemeral: true,
-          content: "Failed to update the CWL rotation import review.",
-        });
-      }
+      await handleBestEffortSelectMenuFailure(
+        interaction,
+        "CWL rotation import select menu",
+        "Failed to update the CWL rotation import review.",
+        err,
+      );
     }
     return;
   }
@@ -562,13 +573,12 @@ const handleSelectMenuInteraction = async (
     try {
       await handleCwlRotationShowSelectMenuInteraction(interaction);
     } catch (err) {
-      console.error(`CWL rotation show select menu failed: ${formatError(err)}`);
-      if (!interaction.replied && !interaction.deferred) {
-        await interaction.reply({
-          ephemeral: true,
-          content: "Failed to update the CWL rotation show overview.",
-        });
-      }
+      await handleBestEffortSelectMenuFailure(
+        interaction,
+        "CWL rotation show select menu",
+        "Failed to update the CWL rotation show overview.",
+        err,
+      );
     }
     return;
   }
@@ -577,13 +587,12 @@ const handleSelectMenuInteraction = async (
     try {
       await handleLinkListSelectMenu(interaction, cocService);
     } catch (err) {
-      console.error(`Link list select menu failed: ${formatError(err)}`);
-      if (!interaction.replied && !interaction.deferred) {
-        await interaction.reply({
-          ephemeral: true,
-          content: "Failed to update link list view.",
-        });
-      }
+      await handleBestEffortSelectMenuFailure(
+        interaction,
+        "Link list select menu",
+        "Failed to update link list view.",
+        err,
+      );
     }
     return;
   }
@@ -592,13 +601,12 @@ const handleSelectMenuInteraction = async (
     try {
       await handleFwaMatchSelectMenu(interaction);
     } catch (err) {
-      console.error(`FWA match select menu failed: ${formatError(err)}`);
-      if (!interaction.replied && !interaction.deferred) {
-        await interaction.reply({
-          ephemeral: true,
-          content: "Failed to open clan match view.",
-        });
-      }
+      await handleBestEffortSelectMenuFailure(
+        interaction,
+        "FWA match select menu",
+        "Failed to open clan match view.",
+        err,
+      );
     }
     return;
   }
@@ -607,13 +615,12 @@ const handleSelectMenuInteraction = async (
     try {
       await handleCompoAdviceClanSelectMenuInteraction(interaction);
     } catch (err) {
-      console.error(`Compo advice clan select menu failed: ${formatError(err)}`);
-      if (!interaction.replied && !interaction.deferred) {
-        await interaction.reply({
-          ephemeral: true,
-          content: "Failed to update compo advice clan selection.",
-        });
-      }
+      await handleBestEffortSelectMenuFailure(
+        interaction,
+        "Compo advice clan select menu",
+        "Failed to update compo advice clan selection.",
+        err,
+      );
     }
     return;
   }

--- a/tests/cwl.command.test.ts
+++ b/tests/cwl.command.test.ts
@@ -2060,6 +2060,97 @@ describe("/cwl command", () => {
     expect(getComponentSelectMenuCustomIds(backInteraction)).toHaveLength(1);
   });
 
+  it("falls back best-effort when the CWL rotation show select update fails and the fallback reply expires", async () => {
+    vi.mocked(cwlRotationService.listOverview).mockResolvedValue([
+      {
+        season: "2026-04",
+        clanTag: "#2QG2C08UP",
+        clanName: "CWL Alpha",
+        version: 4,
+        roundDay: 2,
+        battleDayStartAt: new Date("2026-04-03T12:00:00.000Z"),
+        leaderNames: ["Charlie"],
+        status: "complete",
+        missingExpectedPlayerTags: [],
+        extraActualPlayerTags: [],
+      },
+    ] as any);
+    vi.mocked(cwlRotationService.listActivePlanExports).mockResolvedValue([
+      {
+        season: "2026-04",
+        clanTag: "#2QG2C08UP",
+        clanName: "CWL Alpha",
+        version: 4,
+        warningSummary: null,
+        excludedPlayerTags: [],
+        days: [
+          {
+            roundDay: 2,
+            lineupSize: 2,
+            rows: [
+              { playerTag: "#VJQ28888", playerName: "Charlie", subbedOut: false, assignmentOrder: 0 },
+              { playerTag: "#CUV02898", playerName: "Delta", subbedOut: false, assignmentOrder: 1 },
+            ],
+            actual: null,
+          },
+        ],
+      } as any,
+    ]);
+    vi.mocked(cwlRotationService.getPreferredDisplayDay).mockResolvedValue(2);
+    vi.mocked(cwlRotationService.validatePlanDay).mockResolvedValue({
+      actualAvailable: true,
+      complete: true,
+      missingExpectedPlayerTags: [],
+      extraActualPlayerTags: [],
+      actualPlayerTags: ["#VJQ28888", "#CUV02898"],
+      actualPlayerNames: ["Charlie", "Delta"],
+    } as any);
+    vi.mocked(cwlStateService.getBattleDayStartForClanDay).mockResolvedValue(
+      new Date("2026-04-03T12:00:00.000Z"),
+    );
+    vi.mocked(cwlStateService.getParticipationCountsForClanDay).mockResolvedValue(
+      makeParticipationCounts([
+        ["#VJQ28888", 1],
+        ["#CUV02898", 1],
+      ]),
+    );
+    vi.mocked(cwlStateService.listSeasonRosterForClan).mockResolvedValue([
+      {
+        season: "2026-04",
+        clanTag: "#2QG2C08UP",
+        playerTag: "#VJQ28888",
+        playerName: "Charlie",
+        townHall: 16,
+        linkedDiscordUserId: null,
+        linkedDiscordUsername: null,
+        daysParticipated: 1,
+        currentRound: null,
+      },
+    ]);
+
+    const overviewInteraction = makeInteraction({
+      group: "rotations",
+      subcommand: "show",
+    });
+    await Cwl.run({} as any, overviewInteraction as any);
+    const selectId = getComponentSelectMenuCustomIds(overviewInteraction)[0];
+    expect(selectId).toBeTruthy();
+
+    const expiredSelectInteraction = {
+      customId: selectId,
+      values: ["#2QG2C08UP"],
+      user: { id: "111111111111111111" },
+      update: vi.fn().mockRejectedValue(Object.assign(new Error("Unknown interaction"), { code: 10062 })),
+      reply: vi.fn().mockResolvedValue(undefined),
+      followUp: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await expect(handleCwlRotationShowSelectMenuInteraction(expiredSelectInteraction as any)).resolves.toBeUndefined();
+    expect(expiredSelectInteraction.update).toHaveBeenCalledTimes(1);
+    expect(expiredSelectInteraction.reply).not.toHaveBeenCalled();
+    expect(expiredSelectInteraction.followUp).not.toHaveBeenCalled();
+  });
+
   it("returns to a refreshed overview and reflects updated status after detail refresh", async () => {
     const alphaBattleDay = Math.floor(new Date("2026-04-03T12:00:00.000Z").getTime() / 1000);
     vi.mocked(cwlRotationService.listOverview)

--- a/tests/interactionCreate.rosterCustomize.test.ts
+++ b/tests/interactionCreate.rosterCustomize.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Client } from "discord.js";
+import { handleRosterPostCustomizeMenuInteraction } from "../src/commands/Roster";
 
 vi.mock("../src/commands/Roster", async () => {
   const actual = await vi.importActual<typeof import("../src/commands/Roster")>(
@@ -69,6 +70,21 @@ describe("interactionCreate roster customize fallback", () => {
     await expect(handler(interaction as any)).resolves.toBeUndefined();
 
     expect(interaction.reply).toHaveBeenCalled();
+    expect(interaction.followUp).not.toHaveBeenCalled();
+  }, 30000);
+
+  it("returns without attempting a fallback response when the select interaction already expired", async () => {
+    vi.mocked(handleRosterPostCustomizeMenuInteraction).mockRejectedValueOnce(
+      Object.assign(new Error("Unknown interaction"), { code: 10062 }),
+    );
+    const handler = await loadInteractionHandler();
+    const interaction = makeRosterCustomizeInteraction();
+    interaction.reply = vi.fn().mockResolvedValue(undefined);
+    interaction.followUp = vi.fn().mockResolvedValue(undefined);
+
+    await expect(handler(interaction as any)).resolves.toBeUndefined();
+
+    expect(interaction.reply).not.toHaveBeenCalled();
     expect(interaction.followUp).not.toHaveBeenCalled();
   }, 30000);
 });


### PR DESCRIPTION
- ignore 10062 errors in the interaction listener without retrying replies
- make CWL rotation show select menus best-effort when fallback responses expire