### PR TITLE
fix(cwl): emoji statuses and clan-scoped leaders

### DIFF
--- a/src/commands/Cwl.ts
+++ b/src/commands/Cwl.ts
@@ -224,8 +224,14 @@ function buildCwlRotationRosterTagSet(plan: CwlRotationPlanExport): Set<string> 
 
 function buildCwlRotationLeaderNames(
   entries: Awaited<ReturnType<typeof cwlStateService.listSeasonRosterForClan>>,
+  clanTag?: string | null,
 ): string[] {
+  const selectedClanTag = normalizeClanTag(clanTag ?? "");
   const leaders = entries
+    .filter((entry) => {
+      if (!selectedClanTag) return true;
+      return normalizeClanTag(entry.clanTag) === selectedClanTag;
+    })
     .map((entry) => ({
       name: entry.playerName,
       tag: entry.playerTag,
@@ -489,6 +495,15 @@ async function resolveCwlRotationOverviewStatusIcons(client: Client): Promise<{ 
   } catch {
     return fallback;
   }
+}
+
+function formatCwlRotationOverviewStatusLabel(status: string): string {
+  const normalized = String(status ?? "").trim().toLowerCase();
+  if (normalized === "complete" || normalized === "completed") return "✅";
+  if (normalized === "mismatch") return "⚠️";
+  if (normalized === "no_active_round") return "no active round";
+  if (normalized === "no_plan_day") return "no plan day";
+  return normalized.replace(/_/g, " ");
 }
 
 function buildCwlRotationOverviewLines(input: {
@@ -1576,7 +1591,7 @@ function buildCwlRotationShowOverviewActionRows(input: {
       input.overview.slice(0, CWL_ROTATION_SHOW_OVERVIEW_MAX_OPTIONS).map((entry) => ({
         label: (entry.clanName || entry.clanTag).slice(0, 100),
         value: entry.clanTag,
-        description: `day ${entry.roundDay ?? "unknown"} - ${entry.status.replace(/_/g, " ")}`,
+        description: `day ${entry.roundDay ?? "unknown"} - ${formatCwlRotationOverviewStatusLabel(entry.status)}`,
       })),
     );
   return [new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(menu)];
@@ -1828,7 +1843,7 @@ async function loadCwlRotationShowClanPayload(input: {
     clanTag: planView.clanTag,
     season: planView.season,
   });
-  const leaderNames = buildCwlRotationLeaderNames(seasonRosterEntries);
+  const leaderNames = buildCwlRotationLeaderNames(seasonRosterEntries, planView.clanTag);
 
   return {
     payload: await buildCwlRotationShowClanPayload({

--- a/tests/cwl.command.test.ts
+++ b/tests/cwl.command.test.ts
@@ -1500,8 +1500,49 @@ describe("/cwl command", () => {
     );
     expect(getDescription(interaction)).toContain("- Leaders/Co-leaders: unknown");
     expect(getComponentSelectMenuCustomIds(interaction)).toHaveLength(1);
-    expect(getComponentSelectMenuOptions(interaction).map((option) => option.label)).toEqual(
+    const dropdownOptions = getComponentSelectMenuOptions(interaction);
+    expect(dropdownOptions.map((option) => option.label)).toEqual(
       expect.arrayContaining(["CWL Alpha", "CWL Beta"]),
+    );
+    expect(dropdownOptions.map((option) => option.description)).toEqual(
+      expect.arrayContaining(["day 3 - ⚠️", "day 3 - ✅"]),
+    );
+    expect(dropdownOptions.map((option) => option.description?.toLowerCase() ?? "").join(" ")).not.toContain(
+      "complete",
+    );
+    expect(dropdownOptions.map((option) => option.description?.toLowerCase() ?? "").join(" ")).not.toContain(
+      "completed",
+    );
+    expect(dropdownOptions.map((option) => option.description?.toLowerCase() ?? "").join(" ")).not.toContain(
+      "mismatch",
+    );
+  });
+
+  it("renders overview dropdown status labels for completed clans with emoji", async () => {
+    vi.spyOn(cwlRotationService, "listOverview").mockResolvedValue([
+      {
+        season: "2026-04",
+        clanTag: "#2QG2C08UP",
+        clanName: "CWL Alpha",
+        version: 1,
+        roundDay: 3,
+        battleDayStartAt: new Date("2026-04-03T12:00:00.000Z"),
+        leaderNames: ["Alpha"],
+        status: "completed" as any,
+        missingExpectedPlayerTags: [],
+        extraActualPlayerTags: [],
+      },
+    ]);
+    const interaction = makeInteraction({
+      group: "rotations",
+      subcommand: "show",
+    });
+
+    await Cwl.run({} as any, interaction as any);
+
+    const dropdownOptions = getComponentSelectMenuOptions(interaction);
+    expect(dropdownOptions.map((option) => option.description)).toEqual(
+      expect.arrayContaining(["day 3 - ✅"]),
     );
   });
 
@@ -1542,6 +1583,60 @@ describe("/cwl command", () => {
         ],
       } as any,
     ]);
+    vi.mocked(cwlStateService.listSeasonRosterForClan).mockResolvedValue([
+      {
+        season: "2026-04",
+        clanTag: "#2QG2C08UP",
+        playerTag: "#ALPHA1",
+        playerName: "Alpha Leader",
+        townHall: 18,
+        currentWeight: null,
+        role: "leader",
+        linkedDiscordUserId: null,
+        linkedDiscordUsername: null,
+        daysParticipated: 0,
+        currentRound: null,
+      },
+      {
+        season: "2026-04",
+        clanTag: "#2QG2C08UP",
+        playerTag: "#ALPHA2",
+        playerName: "Alpha CoLeader",
+        townHall: 17,
+        currentWeight: null,
+        role: "coleader",
+        linkedDiscordUserId: null,
+        linkedDiscordUsername: null,
+        daysParticipated: 0,
+        currentRound: null,
+      },
+      {
+        season: "2026-04",
+        clanTag: "#9GLGQCCU",
+        playerTag: "#BRAVO1",
+        playerName: "Bravo Leader",
+        townHall: 18,
+        currentWeight: null,
+        role: "leader",
+        linkedDiscordUserId: null,
+        linkedDiscordUsername: null,
+        daysParticipated: 0,
+        currentRound: null,
+      },
+      {
+        season: "2026-04",
+        clanTag: "#9GLGQCCU",
+        playerTag: "#BRAVO2",
+        playerName: "Bravo CoLeader",
+        townHall: 17,
+        currentWeight: null,
+        role: "coleader",
+        linkedDiscordUserId: null,
+        linkedDiscordUsername: null,
+        daysParticipated: 0,
+        currentRound: null,
+      },
+    ] as any);
     vi.mocked(cwlRotationService.getPreferredDisplayDay).mockResolvedValue(2);
     vi.mocked(cwlRotationService.validatePlanDay).mockResolvedValue({
       actualAvailable: true,
@@ -1595,6 +1690,9 @@ describe("/cwl command", () => {
     await handleCwlRotationShowSelectMenuInteraction(selectInteraction as any);
     expect(getUpdatedDescription(selectInteraction)).toContain("Day 2");
     expect(getUpdatedDescription(selectInteraction)).toContain(":white_check_mark: Charlie (#VJQ28888) | War count: 1");
+    expect(getUpdatedDescription(selectInteraction)).toContain("Leaders/Co-leaders: Alpha Leader, Alpha CoLeader");
+    expect(getUpdatedDescription(selectInteraction)).not.toContain("Bravo Leader");
+    expect(getUpdatedDescription(selectInteraction)).not.toContain("Bravo CoLeader");
     expect(getUpdatedDescription(selectInteraction)).toContain("Battle day start: <t:");
     expect(getUpdatedDescription(selectInteraction)).toContain(":R>");
     expect(getComponentButtonCustomIds(selectInteraction)).toEqual(


### PR DESCRIPTION
- render CWL rotation overview statuses with Unicode icons
- scope clan detail leader names to the selected clan