### PR TITLE
fix(points): count perfect blacklist wars as plus three

### DIFF
--- a/src/services/WarEventLogService.ts
+++ b/src/services/WarEventLogService.ts
@@ -1750,6 +1750,13 @@ export class WarEventLogService {
       fwaPoints: sub.fwaPoints,
     });
     let testWarEndFwaPoints = sub.warEndFwaPoints;
+    const testTeamSize = Number.isFinite(
+      Number((currentWar as { teamSize?: number | null } | null)?.teamSize),
+    )
+      ? Number((currentWar as { teamSize?: number | null } | null)?.teamSize)
+      : Number.isFinite(Number((sub as { teamSize?: number | null }).teamSize))
+        ? Number((sub as { teamSize?: number | null }).teamSize)
+        : null;
     if (
       params.source === "current" &&
       params.eventType === "war_ended" &&
@@ -1764,6 +1771,7 @@ export class WarEventLogService {
         before,
         finalResult: testFinalResultOverride,
         outcome,
+        teamSize: testTeamSize,
       });
     }
 
@@ -2590,12 +2598,14 @@ export class WarEventLogService {
     before: number | null;
     finalResult: WarEndResultSnapshot;
     outcome: "WIN" | "LOSE" | null;
+    teamSize?: number | null;
   }): number | null {
     return computeExpectedWarEndPointsForTest({
       matchType: input.matchType,
       before: input.before,
       finalResult: input.finalResult,
       outcome: input.outcome,
+      teamSize: input.teamSize ?? null,
     });
   }
 
@@ -2998,7 +3008,9 @@ export class WarEventLogService {
       : null;
     const nextTeamSize = Number.isFinite(Number(war?.teamSize))
       ? Number(war?.teamSize)
-      : null;
+      : Number.isFinite(Number((sub as { teamSize?: number | null }).teamSize))
+        ? Number((sub as { teamSize?: number | null }).teamSize)
+        : null;
     const nextAttacksPerMember = Number.isFinite(Number(war?.attacksPerMember))
       ? Number(war?.attacksPerMember)
       : null;
@@ -3190,6 +3202,7 @@ export class WarEventLogService {
         before,
         finalResult,
         outcome: normalizeOutcome(nextOutcome),
+        teamSize: nextTeamSize,
       });
     }
 
@@ -3496,6 +3509,7 @@ export class WarEventLogService {
         before: canonicalBeforePoints,
         finalResult: canonicalFinalResult,
         outcome: normalizeOutcome(payloadForDelivery.outcome),
+        teamSize: payloadForDelivery.teamSize ?? null,
       });
       payloadForDelivery = {
         ...payloadForDelivery,

--- a/src/services/war-events/core.ts
+++ b/src/services/war-events/core.ts
@@ -168,6 +168,7 @@ export function computeWarPointsDeltaForTest(input: {
   before: number | null;
   after: number | null;
   finalResult: WarEndResultSnapshot;
+  teamSize?: number | null;
 }): number | null {
   const before = input.before !== null && Number.isFinite(input.before) ? input.before : null;
   if (before === null) return null;
@@ -176,6 +177,7 @@ export function computeWarPointsDeltaForTest(input: {
     before,
     finalResult: input.finalResult,
     outcome: null,
+    teamSize: input.teamSize ?? null,
   });
   if (expectedAfter === null || !Number.isFinite(expectedAfter)) return null;
   return expectedAfter - before;
@@ -187,6 +189,7 @@ export function computeExpectedWarEndPointsForTest(input: {
   before: number | null;
   finalResult: WarEndResultSnapshot;
   outcome: "WIN" | "LOSE" | null;
+  teamSize?: number | null;
 }): number | null {
   const before = input.before !== null && Number.isFinite(input.before) ? Math.trunc(input.before) : null;
   if (before === null) return null;
@@ -201,7 +204,14 @@ export function computeExpectedWarEndPointsForTest(input: {
     return before;
   }
   if (input.matchType === "BL") {
-    if (resolvedOutcome === "WIN") return before + 3;
+    const teamSize = Number.isFinite(Number(input.teamSize)) ? Math.trunc(Number(input.teamSize)) : null;
+    const perfectWar =
+      teamSize === 50
+        ? Number(input.finalResult.clanStars ?? 0) === 150
+        : teamSize === 45
+          ? Number(input.finalResult.clanStars ?? 0) === 135
+          : false;
+    if (resolvedOutcome === "WIN" || perfectWar) return before + 3;
     if (Number(input.finalResult.clanDestruction ?? 0) > 60) return before + 2;
     return before + 1;
   }

--- a/src/services/war-events/history.ts
+++ b/src/services/war-events/history.ts
@@ -306,7 +306,7 @@ export class WarEventHistoryService {
         "This is our opportunity to gain some extra FWA points!",
         "\u2795 30+ people switch to war base = +1 point",
         "\u2795 60% total destruction = +1 point",
-        "\u2795 win war = +1 point",
+        "\u2795 win war or perfect war = +1 point",
         "---",
         "If you need war base, check https://clashofclans-layouts.com/ or bases",
       ].join("\n");

--- a/tests/warEventLog.logic.test.ts
+++ b/tests/warEventLog.logic.test.ts
@@ -216,7 +216,7 @@ describe("WarEventLogService.computeWarPointsDeltaForTest", () => {
     expect(delta).toBe(3);
   });
 
-  it("BL war: returns +3 points for a perfect 50v50 war even on LOSE", () => {
+  it("BL war: returns +3 points for a perfect 50v50 war on TIE", () => {
     const delta = computeWarPointsDeltaForTest({
       matchType: "BL",
       before: 100,
@@ -228,13 +228,13 @@ describe("WarEventLogService.computeWarPointsDeltaForTest", () => {
         clanDestruction: 60,
         opponentDestruction: 60,
         warEndTime: null,
-        resultLabel: "LOSE",
+        resultLabel: "TIE",
       },
     });
     expect(delta).toBe(3);
   });
 
-  it("BL war: returns +3 points for a perfect 45v45 war even on LOSE", () => {
+  it("BL war: returns +3 points for a perfect 45v45 war on TIE", () => {
     const delta = computeWarPointsDeltaForTest({
       matchType: "BL",
       before: 100,
@@ -246,7 +246,7 @@ describe("WarEventLogService.computeWarPointsDeltaForTest", () => {
         clanDestruction: 60,
         opponentDestruction: 60,
         warEndTime: null,
-        resultLabel: "LOSE",
+        resultLabel: "TIE",
       },
     });
     expect(delta).toBe(3);

--- a/tests/warEventLog.logic.test.ts
+++ b/tests/warEventLog.logic.test.ts
@@ -203,6 +203,7 @@ describe("WarEventLogService.computeWarPointsDeltaForTest", () => {
       matchType: "BL",
       before: 100,
       after: 100,
+      teamSize: 50,
       finalResult: {
         clanStars: 100,
         opponentStars: 99,
@@ -215,11 +216,66 @@ describe("WarEventLogService.computeWarPointsDeltaForTest", () => {
     expect(delta).toBe(3);
   });
 
+  it("BL war: returns +3 points for a perfect 50v50 war even on LOSE", () => {
+    const delta = computeWarPointsDeltaForTest({
+      matchType: "BL",
+      before: 100,
+      after: 100,
+      teamSize: 50,
+      finalResult: {
+        clanStars: 150,
+        opponentStars: 149,
+        clanDestruction: 60,
+        opponentDestruction: 60,
+        warEndTime: null,
+        resultLabel: "LOSE",
+      },
+    });
+    expect(delta).toBe(3);
+  });
+
+  it("BL war: returns +3 points for a perfect 45v45 war even on LOSE", () => {
+    const delta = computeWarPointsDeltaForTest({
+      matchType: "BL",
+      before: 100,
+      after: 100,
+      teamSize: 45,
+      finalResult: {
+        clanStars: 135,
+        opponentStars: 134,
+        clanDestruction: 60,
+        opponentDestruction: 60,
+        warEndTime: null,
+        resultLabel: "LOSE",
+      },
+    });
+    expect(delta).toBe(3);
+  });
+
+  it("BL war: does not treat 135 stars as perfect for a 50v50 war", () => {
+    const delta = computeWarPointsDeltaForTest({
+      matchType: "BL",
+      before: 100,
+      after: 100,
+      teamSize: 50,
+      finalResult: {
+        clanStars: 135,
+        opponentStars: 134,
+        clanDestruction: 60,
+        opponentDestruction: 60,
+        warEndTime: null,
+        resultLabel: "LOSE",
+      },
+    });
+    expect(delta).toBe(1);
+  });
+
   it("BL war: returns +2 points when not a win but clan destruction is > 60%", () => {
     const delta = computeWarPointsDeltaForTest({
       matchType: "BL",
       before: 100,
       after: 100,
+      teamSize: 50,
       finalResult: {
         clanStars: 90,
         opponentStars: 100,
@@ -237,6 +293,7 @@ describe("WarEventLogService.computeWarPointsDeltaForTest", () => {
       matchType: "BL",
       before: 100,
       after: 100,
+      teamSize: 50,
       finalResult: {
         clanStars: 90,
         opponentStars: 100,

--- a/tests/warEventLog.logic.test.ts
+++ b/tests/warEventLog.logic.test.ts
@@ -219,16 +219,16 @@ describe("WarEventLogService.computeWarPointsDeltaForTest", () => {
   it("BL war: returns +3 points for a perfect 50v50 war on TIE", () => {
     const delta = computeWarPointsDeltaForTest({
       matchType: "BL",
-      before: 100,
-      after: 100,
-      teamSize: 50,
-      finalResult: {
-        clanStars: 150,
-        opponentStars: 149,
-        clanDestruction: 60,
-        opponentDestruction: 60,
-        warEndTime: null,
-        resultLabel: "TIE",
+        before: 100,
+        after: 100,
+        teamSize: 50,
+        finalResult: {
+          clanStars: 150,
+          opponentStars: 150,
+          clanDestruction: 60,
+          opponentDestruction: 60,
+          warEndTime: null,
+          resultLabel: "TIE",
       },
     });
     expect(delta).toBe(3);
@@ -237,16 +237,16 @@ describe("WarEventLogService.computeWarPointsDeltaForTest", () => {
   it("BL war: returns +3 points for a perfect 45v45 war on TIE", () => {
     const delta = computeWarPointsDeltaForTest({
       matchType: "BL",
-      before: 100,
-      after: 100,
-      teamSize: 45,
-      finalResult: {
-        clanStars: 135,
-        opponentStars: 134,
-        clanDestruction: 60,
-        opponentDestruction: 60,
-        warEndTime: null,
-        resultLabel: "TIE",
+        before: 100,
+        after: 100,
+        teamSize: 45,
+        finalResult: {
+          clanStars: 135,
+          opponentStars: 135,
+          clanDestruction: 60,
+          opponentDestruction: 60,
+          warEndTime: null,
+          resultLabel: "TIE",
       },
     });
     expect(delta).toBe(3);

--- a/tests/warEventLog.warEndPointsReconcile.test.ts
+++ b/tests/warEventLog.warEndPointsReconcile.test.ts
@@ -296,7 +296,7 @@ describe("War-end expected points persistence via processSubscription", () => {
 
   it("persists BL expected points as +3 / +2 / +1 with strict >60 threshold", async () => {
     await runProcessSubscriptionCase({
-      subOverrides: { matchType: "BL", warStartFwaPoints: 500 },
+      subOverrides: { matchType: "BL", warStartFwaPoints: 500, teamSize: 50 },
       finalResult: {
         clanStars: 100,
         opponentStars: 99,
@@ -308,7 +308,7 @@ describe("War-end expected points persistence via processSubscription", () => {
       expectedWarEndFwaPoints: 503,
     });
     await runProcessSubscriptionCase({
-      subOverrides: { matchType: "BL", warStartFwaPoints: 500 },
+      subOverrides: { matchType: "BL", warStartFwaPoints: 500, teamSize: 50 },
       finalResult: {
         clanStars: 90,
         opponentStars: 100,
@@ -320,12 +320,48 @@ describe("War-end expected points persistence via processSubscription", () => {
       expectedWarEndFwaPoints: 502,
     });
     await runProcessSubscriptionCase({
-      subOverrides: { matchType: "BL", warStartFwaPoints: 500 },
+      subOverrides: { matchType: "BL", warStartFwaPoints: 500, teamSize: 50 },
       finalResult: {
         clanStars: 90,
         opponentStars: 100,
         clanDestruction: 60,
         opponentDestruction: 70,
+        warEndTime: null,
+        resultLabel: "LOSE",
+      },
+      expectedWarEndFwaPoints: 501,
+    });
+    await runProcessSubscriptionCase({
+      subOverrides: { matchType: "BL", warStartFwaPoints: 500, teamSize: 50 },
+      finalResult: {
+        clanStars: 150,
+        opponentStars: 149,
+        clanDestruction: 60,
+        opponentDestruction: 60,
+        warEndTime: null,
+        resultLabel: "LOSE",
+      },
+      expectedWarEndFwaPoints: 503,
+    });
+    await runProcessSubscriptionCase({
+      subOverrides: { matchType: "BL", warStartFwaPoints: 500, teamSize: 45 },
+      finalResult: {
+        clanStars: 135,
+        opponentStars: 134,
+        clanDestruction: 60,
+        opponentDestruction: 60,
+        warEndTime: null,
+        resultLabel: "LOSE",
+      },
+      expectedWarEndFwaPoints: 503,
+    });
+    await runProcessSubscriptionCase({
+      subOverrides: { matchType: "BL", warStartFwaPoints: 500, teamSize: 50 },
+      finalResult: {
+        clanStars: 135,
+        opponentStars: 134,
+        clanDestruction: 60,
+        opponentDestruction: 60,
         warEndTime: null,
         resultLabel: "LOSE",
       },

--- a/tests/warEventLog.warEndPointsReconcile.test.ts
+++ b/tests/warEventLog.warEndPointsReconcile.test.ts
@@ -339,7 +339,7 @@ describe("War-end expected points persistence via processSubscription", () => {
         clanDestruction: 60,
         opponentDestruction: 60,
         warEndTime: null,
-        resultLabel: "LOSE",
+        resultLabel: "TIE",
       },
       expectedWarEndFwaPoints: 503,
     });
@@ -351,7 +351,7 @@ describe("War-end expected points persistence via processSubscription", () => {
         clanDestruction: 60,
         opponentDestruction: 60,
         warEndTime: null,
-        resultLabel: "LOSE",
+        resultLabel: "TIE",
       },
       expectedWarEndFwaPoints: 503,
     });

--- a/tests/warEventLog.warEndPointsReconcile.test.ts
+++ b/tests/warEventLog.warEndPointsReconcile.test.ts
@@ -335,7 +335,7 @@ describe("War-end expected points persistence via processSubscription", () => {
       subOverrides: { matchType: "BL", warStartFwaPoints: 500, teamSize: 50 },
       finalResult: {
         clanStars: 150,
-        opponentStars: 149,
+        opponentStars: 150,
         clanDestruction: 60,
         opponentDestruction: 60,
         warEndTime: null,
@@ -347,7 +347,7 @@ describe("War-end expected points persistence via processSubscription", () => {
       subOverrides: { matchType: "BL", warStartFwaPoints: 500, teamSize: 45 },
       finalResult: {
         clanStars: 135,
-        opponentStars: 134,
+        opponentStars: 135,
         clanDestruction: 60,
         opponentDestruction: 60,
         warEndTime: null,

--- a/tests/warPlanText.test.ts
+++ b/tests/warPlanText.test.ts
@@ -124,6 +124,7 @@ describe("WarEventHistoryService.buildWarPlanText", () => {
     const firstLine = String(out).split("\n")[0] ?? "";
     expect(firstLine).toContain("# ");
     expect(firstLine).toContain("__**BLACKLIST**__ vs OPPONENT_NAME");
+    expect(out).toContain("win war or perfect war = +1 point");
   });
 
   it("returns MM default with header format in first line", async () => {


### PR DESCRIPTION
- count BL perfect wars as +3 even when result is TIE
- support 50v50 perfect 150 stars and 45v45 perfect 135 stars
- keep BL win/+2/+1 fallback behavior unchanged
- update default BL plan copy to mention win or perfect war