### PR TITLE
feat(sync): post and update public spin status

### DIFF
--- a/src/commands/Post.ts
+++ b/src/commands/Post.ts
@@ -4,12 +4,10 @@ import {
   AutocompleteInteraction,
   ChatInputCommandInteraction,
   Client,
-  EmbedBuilder,
-  GuildMember,
-  type MessageMentionOptions,
   ModalBuilder,
   ModalSubmitInteraction,
   PermissionFlagsBits,
+  MessageMentionOptions,
   TextInputBuilder,
   TextInputStyle,
   type Guild,
@@ -28,7 +26,11 @@ import {
   FWA_LEADER_ROLE_SETTING_KEY,
 } from "../services/CommandPermissionService";
 import { SettingsService } from "../services/SettingsService";
-import { trackedMessageService } from "../services/TrackedMessageService";
+import {
+  buildSyncSpinStatusEmbed,
+  parseSyncTimeMetadata,
+  trackedMessageService,
+} from "../services/TrackedMessageService";
 import {
   autocompleteSyncTimeZones,
   normalizeSyncTimeZone,
@@ -236,23 +238,6 @@ async function getSyncBadgesWithTrackedClanFallback(
   return badges;
 }
 
-function parseAllowedRoleIds(raw: string | null): string[] {
-  if (!raw) return [];
-  return [...new Set(raw.split(",").map((s) => s.trim()).filter((s) => /^\d+$/.test(s)))];
-}
-
-async function getLeaderRoleIds(settings: SettingsService, guildId: string): Promise<string[]> {
-  const preferredRole = await settings.get(`${FWA_LEADER_ROLE_SETTING_KEY}:${guildId}`);
-  if (preferredRole && /^\d+$/.test(preferredRole.trim())) {
-    return [preferredRole.trim()];
-  }
-  // Preferred: guild-scoped fwa leader role (new default permission model).
-  // Fallback: command role whitelist for backwards compatibility.
-  const syncRoles = parseAllowedRoleIds(await settings.get("command_roles:sync:time:post"));
-  if (syncRoles.length > 0) return syncRoles;
-  return parseAllowedRoleIds(await settings.get("command_roles:sync"));
-}
-
 function activeSyncPostKey(guildId: string): string {
   return `active_sync_post:${guildId}`;
 }
@@ -366,116 +351,21 @@ async function handleSyncStatusSubcommand(
     return;
   }
 
-  const badges = await getSyncBadgesWithTrackedClanFallback(
-    interaction.client.user?.id,
-    interaction.guild
-  );
-  if (badges.length === 0) {
-    await interaction.editReply(
-      "No clan badge emoji configuration found."
-    );
+  const tracked = await trackedMessageService.fetchSyncTrackedMessageWithClaims(message.id);
+  const metadata = tracked ? parseSyncTimeMetadata(tracked.metadata) : null;
+  if (!tracked || tracked.status !== "ACTIVE" || tracked.featureType !== "SYNC_TIME_POST" || !metadata) {
+    await interaction.editReply("Could not find tracked sync status for that message.");
     return;
   }
 
-  const leaderRoleIds = await getLeaderRoleIds(settings, guild.id);
-  const memberCache = new Map<string, GuildMember | null>();
-  const getMember = async (userId: string): Promise<GuildMember | null> => {
-    if (memberCache.has(userId)) return memberCache.get(userId) ?? null;
-    const member = await guild.members.fetch(userId).catch(() => null);
-    memberCache.set(userId, member);
-    return member;
-  };
-
-  const claimedLines: string[] = [];
-  const unclaimedLines: string[] = [];
-  const unavailableUsers: string[] = [];
-
-  for (const badge of badges) {
-    const reaction = [...message.reactions.cache.values()].find((r) =>
-      reactionMatchesBadge(r, badge)
-    );
-    const claimedBy: string[] = [];
-    const nonLeader: string[] = [];
-
-    if (reaction) {
-      const users = await reaction.users.fetch().catch(() => null);
-      if (users) {
-        for (const user of users.values()) {
-          if (user.bot) continue;
-          const member = await getMember(user.id);
-          if (!member) continue;
-
-          const isAdmin = member.permissions.has(PermissionFlagsBits.Administrator);
-          const hasLeaderRole =
-            leaderRoleIds.length > 0 &&
-            leaderRoleIds.some((roleId) => member.roles.cache.has(roleId));
-          if (isAdmin || hasLeaderRole) {
-            claimedBy.push(`<@${user.id}>`);
-          } else {
-            nonLeader.push(`<@${user.id}>`);
-          }
-        }
-      }
-    }
-
-    const emojiInline = badge.emojiInline;
-    if (claimedBy.length > 0) {
-      const extra =
-        nonLeader.length > 0 ? ` | non-leader: ${[...new Set(nonLeader)].join(", ")}` : "";
-      claimedLines.push(
-        `- ${emojiInline} **${badge.code}** (${badge.label}) - ${[...new Set(claimedBy)].join(", ")}${extra}`
-      );
-    } else {
-      const extra =
-        nonLeader.length > 0 ? ` (only non-leader: ${[...new Set(nonLeader)].join(", ")})` : "";
-      unclaimedLines.push(`- ${emojiInline} **${badge.code}** (${badge.label})${extra}`);
-    }
-  }
-
-  const unavailableReaction = [...message.reactions.cache.values()].find(
-    (reaction) => !reaction.emoji.id && reaction.emoji.name === SYNC_UNAVAILABLE_EMOJI
-  );
-  if (unavailableReaction) {
-    const users = await unavailableReaction.users.fetch().catch(() => null);
-    if (users) {
-      for (const user of users.values()) {
-        if (user.bot) continue;
-        unavailableUsers.push(`<@${user.id}>`);
-      }
-    }
-  }
-
-  const embed = new EmbedBuilder()
-    .setTitle("Sync Claim Status")
-    .setDescription(
-      [
-        `Message: https://discord.com/channels/${guild.id}/${message.channelId}/${message.id}`,
-        (() => {
-          const epoch = extractSyncEpochSeconds(message.content);
-          return epoch
-            ? `Sync time: <t:${epoch}:F> (<t:${epoch}:R>)`
-            : "Sync time: not detected from message content";
-        })(),
-        "",
-        `Claimed: **${claimedLines.length}/${badges.length}**`,
-        `Unavailable (${SYNC_UNAVAILABLE_EMOJI}): **${[...new Set(unavailableUsers)].length}**`,
-        ...(unavailableUsers.length > 0
-          ? [`${SYNC_UNAVAILABLE_EMOJI} ${[...new Set(unavailableUsers)].join(", ")}`]
-          : []),
-        "",
-        "**Claimed Clans**",
-        ...(claimedLines.length > 0 ? claimedLines : ["- None"]),
-        "",
-        "**Unclaimed Clans**",
-        ...(unclaimedLines.length > 0 ? unclaimedLines : ["- None"]),
-      ].join("\n")
-    )
-    .setFooter({
-      text:
-        leaderRoleIds.length > 0
-          ? "Leader eligibility: Administrator or role allowed for /sync time post"
-          : "Leader eligibility: Administrator only (no /sync time post role whitelist configured)",
-    });
+  const embed = buildSyncSpinStatusEmbed({
+    guildId: guild.id,
+    sourceChannelId: tracked.channelId,
+    sourceMessageId: tracked.referenceId ?? tracked.messageId,
+    metadata,
+    claimedClanTags: tracked.claims.map((claim) => claim.clanTag),
+    title: "Sync Spin Status",
+  });
 
   await interaction.editReply({ embeds: [embed] });
 }
@@ -632,14 +522,6 @@ function extractSyncEpochSeconds(content: string): number | null {
   const epoch = Number(match[1]);
   if (!Number.isFinite(epoch) || epoch <= 0) return null;
   return epoch;
-}
-
-function reactionMatchesBadge(
-  reaction: { emoji: { id: string | null; name: string | null } },
-  badge: SyncBadge
-): boolean {
-  if (reaction.emoji.id && badge.matchEmojiIds.includes(reaction.emoji.id)) return true;
-  return Boolean(reaction.emoji.name && badge.matchEmojiNames.includes(reaction.emoji.name));
 }
 
 function buildModalCustomId(userId: string): string {
@@ -928,6 +810,7 @@ export async function handlePostModalSubmit(
       syncEpochSeconds: epochSeconds,
       roleId: role.id,
       clans: badges.map((badge) => ({
+        code: badge.code,
         clanTag: badge.clanTag,
         clanName: badge.label,
         emojiId: badge.id,

--- a/src/listeners/messageReactionAdd.ts
+++ b/src/listeners/messageReactionAdd.ts
@@ -57,7 +57,14 @@ export default (client: Client): void => {
       }
 
       if (tracked.featureType === TRACKED_MESSAGE_FEATURE_TYPE.SYNC_TIME_POST) {
-        await trackedMessageService.recordSyncClaim(fullReaction.message.id, fullUser.id, fullReaction);
+        const recorded = await trackedMessageService.recordSyncClaim(
+          fullReaction.message.id,
+          fullUser.id,
+          fullReaction,
+        );
+        if (recorded && tracked.referenceId) {
+          await trackedMessageService.refreshSyncSpinStatusMessage(fullReaction.message);
+        }
       }
     } catch (err) {
       console.error(`messageReactionAdd failed: ${formatError(err)}`);

--- a/src/listeners/messageReactionRemove.ts
+++ b/src/listeners/messageReactionRemove.ts
@@ -44,7 +44,14 @@ export default (client: Client): void => {
       const tracked = await trackedMessageService.getActiveByMessageId(fullReaction.message.id);
       if (!tracked || tracked.status !== "ACTIVE") return;
       if (tracked.featureType !== TRACKED_MESSAGE_FEATURE_TYPE.SYNC_TIME_POST) return;
-      await trackedMessageService.removeSyncClaim(fullReaction.message.id, fullUser.id, fullReaction);
+      const removed = await trackedMessageService.removeSyncClaim(
+        fullReaction.message.id,
+        fullUser.id,
+        fullReaction,
+      );
+      if (removed && tracked.referenceId) {
+        await trackedMessageService.refreshSyncSpinStatusMessage(fullReaction.message);
+      }
     } catch (err) {
       console.error(`messageReactionRemove failed: ${formatError(err)}`);
     }

--- a/src/services/TrackedMessageService.ts
+++ b/src/services/TrackedMessageService.ts
@@ -1,4 +1,5 @@
-import { Client } from "discord.js";
+import { Client, EmbedBuilder } from "discord.js";
+import { normalizeClanTag } from "./PlayerLinkService";
 import { prisma } from "../prisma";
 import { formatError } from "../helper/formatError";
 
@@ -70,6 +71,7 @@ export type SyncTimeTrackedMetadata = {
   syncEpochSeconds: number;
   roleId: string;
   clans: Array<{
+    code: string;
     clanTag: string;
     clanName: string;
     emojiId: string | null;
@@ -95,6 +97,24 @@ function normalizeTagBare(tag: string): string {
 
 function isObject(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function resolveSyncClanCode(input: { code?: unknown; clanTag: string; clanName: string }): string {
+  const explicitCode = String(input.code ?? "").replace(/\s+/g, " ").trim();
+  if (explicitCode) return explicitCode.toUpperCase();
+
+  const source = String(input.clanName ?? "").replace(/\s+/g, " ").trim() || input.clanTag.replace(/^#/, "");
+  const lettersAndNumbers = source
+    .normalize("NFKC")
+    .replace(/["'`]/g, "")
+    .replace(/[^A-Za-z0-9 ]/g, "")
+    .replace(/\s+/g, " ")
+    .trim()
+    .toUpperCase()
+    .replace(/[^A-Z0-9]/g, "");
+  const base = lettersAndNumbers.length > 0 ? lettersAndNumbers : source.replace(/\s+/g, "");
+  const tagBase = input.clanTag.replace(/^#/, "").toUpperCase();
+  return (base + tagBase).slice(0, 3).toUpperCase();
 }
 
 export function parseFwaBaseSwapMetadata(value: unknown): FwaBaseSwapTrackedMetadata | null {
@@ -188,6 +208,11 @@ export function parseSyncTimeMetadata(value: unknown): SyncTimeTrackedMetadata |
   const clans = value.clans
     .map((clan) => {
       if (!isObject(clan)) return null;
+      const clanCode = resolveSyncClanCode({
+        code: clan.code,
+        clanTag: String(clan.clanTag ?? "").trim(),
+        clanName: String(clan.clanName ?? "").trim(),
+      });
       const clanTag = String(clan.clanTag ?? "").trim();
       const clanName = String(clan.clanName ?? "").trim();
       const emojiInline = String(clan.emojiInline ?? "").trim();
@@ -195,6 +220,7 @@ export function parseSyncTimeMetadata(value: unknown): SyncTimeTrackedMetadata |
       const emojiNameRaw = String(clan.emojiName ?? "").trim();
       if (!clanTag || !clanName || !emojiInline) return null;
       return {
+        code: clanCode,
         clanTag,
         clanName,
         emojiId: emojiIdRaw || null,
@@ -211,6 +237,41 @@ export function parseSyncTimeMetadata(value: unknown): SyncTimeTrackedMetadata |
     clans,
     reminderSentAt: typeof value.reminderSentAt === "string" ? value.reminderSentAt : null,
   };
+}
+
+/** Purpose: render the current sync spin/claim state into one embed shared by the scheduler and the manual command. */
+export function buildSyncSpinStatusEmbed(input: {
+  guildId: string;
+  sourceChannelId: string;
+  sourceMessageId: string;
+  metadata: SyncTimeTrackedMetadata;
+  claimedClanTags: Iterable<string>;
+  title?: string;
+}): EmbedBuilder {
+  const claimedSet = new Set(
+    [...input.claimedClanTags]
+      .map((clanTag) => normalizeClanTag(clanTag))
+      .filter((clanTag): clanTag is string => Boolean(clanTag)),
+  );
+  const claimedCount = input.metadata.clans.filter((clan) => claimedSet.has(normalizeClanTag(clan.clanTag))).length;
+
+  const embed = new EmbedBuilder()
+    .setTitle(input.title ?? "Sync Spin Status")
+    .setDescription(
+      [
+        `Message: https://discord.com/channels/${input.guildId}/${input.sourceChannelId}/${input.sourceMessageId}`,
+        `Sync time: <t:${input.metadata.syncEpochSeconds}:F> (<t:${input.metadata.syncEpochSeconds}:R>)`,
+        "",
+        `Claimed: **${claimedCount}/${input.metadata.clans.length}**`,
+        "",
+        "**Clan Status**",
+        ...input.metadata.clans.map((clan) => {
+          const prefix = claimedSet.has(normalizeClanTag(clan.clanTag)) ? "✅" : "-";
+          return `${prefix} ${clan.emojiInline} **${clan.code}** (${clan.clanName})`;
+        }),
+      ].join("\n"),
+    );
+  return embed;
 }
 
 function emojiMatches(
@@ -426,10 +487,24 @@ export class TrackedMessageService {
     const tracked = await prisma.trackedMessage.findUnique({ where: { messageId } });
     if (!tracked) return;
     if (tracked.status === TRACKED_MESSAGE_STATUS.DELETED) return;
-    await prisma.trackedMessage.update({
-      where: { messageId },
-      data: { status: TRACKED_MESSAGE_STATUS.DELETED },
-    });
+    await prisma.$transaction([
+      prisma.trackedMessage.update({
+        where: { messageId },
+        data: { status: TRACKED_MESSAGE_STATUS.DELETED },
+      }),
+      ...(tracked.referenceId
+        ? []
+        : [
+            prisma.trackedMessage.updateMany({
+              where: {
+                referenceId: messageId,
+                featureType: TRACKED_MESSAGE_FEATURE_TYPE.SYNC_TIME_POST,
+                status: TRACKED_MESSAGE_STATUS.ACTIVE,
+              },
+              data: { status: TRACKED_MESSAGE_STATUS.DELETED },
+            }),
+          ]),
+    ]);
   }
 
   async handleFwaBaseSwapReaction(params: {
@@ -556,8 +631,9 @@ export class TrackedMessageService {
     guildId: string;
     channelId: string;
     messageId: string;
-    remindAt: Date;
+    remindAt?: Date | null;
     expiresAt: Date;
+    referenceId?: string | null;
     metadata: SyncTimeTrackedMetadata;
   }): Promise<void> {
     await prisma.trackedMessage.upsert({
@@ -567,7 +643,8 @@ export class TrackedMessageService {
         channelId: params.channelId,
         featureType: TRACKED_MESSAGE_FEATURE_TYPE.SYNC_TIME_POST,
         status: TRACKED_MESSAGE_STATUS.ACTIVE,
-        remindAt: params.remindAt,
+        referenceId: params.referenceId ?? null,
+        remindAt: params.remindAt ?? null,
         expiresAt: params.expiresAt,
         metadata: params.metadata as any,
       },
@@ -577,7 +654,8 @@ export class TrackedMessageService {
         messageId: params.messageId,
         featureType: TRACKED_MESSAGE_FEATURE_TYPE.SYNC_TIME_POST,
         status: TRACKED_MESSAGE_STATUS.ACTIVE,
-        remindAt: params.remindAt,
+        referenceId: params.referenceId ?? null,
+        remindAt: params.remindAt ?? null,
         expiresAt: params.expiresAt,
         metadata: params.metadata as any,
       },
@@ -632,6 +710,7 @@ export class TrackedMessageService {
     return prisma.trackedMessage.findFirst({
       where: {
         guildId,
+        referenceId: null,
         ...activeWhere(TRACKED_MESSAGE_FEATURE_TYPE.SYNC_TIME_POST),
       },
       orderBy: [{ remindAt: "desc" }, { createdAt: "desc" }],
@@ -656,6 +735,7 @@ export class TrackedMessageService {
       where: {
         featureType: TRACKED_MESSAGE_FEATURE_TYPE.SYNC_TIME_POST,
         status: TRACKED_MESSAGE_STATUS.ACTIVE,
+        referenceId: null,
         remindAt: { lte: now },
       },
       include: { claims: true },
@@ -673,55 +753,104 @@ export class TrackedMessageService {
         continue;
       }
       if (metadata.reminderSentAt) continue;
-      const claimsByUser = new Map<string, string[]>();
-      const countByClan = new Map<string, number>();
-      for (const claim of tracked.claims) {
-        claimsByUser.set(claim.userId, [...(claimsByUser.get(claim.userId) ?? []), claim.clanTag]);
-        countByClan.set(claim.clanTag, (countByClan.get(claim.clanTag) ?? 0) + 1);
+      const existingStatus = await prisma.trackedMessage.findFirst({
+        where: {
+          featureType: TRACKED_MESSAGE_FEATURE_TYPE.SYNC_TIME_POST,
+          status: TRACKED_MESSAGE_STATUS.ACTIVE,
+          referenceId: tracked.messageId,
+        },
+        select: { id: true },
+      });
+      if (existingStatus) {
+        if (!metadata.reminderSentAt) {
+          metadata.reminderSentAt = now.toISOString();
+          await prisma.trackedMessage.update({
+            where: { id: tracked.id },
+            data: { metadata: metadata as any },
+          });
+        }
+        continue;
       }
 
-      for (const [userId, clanTags] of claimsByUser.entries()) {
-        const user = await client.users.fetch(userId).catch(() => null);
-        if (!user) continue;
-        const uniqueClanTags = [...new Set(clanTags)];
-        const clans = uniqueClanTags
-          .map((clanTag) => {
-            const clan = metadata.clans.find((entry) => entry.clanTag === clanTag);
-            if (!clan) return null;
-            const claimedCount = countByClan.get(clanTag) ?? 0;
-            return {
-              clanTag,
-              clanName: clan.clanName,
-              claimedCount,
-              exclusive: claimedCount === 1,
-            };
-          })
-          .filter((entry): entry is { clanTag: string; clanName: string; claimedCount: number; exclusive: boolean } => Boolean(entry))
-          .sort((a, b) => {
-            if (a.exclusive !== b.exclusive) return a.exclusive ? -1 : 1;
-            return a.clanName.localeCompare(b.clanName, undefined, { sensitivity: "base" });
-          });
-        if (clans.length === 0) continue;
-
-        const lines = clans.map((clan) => `- ${clan.clanName} (${clan.claimedCount})`);
-        await user
-          .send([
-            `<@${userId}> sync reminder for <t:${metadata.syncEpochSeconds}:F> (<t:${metadata.syncEpochSeconds}:R>).`,
-            "You opted into these clans:",
-            ...lines,
-          ].join("\n"))
-          .catch((err) => {
-            console.error(
-              `[tracked-message] sync reminder DM failed user=${userId} message=${tracked.messageId} error=${formatError(err)}`,
-            );
-          });
+      const guild = await client.guilds.fetch(tracked.guildId).catch(() => null);
+      if (!guild) {
+        console.error(
+          `[tracked-message] sync status post skipped guild_missing message=${tracked.messageId}`,
+        );
+        continue;
+      }
+      const channel = await guild.channels.fetch(tracked.channelId).catch(() => null);
+      if (!channel || !channel.isTextBased() || !("send" in channel)) {
+        console.error(
+          `[tracked-message] sync status post skipped channel_unavailable guild=${tracked.guildId} channel=${tracked.channelId} message=${tracked.messageId}`,
+        );
+        continue;
       }
 
-      metadata.reminderSentAt = new Date().toISOString();
+      const embed = buildSyncSpinStatusEmbed({
+        guildId: tracked.guildId,
+        sourceChannelId: tracked.channelId,
+        sourceMessageId: tracked.messageId,
+        metadata,
+        claimedClanTags: new Set(
+          tracked.claims.map((claim) => String(claim.clanTag ?? "").trim()).filter(Boolean),
+        ),
+        title: "Sync Spin Status",
+      });
+
+      const sentMessage = await channel.send({
+        embeds: [embed],
+        allowedMentions: { parse: [] },
+      }).catch((err) => {
+        console.error(
+          `[tracked-message] sync status post failed guild=${tracked.guildId} channel=${tracked.channelId} message=${tracked.messageId} error=${formatError(err)}`,
+        );
+        return null;
+      });
+      if (!sentMessage) continue;
+
+      metadata.reminderSentAt = now.toISOString();
       await prisma.trackedMessage.update({
         where: { id: tracked.id },
         data: { metadata: metadata as any },
       });
+
+      await prisma.trackedMessage.upsert({
+        where: { messageId: sentMessage.id },
+        update: {
+          guildId: tracked.guildId,
+          channelId: tracked.channelId,
+          featureType: TRACKED_MESSAGE_FEATURE_TYPE.SYNC_TIME_POST,
+          status: TRACKED_MESSAGE_STATUS.ACTIVE,
+          clanTag: tracked.clanTag ?? null,
+          referenceId: tracked.messageId,
+          remindAt: null,
+          expiresAt: tracked.expiresAt,
+          metadata: metadata as any,
+        },
+        create: {
+          guildId: tracked.guildId,
+          channelId: tracked.channelId,
+          messageId: sentMessage.id,
+          featureType: TRACKED_MESSAGE_FEATURE_TYPE.SYNC_TIME_POST,
+          status: TRACKED_MESSAGE_STATUS.ACTIVE,
+          clanTag: tracked.clanTag ?? null,
+          referenceId: tracked.messageId,
+          remindAt: null,
+          expiresAt: tracked.expiresAt,
+          metadata: metadata as any,
+        },
+      });
+
+      for (const clan of metadata.clans) {
+        try {
+          await sentMessage.react(clan.emojiInline);
+        } catch (err) {
+          console.error(
+            `[tracked-message] sync status post react failed guild=${tracked.guildId} channel=${tracked.channelId} message=${sentMessage.id} clan=${clan.clanTag} emoji=${clan.emojiInline} error=${formatError(err)}`,
+          );
+        }
+      }
       sentCount += 1;
     }
     return sentCount;
@@ -732,6 +861,35 @@ export class TrackedMessageService {
       where: { messageId },
       include: { claims: true },
     });
+  }
+
+  async refreshSyncSpinStatusMessage(message: {
+    id: string;
+    edit: (payload: { embeds: EmbedBuilder[] }) => Promise<unknown>;
+  }): Promise<boolean> {
+    const tracked = await prisma.trackedMessage.findUnique({
+      where: { messageId: message.id },
+      include: { claims: true },
+    });
+    if (!tracked || tracked.status !== TRACKED_MESSAGE_STATUS.ACTIVE) return false;
+    if (tracked.featureType !== TRACKED_MESSAGE_FEATURE_TYPE.SYNC_TIME_POST) return false;
+    if (!tracked.referenceId) return false;
+
+    const metadata = parseSyncTimeMetadata(tracked.metadata);
+    if (!metadata) return false;
+
+    const embed = buildSyncSpinStatusEmbed({
+      guildId: tracked.guildId,
+      sourceChannelId: tracked.channelId,
+      sourceMessageId: tracked.referenceId,
+      metadata,
+      claimedClanTags: new Set(
+        tracked.claims.map((claim) => String(claim.clanTag ?? "").trim()).filter(Boolean),
+      ),
+      title: "Sync Spin Status",
+    });
+    await message.edit({ embeds: [embed] });
+    return true;
   }
 }
 

--- a/tests/sync.command.test.ts
+++ b/tests/sync.command.test.ts
@@ -202,6 +202,7 @@ describe("/sync time post modal submit", () => {
     vi.spyOn(SettingsService.prototype, "get").mockResolvedValue(null);
     vi.spyOn(SettingsService.prototype, "set").mockResolvedValue(undefined);
     vi.spyOn(trackedMessageService, "createSyncTimeTrackedMessage").mockResolvedValue(undefined);
+    vi.spyOn(trackedMessageService, "fetchSyncTrackedMessageWithClaims").mockResolvedValue(null);
     vi.spyOn(trackedMessageService, "resolveLatestActiveSyncPost").mockResolvedValue(null);
   });
 
@@ -220,5 +221,95 @@ describe("/sync time post modal submit", () => {
     expect(interaction.editReply).toHaveBeenCalledWith(
       expect.stringContaining("America/Chicago"),
     );
+  });
+
+  it("renders sync post status with the shared spin-status renderer", async () => {
+    const syncMessage = {
+      id: "123456789012345678",
+      channelId: "channel-1",
+      author: { bot: true },
+      content: "# Sync time :gem: <t:1742407800:F> (<t:1742407800:R>)",
+    };
+    const channel = {
+      isTextBased: () => true,
+      messages: {
+        fetch: vi.fn().mockResolvedValue(syncMessage),
+      },
+    };
+    const channelCache = new Map([["channel-1", channel]]) as any;
+    channelCache.filter = (fn: (value: any) => boolean) =>
+      new Map([...channelCache.entries()].filter(([, value]) => fn(value)));
+
+    vi.mocked(trackedMessageService.fetchSyncTrackedMessageWithClaims).mockResolvedValue({
+      id: "tracked-1",
+      guildId: "guild-1",
+      channelId: "channel-1",
+      messageId: syncMessage.id,
+      featureType: "SYNC_TIME_POST",
+      status: "ACTIVE",
+      referenceId: null,
+      remindAt: null,
+      expiresAt: new Date("2026-04-10T02:00:00.000Z"),
+      metadata: {
+        syncTimeIso: "2026-03-19T15:30:00.000Z",
+        syncEpochSeconds: 1742407800,
+        roleId: "456",
+        reminderSentAt: null,
+        clans: [
+          {
+            code: "RR",
+            clanTag: "#PYLQ",
+            clanName: "Rocky Road",
+            emojiId: "111",
+            emojiName: "rr",
+            emojiInline: "<:rr:111>",
+          },
+          {
+            code: "TWC",
+            clanTag: "#PYLG",
+            clanName: "TheWiseCowboys",
+            emojiId: "222",
+            emojiName: "twc",
+            emojiInline: "<:twc:222>",
+          },
+        ],
+      },
+      claims: [{ clanTag: "#PYLQ" }],
+    } as any);
+
+    const interaction = {
+      inGuild: () => true,
+      guildId: "guild-1",
+      guild: {
+        id: "guild-1",
+        channels: {
+          cache: channelCache,
+        },
+      },
+      options: {
+        getSubcommandGroup: vi.fn().mockReturnValue("post"),
+        getSubcommand: vi.fn().mockReturnValue("status"),
+        getString: vi.fn((name: string) => (name === "message-id" ? syncMessage.id : null)),
+      },
+      deferReply: vi.fn().mockResolvedValue(undefined),
+      editReply: vi.fn().mockResolvedValue(undefined),
+      reply: vi.fn().mockResolvedValue(undefined),
+      client: { user: { id: "bot-1" } },
+      user: { id: "user-1" },
+    };
+
+    await Post.run({} as any, interaction as any, {} as any);
+
+    expect(interaction.deferReply).toHaveBeenCalledTimes(1);
+    expect(interaction.editReply).toHaveBeenCalledTimes(1);
+    const payload = interaction.editReply.mock.calls
+      .map((call) => call[0])
+      .find((value) => value && typeof value === "object" && "embeds" in value) as any;
+    expect(payload).toBeTruthy();
+    const embed = payload.embeds[0].toJSON() as any;
+    expect(embed.title).toBe("Sync Spin Status");
+    expect(embed.description).toContain("Claimed: **1/2**");
+    expect(embed.description).toContain("✅ <:rr:111> **RR** (Rocky Road)");
+    expect(embed.description).toContain("- <:twc:222> **TWC** (TheWiseCowboys)");
   });
 });

--- a/tests/trackedMessage.syncStatus.test.ts
+++ b/tests/trackedMessage.syncStatus.test.ts
@@ -1,0 +1,207 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  TRACKED_MESSAGE_FEATURE_TYPE,
+  TRACKED_MESSAGE_STATUS,
+  trackedMessageService,
+} from "../src/services/TrackedMessageService";
+
+const prismaMock = vi.hoisted(() => ({
+  trackedMessage: {
+    findMany: vi.fn(),
+    findFirst: vi.fn(),
+    findUnique: vi.fn(),
+    upsert: vi.fn(),
+    update: vi.fn(),
+    updateMany: vi.fn(),
+  },
+  trackedMessageClaim: {
+    findFirst: vi.fn(),
+    createMany: vi.fn(),
+    deleteMany: vi.fn(),
+    upsert: vi.fn(),
+  },
+}));
+
+vi.mock("../src/prisma", () => ({
+  prisma: prismaMock,
+}));
+
+function makeMetadata() {
+  return {
+    syncTimeIso: "2026-03-19T15:30:00.000Z",
+    syncEpochSeconds: 1742407800,
+    roleId: "456",
+    reminderSentAt: null,
+    clans: [
+      {
+      code: "RR",
+        clanTag: "#PYLQ",
+        clanName: "Rocky Road",
+        emojiId: "111",
+        emojiName: "rr",
+        emojiInline: "<:rr:111>",
+      },
+      {
+        code: "TWC",
+        clanTag: "#PYLG",
+        clanName: "TheWiseCowboys",
+        emojiId: "222",
+        emojiName: "twc",
+        emojiInline: "<:twc:222>",
+      },
+    ],
+  };
+}
+
+function makeTrackedRow(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: "tracked-1",
+    guildId: "guild-1",
+    channelId: "channel-1",
+    messageId: "sync-message-1",
+    featureType: TRACKED_MESSAGE_FEATURE_TYPE.SYNC_TIME_POST,
+    status: TRACKED_MESSAGE_STATUS.ACTIVE,
+    referenceId: null,
+    remindAt: new Date("2026-03-19T15:25:00.000Z"),
+    expiresAt: new Date("2026-03-19T17:30:00.000Z"),
+    metadata: makeMetadata(),
+    claims: [],
+    ...overrides,
+  };
+}
+
+describe("TrackedMessageService sync spin status", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prismaMock.trackedMessage.findMany.mockResolvedValue([]);
+    prismaMock.trackedMessage.findFirst.mockResolvedValue(null);
+    prismaMock.trackedMessage.findUnique.mockResolvedValue(null);
+    prismaMock.trackedMessage.upsert.mockResolvedValue(undefined);
+    prismaMock.trackedMessage.update.mockResolvedValue(undefined);
+    prismaMock.trackedMessage.updateMany.mockResolvedValue({ count: 0 });
+  });
+
+  it("posts the scheduled status embed once and reacts with every clan badge", async () => {
+    prismaMock.trackedMessage.findMany.mockResolvedValue([makeTrackedRow()]);
+
+    const react = vi.fn().mockResolvedValue(undefined);
+    const send = vi.fn().mockResolvedValue({ id: "status-message-1", react });
+    const channel = {
+      isTextBased: () => true,
+      send,
+    };
+    const guild = {
+      channels: {
+        fetch: vi.fn().mockResolvedValue(channel),
+      },
+    };
+    const client = {
+      guilds: {
+        fetch: vi.fn().mockResolvedValue(guild),
+      },
+    } as any;
+
+    const result = await trackedMessageService.processDueSyncReminders(client);
+
+    expect(result).toBe(1);
+    expect(send).toHaveBeenCalledTimes(1);
+    const payload = send.mock.calls[0]?.[0] as any;
+    const embed = payload.embeds[0].toJSON() as any;
+    expect(embed.title).toBe("Sync Spin Status");
+    expect(embed.description).toContain("Claimed: **0/2**");
+    expect(embed.description).toContain("- <:rr:111> **RR** (Rocky Road)");
+    expect(embed.description).toContain("- <:twc:222> **TWC** (TheWiseCowboys)");
+    expect(react).toHaveBeenCalledWith("<:rr:111>");
+    expect(react).toHaveBeenCalledWith("<:twc:222>");
+    expect(prismaMock.trackedMessage.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { messageId: "status-message-1" },
+        create: expect.objectContaining({
+          referenceId: "sync-message-1",
+          remindAt: null,
+        }),
+      }),
+    );
+    expect(prismaMock.trackedMessage.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "tracked-1" },
+        data: expect.objectContaining({
+          metadata: expect.objectContaining({
+            reminderSentAt: expect.any(String),
+          }),
+        }),
+      }),
+    );
+  });
+
+  it("does not create a duplicate scheduled status post when one already exists", async () => {
+    prismaMock.trackedMessage.findMany.mockImplementation(() => [makeTrackedRow()]);
+    prismaMock.trackedMessage.findFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ id: "status-message-1" });
+
+    const react = vi.fn().mockResolvedValue(undefined);
+    const send = vi.fn().mockResolvedValue({ id: "status-message-1", react });
+    const channel = {
+      isTextBased: () => true,
+      send,
+    };
+    const guild = {
+      channels: {
+        fetch: vi.fn().mockResolvedValue(channel),
+      },
+    };
+    const client = {
+      guilds: {
+        fetch: vi.fn().mockResolvedValue(guild),
+      },
+    } as any;
+
+    await trackedMessageService.processDueSyncReminders(client);
+    await trackedMessageService.processDueSyncReminders(client);
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(prismaMock.trackedMessage.upsert).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-renders the status message line to claimed and back to unclaimed", async () => {
+    prismaMock.trackedMessage.findUnique
+      .mockResolvedValueOnce({
+        ...makeTrackedRow({
+          messageId: "status-message-1",
+          referenceId: "sync-message-1",
+          claims: [{ clanTag: "#PYLQ", userId: "user-1" }],
+        }),
+      })
+      .mockResolvedValueOnce({
+        ...makeTrackedRow({
+          messageId: "status-message-1",
+          referenceId: "sync-message-1",
+          claims: [],
+        }),
+      });
+
+    const edit = vi.fn().mockResolvedValue(undefined);
+    const message = {
+      id: "status-message-1",
+      edit,
+    };
+
+    await expect(trackedMessageService.refreshSyncSpinStatusMessage(message as any)).resolves.toBe(
+      true,
+    );
+    expect(edit).toHaveBeenCalledTimes(1);
+    expect((edit.mock.calls[0]?.[0] as any).embeds[0].toJSON().description).toContain(
+      "✅ <:rr:111> **RR** (Rocky Road)",
+    );
+
+    edit.mockClear();
+    await expect(trackedMessageService.refreshSyncSpinStatusMessage(message as any)).resolves.toBe(
+      true,
+    );
+    expect(edit).toHaveBeenCalledTimes(1);
+    expect((edit.mock.calls[0]?.[0] as any).embeds[0].toJSON().description).toContain(
+      "- <:rr:111> **RR** (Rocky Road)",
+    );
+  });
+});

--- a/tests/trackedMessageMetadata.logic.test.ts
+++ b/tests/trackedMessageMetadata.logic.test.ts
@@ -171,6 +171,7 @@ describe("tracked message metadata parsing", () => {
       reminderSentAt: "2026-03-19T15:25:00.000Z",
       clans: [
         {
+          code: "RR",
           clanTag: "#AAA111",
           clanName: "Rocky Road",
           emojiId: " 111 ",
@@ -192,6 +193,7 @@ describe("tracked message metadata parsing", () => {
       reminderSentAt: "2026-03-19T15:25:00.000Z",
       clans: [
         {
+          code: "RR",
           clanTag: "#AAA111",
           clanName: "Rocky Road",
           emojiId: "111",


### PR DESCRIPTION
- share sync status rendering between scheduler and manual command
- update reaction handlers to edit the public status embed in place