### PR TITLE
fix(raids): parse compact raid season timestamps

### DIFF
--- a/src/services/RaidDashboardService.ts
+++ b/src/services/RaidDashboardService.ts
@@ -133,6 +133,26 @@ function formatAttacksLabel(input: { attacksCompleted: number | null; attacksMax
   return `${input.attacksCompleted}/${input.attacksMax}`;
 }
 
+export function parseRaidSeasonTimeMs(value: unknown): number | null {
+  if (value === null || value === undefined) return null;
+  const raw = String(value).trim();
+  if (!raw) return null;
+
+  const compactMatch = raw.match(
+    /^(\d{4})(\d{2})(\d{2})T(\d{2})(\d{2})(\d{2})(?:\.(\d{1,3}))?Z$/,
+  );
+  if (compactMatch) {
+    const [, year, month, day, hour, minute, second, fraction = "0"] = compactMatch;
+    const millis = fraction.padEnd(3, "0").slice(0, 3);
+    const iso = `${year}-${month}-${day}T${hour}:${minute}:${second}.${millis}Z`;
+    const parsed = Date.parse(iso);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  const parsed = Date.parse(raw);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
 function selectCurrentRaidSeason(input: {
   seasons: ClanCapitalRaidSeason[];
   nowMs: number;
@@ -142,12 +162,12 @@ function selectCurrentRaidSeason(input: {
   }
 
   const candidates = input.seasons.map((season) => {
-    const startMs = Date.parse(String(season.startTime ?? ""));
-    const endMs = Date.parse(String(season.endTime ?? ""));
+    const startMs = parseRaidSeasonTimeMs(season.startTime);
+    const endMs = parseRaidSeasonTimeMs(season.endTime);
     return {
       season,
-      startMs: Number.isFinite(startMs) ? startMs : null,
-      endMs: Number.isFinite(endMs) ? endMs : null,
+      startMs,
+      endMs,
     };
   });
 

--- a/tests/raidDashboard.service.test.ts
+++ b/tests/raidDashboard.service.test.ts
@@ -40,6 +40,7 @@ import {
   loadRaidIntelSeasonDetailWithQueueContext,
   listRaidDashboardRows,
   listRaidDashboardRowsWithQueueContext,
+  parseRaidSeasonTimeMs,
 } from "../src/services/RaidDashboardService";
 
 describe("RaidDashboardService", () => {
@@ -136,6 +137,124 @@ describe("RaidDashboardService", () => {
     expect(single).toContain("Join type: Open");
     expect(single).toContain("Upgrades: 2210");
     expect(single).toContain("Attacks: 11/12");
+  });
+
+  it("parses compact Clash raid timestamps and selects the active season", async () => {
+    prismaMock.raidTrackedClan.findMany.mockResolvedValueOnce([
+      {
+        clanTag: "2QG2C08UP",
+        name: "Alpha Raid",
+        upgrades: 2210,
+        joinType: "open",
+        createdAt: new Date("2026-05-01T00:00:00.000Z"),
+        updatedAt: new Date("2026-05-08T11:00:00.000Z"),
+      },
+    ]);
+
+    const cocService = {
+      getClanCapitalRaidSeasons: vi.fn(async () => [
+        {
+          startTime: "20260508T070000.000Z",
+          endTime: "20260511T070000.000Z",
+          members: [{ attacks: 6 }, { attacks: 5 }],
+          attackLog: [],
+          defenseLog: [],
+          raidsCompleted: null,
+        },
+      ]),
+    };
+
+    const rows = await listRaidDashboardRows({ cocService: cocService as any });
+    expect(rows[0]?.attacksCompleted).toBe(11);
+    expect(rows[0]?.attacksMax).toBe(12);
+    expect(rows[0]?.raidsCompleted).toBeNull();
+    expect(buildRaidDashboardOverviewDescription(rows)).toContain("Attacks: 11/12");
+  });
+
+  it("parses compact raid timestamps without milliseconds and still selects the active season", async () => {
+    prismaMock.raidTrackedClan.findMany.mockResolvedValueOnce([
+      {
+        clanTag: "20RLGVJPP",
+        name: "Bravo Raid",
+        upgrades: 3331,
+        joinType: "open",
+        createdAt: new Date("2026-05-01T00:00:00.000Z"),
+        updatedAt: new Date("2026-05-08T11:00:00.000Z"),
+      },
+    ]);
+
+    const cocService = {
+      getClanCapitalRaidSeasons: vi.fn(async () => [
+        {
+          startTime: "20260508T070000Z",
+          endTime: "20260511T070000Z",
+          members: [{ attacks: 6 }, { attacks: 6 }, { attacks: 1 }],
+          attackLog: [
+            {
+              defender: { name: "Defender One", tag: "#DEF1" },
+              districtCount: 9,
+              districtsDestroyed: 9,
+              districts: [
+                {
+                  name: "Capital Hall",
+                  districtHallLevel: 5,
+                  attackCount: 3,
+                  destructionPercent: 100,
+                  stars: 3,
+                },
+              ],
+            },
+          ],
+          defenseLog: [],
+          raidsCompleted: null,
+        },
+      ]),
+    };
+
+    const rows = await listRaidDashboardRows({ cocService: cocService as any });
+    expect(rows[0]?.attacksCompleted).toBe(13);
+    expect(rows[0]?.attacksMax).toBe(18);
+    expect(rows[0]?.raidsCompleted).toBe(1);
+    expect(buildRaidDashboardOverviewDescription(rows)).toContain("Attacks: 13/18");
+  });
+
+  it("treats invalid raid timestamps as missing", async () => {
+    expect(parseRaidSeasonTimeMs(null)).toBeNull();
+    expect(parseRaidSeasonTimeMs("")).toBeNull();
+    expect(parseRaidSeasonTimeMs("not-a-timestamp")).toBeNull();
+    expect(parseRaidSeasonTimeMs("20260508T070000.000Z")).toBe(Date.parse("2026-05-08T07:00:00.000Z"));
+  });
+
+  it("returns no active season when raid timestamps are invalid", async () => {
+    prismaMock.raidTrackedClan.findMany.mockResolvedValueOnce([
+      {
+        clanTag: "2QG2C08UP",
+        name: "Alpha Raid",
+        upgrades: 2210,
+        joinType: "open",
+        createdAt: new Date("2026-05-01T00:00:00.000Z"),
+        updatedAt: new Date("2026-05-08T11:00:00.000Z"),
+      },
+    ]);
+
+    const cocService = {
+      getClanCapitalRaidSeasons: vi.fn(async () => [
+        {
+          startTime: "not-a-time",
+          endTime: "also-not-a-time",
+          state: "ongoing",
+          members: [{ attacks: 6 }, { attacks: 5 }],
+          attackLog: [],
+          defenseLog: [],
+          raidsCompleted: null,
+        },
+      ]),
+    };
+
+    const rows = await listRaidDashboardRows({ cocService: cocService as any });
+    expect(rows[0]?.attacksCompleted).toBeNull();
+    expect(rows[0]?.attacksMax).toBeNull();
+    expect(rows[0]?.raidsCompleted).toBeNull();
   });
 
   it("loads raid rows through a queue context wrapper for dashboard refreshes", async () => {


### PR DESCRIPTION
## Summary
- parse Clash compact raid-season timestamps like `YYYYMMDDTHHmmss.SSSZ` and `YYYYMMDDTHHmmssZ`
- keep `/raids overview` attack counts working for active clans whose raid seasons use compact timestamps
- add regression coverage for compact, ISO, and invalid timestamp handling

## Diagnosis
- live raid-season payloads for affected clans contain real `members[].attacks` values
- the previous `Date.parse(...)` path rejected compact Clash timestamps, causing active seasons to be filtered out