### PR TITLE
feat(raids): polish overview display

### DIFF
--- a/src/commands/Raids.ts
+++ b/src/commands/Raids.ts
@@ -179,14 +179,10 @@ function buildRaidDashboardEmbed(
   selectedRow: RaidDashboardClanRow | null,
   detail: Awaited<ReturnType<typeof loadRaidDashboardSeasonDetailWithQueueContext>> | null,
 ) {
-  const title = selectedRow ? "Raid Clan" : "Raid Clans";
   const description = selectedRow
     ? buildRaidDashboardSingleClanDescription(selectedRow, detail)
     : buildRaidDashboardOverviewDescription(rows);
-  return new EmbedBuilder()
-    .setTitle(title)
-    .setDescription(description)
-    .setColor(0x5865f2);
+  return new EmbedBuilder().setDescription(description).setColor(0x5865f2);
 }
 
 function buildRaidIntelEmbed(input: {

--- a/src/services/RaidDashboardService.ts
+++ b/src/services/RaidDashboardService.ts
@@ -423,6 +423,10 @@ function buildRaidDetailLines(detail: RaidDashboardSeasonDetail): RaidDetailLine
         lines.push({ text: "", item: false });
       }
     });
+  } else {
+    lines.push({ text: "## Attacking", item: false });
+    lines.push({ text: "", item: false });
+    lines.push({ text: "No attack log available yet.", item: false });
   }
 
   if (detail.defenseSections.length > 0) {
@@ -437,6 +441,13 @@ function buildRaidDetailLines(detail: RaidDashboardSeasonDetail): RaidDetailLine
         lines.push({ text: "", item: false });
       }
     });
+  } else {
+    if (lines.length > 0) {
+      lines.push({ text: "", item: false });
+    }
+    lines.push({ text: "## Defending", item: false });
+    lines.push({ text: "", item: false });
+    lines.push({ text: "No defense log available yet.", item: false });
   }
 
   return lines;

--- a/src/services/RaidDashboardService.ts
+++ b/src/services/RaidDashboardService.ts
@@ -126,11 +126,38 @@ function formatJoinTypeLabel(joinType: RaidTrackedClanJoinType | null): string {
   return "Unknown";
 }
 
-function formatAttacksLabel(input: { attacksCompleted: number | null; attacksMax: number | null }): string {
-  if (input.attacksCompleted === null || input.attacksMax === null) {
-    return "—";
+function formatCompletedAttacksLabel(attacksCompleted: number | null): string {
+  return attacksCompleted === null ? "—" : String(attacksCompleted);
+}
+
+const RAID_DISTRICT_MAX_HALL_LEVELS = new Map<string, number>([
+  ["capital hall", 10],
+  ["capital peak", 10],
+  ["barbarian camp", 5],
+  ["wizard valley", 5],
+  ["balloon lagoon", 5],
+  ["builder's workshop", 5],
+  ["builders workshop", 5],
+  ["dragon cliffs", 5],
+  ["golem quarry", 5],
+  ["skeleton park", 4],
+  ["goblin mines", 4],
+]);
+
+function normalizeRaidDistrictName(name: string): string {
+  return String(name ?? "").replace(/\s+/g, " ").trim().toLowerCase();
+}
+
+export function formatRaidDistrictHallLabel(
+  districtName: string,
+  hallLevel: number | null,
+): string | null {
+  if (hallLevel === null) return null;
+  const maxHallLevel = RAID_DISTRICT_MAX_HALL_LEVELS.get(normalizeRaidDistrictName(districtName));
+  if (maxHallLevel !== undefined && hallLevel >= maxHallLevel) {
+    return "MAX";
   }
-  return `${input.attacksCompleted}/${input.attacksMax}`;
+  return `DH${hallLevel}`;
 }
 
 export function parseRaidSeasonTimeMs(value: unknown): number | null {
@@ -282,9 +309,10 @@ function calculateCompletedRaidsFromAttackLog(
 }
 
 function buildRaidDistrictLabel(row: RaidDashboardDistrictRow): string {
-  const hallLevel = row.districtHallLevel === null ? "" : ` DH${row.districtHallLevel}`;
+  const hallLabel = formatRaidDistrictHallLabel(row.name, row.districtHallLevel);
+  const hallSuffix = hallLabel === null ? "" : ` ${hallLabel}`;
   const attackCount = row.attackCount === null ? "— attacks" : `${row.attackCount} attacks`;
-  return `${row.name}${hallLevel} — ${attackCount}`;
+  return `${row.name}${hallSuffix} — ${attackCount}`;
 }
 
 function buildRaidDetailDescription(input: {
@@ -384,25 +412,17 @@ function buildRaidDefenseSectionLines(section: RaidDashboardDefenseSection): Rai
 }
 
 function buildRaidDetailLines(detail: RaidDashboardSeasonDetail): RaidDetailLine[] {
-  if (!detail.activeSeason) {
-    return [{ text: "No active raid weekend data available.", item: false }];
-  }
-
   const lines: RaidDetailLine[] = [];
+
   if (detail.attackSections.length > 0) {
     lines.push({ text: "## Attacking", item: false });
     lines.push({ text: "", item: false });
-    for (const section of detail.attackSections) {
+    detail.attackSections.forEach((section, index) => {
       lines.push(...buildRaidAttackSectionLines(section));
-      lines.push({ text: "", item: false });
-    }
-    if (lines.length > 0 && lines[lines.length - 1]?.text === "") {
-      lines.pop();
-    }
-  } else {
-    lines.push({ text: "## Attacking", item: false });
-    lines.push({ text: "", item: false });
-    lines.push({ text: "No attack log available yet.", item: false });
+      if (index < detail.attackSections.length - 1) {
+        lines.push({ text: "", item: false });
+      }
+    });
   }
 
   if (detail.defenseSections.length > 0) {
@@ -411,29 +431,15 @@ function buildRaidDetailLines(detail: RaidDashboardSeasonDetail): RaidDetailLine
     }
     lines.push({ text: "## Defending", item: false });
     lines.push({ text: "", item: false });
-    for (const section of detail.defenseSections) {
+    detail.defenseSections.forEach((section, index) => {
       lines.push(...buildRaidDefenseSectionLines(section));
-      lines.push({ text: "", item: false });
-    }
-    if (lines.length > 0 && lines[lines.length - 1]?.text === "") {
-      lines.pop();
-    }
-  } else {
-    if (lines.length > 0) {
-      lines.push({ text: "", item: false });
-    }
-    lines.push({ text: "## Defending", item: false });
-    lines.push({ text: "", item: false });
-    lines.push({ text: "No defense log available yet.", item: false });
+      if (index < detail.defenseSections.length - 1) {
+        lines.push({ text: "", item: false });
+      }
+    });
   }
 
   return lines;
-}
-
-function buildRaidDetailSections(detail: RaidDashboardSeasonDetail): string {
-  return buildRaidDetailDescription({
-    lines: buildRaidDetailLines(detail),
-  });
 }
 
 function normalizeAttackSections(season: ClanCapitalRaidSeason): RaidDashboardAttackSection[] {
@@ -575,10 +581,6 @@ function calculateCompletedRaidsFromSeason(
   season: ClanCapitalRaidSeason,
   attackSections: RaidDashboardAttackSection[],
 ): number | null {
-  const explicit = normalizeNonNegativeInt(season.raidsCompleted);
-  if (explicit !== null) {
-    return explicit;
-  }
   if (attackSections.length <= 0) {
     return calculateCompletedRaidsFromAttackLog(season.attackLog);
   }
@@ -958,15 +960,8 @@ export function buildRaidDashboardOverviewDescription(rows: RaidDashboardClanRow
   const lines: string[] = ["## Raid Clans", ""];
   for (const row of rows) {
     lines.push(buildRaidDashboardClanTitle(row));
-    lines.push(`Upgrades: ${row.upgrades === null ? "—" : row.upgrades}`);
-    lines.push(
-      `Attacks: ${formatAttacksLabel({
-        attacksCompleted: row.attacksCompleted,
-        attacksMax: row.attacksMax,
-      })}`,
-    );
+    lines.push(`Attacks: ${formatCompletedAttacksLabel(row.attacksCompleted)}`);
     lines.push(`Raids completed: ${row.raidsCompleted === null ? "—" : row.raidsCompleted}`);
-    lines.push(`Updated: ${formatRelativeTimestamp(row.updatedAt)}`);
     lines.push("");
   }
 
@@ -997,18 +992,11 @@ export function buildRaidDashboardSingleClanDescription(
       item: false,
     },
     {
-      text: `Attacks: ${formatAttacksLabel({
-        attacksCompleted: row.attacksCompleted,
-        attacksMax: row.attacksMax,
-      })}`,
+      text: `Attacks: ${formatCompletedAttacksLabel(row.attacksCompleted)}`,
       item: false,
     },
     {
       text: `Raids completed: ${raidsCompleted === null ? "—" : raidsCompleted}`,
-      item: false,
-    },
-    {
-      text: `Updated: ${formatRelativeTimestamp(row.updatedAt)}`,
       item: false,
     },
   ];
@@ -1041,15 +1029,10 @@ export function buildRaidDashboardSelectChoices(
   return orderedRows.slice(0, 25).map((row) => {
     const clanTag = formatRaidTrackedClanTag(row.clanTag);
     const label = row.clanName?.trim() || clanTag;
-    const descriptionParts = [`${clanTag}`];
-    if (row.upgrades !== null) {
-      descriptionParts.push(`Upgrades ${row.upgrades}`);
-    }
-    const description = descriptionParts.join(" • ").slice(0, 100);
     return {
       label: label.slice(0, 100),
       value: normalizeRaidTrackedClanTag(row.clanTag) ?? row.clanTag,
-      description,
+      description: clanTag.slice(0, 100),
       emoji: getRaidTrackedClanJoinTypeEmoji(row.joinType),
     };
   });

--- a/tests/raidDashboard.service.test.ts
+++ b/tests/raidDashboard.service.test.ts
@@ -833,6 +833,8 @@ describe("RaidDashboardService", () => {
     });
 
     expect(description).toBe("No active raid weekend data available.");
+    expect(description).not.toContain("No attack log available yet.");
+    expect(description).not.toContain("No defense log available yet.");
   });
 
   it("renders a no-attack-log section when the active raid season has no attack sections", () => {

--- a/tests/raidDashboard.service.test.ts
+++ b/tests/raidDashboard.service.test.ts
@@ -835,6 +835,75 @@ describe("RaidDashboardService", () => {
     expect(description).toBe("No active raid weekend data available.");
   });
 
+  it("renders a no-attack-log section when the active raid season has no attack sections", () => {
+    const row = {
+      clanTag: "2QG2C08UP",
+      clanName: "Alpha Raid",
+      upgrades: 2210,
+      joinType: "open",
+      createdAt: new Date("2026-05-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-05-08T11:00:00.000Z"),
+      attacksCompleted: 11,
+      attacksMax: 12,
+      raidsCompleted: 1,
+    } as any;
+
+    const description = buildRaidDashboardSingleClanDescription(row, {
+      activeSeason: { state: "ongoing" } as any,
+      attackSections: [],
+      defenseSections: [
+        {
+          attackerName: "Enemy Clan",
+          attackerTag: "#ENEMY",
+          joinType: "open",
+          districtsRemaining: 3,
+        },
+      ],
+      raidsCompleted: 1,
+    });
+
+    expect(description).toContain("## Attacking");
+    expect(description).toContain("No attack log available yet.");
+  });
+
+  it("renders a no-defense-log section when the active raid season has no defense sections", () => {
+    const row = {
+      clanTag: "2QG2C08UP",
+      clanName: "Alpha Raid",
+      upgrades: 2210,
+      joinType: "open",
+      createdAt: new Date("2026-05-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-05-08T11:00:00.000Z"),
+      attacksCompleted: 11,
+      attacksMax: 12,
+      raidsCompleted: 1,
+    } as any;
+
+    const description = buildRaidDashboardSingleClanDescription(row, {
+      activeSeason: { state: "ongoing" } as any,
+      attackSections: [
+        {
+          defenderName: "Defender One",
+          defenderTag: "#DEF1",
+          districts: [
+            {
+              name: "Capital Hall",
+              districtHallLevel: 5,
+              attackCount: 3,
+              destructionPercent: 100,
+              stars: 3,
+            },
+          ],
+        },
+      ],
+      defenseSections: [],
+      raidsCompleted: 1,
+    });
+
+    expect(description).toContain("## Defending");
+    expect(description).toContain("No defense log available yet.");
+  });
+
   it("truncates long raid detail descriptions gracefully", () => {
     const row = {
       clanTag: "2QG2C08UP",

--- a/tests/raidDashboard.service.test.ts
+++ b/tests/raidDashboard.service.test.ts
@@ -40,6 +40,7 @@ import {
   loadRaidIntelSeasonDetailWithQueueContext,
   listRaidDashboardRows,
   listRaidDashboardRowsWithQueueContext,
+  formatRaidDistrictHallLabel,
   parseRaidSeasonTimeMs,
 } from "../src/services/RaidDashboardService";
 
@@ -128,15 +129,16 @@ describe("RaidDashboardService", () => {
     const overview = buildRaidDashboardOverviewDescription(rows);
     expect(overview).toContain("## Raid Clans");
     expect(overview).toContain("🔓 [Alpha Raid]");
-    expect(overview).toContain("Attacks: 11/12");
+    expect(overview).toContain("Attacks: 11");
     expect(overview).toContain("Raids completed: 1");
-    expect(overview).toContain("Updated:");
+    expect(overview).not.toContain("Updated:");
+    expect(overview).not.toContain("Upgrades:");
 
     const single = buildRaidDashboardSingleClanDescription(rows[0]!);
     expect(single).toContain("## Raid Clan");
     expect(single).toContain("Join type: Open");
     expect(single).toContain("Upgrades: 2210");
-    expect(single).toContain("Attacks: 11/12");
+    expect(single).toContain("Attacks: 11");
   });
 
   it("parses compact Clash raid timestamps and selects the active season", async () => {
@@ -168,7 +170,7 @@ describe("RaidDashboardService", () => {
     expect(rows[0]?.attacksCompleted).toBe(11);
     expect(rows[0]?.attacksMax).toBe(12);
     expect(rows[0]?.raidsCompleted).toBeNull();
-    expect(buildRaidDashboardOverviewDescription(rows)).toContain("Attacks: 11/12");
+    expect(buildRaidDashboardOverviewDescription(rows)).toContain("Attacks: 11");
   });
 
   it("parses compact raid timestamps without milliseconds and still selects the active season", async () => {
@@ -215,7 +217,214 @@ describe("RaidDashboardService", () => {
     expect(rows[0]?.attacksCompleted).toBe(13);
     expect(rows[0]?.attacksMax).toBe(18);
     expect(rows[0]?.raidsCompleted).toBe(1);
-    expect(buildRaidDashboardOverviewDescription(rows)).toContain("Attacks: 13/18");
+    expect(buildRaidDashboardOverviewDescription(rows)).toContain("Attacks: 13");
+  });
+
+  it("treats started aggregate raid logs as not completed", async () => {
+    prismaMock.raidTrackedClan.findMany.mockResolvedValueOnce([
+      {
+        clanTag: "2QG2C08UP",
+        name: "Alpha Raid",
+        upgrades: 2210,
+        joinType: "open",
+        createdAt: new Date("2026-05-01T00:00:00.000Z"),
+        updatedAt: new Date("2026-05-08T11:00:00.000Z"),
+      },
+    ]);
+
+    const cocService = {
+      getClanCapitalRaidSeasons: vi.fn(async () => [
+        {
+          startTime: "2026-05-08T00:00:00.000Z",
+          endTime: "2026-05-11T00:00:00.000Z",
+          members: [{ attacks: 1 }],
+          attackLog: [
+            {
+              defender: { name: "Defender One", tag: "#DEF1" },
+              districtCount: 9,
+              districtsDestroyed: 0,
+              districts: [
+                {
+                  name: "Capital Hall",
+                  districtHallLevel: 10,
+                  attackCount: 3,
+                  destructionPercent: 50,
+                  stars: 1,
+                },
+              ],
+            },
+          ],
+          defenseLog: [],
+          raidsCompleted: null,
+        },
+      ]),
+    };
+
+    const rows = await listRaidDashboardRows({ cocService: cocService as any });
+    expect(rows[0]?.raidsCompleted).toBe(0);
+    expect(buildRaidDashboardOverviewDescription(rows)).toContain("Raids completed: 0");
+  });
+
+  it("treats incomplete per-district raid logs as not completed", async () => {
+    prismaMock.raidTrackedClan.findMany.mockResolvedValueOnce([
+      {
+        clanTag: "2QG2C08UP",
+        name: "Alpha Raid",
+        upgrades: 2210,
+        joinType: "open",
+        createdAt: new Date("2026-05-01T00:00:00.000Z"),
+        updatedAt: new Date("2026-05-08T11:00:00.000Z"),
+      },
+    ]);
+
+    const cocService = {
+      getClanCapitalRaidSeasons: vi.fn(async () => [
+        {
+          startTime: "2026-05-08T00:00:00.000Z",
+          endTime: "2026-05-11T00:00:00.000Z",
+          members: [{ attacks: 6 }],
+          attackLog: [
+            {
+              defender: { name: "Defender One", tag: "#DEF1" },
+              districts: [
+                {
+                  name: "Capital Hall",
+                  districtHallLevel: 10,
+                  attackCount: 3,
+                  destructionPercent: 100,
+                  stars: 3,
+                },
+                {
+                  name: "Wizard Valley",
+                  districtHallLevel: 5,
+                  attackCount: 2,
+                  destructionPercent: 50,
+                  stars: 1,
+                },
+              ],
+            },
+          ],
+          defenseLog: [],
+          raidsCompleted: null,
+        },
+      ]),
+    };
+
+    const rows = await listRaidDashboardRows({ cocService: cocService as any });
+    expect(rows[0]?.raidsCompleted).toBe(0);
+    expect(buildRaidDashboardOverviewDescription(rows)).toContain("Raids completed: 0");
+  });
+
+  it("treats fully destroyed per-district raid logs as completed", async () => {
+    prismaMock.raidTrackedClan.findMany.mockResolvedValueOnce([
+      {
+        clanTag: "2QG2C08UP",
+        name: "Alpha Raid",
+        upgrades: 2210,
+        joinType: "open",
+        createdAt: new Date("2026-05-01T00:00:00.000Z"),
+        updatedAt: new Date("2026-05-08T11:00:00.000Z"),
+      },
+    ]);
+
+    const cocService = {
+      getClanCapitalRaidSeasons: vi.fn(async () => [
+        {
+          startTime: "2026-05-08T00:00:00.000Z",
+          endTime: "2026-05-11T00:00:00.000Z",
+          members: [{ attacks: 6 }],
+          attackLog: [
+            {
+              defender: { name: "Defender One", tag: "#DEF1" },
+              districts: [
+                {
+                  name: "Capital Hall",
+                  districtHallLevel: 10,
+                  attackCount: 3,
+                  destructionPercent: 100,
+                  stars: 3,
+                },
+                {
+                  name: "Barbarian Camp",
+                  districtHallLevel: 5,
+                  attackCount: 2,
+                  destructionPercent: 100,
+                  stars: 3,
+                },
+              ],
+            },
+          ],
+          defenseLog: [],
+          raidsCompleted: null,
+        },
+      ]),
+    };
+
+    const rows = await listRaidDashboardRows({ cocService: cocService as any });
+    expect(rows[0]?.raidsCompleted).toBe(1);
+    expect(buildRaidDashboardOverviewDescription(rows)).toContain("Raids completed: 1");
+  });
+
+  it("renders MAX for maxed raid district hall levels and falls back to DH labels otherwise", () => {
+    const row = {
+      clanTag: "2QG2C08UP",
+      clanName: "Alpha Raid",
+      upgrades: 2210,
+      joinType: "open",
+      createdAt: new Date("2026-05-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-05-08T11:00:00.000Z"),
+      attacksCompleted: 13,
+      attacksMax: 18,
+      raidsCompleted: 1,
+    } as any;
+
+    const detail = {
+      activeSeason: { state: "ongoing" },
+      attackSections: [
+        {
+          defenderName: "Defender One",
+          defenderTag: "#DEF1",
+          districts: [
+            {
+              name: "Capital Hall",
+              districtHallLevel: 10,
+              attackCount: 3,
+              destructionPercent: 100,
+              stars: 3,
+            },
+            {
+              name: "Barbarian Camp",
+              districtHallLevel: 5,
+              attackCount: 2,
+              destructionPercent: 100,
+              stars: 3,
+            },
+            {
+              name: "Skeleton Park",
+              districtHallLevel: 3,
+              attackCount: 4,
+              destructionPercent: 100,
+              stars: 3,
+            },
+            {
+              name: "Unknown District",
+              districtHallLevel: 7,
+              attackCount: 1,
+              destructionPercent: 100,
+              stars: 3,
+            },
+          ],
+        },
+      ],
+      defenseSections: [],
+      raidsCompleted: 1,
+    } as any;
+
+    const description = buildRaidDashboardSingleClanDescription(row, detail);
+    expect(description).toContain("Capital Hall MAX — 3 attacks");
+    expect(description).toContain("Barbarian Camp MAX — 2 attacks");
+    expect(description).toContain("Skeleton Park DH3 — 4 attacks");
+    expect(description).toContain("Unknown District DH7 — 1 attacks");
   });
 
   it("treats invalid raid timestamps as missing", async () => {

--- a/tests/raids.command.test.ts
+++ b/tests/raids.command.test.ts
@@ -252,8 +252,11 @@ describe("/raids command", () => {
     const description = payload.embeds[0].toJSON().description as string;
     expect(description).toContain("## Raid Clans");
     expect(description).toContain("🔓 [Alpha Raid]");
-    expect(description).toContain("Attacks: 11/12");
+    expect(description).toContain("Attacks: 11");
     expect(description).toContain("Raids completed: 1");
+    expect(description).not.toContain("Upgrades:");
+    expect(description).not.toContain("Updated:");
+    expect(payload.embeds[0].toJSON().title).toBeUndefined();
     expect(cocService.getClan).not.toHaveBeenCalled();
 
     const selectRow = payload.components[0]?.toJSON?.().components[0];
@@ -577,6 +580,9 @@ describe("/raids command", () => {
     const description = payload.embeds[0].toJSON().description as string;
     expect(description).toContain("## Raid Clan");
     expect(description).toContain("Join type: Closed");
+    expect(description).not.toContain("Updated:");
+    expect(description).toContain("Upgrades: —");
+    expect(payload.embeds[0].toJSON().title).toBeUndefined();
     expect(description).toContain("Bravo Raid");
     expect(description).toContain("## Attacking");
     expect(description).toContain("### [Defender One]");


### PR DESCRIPTION
## Summary
- remove duplicate raid dashboard embed titles
- show completed attacks only
- derive completed raids from full district destruction
- remove Updated metadata from overview and drilldown
- hide upgrades in overview while keeping them in drilldown
- render maxed raid districts as MAX
- preserve drilldown empty states

## Notes
- `/raids overview` and `/raids overview clan:<tag>` keep the lightweight display polish only
- `/raids intel` layout-marking behavior is unchanged