### PR TITLE
fix(autorole): use clan member indexes for cwl roles

### DIFF
--- a/src/services/AutoRoleEvaluationService.ts
+++ b/src/services/AutoRoleEvaluationService.ts
@@ -1,6 +1,13 @@
 import { createHash } from "node:crypto";
 import { AutoRoleRuleType, type AutoRoleGuildConfig, type AutoRoleRule } from "@prisma/client";
-import { normalizeClanTag, getPlayerLinkTrustTier, isPlayerLinkTrustedForAutorole, isPlayerLinkVerifiedForAutorole, type PlayerLinkWithTrust } from "./PlayerLinkService";
+import {
+  getPlayerLinkTrustTier,
+  isPlayerLinkTrustedForAutorole,
+  isPlayerLinkVerifiedForAutorole,
+  normalizeClanTag,
+  normalizePlayerTag,
+  type PlayerLinkWithTrust,
+} from "./PlayerLinkService";
 import type { PlayerCurrentLike } from "./PlayerCurrentService";
 
 export type AutoRoleClanMembershipSource = "FWA" | "CWL" | "AMBIGUOUS" | "UNKNOWN";
@@ -30,6 +37,8 @@ export type AutoRoleGuildConfigSnapshot = Pick<
 export type AutoRoleTrackedClanScope = {
   fwaClanTags: Set<string>;
   cwlClanTags: Set<string>;
+  fwaMemberTags: Set<string>;
+  cwlMemberTags: Set<string>;
 };
 
 export type AutoRoleEvaluationMemberLike = {
@@ -137,6 +146,15 @@ function isLinkedAccountCurrentlyInTrackedClan(
   return currentClanTag.length > 0 && trackedClanTags.has(currentClanTag);
 }
 
+function isLinkedAccountInTrackedMembershipTags(
+  linkedAccount: RankedLinkedAccount,
+  trackedMemberTags: Set<string>,
+): boolean {
+  if (trackedMemberTags.size === 0) return false;
+  const playerTag = normalizePlayerTag(linkedAccount.playerTag);
+  return playerTag.length > 0 && trackedMemberTags.has(playerTag);
+}
+
 function isLinkedAccountInClanTarget(
   linkedAccount: RankedLinkedAccount,
   targetClanTag: string,
@@ -238,14 +256,8 @@ export class AutoRoleEvaluationService {
       input.config.familyRoleId &&
       input.managedRoleIds.has(input.config.familyRoleId) &&
       linkedAccounts.some((account) =>
-        isLinkedAccountCurrentlyInTrackedClan(
-          account,
-          input.trackedClanScope.fwaClanTags,
-        ) ||
-        isLinkedAccountCurrentlyInTrackedClan(
-          account,
-          input.trackedClanScope.cwlClanTags,
-        ),
+        isLinkedAccountInTrackedMembershipTags(account, input.trackedClanScope.fwaMemberTags) ||
+        isLinkedAccountInTrackedMembershipTags(account, input.trackedClanScope.cwlMemberTags),
       )
     ) {
       desiredManagedRoleIds.add(input.config.familyRoleId);
@@ -255,7 +267,7 @@ export class AutoRoleEvaluationService {
       input.config.cwlClanRoleId &&
       input.managedRoleIds.has(input.config.cwlClanRoleId) &&
       linkedAccounts.some((account) =>
-        isLinkedAccountCurrentlyInTrackedClan(account, input.trackedClanScope.cwlClanTags),
+        isLinkedAccountInTrackedMembershipTags(account, input.trackedClanScope.cwlMemberTags),
       )
     ) {
       desiredManagedRoleIds.add(input.config.cwlClanRoleId);

--- a/src/services/AutoRoleRefreshService.ts
+++ b/src/services/AutoRoleRefreshService.ts
@@ -4,7 +4,11 @@ import { dozzleLog } from "../helper/dozzleLogger";
 import { prisma } from "../prisma";
 import { CoCService } from "./CoCService";
 import { isMirrorPollingMode } from "./PollingModeService";
-import { playerCurrentService, type PlayerCurrentLike } from "./PlayerCurrentService";
+import {
+  playerCurrentService,
+  type PlayerCurrentLike,
+  type PlayerCurrentResolutionField,
+} from "./PlayerCurrentService";
 import {
   autoRoleApplyService,
   type AutoRoleMemberApplyResult,
@@ -172,21 +176,63 @@ async function loadLinkedAccountsForGuildMemberIds(input: {
   return byUserId;
 }
 
+function collectPlayerCurrentRequirementFields(input: {
+  snapshot: AutoRoleGuildStateSnapshot;
+  nicknameEnabled: boolean;
+}): PlayerCurrentResolutionField[] {
+  const fields: PlayerCurrentResolutionField[] = [];
+  const addField = (field: PlayerCurrentResolutionField) => {
+    if (!fields.includes(field)) {
+      fields.push(field);
+    }
+  };
+
+  if (input.nicknameEnabled) {
+    addField("currentClanTag");
+    addField("townHall");
+    addField("role");
+    addField("leagueName");
+  }
+
+  for (const rule of input.snapshot.rules) {
+    if (!rule.enabled) continue;
+    switch (rule.type) {
+      case "TOWN_HALL":
+        addField("townHall");
+        break;
+      case "CLAN_ROLE":
+        addField("role");
+        break;
+      case "LEAGUE":
+        addField("leagueName");
+        break;
+      case "CLAN":
+        addField("currentClanTag");
+        break;
+      default:
+        break;
+    }
+  }
+
+  return fields;
+}
+
 async function loadPlayerCurrentByLinkedAccounts(input: {
   linkedAccountsByUserId: Map<string, PlayerLinkWithTrust[]>;
   cocService?: CoCService | null;
+  requireFields: PlayerCurrentResolutionField[];
 }): Promise<Map<string, PlayerCurrentLike>> {
   const playerTags = normalizePlayerTags(
     [...input.linkedAccountsByUserId.values()].flatMap((rows) => rows.map((row) => row.playerTag)),
   );
-  if (playerTags.length === 0) {
+  if (playerTags.length === 0 || input.requireFields.length === 0) {
     return new Map();
   }
   const resolution = () =>
-      playerCurrentService.resolveCurrentPlayersForTags({
+    playerCurrentService.resolveCurrentPlayersForTags({
       playerTags,
       cocService: input.cocService ?? null,
-      requireFields: ["currentClanTag", "townHall", "role", "leagueName"],
+      requireFields: input.requireFields,
       refreshPolicy: "missing_only",
     });
 
@@ -221,9 +267,16 @@ async function loadTrackedClansForNickname(): Promise<AutoRoleNicknameTrackedCla
     .filter((row) => row.tag.length > 0);
 }
 
-async function loadTrackedClanScope(input: {
+async function loadTrackedClanMembershipScope(input: {
   season: string;
-}): Promise<{ fwaClanTags: Set<string>; cwlClanTags: Set<string> }> {
+  cocService?: CoCService | null;
+}): Promise<{
+  fwaClanTags: Set<string>;
+  cwlClanTags: Set<string>;
+  fwaMemberTags: Set<string>;
+  cwlMemberTags: Set<string>;
+  cwlClanFetchCount: number;
+}> {
   const [fwaRows, cwlRows] = await Promise.all([
     prisma.trackedClan.findMany({
       select: { tag: true },
@@ -234,9 +287,74 @@ async function loadTrackedClanScope(input: {
     }),
   ]);
 
+  const fwaClanTags = normalizeClanTags(fwaRows.map((row) => row.tag));
+  const cwlClanTags = normalizeClanTags(cwlRows.map((row) => row.tag));
+
+  const fwaMemberTags = new Set<string>();
+  if (fwaClanTags.size > 0) {
+    const fwaMemberRows = await prisma.fwaClanMemberCurrent.findMany({
+      where: { clanTag: { in: [...fwaClanTags] } },
+      select: {
+        clanTag: true,
+        playerTag: true,
+      },
+    });
+    for (const row of fwaMemberRows) {
+      const playerTag = normalizePlayerTag(row.playerTag);
+      if (!playerTag) continue;
+      fwaMemberTags.add(playerTag);
+    }
+  }
+
+  const cwlMemberTags = new Set<string>();
+  let cwlClanFetchCount = 0;
+  const cwlRoundRows = cwlClanTags.size > 0
+    ? await prisma.cwlRoundMemberCurrent.findMany({
+        where: { season: input.season, clanTag: { in: [...cwlClanTags] } },
+        select: {
+          clanTag: true,
+          playerTag: true,
+        },
+      })
+    : [];
+  const cwlClanTagsSeen = new Set<string>();
+  for (const row of cwlRoundRows) {
+    const playerTag = normalizePlayerTag(row.playerTag);
+    if (playerTag) {
+      cwlMemberTags.add(playerTag);
+    }
+    const clanTag = normalizeClanTag(row.clanTag);
+    if (clanTag) {
+      cwlClanTagsSeen.add(clanTag);
+    }
+  }
+
+  const missingCwlClanTags = [...cwlClanTags].filter((tag) => !cwlClanTagsSeen.has(tag));
+  if (missingCwlClanTags.length > 0 && input.cocService && typeof input.cocService.getClan === "function") {
+    const cocService = input.cocService;
+    const fetchedClans = await Promise.all(
+      missingCwlClanTags.map(async (clanTag) => {
+        const clan = await cocService.getClan(clanTag).catch(() => null);
+        return { clanTag, clan };
+      }),
+    );
+    for (const { clan } of fetchedClans) {
+      cwlClanFetchCount += 1;
+      for (const member of clan?.members ?? []) {
+        const playerTag = normalizePlayerTag(String(member?.tag ?? ""));
+        if (playerTag) {
+          cwlMemberTags.add(playerTag);
+        }
+      }
+    }
+  }
+
   return {
-    fwaClanTags: normalizeClanTags(fwaRows.map((row) => row.tag)),
-    cwlClanTags: normalizeClanTags(cwlRows.map((row) => row.tag)),
+    fwaClanTags,
+    cwlClanTags,
+    fwaMemberTags,
+    cwlMemberTags,
+    cwlClanFetchCount,
   };
 }
 
@@ -560,7 +678,13 @@ async function runRefreshPass(input: {
   playerCurrentByTag: Map<string, PlayerCurrentLike>;
   trackedClans: AutoRoleNicknameTrackedClanLike[];
   clanMembershipIndex: AutoRoleClanMembershipIndex;
-  trackedClanScope: { fwaClanTags: Set<string>; cwlClanTags: Set<string> };
+  trackedMembershipScope: {
+    fwaClanTags: Set<string>;
+    cwlClanTags: Set<string>;
+    fwaMemberTags: Set<string>;
+    cwlMemberTags: Set<string>;
+    cwlClanFetchCount: number;
+  };
   runId: string;
   now: Date;
 }): Promise<AutoRoleRefreshResult> {
@@ -643,7 +767,7 @@ async function runRefreshPass(input: {
         linkedAccounts,
         playerCurrentByTag: input.playerCurrentByTag,
         clanMembershipByTag: input.clanMembershipIndex,
-        trackedClanScope: input.trackedClanScope,
+        trackedClanScope: input.trackedMembershipScope,
       });
       dozzleLog.trace(
         `[autorole] event=evaluate guild_id=${input.guildId} scope=${input.scope.kind} user_id=${userId} skip_reason=${evaluation.skipReason ?? "none"} desired_roles=${evaluation.desiredManagedRoleIds.join(",") || "none"} primary_player=${evaluation.primaryPlayerTag ?? "none"}`,
@@ -803,17 +927,23 @@ export class AutoRoleRefreshService {
       const linkedAccountsByUserId = await loadLinkedAccountsForGuildMemberIds({
         guildMemberIds: [...membersById.keys()],
       });
+      const nicknameTemplate = normalizeNicknameTemplate(snapshot.config.nicknameTemplate);
+      const playerCurrentRequiredFields = collectPlayerCurrentRequirementFields({
+        snapshot,
+        nicknameEnabled: snapshot.config.applyNicknames && nicknameTemplate !== null && nicknameTemplate !== undefined,
+      });
       const playerCurrentByTag = await loadPlayerCurrentByLinkedAccounts({
         linkedAccountsByUserId,
         cocService: input.cocService ?? null,
+        requireFields: playerCurrentRequiredFields,
       });
-      const nicknameTemplate = normalizeNicknameTemplate(snapshot.config.nicknameTemplate);
       const trackedClans = snapshot.config.applyNicknames && nicknameTemplate !== null && nicknameTemplate !== undefined
         ? await loadTrackedClansForNickname()
         : [];
       const cwlSeason = resolveCurrentCwlSeasonKey();
-      const trackedClanScope = await loadTrackedClanScope({
+      const trackedMembershipScope = await loadTrackedClanMembershipScope({
         season: cwlSeason,
+        cocService: input.cocService ?? null,
       });
       const clanMembershipIndex = await loadClanMembershipIndex({
         season: cwlSeason,
@@ -821,7 +951,7 @@ export class AutoRoleRefreshService {
       });
 
       dozzleLog.info(
-        `[autorole] event=refresh_start guild_id=${input.guildId} scope=${input.scope.kind} candidate_members=${membersById.size} linked_users=${linkedAccountsByUserId.size} managed_roles=${managedRoleIds.size}`,
+        `[autorole] event=refresh_start guild_id=${input.guildId} scope=${input.scope.kind} candidate_members=${membersById.size} linked_users=${linkedAccountsByUserId.size} managed_roles=${managedRoleIds.size} fwa_member_tags=${trackedMembershipScope.fwaMemberTags.size} cwl_member_tags=${trackedMembershipScope.cwlMemberTags.size} cwl_clan_fetches=${trackedMembershipScope.cwlClanFetchCount} player_current_tags=${playerCurrentByTag.size} player_current_fields=${playerCurrentRequiredFields.length > 0 ? playerCurrentRequiredFields.join(",") : "none"}`,
       );
 
       return runRefreshPass({
@@ -834,7 +964,7 @@ export class AutoRoleRefreshService {
         playerCurrentByTag,
         trackedClans,
         clanMembershipIndex,
-        trackedClanScope,
+        trackedMembershipScope,
         runId: run.id,
         now: input.now,
       });

--- a/src/services/AutoRoleRefreshService.ts
+++ b/src/services/AutoRoleRefreshService.ts
@@ -176,6 +176,81 @@ async function loadLinkedAccountsForGuildMemberIds(input: {
   return byUserId;
 }
 
+async function loadLinkedAccountsForPlayerTags(input: {
+  playerTags: string[];
+}): Promise<Map<string, PlayerLinkWithTrust[]>> {
+  const normalizedTags = normalizePlayerTags(input.playerTags);
+  if (normalizedTags.length === 0) {
+    return new Map();
+  }
+
+  const rows = await prisma.playerLink.findMany({
+    where: {
+      playerTag: { in: normalizedTags },
+    },
+    select: {
+      playerTag: true,
+      discordUserId: true,
+      discordUsername: true,
+      playerName: true,
+      linkSource: true,
+      verificationStatus: true,
+      verificationMethod: true,
+      verifiedAt: true,
+      verifiedByDiscordUserId: true,
+      lastVerifiedAt: true,
+      verificationFailureReason: true,
+      importBatchKey: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+  });
+
+  const byUserId = new Map<string, PlayerLinkWithTrust[]>();
+  for (const row of rows) {
+    const discordUserId = String(row.discordUserId ?? "").trim();
+    if (!discordUserId) continue;
+    const list = byUserId.get(discordUserId) ?? [];
+    list.push({
+      playerTag: row.playerTag,
+      discordUserId,
+      discordUsername: row.discordUsername,
+      playerName: row.playerName,
+      linkSource: row.linkSource,
+      verificationStatus: row.verificationStatus,
+      verificationMethod: row.verificationMethod,
+      verifiedAt: row.verifiedAt,
+      verifiedByDiscordUserId: row.verifiedByDiscordUserId,
+      lastVerifiedAt: row.lastVerifiedAt,
+      verificationFailureReason: row.verificationFailureReason,
+      importBatchKey: row.importBatchKey,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+    });
+    byUserId.set(discordUserId, list);
+  }
+  return byUserId;
+}
+
+async function collectMembershipScopedCandidateUsers(input: {
+  membersById: Map<string, AutoRoleGuildMemberLike>;
+  trackedMemberPlayerTags: string[];
+  targetRoleId: string;
+}): Promise<Set<string>> {
+  const candidateIds = collectCurrentRoleHolders(input.membersById, new Set([input.targetRoleId]));
+  const linkedAccountsByUserId = await loadLinkedAccountsForPlayerTags({
+    playerTags: input.trackedMemberPlayerTags,
+  });
+
+  for (const userId of linkedAccountsByUserId.keys()) {
+    if (input.membersById.has(userId)) {
+      candidateIds.add(userId);
+    }
+  }
+
+  return candidateIds;
+}
+
 function collectPlayerCurrentRequirementFields(input: {
   snapshot: AutoRoleGuildStateSnapshot;
   nicknameEnabled: boolean;
@@ -924,9 +999,39 @@ export class AutoRoleRefreshService {
       }
 
       const membersById = await fetchGuildMembersMap(input.guild, input.scope);
-      const linkedAccountsByUserId = await loadLinkedAccountsForGuildMemberIds({
-        guildMemberIds: [...membersById.keys()],
+      const cwlSeason = resolveCurrentCwlSeasonKey();
+      const trackedMembershipScope = await loadTrackedClanMembershipScope({
+        season: cwlSeason,
+        cocService: input.cocService ?? null,
       });
+      const clanMembershipIndex = await loadClanMembershipIndex({
+        season: cwlSeason,
+        rules: snapshot.rules,
+      });
+      const roleScope = input.scope.kind === "role" ? input.scope : null;
+      const isFamilyRoleScope = roleScope !== null && snapshot.config.familyRoleId === roleScope.discordRoleId;
+      const isCwlClanRoleScope = roleScope !== null && snapshot.config.cwlClanRoleId === roleScope.discordRoleId;
+
+      const candidateUserIds =
+        roleScope && (isFamilyRoleScope || isCwlClanRoleScope)
+          ? await collectMembershipScopedCandidateUsers({
+              membersById,
+              trackedMemberPlayerTags: isFamilyRoleScope
+                ? [...trackedMembershipScope.fwaMemberTags, ...trackedMembershipScope.cwlMemberTags]
+                : [...trackedMembershipScope.cwlMemberTags],
+              targetRoleId: roleScope.discordRoleId,
+            })
+          : new Set<string>(membersById.keys());
+
+      const linkedAccountsByUserId =
+        input.scope.kind === "guild" || roleScope === null || (!isFamilyRoleScope && !isCwlClanRoleScope)
+          ? await loadLinkedAccountsForGuildMemberIds({
+              guildMemberIds: [...membersById.keys()],
+            })
+          : await loadLinkedAccountsForGuildMemberIds({
+              guildMemberIds: [...candidateUserIds],
+            });
+
       const nicknameTemplate = normalizeNicknameTemplate(snapshot.config.nicknameTemplate);
       const playerCurrentRequiredFields = collectPlayerCurrentRequirementFields({
         snapshot,
@@ -940,18 +1045,9 @@ export class AutoRoleRefreshService {
       const trackedClans = snapshot.config.applyNicknames && nicknameTemplate !== null && nicknameTemplate !== undefined
         ? await loadTrackedClansForNickname()
         : [];
-      const cwlSeason = resolveCurrentCwlSeasonKey();
-      const trackedMembershipScope = await loadTrackedClanMembershipScope({
-        season: cwlSeason,
-        cocService: input.cocService ?? null,
-      });
-      const clanMembershipIndex = await loadClanMembershipIndex({
-        season: cwlSeason,
-        rules: snapshot.rules,
-      });
 
       dozzleLog.info(
-        `[autorole] event=refresh_start guild_id=${input.guildId} scope=${input.scope.kind} candidate_members=${membersById.size} linked_users=${linkedAccountsByUserId.size} managed_roles=${managedRoleIds.size} fwa_member_tags=${trackedMembershipScope.fwaMemberTags.size} cwl_member_tags=${trackedMembershipScope.cwlMemberTags.size} cwl_clan_fetches=${trackedMembershipScope.cwlClanFetchCount} player_current_tags=${playerCurrentByTag.size} player_current_fields=${playerCurrentRequiredFields.length > 0 ? playerCurrentRequiredFields.join(",") : "none"}`,
+        `[autorole] event=refresh_start guild_id=${input.guildId} scope=${input.scope.kind} guild_members=${membersById.size} candidate_members=${candidateUserIds.size} linked_users=${linkedAccountsByUserId.size} managed_roles=${managedRoleIds.size} fwa_member_tags=${trackedMembershipScope.fwaMemberTags.size} cwl_member_tags=${trackedMembershipScope.cwlMemberTags.size} cwl_clan_fetches=${trackedMembershipScope.cwlClanFetchCount} player_current_tags=${playerCurrentByTag.size} player_current_fields=${playerCurrentRequiredFields.length > 0 ? playerCurrentRequiredFields.join(",") : "none"}`,
       );
 
       return runRefreshPass({

--- a/tests/autorole.refresh.service.test.ts
+++ b/tests/autorole.refresh.service.test.ts
@@ -21,6 +21,9 @@ const prismaMock = vi.hoisted(() => ({
   cwlTrackedClan: {
     findMany: vi.fn(),
   },
+  cwlRoundMemberCurrent: {
+    findMany: vi.fn(),
+  },
   fwaClanMemberCurrent: {
     findMany: vi.fn(),
   },
@@ -217,6 +220,7 @@ describe("AutoRoleRefreshService", () => {
     prismaMock.playerLink.findMany.mockResolvedValue([]);
     prismaMock.trackedClan.findMany.mockResolvedValue([]);
     prismaMock.cwlTrackedClan.findMany.mockResolvedValue([]);
+    prismaMock.cwlRoundMemberCurrent.findMany.mockResolvedValue([]);
     prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue([]);
     prismaMock.cwlPlayerClanSeason.findMany.mockResolvedValue([]);
     prismaMock.autoRolePendingRemoval.findMany.mockResolvedValue([]);
@@ -430,7 +434,7 @@ describe("AutoRoleRefreshService", () => {
     });
   });
 
-  it("uses current-season tracked CWL clans for family and CWL clan roles", async () => {
+  it("uses current-season tracked CWL member tags for family and CWL clan roles", async () => {
     const familyRoleId = "222222222222222222";
     const cwlClanRoleId = "333333333333333333";
     const fwaMemberId = "111111111111111111";
@@ -467,39 +471,28 @@ describe("AutoRoleRefreshService", () => {
     });
     prismaMock.trackedClan.findMany.mockResolvedValue([{ tag: "#2QG2C08UP" }]);
     prismaMock.cwlTrackedClan.findMany.mockResolvedValue([{ tag: "#PYLQ0289" }]);
+    prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue([
+      {
+        clanTag: "#2QG2C08UP",
+        playerTag: "#2QG2C08UP",
+      },
+    ]);
+    prismaMock.cwlRoundMemberCurrent.findMany.mockResolvedValue([
+      {
+        clanTag: "#PYLQ0289",
+        playerTag: "#PYLQ0289",
+      },
+    ]);
     vi.spyOn(autoRoleService, "getGuildStateSnapshot").mockResolvedValue({
       config: makeConfig({
         familyRoleId,
         cwlClanRoleId,
+        applyNicknames: false,
         removeStaleManagedRoles: true,
       }),
       rules: [],
       exclusions: { users: [], roles: [] },
     } as any);
-    vi.spyOn(playerCurrentService, "resolveCurrentPlayersForTags").mockImplementation(async ({ playerTags }) => {
-      const map = new Map<string, any>();
-      for (const playerTag of playerTags) {
-        map.set(
-          playerTag,
-          makePlayerCurrent({
-            playerTag,
-            playerName:
-              playerTag === "#2QG2C08UP"
-                ? "FWA Member"
-                : playerTag === "#PYLQ0289"
-                  ? "CWL Member"
-                  : "Outsider",
-            currentClanTag:
-              playerTag === "#2QG2C08UP"
-                ? "#2QG2C08UP"
-                : playerTag === "#PYLQ0289"
-                  ? "#PYLQ0289"
-                  : "#QGRJ2222",
-          }),
-        );
-      }
-      return map;
-    });
 
     const result = await autoRoleRefreshService.refreshGuild({
       guild,
@@ -513,6 +506,19 @@ describe("AutoRoleRefreshService", () => {
         select: { tag: true },
       }),
     );
+    expect(prismaMock.fwaClanMemberCurrent.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { clanTag: { in: ["#2QG2C08UP"] } },
+        select: { clanTag: true, playerTag: true },
+      }),
+    );
+    expect(prismaMock.cwlRoundMemberCurrent.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { season: "2026-04", clanTag: { in: ["#PYLQ0289"] } },
+        select: { clanTag: true, playerTag: true },
+      }),
+    );
+    expect(playerCurrentService.resolveCurrentPlayersForTags).not.toHaveBeenCalled();
     expect(fwaMember.roles.add).toHaveBeenCalledWith(familyRoleId);
     expect(cwlMember.roles.add).toHaveBeenCalledWith(familyRoleId);
     expect(cwlMember.roles.add).toHaveBeenCalledWith(cwlClanRoleId);
@@ -539,32 +545,23 @@ describe("AutoRoleRefreshService", () => {
     ]);
     prismaMock.trackedClan.findMany.mockResolvedValue([{ tag: "#2QG2C08UP" }]);
     prismaMock.cwlTrackedClan.findMany.mockResolvedValue([{ tag: "#PYLQ0289" }]);
+    prismaMock.cwlRoundMemberCurrent.findMany.mockResolvedValue([]);
     vi.spyOn(autoRoleService, "getGuildStateSnapshot").mockResolvedValue({
       config: makeConfig({
         cwlClanRoleId,
+        applyNicknames: false,
         removeStaleManagedRoles: true,
       }),
       rules: [],
       exclusions: { users: [], roles: [] },
     } as any);
-    vi.spyOn(playerCurrentService, "resolveCurrentPlayersForTags").mockResolvedValue(
-      new Map([
-        [
-          "#PYLQ0289",
-          makePlayerCurrent({
-            playerTag: "#PYLQ0289",
-            playerName: "CWL Member",
-            currentClanTag: "#QGRJ2222",
-          }),
-        ],
-      ]),
-    );
 
     const result = await autoRoleRefreshService.refreshGuild({
       guild,
       guildId: "111111111111111111",
     });
 
+    expect(playerCurrentService.resolveCurrentPlayersForTags).not.toHaveBeenCalled();
     expect(member.roles.remove).toHaveBeenCalledWith(cwlClanRoleId);
     expect(result.removedCount).toBe(1);
     expect(result.addedCount).toBe(0);

--- a/tests/autorole.refresh.service.test.ts
+++ b/tests/autorole.refresh.service.test.ts
@@ -530,6 +530,186 @@ describe("AutoRoleRefreshService", () => {
     });
   });
 
+  it("builds family role-scoped candidates from tracked member tags and current holders without resolving PlayerCurrent", async () => {
+    const familyRoleId = "222222222222222222";
+    const staleHolderId = "111111111111111111";
+    const fwaCandidateId = "333333333333333333";
+    const cwlCandidateId = "444444444444444444";
+    const staleHolder = makeMember(staleHolderId, [familyRoleId]);
+    const fwaCandidate = makeMember(fwaCandidateId);
+    const cwlCandidate = makeMember(cwlCandidateId);
+    const guild = makeGuild(new Map([
+      [staleHolderId, staleHolder],
+      [fwaCandidateId, fwaCandidate],
+      [cwlCandidateId, cwlCandidate],
+    ]));
+
+    prismaMock.playerLink.findMany.mockImplementation(async ({ where }: any) => {
+      if (where.playerTag?.in) {
+        const wanted = new Set(where.playerTag.in);
+        return [
+          makeLinkedAccount({
+            playerTag: "#2QG2C08UP",
+            discordUserId: fwaCandidateId,
+            playerName: "FWA Candidate",
+          }),
+          makeLinkedAccount({
+            playerTag: "#PYLQ0289",
+            discordUserId: cwlCandidateId,
+            playerName: "CWL Candidate",
+          }),
+        ].filter((row) => wanted.has(row.playerTag));
+      }
+      if (where.discordUserId?.in) {
+        const wanted = new Set(where.discordUserId.in);
+        return [
+          makeLinkedAccount({
+            playerTag: "#QGRJ2222",
+            discordUserId: staleHolderId,
+            playerName: "Stale Holder",
+          }),
+          makeLinkedAccount({
+            playerTag: "#2QG2C08UP",
+            discordUserId: fwaCandidateId,
+            playerName: "FWA Candidate",
+          }),
+          makeLinkedAccount({
+            playerTag: "#PYLQ0289",
+            discordUserId: cwlCandidateId,
+            playerName: "CWL Candidate",
+          }),
+        ].filter((row) => wanted.has(row.discordUserId));
+      }
+      return [];
+    });
+    prismaMock.trackedClan.findMany.mockResolvedValue([{ tag: "#2QG2C08UP" }]);
+    prismaMock.cwlTrackedClan.findMany.mockResolvedValue([{ tag: "#PYLQ0289" }]);
+    prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue([
+      {
+        clanTag: "#2QG2C08UP",
+        playerTag: "#2QG2C08UP",
+      },
+    ]);
+    prismaMock.cwlRoundMemberCurrent.findMany.mockResolvedValue([
+      {
+        clanTag: "#PYLQ0289",
+        playerTag: "#PYLQ0289",
+      },
+    ]);
+    vi.spyOn(autoRoleService, "getGuildStateSnapshot").mockResolvedValue({
+      config: makeConfig({
+        familyRoleId,
+        applyNicknames: false,
+        removeStaleManagedRoles: true,
+      }),
+      rules: [],
+      exclusions: { users: [], roles: [] },
+    } as any);
+
+    const result = await autoRoleRefreshService.refreshRole({
+      guild,
+      guildId: "111111111111111111",
+      discordRoleId: familyRoleId,
+    });
+
+    expect(prismaMock.playerLink.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          playerTag: { in: expect.arrayContaining(["#2QG2C08UP", "#PYLQ0289"]) },
+        }),
+      }),
+    );
+    expect(playerCurrentService.resolveCurrentPlayersForTags).not.toHaveBeenCalled();
+    expect(staleHolder.roles.remove).toHaveBeenCalledWith(familyRoleId);
+    expect(fwaCandidate.roles.add).toHaveBeenCalledWith(familyRoleId);
+    expect(cwlCandidate.roles.add).toHaveBeenCalledWith(familyRoleId);
+    expect(result).toMatchObject({
+      evaluatedCount: 3,
+      addedCount: 2,
+      removedCount: 1,
+    });
+  });
+
+  it("builds cwl role-scoped candidates from tracked member tags and current holders without resolving PlayerCurrent", async () => {
+    const cwlClanRoleId = "333333333333333333";
+    const staleHolderId = "111111111111111111";
+    const cwlCandidateId = "444444444444444444";
+    const staleHolder = makeMember(staleHolderId, [cwlClanRoleId]);
+    const cwlCandidate = makeMember(cwlCandidateId);
+    const guild = makeGuild(new Map([
+      [staleHolderId, staleHolder],
+      [cwlCandidateId, cwlCandidate],
+    ]));
+
+    prismaMock.playerLink.findMany.mockImplementation(async ({ where }: any) => {
+      if (where.playerTag?.in) {
+        const wanted = new Set(where.playerTag.in);
+        return [
+          makeLinkedAccount({
+            playerTag: "#PYLQ0289",
+            discordUserId: cwlCandidateId,
+            playerName: "CWL Candidate",
+          }),
+        ].filter((row) => wanted.has(row.playerTag));
+      }
+      if (where.discordUserId?.in) {
+        const wanted = new Set(where.discordUserId.in);
+        return [
+          makeLinkedAccount({
+            playerTag: "#QGRJ2222",
+            discordUserId: staleHolderId,
+            playerName: "Stale Holder",
+          }),
+          makeLinkedAccount({
+            playerTag: "#PYLQ0289",
+            discordUserId: cwlCandidateId,
+            playerName: "CWL Candidate",
+          }),
+        ].filter((row) => wanted.has(row.discordUserId));
+      }
+      return [];
+    });
+    prismaMock.trackedClan.findMany.mockResolvedValue([{ tag: "#2QG2C08UP" }]);
+    prismaMock.cwlTrackedClan.findMany.mockResolvedValue([{ tag: "#PYLQ0289" }]);
+    prismaMock.cwlRoundMemberCurrent.findMany.mockResolvedValue([
+      {
+        clanTag: "#PYLQ0289",
+        playerTag: "#PYLQ0289",
+      },
+    ]);
+    vi.spyOn(autoRoleService, "getGuildStateSnapshot").mockResolvedValue({
+      config: makeConfig({
+        cwlClanRoleId,
+        applyNicknames: false,
+        removeStaleManagedRoles: true,
+      }),
+      rules: [],
+      exclusions: { users: [], roles: [] },
+    } as any);
+
+    const result = await autoRoleRefreshService.refreshRole({
+      guild,
+      guildId: "111111111111111111",
+      discordRoleId: cwlClanRoleId,
+    });
+
+    expect(prismaMock.playerLink.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          playerTag: { in: ["#PYLQ0289"] },
+        }),
+      }),
+    );
+    expect(playerCurrentService.resolveCurrentPlayersForTags).not.toHaveBeenCalled();
+    expect(staleHolder.roles.remove).toHaveBeenCalledWith(cwlClanRoleId);
+    expect(cwlCandidate.roles.add).toHaveBeenCalledWith(cwlClanRoleId);
+    expect(result).toMatchObject({
+      evaluatedCount: 2,
+      addedCount: 1,
+      removedCount: 1,
+    });
+  });
+
   it("removes the generic CWL clan role when the member is no longer in a tracked CWL clan", async () => {
     const cwlClanRoleId = "333333333333333333";
     const userId = "111111111111111111";

--- a/tests/autoroleEvaluation.service.test.ts
+++ b/tests/autoroleEvaluation.service.test.ts
@@ -125,6 +125,8 @@ describe("AutoRoleEvaluationService league rules", () => {
   const trackedClanScope = {
     fwaClanTags: new Set(["#2QG2C08UP"]),
     cwlClanTags: new Set(["#PYLQ0289"]),
+    fwaMemberTags: new Set(["#2QG2C08UP"]),
+    cwlMemberTags: new Set(["#PYLQ0289"]),
   };
 
   it("matches a linked account with leagueName set to Legend League", () => {
@@ -210,7 +212,7 @@ describe("AutoRoleEvaluationService league rules", () => {
     const member = makeMember();
     const linkedAccounts = [makeLinkedAccount({ playerTag: "#PYLQ0289" })];
     const playerCurrentByTag = new Map([
-      ["#PYLQ0289", makePlayerCurrent({ playerTag: "#PYLQ0289", currentClanTag: "#PYLQ0289" })],
+      ["#PYLQ0289", makePlayerCurrent({ playerTag: "#PYLQ0289", currentClanTag: "#QGRJ2222" })],
     ]);
 
     const result = service.evaluateMember({
@@ -235,10 +237,15 @@ describe("AutoRoleEvaluationService league rules", () => {
 
   it("grants the family role for eligible linked accounts in tracked FWA clans", () => {
     const member = makeMember();
-    const linkedAccounts = [makeLinkedAccount({ playerTag: "#FWA12345" })];
+    const linkedAccounts = [makeLinkedAccount({ playerTag: "#PYLQ0289" })];
     const playerCurrentByTag = new Map([
-      ["#FWA12345", makePlayerCurrent({ playerTag: "#FWA12345", currentClanTag: "#2QG2C08UP" })],
+      ["#PYLQ0289", makePlayerCurrent({ playerTag: "#PYLQ0289", currentClanTag: "#QGRJ2222" })],
     ]);
+    const fwaTrackedScope = {
+      ...trackedClanScope,
+      fwaMemberTags: new Set(["#PYLQ0289"]),
+      cwlMemberTags: new Set<string>(),
+    };
 
     const result = service.evaluateMember({
       config: makeConfig({
@@ -251,10 +258,47 @@ describe("AutoRoleEvaluationService league rules", () => {
       linkedAccounts,
       playerCurrentByTag,
       clanMembershipByTag,
-      trackedClanScope,
+      trackedClanScope: fwaTrackedScope,
     });
 
     expect(result.desiredManagedRoleIds).toEqual(["333333333333333333"]);
+  });
+
+  it("matches clan roles from current clan tags as before", () => {
+    const member = makeMember();
+    const linkedAccounts = [makeLinkedAccount({ playerTag: "#2QG2C08UP" })];
+    const playerCurrentByTag = new Map([
+      ["#2QG2C08UP", makePlayerCurrent({ playerTag: "#2QG2C08UP", currentClanTag: "#2QG2C08UP" })],
+    ]);
+
+    const result = service.evaluateMember({
+      config: makeConfig({
+        familyRoleId: "333333333333333333",
+        cwlClanRoleId: "444444444444444444",
+      }),
+      rules: [
+        {
+          id: "rule-1",
+          guildId: "111111111111111111",
+          type: AutoRoleRuleType.CLAN,
+          targetValue: "#2QG2C08UP",
+          discordRoleId: "555555555555555555",
+          priority: 100,
+          enabled: true,
+          createdAt: new Date("2026-04-01T00:00:00.000Z"),
+          updatedAt: new Date("2026-04-01T00:00:00.000Z"),
+        },
+      ],
+      managedRoleIds: new Set(["333333333333333333", "444444444444444444", "555555555555555555"]),
+      member,
+      linkedAccounts,
+      playerCurrentByTag,
+      clanMembershipByTag,
+      trackedClanScope,
+    });
+
+    expect(result.desiredManagedRoleIds).toContain("555555555555555555");
+    expect(result.matchedRuleIds).toContain("rule-1");
   });
 
   it("does not grant tracked-clan roles to untrusted or revoked links when trusted links are disabled", () => {


### PR DESCRIPTION
- build CWL family/generic role eligibility from tracked member-tag sets instead of player-by-player current clan refreshes
- keep CLAN/TH/role/league refresh requirements intact while avoiding unnecessary PlayerCurrent lookups