### PR TITLE
feat(defer): defer now upserts

### DIFF
--- a/src/commands/Defer.ts
+++ b/src/commands/Defer.ts
@@ -130,14 +130,14 @@ export const Defer: Command = {
               `failed: unable to save deferment for ${playerTag}. Check bot logs.`
             );
             return;
-          case "already_exists":
-            await interaction.editReply(
-              `already_exists: ${playerTag} is already open in ${renderScopeLabel(result.record)}.`
-            );
-            return;
           case "created":
             await interaction.editReply(
               `created: ${playerTag} queued at ${deferredWeight} in ${renderScopeLabel(result.record)}.`
+            );
+            return;
+          case "updated":
+            await interaction.editReply(
+              `updated: ${playerTag} queued at ${deferredWeight} in ${renderScopeLabel(result.record)}.`
             );
             return;
         }

--- a/src/services/WeightInputDefermentService.ts
+++ b/src/services/WeightInputDefermentService.ts
@@ -17,7 +17,7 @@ export type DefermentScopeContext = {
 };
 
 export type AddDefermentResult = {
-  outcome: "created" | "already_exists";
+  outcome: "created" | "updated";
   record: {
     id: string;
     guildId: string;
@@ -128,7 +128,7 @@ function parseStatus(input: string): DefermentStatus | null {
   return null;
 }
 
-async function findOpenWeightInputDeferment(input: {
+async function findWeightInputDeferment(input: {
   scopeKey: string;
   playerTag: string;
 }) {
@@ -140,10 +140,7 @@ async function findOpenWeightInputDeferment(input: {
       },
     },
   });
-  if (existing && parseStatus(existing.status) === "open") {
-    return existing;
-  }
-  return null;
+  return existing && parseStatus(existing.status) ? existing : null;
 }
 
 async function resolveClanScopeFromChannel(
@@ -236,13 +233,10 @@ export async function addWeightInputDeferment(input: {
       guildId: input.guildId,
       channelId: input.channelId,
     }));
-  const existing = await findOpenWeightInputDeferment({
+  const existing = await findWeightInputDeferment({
     scopeKey: scope.scopeKey,
     playerTag: input.playerTag,
   });
-  if (existing) {
-    return { outcome: "already_exists", record: existing };
-  }
 
   const next = await prisma.weightInputDeferment.upsert({
     where: {
@@ -255,7 +249,6 @@ export async function addWeightInputDeferment(input: {
       clanTag: scope.clanTag,
       deferredWeight: input.deferredWeight,
       status: "open",
-      createdAt: new Date(),
       resolvedAt: null,
       clearedAt: null,
       reminded48At: null,
@@ -273,7 +266,7 @@ export async function addWeightInputDeferment(input: {
       status: "open",
     },
   });
-  return { outcome: "created", record: next };
+  return { outcome: existing ? "updated" : "created", record: next };
 }
 
 /** Purpose: add one deferment row after resolving the live player profile and upserting deferred fallback weight. */
@@ -327,17 +320,6 @@ export async function addWeightInputDefermentWithPlayerProfile(input: {
       error,
     });
     throw error;
-  }
-
-  const existing = await findOpenWeightInputDeferment({
-    scopeKey: scope.scopeKey,
-    playerTag,
-  });
-  if (existing) {
-    return {
-      outcome: "already_exists",
-      record: existing,
-    };
   }
 
   logDeferStage({

--- a/tests/defer.command.run.test.ts
+++ b/tests/defer.command.run.test.ts
@@ -122,32 +122,71 @@ describe("/defer add", () => {
     );
   });
 
-  it("returns already_exists without calling cocService.getPlayerRaw when an open deferment already exists", async () => {
-    prismaMock.weightInputDeferment.findUnique.mockResolvedValue({
-      id: "defer-open-1",
-      guildId: "guild-1",
-      clanTag: "#PQL0289",
-      scopeKey: "guild:guild-1|clan:PQL0289",
-      playerTag: "#PYLQ0289",
-      deferredWeight: 145000,
-      createdAt: new Date("2026-04-01T00:00:00.000Z"),
-      status: "open",
-    });
-    const interaction = makeInteraction({
+  it("updates the same deferment row on a second add instead of creating a duplicate", async () => {
+    const firstInteraction = makeInteraction({
       playerTag: "#pylq0289",
       weight: "145k",
     });
+    const secondInteraction = makeInteraction({
+      playerTag: "#pylq0289",
+      weight: "150k",
+    });
     const cocService = {
-      getPlayerRaw: vi.fn(),
+      getPlayerRaw: vi.fn().mockResolvedValue({
+        tag: "#PYLQ0289",
+        name: "Live Player",
+        townHallLevel: 16,
+        clan: {
+          tag: "#PQL0289",
+          name: "Alpha Clan",
+        },
+      }),
     };
+    prismaMock.weightInputDeferment.findUnique
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({
+        id: "defer-1",
+        guildId: "guild-1",
+        clanTag: "#PQL0289",
+        scopeKey: "guild:guild-1|clan:PQL0289",
+        playerTag: "#PYLQ0289",
+        deferredWeight: 145000,
+        createdAt: new Date("2026-04-01T00:00:00.000Z"),
+        status: "open",
+      });
+    prismaMock.weightInputDeferment.upsert
+      .mockResolvedValueOnce({
+        id: "defer-1",
+        guildId: "guild-1",
+        clanTag: "#PQL0289",
+        scopeKey: "guild:guild-1|clan:PQL0289",
+        playerTag: "#PYLQ0289",
+        deferredWeight: 145000,
+        createdAt: new Date("2026-04-01T00:00:00.000Z"),
+        status: "open",
+      })
+      .mockResolvedValueOnce({
+        id: "defer-1",
+        guildId: "guild-1",
+        clanTag: "#PQL0289",
+        scopeKey: "guild:guild-1|clan:PQL0289",
+        playerTag: "#PYLQ0289",
+        deferredWeight: 150000,
+        createdAt: new Date("2026-04-01T00:00:00.000Z"),
+        status: "open",
+      });
 
-    await Defer.run({} as any, interaction as any, cocService as any);
+    await Defer.run({} as any, firstInteraction as any, cocService as any);
+    await Defer.run({} as any, secondInteraction as any, cocService as any);
 
-    expect(cocService.getPlayerRaw).not.toHaveBeenCalled();
-    expect(prismaMock.playerCurrent.upsert).not.toHaveBeenCalled();
-    expect(prismaMock.weightInputDeferment.upsert).not.toHaveBeenCalled();
-    expect(interaction.editReply).toHaveBeenCalledWith(
-      "already_exists: #PYLQ0289 is already open in #PQL0289.",
+    expect(cocService.getPlayerRaw).toHaveBeenCalledTimes(2);
+    expect(prismaMock.weightInputDeferment.findUnique).toHaveBeenCalledTimes(2);
+    expect(prismaMock.weightInputDeferment.upsert).toHaveBeenCalledTimes(2);
+    expect(firstInteraction.editReply).toHaveBeenCalledWith(
+      "created: #PYLQ0289 queued at 145000 in #PQL0289.",
+    );
+    expect(secondInteraction.editReply).toHaveBeenCalledWith(
+      "updated: #PYLQ0289 queued at 150000 in #PQL0289.",
     );
   });
 


### PR DESCRIPTION
## Summary
- Changed `/defer add` to upsert existing deferred weight entries instead of failing on duplicates.
- Existing `(scopeKey, playerTag)` entries now update to the newly provided weight.
- Duplicate adds now return `updated:` instead of `already_exists:`.
- Added coverage for create-then-update behavior to ensure no duplicate rows are created.

## Validation
- npx vitest run tests/defer.command.run.test.ts
- npx tsc --noEmit