### PR TITLE
feat(cwl): share clan leadership lookup for rotation views

### DIFF
--- a/src/commands/Cwl.ts
+++ b/src/commands/Cwl.ts
@@ -239,33 +239,6 @@ function buildCwlRotationRosterTagSet(plan: CwlRotationPlanExport): Set<string> 
   return new Set(buildCwlRotationOriginalRosterMembers(plan).map((member) => member.playerTag));
 }
 
-function buildCwlRotationLeaderNames(
-  entries: Awaited<ReturnType<typeof cwlStateService.listSeasonRosterForClan>>,
-  clanTag?: string | null,
-): string[] {
-  const selectedClanTag = normalizeClanTag(clanTag ?? "");
-  const leaders = entries
-    .filter((entry) => {
-      if (!selectedClanTag) return true;
-      return normalizeClanTag(entry.clanTag) === selectedClanTag;
-    })
-    .map((entry) => ({
-      name: entry.playerName,
-      tag: entry.playerTag,
-      role: normalizeClanMemberRole(entry.role),
-    }))
-    .filter((entry) => entry.role !== null)
-    .sort((left, right) => {
-      const leftRank = left.role === "leader" ? 0 : 1;
-      const rightRank = right.role === "leader" ? 0 : 1;
-      if (leftRank !== rightRank) return leftRank - rightRank;
-      const byName = left.name.localeCompare(right.name, undefined, { sensitivity: "base" });
-      if (byName !== 0) return byName;
-      return left.tag.localeCompare(right.tag);
-    });
-  return leaders.map((entry) => entry.name);
-}
-
 function renderTownHallIcon(
   townHall: number | null | undefined,
   townHallEmojiByLevel: Map<number, string>,
@@ -1891,11 +1864,9 @@ async function loadCwlRotationShowClanPayload(input: {
       throughRoundDay: selectedDay.roundDay,
     }),
   ]);
-  const seasonRosterEntries = await cwlStateService.listSeasonRosterForClan({
+  const leaderNames = await cwlRotationService.listClanLeadershipNames({
     clanTag: planView.clanTag,
-    season: planView.season,
   });
-  const leaderNames = buildCwlRotationLeaderNames(seasonRosterEntries, planView.clanTag);
 
   return {
     payload: await buildCwlRotationShowClanPayload({

--- a/src/services/CwlRotationService.ts
+++ b/src/services/CwlRotationService.ts
@@ -292,6 +292,13 @@ export type CwlRotationOverviewEntry = {
   extraActualPlayerTags: string[];
 };
 
+type CwlClanLeadershipRow = {
+  clanTag: string;
+  playerTag: string;
+  playerName: string | null;
+  role: unknown;
+};
+
 function normalizeClanMemberRole(input: unknown): "leader" | "coleader" | null {
   const normalized = String(input ?? "")
     .trim()
@@ -303,6 +310,41 @@ function normalizeClanMemberRole(input: unknown): "leader" | "coleader" | null {
 }
 
 const fwaClanMembersSyncService = new FwaClanMembersSyncService();
+
+function buildClanLeadershipNamesByClanTag(rows: CwlClanLeadershipRow[]): Map<string, string[]> {
+  const leaderNamesByClanTag = new Map<string, string[]>();
+  const leaderRowsByClanTag = new Map<
+    string,
+    Array<{ roleRank: number; playerName: string; playerTag: string }>
+  >();
+  for (const row of rows) {
+    const clanTag = normalizeClanTag(row.clanTag);
+    const role = normalizeClanMemberRole(row.role);
+    if (!clanTag || !role) continue;
+    const roleRank = role === "leader" ? 0 : 1;
+    const entries = leaderRowsByClanTag.get(clanTag) ?? [];
+    entries.push({
+      roleRank,
+      playerName: String(row.playerName ?? "").trim() || row.playerTag,
+      playerTag: String(row.playerTag ?? "").trim() || "",
+    });
+    leaderRowsByClanTag.set(clanTag, entries);
+  }
+  for (const [clanTag, rowsByClanTag] of leaderRowsByClanTag.entries()) {
+    leaderNamesByClanTag.set(
+      clanTag,
+      rowsByClanTag
+        .sort((a, b) => {
+          if (a.roleRank !== b.roleRank) return a.roleRank - b.roleRank;
+          const byName = a.playerName.localeCompare(b.playerName, undefined, { sensitivity: "base" });
+          if (byName !== 0) return byName;
+          return a.playerTag.localeCompare(b.playerTag);
+        })
+        .map((row) => row.playerName),
+    );
+  }
+  return leaderNamesByClanTag;
+}
 
 function compareRosterEntries(
   a: CwlRotationSeedRosterEntry,
@@ -1929,29 +1971,17 @@ export class CwlRotationService {
     };
   }
 
-  /** Purpose: summarize current-day plan-vs-actual status across all active CWL rotation plans. */
-  async listOverview(input?: {
-    season?: string;
+  private async loadClanLeadershipNamesByClanTag(input: {
+    clanTags: string[];
     refreshLeadershipMembers?: boolean;
-  }): Promise<CwlRotationOverviewEntry[]> {
-    const season = input?.season ?? resolveCurrentCwlSeasonKey();
-    const activePlans = await prisma.cwlRotationPlan.findMany({
-      where: {
-        season,
-        isActive: true,
-      },
-      orderBy: [{ clanTag: "asc" }, { version: "desc" }],
-    });
-    const clanTags = [...new Set(activePlans.map((plan) => plan.clanTag).filter(Boolean))];
-    const uniquePlans = new Map<string, typeof activePlans[number]>();
-    for (const plan of activePlans) {
-      if (!uniquePlans.has(plan.clanTag)) {
-        uniquePlans.set(plan.clanTag, plan);
-      }
-    }
+  }): Promise<{
+    leaderNamesByClanTag: Map<string, string[]>;
+    failedLeadershipClanTags: Set<string>;
+  }> {
+    const clanTags = [...new Set(input.clanTags.map((tag) => normalizeClanTag(tag)).filter(Boolean))];
 
     const failedLeadershipClanTags = new Set<string>();
-    if (input?.refreshLeadershipMembers && clanTags.length > 0) {
+    if (input.refreshLeadershipMembers && clanTags.length > 0) {
       try {
         const refreshResult = await fwaClanMembersSyncService.refreshCurrentClanMembersForClanTags(
           clanTags,
@@ -1994,46 +2024,62 @@ export class CwlRotationService {
           ],
         })
       : [];
-    const leaderNamesByClanTag = new Map<string, string[]>();
-    const leaderRowsByClanTag = new Map<
-      string,
-      Array<{ roleRank: number; playerName: string; playerTag: string }>
-    >();
-    for (const row of leaderRows) {
-      const clanTag = normalizeClanTag(row.clanTag);
-      const role = normalizeClanMemberRole(row.role);
-      if (!clanTag || !role) continue;
-      const roleRank = role === "leader" ? 0 : 1;
-      const entries = leaderRowsByClanTag.get(clanTag) ?? [];
-      entries.push({
-        roleRank,
-        playerName: String(row.playerName ?? "").trim() || row.playerTag,
-        playerTag: String(row.playerTag ?? "").trim() || "",
-      });
-      leaderRowsByClanTag.set(clanTag, entries);
+
+    return {
+      leaderNamesByClanTag: buildClanLeadershipNamesByClanTag(leaderRows),
+      failedLeadershipClanTags,
+    };
+  }
+
+  async listClanLeadershipNames(input: {
+    clanTag: string;
+    refreshLeadershipMembers?: boolean;
+  }): Promise<string[]> {
+    const clanTag = normalizeClanTag(input.clanTag);
+    if (!clanTag) {
+      return [];
     }
-    for (const [clanTag, rows] of leaderRowsByClanTag.entries()) {
-      leaderNamesByClanTag.set(
-        clanTag,
-        rows
-          .sort((a, b) => {
-            if (a.roleRank !== b.roleRank) return a.roleRank - b.roleRank;
-            const byName = a.playerName.localeCompare(b.playerName, undefined, { sensitivity: "base" });
-            if (byName !== 0) return byName;
-            return a.playerTag.localeCompare(b.playerTag);
-          })
-          .map((row) => row.playerName),
-      );
+
+    const { leaderNamesByClanTag } = await this.loadClanLeadershipNamesByClanTag({
+      clanTags: [clanTag],
+      refreshLeadershipMembers: input.refreshLeadershipMembers,
+    });
+    return leaderNamesByClanTag.get(clanTag) ?? [];
+  }
+
+  /** Purpose: summarize current-day plan-vs-actual status across all active CWL rotation plans. */
+  async listOverview(input?: {
+    season?: string;
+    refreshLeadershipMembers?: boolean;
+  }): Promise<CwlRotationOverviewEntry[]> {
+    const season = input?.season ?? resolveCurrentCwlSeasonKey();
+    const activePlans = await prisma.cwlRotationPlan.findMany({
+      where: {
+        season,
+        isActive: true,
+      },
+      orderBy: [{ clanTag: "asc" }, { version: "desc" }],
+    });
+    const clanTags = [...new Set(activePlans.map((plan) => plan.clanTag).filter(Boolean))];
+    const uniquePlans = new Map<string, typeof activePlans[number]>();
+    for (const plan of activePlans) {
+      if (!uniquePlans.has(plan.clanTag)) {
+        uniquePlans.set(plan.clanTag, plan);
+      }
     }
+
+    const { leaderNamesByClanTag, failedLeadershipClanTags } = await this.loadClanLeadershipNamesByClanTag({
+      clanTags,
+      refreshLeadershipMembers: input?.refreshLeadershipMembers,
+    });
 
     const entries: CwlRotationOverviewEntry[] = [];
     for (const plan of uniquePlans.values()) {
       const refreshFailed = failedLeadershipClanTags.has(plan.clanTag);
-      const leaderRowsForClan = leaderRowsByClanTag.get(plan.clanTag) ?? [];
       const leaderNames = refreshFailed ? [] : leaderNamesByClanTag.get(plan.clanTag) ?? [];
       if (input?.refreshLeadershipMembers) {
         console.info(
-          `[cwl] overview leadership clan=${plan.clanTag} persisted_rows=${leaderRowsForClan.length} refresh_failed=${refreshFailed ? "yes" : "no"}`,
+          `[cwl] overview leadership clan=${plan.clanTag} leaders=${leaderNames.length} refresh_failed=${refreshFailed ? "yes" : "no"}`,
         );
       }
       const [currentRound, preferredDay] = await Promise.all([

--- a/tests/cwl.command.test.ts
+++ b/tests/cwl.command.test.ts
@@ -335,6 +335,7 @@ describe("/cwl command", () => {
     vi.spyOn(cwlRotationService, "deleteActivePlan");
     vi.spyOn(cwlRotationService, "listActivePlanExports");
     vi.spyOn(cwlRotationService, "listOverview");
+    vi.spyOn(cwlRotationService, "listClanLeadershipNames").mockResolvedValue([] as any);
     vi.spyOn(cwlRotationService, "getPreferredDisplayDay").mockResolvedValue(null);
     vi.spyOn(cwlRotationService, "validatePlanDay");
     vi.spyOn(cwlStateService, "getBattleDayStartForClanDay").mockResolvedValue(null);
@@ -1583,6 +1584,10 @@ describe("/cwl command", () => {
         ],
       } as any,
     ]);
+    vi.mocked(cwlRotationService.listClanLeadershipNames).mockResolvedValue([
+      "Alpha Leader",
+      "Alpha CoLeader",
+    ]);
     vi.mocked(cwlStateService.listSeasonRosterForClan).mockResolvedValue([
       {
         season: "2026-04",
@@ -1995,6 +2000,7 @@ describe("/cwl command", () => {
     expect(getDescription(interaction)).toContain(":x: Bravo (#QGRJ2222) | War count: 0");
     expect(getDescription(interaction)).toContain(":x: Delta (#CUV02898) | War count: 0");
     expect(getDescription(interaction)).not.toContain(":x: Hotel (#JQJQ2222)");
+    expect(cwlStateService.listSeasonRosterForClan).not.toHaveBeenCalled();
     expect(getDescription(interaction)).not.toContain("Actual:");
     expect(getDescription(interaction)).not.toContain("Status:");
     expect(getComponentButtonCustomIds(interaction)).toHaveLength(4);

--- a/tests/cwlRotation.service.test.ts
+++ b/tests/cwlRotation.service.test.ts
@@ -1594,6 +1594,69 @@ describe("CwlRotationService", () => {
     ]);
   });
 
+  it("returns clan-scoped leadership names from persisted current clan members", async () => {
+    vi.spyOn(FwaClanMembersSyncService.prototype, "refreshCurrentClanMembersForClanTags").mockResolvedValue({
+      clanCount: 1,
+      rowCount: 3,
+      changedRowCount: 0,
+      failedClans: [],
+    });
+    prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue([
+      {
+        clanTag: "#2QG2C08UP",
+        playerTag: "#AAA",
+        playerName: "elle ♡ duck",
+        role: "leader",
+      },
+      {
+        clanTag: "#2QG2C08UP",
+        playerTag: "#BBB",
+        playerName: "sim-fill-void-3",
+        role: "coleader",
+      },
+      {
+        clanTag: "#9GLGQCCU",
+        playerTag: "#CCC",
+        playerName: "Other Clan Leader",
+        role: "leader",
+      },
+      {
+        clanTag: "#2QG2C08UP",
+        playerTag: "#DDD",
+        playerName: "DuskComet",
+        role: "coleader",
+      },
+    ]);
+
+    const leaderNames = await cwlRotationService.listClanLeadershipNames({
+      clanTag: "#2QG2C08UP",
+      refreshLeadershipMembers: true,
+    });
+
+    expect(leaderNames).toEqual(["elle ♡ duck", "DuskComet", "sim-fill-void-3"]);
+    expect(prismaMock.fwaClanMemberCurrent.findMany).toHaveBeenCalledWith({
+      where: {
+        clanTag: { in: ["#2QG2C08UP"] },
+        role: { not: null },
+      },
+      select: {
+        clanTag: true,
+        playerTag: true,
+        playerName: true,
+        role: true,
+      },
+      orderBy: [
+        { clanTag: "asc" },
+        { role: "asc" },
+        { playerName: "asc" },
+        { playerTag: "asc" },
+      ],
+    });
+    expect(FwaClanMembersSyncService.prototype.refreshCurrentClanMembersForClanTags).toHaveBeenCalledWith([
+      "#2QG2C08UP",
+    ]);
+  });
+
   it("allows create during overlap, uses the battle lineup as the seed, and locks the battle day", async () => {
     vi.spyOn(cwlStateService, "getCurrentRoundForClan").mockResolvedValue({
       season: "2026-04",


### PR DESCRIPTION
- extract clan-scoped leadership names from FwaClanMemberCurrent
- reuse the shared helper for overview and show pages