### PR TITLE
feat(autorole): add nickname template renderer

### DIFF
--- a/src/services/AutoRoleNicknameService.ts
+++ b/src/services/AutoRoleNicknameService.ts
@@ -1,0 +1,301 @@
+import type { AutoRoleGuildConfigSnapshot } from "./AutoRoleEvaluationService";
+import {
+  getPlayerLinkTrustTier,
+  isPlayerLinkTrustedForAutorole,
+  isPlayerLinkVerifiedForAutorole,
+  normalizeClanTag,
+  type PlayerLinkWithTrust,
+} from "./PlayerLinkService";
+import type { PlayerCurrentLike } from "./PlayerCurrentService";
+
+export type AutoRoleNicknameTrackedClanLike = {
+  tag: string;
+  name: string | null;
+  shortName: string | null;
+};
+
+export type AutoRoleNicknameMemberLike = {
+  id: string;
+  displayName?: string | null;
+  user: {
+    username?: string | null;
+    globalName?: string | null;
+  };
+};
+
+export type AutoRoleNicknameRenderInput = {
+  config: AutoRoleGuildConfigSnapshot;
+  template: string | null;
+  member: AutoRoleNicknameMemberLike;
+  linkedAccounts: PlayerLinkWithTrust[];
+  playerCurrentByTag: Map<string, PlayerCurrentLike>;
+  trackedClans: AutoRoleNicknameTrackedClanLike[];
+};
+
+export type AutoRoleNicknameRenderResult = {
+  renderedNickname: string | null;
+  primaryPlayerTag: string | null;
+  primaryPlayerName: string | null;
+  primaryClanTag: string | null;
+  primaryClanName: string | null;
+  primaryClanShort: string | null;
+  trackedClans: string[];
+};
+
+type AutoRoleNicknameTokenName =
+  | "player"
+  | "tag"
+  | "th"
+  | "clan"
+  | "clanTag"
+  | "clanShort"
+  | "trackedClans"
+  | "discord"
+  | "username"
+  | "role";
+
+type AutoRoleNicknameTokens = Record<AutoRoleNicknameTokenName, string>;
+type AutoRoleNicknameTokenLookup = Record<string, string>;
+
+type RankedNicknameAccount = PlayerLinkWithTrust & {
+  playerCurrent: PlayerCurrentLike | null;
+  trackedClan: NormalizedTrackedClan | null;
+};
+
+type NormalizedTrackedClan = {
+  tag: string;
+  name: string | null;
+  shortName: string | null;
+  label: string;
+};
+
+const TRUST_TIER_ORDER: Record<string, number> = {
+  verified: 0,
+  trusted: 1,
+  legacy: 2,
+  untrusted: 3,
+  revoked: 4,
+};
+
+function normalizeText(input: unknown): string | null {
+  const normalized = String(input ?? "").replace(/\s+/g, " ").trim();
+  return normalized.length > 0 ? normalized : null;
+}
+
+function normalizeTrackedClan(input: AutoRoleNicknameTrackedClanLike): NormalizedTrackedClan | null {
+  const tag = normalizeClanTag(input.tag);
+  if (!tag) {
+    return null;
+  }
+  const shortName = normalizeText(input.shortName);
+  const name = normalizeText(input.name);
+  return {
+    tag,
+    shortName,
+    name,
+    label: shortName ?? name ?? tag,
+  };
+}
+
+function isEligibleAutoroleLink(
+  link: Pick<PlayerLinkWithTrust, "linkSource" | "verificationStatus" | "verificationMethod">,
+  config: AutoRoleGuildConfigSnapshot,
+): boolean {
+  if (link.verificationStatus === "REVOKED") {
+    return false;
+  }
+
+  if (config.verifiedOnlyMode || config.trustedLinksAllowed === false) {
+    return isPlayerLinkVerifiedForAutorole(link);
+  }
+
+  return isPlayerLinkTrustedForAutorole(link);
+}
+
+function compareLinkedAccounts(left: RankedNicknameAccount, right: RankedNicknameAccount): number {
+  const leftTracked = left.trackedClan ? 0 : 1;
+  const rightTracked = right.trackedClan ? 0 : 1;
+  if (leftTracked !== rightTracked) return leftTracked - rightTracked;
+
+  const leftTh = left.playerCurrent?.townHall ?? -1;
+  const rightTh = right.playerCurrent?.townHall ?? -1;
+  if (leftTh !== rightTh) return rightTh - leftTh;
+
+  const leftTier = TRUST_TIER_ORDER[getPlayerLinkTrustTier(left)] ?? 99;
+  const rightTier = TRUST_TIER_ORDER[getPlayerLinkTrustTier(right)] ?? 99;
+  if (leftTier !== rightTier) return leftTier - rightTier;
+
+  const leftLinkedAt = left.createdAt?.getTime?.() ?? 0;
+  const rightLinkedAt = right.createdAt?.getTime?.() ?? 0;
+  if (leftLinkedAt !== rightLinkedAt) return leftLinkedAt - rightLinkedAt;
+
+  return left.playerTag.localeCompare(right.playerTag);
+}
+
+function safeTruncate(input: string, maxLength: number): string {
+  const chars = Array.from(input);
+  if (chars.length <= maxLength) {
+    return input;
+  }
+  return chars.slice(0, maxLength).join("").trimEnd().replace(/[|/-]\s*$/u, "").trimEnd();
+}
+
+function cleanNicknameOutput(input: string): string {
+  let output = normalizeText(input) ?? "";
+  if (!output) {
+    return "";
+  }
+
+  output = output.replace(/\s*([|/-])\s*/g, " $1 ");
+  output = output.replace(/^(?:\s*[|/-]\s*)+/g, "");
+  output = output.replace(/(?:\s*[|/-]\s*)+$/g, "");
+  output = output.replace(/\s{2,}/g, " ").trim();
+  output = output.replace(/\s*([|/-])(?:\s*\1)+\s*/g, " $1 ");
+  output = output.replace(/^(?:\s*[|/-]\s*)+/g, "");
+  output = output.replace(/(?:\s*[|/-]\s*)+$/g, "");
+  output = output.replace(/\s{2,}/g, " ").trim();
+
+  return output;
+}
+
+function resolveTrackedClanLabel(clan: NormalizedTrackedClan): string {
+  return clan.label;
+}
+
+function buildTrackedClanIndex(trackedClans: AutoRoleNicknameTrackedClanLike[]): Map<string, NormalizedTrackedClan> {
+  const index = new Map<string, NormalizedTrackedClan>();
+  for (const clan of trackedClans) {
+    const normalized = normalizeTrackedClan(clan);
+    if (!normalized || index.has(normalized.tag)) {
+      continue;
+    }
+    index.set(normalized.tag, normalized);
+  }
+  return index;
+}
+
+/** Purpose: render autorole nickname templates from persisted linked-account and clan context without mutating Discord nicknames yet. */
+export class AutoRoleNicknameService {
+  renderNickname(input: AutoRoleNicknameRenderInput): AutoRoleNicknameRenderResult {
+    const trackedClanIndex = buildTrackedClanIndex(input.trackedClans);
+    const eligibleAccounts = [...input.linkedAccounts]
+      .map((account) => ({
+        ...account,
+        playerCurrent: input.playerCurrentByTag.get(account.playerTag) ?? null,
+        trackedClan: trackedClanIndex.get(
+          normalizeClanTag(input.playerCurrentByTag.get(account.playerTag)?.currentClanTag ?? ""),
+        ) ?? null,
+      }))
+      .filter((account) => account.playerTag.length > 0)
+      .filter((account) => isEligibleAutoroleLink(account, input.config))
+      .sort(compareLinkedAccounts);
+
+    const primary = eligibleAccounts[0] ?? null;
+    const primaryClan = primary?.trackedClan ?? null;
+    const trackedClanLabels = this.buildTrackedClanLabels({
+      accounts: eligibleAccounts,
+      trackedClanIndex,
+      primaryClanTag: primaryClan?.tag ?? null,
+    });
+
+    const primaryPlayerCurrent = primary ? primary.playerCurrent : null;
+    const primaryPlayerTag = primary?.playerTag ?? null;
+    const primaryPlayerName =
+      normalizeText(primaryPlayerCurrent?.playerName) ??
+      normalizeText(primary?.playerName) ??
+      null;
+    const primaryClanTag = primaryClan?.tag ?? null;
+    const primaryClanName =
+      normalizeText(primaryClan?.name) ??
+      normalizeText(primaryPlayerCurrent?.currentClanName) ??
+      null;
+    const primaryClanShort = normalizeText(primaryClan?.shortName) ?? null;
+
+    const tokens: AutoRoleNicknameTokens = {
+      player: primaryPlayerName ?? "",
+      tag: primaryPlayerTag ?? "",
+      th: primaryPlayerCurrent?.townHall !== null && primaryPlayerCurrent?.townHall !== undefined
+        ? String(primaryPlayerCurrent.townHall)
+        : "",
+      clan: primaryClanName ?? primaryClanShort ?? primaryClanTag ?? "",
+      "clanTag": primaryClanTag ?? "",
+      clanShort: primaryClanShort ?? primaryClanName ?? primaryClanTag ?? "",
+      trackedClans: trackedClanLabels.join(" | "),
+      discord: normalizeText(input.member.displayName) ?? "",
+      username: normalizeText(input.member.user.username ?? input.member.user.globalName ?? null) ?? "",
+      role: normalizeText(primaryPlayerCurrent?.role ?? null) ?? "",
+    };
+    const tokenLookup: AutoRoleNicknameTokenLookup = {
+      player: tokens.player,
+      tag: tokens.tag,
+      th: tokens.th,
+      clan: tokens.clan,
+      clantag: tokens.clanTag,
+      clanshort: tokens.clanShort,
+      trackedclans: tokens.trackedClans,
+      discord: tokens.discord,
+      username: tokens.username,
+      role: tokens.role,
+    };
+
+    const template = normalizeText(input.template) ?? "";
+    const rendered = template
+      ? this.renderTemplate(template, tokenLookup)
+      : "";
+    const cleaned = cleanNicknameOutput(rendered);
+    const truncated = safeTruncate(cleaned, 32);
+
+    return {
+      renderedNickname: truncated.length > 0 ? truncated : null,
+      primaryPlayerTag,
+      primaryPlayerName,
+      primaryClanTag,
+      primaryClanName,
+      primaryClanShort,
+      trackedClans: trackedClanLabels,
+    };
+  }
+
+  private renderTemplate(template: string, tokens: AutoRoleNicknameTokenLookup): string {
+    return template.replace(/\{([a-zA-Z]+)\}/g, (match, tokenName) => {
+      const token = tokenName.toLowerCase();
+      return Object.prototype.hasOwnProperty.call(tokens, token) ? tokens[token] : match;
+    });
+  }
+
+  private buildTrackedClanLabels(input: {
+    accounts: RankedNicknameAccount[];
+    trackedClanIndex: Map<string, NormalizedTrackedClan>;
+    primaryClanTag: string | null;
+  }): string[] {
+    const tags = new Set<string>();
+    for (const account of input.accounts) {
+      const currentClanTag = normalizeClanTag(account.playerCurrent?.currentClanTag ?? "");
+      if (currentClanTag && input.trackedClanIndex.has(currentClanTag)) {
+        tags.add(currentClanTag);
+      }
+    }
+
+    const labels = [...tags].map((tag) => input.trackedClanIndex.get(tag)!).filter(Boolean);
+    labels.sort((left, right) => {
+      const leftLabel = resolveTrackedClanLabel(left).toLowerCase();
+      const rightLabel = resolveTrackedClanLabel(right).toLowerCase();
+      if (leftLabel !== rightLabel) return leftLabel.localeCompare(rightLabel);
+      return left.tag.localeCompare(right.tag);
+    });
+
+    const primary = input.primaryClanTag ? input.trackedClanIndex.get(input.primaryClanTag) ?? null : null;
+    const ordered = primary ? [primary, ...labels.filter((clan) => clan.tag !== primary.tag)] : labels;
+    const deduped: NormalizedTrackedClan[] = [];
+    const seen = new Set<string>();
+    for (const clan of ordered) {
+      if (seen.has(clan.tag)) continue;
+      seen.add(clan.tag);
+      deduped.push(clan);
+    }
+
+    return deduped.map(resolveTrackedClanLabel);
+  }
+}
+
+export const autoRoleNicknameService = new AutoRoleNicknameService();

--- a/tests/autoroleNickname.service.test.ts
+++ b/tests/autoroleNickname.service.test.ts
@@ -1,0 +1,312 @@
+import { describe, expect, it } from "vitest";
+import { AutoRoleNicknameService, type AutoRoleNicknameRenderInput } from "../src/services/AutoRoleNicknameService";
+import type { AutoRoleGuildConfigSnapshot } from "../src/services/AutoRoleEvaluationService";
+import type { PlayerCurrentLike } from "../src/services/PlayerCurrentService";
+import type { PlayerLinkWithTrust } from "../src/services/PlayerLinkService";
+
+function makeConfig(overrides: Partial<AutoRoleGuildConfigSnapshot> = {}): AutoRoleGuildConfigSnapshot {
+  return {
+    enabled: true,
+    killSwitchEnabled: false,
+    removeStaleManagedRoles: true,
+    applyNicknames: true,
+    nicknameTemplate: "{player}",
+    trustedLinksAllowed: true,
+    verifiedOnlyMode: false,
+    verifiedRoleId: null,
+    familyRoleId: null,
+    ...overrides,
+  };
+}
+
+function makeMember(overrides: Partial<AutoRoleNicknameRenderInput["member"]> = {}): AutoRoleNicknameRenderInput["member"] {
+  return {
+    id: "111111111111111111",
+    displayName: "D",
+    user: {
+      username: "U",
+      globalName: "DG",
+    },
+    ...overrides,
+  };
+}
+
+function makeLink(overrides: Partial<PlayerLinkWithTrust> & Pick<PlayerLinkWithTrust, "playerTag">): PlayerLinkWithTrust {
+  return {
+    playerTag: overrides.playerTag,
+    discordUserId: overrides.discordUserId ?? "111111111111111111",
+    discordUsername: overrides.discordUsername ?? "Discord User",
+    playerName: overrides.playerName ?? null,
+    linkSource: overrides.linkSource ?? "LEGACY",
+    verificationStatus: overrides.verificationStatus ?? "UNVERIFIED",
+    verificationMethod: overrides.verificationMethod ?? null,
+    verifiedAt: overrides.verifiedAt ?? null,
+    verifiedByDiscordUserId: overrides.verifiedByDiscordUserId ?? null,
+    lastVerifiedAt: overrides.lastVerifiedAt ?? null,
+    verificationFailureReason: overrides.verificationFailureReason ?? null,
+    importBatchKey: overrides.importBatchKey ?? null,
+    createdAt: overrides.createdAt ?? new Date("2026-04-01T00:00:00.000Z"),
+    updatedAt: overrides.updatedAt ?? new Date("2026-04-01T00:00:00.000Z"),
+  };
+}
+
+function makePlayerCurrent(overrides: Partial<PlayerCurrentLike> & Pick<PlayerCurrentLike, "playerTag">): PlayerCurrentLike {
+  return {
+    playerTag: overrides.playerTag,
+    playerName: overrides.playerName ?? null,
+    townHall: overrides.townHall ?? null,
+    currentClanTag: overrides.currentClanTag ?? null,
+    currentClanName: overrides.currentClanName ?? null,
+    trophies: overrides.trophies ?? null,
+    builderTrophies: overrides.builderTrophies ?? null,
+    warStars: overrides.warStars ?? null,
+    expLevel: overrides.expLevel ?? null,
+    role: overrides.role ?? null,
+    leagueName: overrides.leagueName ?? null,
+    currentWeight: overrides.currentWeight ?? null,
+    currentWeightSource: overrides.currentWeightSource ?? null,
+    currentWeightMeasuredAt: overrides.currentWeightMeasuredAt ?? null,
+    achievementsJson: overrides.achievementsJson ?? null,
+    lastSeenAt: overrides.lastSeenAt ?? null,
+    lastFetchedAt: overrides.lastFetchedAt ?? null,
+    lastSource: overrides.lastSource ?? null,
+    createdAt: overrides.createdAt ?? null,
+    updatedAt: overrides.updatedAt ?? null,
+    source: overrides.source ?? "player_current",
+    liveRefreshInvoked: overrides.liveRefreshInvoked ?? false,
+  };
+}
+
+describe("AutoRoleNicknameService", () => {
+  const service = new AutoRoleNicknameService();
+
+  it("renders the basic template from the selected linked account", () => {
+    const result = service.renderNickname({
+      config: makeConfig(),
+      template: "{player} ({tag}) TH{th} {clanShort} {discord} {username} {role}",
+      member: makeMember(),
+      linkedAccounts: [
+        makeLink({
+          playerTag: "#2QG2C08UP",
+          playerName: "Untracked",
+        }),
+        makeLink({
+          playerTag: "#2CGG9GGRV",
+          playerName: "A",
+        }),
+      ],
+      playerCurrentByTag: new Map<string, PlayerCurrentLike>([
+        [
+          "#2QG2C08UP",
+          makePlayerCurrent({
+            playerTag: "#2QG2C08UP",
+            playerName: "Untracked",
+            townHall: 18,
+            currentClanTag: "#PQLQG",
+            currentClanName: "Untracked Clan",
+            role: "member",
+          }),
+        ],
+        [
+          "#2CGG9GGRV",
+          makePlayerCurrent({
+            playerTag: "#2CGG9GGRV",
+            playerName: "A",
+            townHall: 1,
+            currentClanTag: "#2CGG9GGRV",
+            currentClanName: "Tracked",
+            role: "R",
+          }),
+        ],
+      ]),
+      trackedClans: [
+        {
+          tag: "#2CGG9GGRV",
+          name: "Tracked",
+          shortName: "T",
+        },
+      ],
+    });
+
+    expect(result.primaryPlayerTag).toBe("#2CGG9GGRV");
+    expect(result.primaryPlayerName).toBe("A");
+    expect(result.primaryClanTag).toBe("#2CGG9GGRV");
+    expect(result.renderedNickname).toBe("A (#2CGG9GGRV) TH1 T D U R");
+  });
+
+  it("renders tracked clans with the primary clan first and de-dupes repeated memberships", () => {
+    const result = service.renderNickname({
+      config: makeConfig(),
+      template: "{trackedClans}",
+      member: makeMember(),
+      linkedAccounts: [
+        makeLink({
+          playerTag: "#2CGG9GGRV",
+          playerName: "Primary",
+        }),
+        makeLink({
+          playerTag: "#2QG2C08UP",
+          playerName: "Second",
+        }),
+        makeLink({
+          playerTag: "#PQLQGRJV",
+          playerName: "Third",
+        }),
+      ],
+      playerCurrentByTag: new Map<string, PlayerCurrentLike>([
+        [
+          "#2CGG9GGRV",
+          makePlayerCurrent({
+            playerTag: "#2CGG9GGRV",
+            playerName: "Primary",
+            townHall: 18,
+            currentClanTag: "#2CGG9GGRV",
+            currentClanName: "Charlie Clan",
+          }),
+        ],
+        [
+          "#2QG2C08UP",
+          makePlayerCurrent({
+            playerTag: "#2QG2C08UP",
+            playerName: "Second",
+            townHall: 16,
+            currentClanTag: "#2QG2C08UP",
+            currentClanName: "Alpha Clan",
+          }),
+        ],
+        [
+          "#PQLQGRJV",
+          makePlayerCurrent({
+            playerTag: "#PQLQGRJV",
+            playerName: "Third",
+            townHall: 14,
+            currentClanTag: "#2QG2C08UP",
+            currentClanName: "Alpha Clan",
+          }),
+        ],
+      ]),
+      trackedClans: [
+        {
+          tag: "#2QG2C08UP",
+          name: "Alpha Clan",
+          shortName: "Alpha",
+        },
+        {
+          tag: "#2CGG9GGRV",
+          name: "Charlie Clan",
+          shortName: "Charlie",
+        },
+      ],
+    });
+
+    expect(result.trackedClans).toEqual(["Charlie", "Alpha"]);
+    expect(result.renderedNickname).toBe("Charlie | Alpha");
+  });
+
+  it("falls back to the clan name when a tracked clan has no short name", () => {
+    const result = service.renderNickname({
+      config: makeConfig(),
+      template: "{trackedClans}",
+      member: makeMember(),
+      linkedAccounts: [
+        makeLink({
+          playerTag: "#2CGG9GGRV",
+          playerName: "Primary",
+        }),
+      ],
+      playerCurrentByTag: new Map<string, PlayerCurrentLike>([
+        [
+          "#2CGG9GGRV",
+          makePlayerCurrent({
+            playerTag: "#2CGG9GGRV",
+            playerName: "Primary",
+            townHall: 16,
+            currentClanTag: "#2QG2C08UP",
+            currentClanName: "Fallback Clan",
+          }),
+        ],
+      ]),
+      trackedClans: [
+        {
+          tag: "#2QG2C08UP",
+          name: "Fallback Clan",
+          shortName: null,
+        },
+      ],
+    });
+
+    expect(result.trackedClans).toEqual(["Fallback Clan"]);
+    expect(result.renderedNickname).toBe("Fallback Clan");
+  });
+
+  it("cleans up empty separators when a token renders blank", () => {
+    const result = service.renderNickname({
+      config: makeConfig(),
+      template: "{player} - {clan}",
+      member: makeMember(),
+      linkedAccounts: [
+        makeLink({
+          playerTag: "#2CGG9GGRV",
+          playerName: null,
+        }),
+      ],
+      playerCurrentByTag: new Map<string, PlayerCurrentLike>([
+        [
+          "#2CGG9GGRV",
+          makePlayerCurrent({
+            playerTag: "#2CGG9GGRV",
+            playerName: null,
+            townHall: 16,
+            currentClanTag: "#2QG2C08UP",
+            currentClanName: "Active Clan",
+          }),
+        ],
+      ]),
+      trackedClans: [
+        {
+          tag: "#2QG2C08UP",
+          name: "Active Clan",
+          shortName: "AC",
+        },
+      ],
+    });
+
+    expect(result.renderedNickname).toBe("Active Clan");
+  });
+
+  it("caps the rendered nickname at 32 characters with safe truncation", () => {
+    const result = service.renderNickname({
+      config: makeConfig(),
+      template: "{player}",
+      member: makeMember(),
+      linkedAccounts: [
+        makeLink({
+          playerTag: "#2CGG9GGRV",
+          playerName: "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789",
+        }),
+      ],
+      playerCurrentByTag: new Map<string, PlayerCurrentLike>([
+        [
+          "#2CGG9GGRV",
+          makePlayerCurrent({
+            playerTag: "#2CGG9GGRV",
+            playerName: "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789",
+            townHall: 16,
+            currentClanTag: "#2QG2C08UP",
+            currentClanName: "Active Clan",
+          }),
+        ],
+      ]),
+      trackedClans: [
+        {
+          tag: "#2QG2C08UP",
+          name: "Active Clan",
+          shortName: "AC",
+        },
+      ],
+    });
+
+    expect(result.renderedNickname).toBe("ABCDEFGHIJKLMNOPQRSTUVWXYZ012345");
+    expect(result.renderedNickname?.length).toBe(32);
+  });
+});


### PR DESCRIPTION
- add a pure AutoRoleNicknameService for template rendering
- cover token selection, tracked clan formatting, cleanup, and truncation