### PR TITLE
fix(inactive): use ended-war participation for wars mode

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -12,7 +12,7 @@
 - `/permission list [command:<name>]` - List role policy for one command target, or all if omitted.
 - `/lastseen tag:<playerTag>` - Show a player's last seen activity, with drill-down button for tracked signal timestamps.
 - `/inactive days:<number>` - List players inactive for N days.
-- `/inactive wars:<number>` - List tracked-clan members who used 0/2 attacks in each of the last N ended wars they actually participated in (requires war-history tracking window).
+- `/inactive wars:<number>` - List tracked-clan members who missed both attacks in at least one of the last N ended FWA wars (requires war-history tracking window). When no rows match, the bot includes a short diagnostic note showing whether ended-war rows and participation rows were found.
 - `/clan-health [visibility:private|public] tag:<trackedClanTag>` - Leadership snapshot from persisted data only: match rate and win rate (last 30 ended wars), inactive counts (missed-both in last 3 ended FWA wars + last-seen >=7d), and missing Discord links among observed members.
 - `/role-users role:<discordRole>` - List users in a role with pagination.
 - `/layout [th:<number>] [type:RISINGDAWN|BASIC|ICE] [edit:<layout-link>] [img-url:<url>]` - Fetch or list stored FWA layouts; `edit` upserts are admin-only at runtime, and `img-url` is only valid when `edit` is provided.

--- a/src/commands/Help.ts
+++ b/src/commands/Help.ts
@@ -137,7 +137,8 @@ const COMMAND_DOCS: Record<string, CommandDoc> = {
     summary: "List players inactive for a given number of days.",
     details: [
       "Shows oldest inactive players first.",
-      "Supports `wars` mode to list tracked members who used 0/2 attacks in each of the last X ended wars they actually participated in.",
+      "Supports `wars` mode to list tracked members who missed both attacks in at least one of the last X ended FWA wars.",
+      "When wars mode finds no rows, the bot includes a short diagnostic note about ended-war and participation-row coverage.",
       "Large results are clipped to keep replies readable.",
     ],
     examples: ["/inactive days:7", "/inactive days:30", "/inactive wars:3"],

--- a/src/commands/Inactive.ts
+++ b/src/commands/Inactive.ts
@@ -482,10 +482,8 @@ async function runWarsMode(
   interaction: ChatInputCommandInteraction,
   wars: number
 ): Promise<void> {
-  const { results, trackedTags, trackedNameByTag, warnings } = await fetchInactiveWarEntries(
-    interaction,
-    wars
-  );
+  const { results, trackedTags, trackedNameByTag, warnings, diagnosticNote } =
+    await fetchInactiveWarEntries(interaction, wars);
 
   if (trackedTags.length === 0) {
     await interaction.editReply(
@@ -496,8 +494,9 @@ async function runWarsMode(
 
   if (results.length === 0) {
     const warningText = warnings.length > 0 ? `\n\nTracking note:\n- ${warnings.join("\n- ")}` : "";
+    const diagnosticText = diagnosticNote ? `\n\n${diagnosticNote}` : "";
     await interaction.editReply(
-      `No players found who missed both attacks in the last ${wars} FWA war(s).${warningText}`
+      `No players found who missed both attacks in at least one of the last ${wars} ended FWA war(s).${warningText}${diagnosticText}`
     );
     return;
   }
@@ -599,8 +598,9 @@ async function runCombinedMode(
   if (rows.length === 0) {
     const warningText =
       warsResult.warnings.length > 0 ? `\n\nTracking note:\n- ${warsResult.warnings.join("\n- ")}` : "";
+    const diagnosticText = warsResult.diagnosticNote ? `\n\n${warsResult.diagnosticNote}` : "";
     await interaction.editReply(
-      `No players matched \`days:${days}\` or \`wars:${wars}\`.${warningText}`
+      `No players matched \`days:${days}\` or \`wars:${wars}\`.${warningText}${diagnosticText}`
     );
     return;
   }
@@ -661,7 +661,7 @@ export const Inactive: Command = {
     },
     {
       name: "wars",
-      description: "Missed both attacks for the last X wars",
+      description: "Players who missed both attacks in at least one of the last X ended wars",
       type: 4, // INTEGER
       required: false,
     },

--- a/src/services/InactiveWarService.ts
+++ b/src/services/InactiveWarService.ts
@@ -43,10 +43,15 @@ export type InactiveWarSummary = {
   trackedTags: string[];
   trackedNameByTag: Map<string, string>;
   warnings: string[];
+  diagnosticNote: string | null;
 };
 
 function normalizeClanTagInput(input: string): string {
   return input.trim().toUpperCase().replace(/^#/, "");
+}
+
+function buildClanTagQueryValues(trackedTags: string[]): string[] {
+  return [...new Set(trackedTags.flatMap((tag) => [tag, `#${tag}`]))];
 }
 
 function normalizePlayerName(playerName: string | null | undefined, playerTag: string): string {
@@ -55,12 +60,34 @@ function normalizePlayerName(playerName: string | null | undefined, playerTag: s
 }
 
 function buildTrackedNameMap(trackedClans: TrackedClanRow[]): Map<string, string> {
-  return new Map(
-    trackedClans.map((clan) => {
-      const clanTag = normalizeClanTagInput(clan.tag);
-      return [clanTag, String(clan.name ?? "").trim() || clanTag] as const;
-    })
-  );
+  const trackedNameByTag = new Map<string, string>();
+  for (const clan of trackedClans) {
+    const clanTag = normalizeClanTagInput(clan.tag);
+    if (!clanTag) continue;
+    const clanName = String(clan.name ?? "").trim() || clanTag;
+    trackedNameByTag.set(clanTag, clanName);
+    trackedNameByTag.set(`#${clanTag}`, clanName);
+  }
+  return trackedNameByTag;
+}
+
+function buildTrackedTagList(trackedClans: TrackedClanRow[]): string[] {
+  const trackedTags: string[] = [];
+  const seenTags = new Set<string>();
+  for (const clan of trackedClans) {
+    const clanTag = normalizeClanTagInput(clan.tag);
+    if (!clanTag || seenTags.has(clanTag)) continue;
+    seenTags.add(clanTag);
+    trackedTags.push(clanTag);
+  }
+  return trackedTags;
+}
+
+function buildInactiveWarDiagnosticNote(input: {
+  endedWarCount: number;
+  participationRowCount: number;
+}): string {
+  return `Diagnostic: ended wars found ${input.endedWarCount > 0 ? "yes" : "no"} (${input.endedWarCount}), participation rows found ${input.participationRowCount > 0 ? "yes" : "no"} (${input.participationRowCount}).`;
 }
 
 function buildRecentEndedWarSelection(input: {
@@ -203,7 +230,7 @@ function aggregateInactiveWarRows(input: {
   }
 
   return [...rowsByKey.values()]
-    .filter((row) => row.participationWars > 0 && row.missedWars === row.participationWars)
+    .filter((row) => row.participationWars > 0 && row.missedWars > 0)
     .map((row) => ({
       clanTag: row.clanTag,
       playerTag: row.playerTag,
@@ -227,15 +254,16 @@ export class InactiveWarService {
       orderBy: { createdAt: "asc" },
       select: { tag: true, name: true },
     });
-    const trackedTags = trackedClans.map((clan) => normalizeClanTagInput(clan.tag));
+    const trackedTags = buildTrackedTagList(trackedClans);
     const trackedNameByTag = buildTrackedNameMap(trackedClans);
     if (trackedTags.length === 0) {
-      return { results: [], trackedTags, trackedNameByTag, warnings: [] };
+      return { results: [], trackedTags, trackedNameByTag, warnings: [], diagnosticNote: null };
     }
+    const trackedClanTagValues = buildClanTagQueryValues(trackedTags);
 
     const historyRows = await prisma.clanWarHistory.findMany({
       where: {
-        clanTag: { in: trackedTags },
+        clanTag: { in: trackedClanTagValues },
         warEndTime: { not: null },
         matchType: "FWA",
       },
@@ -268,7 +296,7 @@ export class InactiveWarService {
       ? await prisma.clanWarParticipation.findMany({
           where: {
             guildId: input.guildId,
-            clanTag: { in: trackedTags },
+            clanTag: { in: trackedClanTagValues },
             warId: { in: selectedWarIds },
             matchType: "FWA",
           },
@@ -297,6 +325,13 @@ export class InactiveWarService {
       selectionByClan,
       participationRows,
     });
+    const diagnosticNote =
+      results.length === 0
+        ? buildInactiveWarDiagnosticNote({
+            endedWarCount: historyRows.length,
+            participationRowCount: participationRows.length,
+          })
+        : null;
     const warnings = trackedTags
       .map((clanTag) => {
         const selection = selectionByClan.get(clanTag);
@@ -307,7 +342,7 @@ export class InactiveWarService {
       })
       .filter((value): value is string => value !== null);
 
-    return { results, trackedTags, trackedNameByTag, warnings };
+    return { results, trackedTags, trackedNameByTag, warnings, diagnosticNote };
   }
 }
 

--- a/tests/inactive.command.test.ts
+++ b/tests/inactive.command.test.ts
@@ -78,4 +78,23 @@ describe("/inactive command", () => {
     expect(embed.description).toContain("Bravo");
     expect(embed.description).toContain("missed both in 3/3 war(s)");
   });
+
+  it("includes the service diagnostic note when wars mode has no inactive players", async () => {
+    inactiveWarServiceMock.listInactiveWarPlayers.mockResolvedValue({
+      results: [],
+      trackedTags: ["#AAA111"],
+      trackedNameByTag: new Map([["#AAA111", "Alpha"]]),
+      warnings: [],
+      diagnosticNote: "Diagnostic: ended wars found yes (3), participation rows found yes (6).",
+    });
+
+    const interaction = makeInteraction(3);
+    const cocService = {} as any;
+
+    await Inactive.run({} as any, interaction as any, cocService);
+
+    expect(interaction.editReply).toHaveBeenCalledWith(
+      expect.stringContaining("Diagnostic: ended wars found yes (3), participation rows found yes (6).")
+    );
+  });
 });

--- a/tests/inactiveWar.service.test.ts
+++ b/tests/inactiveWar.service.test.ts
@@ -53,6 +53,24 @@ function makeParticipationRow(input: {
   };
 }
 
+function getQueryInValues(args: any, path: "clanTag" | "warId"): Set<string> {
+  return new Set((args?.where?.[path]?.in ?? []).map((value: string) => String(value)));
+}
+
+function filterHistoryRowsByClanTags(rows: Array<{ clanTag: string }>, args: any) {
+  const clanTags = getQueryInValues(args, "clanTag");
+  return rows.filter((row) => clanTags.has(String(row.clanTag)));
+}
+
+function filterParticipationRows(
+  rows: Array<{ clanTag: string; warId: string }>,
+  args: any
+) {
+  const clanTags = getQueryInValues(args, "clanTag");
+  const warIds = getQueryInValues(args, "warId");
+  return rows.filter((row) => clanTags.has(String(row.clanTag)) && warIds.has(String(row.warId)));
+}
+
 describe("InactiveWarService", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -76,8 +94,7 @@ describe("InactiveWarService", () => {
       }),
     ];
     prismaMock.clanWarParticipation.findMany.mockImplementation(async (args: any) => {
-      const warIds = new Set((args?.where?.warId?.in ?? []).map((value: string) => String(value)));
-      return participationRows.filter((row) => warIds.has(String(row.warId)));
+      return filterParticipationRows(participationRows, args);
     });
 
     const service = new InactiveWarService();
@@ -94,9 +111,12 @@ describe("InactiveWarService", () => {
     ]);
     expect(summary.results).toEqual([]);
     expect(summary.warnings).toEqual([]);
+    expect(summary.diagnosticNote).toBe(
+      "Diagnostic: ended wars found yes (4), participation rows found no (0)."
+    );
   });
 
-  it("flags a player inactive only when every counted participation row is missedBoth", async () => {
+  it("includes a player when at least one of the selected wars was missedBoth and excludes players with no missed-both rows", async () => {
     prismaMock.trackedClan.findMany.mockResolvedValue([{ tag: "#AAA111", name: "Alpha" }]);
     prismaMock.clanWarHistory.findMany.mockResolvedValue([
       makeHistoryRow(400, "#AAA111", "2026-04-04T00:00:00.000Z"),
@@ -119,7 +139,7 @@ describe("InactiveWarService", () => {
         playerTag: "#B",
         playerName: "Bravo",
         warId: "399",
-        missedBoth: true,
+        missedBoth: false,
         trueStars: 0,
         attackDelayMinutes: 55,
         attackWindowMissed: false,
@@ -129,15 +149,34 @@ describe("InactiveWarService", () => {
         playerTag: "#B",
         playerName: "Bravo",
         warId: "398",
-        missedBoth: true,
+        missedBoth: false,
         trueStars: 0,
         attackDelayMinutes: null,
         attackWindowMissed: null,
       }),
+      makeParticipationRow({
+        clanTag: "#AAA111",
+        playerTag: "#C",
+        playerName: "Charlie",
+        warId: "400",
+        missedBoth: false,
+        trueStars: 2,
+        attackDelayMinutes: 12,
+        attackWindowMissed: false,
+      }),
+      makeParticipationRow({
+        clanTag: "#AAA111",
+        playerTag: "#C",
+        playerName: "Charlie",
+        warId: "399",
+        missedBoth: false,
+        trueStars: 1,
+        attackDelayMinutes: 20,
+        attackWindowMissed: false,
+      }),
     ];
     prismaMock.clanWarParticipation.findMany.mockImplementation(async (args: any) => {
-      const warIds = new Set((args?.where?.warId?.in ?? []).map((value: string) => String(value)));
-      return participationRows.filter((row) => warIds.has(String(row.warId)));
+      return filterParticipationRows(participationRows, args);
     });
 
     const service = new InactiveWarService();
@@ -151,16 +190,73 @@ describe("InactiveWarService", () => {
       clanTag: "AAA111",
       playerTag: "B",
       playerName: "Bravo",
-      missedWars: 3,
+      missedWars: 1,
       participationWars: 3,
       totalTrueStars: 0,
       lateAttacks: 1,
       warsAvailable: 3,
     });
     expect(summary.results[0]?.avgAttackDelay).toBeCloseTo(47.5);
+    expect(summary.results.some((row) => row.playerTag === "C")).toBe(false);
   });
 
-  it("excludes a player who was active in any counted participation row", async () => {
+  it("matches tracked-clan history and participation rows stored with either bare or # clan tags", async () => {
+    prismaMock.trackedClan.findMany.mockResolvedValue([{ tag: "AAA111", name: "Alpha" }]);
+    const historyRows = [
+      makeHistoryRow(400, "AAA111", "2026-04-04T00:00:00.000Z"),
+      makeHistoryRow(399, "#AAA111", "2026-04-03T00:00:00.000Z"),
+    ];
+    prismaMock.clanWarHistory.findMany.mockImplementation(async (args: any) =>
+      filterHistoryRowsByClanTags(historyRows, args)
+    );
+    const participationRows = [
+      makeParticipationRow({
+        clanTag: "AAA111",
+        playerTag: "#B",
+        playerName: "Bravo",
+        warId: "400",
+        missedBoth: true,
+      }),
+      makeParticipationRow({
+        clanTag: "#AAA111",
+        playerTag: "#C",
+        playerName: "Charlie",
+        warId: "399",
+        missedBoth: true,
+      }),
+    ];
+    prismaMock.clanWarParticipation.findMany.mockImplementation(async (args: any) =>
+      filterParticipationRows(participationRows, args)
+    );
+
+    const service = new InactiveWarService();
+    const summary = await service.listInactiveWarPlayers({
+      guildId: "guild-1",
+      wars: 2,
+    });
+
+    expect(prismaMock.clanWarHistory.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          clanTag: expect.objectContaining({
+            in: expect.arrayContaining(["AAA111", "#AAA111"]),
+          }),
+        }),
+      })
+    );
+    expect(prismaMock.clanWarParticipation.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          clanTag: expect.objectContaining({
+            in: expect.arrayContaining(["AAA111", "#AAA111"]),
+          }),
+        }),
+      })
+    );
+    expect(summary.results.map((row) => row.playerTag).sort()).toEqual(["B", "C"]);
+  });
+
+  it("omits players with no missed-both rows", async () => {
     prismaMock.trackedClan.findMany.mockResolvedValue([{ tag: "#AAA111", name: "Alpha" }]);
     prismaMock.clanWarHistory.findMany.mockResolvedValue([
       makeHistoryRow(400, "#AAA111", "2026-04-04T00:00:00.000Z"),
@@ -173,7 +269,7 @@ describe("InactiveWarService", () => {
         playerTag: "#C",
         playerName: "Charlie",
         warId: "400",
-        missedBoth: true,
+        missedBoth: false,
       }),
       makeParticipationRow({
         clanTag: "#AAA111",
@@ -184,8 +280,7 @@ describe("InactiveWarService", () => {
       }),
     ];
     prismaMock.clanWarParticipation.findMany.mockImplementation(async (args: any) => {
-      const warIds = new Set((args?.where?.warId?.in ?? []).map((value: string) => String(value)));
-      return participationRows.filter((row) => warIds.has(String(row.warId)));
+      return filterParticipationRows(participationRows, args);
     });
 
     const service = new InactiveWarService();
@@ -195,9 +290,10 @@ describe("InactiveWarService", () => {
     });
 
     expect(summary.results).toEqual([]);
+    expect(summary.diagnosticNote).toContain("ended wars found yes");
   });
 
-  it("treats partial roster participation as inactive only when all counted participation rows are missedBoth", async () => {
+  it("reports a short diagnostic note when no inactive players are found but data exists", async () => {
     prismaMock.trackedClan.findMany.mockResolvedValue([{ tag: "#AAA111", name: "Alpha" }]);
     prismaMock.clanWarHistory.findMany.mockResolvedValue([
       makeHistoryRow(400, "#AAA111", "2026-04-04T00:00:00.000Z"),
@@ -210,19 +306,18 @@ describe("InactiveWarService", () => {
         playerTag: "#D",
         playerName: "Delta",
         warId: "400",
-        missedBoth: true,
+        missedBoth: false,
       }),
       makeParticipationRow({
         clanTag: "#AAA111",
         playerTag: "#D",
         playerName: "Delta",
         warId: "398",
-        missedBoth: true,
+        missedBoth: false,
       }),
     ];
     prismaMock.clanWarParticipation.findMany.mockImplementation(async (args: any) => {
-      const warIds = new Set((args?.where?.warId?.in ?? []).map((value: string) => String(value)));
-      return participationRows.filter((row) => warIds.has(String(row.warId)));
+      return filterParticipationRows(participationRows, args);
     });
 
     const service = new InactiveWarService();
@@ -231,13 +326,9 @@ describe("InactiveWarService", () => {
       wars: 3,
     });
 
-    expect(summary.results).toHaveLength(1);
-    expect(summary.results[0]).toMatchObject({
-      clanTag: "AAA111",
-      playerTag: "D",
-      playerName: "Delta",
-      missedWars: 2,
-      participationWars: 2,
-    });
+    expect(summary.results).toEqual([]);
+    expect(summary.diagnosticNote).toBe(
+      "Diagnostic: ended wars found yes (3), participation rows found yes (2)."
+    );
   });
 });


### PR DESCRIPTION
- query ClanWarHistory and ClanWarParticipation with normalized clan-tag aliases
- include players with any missed-both row across the selected wars
- surface empty-state diagnostics and refresh docs/tests