### PR TITLE
feat(compo): add /compo place response diagnostics

### DIFF
--- a/src/commands/Compo.ts
+++ b/src/commands/Compo.ts
@@ -282,13 +282,69 @@ function summarizeDiscordRestError(error: unknown): Record<string, unknown> {
   };
 }
 
+function findFirstValidationPath(
+  value: unknown,
+  trail: string[] = [],
+): string | null {
+  if (value == null) {
+    return trail.length > 0 ? trail.join(".") : null;
+  }
+  if (Array.isArray(value)) {
+    for (let index = 0; index < value.length; index += 1) {
+      const nested = findFirstValidationPath(value[index], [...trail, String(index)]);
+      if (nested) return nested;
+    }
+    return trail.length > 0 ? trail.join(".") : null;
+  }
+  if (typeof value !== "object") {
+    return trail.length > 0 ? trail.join(".") : null;
+  }
+  const entries = Object.entries(value as Record<string, unknown>);
+  if (entries.length === 0) {
+    return trail.length > 0 ? trail.join(".") : null;
+  }
+  for (const [key, current] of entries) {
+    const nextTrail = [...trail, key];
+    if (current && typeof current === "object") {
+      const nested = findFirstValidationPath(current, nextTrail);
+      if (nested) return nested;
+    }
+    if (current !== undefined && (current === null || typeof current !== "object")) {
+      return nextTrail.join(".");
+    }
+  }
+  return trail.length > 0 ? trail.join(".") : null;
+}
+
+function getDiscordValidationPath(errorSummary: Record<string, unknown>): string | null {
+  const candidates = [
+    errorSummary.responseData,
+    errorSummary.errors,
+    errorSummary.rawError,
+  ];
+  for (const candidate of candidates) {
+    const path = findFirstValidationPath(candidate);
+    if (path) return path;
+  }
+  return null;
+}
+
 function logCompoPlaceSendFailure(input: {
   interaction: ChatInputCommandInteraction;
   attemptedMethod: "editReply" | "followUp" | "reply";
   payloadMetrics: ReturnType<typeof summarizeCompoPlacePayloadMetrics>;
   error: unknown;
+  durationMs?: number;
 }): void {
   const telemetryContext = getTelemetryContext();
+  const errorSummary = summarizeDiscordRestError(input.error);
+  const validationPath =
+    typeof errorSummary === "object" && errorSummary !== null
+      ? getDiscordValidationPath(errorSummary)
+      : null;
+  console.error(
+    `[compo-command-error] stage=response_send_failed_header command=compo subcommand=place guildId=${input.interaction.guildId ?? null} userId=${input.interaction.user.id} interactionId=${input.interaction.id} runId=${telemetryContext?.runId ?? null} method=${input.attemptedMethod} deferred=${Boolean(input.interaction.deferred)} replied=${Boolean(input.interaction.replied)} errorName=${String(errorSummary.name ?? "")} errorMessage=${String(errorSummary.message ?? "")} code=${String(errorSummary.code ?? "")} status=${String(errorSummary.status ?? "")} validationPath=${String(validationPath ?? "")} durationMs=${String(input.durationMs ?? "")}`,
+  );
   const details = {
     command: "compo",
     subcommand: "place",
@@ -299,7 +355,9 @@ function logCompoPlaceSendFailure(input: {
     deferred: Boolean(input.interaction.deferred),
     replied: Boolean(input.interaction.replied),
     method: input.attemptedMethod,
-    error: summarizeDiscordRestError(input.error),
+    durationMs: input.durationMs ?? null,
+    validationPath,
+    error: errorSummary,
     payload: input.payloadMetrics,
   };
   console.error(
@@ -2541,18 +2599,43 @@ export const Compo: Command = {
     );
     if (subcommandHint === "place" && !interaction.deferred && !interaction.replied) {
       logCompoStage(interaction, "before_defer");
+      const deferStartedAt = Date.now();
+      const deferBeforeDeferred = Boolean(interaction.deferred);
+      const deferBeforeReplied = Boolean(interaction.replied);
+      logCompoStage(interaction, "defer_attempt", {
+        method: "deferReply",
+        deferredBefore: deferBeforeDeferred,
+        repliedBefore: deferBeforeReplied,
+        isPublic,
+      });
       try {
         await interaction.deferReply(
           isPublic ? {} : { flags: MessageFlags.Ephemeral },
         );
         logCompoStage(interaction, "after_defer");
+        logCompoStage(interaction, "defer_success", {
+          method: "deferReply",
+          durationMs: Date.now() - deferStartedAt,
+          deferredBefore: deferBeforeDeferred,
+          repliedBefore: deferBeforeReplied,
+          deferredAfter: Boolean(interaction.deferred),
+          repliedAfter: Boolean(interaction.replied),
+          isPublic,
+        });
         logCompoStage(interaction, "defer_reply_ok");
       } catch (err) {
         logCompoPlaceStageFailure({
           interaction,
-          stage: "defer_reply",
+          stage: "defer",
           error: err,
-          detail: { isPublic },
+          detail: {
+            isPublic,
+            durationMs: Date.now() - deferStartedAt,
+            deferredBefore: deferBeforeDeferred,
+            repliedBefore: deferBeforeReplied,
+            deferredAfter: Boolean(interaction.deferred),
+            repliedAfter: Boolean(interaction.replied),
+          },
         });
         throw err;
       }
@@ -2920,6 +3003,15 @@ export const Compo: Command = {
           embeds: placeResponsePayload.embeds,
           components: placeResponsePayload.components,
         });
+        const responseSendStartedAt = Date.now();
+        logCompoStage(interaction, "response_send_attempt", {
+          method: "editReply",
+          deferred: Boolean(interaction.deferred),
+          replied: Boolean(interaction.replied),
+          embedCount: placeResponseMetrics.embedCount,
+          componentRowCount: placeResponseMetrics.componentRowCount,
+          payloadJsonLength: placeResponseMetrics.payloadJsonLength,
+        });
         try {
           await interaction.editReply(placeResponsePayload);
         } catch (sendErr) {
@@ -2928,6 +3020,7 @@ export const Compo: Command = {
             attemptedMethod: "editReply",
             payloadMetrics: placeResponseMetrics,
             error: sendErr,
+            durationMs: Date.now() - responseSendStartedAt,
           });
           placeOutcome = "response_send_failed";
           throw sendErr;
@@ -2935,7 +3028,9 @@ export const Compo: Command = {
         logCompoStage(interaction, "response_sent_success", {
           method: "editReply",
           embedCount: placeResponseMetrics.embedCount,
+          componentRowCount: placeResponseMetrics.componentRowCount,
           componentCount: placeResponseMetrics.componentRowCount,
+          durationMs: Date.now() - responseSendStartedAt,
         });
         logCompoStage(interaction, "response_sent", {
           reason:

--- a/tests/compoPlace.command.test.ts
+++ b/tests/compoPlace.command.test.ts
@@ -29,6 +29,20 @@ function makeInteraction(weight: string) {
   return interaction;
 }
 
+function captureConsoleLogs() {
+  const captured: Array<{ level: "log" | "error" | "info"; text: string }> = [];
+  const logSpy = vi.spyOn(console, "log").mockImplementation((...args) => {
+    captured.push({ level: "log", text: args.map((value) => String(value)).join(" ") });
+  });
+  const errorSpy = vi.spyOn(console, "error").mockImplementation((...args) => {
+    captured.push({ level: "error", text: args.map((value) => String(value)).join(" ") });
+  });
+  const infoSpy = vi.spyOn(console, "info").mockImplementation((...args) => {
+    captured.push({ level: "info", text: args.map((value) => String(value)).join(" ") });
+  });
+  return { captured, logSpy, errorSpy, infoSpy };
+}
+
 function getComponentCustomIds(payload: unknown): string[] {
   if (!payload || typeof payload !== "object") return [];
   const rows = Array.isArray((payload as { components?: unknown[] }).components)
@@ -82,6 +96,7 @@ describe("/compo place command", () => {
   });
 
   it("uses the place service, keeps sheet access out of the command layer, and restores the place refresh button", async () => {
+    const { captured, logSpy, errorSpy, infoSpy } = captureConsoleLogs();
     const readPlaceSpy = vi
       .spyOn(CompoPlaceService.prototype, "readPlace")
       .mockResolvedValue({
@@ -122,6 +137,36 @@ describe("/compo place command", () => {
       label: "Refresh Data",
       disabled: false,
     });
+
+    const deferAttemptIndex = captured.findIndex((entry) =>
+      entry.text.includes("stage=defer_attempt"),
+    );
+    const deferSuccessIndex = captured.findIndex((entry) =>
+      entry.text.includes("stage=defer_success"),
+    );
+    const responseSendAttemptIndex = captured.findIndex((entry) =>
+      entry.text.includes("stage=response_send_attempt"),
+    );
+    const responseSentSuccessIndex = captured.findIndex((entry) =>
+      entry.text.includes("stage=response_sent_success") &&
+      entry.text.includes("method=editReply"),
+    );
+    const placeReturnSuccessIndex = captured.findIndex((entry) =>
+      entry.text.includes("stage=place_return_success"),
+    );
+    expect(deferAttemptIndex).toBeGreaterThanOrEqual(0);
+    expect(deferSuccessIndex).toBeGreaterThanOrEqual(0);
+    expect(responseSendAttemptIndex).toBeGreaterThanOrEqual(0);
+    expect(responseSentSuccessIndex).toBeGreaterThanOrEqual(0);
+    expect(placeReturnSuccessIndex).toBeGreaterThanOrEqual(0);
+    expect(deferAttemptIndex).toBeLessThan(deferSuccessIndex);
+    expect(deferSuccessIndex).toBeLessThan(responseSendAttemptIndex);
+    expect(responseSendAttemptIndex).toBeLessThan(responseSentSuccessIndex);
+    expect(responseSentSuccessIndex).toBeLessThan(placeReturnSuccessIndex);
+
+    logSpy.mockRestore();
+    errorSpy.mockRestore();
+    infoSpy.mockRestore();
   });
 
   it("maps lower persisted weight buckets into the stable <=TH13 place bucket", async () => {
@@ -156,16 +201,7 @@ describe("/compo place command", () => {
   });
 
   it("logs the raw run_catch error before the fallback response build when place throws", async () => {
-    const captured: Array<{ level: "log" | "error"; message: unknown[] }> = [];
-    const infoSpy = vi.spyOn(console, "info").mockImplementation((...args) => {
-      captured.push({ level: "log", message: args });
-    });
-    const logSpy = vi.spyOn(console, "log").mockImplementation((...args) => {
-      captured.push({ level: "log", message: args });
-    });
-    const errorSpy = vi.spyOn(console, "error").mockImplementation((...args) => {
-      captured.push({ level: "error", message: args });
-    });
+    const { captured, logSpy, errorSpy, infoSpy } = captureConsoleLogs();
     const readPlaceSpy = vi
       .spyOn(CompoPlaceService.prototype, "readPlace")
       .mockRejectedValue(new Error("boom"));
@@ -177,40 +213,34 @@ describe("/compo place command", () => {
     const runEntrySyncIndex = captured.findIndex(
       (entry) =>
         entry.level === "error" &&
-        entry.message.some((part) => String(part).includes("stage=run_entry_sync")),
+        entry.text.includes("stage=run_entry_sync"),
     );
     const runEntryIndex = captured.findIndex(
       (entry) =>
         entry.level === "log" &&
-        entry.message.some((part) => String(part).includes("stage=run_entry command=")),
+        entry.text.includes("stage=run_entry command="),
     );
     const rawIndex = captured.findIndex(
       (entry) =>
         entry.level === "error" &&
-        entry.message.some(
-          (part) =>
-            String(part).includes("stage=place_error_raw") ||
-            String(part).includes("stage=run_catch_raw"),
-        ),
+        (entry.text.includes("stage=place_error_raw") ||
+          entry.text.includes("stage=run_catch_raw")),
     );
     const fallbackReturnIndex = captured.findIndex(
       (entry) =>
         entry.level === "log" &&
-        entry.message.some((part) => String(part).includes("stage=place_return_error_fallback")),
+        entry.text.includes("stage=place_return_error_fallback"),
     );
     const fallbackBuildIndex = captured.findIndex(
       (entry) =>
         entry.level === "log" &&
-        entry.message.some(
-          (part) =>
-            String(part).includes("stage=response_build") &&
-            String(part).includes("reason=run_catch"),
-        ),
+        entry.text.includes("stage=response_build") &&
+        entry.text.includes("reason=run_catch"),
     );
     const finallyIndex = captured.findIndex(
       (entry) =>
         entry.level === "log" &&
-        entry.message.some((part) => String(part).includes("stage=place_finally")),
+        entry.text.includes("stage=place_finally"),
     );
     expect(runEntrySyncIndex).toBeGreaterThanOrEqual(0);
     expect(runEntryIndex).toBeGreaterThanOrEqual(0);
@@ -223,6 +253,114 @@ describe("/compo place command", () => {
     expect(rawIndex).toBeLessThan(fallbackBuildIndex);
     expect(fallbackReturnIndex).toBeLessThan(fallbackBuildIndex);
     expect(fallbackBuildIndex).toBeLessThan(finallyIndex);
+
+    logSpy.mockRestore();
+    infoSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it("logs defer attempt, success, and defer failure details when deferReply rejects", async () => {
+    const { captured, logSpy, errorSpy, infoSpy } = captureConsoleLogs();
+    const deferError = Object.assign(new Error("defer failed"), {
+      name: "DiscordAPIError",
+      code: 40060,
+      status: 400,
+      rawError: { message: "already acknowledged" },
+      response: { data: { message: "already acknowledged" } },
+      requestBody: { json: { flags: 64 } },
+    });
+    const readPlaceSpy = vi
+      .spyOn(CompoPlaceService.prototype, "readPlace")
+      .mockResolvedValue({
+        content: "",
+        embeds: [new EmbedBuilder().setTitle("Compo Placement Suggestions")],
+        trackedClanTags: [],
+        eligibleClanTags: [],
+        candidateCount: 0,
+        recommendedCount: 0,
+        vacancyCount: 0,
+        compositionCount: 0,
+      });
+
+    const interaction = makeInteraction("145k");
+    interaction.deferReply.mockRejectedValueOnce(deferError);
+
+    await expect(Compo.run({} as any, interaction as any, {} as any)).rejects.toThrow(
+      "defer failed",
+    );
+
+    expect(readPlaceSpy).not.toHaveBeenCalled();
+    expect(captured.some((entry) => entry.text.includes("stage=defer_attempt"))).toBe(true);
+    expect(captured.some((entry) => entry.text.includes("stage=defer_failed"))).toBe(true);
+    const attemptIndex = captured.findIndex((entry) => entry.text.includes("stage=defer_attempt"));
+    const failedIndex = captured.findIndex((entry) => entry.text.includes("stage=defer_failed"));
+    expect(attemptIndex).toBeGreaterThanOrEqual(0);
+    expect(failedIndex).toBeGreaterThan(attemptIndex);
+
+    logSpy.mockRestore();
+    infoSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it("logs response_send_failed_header before the detailed payload dump when editReply rejects", async () => {
+    const { captured, logSpy, errorSpy, infoSpy } = captureConsoleLogs();
+    const sendError = Object.assign(new Error("embed failure"), {
+      name: "DiscordAPIError",
+      code: 50035,
+      status: 400,
+      rawError: {
+        message: "Invalid Form Body",
+        embeds: { _errors: [{ code: "BASE_TYPE_BAD_LENGTH", message: "too long" }] },
+      },
+      response: {
+        data: {
+          message: "Invalid Form Body",
+          embeds: { _errors: [{ code: "BASE_TYPE_BAD_LENGTH", message: "too long" }] },
+        },
+      },
+      requestBody: { json: { embeds: [{ title: "Too long" }] } },
+    });
+    const readPlaceSpy = vi
+      .spyOn(CompoPlaceService.prototype, "readPlace")
+      .mockResolvedValue({
+        content: "",
+        embeds: [new EmbedBuilder().setTitle("Compo Placement Suggestions")],
+        trackedClanTags: ["#AAA111"],
+        eligibleClanTags: ["#AAA111"],
+        candidateCount: 1,
+        recommendedCount: 0,
+        vacancyCount: 0,
+        compositionCount: 1,
+      });
+
+    const interaction = makeInteraction("145k");
+    interaction.editReply.mockRejectedValueOnce(sendError).mockResolvedValueOnce(undefined);
+
+    await Compo.run({} as any, interaction as any, {} as any);
+
+    expect(readPlaceSpy).toHaveBeenCalled();
+    const attemptIndex = captured.findIndex((entry) =>
+      entry.text.includes("stage=response_send_attempt"),
+    );
+    const headerIndex = captured.findIndex((entry) =>
+      entry.text.includes("stage=response_send_failed_header"),
+    );
+    const failedIndex = captured.findIndex((entry) =>
+      entry.text.includes("stage=response_send_failed") &&
+      !entry.text.includes("stage=response_send_failed_header"),
+    );
+    const fallbackIndex = captured.findIndex((entry) =>
+      entry.text.includes("stage=place_return_error_fallback"),
+    );
+    const buildIndex = captured.findIndex((entry) =>
+      entry.text.includes("stage=response_build") &&
+      entry.text.includes("reason=run_catch"),
+    );
+    expect(attemptIndex).toBeGreaterThanOrEqual(0);
+    expect(headerIndex).toBeGreaterThan(attemptIndex);
+    expect(failedIndex).toBeGreaterThan(headerIndex);
+    expect(fallbackIndex).toBeGreaterThan(failedIndex);
+    expect(buildIndex).toBeGreaterThan(fallbackIndex);
 
     logSpy.mockRestore();
     infoSpy.mockRestore();


### PR DESCRIPTION
Adds compact defer and response-send diagnostics to `/compo place` so the final `editReply` path is always visible in prod logs.

Summary:
- logs defer attempt/success/failure with duration and state
- logs response send attempt/success/failure with compact header + detailed payload dump
- preserves existing place return breadcrumbs
- adds regressions for success, defer failure, and send failure logging

Scope:
- `src/commands/Compo.ts`
- `tests/compoPlace.command.test.ts`

No raids files were changed.