### PR TITLE
fix(compo): restore command dispatch acknowledgement

### DIFF
--- a/src/commands/Compo.ts
+++ b/src/commands/Compo.ts
@@ -2597,7 +2597,7 @@ export const Compo: Command = {
     console.error(
       `[compo-command] stage=run_after_is_public command=compo subcommand=${subcommandHint} isPublic=${isPublic} guild=${interaction.guildId ?? "DM"} user=${interaction.user.id} interactionId=${interaction.id} runId=`,
     );
-    if (subcommandHint === "place" && !interaction.deferred && !interaction.replied) {
+    if (!interaction.deferred && !interaction.replied) {
       logCompoStage(interaction, "before_defer");
       const deferStartedAt = Date.now();
       const deferBeforeDeferred = Boolean(interaction.deferred);

--- a/tests/compo.commandSheetRead.test.ts
+++ b/tests/compo.commandSheetRead.test.ts
@@ -147,6 +147,7 @@ describe("/compo advice command", () => {
     });
     await Compo.run({} as any, interaction as any, {} as any);
 
+    expect(interaction.deferReply).toHaveBeenCalledTimes(1);
     expect(readAdviceSpy).toHaveBeenCalledWith({
       guildId: "guild-1",
       targetTag: "LQQ99UV8",
@@ -314,6 +315,7 @@ describe("/compo advice command", () => {
     });
     await Compo.run({} as any, interaction as any, {} as any);
 
+    expect(interaction.deferReply).toHaveBeenCalledTimes(1);
     const payload = interaction.editReply.mock.calls.at(-1)?.[0];
     const embed = payload?.embeds?.[0]?.data ?? {};
     expect(JSON.stringify(embed?.fields ?? [])).toContain("Raw roster deficits:");
@@ -405,6 +407,7 @@ describe("/compo advice command", () => {
     });
     await Compo.run({} as any, interaction as any, {} as any);
 
+    expect(interaction.deferReply).toHaveBeenCalledTimes(1);
     const payload = interaction.editReply.mock.calls.at(-1)?.[0];
     expect(String(payload?.content ?? "")).toBe("RAW Data last refreshed: <t:1709900000:F>");
     expect(JSON.stringify(payload?.embeds?.[0]?.data?.fields ?? [])).toContain(
@@ -439,6 +442,7 @@ describe("/compo advice command", () => {
     });
     await Compo.run({} as any, interaction as any, {} as any);
 
+    expect(interaction.deferReply).toHaveBeenCalledTimes(1);
     const payload = interaction.editReply.mock.calls.at(-1)?.[0];
     expect(String(payload?.content ?? "")).toBe("RAW Data last refreshed: <t:1709900000:F>");
     expect(String(payload?.embeds?.[0]?.data?.description ?? "")).toContain(

--- a/tests/compoWarState.command.test.ts
+++ b/tests/compoWarState.command.test.ts
@@ -77,6 +77,7 @@ describe("/compo state mode:war DB cutover", () => {
     const interaction = makeInteraction({ subcommand: "state", mode: "war" });
     await Compo.run({} as any, interaction as any, {} as any);
 
+    expect(interaction.deferReply).toHaveBeenCalledTimes(1);
     expect(readStateSpy).toHaveBeenCalledTimes(1);
     expect(getSheetSpy).not.toHaveBeenCalled();
     expect(readSheetSpy).not.toHaveBeenCalled();
@@ -103,6 +104,7 @@ describe("/compo state mode:war DB cutover", () => {
     const interaction = makeInteraction({ subcommand: "state", mode: "war" });
     await Compo.run({} as any, interaction as any, {} as any);
 
+    expect(interaction.deferReply).toHaveBeenCalledTimes(1);
     const payload = interaction.editReply.mock.calls.at(-1)?.[0];
     expect(String(payload?.content ?? "")).toContain("No DB-backed WAR roster snapshots are currently renderable.");
     expect(Object.prototype.hasOwnProperty.call(payload, "files")).toBe(false);
@@ -128,6 +130,7 @@ describe("/compo state mode:war DB cutover", () => {
     const interaction = makeInteraction({ subcommand: "state", mode: "actual" });
     await Compo.run({} as any, interaction as any, {} as any);
 
+    expect(interaction.deferReply).toHaveBeenCalledTimes(1);
     expect(readStateSpy).not.toHaveBeenCalled();
     expect(actualReadStateSpy).toHaveBeenCalledTimes(1);
     expect(actualReadStateSpy).toHaveBeenCalledWith("guild-1", { view: "auto" });


### PR DESCRIPTION
Emergency regression fix for `/compo`.

Summary:
- moves the shared defer earlier so `advice`, `state`, `heatmapref`, and `place` all acknowledge before longer work
- keeps the existing place diagnostics intact
- updates command tests to assert the early defer behavior

Verified locally:
- `npx vitest run tests/compo.commandSheetRead.test.ts tests/compoWarState.command.test.ts tests/compoHeatMapRef.command.test.ts tests/compoPlace.command.test.ts tests/compoPlace.refresh.test.ts`
- `npx tsc --noEmit`

No raids files were changed.