### PR TITLE
feat(cwl): add expected roster suffix for substituted lineup slots

### DIFF
--- a/src/commands/Cwl.ts
+++ b/src/commands/Cwl.ts
@@ -205,21 +205,38 @@ function formatCwlMembersRoleBadge(role: string | null | undefined): string {
   return normalized ? "👑" : "";
 }
 
-function buildCwlRotationRosterTagSet(plan: CwlRotationPlanExport): Set<string> {
+function sanitizeDisplayText(input: unknown): string {
+  return String(input ?? "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function buildCwlRotationOriginalRosterMembers(plan: CwlRotationPlanExport): Array<{
+  playerTag: string;
+  playerName: string;
+}> {
   const rosterRowsValue = (plan.metadata as { rosterRows?: unknown } | null)?.rosterRows;
   if (!Array.isArray(rosterRowsValue)) {
-    return new Set();
+    return [];
   }
 
-  return new Set(
-    rosterRowsValue
-      .map((row) => {
-        if (!row || typeof row !== "object" || Array.isArray(row)) return null;
-        const record = row as { playerTag?: unknown };
-        return normalizePlayerTag(String(record.playerTag ?? ""));
-      })
-      .filter((tag): tag is string => Boolean(tag)),
-  );
+  return rosterRowsValue
+    .map((row) => {
+      if (!row || typeof row !== "object" || Array.isArray(row)) return null;
+      const record = row as { playerTag?: unknown; playerName?: unknown };
+      const playerTag = normalizePlayerTag(String(record.playerTag ?? ""));
+      if (!playerTag) return null;
+      const playerName = sanitizeDisplayText(record.playerName);
+      return {
+        playerTag,
+        playerName: playerName || playerTag,
+      };
+    })
+    .filter((row): row is { playerTag: string; playerName: string } => Boolean(row));
+}
+
+function buildCwlRotationRosterTagSet(plan: CwlRotationPlanExport): Set<string> {
+  return new Set(buildCwlRotationOriginalRosterMembers(plan).map((member) => member.playerTag));
 }
 
 function buildCwlRotationLeaderNames(
@@ -618,7 +635,12 @@ function buildCwlRotationMergedRosterLines(input: {
     playerName: string;
     subbedOut: boolean;
   }>;
+  originalRosterMembers: Array<{
+    playerTag: string;
+    playerName: string;
+  }>;
   actualPlayerRows: Array<{
+    position: number;
     playerTag: string;
     playerName: string;
   }>;
@@ -672,6 +694,7 @@ function buildCwlRotationMergedRosterLines(input: {
   }
 
   const actualRows = input.actualPlayerRows.map((member) => ({
+    position: Math.max(1, Math.trunc(member.position)),
     normalizedTag: normalizePlayerTag(member.playerTag),
     playerTag: member.playerTag,
     playerName: member.playerName,
@@ -691,8 +714,34 @@ function buildCwlRotationMergedRosterLines(input: {
   const hasRosterTagSet = input.rosterTagSet.size > 0;
   let missingExpectedIndex = 0;
   for (const actual of actualRows) {
+    const expectedForPosition = input.originalRosterMembers[actual.position - 1] ?? null;
     if (actual.normalizedTag && expectedByTag.has(actual.normalizedTag)) {
       lines.push(`:white_check_mark: ${actual.playerName} (${actual.playerTag}) | War count: ${actual.warCount}`);
+      continue;
+    }
+
+    const expectedSuffix =
+      expectedForPosition &&
+      normalizePlayerTag(expectedForPosition.playerTag) &&
+      (!actual.normalizedTag ||
+        normalizePlayerTag(expectedForPosition.playerTag) !== actual.normalizedTag)
+        ? ` - Expected ${expectedForPosition.playerName} (${expectedForPosition.playerTag})`
+        : "";
+
+    const isBlockedForExpected =
+      Boolean(actual.normalizedTag) &&
+      (input.excludedTagSet.has(actual.normalizedTag) ||
+        (hasRosterTagSet && !input.rosterTagSet.has(actual.normalizedTag)));
+    if (isBlockedForExpected && expectedSuffix) {
+      hasBlockedWarning = true;
+      lines.push(`â›”ï¸ ${actual.playerName} (${actual.playerTag}) | War count: ${actual.warCount}${expectedSuffix}`);
+      continue;
+    }
+    if (expectedSuffix) {
+      hasMismatchWarning = true;
+      lines.push(
+        `:warning: ${actual.playerName} (${actual.playerTag}) | War count: ${actual.warCount}${expectedSuffix}`,
+      );
       continue;
     }
 
@@ -1610,7 +1659,7 @@ function buildCwlRotationShowPageLines(input: {
     complete: boolean;
     missingExpectedPlayerTags: string[];
     extraActualPlayerTags: string[];
-    actualPlayerRows: Array<{ playerTag: string; playerName: string }>;
+    actualPlayerRows: Array<{ position: number; playerTag: string; playerName: string }>;
   } | null;
 }): string[] {
   const visibleDayRows = cwlRotationService.getVisibleRotationShowDayRows({
@@ -1618,6 +1667,7 @@ function buildCwlRotationShowPageLines(input: {
     days: input.plan.days,
     day: input.day,
   });
+  const originalRosterMembers = buildCwlRotationOriginalRosterMembers(input.plan);
   const rosterTagSet = buildCwlRotationRosterTagSet(input.plan);
   const excludedTagSet = new Set(
     input.plan.excludedPlayerTags.map((tag) => normalizePlayerTag(tag)).filter((tag): tag is string => Boolean(tag)),
@@ -1641,6 +1691,7 @@ function buildCwlRotationShowPageLines(input: {
     const merged = buildCwlRotationMergedRosterLines({
       warCountByPlayerTag: input.warCountByPlayerTag,
       plannedMembers: visibleDayRows,
+      originalRosterMembers,
       actualPlayerRows: [],
       actualAvailable: false,
       rosterTagSet,
@@ -1651,6 +1702,7 @@ function buildCwlRotationShowPageLines(input: {
     const merged = buildCwlRotationMergedRosterLines({
       warCountByPlayerTag: input.warCountByPlayerTag,
       plannedMembers: visibleDayRows,
+      originalRosterMembers,
       actualPlayerRows: input.validation.actualPlayerRows,
       actualAvailable: input.validation.actualAvailable,
       rosterTagSet,
@@ -1683,7 +1735,7 @@ function buildCwlRotationShowPageEmbed(input: {
     complete: boolean;
     missingExpectedPlayerTags: string[];
     extraActualPlayerTags: string[];
-    actualPlayerRows: Array<{ playerTag: string; playerName: string }>;
+    actualPlayerRows: Array<{ position: number; playerTag: string; playerName: string }>;
   } | null;
 }): EmbedBuilder {
   return new EmbedBuilder()
@@ -1863,6 +1915,7 @@ async function loadCwlRotationShowClanPayload(input: {
             missingExpectedPlayerTags: validation.missingExpectedPlayerTags,
             extraActualPlayerTags: validation.extraActualPlayerTags,
             actualPlayerRows: validation.actualPlayerTags.map((playerTag, index) => ({
+              position: index + 1,
               playerTag,
               playerName: validation.actualPlayerNames[index] ?? playerTag,
             })),
@@ -1891,7 +1944,7 @@ async function buildCwlRotationShowClanPayload(input: {
     complete: boolean;
     missingExpectedPlayerTags: string[];
     extraActualPlayerTags: string[];
-    actualPlayerRows: Array<{ playerTag: string; playerName: string }>;
+    actualPlayerRows: Array<{ position: number; playerTag: string; playerName: string }>;
   } | null;
 }): Promise<{
   embed: EmbedBuilder;

--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -338,9 +338,9 @@ const FWA_BASE_SWAP_FWA_ANNOUNCEMENT_HEADING =
 const FWA_BASE_SWAP_FWA_ANNOUNCEMENT_NOTE =
   "These players currently have an active FWA base. Please swap to an active war base to increase our chances of beating the blacklisted clan!";
 const CWL_BASE_SWAP_ANNOUNCEMENT_HEADING =
-  "# {emoji} YOU HAVE AN ACTIVE CWL LINEUP {emoji}";
+  "# {emoji} YOU HAVE AN ACTIVE FWA BASE IN CWL {emoji}";
 const CWL_BASE_SWAP_ANNOUNCEMENT_NOTE =
-  "These players currently have an active CWL lineup. Please swap to an active war base.";
+  "These players currently have an active FWA base in CWL. Please swap to an active war base.";
 const FWA_BASE_SWAP_AUDIT_LOG_LIMIT = 1800;
 
 type FwaBaseSwapRenderVariant = "single" | "split_part_1" | "split_part_2";
@@ -1526,9 +1526,15 @@ function buildFwaBaseSwapAnnouncementLines(state: {
   }
 
   if (lines.length > 0) {
-    lines.push("", FWA_BASE_SWAP_SECTION_SEPARATOR);
-    if (layoutLinkLines.length > 0) lines.push("", ...layoutLinkLines);
-    if (state.phaseTimingLine) lines.push("", state.phaseTimingLine);
+    if (clanKind === "CWL") {
+      lines.push("", FWA_BASE_SWAP_SECTION_SEPARATOR);
+      if (layoutLinkLines.length > 0) lines.push(...layoutLinkLines);
+      if (state.phaseTimingLine) lines.push(state.phaseTimingLine);
+    } else {
+      lines.push("", FWA_BASE_SWAP_SECTION_SEPARATOR);
+      if (layoutLinkLines.length > 0) lines.push("", ...layoutLinkLines);
+      if (state.phaseTimingLine) lines.push("", state.phaseTimingLine);
+    }
     lines.push("", FWA_BASE_SWAP_REACT_LINE);
   }
 

--- a/tests/cwl.command.test.ts
+++ b/tests/cwl.command.test.ts
@@ -2749,7 +2749,7 @@ describe("/cwl command", () => {
     expect(getDescription(interaction)).not.toContain("Status:");
   });
 
-  it("shows unexpected actual members with zero war count when they are absent from the plan", async () => {
+  it("shows the expected original slot player when an active CWL lineup member is substituted in", async () => {
     vi.mocked(cwlRotationService.listActivePlanExports).mockResolvedValue([
       {
         season: "2026-04",
@@ -2791,7 +2791,112 @@ describe("/cwl command", () => {
     await Cwl.run({} as any, interaction as any);
 
     expect(getDescription(interaction)).toContain(":warning: Visitor (#VJQ28888) | War count: 0");
-    expect(getDescription(interaction)).not.toContain(":x: Hotel (#JQJQ2222)");
+    expect(getDescription(interaction)).not.toContain("Expected Hotel (#JQJQ2222)");
+  });
+
+  it("shows a blocked substituted CWL lineup member with the expected original slot player suffix", async () => {
+    vi.mocked(cwlRotationService.listActivePlanExports).mockResolvedValue([
+      {
+        season: "2026-04",
+        clanTag: "#2QG2C08UP",
+        clanName: "CWL Alpha",
+        version: 4,
+        warningSummary: null,
+        excludedPlayerTags: [],
+        metadata: {
+          rosterRows: [
+            { playerTag: "#PYLQ0289", playerName: "Alpha" },
+            { playerTag: "#GGLLP22RJ", playerName: "Achin4Bacon" },
+            { playerTag: "#QGRJ2222", playerName: "Bravo" },
+          ],
+        },
+        days: [
+          {
+            roundDay: 6,
+            lineupSize: 3,
+            rows: [
+              { playerTag: "#PYLQ0289", playerName: "Alpha", subbedOut: false, assignmentOrder: 0 },
+              { playerTag: "#GGLLP22RJ", playerName: "Achin4Bacon", subbedOut: true, assignmentOrder: 1 },
+              { playerTag: "#QGRJ2222", playerName: "Bravo", subbedOut: false, assignmentOrder: 2 },
+            ],
+            actual: null,
+          },
+        ],
+      } as any,
+    ]);
+    vi.mocked(cwlRotationService.validatePlanDay).mockResolvedValue({
+      actualAvailable: true,
+      complete: false,
+      missingExpectedPlayerTags: ["#GGLLP22RJ"],
+      extraActualPlayerTags: ["#GUR9CGGVQ"],
+      actualPlayerTags: ["#PYLQ0289", "#GUR9CGGVQ", "#QGRJ2222"],
+      actualPlayerNames: ["Alpha", "TouchGrassLLC", "Bravo"],
+    } as any);
+    vi.mocked(cwlStateService.getParticipationCountsForClanDay).mockResolvedValue(
+      makeParticipationCounts([
+        ["#PYLQ0289", 1],
+        ["#GUR9CGGVQ", 0],
+        ["#QGRJ2222", 1],
+      ]),
+    );
+    const interaction = makeInteraction({
+      group: "rotations",
+      subcommand: "show",
+      clan: "#2QG2C08UP",
+      day: 6,
+    });
+
+    await Cwl.run({} as any, interaction as any);
+
+    expect(getDescription(interaction)).toContain(
+      "TouchGrassLLC (#GUR9CGGVQ) | War count: 0 - Expected Achin4Bacon (#GGLLP22RJ)",
+    );
+    expect(getDescription(interaction)).toContain(":white_check_mark: Alpha (#PYLQ0289) | War count: 1");
+    expect(getDescription(interaction)).toContain(":white_check_mark: Bravo (#QGRJ2222) | War count: 1");
+    expect(getDescription(interaction)).not.toContain("TouchGrassLLC (#GUR9CGGVQ) | War count: 0 - Expected TouchGrassLLC");
+  });
+
+  it("keeps the current output when no expected CWL slot can be resolved", async () => {
+    vi.mocked(cwlRotationService.listActivePlanExports).mockResolvedValue([
+      {
+        season: "2026-04",
+        clanTag: "#2QG2C08UP",
+        clanName: "CWL Alpha",
+        version: 4,
+        warningSummary: null,
+        excludedPlayerTags: [],
+        days: [
+          {
+            roundDay: 7,
+            lineupSize: 0,
+            rows: [],
+            actual: null,
+          },
+        ],
+      } as any,
+    ]);
+    vi.mocked(cwlRotationService.validatePlanDay).mockResolvedValue({
+      actualAvailable: true,
+      complete: false,
+      missingExpectedPlayerTags: [],
+      extraActualPlayerTags: ["#VJQ28888"],
+      actualPlayerTags: ["#VJQ28888"],
+      actualPlayerNames: ["Visitor"],
+    } as any);
+    vi.mocked(cwlStateService.getParticipationCountsForClanDay).mockResolvedValue(
+      makeParticipationCounts([["#VJQ28888", 0]]),
+    );
+    const interaction = makeInteraction({
+      group: "rotations",
+      subcommand: "show",
+      clan: "#2QG2C08UP",
+      day: 7,
+    });
+
+    await Cwl.run({} as any, interaction as any);
+
+    expect(getDescription(interaction)).toContain(":warning: Visitor (#VJQ28888) | War count: 0");
+    expect(getDescription(interaction)).not.toContain("Expected");
   });
 
   it("renders an import preview before save and confirms only after a button interaction", async () => {

--- a/tests/fwaBaseSwap.layoutLinks.test.ts
+++ b/tests/fwaBaseSwap.layoutLinks.test.ts
@@ -1753,6 +1753,8 @@ describe("CWL base-swap labels", () => {
         }),
       ],
       layoutLinks: [],
+      phaseTimingLine:
+        "## Battle Day ends <t:1778093832:F> (<t:1778093832:R>)",
       alertEmoji: "<a:alert:10001>",
       fwaAlertEmoji: "<a:alert_blue:10003>",
     });
@@ -1787,7 +1789,16 @@ describe("CWL base-swap labels", () => {
       "# <a:alert:10001> YOU HAVE AN ACTIVE WAR BASE <a:alert:10001>",
     );
     expect(announcementContent).toContain(
-      "# <a:alert_blue:10003> YOU HAVE AN ACTIVE CWL LINEUP <a:alert_blue:10003>",
+      "# <a:alert_blue:10003> YOU HAVE AN ACTIVE FWA BASE IN CWL <a:alert_blue:10003>",
+    );
+    expect(announcementContent).toContain(
+      "These players currently have an active FWA base in CWL. Please swap to an active war base.",
+    );
+    expect(announcementContent).toContain(
+      "\n## Battle Day ends <t:1778093832:F> (<t:1778093832:R>)",
+    );
+    expect(announcementContent).not.toContain(
+      "\n\n## Battle Day ends <t:1778093832:F> (<t:1778093832:R>)",
     );
     expect(dmContent).toContain("CWL lineup swap messages:");
     expect(dmContent).toContain("CWL base error messages:");


### PR DESCRIPTION
- resolve CWL expected players from original roster metadata by slot
- keep missing-slot output unchanged when no original roster member is available