### PR TITLE
feat(autorole): apply nickname templates during refresh

### DIFF
--- a/src/services/AutoRoleApplyService.ts
+++ b/src/services/AutoRoleApplyService.ts
@@ -1,6 +1,12 @@
 import type { AutoRoleGuildConfigSnapshot, AutoRoleEvaluationMemberLike, AutoRoleMemberEvaluation } from "./AutoRoleEvaluationService";
+import {
+  autoRoleNicknameService,
+  type AutoRoleNicknameTrackedClanLike,
+} from "./AutoRoleNicknameService";
+import type { PlayerCurrentLike } from "./PlayerCurrentService";
+import type { PlayerLinkWithTrust } from "./PlayerLinkService";
 
-export type AutoRoleApplyNicknameStatus = "changed" | "skipped" | "unchanged";
+export type AutoRoleApplyNicknameStatus = "changed" | "skipped" | "unchanged" | "failed";
 
 export type AutoRoleMemberApplyResult = {
   discordUserId: string;
@@ -19,6 +25,9 @@ export type AutoRoleApplyInput = {
   managedRoleIds: Set<string>;
   member: AutoRoleEvaluationMemberLike;
   evaluation: AutoRoleMemberEvaluation;
+  linkedAccounts: PlayerLinkWithTrust[];
+  playerCurrentByTag: Map<string, PlayerCurrentLike>;
+  trackedClans: AutoRoleNicknameTrackedClanLike[];
 };
 
 function normalizeRoleIds(roleIds: Iterable<string>): Set<string> {
@@ -32,6 +41,21 @@ function formatRoleMention(roleId: string): string {
 function formatFailureReason(action: "add" | "remove", roleId: string, error: unknown): string {
   const message = String((error as { message?: string } | null | undefined)?.message ?? error ?? "").trim();
   return `${action} ${formatRoleMention(roleId)} failed${message ? `: ${message}` : ""}`;
+}
+
+function formatNicknameFailureReason(error: unknown): string {
+  const code = String((error as { code?: string } | null | undefined)?.code ?? "").trim();
+  const message = String((error as { message?: string } | null | undefined)?.message ?? error ?? "").trim();
+  const normalizedMessage = message.toLowerCase();
+  if (code === "50013" || normalizedMessage.includes("missing permissions") || normalizedMessage.includes("missing access") || normalizedMessage.includes("hierarchy")) {
+    return `nickname update failed: ${message || "insufficient permissions"}`;
+  }
+  return `nickname update failed${message ? `: ${message}` : ""}`;
+}
+
+function normalizeText(input: unknown): string | null {
+  const normalized = String(input ?? "").replace(/\s+/g, " ").trim();
+  return normalized.length > 0 ? normalized : null;
 }
 
 /** Purpose: apply the evaluated autorole state to one Discord member while respecting kill switch and stale-removal policy. */
@@ -54,7 +78,7 @@ export class AutoRoleApplyService {
         rolesAdded: [],
         rolesRemoved: [],
         nicknameStatus: "skipped",
-        nicknameReason: input.config.applyNicknames ? "nickname renderer not implemented" : "nickname sync disabled",
+        nicknameReason: input.config.applyNicknames ? input.evaluation.skipReason : "nickname sync disabled",
         failureReasons: [],
         resultHash: input.evaluation.resultHash,
       };
@@ -101,15 +125,51 @@ export class AutoRoleApplyService {
       }
     }
 
-    const nicknameStatus: AutoRoleApplyNicknameStatus = "skipped";
-    const nicknameReason = input.config.applyNicknames
-      ? "nickname renderer not implemented"
-      : "nickname sync disabled";
+    let nicknameStatus: AutoRoleApplyNicknameStatus = "skipped";
+    let nicknameReason: string | null = null;
+    if (!input.config.applyNicknames) {
+      nicknameReason = "nickname sync disabled";
+    } else if (!normalizeText(input.config.nicknameTemplate)) {
+      nicknameReason = "nickname template not configured";
+    } else {
+      const nicknameResult = autoRoleNicknameService.renderNickname({
+        config: input.config,
+        template: input.config.nicknameTemplate ?? null,
+        member: input.member,
+        linkedAccounts: input.linkedAccounts,
+        playerCurrentByTag: input.playerCurrentByTag,
+        trackedClans: input.trackedClans,
+      });
+
+      const renderedNickname = nicknameResult.renderedNickname;
+      if (!renderedNickname) {
+        nicknameReason = "nickname template rendered empty";
+      } else {
+        const currentDisplayNickname = normalizeText(input.member.displayName ?? input.member.nickname ?? null) ?? "";
+        if (currentDisplayNickname === renderedNickname) {
+          nicknameStatus = "unchanged";
+        } else {
+          try {
+            if (typeof input.member.setNickname === "function") {
+              await input.member.setNickname(renderedNickname);
+              nicknameStatus = "changed";
+            } else {
+              nicknameStatus = "skipped";
+              nicknameReason = "nickname updates are not supported on this member";
+            }
+          } catch (error) {
+            nicknameStatus = "failed";
+            nicknameReason = formatNicknameFailureReason(error);
+            failureReasons.push(nicknameReason);
+          }
+        }
+      }
+    }
 
     let status: AutoRoleMemberApplyResult["status"] = "skipped";
     if (failureReasons.length > 0) {
       status = rolesAdded.length > 0 || rolesRemoved.length > 0 ? "failed" : "failed";
-    } else if (rolesAdded.length > 0 || rolesRemoved.length > 0) {
+    } else if (rolesAdded.length > 0 || rolesRemoved.length > 0 || nicknameStatus === "changed") {
       status = "applied";
     }
 

--- a/src/services/AutoRoleEvaluationService.ts
+++ b/src/services/AutoRoleEvaluationService.ts
@@ -27,6 +27,12 @@ export type AutoRoleGuildConfigSnapshot = Pick<
 
 export type AutoRoleEvaluationMemberLike = {
   id: string;
+  displayName?: string | null;
+  nickname?: string | null;
+  user?: {
+    username?: string | null;
+    globalName?: string | null;
+  } | null;
   roles: {
     cache: {
       keys(): IterableIterator<string>;
@@ -35,6 +41,7 @@ export type AutoRoleEvaluationMemberLike = {
     add(roleId: string): Promise<unknown>;
     remove(roleId: string): Promise<unknown>;
   };
+  setNickname?(nickname: string | null): Promise<unknown>;
 };
 
 export type AutoRoleMemberEvaluation = {

--- a/src/services/AutoRoleNicknameService.ts
+++ b/src/services/AutoRoleNicknameService.ts
@@ -17,10 +17,11 @@ export type AutoRoleNicknameTrackedClanLike = {
 export type AutoRoleNicknameMemberLike = {
   id: string;
   displayName?: string | null;
-  user: {
+  nickname?: string | null;
+  user?: {
     username?: string | null;
     globalName?: string | null;
-  };
+  } | null;
 };
 
 export type AutoRoleNicknameRenderInput = {
@@ -147,12 +148,9 @@ function cleanNicknameOutput(input: string): string {
   }
 
   output = output.replace(/\s*([|/-])\s*/g, " $1 ");
-  output = output.replace(/^(?:\s*[|/-]\s*)+/g, "");
-  output = output.replace(/(?:\s*[|/-]\s*)+$/g, "");
   output = output.replace(/\s{2,}/g, " ").trim();
-  output = output.replace(/\s*([|/-])(?:\s*\1)+\s*/g, " $1 ");
-  output = output.replace(/^(?:\s*[|/-]\s*)+/g, "");
-  output = output.replace(/(?:\s*[|/-]\s*)+$/g, "");
+  output = output.replace(/^(?:[|/-]\s*)+/g, "");
+  output = output.replace(/(?:\s*[|/-])+\s*$/g, "");
   output = output.replace(/\s{2,}/g, " ").trim();
 
   return output;
@@ -204,7 +202,7 @@ export class AutoRoleNicknameService {
       normalizeText(primaryPlayerCurrent?.playerName) ??
       normalizeText(primary?.playerName) ??
       null;
-    const primaryClanTag = primaryClan?.tag ?? null;
+    const primaryClanTag = primaryClan?.tag ?? primaryPlayerCurrent?.currentClanTag ?? null;
     const primaryClanName =
       normalizeText(primaryClan?.name) ??
       normalizeText(primaryPlayerCurrent?.currentClanName) ??
@@ -218,11 +216,11 @@ export class AutoRoleNicknameService {
         ? String(primaryPlayerCurrent.townHall)
         : "",
       clan: primaryClanName ?? primaryClanShort ?? primaryClanTag ?? "",
-      "clanTag": primaryClanTag ?? "",
+      clanTag: primaryClanTag ?? "",
       clanShort: primaryClanShort ?? primaryClanName ?? primaryClanTag ?? "",
       trackedClans: trackedClanLabels.join(" | "),
-      discord: normalizeText(input.member.displayName) ?? "",
-      username: normalizeText(input.member.user.username ?? input.member.user.globalName ?? null) ?? "",
+      discord: normalizeText(input.member.displayName ?? input.member.nickname ?? null) ?? "",
+      username: normalizeText(input.member.user?.username ?? input.member.user?.globalName ?? null) ?? "",
       role: normalizeText(primaryPlayerCurrent?.role ?? null) ?? "",
     };
     const tokenLookup: AutoRoleNicknameTokenLookup = {
@@ -239,9 +237,7 @@ export class AutoRoleNicknameService {
     };
 
     const template = normalizeText(input.template) ?? "";
-    const rendered = template
-      ? this.renderTemplate(template, tokenLookup)
-      : "";
+    const rendered = template ? this.renderTemplate(template, tokenLookup) : "";
     const cleaned = cleanNicknameOutput(rendered);
     const truncated = safeTruncate(cleaned, 32);
 
@@ -276,7 +272,9 @@ export class AutoRoleNicknameService {
       }
     }
 
-    const labels = [...tags].map((tag) => input.trackedClanIndex.get(tag)!).filter(Boolean);
+    const labels = [...tags]
+      .map((tag) => input.trackedClanIndex.get(tag)!)
+      .filter(Boolean);
     labels.sort((left, right) => {
       const leftLabel = resolveTrackedClanLabel(left).toLowerCase();
       const rightLabel = resolveTrackedClanLabel(right).toLowerCase();

--- a/src/services/AutoRoleRefreshService.ts
+++ b/src/services/AutoRoleRefreshService.ts
@@ -15,6 +15,7 @@ import {
   type AutoRoleClanMembershipIndexRow,
   type AutoRoleMemberEvaluation,
 } from "./AutoRoleEvaluationService";
+import type { AutoRoleNicknameTrackedClanLike } from "./AutoRoleNicknameService";
 import {
   autoRoleService,
   type AutoRoleGuildStateSnapshot,
@@ -49,7 +50,8 @@ export type AutoRoleRefreshResult = {
 type AutoRoleGuildMemberLike = {
   id: string;
   displayName?: string;
-  user: { id: string };
+  nickname?: string | null;
+  user: { id: string; username?: string | null; globalName?: string | null };
   roles: {
     cache: {
       keys(): IterableIterator<string>;
@@ -58,6 +60,7 @@ type AutoRoleGuildMemberLike = {
     add(roleId: string): Promise<unknown>;
     remove(roleId: string): Promise<unknown>;
   };
+  setNickname?(nickname: string | null): Promise<unknown>;
 };
 
 type AutoRoleMemberCollectionLike =
@@ -189,6 +192,24 @@ async function loadPlayerCurrentByLinkedAccounts(input: {
     },
     resolution,
   );
+}
+
+async function loadTrackedClansForNickname(): Promise<AutoRoleNicknameTrackedClanLike[]> {
+  const rows = await prisma.trackedClan.findMany({
+    select: {
+      tag: true,
+      name: true,
+      shortName: true,
+    },
+  });
+
+  return rows
+    .map((row) => ({
+      tag: normalizeClanTag(row.tag),
+      name: row.name ?? null,
+      shortName: row.shortName ?? null,
+    }))
+    .filter((row) => row.tag.length > 0);
 }
 
 async function loadClanMembershipIndex(input: {
@@ -509,6 +530,7 @@ async function runRefreshPass(input: {
   membersById: Map<string, AutoRoleGuildMemberLike>;
   linkedAccountsByUserId: Map<string, PlayerLinkWithTrust[]>;
   playerCurrentByTag: Map<string, PlayerCurrentLike>;
+  trackedClans: AutoRoleNicknameTrackedClanLike[];
   clanMembershipIndex: AutoRoleClanMembershipIndex;
   runId: string;
 }): Promise<AutoRoleRefreshResult> {
@@ -601,6 +623,9 @@ async function runRefreshPass(input: {
         managedRoleIds,
         member,
         evaluation,
+        linkedAccounts,
+        playerCurrentByTag: input.playerCurrentByTag,
+        trackedClans: input.trackedClans,
       });
 
       memberResults.push(result);
@@ -741,6 +766,10 @@ export class AutoRoleRefreshService {
         linkedAccountsByUserId,
         cocService: input.cocService ?? null,
       });
+      const nicknameTemplate = String(snapshot.config.nicknameTemplate ?? "").trim();
+      const trackedClans = snapshot.config.applyNicknames && nicknameTemplate.length > 0
+        ? await loadTrackedClansForNickname()
+        : [];
       const clanMembershipIndex = await loadClanMembershipIndex({
         season: resolveCurrentCwlSeasonKey(),
         rules: snapshot.rules,
@@ -758,6 +787,7 @@ export class AutoRoleRefreshService {
         membersById,
         linkedAccountsByUserId,
         playerCurrentByTag,
+        trackedClans,
         clanMembershipIndex,
         runId: run.id,
       });

--- a/tests/autorole.apply.service.test.ts
+++ b/tests/autorole.apply.service.test.ts
@@ -1,0 +1,214 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { autoRoleApplyService } from "../src/services/AutoRoleApplyService";
+import type { AutoRoleGuildConfigSnapshot, AutoRoleMemberEvaluation } from "../src/services/AutoRoleEvaluationService";
+import type { AutoRoleNicknameTrackedClanLike } from "../src/services/AutoRoleNicknameService";
+import type { PlayerCurrentLike } from "../src/services/PlayerCurrentService";
+import type { PlayerLinkWithTrust } from "../src/services/PlayerLinkService";
+
+type TestMember = {
+  id: string;
+  displayName: string;
+  nickname: string | null;
+  user: {
+    username: string | null;
+    globalName: string | null;
+  };
+  roles: {
+    cache: {
+      keys(): IterableIterator<string>;
+      has(roleId: string): boolean;
+    };
+    add: ReturnType<typeof vi.fn>;
+    remove: ReturnType<typeof vi.fn>;
+  };
+  setNickname: ReturnType<typeof vi.fn>;
+};
+
+function makeConfig(overrides: Partial<AutoRoleGuildConfigSnapshot> = {}): AutoRoleGuildConfigSnapshot {
+  return {
+    enabled: true,
+    killSwitchEnabled: false,
+    removeStaleManagedRoles: true,
+    applyNicknames: true,
+    nicknameTemplate: "{player}",
+    trustedLinksAllowed: true,
+    verifiedOnlyMode: false,
+    verifiedRoleId: null,
+    familyRoleId: null,
+    ...overrides,
+  };
+}
+
+function makeMember(displayName = "Old Nick"): TestMember {
+  return {
+    id: "111111111111111111",
+    displayName,
+    nickname: displayName,
+    user: {
+      username: "DiscordUser",
+      globalName: "Discord Global",
+    },
+    roles: {
+      cache: {
+        keys: () => [].values(),
+        has: () => false,
+      },
+      add: vi.fn(async () => undefined),
+      remove: vi.fn(async () => undefined),
+    },
+    setNickname: vi.fn(async () => undefined),
+  };
+}
+
+function makeLinkedAccount(tag = "#2CGG9GGRV", playerName = "Alpha"): PlayerLinkWithTrust {
+  return {
+    playerTag: tag,
+    discordUserId: "111111111111111111",
+    discordUsername: "DiscordUser",
+    playerName,
+    linkSource: "SELF_SERVICE",
+    verificationStatus: "VERIFIED",
+    verificationMethod: "PLAYER_API_TOKEN",
+    verifiedAt: new Date("2026-04-01T00:00:00.000Z"),
+    verifiedByDiscordUserId: null,
+    lastVerifiedAt: null,
+    verificationFailureReason: null,
+    importBatchKey: null,
+    createdAt: new Date("2026-04-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-04-01T00:00:00.000Z"),
+  };
+}
+
+function makePlayerCurrent(overrides: Partial<PlayerCurrentLike> & Pick<PlayerCurrentLike, "playerTag">): PlayerCurrentLike {
+  return {
+    playerTag: overrides.playerTag,
+    playerName: overrides.playerName ?? null,
+    townHall: overrides.townHall ?? 16,
+    currentClanTag: overrides.currentClanTag ?? "#2CGG9GGRV",
+    currentClanName: overrides.currentClanName ?? "Tracked Clan",
+    trophies: null,
+    builderTrophies: null,
+    warStars: null,
+    expLevel: null,
+    role: null,
+    leagueName: null,
+    currentWeight: null,
+    currentWeightSource: null,
+    currentWeightMeasuredAt: null,
+    achievementsJson: null,
+    lastSeenAt: null,
+    lastFetchedAt: null,
+    lastSource: null,
+    createdAt: null,
+    updatedAt: null,
+    source: "player_current",
+    liveRefreshInvoked: false,
+  };
+}
+
+function makeEvaluation(overrides: Partial<AutoRoleMemberEvaluation> = {}): AutoRoleMemberEvaluation {
+  return {
+    discordUserId: "111111111111111111",
+    skipReason: null,
+    desiredManagedRoleIds: [],
+    matchedRuleIds: [],
+    primaryPlayerTag: "#2CGG9GGRV",
+    primaryPlayerName: "Alpha",
+    resultHash: "hash-1",
+    ...overrides,
+  };
+}
+
+describe("AutoRoleApplyService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("skips nickname sync when disabled", async () => {
+    const member = makeMember();
+    const result = await autoRoleApplyService.applyMember({
+      config: makeConfig({ applyNicknames: false }),
+      managedRoleIds: new Set(),
+      member: member as any,
+      evaluation: makeEvaluation(),
+      linkedAccounts: [makeLinkedAccount()],
+      playerCurrentByTag: new Map([["#2CGG9GGRV", makePlayerCurrent({ playerTag: "#2CGG9GGRV" })]]),
+      trackedClans: [{ tag: "#2CGG9GGRV", name: "Tracked Clan", shortName: "TC" }],
+    });
+
+    expect(member.setNickname).not.toHaveBeenCalled();
+    expect(result.nicknameStatus).toBe("skipped");
+    expect(result.nicknameReason).toBe("nickname sync disabled");
+  });
+
+  it("skips nickname sync when the template is not configured", async () => {
+    const member = makeMember();
+    const result = await autoRoleApplyService.applyMember({
+      config: makeConfig({ nicknameTemplate: "   " }),
+      managedRoleIds: new Set(),
+      member: member as any,
+      evaluation: makeEvaluation(),
+      linkedAccounts: [makeLinkedAccount()],
+      playerCurrentByTag: new Map([["#2CGG9GGRV", makePlayerCurrent({ playerTag: "#2CGG9GGRV" })]]),
+      trackedClans: [{ tag: "#2CGG9GGRV", name: "Tracked Clan", shortName: "TC" }],
+    });
+
+    expect(member.setNickname).not.toHaveBeenCalled();
+    expect(result.nicknameStatus).toBe("skipped");
+    expect(result.nicknameReason).toBe("nickname template not configured");
+  });
+
+  it("returns unchanged when the rendered nickname already matches", async () => {
+    const member = makeMember("Alpha");
+    const result = await autoRoleApplyService.applyMember({
+      config: makeConfig({ nicknameTemplate: "{player}" }),
+      managedRoleIds: new Set(),
+      member: member as any,
+      evaluation: makeEvaluation(),
+      linkedAccounts: [makeLinkedAccount()],
+      playerCurrentByTag: new Map([["#2CGG9GGRV", makePlayerCurrent({ playerTag: "#2CGG9GGRV", playerName: "Alpha" })]]),
+      trackedClans: [{ tag: "#2CGG9GGRV", name: "Tracked Clan", shortName: "TC" }],
+    });
+
+    expect(member.setNickname).not.toHaveBeenCalled();
+    expect(result.nicknameStatus).toBe("unchanged");
+    expect(result.status).toBe("skipped");
+  });
+
+  it("applies a rendered nickname when it differs from the current display nickname", async () => {
+    const member = makeMember("Old Nick");
+    const result = await autoRoleApplyService.applyMember({
+      config: makeConfig({ nicknameTemplate: "{player}" }),
+      managedRoleIds: new Set(),
+      member: member as any,
+      evaluation: makeEvaluation(),
+      linkedAccounts: [makeLinkedAccount()],
+      playerCurrentByTag: new Map([["#2CGG9GGRV", makePlayerCurrent({ playerTag: "#2CGG9GGRV", playerName: "Alpha" })]]),
+      trackedClans: [{ tag: "#2CGG9GGRV", name: "Tracked Clan", shortName: "TC" }],
+    });
+
+    expect(member.setNickname).toHaveBeenCalledWith("Alpha");
+    expect(result.nicknameStatus).toBe("changed");
+    expect(result.status).toBe("applied");
+  });
+
+  it("captures nickname permission failures without crashing", async () => {
+    const member = makeMember("Old Nick");
+    member.setNickname.mockRejectedValueOnce(new Error("Missing Permissions"));
+
+    const result = await autoRoleApplyService.applyMember({
+      config: makeConfig({ nicknameTemplate: "{player}" }),
+      managedRoleIds: new Set(),
+      member: member as any,
+      evaluation: makeEvaluation(),
+      linkedAccounts: [makeLinkedAccount()],
+      playerCurrentByTag: new Map([["#2CGG9GGRV", makePlayerCurrent({ playerTag: "#2CGG9GGRV", playerName: "Alpha" })]]),
+      trackedClans: [{ tag: "#2CGG9GGRV", name: "Tracked Clan", shortName: "TC" }],
+    });
+
+    expect(member.setNickname).toHaveBeenCalledWith("Alpha");
+    expect(result.nicknameStatus).toBe("failed");
+    expect(result.failureReasons[0]).toContain("nickname update failed");
+    expect(result.status).toBe("failed");
+  });
+});

--- a/tests/autorole.refresh.service.test.ts
+++ b/tests/autorole.refresh.service.test.ts
@@ -49,6 +49,7 @@ type GuildMemberLike = {
   id: string;
   user: { id: string };
   displayName: string;
+  nickname: string | null;
   roles: {
     cache: {
       keys(): IterableIterator<string>;
@@ -57,6 +58,7 @@ type GuildMemberLike = {
     add: ReturnType<typeof vi.fn>;
     remove: ReturnType<typeof vi.fn>;
   };
+  setNickname: ReturnType<typeof vi.fn>;
   __roleIds: string[];
 };
 
@@ -73,10 +75,12 @@ function makeMember(id: string, roleIds: string[] = []): GuildMemberLike {
       roleState.splice(index, 1);
     }
   });
+  const setNickname = vi.fn(async () => undefined);
   return {
     id,
     user: { id },
     displayName: `Member ${id}`,
+    nickname: null,
     roles: {
       cache: {
         keys: () => roleState.values(),
@@ -85,6 +89,7 @@ function makeMember(id: string, roleIds: string[] = []): GuildMemberLike {
       add,
       remove,
     },
+    setNickname,
     __roleIds: roleState,
   };
 }
@@ -110,7 +115,7 @@ function makeConfig(overrides: Record<string, unknown> = {}) {
     killSwitchEnabled: false,
     removeStaleManagedRoles: false,
     applyNicknames: true,
-    nicknameTemplate: "TH{th} {name}",
+    nicknameTemplate: "TH{th} {player}",
     trustedLinksAllowed: true,
     verifiedOnlyMode: false,
     syncEnabled: true,
@@ -238,6 +243,19 @@ describe("AutoRoleRefreshService", () => {
         }),
       ].filter((row) => wanted.has(row.discordUserId));
     });
+    vi.spyOn(playerCurrentService, "resolveCurrentPlayersForTags").mockImplementationOnce(async ({ playerTags }) => {
+      const map = new Map<string, any>();
+      for (const playerTag of playerTags) {
+        map.set(
+          playerTag,
+          makePlayerCurrent({
+            playerTag,
+            playerName: playerTag === "#2QG2C08UP" ? "Alpha" : `Player ${playerTag}`,
+          }),
+        );
+      }
+      return map;
+    });
 
     vi.spyOn(autoRoleService, "getGuildStateSnapshot").mockResolvedValue({
       config: makeConfig({ applyNicknames: true, removeStaleManagedRoles: false }),
@@ -270,9 +288,10 @@ describe("AutoRoleRefreshService", () => {
     expect(result.memberResults[0]).toMatchObject({
       discordUserId: userId,
       status: "applied",
-      nicknameStatus: "skipped",
-      nicknameReason: "nickname renderer not implemented",
+      nicknameStatus: "changed",
+      nicknameReason: null,
     });
+    expect(member.setNickname).toHaveBeenCalledWith("TH16 Alpha");
     expect(prismaMock.autoRoleSyncRun.create).toHaveBeenCalledWith(
       expect.objectContaining({
         data: expect.objectContaining({

--- a/tests/autoroleNickname.service.test.ts
+++ b/tests/autoroleNickname.service.test.ts
@@ -23,6 +23,7 @@ function makeMember(overrides: Partial<AutoRoleNicknameRenderInput["member"]> = 
   return {
     id: "111111111111111111",
     displayName: "D",
+    nickname: null,
     user: {
       username: "U",
       globalName: "DG",
@@ -102,7 +103,7 @@ describe("AutoRoleNicknameService", () => {
             playerTag: "#2QG2C08UP",
             playerName: "Untracked",
             townHall: 18,
-            currentClanTag: "#PQLQG",
+            currentClanTag: "#PYLQ0289",
             currentClanName: "Untracked Clan",
             role: "member",
           }),
@@ -170,7 +171,7 @@ describe("AutoRoleNicknameService", () => {
             playerTag: "#2QG2C08UP",
             playerName: "Second",
             townHall: 16,
-            currentClanTag: "#2QG2C08UP",
+            currentClanTag: "#PYLQ0289",
             currentClanName: "Alpha Clan",
           }),
         ],
@@ -180,14 +181,14 @@ describe("AutoRoleNicknameService", () => {
             playerTag: "#PQLQGRJV",
             playerName: "Third",
             townHall: 14,
-            currentClanTag: "#2QG2C08UP",
+            currentClanTag: "#PYLQ0289",
             currentClanName: "Alpha Clan",
           }),
         ],
       ]),
       trackedClans: [
         {
-          tag: "#2QG2C08UP",
+          tag: "#PYLQ0289",
           name: "Alpha Clan",
           shortName: "Alpha",
         },
@@ -221,20 +222,21 @@ describe("AutoRoleNicknameService", () => {
             playerTag: "#2CGG9GGRV",
             playerName: "Primary",
             townHall: 16,
-            currentClanTag: "#2QG2C08UP",
+            currentClanTag: "#PYLQ0289",
             currentClanName: "Fallback Clan",
           }),
         ],
       ]),
       trackedClans: [
         {
-          tag: "#2QG2C08UP",
+          tag: "#PYLQ0289",
           name: "Fallback Clan",
           shortName: null,
         },
       ],
     });
 
+    expect(result.primaryClanShort).toBeNull();
     expect(result.trackedClans).toEqual(["Fallback Clan"]);
     expect(result.renderedNickname).toBe("Fallback Clan");
   });
@@ -257,14 +259,14 @@ describe("AutoRoleNicknameService", () => {
             playerTag: "#2CGG9GGRV",
             playerName: null,
             townHall: 16,
-            currentClanTag: "#2QG2C08UP",
+            currentClanTag: "#PYLQ0289",
             currentClanName: "Active Clan",
           }),
         ],
       ]),
       trackedClans: [
         {
-          tag: "#2QG2C08UP",
+          tag: "#PYLQ0289",
           name: "Active Clan",
           shortName: "AC",
         },
@@ -292,14 +294,14 @@ describe("AutoRoleNicknameService", () => {
             playerTag: "#2CGG9GGRV",
             playerName: "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789",
             townHall: 16,
-            currentClanTag: "#2QG2C08UP",
+            currentClanTag: "#PYLQ0289",
             currentClanName: "Active Clan",
           }),
         ],
       ]),
       trackedClans: [
         {
-          tag: "#2QG2C08UP",
+          tag: "#PYLQ0289",
           name: "Active Clan",
           shortName: "AC",
         },


### PR DESCRIPTION
- add a shared nickname renderer for autorole context
- apply nickname updates alongside autorole refresh with clear status reporting