### PR TITLE
feat(autorole): normalize nickname rendering semantics

### DIFF
--- a/src/services/AutoRoleApplyService.ts
+++ b/src/services/AutoRoleApplyService.ts
@@ -2,6 +2,7 @@ import type { AutoRoleGuildConfigSnapshot, AutoRoleEvaluationMemberLike, AutoRol
 import {
   autoRoleNicknameService,
   type AutoRoleNicknameTrackedClanLike,
+  normalizeNicknameTemplate,
 } from "./AutoRoleNicknameService";
 import type { PlayerCurrentLike } from "./PlayerCurrentService";
 import type { PlayerLinkWithTrust } from "./PlayerLinkService";
@@ -129,7 +130,7 @@ export class AutoRoleApplyService {
     let nicknameReason: string | null = null;
     if (!input.config.applyNicknames) {
       nicknameReason = "nickname sync disabled";
-    } else if (!normalizeText(input.config.nicknameTemplate)) {
+    } else if (!normalizeNicknameTemplate(input.config.nicknameTemplate)) {
       nicknameReason = "nickname template not configured";
     } else {
       const nicknameResult = autoRoleNicknameService.renderNickname({

--- a/src/services/AutoRoleNicknameService.ts
+++ b/src/services/AutoRoleNicknameService.ts
@@ -1,12 +1,14 @@
+import { normalizeNicknameTemplate } from "./AutoRoleService";
 import type { AutoRoleGuildConfigSnapshot } from "./AutoRoleEvaluationService";
 import {
   getPlayerLinkTrustTier,
-  isPlayerLinkTrustedForAutorole,
   isPlayerLinkVerifiedForAutorole,
   normalizeClanTag,
   type PlayerLinkWithTrust,
 } from "./PlayerLinkService";
 import type { PlayerCurrentLike } from "./PlayerCurrentService";
+
+export { normalizeNicknameTemplate };
 
 export type AutoRoleNicknameTrackedClanLike = {
   tag: string;
@@ -110,7 +112,7 @@ function isEligibleAutoroleLink(
     return isPlayerLinkVerifiedForAutorole(link);
   }
 
-  return isPlayerLinkTrustedForAutorole(link);
+  return true;
 }
 
 function compareLinkedAccounts(left: RankedNicknameAccount, right: RankedNicknameAccount): number {
@@ -154,6 +156,12 @@ function cleanNicknameOutput(input: string): string {
   output = output.replace(/\s{2,}/g, " ").trim();
 
   return output;
+}
+
+function isMeaningfulNicknameOutput(input: string): boolean {
+  return String(input ?? "")
+    .replace(/[\p{P}\p{Z}]+/gu, "")
+    .trim().length > 0;
 }
 
 function resolveTrackedClanLabel(clan: NormalizedTrackedClan): string {
@@ -236,10 +244,33 @@ export class AutoRoleNicknameService {
       role: tokens.role,
     };
 
-    const template = normalizeText(input.template) ?? "";
+    const template = normalizeNicknameTemplate(input.template) ?? "";
     const rendered = template ? this.renderTemplate(template, tokenLookup) : "";
     const cleaned = cleanNicknameOutput(rendered);
+    if (!cleaned || !isMeaningfulNicknameOutput(cleaned)) {
+      return {
+        renderedNickname: null,
+        primaryPlayerTag,
+        primaryPlayerName,
+        primaryClanTag,
+        primaryClanName,
+        primaryClanShort,
+        trackedClans: trackedClanLabels,
+      };
+    }
+
     const truncated = safeTruncate(cleaned, 32);
+    if (!isMeaningfulNicknameOutput(truncated)) {
+      return {
+        renderedNickname: null,
+        primaryPlayerTag,
+        primaryPlayerName,
+        primaryClanTag,
+        primaryClanName,
+        primaryClanShort,
+        trackedClans: trackedClanLabels,
+      };
+    }
 
     return {
       renderedNickname: truncated.length > 0 ? truncated : null,

--- a/src/services/AutoRoleRefreshService.ts
+++ b/src/services/AutoRoleRefreshService.ts
@@ -16,6 +16,7 @@ import {
   type AutoRoleMemberEvaluation,
 } from "./AutoRoleEvaluationService";
 import type { AutoRoleNicknameTrackedClanLike } from "./AutoRoleNicknameService";
+import { normalizeNicknameTemplate } from "./AutoRoleService";
 import {
   autoRoleService,
   type AutoRoleGuildStateSnapshot,
@@ -766,8 +767,8 @@ export class AutoRoleRefreshService {
         linkedAccountsByUserId,
         cocService: input.cocService ?? null,
       });
-      const nicknameTemplate = String(snapshot.config.nicknameTemplate ?? "").trim();
-      const trackedClans = snapshot.config.applyNicknames && nicknameTemplate.length > 0
+      const nicknameTemplate = normalizeNicknameTemplate(snapshot.config.nicknameTemplate);
+      const trackedClans = snapshot.config.applyNicknames && nicknameTemplate !== null && nicknameTemplate !== undefined
         ? await loadTrackedClansForNickname()
         : [];
       const clanMembershipIndex = await loadClanMembershipIndex({

--- a/src/services/AutoRoleService.ts
+++ b/src/services/AutoRoleService.ts
@@ -122,12 +122,21 @@ function toIntegerOrNull(input: unknown): number | null | undefined {
   return Math.trunc(input);
 }
 
-/** Purpose: normalize an optional template string. */
-function normalizeTemplate(input: string | null | undefined): string | null | undefined {
+/** Purpose: normalize an optional nickname template while preserving explicit clears. */
+export function normalizeNicknameTemplate(input: string | null | undefined): string | null | undefined {
   if (input === undefined) return undefined;
   if (input === null) return null;
-  const normalized = String(input).trim();
-  return normalized.length > 0 ? normalized : null;
+  const trimmed = String(input).trim();
+  if (!trimmed) return null;
+
+  const firstChar = trimmed.at(0);
+  const lastChar = trimmed.at(-1);
+  if (trimmed.length >= 2 && firstChar === lastChar && (firstChar === '"' || firstChar === "'")) {
+    const unquoted = trimmed.slice(1, -1);
+    return unquoted.length > 0 ? unquoted : null;
+  }
+
+  return trimmed;
 }
 
 /** Purpose: normalize an optional snowflake string while preserving explicit clears. */
@@ -342,7 +351,7 @@ function normalizeGuildConfigUpdate(input: AutoRoleGuildConfigUpdateInput): Reco
   const applyNicknames = toBooleanOrUndefined(input.applyNicknames);
   if (applyNicknames !== undefined) data.applyNicknames = applyNicknames;
 
-  const nicknameTemplate = normalizeTemplate(input.nicknameTemplate);
+  const nicknameTemplate = normalizeNicknameTemplate(input.nicknameTemplate);
   if (nicknameTemplate !== undefined) data.nicknameTemplate = nicknameTemplate;
 
   const trustedLinksAllowed = toBooleanOrUndefined(input.trustedLinksAllowed);

--- a/tests/autorole.apply.service.test.ts
+++ b/tests/autorole.apply.service.test.ts
@@ -60,7 +60,7 @@ function makeMember(displayName = "Old Nick"): TestMember {
   };
 }
 
-function makeLinkedAccount(tag = "#2CGG9GGRV", playerName = "Alpha"): PlayerLinkWithTrust {
+function makeLinkedAccount(tag = "#2CGG9GGRV", playerName: string | null = "Alpha"): PlayerLinkWithTrust {
   return {
     playerTag: tag,
     discordUserId: "111111111111111111",
@@ -156,6 +156,35 @@ describe("AutoRoleApplyService", () => {
     expect(member.setNickname).not.toHaveBeenCalled();
     expect(result.nicknameStatus).toBe("skipped");
     expect(result.nicknameReason).toBe("nickname template not configured");
+  });
+
+  it("skips nickname sync when rendering produces only separators", async () => {
+    const member = makeMember();
+    const result = await autoRoleApplyService.applyMember({
+      config: makeConfig({ nicknameTemplate: '"{player} | {trackedClans}"' }),
+      managedRoleIds: new Set(),
+      member: member as any,
+      evaluation: makeEvaluation(),
+      linkedAccounts: [
+        makeLinkedAccount("#2CGG9GGRV", null),
+      ],
+      playerCurrentByTag: new Map([
+        [
+          "#2CGG9GGRV",
+          makePlayerCurrent({
+            playerTag: "#2CGG9GGRV",
+            playerName: null,
+            currentClanTag: null,
+            currentClanName: null,
+          }),
+        ],
+      ]),
+      trackedClans: [],
+    });
+
+    expect(member.setNickname).not.toHaveBeenCalled();
+    expect(result.nicknameStatus).toBe("skipped");
+    expect(result.nicknameReason).toBe("nickname template rendered empty");
   });
 
   it("returns unchanged when the rendered nickname already matches", async () => {

--- a/tests/autoroleNickname.service.test.ts
+++ b/tests/autoroleNickname.service.test.ts
@@ -81,6 +81,56 @@ function makePlayerCurrent(overrides: Partial<PlayerCurrentLike> & Pick<PlayerCu
 describe("AutoRoleNicknameService", () => {
   const service = new AutoRoleNicknameService();
 
+  const baseTrackedClans = [
+    {
+      tag: "#2CGG9GGRV",
+      name: "Tracked Clan",
+      shortName: "TC",
+    },
+  ];
+
+  function makeAllowedRenderInput(overrides: {
+    template?: string;
+    config?: Partial<AutoRoleGuildConfigSnapshot>;
+    linkOverrides?: Partial<PlayerLinkWithTrust> & Pick<PlayerLinkWithTrust, "playerTag">;
+    playerCurrent?: Partial<PlayerCurrentLike> & Pick<PlayerCurrentLike, "playerTag">;
+    trackedClans?: AutoRoleNicknameRenderInput["trackedClans"];
+  } = {}): AutoRoleNicknameRenderInput {
+    const playerTag = overrides.linkOverrides?.playerTag ?? "#2CGG9GGRV";
+    const trackedClans = overrides.trackedClans ?? baseTrackedClans;
+    const link = makeLink({
+      playerTag,
+      playerName: overrides.linkOverrides?.playerName ?? "Alpha",
+      linkSource: overrides.linkOverrides?.linkSource ?? "SELF_SERVICE",
+      verificationStatus: overrides.linkOverrides?.verificationStatus ?? "VERIFIED",
+      verificationMethod: overrides.linkOverrides?.verificationMethod ?? "PLAYER_API_TOKEN",
+      verifiedAt: overrides.linkOverrides?.verifiedAt ?? new Date("2026-04-01T00:00:00.000Z"),
+      ...overrides.linkOverrides,
+    });
+
+    return {
+      config: makeConfig(overrides.config),
+      template: overrides.template ?? "{player}",
+      member: makeMember(),
+      linkedAccounts: [link],
+      playerCurrentByTag: new Map<string, PlayerCurrentLike>([
+        [
+          playerTag,
+          makePlayerCurrent({
+            playerTag,
+            playerName: overrides.playerCurrent?.playerName ?? "Alpha",
+            currentClanTag: overrides.playerCurrent?.currentClanTag ?? "#2CGG9GGRV",
+            currentClanName: overrides.playerCurrent?.currentClanName ?? "Tracked Clan",
+            townHall: overrides.playerCurrent?.townHall ?? 16,
+            role: overrides.playerCurrent?.role ?? "member",
+            ...overrides.playerCurrent,
+          }),
+        ],
+      ]),
+      trackedClans,
+    };
+  }
+
   it("renders the basic template from the selected linked account", () => {
     const result = service.renderNickname({
       config: makeConfig(),
@@ -202,6 +252,187 @@ describe("AutoRoleNicknameService", () => {
 
     expect(result.trackedClans).toEqual(["Charlie", "Alpha"]);
     expect(result.renderedNickname).toBe("Charlie | Alpha");
+  });
+
+  it.each([
+    {
+      name: "EMBED_SELF_SERVICE",
+      linkSource: "EMBED_SELF_SERVICE",
+    },
+    {
+      name: "SELF_SERVICE",
+      linkSource: "SELF_SERVICE",
+    },
+  ])("allows unverified $name links when trusted links are allowed", ({ linkSource }) => {
+    const result = service.renderNickname(
+      makeAllowedRenderInput({
+        template: "{tag}",
+        linkOverrides: {
+          playerTag: "#2CGG9GGRV",
+          playerName: "Alpha",
+          linkSource: linkSource as PlayerLinkWithTrust["linkSource"],
+          verificationStatus: "UNVERIFIED",
+          verificationMethod: null,
+          verifiedAt: null,
+        },
+      }),
+    );
+
+    expect(result.primaryPlayerTag).toBe("#2CGG9GGRV");
+    expect(result.renderedNickname).toBe("#2CGG9GGRV");
+  });
+
+  it.each([
+    {
+      name: "verified-only mode enabled",
+      config: { verifiedOnlyMode: true },
+    },
+    {
+      name: "trusted links disabled",
+      config: { trustedLinksAllowed: false },
+    },
+  ])("blocks unverified links when $name", ({ config }) => {
+    const result = service.renderNickname(
+      makeAllowedRenderInput({
+        template: "{tag}",
+        config,
+        linkOverrides: {
+          playerTag: "#2CGG9GGRV",
+          playerName: "Alpha",
+          linkSource: "EMBED_SELF_SERVICE",
+          verificationStatus: "UNVERIFIED",
+          verificationMethod: null,
+          verifiedAt: null,
+        },
+      }),
+    );
+
+    expect(result.primaryPlayerTag).toBeNull();
+    expect(result.renderedNickname).toBeNull();
+  });
+
+  it("blocks revoked links even when trusted links are allowed", () => {
+    const result = service.renderNickname(
+      makeAllowedRenderInput({
+        template: "{tag}",
+        linkOverrides: {
+          playerTag: "#2CGG9GGRV",
+          playerName: "Alpha",
+          linkSource: "SELF_SERVICE",
+          verificationStatus: "REVOKED",
+          verificationMethod: null,
+          verifiedAt: null,
+        },
+      }),
+    );
+
+    expect(result.primaryPlayerTag).toBeNull();
+    expect(result.renderedNickname).toBeNull();
+  });
+
+  it("strips matching outer double quotes before rendering", () => {
+    const result = service.renderNickname(
+      makeAllowedRenderInput({
+        template: '"{player} | {trackedClans}"',
+        linkOverrides: {
+          playerTag: "#8PJLYRC8P",
+          playerName: "Elrond♣️",
+          linkSource: "EMBED_SELF_SERVICE",
+          verificationStatus: "UNVERIFIED",
+          verificationMethod: null,
+          verifiedAt: null,
+        },
+        playerCurrent: {
+          playerTag: "#8PJLYRC8P",
+          playerName: "Elrond♣️",
+          currentClanTag: "#2CGG9GGRV",
+          currentClanName: "Tracked Clan",
+          townHall: 15,
+          role: "member",
+        },
+        trackedClans: [
+          {
+            tag: "#2CGG9GGRV",
+            name: "Tracked Clan",
+            shortName: "RR",
+          },
+        ],
+      }),
+    );
+
+    expect(result.renderedNickname).toBe("Elrond♣️ | RR");
+  });
+
+  it("strips matching outer single quotes before rendering", () => {
+    const result = service.renderNickname(
+      makeAllowedRenderInput({
+        template: "'{player} | {trackedClans}'",
+        linkOverrides: {
+          playerTag: "#8PJLYRC8P",
+          playerName: "Elrond♣️",
+          linkSource: "SELF_SERVICE",
+          verificationStatus: "VERIFIED",
+          verificationMethod: "PLAYER_API_TOKEN",
+        },
+        playerCurrent: {
+          playerTag: "#8PJLYRC8P",
+          playerName: "Elrond♣️",
+          currentClanTag: "#2CGG9GGRV",
+          currentClanName: "Tracked Clan",
+          townHall: 15,
+          role: "member",
+        },
+        trackedClans: [
+          {
+            tag: "#2CGG9GGRV",
+            name: "Tracked Clan",
+            shortName: "RR",
+          },
+        ],
+      }),
+    );
+
+    expect(result.renderedNickname).toBe("Elrond♣️ | RR");
+  });
+
+  it("preserves interior quotes while stripping only the outer pair", () => {
+    const result = service.renderNickname(
+      makeAllowedRenderInput({
+        template: '"{player} - "VIP""',
+        linkOverrides: {
+          playerTag: "#2CGG9GGRV",
+          playerName: "Alpha",
+        },
+      }),
+    );
+
+    expect(result.renderedNickname).toBe('Alpha - "VIP"');
+  });
+
+  it("returns null for separator-only output", () => {
+    const result = service.renderNickname(
+      makeAllowedRenderInput({
+        template: '"{player} | {trackedClans}"',
+        linkOverrides: {
+          playerTag: "#2CGG9GGRV",
+          playerName: null,
+          linkSource: "SELF_SERVICE",
+          verificationStatus: "VERIFIED",
+          verificationMethod: "PLAYER_API_TOKEN",
+        },
+        playerCurrent: {
+          playerTag: "#2CGG9GGRV",
+          playerName: null,
+          currentClanTag: null,
+          currentClanName: null,
+          townHall: 16,
+          role: null,
+        },
+        trackedClans: [],
+      }),
+    );
+
+    expect(result.renderedNickname).toBeNull();
   });
 
   it("falls back to the clan name when a tracked clan has no short name", () => {


### PR DESCRIPTION
- align nickname eligibility with autorole evaluation
- strip quoted templates and reject separator-only nickname renders