### PR TITLE
fix(fillers): harden editor collector interactions

### DIFF
--- a/src/commands/Fillers.ts
+++ b/src/commands/Fillers.ts
@@ -66,6 +66,22 @@ function normalizePositiveInteger(input: unknown): number | null {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
 }
 
+function getDiscordErrorCode(error: unknown): number | null {
+  if (!error || typeof error !== "object") return null;
+  const maybeError = error as { code?: unknown };
+  const code = maybeError.code;
+  if (typeof code === "number" && Number.isFinite(code)) return code;
+  if (typeof code === "string" && /^[0-9]+$/.test(code)) {
+    return Number(code);
+  }
+  return null;
+}
+
+function isIgnorableCollectorInteractionError(error: unknown): boolean {
+  const code = getDiscordErrorCode(error);
+  return code === 10062 || code === 40060;
+}
+
 function truncateDiagnosticText(input: string, maxLength = 220): string {
   if (input.length <= maxLength) return input;
   return `${input.slice(0, maxLength)}…[len=${input.length}]`;
@@ -1083,13 +1099,17 @@ async function renderEditorReply(input: {
 
   collector.on("collect", async (component: ButtonInteraction | StringSelectMenuInteraction) => {
     try {
+      if (!component.deferred && !component.replied) {
+        await component.deferUpdate();
+      }
+
       if (component.isButton()) {
         if (component.customId.endsWith(":prev")) {
           page = Math.max(0, page - 1);
         } else if (component.customId.endsWith(":next")) {
           page = Math.min(totalPages - 1, page + 1);
         }
-        await component.update(buildRenderPayload());
+        await message.edit(buildRenderPayload());
         return;
       }
 
@@ -1114,15 +1134,23 @@ async function renderEditorReply(input: {
         linkedPlayerTags: sortedRows.map((row) => row.tag),
         selectedPlayerTags: [...selectedTags],
       });
-      await component.update(buildRenderPayload());
+      await message.edit(buildRenderPayload());
     } catch (error) {
+      if (isIgnorableCollectorInteractionError(error)) {
+        console.warn(`fillers editor collector ignored interaction error: ${formatError(error)}`);
+        return;
+      }
       console.error(`fillers editor collector failed: ${formatError(error)}`);
-      if (!component.replied && !component.deferred) {
-        await component.reply({
+      await component
+        .followUp({
           ephemeral: true,
           content: FILLERS_EDITOR_FAILURE_MESSAGE,
+        })
+        .catch((followUpError) => {
+          if (!isIgnorableCollectorInteractionError(followUpError)) {
+            console.error(`fillers editor collector follow-up failed: ${formatError(followUpError)}`);
+          }
         });
-      }
     }
   });
 

--- a/tests/fillers.command.test.ts
+++ b/tests/fillers.command.test.ts
@@ -297,6 +297,7 @@ function makeInteraction(input: {
     }),
   };
   const message = {
+    edit: vi.fn().mockResolvedValue(undefined),
     createMessageComponentCollector: vi.fn(() => collector),
   };
 
@@ -322,6 +323,7 @@ function makeInteraction(input: {
       }),
     },
     __collectorHandlers: collectorHandlers,
+    __message: message,
   };
 }
 
@@ -336,6 +338,7 @@ function makeSelectInteraction(input: {
     isButton: () => false,
     update: vi.fn().mockResolvedValue(undefined),
     deferUpdate: vi.fn().mockResolvedValue(undefined),
+    followUp: vi.fn().mockResolvedValue(undefined),
     replied: false,
     deferred: false,
     reply: vi.fn().mockResolvedValue(undefined),
@@ -351,6 +354,7 @@ function makeButtonInteraction(input: {
     isButton: () => true,
     update: vi.fn().mockResolvedValue(undefined),
     deferUpdate: vi.fn().mockResolvedValue(undefined),
+    followUp: vi.fn().mockResolvedValue(undefined),
     replied: false,
     deferred: false,
     reply: vi.fn().mockResolvedValue(undefined),
@@ -359,6 +363,10 @@ function makeButtonInteraction(input: {
 
 function getLastEditPayload(interaction: any): any {
   return interaction.editReply.mock.calls.at(-1)?.[0] ?? {};
+}
+
+function getLastMessageEditPayload(interaction: any): any {
+  return interaction.__message.edit.mock.calls.at(-1)?.[0] ?? {};
 }
 
 function getEmbedJson(payload: any): any {
@@ -509,10 +517,46 @@ describe("/fillers command", () => {
     expect(prismaMock.fillerAccount.upsert).toHaveBeenCalledTimes(1);
     expect(fillerState.has(makeValidPlayerTag(0))).toBe(true);
 
-    const rerenderPayload = select.update.mock.calls.at(-1)?.[0];
+    const rerenderPayload = getLastMessageEditPayload(interaction);
     const rerenderComponents = getComponentJson(rerenderPayload);
     const rerenderMenu = rerenderComponents[0].components[0];
     expect(rerenderMenu.options[0].default).toBe(true);
+  });
+
+  it("suppresses stale collector interactions without crashing the process", async () => {
+    for (let index = 0; index < 2; index += 1) {
+      seedAccount({
+        playerTag: makeValidPlayerTag(index),
+        discordUserId: "222222222222222222",
+        playerName: `Player ${String(index + 1).padStart(3, "0")}`,
+        townHall: 18,
+        clanTag: "#PQL0289",
+        clanName: "Alpha Clan",
+        weight: index === 0 ? 9200 : 8400,
+      });
+    }
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const interaction = makeInteraction({
+      subcommand: "set",
+      targetUserId: "222222222222222222",
+    });
+
+    await runFillers(interaction);
+
+    const payload = getLastEditPayload(interaction);
+    const firstMenu = getComponentJson(payload)[0].components[0];
+    const select = makeSelectInteraction({
+      customId: firstMenu.custom_id ?? firstMenu.customId,
+      values: [makeValidPlayerTag(0)],
+    });
+    select.deferUpdate.mockRejectedValueOnce(Object.assign(new Error("Unknown interaction"), { code: 10062 }));
+
+    await expect(interaction.__collectorHandlers.collect(select)).resolves.toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("fillers editor collector ignored interaction error"),
+    );
+    expect(prismaMock.fillerAccount.upsert).not.toHaveBeenCalled();
   });
 
   it("renders a sorted, paginated editor with filler markers and dropdown groups", async () => {
@@ -614,7 +658,7 @@ describe("/fillers command", () => {
     });
     await interaction.__collectorHandlers.collect(nextInteraction);
 
-    const nextPayload = nextInteraction.update.mock.calls.at(-1)?.[0];
+    const nextPayload = getLastMessageEditPayload(interaction);
     const nextEmbed = getEmbedJson(nextPayload);
     const nextVisibleTags = extractVisibleTags(String(nextEmbed.description));
     expect(nextVisibleTags[0]).toBe(seededOrder[visibleTags.length]);
@@ -699,7 +743,7 @@ describe("/fillers command", () => {
     expect(prismaMock.fillerAccount.upsert).toHaveBeenCalledTimes(1);
     expect(fillerState.has(makeValidPlayerTag(0))).toBe(true);
     expect(fillerState.has(makeValidPlayerTag(1))).toBe(false);
-    const selectAlphaPayload = selectAlpha.update.mock.calls.at(-1)?.[0];
+    const selectAlphaPayload = getLastMessageEditPayload(interaction);
     const selectAlphaEmbed = getEmbedJson(selectAlphaPayload);
     expect(String(selectAlphaEmbed.description)).toContain("Alpha");
     expect(String(selectAlphaEmbed.footer?.text)).toContain("1/26 filler accounts selected");
@@ -798,7 +842,7 @@ describe("/fillers command", () => {
     });
     await secondSession.__collectorHandlers.collect(nextInteraction);
 
-    const nextPayload = nextInteraction.update.mock.calls.at(-1)?.[0];
+    const nextPayload = getLastMessageEditPayload(secondSession);
     const nextComponents = getComponentJson(nextPayload);
     const nextMenu = nextComponents[0].components[0];
     const secondSelection = [
@@ -935,7 +979,7 @@ describe("/fillers command", () => {
     });
     await interaction.__collectorHandlers.collect(nextInteraction);
 
-    const nextPayload = nextInteraction.update.mock.calls.at(-1)?.[0];
+    const nextPayload = nextInteraction.update.mock.calls.at(-1)?.[0] ?? {};
     const nextEmbed = getEmbedJson(nextPayload);
     expect(String(nextEmbed.description)).toContain(
       "Clan membership uses saved account data. If accounts are missing after moving clans, run /accounts and Refresh.",
@@ -952,7 +996,7 @@ describe("/fillers command", () => {
     });
     await interaction.__collectorHandlers.collect(prevInteraction);
 
-    const prevPayload = prevInteraction.update.mock.calls.at(-1)?.[0];
+    const prevPayload = prevInteraction.update.mock.calls.at(-1)?.[0] ?? {};
     const prevEmbed = getEmbedJson(prevPayload);
     expect(String(prevEmbed.description)).toContain(
       "Clan membership uses saved account data. If accounts are missing after moving clans, run /accounts and Refresh.",


### PR DESCRIPTION
Harden the `/fillers set` editor collector so stale Discord interactions do not crash the bot.

Changes:
- acknowledge component interactions quickly with `deferUpdate()`
- edit the fetched message instead of replying from the collector fallback
- suppress `10062 Unknown interaction` and `40060 already acknowledged` in collector error paths
- add regression coverage for stale collector interactions

Verified with:
- `npx vitest run tests/fillers.command.test.ts`
- `npx tsc --noEmit`