### PR TITLE
fix(inactive): use catalog town halls for war fallback

### DIFF
--- a/src/services/InactiveWarService.ts
+++ b/src/services/InactiveWarService.ts
@@ -79,6 +79,13 @@ function buildPlayerTagQueryValues(playerTags: string[]): string[] {
   return [...new Set(playerTags.flatMap((tag) => [tag, `#${tag}`]))];
 }
 
+function normalizePositiveInteger(input: unknown): number | null {
+  const numeric = Number(input);
+  if (!Number.isFinite(numeric)) return null;
+  const normalized = Math.trunc(numeric);
+  return normalized > 0 ? normalized : null;
+}
+
 function normalizeInactiveWarMatchType(
   input: string | null | undefined,
 ): "FWA" | "BL" | "MM" | "SKIP" | "UNKNOWN" | null {
@@ -566,9 +573,36 @@ async function loadInactiveWarTownHallFallbacks(input: {
   }
 
   const unresolvedAfterFwaMembersQueryValues = buildPlayerTagQueryValues(unresolvedAfterFwaMembers);
-  const rosterMemberRows = await prisma.fwaTrackedClanWarRosterMemberCurrent.findMany({
+  const fwaPlayerCatalogRows = await prisma.fwaPlayerCatalog.findMany({
     where: {
       playerTag: { in: unresolvedAfterFwaMembersQueryValues },
+      latestTownHall: { not: null },
+    },
+    select: {
+      playerTag: true,
+      latestTownHall: true,
+    },
+  });
+  for (const row of fwaPlayerCatalogRows as Array<{ playerTag: string; latestTownHall: number | null }>) {
+    const playerTag = normalizePlayerTagInput(row.playerTag);
+    const townHall = normalizePositiveInteger(row.latestTownHall);
+    if (!playerTag || townHall === null) continue;
+    if (!fallbackTownHallByPlayerTag.has(playerTag)) {
+      fallbackTownHallByPlayerTag.set(playerTag, townHall);
+    }
+  }
+
+  const unresolvedAfterCatalog = unresolvedAfterFwaMembers.filter(
+    (playerTag) => !fallbackTownHallByPlayerTag.has(playerTag),
+  );
+  if (unresolvedAfterCatalog.length === 0) {
+    return fallbackTownHallByPlayerTag;
+  }
+
+  const unresolvedAfterCatalogQueryValues = buildPlayerTagQueryValues(unresolvedAfterCatalog);
+  const rosterMemberRows = await prisma.fwaTrackedClanWarRosterMemberCurrent.findMany({
+    where: {
+      playerTag: { in: unresolvedAfterCatalogQueryValues },
       clanTag: { in: trackedClanTagValues },
     },
     select: {

--- a/tests/inactiveWar.service.test.ts
+++ b/tests/inactiveWar.service.test.ts
@@ -16,6 +16,9 @@ const prismaMock = vi.hoisted(() => ({
   fwaClanMemberCurrent: {
     findMany: vi.fn(),
   },
+  fwaPlayerCatalog: {
+    findMany: vi.fn(),
+  },
   fwaTrackedClanWarRosterMemberCurrent: {
     findMany: vi.fn(),
   },
@@ -95,6 +98,16 @@ function makeFwaClanMemberCurrentRow(input: {
   };
 }
 
+function makeFwaPlayerCatalogRow(input: {
+  playerTag: string;
+  latestTownHall: number | null;
+}) {
+  return {
+    playerTag: input.playerTag,
+    latestTownHall: input.latestTownHall,
+  };
+}
+
 function makeFwaTrackedClanWarRosterMemberCurrentRow(input: {
   clanTag: string;
   playerTag: string;
@@ -145,6 +158,7 @@ describe("InactiveWarService", () => {
     vi.clearAllMocks();
     prismaMock.playerCurrent.findMany.mockResolvedValue([]);
     prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue([]);
+    prismaMock.fwaPlayerCatalog.findMany.mockResolvedValue([]);
     prismaMock.fwaTrackedClanWarRosterMemberCurrent.findMany.mockResolvedValue([]);
   });
 
@@ -812,6 +826,128 @@ describe("InactiveWarService", () => {
     expect(summary.results[0]?.townHall).toBe(19);
     expect(prismaMock.playerCurrent.findMany).toHaveBeenCalledTimes(1);
     expect(prismaMock.fwaClanMemberCurrent.findMany).toHaveBeenCalledTimes(1);
+    expect(prismaMock.fwaPlayerCatalog.findMany).not.toHaveBeenCalled();
+    expect(prismaMock.fwaTrackedClanWarRosterMemberCurrent.findMany).not.toHaveBeenCalled();
+  });
+
+  it("falls back to FwaPlayerCatalog latestTownHall when earlier sources are missing", async () => {
+    prismaMock.trackedClan.findMany.mockResolvedValue([{ tag: "#AAA111", name: "Alpha" }]);
+    prismaMock.clanWarHistory.findMany.mockResolvedValue([
+      makeHistoryRow({
+        warId: 401,
+        clanTag: "#AAA111",
+        endedAt: "2026-04-05T00:00:00.000Z",
+        matchType: "FWA",
+        actualOutcome: "WIN",
+      }),
+    ]);
+    prismaMock.clanWarParticipation.findMany.mockResolvedValue([
+      makeParticipationRow({
+        clanTag: "#AAA111",
+        playerTag: "9Q8R0VRJ",
+        playerName: "Alpha",
+        warId: "401",
+        missedBoth: true,
+        townHall: null,
+      }),
+    ]);
+    prismaMock.playerCurrent.findMany.mockResolvedValue([]);
+    prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue([]);
+    prismaMock.fwaPlayerCatalog.findMany.mockResolvedValue([
+      makeFwaPlayerCatalogRow({ playerTag: "9Q8R0VRJ", latestTownHall: 15 }),
+    ]);
+
+    const service = new InactiveWarService();
+    const summary = await service.listInactiveWarPlayers({
+      guildId: "guild-1",
+      wars: 1,
+    });
+
+    expect(summary.results[0]?.playerTag).toBe("9Q8R0VRJ");
+    expect(summary.results[0]?.townHall).toBe(15);
+    expect(prismaMock.playerCurrent.findMany).toHaveBeenCalledTimes(1);
+    expect(prismaMock.fwaClanMemberCurrent.findMany).toHaveBeenCalledTimes(1);
+    expect(prismaMock.fwaPlayerCatalog.findMany).toHaveBeenCalledTimes(1);
+    expect(prismaMock.fwaTrackedClanWarRosterMemberCurrent.findMany).not.toHaveBeenCalled();
+  });
+
+  it("prefers PlayerCurrent town hall over catalog town hall", async () => {
+    prismaMock.trackedClan.findMany.mockResolvedValue([{ tag: "#AAA111", name: "Alpha" }]);
+    prismaMock.clanWarHistory.findMany.mockResolvedValue([
+      makeHistoryRow({
+        warId: 401,
+        clanTag: "#AAA111",
+        endedAt: "2026-04-05T00:00:00.000Z",
+        matchType: "FWA",
+        actualOutcome: "WIN",
+      }),
+    ]);
+    prismaMock.clanWarParticipation.findMany.mockResolvedValue([
+      makeParticipationRow({
+        clanTag: "#AAA111",
+        playerTag: "9Q8R0VRJ",
+        playerName: "Alpha",
+        warId: "401",
+        missedBoth: true,
+        townHall: null,
+      }),
+    ]);
+    prismaMock.playerCurrent.findMany.mockResolvedValue([
+      makePlayerCurrentRow({ playerTag: "9Q8R0VRJ", townHall: 18 }),
+    ]);
+    prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue([]);
+    prismaMock.fwaPlayerCatalog.findMany.mockResolvedValue([
+      makeFwaPlayerCatalogRow({ playerTag: "9Q8R0VRJ", latestTownHall: 15 }),
+    ]);
+
+    const service = new InactiveWarService();
+    const summary = await service.listInactiveWarPlayers({
+      guildId: "guild-1",
+      wars: 1,
+    });
+
+    expect(summary.results[0]?.townHall).toBe(18);
+    expect(prismaMock.fwaPlayerCatalog.findMany).not.toHaveBeenCalled();
+    expect(prismaMock.fwaTrackedClanWarRosterMemberCurrent.findMany).not.toHaveBeenCalled();
+  });
+
+  it("prefers FWA clan member current town hall over catalog town hall", async () => {
+    prismaMock.trackedClan.findMany.mockResolvedValue([{ tag: "#AAA111", name: "Alpha" }]);
+    prismaMock.clanWarHistory.findMany.mockResolvedValue([
+      makeHistoryRow({
+        warId: 401,
+        clanTag: "#AAA111",
+        endedAt: "2026-04-05T00:00:00.000Z",
+        matchType: "FWA",
+        actualOutcome: "WIN",
+      }),
+    ]);
+    prismaMock.clanWarParticipation.findMany.mockResolvedValue([
+      makeParticipationRow({
+        clanTag: "#AAA111",
+        playerTag: "9Q8R0VRJ",
+        playerName: "Alpha",
+        warId: "401",
+        missedBoth: true,
+        townHall: null,
+      }),
+    ]);
+    prismaMock.playerCurrent.findMany.mockResolvedValue([]);
+    prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue([
+      makeFwaClanMemberCurrentRow({ clanTag: "#AAA111", playerTag: "9Q8R0VRJ", townHall: 19 }),
+    ]);
+    prismaMock.fwaPlayerCatalog.findMany.mockResolvedValue([
+      makeFwaPlayerCatalogRow({ playerTag: "9Q8R0VRJ", latestTownHall: 15 }),
+    ]);
+
+    const service = new InactiveWarService();
+    const summary = await service.listInactiveWarPlayers({
+      guildId: "guild-1",
+      wars: 1,
+    });
+
+    expect(summary.results[0]?.townHall).toBe(19);
+    expect(prismaMock.fwaPlayerCatalog.findMany).not.toHaveBeenCalled();
     expect(prismaMock.fwaTrackedClanWarRosterMemberCurrent.findMany).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
Adds `FwaPlayerCatalog.latestTownHall` to the `/inactive wars` DB-only Town Hall fallback chain so rows no longer render `❔` when the catalog already knows the player’s TH.

- selected participation TH still wins
- historical participation rows remain the first fallback
- PlayerCurrent, FwaClanMemberCurrent, FwaPlayerCatalog, and tracked war roster snapshots are used in order
- `/inactive days` remains unchanged
- tests cover the catalog fallback, precedence, and the `9Q8R0VRJ`-style case