### PR TITLE
feat(inactive): show clan badges and town hall icons

### DIFF
--- a/src/commands/Inactive.ts
+++ b/src/commands/Inactive.ts
@@ -15,7 +15,12 @@ import { CoCService } from "../services/CoCService";
 import { InactiveWarService, type InactiveWarSummary } from "../services/InactiveWarService";
 import { formatError } from "../helper/formatError";
 import { formatClanBadgeEmoji } from "../helper/clanBadgeEmoji";
-import { renderTownHallIcon, resolveTownHallEmojiMap, type TownHallEmojiMap } from "../helper/townHallEmoji";
+import {
+  normalizeTownHallLevel,
+  renderTownHallIcon,
+  resolveTownHallEmojiMap,
+  type TownHallEmojiMap,
+} from "../helper/townHallEmoji";
 import { listPlayerLinksForClanMembers } from "../services/PlayerLinkService";
 import { normalizeClanTag } from "../services/PlayerLinkService";
 
@@ -333,11 +338,10 @@ async function getRosterSnapshot(
         liveMemberTags.add(memberTag);
         liveMemberClanByTag.set(memberTag, clanName);
         liveMemberTrackedClanByTag.set(memberTag, trackedTag);
-        const townHall = Number(member?.townHall);
-        liveMemberTownHallByTag.set(
-          memberTag,
-          Number.isFinite(townHall) && townHall > 0 ? Math.trunc(townHall) : null,
+        const townHall = normalizeTownHallLevel(
+          member?.townHall ?? member?.townHallLevel ?? member?.townhallLevel,
         );
+        liveMemberTownHallByTag.set(memberTag, townHall);
       }
       liveMembersByClan.set(trackedTag, memberSet);
     } catch (err) {
@@ -1148,5 +1152,4 @@ export const Inactive: Command = {
     await interaction.respond(choices);
   },
 };
-
 

--- a/src/commands/Inactive.ts
+++ b/src/commands/Inactive.ts
@@ -14,6 +14,8 @@ import { prisma } from "../prisma";
 import { CoCService } from "../services/CoCService";
 import { InactiveWarService, type InactiveWarSummary } from "../services/InactiveWarService";
 import { formatError } from "../helper/formatError";
+import { formatClanBadgeEmoji } from "../helper/clanBadgeEmoji";
+import { renderTownHallIcon, resolveTownHallEmojiMap, type TownHallEmojiMap } from "../helper/townHallEmoji";
 import { listPlayerLinksForClanMembers } from "../services/PlayerLinkService";
 import { normalizeClanTag } from "../services/PlayerLinkService";
 
@@ -31,9 +33,23 @@ function formatInactiveClanTag(tag: string): string {
   return normalized ? `#${normalized}` : tag.trim();
 }
 
+function formatInactiveClanBadge(badge: string | null | undefined): string | null {
+  return formatClanBadgeEmoji(badge);
+}
+
 function formatInactivePlayerTag(tag: string): string {
   const normalized = normalizeClanTagInput(tag);
   return normalized ? `#${normalized}` : tag.trim();
+}
+
+function formatInactivePlayerIdentity(input: {
+  townHallIcon: string;
+  playerName: string;
+  playerTag: string;
+  discordText: string;
+}): string {
+  const normalizedName = String(input.playerName ?? "").trim() || input.playerTag;
+  return `${input.townHallIcon} ${normalizedName} \`${formatInactivePlayerTag(input.playerTag)}\` ${input.discordText}`;
 }
 
 function buildInactiveWarRatioText(input: {
@@ -94,7 +110,7 @@ function buildInactivePlayerDiscordText(
   playerTag: string,
 ): string {
   const discordUserId = discordUserIdByPlayerTag.get(normalizeClanTagInput(playerTag)) ?? null;
-  return discordUserId ? `<@${discordUserId}>` : "—";
+  return discordUserId ? `<@${discordUserId}>` : "\u2014";
 }
 
 async function loadInactiveWarDiscordLinks(
@@ -160,7 +176,9 @@ function buildInactiveWarGroupedPages(input: {
   rows: InactiveWarSummary["results"];
   trackedTags: string[];
   trackedNameByTag: Map<string, string>;
+  trackedBadgeByTag: Map<string, string | null>;
   discordUserIdByPlayerTag: Map<string, string>;
+  townHallEmojiByLevel: TownHallEmojiMap;
   requestedWars: number;
 }): string[] {
   const rowsByClan = new Map<string, InactiveWarSummary["results"]>();
@@ -178,7 +196,10 @@ function buildInactiveWarGroupedPages(input: {
     if (clanRows.length === 0) continue;
 
     const clanName = input.trackedNameByTag.get(trackedTag) ?? input.trackedNameByTag.get(clanTag) ?? clanTag;
-    lines.push(`${clanName} (${clanRows.length})`);
+    const clanBadge = formatInactiveClanBadge(
+      input.trackedBadgeByTag.get(clanTag) ?? input.trackedBadgeByTag.get(trackedTag) ?? null,
+    );
+    lines.push(`${clanBadge ? `${clanBadge} ` : ""}${clanName} (${clanRows.length})`);
 
     const byMissedCount = new Map<number, InactiveWarSummary["results"]>();
     for (const row of clanRows) {
@@ -210,9 +231,20 @@ function buildInactiveWarGroupedPages(input: {
         );
         const emojiSequence = buildInactiveWarEmojiSequence(row.missedWarStates);
         const playerTag = formatInactivePlayerTag(row.playerTag);
+        const townHallIcon = renderTownHallIcon(row.townHall, input.townHallEmojiByLevel);
         const rowText = ratioText
-          ? `  - ${row.playerName} \`${playerTag}\` ${discordText} - ${ratioText} - ${emojiSequence}`
-          : `  - ${row.playerName} \`${playerTag}\` ${discordText} - ${emojiSequence}`;
+          ? `  - ${formatInactivePlayerIdentity({
+              townHallIcon,
+              playerName: row.playerName,
+              playerTag,
+              discordText,
+            })} - ${ratioText} - ${emojiSequence}`
+          : `  - ${formatInactivePlayerIdentity({
+              townHallIcon,
+              playerName: row.playerName,
+              playerTag,
+              discordText,
+            })} - ${emojiSequence}`;
         lines.push(rowText);
       }
     }
@@ -242,10 +274,12 @@ function buildInactiveWarGroupedPages(input: {
 type RosterSnapshot = {
   trackedTags: string[];
   trackedNameByTag: Map<string, string>;
+  trackedBadgeByTag: Map<string, string | null>;
   liveMemberTags: Set<string>;
   liveMembersByClan: Map<string, Set<string>>;
   liveMemberClanByTag: Map<string, string>;
   liveMemberTrackedClanByTag: Map<string, string>;
+  liveMemberTownHallByTag: Map<string, number | null>;
 };
 
 function buildPaginationRow(customIdPrefix: string, page: number, totalPages: number) {
@@ -269,7 +303,7 @@ async function getRosterSnapshot(
 ): Promise<RosterSnapshot> {
   const dbTracked = await prisma.trackedClan.findMany({
     orderBy: { createdAt: "asc" },
-    select: { tag: true, name: true },
+    select: { tag: true, name: true, clanBadge: true },
   });
   const normalizedClanFilter = normalizeClanTagInput(clanTag ?? "");
   const scopedTracked = normalizedClanFilter
@@ -277,11 +311,15 @@ async function getRosterSnapshot(
     : dbTracked;
   const trackedTags = scopedTracked.map((c) => c.tag);
   const trackedNameByTag = new Map(scopedTracked.map((c) => [c.tag, c.name?.trim() || c.tag]));
+  const trackedBadgeByTag = new Map(
+    scopedTracked.map((c) => [c.tag, formatInactiveClanBadge(c.clanBadge)] as const),
+  );
 
   const liveMemberTags = new Set<string>();
   const liveMembersByClan = new Map<string, Set<string>>();
   const liveMemberClanByTag = new Map<string, string>();
   const liveMemberTrackedClanByTag = new Map<string, string>();
+  const liveMemberTownHallByTag = new Map<string, number | null>();
   for (const trackedTag of trackedTags) {
     try {
       const clan = await cocService.getClan(trackedTag);
@@ -295,6 +333,11 @@ async function getRosterSnapshot(
         liveMemberTags.add(memberTag);
         liveMemberClanByTag.set(memberTag, clanName);
         liveMemberTrackedClanByTag.set(memberTag, trackedTag);
+        const townHall = Number(member?.townHall);
+        liveMemberTownHallByTag.set(
+          memberTag,
+          Number.isFinite(townHall) && townHall > 0 ? Math.trunc(townHall) : null,
+        );
       }
       liveMembersByClan.set(trackedTag, memberSet);
     } catch (err) {
@@ -305,18 +348,22 @@ async function getRosterSnapshot(
   return {
     trackedTags,
     trackedNameByTag,
+    trackedBadgeByTag,
     liveMemberTags,
     liveMembersByClan,
     liveMemberClanByTag,
     liveMemberTrackedClanByTag,
+    liveMemberTownHallByTag,
   };
 }
 
 type InactiveDaysEntry = {
   clanTag: string;
   clanName: string;
+  clanBadge: string | null;
   playerTag: string;
   playerName: string;
+  townHall: number | null;
   daysAgo: number;
 };
 
@@ -478,8 +525,10 @@ async function fetchInactiveDaysEntries(
         roster.liveMemberClanByTag.get(p.tag) ??
         p.clanTag ??
         "Unknown Clan",
+      clanBadge: roster.trackedBadgeByTag.get(normalizedClanTag) ?? null,
       playerTag: p.tag,
       playerName: p.name,
+      townHall: roster.liveMemberTownHallByTag.get(p.tag) ?? null,
       daysAgo: Math.floor((Date.now() - p.lastSeenAt.getTime()) / (24 * 60 * 60 * 1000)),
     };
   });
@@ -567,13 +616,17 @@ async function renderEmbedsWithPager(
 
 function buildGroupedPages<T>(
   entries: T[],
+  getClanKey: (entry: T) => string,
   getClanName: (entry: T) => string,
-  renderLine: (entry: T) => string
+  getClanBadge: (entry: T) => string | null,
+  renderLine: (entry: T) => string,
 ): string[] {
   const clanCounts = new Map<string, number>();
+  const clanFirstEntry = new Map<string, T>();
   for (const entry of entries) {
-    const clanName = getClanName(entry);
-    clanCounts.set(clanName, (clanCounts.get(clanName) ?? 0) + 1);
+    const clanKey = normalizeClanTagInput(getClanKey(entry));
+    clanCounts.set(clanKey, (clanCounts.get(clanKey) ?? 0) + 1);
+    if (!clanFirstEntry.has(clanKey)) clanFirstEntry.set(clanKey, entry);
   }
 
   const pages: string[] = [];
@@ -582,14 +635,16 @@ function buildGroupedPages<T>(
   const clanPageCounts = new Map<string, number>();
 
   for (const entry of entries) {
+    const clanKey = normalizeClanTagInput(getClanKey(entry));
     const clanName = getClanName(entry);
-    const isNewClan = currentClan !== clanName;
+    const isNewClan = currentClan !== clanKey;
     if (isNewClan) {
-      const continuationCount = clanPageCounts.get(clanName) ?? 0;
+      const continuationCount = clanPageCounts.get(clanKey) ?? 0;
+      const clanBadge = getClanBadge(clanFirstEntry.get(clanKey) ?? entry);
       const header =
         continuationCount === 0
-          ? `**${clanName} (${clanCounts.get(clanName) ?? 0})**`
-          : `**${clanName} (${clanCounts.get(clanName) ?? 0}) (cont.)**`;
+          ? `**${clanBadge ? `${clanBadge} ` : ""}${clanName} (${clanCounts.get(clanKey) ?? 0})**`
+          : `**${clanBadge ? `${clanBadge} ` : ""}${clanName} (${clanCounts.get(clanKey) ?? 0}) (cont.)**`;
 
       const projectedLines = currentLines.length + (currentLines.length > 0 ? 2 : 1);
       if (projectedLines > MAX_LINES_PER_PAGE) {
@@ -599,19 +654,19 @@ function buildGroupedPages<T>(
 
       if (currentLines.length > 0) currentLines.push("");
       currentLines.push(header);
-      currentClan = clanName;
-      clanPageCounts.set(clanName, continuationCount + 1);
+      currentClan = clanKey;
+      clanPageCounts.set(clanKey, continuationCount + 1);
     }
 
     const line = renderLine(entry);
     if (currentLines.length + 1 > MAX_LINES_PER_PAGE) {
       pages.push(currentLines.join("\n"));
       currentLines = [
-        `**${clanName} (${clanCounts.get(clanName) ?? 0}) (cont.)**`,
+        `**${getClanBadge(entry) ? `${getClanBadge(entry)} ` : ""}${clanName} (${clanCounts.get(clanKey) ?? 0}) (cont.)**`,
         line,
       ];
-      currentClan = clanName;
-      clanPageCounts.set(clanName, (clanPageCounts.get(clanName) ?? 0) + 1);
+      currentClan = clanKey;
+      clanPageCounts.set(clanKey, (clanPageCounts.get(clanKey) ?? 0) + 1);
     } else {
       currentLines.push(line);
     }
@@ -626,6 +681,7 @@ function buildGroupedPages<T>(
 async function runDaysMode(
   interaction: ChatInputCommandInteraction,
   cocService: CoCService,
+  townHallEmojiByLevel: TownHallEmojiMap,
   days: number,
   clanTag?: string | null,
 ): Promise<void> {
@@ -749,6 +805,11 @@ async function runDaysMode(
   const inactiveWithClan = inactivePlayers.map((p) => ({
     player: p,
     clan: roster.liveMemberClanByTag.get(p.tag) ?? p.clanTag ?? "Unknown Clan",
+    clanTag: roster.liveMemberTrackedClanByTag.get(p.tag) ?? normalizeClanTagInput(p.clanTag ?? ""),
+    clanBadge: roster.trackedBadgeByTag.get(
+      roster.liveMemberTrackedClanByTag.get(p.tag) ?? normalizeClanTagInput(p.clanTag ?? ""),
+    ) ?? null,
+    townHall: roster.liveMemberTownHallByTag.get(p.tag) ?? null,
   }));
   inactiveWithClan.sort((a, b) => {
     const orderA = clanOrder.get(a.clan) ?? Number.MAX_SAFE_INTEGER;
@@ -763,20 +824,26 @@ async function runDaysMode(
   );
   const pages = buildGroupedPages(
     inactiveWithClan,
+    (e) => e.clanTag,
     (e) => e.clan,
+    (e) => e.clanBadge,
     (e) => {
       const daysAgo = Math.floor((Date.now() - e.player.lastSeenAt.getTime()) / (24 * 60 * 60 * 1000));
       const discordText = buildInactivePlayerDiscordText(
         daysDiscordUserIdByPlayerTag,
         e.player.tag
       );
-      return `- **${e.player.name}** (\`${formatInactivePlayerTag(e.player.tag)}\`) ${discordText} - ${daysAgo}d`;
+      const townHallIcon = renderTownHallIcon(e.townHall, townHallEmojiByLevel);
+      return `- ${formatInactivePlayerIdentity({
+        townHallIcon,
+        playerName: e.player.name,
+        playerTag: e.player.tag,
+        discordText,
+      })} - ${daysAgo}d`;
     }
   );
 
-  const summary =
-    ` • Scope: ${roster.trackedTags.length} tracked clan(s), ${roster.liveMemberTags.size} live member(s), ` +
-    `${activitySnapshot._count.tag} observed record(s), ${freshObservedCount} fresh in last ${staleHours}h`;
+  const summary = ` • Scope: ${roster.trackedTags.length} tracked clan(s), ${roster.liveMemberTags.size} live member(s), ${activitySnapshot._count.tag} observed record(s), ${freshObservedCount} fresh in last ${staleHours}h`;
   await renderEmbedsWithPager(
     interaction,
     `Inactive for ${days}+ days (${inactivePlayers.length})`,
@@ -787,10 +854,11 @@ async function runDaysMode(
 
 async function runWarsMode(
   interaction: ChatInputCommandInteraction,
+  townHallEmojiByLevel: TownHallEmojiMap,
   wars: number,
   clanTag?: string | null,
 ): Promise<void> {
-  const { results, trackedTags, trackedNameByTag, warnings, diagnosticNote } =
+  const { results, trackedTags, trackedNameByTag, trackedBadgeByTag, warnings, diagnosticNote } =
     await fetchInactiveWarEntries(interaction, wars, clanTag);
 
   if (trackedTags.length === 0) {
@@ -828,11 +896,13 @@ async function runWarsMode(
     rows: sortedResults,
     trackedTags,
     trackedNameByTag,
+    trackedBadgeByTag,
     discordUserIdByPlayerTag,
+    townHallEmojiByLevel,
     requestedWars: wars,
   });
 
-  const footerSuffix = warnings.length > 0 ? ` • Partial data: ${warnings.length} clan(s)` : "";
+  const footerSuffix = warnings.length > 0 ? ` � Partial data: ${warnings.length} clan(s)` : "";
   await renderEmbedsWithPager(
     interaction,
     `Missed Both Attacks - Last ${wars} War(s) (${results.length})`,
@@ -844,6 +914,7 @@ async function runWarsMode(
 async function runCombinedMode(
   interaction: ChatInputCommandInteraction,
   cocService: CoCService,
+  townHallEmojiByLevel: TownHallEmojiMap,
   days: number,
   wars: number,
   clanTag?: string | null,
@@ -869,8 +940,10 @@ async function runCombinedMode(
     {
       clanTag: string;
       clanName: string;
+      clanBadge: string | null;
       playerTag: string;
       playerName: string;
+      townHall: number | null;
       daysAgo: number | null;
       missedWars: number | null;
       participationWars: number | null;
@@ -885,8 +958,10 @@ async function runCombinedMode(
     combined.set(entry.playerTag, {
       clanTag: entry.clanTag,
       clanName: entry.clanName,
+      clanBadge: entry.clanBadge,
       playerTag: entry.playerTag,
       playerName: entry.playerName,
+      townHall: entry.townHall,
       daysAgo: entry.daysAgo,
       missedWars: null,
       participationWars: null,
@@ -903,8 +978,10 @@ async function runCombinedMode(
     combined.set(entry.playerTag, {
       clanTag: entry.clanTag,
       clanName,
+      clanBadge: warsResult.trackedBadgeByTag.get(entry.clanTag) ?? null,
       playerTag: entry.playerTag,
       playerName: existing?.playerName ?? entry.playerName,
+      townHall: entry.townHall ?? existing?.townHall ?? null,
       daysAgo: existing?.daysAgo ?? null,
       missedWars: entry.missedWars,
       participationWars: entry.participationWars,
@@ -929,10 +1006,10 @@ async function runCombinedMode(
   }
 
   const clanOrder = new Map<string, number>();
-  daysResult.roster.trackedTags.forEach((tag, i) => clanOrder.set(tag, i));
+  daysResult.roster.trackedTags.forEach((tag, i) => clanOrder.set(normalizeClanTagInput(tag), i));
   rows.sort((a, b) => {
-    const orderA = clanOrder.get(a.clanTag) ?? Number.MAX_SAFE_INTEGER;
-    const orderB = clanOrder.get(b.clanTag) ?? Number.MAX_SAFE_INTEGER;
+    const orderA = clanOrder.get(normalizeClanTagInput(a.clanTag)) ?? Number.MAX_SAFE_INTEGER;
+    const orderB = clanOrder.get(normalizeClanTagInput(b.clanTag)) ?? Number.MAX_SAFE_INTEGER;
     if (orderA !== orderB) return orderA - orderB;
     const daysA = a.daysAgo ?? -1;
     const daysB = b.daysAgo ?? -1;
@@ -953,7 +1030,9 @@ async function runCombinedMode(
   );
   const pages = buildGroupedPages(
     rows,
+    (e) => e.clanTag,
     (e) => e.clanName,
+    (e) => e.clanBadge,
     (e) => {
       const reasons: string[] = [];
       if (e.daysAgo !== null) reasons.push(`${e.daysAgo}d inactive`);
@@ -968,15 +1047,19 @@ async function runCombinedMode(
         e.playerTag
       );
       const emojiSequence = warsRow ? buildInactiveWarEmojiSequence(warsRow.missedWarStates) : "";
-      const playerTag = formatInactivePlayerTag(e.playerTag);
+      const townHallIcon = renderTownHallIcon(e.townHall, townHallEmojiByLevel);
       const reasonText = reasons.length > 0 ? ` - ${reasons.join(" | ")}` : "";
       const emojiText = warsRow ? ` - ${emojiSequence}` : "";
-      return `- ${e.playerName} \`${playerTag}\` ${discordText}${reasonText}${emojiText}`;
+      return `- ${formatInactivePlayerIdentity({
+        townHallIcon,
+        playerName: e.playerName,
+        playerTag: e.playerTag,
+        discordText,
+      })}${reasonText}${emojiText}`;
     }
   );
 
-  const footerSuffix =
-    warsResult.warnings.length > 0 ? ` • Partial war data: ${warsResult.warnings.length} clan(s)` : "";
+  const footerSuffix = warsResult.warnings.length > 0 ? ` • Partial war data: ${warsResult.warnings.length} clan(s)` : "";
   await renderEmbedsWithPager(
     interaction,
     `Inactive Players - Days ${days} + Wars ${wars} (${rows.length})`,
@@ -1011,11 +1094,12 @@ export const Inactive: Command = {
   ],
 
   run: async (
-    _client: Client,
+    client: Client,
     interaction: ChatInputCommandInteraction,
     cocService: CoCService
   ) => {
     await interaction.deferReply({ ephemeral: true });
+    const townHallEmojiByLevel = await resolveTownHallEmojiMap(client);
 
     const daysValue = interaction.options.getInteger("days", false) ?? undefined;
     const warsValue = interaction.options.getInteger("wars", false) ?? undefined;
@@ -1036,14 +1120,21 @@ export const Inactive: Command = {
     }
 
     if (daysValue && warsValue) {
-      await runCombinedMode(interaction, cocService, daysValue, warsValue, clanValue);
+      await runCombinedMode(
+        interaction,
+        cocService,
+        townHallEmojiByLevel,
+        daysValue,
+        warsValue,
+        clanValue,
+      );
       return;
     }
     if (daysValue) {
-      await runDaysMode(interaction, cocService, daysValue, clanValue);
+      await runDaysMode(interaction, cocService, townHallEmojiByLevel, daysValue, clanValue);
       return;
     }
-    await runWarsMode(interaction, warsValue!, clanValue);
+    await runWarsMode(interaction, townHallEmojiByLevel, warsValue!, clanValue);
   },
   autocomplete: async (interaction: AutocompleteInteraction) => {
     const focused = interaction.options.getFocused(true);

--- a/src/helper/clanBadgeEmoji.ts
+++ b/src/helper/clanBadgeEmoji.ts
@@ -1,0 +1,5 @@
+/** Purpose: normalize one tracked-clan badge emoji for display-only rendering. */
+export function formatClanBadgeEmoji(input: string | null | undefined): string | null {
+  const normalized = String(input ?? "").trim();
+  return normalized.length > 0 ? normalized : null;
+}

--- a/src/helper/townHallEmoji.ts
+++ b/src/helper/townHallEmoji.ts
@@ -3,6 +3,14 @@ import { emojiResolverService } from "../services/emoji/EmojiResolverService";
 
 export type TownHallEmojiMap = Map<number, string>;
 
+/** Purpose: normalize any likely Town Hall field to a positive integer or null. */
+export function normalizeTownHallLevel(input: unknown): number | null {
+  const numeric = Number(input);
+  if (!Number.isFinite(numeric)) return null;
+  const normalized = Math.trunc(numeric);
+  return normalized > 0 ? normalized : null;
+}
+
 /** Purpose: load rendered Town Hall application emojis once for display-only command rendering. */
 export async function resolveTownHallEmojiMap(client: Client): Promise<TownHallEmojiMap> {
   const inventory = await emojiResolverService.fetchApplicationEmojiInventory(client).catch(() => null);
@@ -26,7 +34,7 @@ export function renderTownHallIcon(
   townHall: number | null | undefined,
   townHallEmojiByLevel: TownHallEmojiMap,
 ): string {
-  const normalized = Number.isFinite(Number(townHall)) ? Math.trunc(Number(townHall)) : null;
-  if (normalized === null || normalized <= 0) return "\u2754";
+  const normalized = normalizeTownHallLevel(townHall);
+  if (normalized === null) return "\u2754";
   return townHallEmojiByLevel.get(normalized) ?? "\u2754";
 }

--- a/src/helper/townHallEmoji.ts
+++ b/src/helper/townHallEmoji.ts
@@ -1,0 +1,32 @@
+import { Client } from "discord.js";
+import { emojiResolverService } from "../services/emoji/EmojiResolverService";
+
+export type TownHallEmojiMap = Map<number, string>;
+
+/** Purpose: load rendered Town Hall application emojis once for display-only command rendering. */
+export async function resolveTownHallEmojiMap(client: Client): Promise<TownHallEmojiMap> {
+  const inventory = await emojiResolverService.fetchApplicationEmojiInventory(client).catch(() => null);
+  if (!inventory?.ok) return new Map();
+
+  const renderedByTownHall = new Map<number, string>();
+  for (let townHall = 1; townHall <= 18; townHall += 1) {
+    const shortcode = `th${townHall}`;
+    const exact = inventory.snapshot.exactByName.get(shortcode);
+    const lower = inventory.snapshot.lowercaseByName.get(shortcode.toLowerCase());
+    const rendered = exact?.rendered ?? lower?.rendered ?? null;
+    if (rendered) {
+      renderedByTownHall.set(townHall, rendered);
+    }
+  }
+  return renderedByTownHall;
+}
+
+/** Purpose: render one Town Hall icon with safe fallback text when no emoji exists. */
+export function renderTownHallIcon(
+  townHall: number | null | undefined,
+  townHallEmojiByLevel: TownHallEmojiMap,
+): string {
+  const normalized = Number.isFinite(Number(townHall)) ? Math.trunc(Number(townHall)) : null;
+  if (normalized === null || normalized <= 0) return "\u2754";
+  return townHallEmojiByLevel.get(normalized) ?? "\u2754";
+}

--- a/src/services/InactiveWarService.ts
+++ b/src/services/InactiveWarService.ts
@@ -4,6 +4,7 @@ import { resolveFwaMatchStateEmoji } from "../commands/fwa/matchStateEmoji";
 type TrackedClanRow = {
   tag: string;
   name: string | null;
+  clanBadge: string | null;
 };
 
 type ClanWarHistoryRow = {
@@ -19,6 +20,7 @@ type ClanWarHistoryRow = {
 type ClanWarParticipationRow = {
   clanTag: string;
   playerTag: string;
+  townHall: number | null;
   playerName: string | null;
   warId: string;
   missedBoth: boolean;
@@ -42,6 +44,7 @@ export type InactiveWarRow = {
   clanTag: string;
   playerTag: string;
   playerName: string;
+  townHall: number | null;
   missedWars: number;
   participationWars: number;
   totalTrueStars: number;
@@ -55,6 +58,7 @@ export type InactiveWarSummary = {
   results: InactiveWarRow[];
   trackedTags: string[];
   trackedNameByTag: Map<string, string>;
+  trackedBadgeByTag: Map<string, string | null>;
   warnings: string[];
   diagnosticNote: string | null;
 };
@@ -107,6 +111,18 @@ function buildTrackedNameMap(trackedClans: TrackedClanRow[]): Map<string, string
     trackedNameByTag.set(`#${clanTag}`, clanName);
   }
   return trackedNameByTag;
+}
+
+function buildTrackedBadgeMap(trackedClans: TrackedClanRow[]): Map<string, string | null> {
+  const trackedBadgeByTag = new Map<string, string | null>();
+  for (const clan of trackedClans) {
+    const clanTag = normalizeClanTagInput(clan.tag);
+    if (!clanTag) continue;
+    const clanBadge = String(clan.clanBadge ?? "").trim();
+    trackedBadgeByTag.set(clanTag, clanBadge.length > 0 ? clanBadge : null);
+    trackedBadgeByTag.set(`#${clanTag}`, clanBadge.length > 0 ? clanBadge : null);
+  }
+  return trackedBadgeByTag;
 }
 
 function buildTrackedTagList(trackedClans: TrackedClanRow[]): string[] {
@@ -252,6 +268,7 @@ function aggregateInactiveWarRows(input: {
       clanTag: string;
       playerTag: string;
       playerName: string;
+      townHall: number | null;
       missedWars: number;
       participationWars: number;
       totalTrueStars: number;
@@ -276,6 +293,7 @@ function aggregateInactiveWarRows(input: {
       clanTag,
       playerTag,
       playerName: normalizePlayerName(row.playerName, playerTag),
+      townHall: row.townHall ?? null,
       missedWars: 0,
       participationWars: 0,
       totalTrueStars: 0,
@@ -283,7 +301,7 @@ function aggregateInactiveWarRows(input: {
       avgAttackDelayCount: 0,
       lateAttacks: 0,
       warsAvailable: clanSelection.warsAvailable,
-      missedWarStates: [],
+      missedWarStates: [] as InactiveWarMissedState[],
     };
 
     if (!rowsByKey.has(key)) {
@@ -293,6 +311,9 @@ function aggregateInactiveWarRows(input: {
     if (existing.playerName === existing.playerTag) {
       const resolvedPlayerName = normalizePlayerName(row.playerName, playerTag);
       if (resolvedPlayerName) existing.playerName = resolvedPlayerName;
+    }
+    if (existing.townHall === null && row.townHall !== null && row.townHall !== undefined) {
+      existing.townHall = row.townHall;
     }
 
     existing.participationWars += 1;
@@ -332,6 +353,7 @@ function aggregateInactiveWarRows(input: {
       clanTag: row.clanTag,
       playerTag: row.playerTag,
       playerName: row.playerName,
+      townHall: row.townHall,
       missedWars: row.missedWars,
       participationWars: row.participationWars,
       totalTrueStars: row.totalTrueStars,
@@ -351,7 +373,7 @@ export class InactiveWarService {
   }): Promise<InactiveWarSummary> {
     const trackedClans = await prisma.trackedClan.findMany({
       orderBy: { createdAt: "asc" },
-      select: { tag: true, name: true },
+      select: { tag: true, name: true, clanBadge: true },
     });
     const normalizedClanFilter = normalizeClanTagInput(input.clanTag ?? "");
     const selectedTrackedClans = normalizedClanFilter
@@ -361,11 +383,13 @@ export class InactiveWarService {
       : trackedClans;
     const trackedTags = buildTrackedTagList(selectedTrackedClans);
     const trackedNameByTag = buildTrackedNameMap(selectedTrackedClans);
+    const trackedBadgeByTag = buildTrackedBadgeMap(selectedTrackedClans);
     if (normalizedClanFilter && trackedTags.length === 0) {
       return {
         results: [],
         trackedTags,
         trackedNameByTag,
+        trackedBadgeByTag,
         warnings: [
           buildInactiveWarFilterMismatchDiagnosticNote(
             `#${normalizedClanFilter}`,
@@ -377,7 +401,14 @@ export class InactiveWarService {
       };
     }
     if (trackedTags.length === 0) {
-      return { results: [], trackedTags, trackedNameByTag, warnings: [], diagnosticNote: null };
+      return {
+        results: [],
+        trackedTags,
+        trackedNameByTag,
+        trackedBadgeByTag,
+        warnings: [],
+        diagnosticNote: null,
+      };
     }
     const trackedClanTagValues = buildClanTagQueryValues(trackedTags);
 
@@ -431,6 +462,7 @@ export class InactiveWarService {
             clanTag: true,
             playerTag: true,
             playerName: true,
+            townHall: true,
             warId: true,
             missedBoth: true,
             trueStars: true,
@@ -464,7 +496,7 @@ export class InactiveWarService {
       })
       .filter((value): value is string => value !== null);
 
-    return { results, trackedTags, trackedNameByTag, warnings, diagnosticNote };
+    return { results, trackedTags, trackedNameByTag, trackedBadgeByTag, warnings, diagnosticNote };
   }
 }
 

--- a/tests/inactive.command.test.ts
+++ b/tests/inactive.command.test.ts
@@ -419,6 +419,67 @@ describe("/inactive command", () => {
     expect(emojiResolverServiceMock.fetchApplicationEmojiInventory).toHaveBeenCalledTimes(1);
   });
 
+  it("renders days mode rows from alternate live member town hall fields", async () => {
+    const getClan = vi.fn(async (tag: string) => {
+      if (tag === "#AAA111") {
+        return {
+          name: "Alpha",
+          members: [
+            { tag: "#A1", townHallLevel: 17 },
+            { tag: "#A2", townhallLevel: 16 },
+            { tag: "#A3" },
+          ],
+        };
+      }
+      throw new Error(`unexpected clan fetch: ${tag}`);
+    });
+
+    prismaMock.trackedClan.findMany.mockResolvedValue([
+      { tag: "#AAA111", name: "Alpha", clanBadge: "<:badge:1>" },
+    ]);
+    prismaMock.playerActivity.aggregate.mockResolvedValue({
+      _max: { updatedAt: new Date() },
+      _count: { tag: 3 },
+    });
+    prismaMock.playerActivity.count.mockResolvedValue(3);
+    prismaMock.playerActivity.findMany.mockResolvedValue([
+      {
+        tag: "#A1",
+        name: "Alpha One",
+        clanTag: "#AAA111",
+        lastSeenAt: new Date(Date.now() - 8 * 24 * 60 * 60 * 1000),
+        updatedAt: new Date(),
+      },
+      {
+        tag: "#A2",
+        name: "Alpha Two",
+        clanTag: "#AAA111",
+        lastSeenAt: new Date(Date.now() - 9 * 24 * 60 * 60 * 1000),
+        updatedAt: new Date(),
+      },
+      {
+        tag: "#A3",
+        name: "Alpha Three",
+        clanTag: "#AAA111",
+        lastSeenAt: new Date(Date.now() - 10 * 24 * 60 * 60 * 1000),
+        updatedAt: new Date(),
+      },
+    ]);
+    playerLinkServiceMock.listPlayerLinksForClanMembers.mockResolvedValue([]);
+
+    const interaction = makeInteraction({ days: 7 });
+    const cocService = { getClan } as any;
+
+    await Inactive.run({} as any, interaction as any, cocService);
+
+    const payload = interaction.editReply.mock.calls.at(-1)?.[0];
+    const embed = payload.embeds[0].toJSON();
+    expect(embed.description).toContain("- <:th17:117> Alpha One `#A1`");
+    expect(embed.description).toContain("- <:th16:116> Alpha Two `#A2`");
+    expect(embed.description).toContain("\u2754 Alpha Three `#A3`");
+    expect(emojiResolverServiceMock.fetchApplicationEmojiInventory).toHaveBeenCalledTimes(1);
+  });
+
   it("shows ratios for other missed-war count combinations", async () => {
     inactiveWarServiceMock.listInactiveWarPlayers.mockResolvedValue({
       results: [
@@ -511,5 +572,4 @@ describe("/inactive command", () => {
     );
   });
 });
-
 

--- a/tests/inactive.command.test.ts
+++ b/tests/inactive.command.test.ts
@@ -8,6 +8,10 @@ const playerLinkServiceMock = vi.hoisted(() => ({
   listPlayerLinksForClanMembers: vi.fn(),
 }));
 
+const emojiResolverServiceMock = vi.hoisted(() => ({
+  fetchApplicationEmojiInventory: vi.fn(),
+}));
+
 const prismaMock = vi.hoisted(() => ({
   trackedClan: {
     findMany: vi.fn(),
@@ -43,6 +47,16 @@ vi.mock("../src/services/PlayerLinkService", async () => {
   };
 });
 
+vi.mock("../src/services/emoji/EmojiResolverService", async () => {
+  const actual = await vi.importActual<typeof import("../src/services/emoji/EmojiResolverService")>(
+    "../src/services/emoji/EmojiResolverService",
+  );
+  return {
+    ...actual,
+    emojiResolverService: emojiResolverServiceMock,
+  };
+});
+
 import { Inactive } from "../src/commands/Inactive";
 
 function makeInteraction(values: {
@@ -73,6 +87,21 @@ function makeInteraction(values: {
 describe("/inactive command", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    emojiResolverServiceMock.fetchApplicationEmojiInventory.mockResolvedValue({
+      ok: true,
+      snapshot: {
+        exactByName: new Map([
+          ["th16", { rendered: "<:th16:116>" }],
+          ["th17", { rendered: "<:th17:117>" }],
+          ["th18", { rendered: "<:th18:118>" }],
+        ]),
+        lowercaseByName: new Map([
+          ["th16", { rendered: "<:th16:116>" }],
+          ["th17", { rendered: "<:th17:117>" }],
+          ["th18", { rendered: "<:th18:118>" }],
+        ]),
+      },
+    });
   });
 
   it("passes clanTag to the inactive war service for wars mode", async () => {
@@ -80,6 +109,7 @@ describe("/inactive command", () => {
       results: [],
       trackedTags: ["AAA111"],
       trackedNameByTag: new Map([["AAA111", "Alpha"]]),
+      trackedBadgeByTag: new Map([["AAA111", "<:badge:1>"]]),
       warnings: [],
       diagnosticNote: null,
     });
@@ -101,13 +131,15 @@ describe("/inactive command", () => {
       if (tag === "#AAA111") {
         return {
           name: "Alpha",
-          members: [{ tag: "#A1" }, { tag: "#A2" }],
+          members: [{ tag: "#A1", townHall: 17 }, { tag: "#A2", townHall: 16 }],
         };
       }
       throw new Error(`unexpected clan fetch: ${tag}`);
     });
 
-    prismaMock.trackedClan.findMany.mockResolvedValue([{ tag: "#AAA111", name: "Alpha" }]);
+    prismaMock.trackedClan.findMany.mockResolvedValue([
+      { tag: "#AAA111", name: "Alpha", clanBadge: "<:badge:1>" },
+    ]);
     prismaMock.playerActivity.aggregate.mockResolvedValue({
       _max: { updatedAt: new Date() },
       _count: { tag: 2 },
@@ -142,9 +174,10 @@ describe("/inactive command", () => {
     expect(getClan).toHaveBeenCalledWith("#AAA111");
     const payload = interaction.editReply.mock.calls.at(-1)?.[0];
     const embed = payload.embeds[0].toJSON();
-    expect(embed.description).toContain("Alpha (2)");
-    expect(embed.description).toContain("**Alpha One** (`#A1`) <@111111111111111111> - 8d");
-    expect(embed.description).toContain("**Alpha Two** (`#A2`) — - 9d");
+    expect(embed.description).toContain("<:badge:1> Alpha (2)");
+    expect(embed.description).toContain("- <:th17:117> Alpha One `#A1` <@111111111111111111> - 8d");
+    expect(embed.description).toContain("- <:th16:116> Alpha Two `#A2`");
+    expect(emojiResolverServiceMock.fetchApplicationEmojiInventory).toHaveBeenCalledTimes(1);
     expect(embed.description).not.toContain("Beta");
   });
 
@@ -153,13 +186,15 @@ describe("/inactive command", () => {
       if (tag === "#AAA111") {
         return {
           name: "Alpha",
-          members: [{ tag: "#A1" }, { tag: "#A2" }],
+          members: [{ tag: "#A1", townHall: 17 }, { tag: "#A2", townHall: 16 }],
         };
       }
       throw new Error(`unexpected clan fetch: ${tag}`);
     });
 
-    prismaMock.trackedClan.findMany.mockResolvedValue([{ tag: "#AAA111", name: "Alpha" }]);
+    prismaMock.trackedClan.findMany.mockResolvedValue([
+      { tag: "#AAA111", name: "Alpha", clanBadge: "<:badge:1>" },
+    ]);
     prismaMock.playerActivity.aggregate.mockResolvedValue({
       _max: { updatedAt: new Date() },
       _count: { tag: 2 },
@@ -188,6 +223,7 @@ describe("/inactive command", () => {
           clanTag: "AAA111",
           playerTag: "A1",
           playerName: "Alpha One",
+          townHall: 18,
           missedWars: 3,
           participationWars: 3,
           totalTrueStars: 0,
@@ -203,6 +239,7 @@ describe("/inactive command", () => {
       ],
       trackedTags: ["AAA111"],
       trackedNameByTag: new Map([["AAA111", "Alpha"]]),
+      trackedBadgeByTag: new Map([["AAA111", "<:badge:1>"]]),
       warnings: [],
       diagnosticNote: null,
     });
@@ -237,6 +274,7 @@ describe("/inactive command", () => {
           clanTag: "AAA111",
           playerTag: "A1",
           playerName: "Alpha One",
+          townHall: 18,
           missedWars: 3,
           participationWars: 3,
           totalTrueStars: 0,
@@ -253,6 +291,7 @@ describe("/inactive command", () => {
           clanTag: "AAA111",
           playerTag: "A2",
           playerName: "Alpha Two",
+          townHall: 17,
           missedWars: 2,
           participationWars: 3,
           totalTrueStars: 0,
@@ -268,6 +307,7 @@ describe("/inactive command", () => {
           clanTag: "BBB222",
           playerTag: "B1",
           playerName: "Beta One",
+          townHall: 16,
           missedWars: 1,
           participationWars: 2,
           totalTrueStars: 0,
@@ -283,6 +323,10 @@ describe("/inactive command", () => {
       trackedNameByTag: new Map([
         ["AAA111", "Alpha"],
         ["BBB222", "Beta"],
+      ]),
+      trackedBadgeByTag: new Map([
+        ["AAA111", "<:badge:1>"],
+        ["BBB222", "<:badge:2>"],
       ]),
       warnings: [],
       diagnosticNote: null,
@@ -309,31 +353,36 @@ describe("/inactive command", () => {
     const payload = interaction.editReply.mock.calls.at(-1)?.[0];
     const embed = payload.embeds[0].toJSON();
     expect(embed.title).toContain("Missed Both Attacks - Last 3 War(s) (3)");
-    expect(embed.description).toContain("Alpha (2)");
-    expect(embed.description).toContain("- 3 wars missed");
-    expect(embed.description).toContain("  - Alpha One `#A1` <@111111111111111111> - 🟢 🔴 ⚫");
+    expect(embed.description).toContain("<:badge:1> Alpha (2)");
+    expect(embed.description).toContain("<:th18:118> Alpha One `#A1` <@111111111111111111>");
+    expect(embed.description).toContain("\u{1F7E2} \u{1F534} \u26AB");
     expect(embed.description).toContain("- 2 wars missed");
-    expect(embed.description).toContain("  - Alpha Two `#A2` — - 2/3 wars missed - ⚪ 🔘");
+    expect(embed.description).toContain("<:th17:117> Alpha Two `#A2`");
+    expect(embed.description).toContain("2/3 wars missed");
+    expect(embed.description).toContain("\u26AA \u{1F518}");
     expect(embed.description).toContain("Beta (1)");
-    expect(embed.description).toContain("  - Beta One `#B1` <@222222222222222222> - 1/2 wars missed - ⚪");
+    expect(embed.description).toContain("Beta One `#B1` <@222222222222222222>");
+    expect(embed.description).toContain("1/2 wars missed");
+    expect(emojiResolverServiceMock.fetchApplicationEmojiInventory).toHaveBeenCalledTimes(1);
     expect(embed.description).not.toContain("true stars");
     expect(embed.description).not.toContain("avg delay");
     expect(embed.description).not.toContain("late attacks");
     expect(embed.description).not.toContain("3/3 wars missed");
   });
-
   it("renders days mode rows with backticked tags and Discord mentions", async () => {
     const getClan = vi.fn(async (tag: string) => {
       if (tag === "#AAA111") {
         return {
           name: "Alpha",
-          members: [{ tag: "#A1" }, { tag: "#A2" }],
+          members: [{ tag: "#A1", townHall: 17 }, { tag: "#A2", townHall: 16 }],
         };
       }
       throw new Error(`unexpected clan fetch: ${tag}`);
     });
 
-    prismaMock.trackedClan.findMany.mockResolvedValue([{ tag: "#AAA111", name: "Alpha" }]);
+    prismaMock.trackedClan.findMany.mockResolvedValue([
+      { tag: "#AAA111", name: "Alpha", clanBadge: "<:badge:1>" },
+    ]);
     prismaMock.playerActivity.aggregate.mockResolvedValue({
       _max: { updatedAt: new Date() },
       _count: { tag: 2 },
@@ -363,11 +412,11 @@ describe("/inactive command", () => {
     const cocService = { getClan } as any;
 
     await Inactive.run({} as any, interaction as any, cocService);
-
     const payload = interaction.editReply.mock.calls.at(-1)?.[0];
     const embed = payload.embeds[0].toJSON();
-    expect(embed.description).toContain("**Alpha One** (`#A1`) <@111111111111111111> - 8d");
-    expect(embed.description).toContain("**Alpha Two** (`#A2`) — - 9d");
+    expect(embed.description).toContain("- <:th17:117> Alpha One `#A1` <@111111111111111111> - 8d");
+    expect(embed.description).toContain("- <:th16:116> Alpha Two `#A2`");
+    expect(emojiResolverServiceMock.fetchApplicationEmojiInventory).toHaveBeenCalledTimes(1);
   });
 
   it("shows ratios for other missed-war count combinations", async () => {
@@ -419,6 +468,7 @@ describe("/inactive command", () => {
       ],
       trackedTags: ["AAA111"],
       trackedNameByTag: new Map([["AAA111", "Alpha"]]),
+      trackedBadgeByTag: new Map([["AAA111", "<:badge:1>"]]),
       warnings: [],
       diagnosticNote: null,
     });
@@ -441,6 +491,7 @@ describe("/inactive command", () => {
       results: [],
       trackedTags: ["AAA111"],
       trackedNameByTag: new Map([["AAA111", "Alpha"]]),
+      trackedBadgeByTag: new Map([["AAA111", "<:badge:1>"]]),
       warnings: [],
       diagnosticNote: "Diagnostic: ended wars found yes (3), participation rows found yes (6).",
     });
@@ -460,3 +511,5 @@ describe("/inactive command", () => {
     );
   });
 });
+
+


### PR DESCRIPTION
- show tracked clan badge before clan headers in /inactive days, wars, and combined views
- prepend player rows with Town Hall icons
- source days TH from the existing live clan roster fetch and wars TH from participation snapshots
- use the shared `townHallEmoji` helper with the custom/application emoji resolver
- support `townHall`, `townHallLevel`, and `townhallLevel`
- add safe badge/TH fallbacks
- preserve existing pagination, Discord mentions, backticked tags, and wars grouping