### PR TITLE
revert(compo): promote stable place output to main

### DIFF
--- a/src/commands/Compo.ts
+++ b/src/commands/Compo.ts
@@ -37,11 +37,9 @@ import { formatHeatMapRefBandLabel, getHeatMapRefBandKey } from "../helper/compo
 import { formatError } from "../helper/formatError";
 import { getCompoWarDisplayBucket } from "../helper/compoWarWeightBuckets";
 import { normalizeCompoClanDisplayName } from "../helper/compoDisplay";
-import { getCachedTownHallEmojiMap } from "../helper/townHallEmoji";
 import { emojiResolverService } from "../services/emoji/EmojiResolverService";
 import { prisma } from "../prisma";
 import { safeReply } from "../helper/safeReply";
-import { summarizeDiscordEmbedText } from "../helper/embedTextBudget";
 import { CoCService } from "../services/CoCService";
 import {
   CompoAdviceService,
@@ -50,7 +48,6 @@ import {
 import { CompoActualStateService } from "../services/CompoActualStateService";
 import {
   CompoPlaceService,
-  ensureCompoPlaceEmbedsWithinBudgetForSend,
 } from "../services/CompoPlaceService";
 import { CompoWarStateService } from "../services/CompoWarStateService";
 import { buildFwaWeightPageUrl } from "../services/FwaStatsWeightService";
@@ -179,62 +176,6 @@ function getDiscordRestErrorStatus(error: unknown): number | null {
   return null;
 }
 
-type CompoPlaceEmbedMetrics = {
-  index: number;
-  titleLength: number;
-  descriptionLength: number;
-  authorNameLength: number;
-  footerTextLength: number;
-  fieldCount: number;
-  maxFieldNameLength: number;
-  maxFieldValueLength: number;
-  estimatedTextLength: number;
-  fieldLengths: Array<{ nameLength: number; valueLength: number }>;
-};
-
-function summarizeCompoPlacePayloadMetrics(input: {
-  content: string;
-  embeds: EmbedBuilder[];
-  components: Array<unknown>;
-}): {
-  embedCount: number;
-  componentRowCount: number;
-  payloadJsonLength: number;
-  embeds: CompoPlaceEmbedMetrics[];
-} {
-  const embeds = input.embeds.map((embed, index) => {
-    const json = embed.toJSON();
-    const metrics = summarizeDiscordEmbedText(json);
-    return {
-      index,
-      titleLength: metrics.titleLength,
-      descriptionLength: metrics.descriptionLength,
-      authorNameLength: metrics.authorNameLength,
-      footerTextLength: metrics.footerTextLength,
-      fieldCount: metrics.fieldCount,
-      maxFieldNameLength: metrics.maxFieldNameLength,
-      maxFieldValueLength: metrics.maxFieldValueLength,
-      estimatedTextLength: metrics.estimatedTextLength,
-      fieldLengths: metrics.fieldLengths,
-    };
-  });
-
-  return {
-    embedCount: input.embeds.length,
-    componentRowCount: input.components.length,
-    payloadJsonLength: JSON.stringify({
-      content: input.content,
-      embeds: input.embeds.map((embed) => embed.toJSON()),
-      components: input.components.map((component) =>
-        typeof (component as { toJSON?: () => unknown }).toJSON === "function"
-          ? (component as { toJSON: () => unknown }).toJSON()
-          : component,
-      ),
-    }).length,
-    embeds,
-  };
-}
-
 function summarizeDiscordRestError(error: unknown): Record<string, unknown> {
   const err = error as {
     name?: unknown;
@@ -282,114 +223,6 @@ function summarizeDiscordRestError(error: unknown): Record<string, unknown> {
   };
 }
 
-function findFirstValidationPath(
-  value: unknown,
-  trail: string[] = [],
-): string | null {
-  if (value == null) {
-    return trail.length > 0 ? trail.join(".") : null;
-  }
-  if (Array.isArray(value)) {
-    for (let index = 0; index < value.length; index += 1) {
-      const nested = findFirstValidationPath(value[index], [...trail, String(index)]);
-      if (nested) return nested;
-    }
-    return trail.length > 0 ? trail.join(".") : null;
-  }
-  if (typeof value !== "object") {
-    return trail.length > 0 ? trail.join(".") : null;
-  }
-  const entries = Object.entries(value as Record<string, unknown>);
-  if (entries.length === 0) {
-    return trail.length > 0 ? trail.join(".") : null;
-  }
-  for (const [key, current] of entries) {
-    const nextTrail = [...trail, key];
-    if (current && typeof current === "object") {
-      const nested = findFirstValidationPath(current, nextTrail);
-      if (nested) return nested;
-    }
-    if (current !== undefined && (current === null || typeof current !== "object")) {
-      return nextTrail.join(".");
-    }
-  }
-  return trail.length > 0 ? trail.join(".") : null;
-}
-
-function getDiscordValidationPath(errorSummary: Record<string, unknown>): string | null {
-  const candidates = [
-    errorSummary.responseData,
-    errorSummary.errors,
-    errorSummary.rawError,
-  ];
-  for (const candidate of candidates) {
-    const path = findFirstValidationPath(candidate);
-    if (path) return path;
-  }
-  return null;
-}
-
-function logCompoPlaceSendFailure(input: {
-  interaction: ChatInputCommandInteraction;
-  attemptedMethod: "editReply" | "followUp" | "reply";
-  payloadMetrics: ReturnType<typeof summarizeCompoPlacePayloadMetrics>;
-  error: unknown;
-  durationMs?: number;
-}): void {
-  const telemetryContext = getTelemetryContext();
-  const errorSummary = summarizeDiscordRestError(input.error);
-  const validationPath =
-    typeof errorSummary === "object" && errorSummary !== null
-      ? getDiscordValidationPath(errorSummary)
-      : null;
-  console.error(
-    `[compo-command-error] stage=response_send_failed_header command=compo subcommand=place guildId=${input.interaction.guildId ?? null} userId=${input.interaction.user.id} interactionId=${input.interaction.id} runId=${telemetryContext?.runId ?? null} method=${input.attemptedMethod} deferred=${Boolean(input.interaction.deferred)} replied=${Boolean(input.interaction.replied)} errorName=${String(errorSummary.name ?? "")} errorMessage=${String(errorSummary.message ?? "")} code=${String(errorSummary.code ?? "")} status=${String(errorSummary.status ?? "")} validationPath=${String(validationPath ?? "")} durationMs=${String(input.durationMs ?? "")}`,
-  );
-  const details = {
-    command: "compo",
-    subcommand: "place",
-    guildId: input.interaction.guildId ?? null,
-    userId: input.interaction.user.id,
-    interactionId: input.interaction.id,
-    runId: telemetryContext?.runId ?? null,
-    deferred: Boolean(input.interaction.deferred),
-    replied: Boolean(input.interaction.replied),
-    method: input.attemptedMethod,
-    durationMs: input.durationMs ?? null,
-    validationPath,
-    error: errorSummary,
-    payload: input.payloadMetrics,
-  };
-  console.error(
-    `[compo-command-error] stage=response_send_failed details=${safeDiagnosticJson(details, 30000, 1000)}`,
-  );
-}
-
-function logCompoPlaceStageFailure(input: {
-  interaction: ChatInputCommandInteraction;
-  stage: string;
-  error: unknown;
-  detail?: Record<string, string | number | boolean | null | undefined>;
-}): void {
-  const telemetryContext = getTelemetryContext();
-  const details = {
-    command: "compo",
-    subcommand: "place",
-    guildId: input.interaction.guildId ?? null,
-    userId: input.interaction.user.id,
-    interactionId: input.interaction.id,
-    runId: telemetryContext?.runId ?? null,
-    deferred: Boolean(input.interaction.deferred),
-    replied: Boolean(input.interaction.replied),
-    stage: input.stage,
-    error: summarizeDiscordRestError(input.error),
-    ...(input.detail ?? {}),
-  };
-  console.error(
-    `[compo-command-error] stage=${input.stage}_failed details=${safeDiagnosticJson(details, 30000, 1000)}`,
-  );
-}
-
 function logCompoRunCatchError(input: {
   interaction: ChatInputCommandInteraction;
   error: unknown;
@@ -408,27 +241,6 @@ function logCompoRunCatchError(input: {
   };
   console.error(
     `[compo-command-error] stage=run_catch_raw details=${safeDiagnosticJson(details, 30000, 1000)}`,
-  );
-}
-
-function logCompoPlaceErrorRaw(input: {
-  interaction: ChatInputCommandInteraction;
-  error: unknown;
-}): void {
-  const telemetryContext = getTelemetryContext();
-  const details = {
-    command: "compo",
-    subcommand: "place",
-    guildId: input.interaction.guildId ?? null,
-    userId: input.interaction.user.id,
-    interactionId: input.interaction.id,
-    runId: telemetryContext?.runId ?? null,
-    deferred: Boolean(input.interaction.deferred),
-    replied: Boolean(input.interaction.replied),
-    error: summarizeDiscordRestError(input.error),
-  };
-  console.error(
-    `[compo-command-error] stage=place_error_raw details=${safeDiagnosticJson(details, 30000, 1000)}`,
   );
 }
 
@@ -2325,12 +2137,11 @@ export async function handleCompoRefreshButton(
       if (!bucket) {
         throw new Error("Invalid placement bucket for refresh.");
       }
-        const placeResult = await new CompoPlaceService().refreshPlace(
-          parsed.weight,
-          bucket,
-          interaction.guildId ?? null,
-          getCachedTownHallEmojiMap(),
-        );
+      const placeResult = await new CompoPlaceService().refreshPlace(
+        parsed.weight,
+        bucket,
+        interaction.guildId ?? null,
+      );
       await interaction.editReply({
         content: placeResult.content,
         embeds: placeResult.embeds,
@@ -2572,120 +2383,17 @@ export const Compo: Command = {
     interaction: ChatInputCommandInteraction,
     _cocService: CoCService,
   ) => {
-    console.error(
-      `[compo-command] stage=run_entry_sync command=compo subcommand=${interaction.options.getSubcommand(false) ?? ""} guild=${interaction.guildId ?? "DM"} user=${interaction.user.id} interactionId=${interaction.id} runId=`,
-    );
-    console.error(
-      `[compo-command] stage=run_after_entry_sync_1 command=compo subcommand=${interaction.options.getSubcommand(false) ?? ""} guild=${interaction.guildId ?? "DM"} user=${interaction.user.id} interactionId=${interaction.id} runId=`,
-    );
-    console.error(
-      `[compo-command] stage=run_before_subcommand_hint command=compo subcommand=${interaction.options.getSubcommand(false) ?? ""} guild=${interaction.guildId ?? "DM"} user=${interaction.user.id} interactionId=${interaction.id} runId=`,
-    );
-    const subcommandHint = getSubcommandSafe(interaction);
-    console.error(
-      `[compo-command] stage=run_after_subcommand_hint command=compo subcommand=${subcommandHint} guild=${interaction.guildId ?? "DM"} user=${interaction.user.id} interactionId=${interaction.id} runId=`,
-    );
-    console.error(
-      `[compo-command] stage=run_before_visibility_read command=compo subcommand=${subcommandHint} guild=${interaction.guildId ?? "DM"} user=${interaction.user.id} interactionId=${interaction.id} runId=`,
-    );
     const visibility =
       interaction.options.getString("visibility", false) ?? "private";
-    console.error(
-      `[compo-command] stage=run_after_visibility_read command=compo subcommand=${subcommandHint} visibility=${visibility} guild=${interaction.guildId ?? "DM"} user=${interaction.user.id} interactionId=${interaction.id} runId=`,
-    );
     const isPublic = visibility === "public";
-    console.error(
-      `[compo-command] stage=run_after_is_public command=compo subcommand=${subcommandHint} isPublic=${isPublic} guild=${interaction.guildId ?? "DM"} user=${interaction.user.id} interactionId=${interaction.id} runId=`,
-    );
     if (!interaction.deferred && !interaction.replied) {
-      logCompoStage(interaction, "before_defer");
-      const deferStartedAt = Date.now();
-      const deferBeforeDeferred = Boolean(interaction.deferred);
-      const deferBeforeReplied = Boolean(interaction.replied);
-      logCompoStage(interaction, "defer_attempt", {
-        method: "deferReply",
-        deferredBefore: deferBeforeDeferred,
-        repliedBefore: deferBeforeReplied,
-        isPublic,
-      });
-      try {
-        await interaction.deferReply(
-          isPublic ? {} : { flags: MessageFlags.Ephemeral },
-        );
-        logCompoStage(interaction, "after_defer");
-        logCompoStage(interaction, "defer_success", {
-          method: "deferReply",
-          durationMs: Date.now() - deferStartedAt,
-          deferredBefore: deferBeforeDeferred,
-          repliedBefore: deferBeforeReplied,
-          deferredAfter: Boolean(interaction.deferred),
-          repliedAfter: Boolean(interaction.replied),
-          isPublic,
-        });
-        logCompoStage(interaction, "defer_reply_ok");
-      } catch (err) {
-        logCompoPlaceStageFailure({
-          interaction,
-          stage: "defer",
-          error: err,
-          detail: {
-            isPublic,
-            durationMs: Date.now() - deferStartedAt,
-            deferredBefore: deferBeforeDeferred,
-            repliedBefore: deferBeforeReplied,
-            deferredAfter: Boolean(interaction.deferred),
-            repliedAfter: Boolean(interaction.replied),
-          },
-        });
-        throw err;
-      }
-    }
-    console.error(
-      `[compo-command] stage=run_before_telemetry_context command=compo subcommand=${subcommandHint} guild=${interaction.guildId ?? "DM"} user=${interaction.user.id} interactionId=${interaction.id} runId=`,
-    );
-    const telemetryContext = getTelemetryContext();
-    console.error(
-      `[compo-command] stage=run_after_telemetry_context command=compo subcommand=${subcommandHint} guild=${interaction.guildId ?? "DM"} user=${interaction.user.id} interactionId=${interaction.id} runId=${telemetryContext?.runId ?? ""}`,
-    );
-    let placeOutcome: string | null = null;
-    console.error(
-      `[compo-command] stage=run_after_place_outcome_init command=compo subcommand=${subcommandHint} guild=${interaction.guildId ?? "DM"} user=${interaction.user.id} interactionId=${interaction.id} runId=${telemetryContext?.runId ?? ""}`,
-    );
-    logCompoStage(interaction, "run_entry", {
-      interactionId: interaction.id,
-      runId: telemetryContext?.runId ?? null,
-    });
-    try {
-      console.error(
-        `[compo-command] stage=run_before_handler_enter command=compo subcommand=${subcommandHint} guild=${interaction.guildId ?? "DM"} user=${interaction.user.id} interactionId=${interaction.id} runId=${telemetryContext?.runId ?? ""}`,
+      await interaction.deferReply(
+        isPublic ? {} : { flags: MessageFlags.Ephemeral },
       );
-      logCompoStage(interaction, "handler_enter");
-
-      let subcommand = subcommandHint;
-      let mode: ReturnType<typeof readMode> = "actual";
-      try {
-        if (subcommand === "place") {
-          logCompoStage(interaction, "before_options_parse");
-        }
-        subcommand = interaction.options.getSubcommand(true);
-        mode = readMode(interaction);
-        if (subcommand === "place") {
-          logCompoStage(interaction, "after_options_parse");
-        }
-        logCompoStage(interaction, "options_parsed", {
-          mode,
-          tag: interaction.options.getString("tag", false) ?? "",
-          weight: interaction.options.getString("weight", false) ?? "",
-        });
-      } catch (err) {
-        logCompoPlaceStageFailure({
-          interaction,
-          stage: "options_parse",
-          error: err,
-          detail: { isPublic },
-        });
-        throw err;
-      }
+    }
+    try {
+      const subcommand = interaction.options.getSubcommand(true);
+      const mode = readMode(interaction);
 
       if (subcommand === "advice") {
         const tagInput = interaction.options.getString("tag", true);
@@ -2853,28 +2561,13 @@ export const Compo: Command = {
       }
 
       if (subcommand === "place") {
-        let rawWeight = "";
-        let inputWeight: number | null = null;
-        try {
-          logCompoStage(interaction, "before_weight_parse");
-          rawWeight = interaction.options.getString("weight", true);
-          inputWeight = parseWeightInput(rawWeight);
-          logCompoStage(interaction, "after_weight_parse");
-          logCompoStage(interaction, "computation_start", {
-            weightInput: rawWeight,
-            parsedWeight: inputWeight ?? "",
-          });
-        } catch (err) {
-          logCompoPlaceStageFailure({
-            interaction,
-            stage: "weight_parse",
-            error: err,
-            detail: { weightInput: rawWeight || null },
-          });
-          throw err;
-        }
+        const rawWeight = interaction.options.getString("weight", true);
+        const inputWeight = parseWeightInput(rawWeight);
+        logCompoStage(interaction, "computation_start", {
+          weightInput: rawWeight,
+          parsedWeight: inputWeight ?? "",
+        });
         if (!inputWeight || inputWeight <= 0) {
-          placeOutcome = "invalid_weight";
           logCompoStage(interaction, "response_build", {
             reason: "invalid_weight",
           });
@@ -2882,15 +2575,6 @@ export const Compo: Command = {
             ephemeral: !isPublic,
             content:
               "Invalid weight. Use formats like `145000`, `145,000`, or `145k`.",
-          });
-          logCompoStage(interaction, "response_sent_success", {
-            method:
-              interaction.deferred || interaction.replied ? "editReply" : "reply",
-            embedCount: 0,
-            componentCount: 0,
-          });
-          logCompoStage(interaction, "place_return_early", {
-            reason: "invalid_weight",
           });
           logCompoStage(interaction, "response_sent", {
             reason: "invalid_weight",
@@ -2900,7 +2584,6 @@ export const Compo: Command = {
 
         const bucket = getCompoWarDisplayBucket(inputWeight);
         if (!bucket) {
-          placeOutcome = "weight_out_of_range";
           logCompoStage(interaction, "response_build", {
             reason: "weight_out_of_range",
             parsedWeight: inputWeight,
@@ -2909,43 +2592,17 @@ export const Compo: Command = {
             ephemeral: !isPublic,
             content: "Weight is outside supported ranges for ACTUAL compo buckets.",
           });
-          logCompoStage(interaction, "response_sent_success", {
-            method:
-              interaction.deferred || interaction.replied ? "editReply" : "reply",
-            embedCount: 0,
-            componentCount: 0,
-          });
-          logCompoStage(interaction, "place_return_early", {
-            reason: "weight_out_of_range",
-          });
           logCompoStage(interaction, "response_sent", {
             reason: "weight_out_of_range",
           });
           return;
         }
 
-        let placeResult: Awaited<ReturnType<CompoPlaceService["readPlace"]>>;
-        try {
-          logCompoStage(interaction, "before_service_readPlace");
-          placeResult = await new CompoPlaceService().readPlace(
-            inputWeight,
-            bucket,
-            interaction.guildId ?? null,
-            getCachedTownHallEmojiMap(),
-          );
-          logCompoStage(interaction, "after_service_readPlace");
-        } catch (err) {
-          logCompoPlaceStageFailure({
-            interaction,
-            stage: "service_call",
-            error: err,
-            detail: {
-              parsedWeight: inputWeight,
-              bucket,
-            },
-          });
-          throw err;
-        }
+        const placeResult = await new CompoPlaceService().readPlace(
+          inputWeight,
+          bucket,
+          interaction.guildId ?? null,
+        );
         logCompoStage(interaction, "db_fetch", {
           entity: "actual_compo_place_source",
           mode: "actual",
@@ -2967,70 +2624,17 @@ export const Compo: Command = {
           vacancy: placeResult.vacancyCount,
           composition: placeResult.compositionCount,
         });
-        let placeResponseComponents: ReturnType<typeof buildCompoRefreshComponents>;
-        try {
-          placeResponseComponents = buildCompoRefreshComponents({
+        await interaction.editReply({
+          content: placeResult.content,
+          embeds: placeResult.embeds,
+          components: buildCompoRefreshComponents({
             refreshPayload: {
               kind: "place",
               userId: interaction.user.id,
               weight: inputWeight,
             },
             loading: false,
-          });
-        } catch (err) {
-          logCompoPlaceStageFailure({
-            interaction,
-            stage: "response_components",
-            error: err,
-            detail: {
-              parsedWeight: inputWeight,
-              bucket,
-            },
-          });
-          placeOutcome = placeOutcome ?? "response_components_failed";
-          throw err;
-        }
-        const safePlaceEmbeds = ensureCompoPlaceEmbedsWithinBudgetForSend(
-          placeResult.embeds,
-        );
-        const placeResponsePayload = {
-          content: placeResult.content,
-          embeds: safePlaceEmbeds,
-          components: placeResponseComponents,
-        };
-        const placeResponseMetrics = summarizeCompoPlacePayloadMetrics({
-          content: placeResponsePayload.content ?? "",
-          embeds: placeResponsePayload.embeds,
-          components: placeResponsePayload.components,
-        });
-        const responseSendStartedAt = Date.now();
-        logCompoStage(interaction, "response_send_attempt", {
-          method: "editReply",
-          deferred: Boolean(interaction.deferred),
-          replied: Boolean(interaction.replied),
-          embedCount: placeResponseMetrics.embedCount,
-          componentRowCount: placeResponseMetrics.componentRowCount,
-          payloadJsonLength: placeResponseMetrics.payloadJsonLength,
-        });
-        try {
-          await interaction.editReply(placeResponsePayload);
-        } catch (sendErr) {
-          logCompoPlaceSendFailure({
-            interaction,
-            attemptedMethod: "editReply",
-            payloadMetrics: placeResponseMetrics,
-            error: sendErr,
-            durationMs: Date.now() - responseSendStartedAt,
-          });
-          placeOutcome = "response_send_failed";
-          throw sendErr;
-        }
-        logCompoStage(interaction, "response_sent_success", {
-          method: "editReply",
-          embedCount: placeResponseMetrics.embedCount,
-          componentRowCount: placeResponseMetrics.componentRowCount,
-          componentCount: placeResponseMetrics.componentRowCount,
-          durationMs: Date.now() - responseSendStartedAt,
+          }),
         });
         logCompoStage(interaction, "response_sent", {
           reason:
@@ -3038,14 +2642,6 @@ export const Compo: Command = {
               ? "no_candidates"
               : "placement_result",
         });
-        logCompoStage(interaction, "place_return_success", {
-          reason:
-            placeResult.candidateCount === 0
-              ? "no_candidates"
-              : "placement_result",
-        });
-        placeOutcome =
-          placeResult.candidateCount === 0 ? "no_candidates" : "placement_result";
         return;
       }
 
@@ -3061,22 +2657,10 @@ export const Compo: Command = {
       });
       return;
     } catch (err) {
-      if (getSubcommandSafe(interaction) === "place" && placeOutcome == null) {
-        placeOutcome = "run_catch";
-      }
       logCompoRunCatchError({
         interaction,
         error: err,
       });
-      if (getSubcommandSafe(interaction) === "place") {
-        logCompoPlaceErrorRaw({
-          interaction,
-          error: err,
-        });
-        logCompoStage(interaction, "place_return_error_fallback", {
-          reason: "run_catch",
-        });
-      }
       console.error(`compo command failed: ${formatError(err)}`);
       console.error(
         `[compo-command-error] stage=run_catch subcommand=${getSubcommandSafe(interaction)} error=${formatError(err)}`,
@@ -3111,16 +2695,6 @@ export const Compo: Command = {
                   : mapCompoSheetErrorToMessage(err),
       });
       logCompoStage(interaction, "response_sent", { reason: "run_catch" });
-    } finally {
-      if (getSubcommandSafe(interaction) === "place") {
-        logCompoStage(interaction, "place_finally", {
-          interactionId: interaction.id,
-          runId: telemetryContext?.runId ?? null,
-          deferred: Boolean(interaction.deferred),
-          replied: Boolean(interaction.replied),
-          outcome: placeOutcome ?? "unknown",
-        });
-      }
     }
   },
   autocomplete: async (interaction: AutocompleteInteraction) => {

--- a/src/services/CompoPlaceService.ts
+++ b/src/services/CompoPlaceService.ts
@@ -6,34 +6,17 @@ import {
   collapseCompoWarBucketCountsForDisplay,
 } from "../helper/compoWarBucketCounts";
 import { type CompoWarDisplayBucket } from "../helper/compoWarWeightBuckets";
-import {
-  normalizeTownHallLevel,
-  renderTownHallIcon,
-  type TownHallEmojiMap,
-} from "../helper/townHallEmoji";
 import { prisma } from "../prisma";
-import { playerCurrentService } from "./PlayerCurrentService";
 import {
   loadCompoActualStateContext,
   type CompoActualStateClanContext,
 } from "./CompoActualStateService";
-import { FwaClanMembersSyncService } from "./fwa-feeds/FwaClanMembersSyncService";
-import { listFillerAccountTagsForGuild } from "./FillerAccountService";
-import { InactiveWarService, type InactiveWarSummary } from "./InactiveWarService";
-import { listPlayerLinksForClanMembers, normalizePlayerTag } from "./PlayerLinkService";
 import { normalizeTag } from "./war-events/core";
+import { FwaClanMembersSyncService } from "./fwa-feeds/FwaClanMembersSyncService";
 import {
   projectCompoActualStateView,
   type CompoActualStateProjection,
 } from "../helper/compoActualStateView";
-import {
-  DISCORD_EMBED_FIELD_VALUE_LIMIT,
-  isDiscordEmbedTextWithinLimits,
-  summarizeDiscordEmbedText,
-  truncateDiscordFieldName,
-  truncateDiscordFieldValue,
-  truncateDiscordMultilineText,
-} from "../helper/embedTextBudget";
 
 type PlacementCandidate = {
   clanName: string;
@@ -51,30 +34,6 @@ type PlacementCandidate = {
 type PlacementCandidateWithDelta = PlacementCandidate & {
   delta: number;
 };
-
-type ReplaceCandidate = {
-  clanName: string;
-  clanTag: string;
-  playerTag: string;
-  playerName: string;
-  townHall: number | null;
-  clanRole: "leader" | "coLeader" | null;
-  weight: number;
-  filler: boolean;
-  daysInactive: number | null;
-  warsMissed: number | null;
-  inactiveByDays: boolean;
-  inactiveByWars: boolean;
-  linkedDiscordUserId: string | null;
-};
-
-type ReplaceRowsResult = {
-  rows: string[];
-  metadataMayBeStale: boolean;
-};
-
-const REPLACE_FIELD_VALUE_LIMIT = DISCORD_EMBED_FIELD_VALUE_LIMIT;
-
 export type CompoPlaceReadResult = {
   content: string;
   embeds: EmbedBuilder[];
@@ -130,153 +89,17 @@ function formatPlacementRows(lines: string[]): string {
   return lines.length > 0 ? lines.join("\n") : "None";
 }
 
-function buildPlayerProfileMarkdownLink(
-  playerName: string | null,
-  playerTag: string,
-): string {
-  const normalizedTag = normalizePlayerTag(playerTag);
-  const label = String(playerName ?? "").trim() || normalizedTag || "Unknown Player";
-  if (!normalizedTag) return label;
-  const encodedTag = normalizedTag.replace(/^#/, "");
-  return `[${label}](<https://link.clashofclans.com/en/?action=OpenPlayerProfile&tag=${encodedTag}>)`;
-}
-
-function buildTrackedClanShortNameMap(rows: Array<{
-  tag: string;
-  shortName: string | null;
-}>): Map<string, string> {
-  const byTag = new Map<string, string>();
-  for (const row of rows) {
-    const tag = normalizeTag(row.tag);
-    if (!tag) continue;
-    const shortName = String(row.shortName ?? "").trim();
-    if (shortName) {
-      byTag.set(tag, shortName);
-      byTag.set(tag.replace(/^#/, ""), shortName);
-    }
-  }
-  return byTag;
-}
-
-function buildReplaceReasonText(candidate: ReplaceCandidate): string {
-  const parts: string[] = [];
-  if (candidate.filler) parts.push(":man_standing:");
-  if (candidate.daysInactive !== null || candidate.warsMissed !== null) {
-    parts.push(
-      `:zzz: ${Math.max(0, Math.trunc(candidate.daysInactive ?? 0))}d | :x: ${Math.max(
-        0,
-        Math.trunc(candidate.warsMissed ?? 0),
-      )}`,
-    );
-  }
-  return parts.join(" ").trim();
-}
-
-function buildReplaceClanPrefix(input: {
-  clanName: string;
-  clanTag: string;
-  shortNameByClanTag: Map<string, string>;
-}): string {
-  const clanTag = normalizeTag(input.clanTag);
-  const shortName = clanTag ? input.shortNameByClanTag.get(clanTag)?.trim() ?? "" : "";
-  const clanName = normalizePlaceClanDisplayName(String(input.clanName ?? ""));
-  return shortName || clanName || input.clanTag;
-}
-
-function normalizeClanMemberRole(input: unknown): "leader" | "coLeader" | null {
-  const normalized = String(input ?? "")
-    .trim()
-    .replace(/[\s_-]+/g, "")
-    .toLowerCase();
-  if (normalized === "leader") return "leader";
-  if (normalized === "coleader" || normalized === "coleadership") return "coLeader";
-  return null;
-}
-
-function truncateReplaceRow(line: string, limit = REPLACE_FIELD_VALUE_LIMIT): string {
-  if (line.length <= limit) return line;
-  if (limit <= 1) return "\u2026";
-  return `${line.slice(0, limit - 1).trimEnd()}\u2026`;
-}
-
-function paginateReplaceRows(lines: string[]): string[] {
-  const pages: string[] = [];
-  let current = "";
-
-  for (const rawLine of lines) {
-    const line = String(rawLine ?? "").trim();
-    if (!line) continue;
-
-    const next = current.length > 0 ? `${current}\n${line}` : line;
-    if (next.length <= REPLACE_FIELD_VALUE_LIMIT) {
-      current = next;
-      continue;
-    }
-
-    if (current.length > 0) {
-      pages.push(current);
-      current = "";
-    }
-
-    if (line.length <= REPLACE_FIELD_VALUE_LIMIT) {
-      current = line;
-      continue;
-    }
-
-    pages.push(truncateReplaceRow(line));
-  }
-
-  if (current.length > 0) {
-    pages.push(current);
-  }
-
-  return pages;
-}
-
-function cloneEmbed(embed: EmbedBuilder): EmbedBuilder {
-  return EmbedBuilder.from(embed.toJSON());
-}
-
-function isCompoPlaceEmbedWithinBudget(embed: EmbedBuilder): boolean {
-  return isDiscordEmbedTextWithinLimits(summarizeDiscordEmbedText(embed.toJSON()));
-}
-
-function normalizeCompoPlaceField(field: { name: string; value: string }): {
-  name: string;
-  value: string;
-  inline: false;
-} {
-  return {
-    name: truncateDiscordFieldName(String(field.name ?? "")),
-    value: truncateDiscordMultilineText(String(field.value ?? ""), REPLACE_FIELD_VALUE_LIMIT, {
-      suffix: " ... truncated to fit Discord limits",
-    }),
-    inline: false,
-  };
-}
-
-function buildCompoPlaceEmbedShell(params: {
+/** Purpose: preserve the existing `/compo place` embed structure while swapping the source to persisted ACTUAL data. */
+function buildCompoPlaceEmbed(params: {
   inputWeight: number;
   bucket: CompoWarDisplayBucket;
   modeLabel?: string;
   deltaLabel?: string;
-  refreshLine: string;
-}): EmbedBuilder {
-  return new EmbedBuilder().setTitle("Compo Placement Suggestions").setDescription(
-    `Mode: **${params.modeLabel ?? buildCompoPlaceModeLabel()}**\n` +
-      `Deltas: **${params.deltaLabel ?? buildCompoPlaceDeltaLabel()}**\n` +
-      `Weight: **${params.inputWeight.toLocaleString("en-US")}**\n` +
-      `Bucket: **${params.bucket}**\n` +
-      params.refreshLine,
-  );
-}
-
-function buildCompoPlaceCoreFields(params: {
-  bucket: CompoWarDisplayBucket;
   recommended: PlacementCandidateWithDelta[];
   vacancyList: PlacementCandidate[];
   compositionList: PlacementCandidateWithDelta[];
-}): Array<{ name: string; value: string; inline: false }> {
+  refreshLine: string;
+}): EmbedBuilder {
   const recommendedRows = params.recommended.map(
     (candidate) =>
       `${abbreviateClan(normalizePlaceClanDisplayName(candidate.clanName))} - needs ${Math.abs(candidate.delta)} ${params.bucket}`,
@@ -284,7 +107,9 @@ function buildCompoPlaceCoreFields(params: {
   const vacancyRows = params.vacancyList.map(
     (candidate) =>
       `${abbreviateClan(normalizePlaceClanDisplayName(candidate.clanName))} - ${
-        candidate.liveMemberCount !== null ? `${candidate.liveMemberCount}/50` : "unknown/50"
+        candidate.liveMemberCount !== null
+          ? `${candidate.liveMemberCount}/50`
+          : "unknown/50"
       }`,
   );
   const compositionRows = params.compositionList.map(
@@ -292,460 +117,32 @@ function buildCompoPlaceCoreFields(params: {
       `${abbreviateClan(normalizePlaceClanDisplayName(candidate.clanName))} - ${candidate.delta}`,
   );
 
-  return [
-    {
-      name: truncateDiscordFieldName("Recommended"),
-      value: truncateDiscordMultilineText(formatPlacementRows(recommendedRows), REPLACE_FIELD_VALUE_LIMIT, {
-        suffix: " ... truncated to fit Discord limits",
-      }),
-      inline: false,
-    },
-    {
-      name: truncateDiscordFieldName("Vacancy"),
-      value: truncateDiscordMultilineText(formatPlacementRows(vacancyRows), REPLACE_FIELD_VALUE_LIMIT, {
-        suffix: " ... truncated to fit Discord limits",
-      }),
-      inline: false,
-    },
-    {
-      name: truncateDiscordFieldName("Composition"),
-      value: truncateDiscordMultilineText(
-        formatPlacementRows(compositionRows),
-        REPLACE_FIELD_VALUE_LIMIT,
-        {
-          suffix: " ... truncated to fit Discord limits",
-        },
-      ),
-      inline: false,
-    },
-  ];
-}
-
-function buildCompoPlaceReplaceFields(replaceRows: string[]): Array<{ name: string; value: string; inline: false }> {
-  const replacePages = paginateReplaceRows(replaceRows);
-  return replacePages.map((value, index) => ({
-    name: truncateDiscordFieldName(`Replace ${index + 1}/${replacePages.length}`),
-    value: truncateDiscordFieldValue(value),
-    inline: false,
-  }));
-}
-
-function packCompoPlaceFieldsIntoEmbeds(params: {
-  shell: EmbedBuilder;
-  fields: Array<{ name: string; value: string; inline: false }>;
-}): EmbedBuilder[] {
-  const embeds: EmbedBuilder[] = [];
-  let current = cloneEmbed(params.shell);
-  current.setFields([]);
-
-  for (const rawField of params.fields) {
-    const field = normalizeCompoPlaceField(rawField);
-    const candidate = cloneEmbed(current);
-    candidate.addFields(field);
-    if (isCompoPlaceEmbedWithinBudget(candidate)) {
-      current = candidate;
-      continue;
-    }
-
-    if ((current.toJSON().fields?.length ?? 0) > 0) {
-      embeds.push(current);
-      current = cloneEmbed(params.shell);
-      current.setFields([]);
-      const freshCandidate = cloneEmbed(current);
-      freshCandidate.addFields(field);
-      if (isCompoPlaceEmbedWithinBudget(freshCandidate)) {
-        current = freshCandidate;
-        continue;
-      }
-    }
-
-    const safeField = normalizeCompoPlaceField({
-      name: field.name,
-      value: truncateDiscordMultilineText(field.value, REPLACE_FIELD_VALUE_LIMIT, {
-        suffix: " ... truncated to fit Discord limits",
-      }),
-    });
-    const fallbackCandidate = cloneEmbed(current);
-    fallbackCandidate.addFields(safeField);
-    if (isCompoPlaceEmbedWithinBudget(fallbackCandidate)) {
-      current = fallbackCandidate;
-      continue;
-    }
-
-    const noteEmbed = cloneEmbed(params.shell);
-    noteEmbed.setFooter({
-      text: "Some /compo place rows were truncated to fit Discord embed limits.",
-    });
-    if (isCompoPlaceEmbedWithinBudget(noteEmbed)) {
-      if ((current.toJSON().fields?.length ?? 0) > 0) {
-        embeds.push(current);
-      }
-      current = noteEmbed;
-      continue;
-    }
-
-    // Last-resort fallback: keep the current page and avoid sending invalid payloads.
-    if ((current.toJSON().fields?.length ?? 0) > 0) {
-      embeds.push(current);
-    }
-    current = cloneEmbed(params.shell);
-    current.setFields([]);
-    current.setFooter({
-      text: "Some /compo place rows were truncated to fit Discord embed limits.",
-    });
-  }
-
-  if ((current.toJSON().fields?.length ?? 0) > 0 || current.toJSON().footer) {
-    embeds.push(current);
-  }
-
-  return embeds;
-}
-
-function buildCompoPlaceTruncationNoteEmbed(shell: EmbedBuilder): EmbedBuilder {
-  const noteEmbed = cloneEmbed(shell);
-  noteEmbed.setFields([]);
-  noteEmbed.setFooter({
-    text: "Some /compo place rows were truncated to fit Discord embed limits.",
-  });
-  return noteEmbed;
-}
-
-function ensureCompoPlaceEmbedsWithinBudget(params: {
-  shell: EmbedBuilder;
-  embeds: EmbedBuilder[];
-}): EmbedBuilder[] {
-  const sanitized: EmbedBuilder[] = [];
-  for (const embed of params.embeds) {
-    if (isCompoPlaceEmbedWithinBudget(embed)) {
-      sanitized.push(embed);
-      continue;
-    }
-    const embedJson = embed.toJSON();
-    const fields = Array.isArray(embedJson.fields) ? embedJson.fields : [];
-    const repacked = packCompoPlaceFieldsIntoEmbeds({
-      shell: params.shell,
-      fields: fields.map((field) => ({
-        name: String(field?.name ?? ""),
-        value: String(field?.value ?? ""),
-        inline: false as const,
-      })),
-    });
-    if (repacked.length > 0 && repacked.every((candidate) => isCompoPlaceEmbedWithinBudget(candidate))) {
-      sanitized.push(...repacked);
-      continue;
-    }
-    sanitized.push(buildCompoPlaceTruncationNoteEmbed(params.shell));
-  }
-  return sanitized;
-}
-
-export function ensureCompoPlaceEmbedsWithinBudgetForSend(
-  embeds: EmbedBuilder[],
-): EmbedBuilder[] {
-  if (embeds.length === 0) {
-    return [];
-  }
-  const shell = cloneEmbed(embeds[0]);
-  shell.setFields([]);
-  return ensureCompoPlaceEmbedsWithinBudget({
-    shell,
-    embeds,
-  });
-}
-
-function buildSafeCompoPlaceEmbeds(params: {
-  inputWeight: number;
-  bucket: CompoWarDisplayBucket;
-  modeLabel?: string;
-  deltaLabel?: string;
-  recommended: PlacementCandidateWithDelta[];
-  vacancyList: PlacementCandidate[];
-  compositionList: PlacementCandidateWithDelta[];
-  replaceRows?: string[];
-  refreshLine: string;
-}): EmbedBuilder[] {
-  const shell = buildCompoPlaceEmbedShell({
-    inputWeight: params.inputWeight,
-    bucket: params.bucket,
-    modeLabel: params.modeLabel,
-    deltaLabel: params.deltaLabel,
-    refreshLine: params.refreshLine,
-  });
-  const fields = [
-    ...buildCompoPlaceCoreFields({
-      bucket: params.bucket,
-      recommended: params.recommended,
-      vacancyList: params.vacancyList,
-      compositionList: params.compositionList,
-    }),
-    ...buildCompoPlaceReplaceFields(params.replaceRows ?? []),
-  ];
-  const packedEmbeds = packCompoPlaceFieldsIntoEmbeds({ shell, fields });
-  const safeEmbeds = ensureCompoPlaceEmbedsWithinBudget({
-    shell,
-    embeds: packedEmbeds,
-  });
-  return safeEmbeds.length > 0 ? safeEmbeds : [shell];
-}
-
-async function buildReplaceRows(input: {
-  guildId: string | null | undefined;
-  bucket: CompoWarDisplayBucket;
-  clans: CompoActualStateClanContext[];
-  townHallEmojiByLevel: TownHallEmojiMap;
-}): Promise<ReplaceRowsResult> {
-  const sameBucketMembers = input.clans.flatMap((clan) =>
-    clan.members
-      .filter(
-        (member) =>
-          member.resolvedBucket === input.bucket &&
-          member.resolvedWeight !== null &&
-          member.resolvedWeight > 0,
-      )
-      .map((member) => ({
-        clanName: clan.clanName,
-        clanTag: clan.clanTag,
-        playerTag: member.playerTag,
-        playerName: member.playerName,
-        townHall: member.townHall,
-        weight: member.resolvedWeight ?? 0,
-      })),
-  );
-  if (sameBucketMembers.length === 0) {
-    return { rows: [], metadataMayBeStale: false };
-  }
-
-  const uniquePlayerTags = [...new Set(
-    sameBucketMembers
-      .map((member) => normalizePlayerTag(member.playerTag))
-      .filter((tag): tag is string => Boolean(tag)),
-  )];
-
-  const [fillerTags, activityRows, inactiveWarSummary, linkedRows, trackedClanRows, playerCurrentByTag, fwaCatalogRows] = await Promise.all([
-    input.guildId ? listFillerAccountTagsForGuild({ guildId: input.guildId }) : Promise.resolve([]),
-    input.guildId
-      ? prisma.playerActivity.findMany({
-          where: {
-            guildId: input.guildId,
-            tag: { in: uniquePlayerTags },
-          },
-          select: {
-            tag: true,
-            lastSeenAt: true,
-          },
-          orderBy: [{ tag: "asc" }, { lastSeenAt: "desc" }],
-        })
-      : Promise.resolve([] as Array<{ tag: string; lastSeenAt: Date }>),
-    input.guildId
-      ? new InactiveWarService().listInactiveWarPlayers({
-          guildId: input.guildId,
-          wars: 3,
-        })
-      : Promise.resolve(null as InactiveWarSummary | null),
-    listPlayerLinksForClanMembers({ memberTagsInOrder: uniquePlayerTags }),
-    prisma.trackedClan.findMany({
-      where: {
-        tag: {
-          in: input.clans.flatMap((clan) => {
-            const normalized = normalizeTag(clan.clanTag);
-            return normalized ? [normalized, normalized.replace(/^#/, "")] : [];
-          }),
-        },
+  return new EmbedBuilder()
+    .setTitle("Compo Placement Suggestions")
+    .setDescription(
+      `Mode: **${params.modeLabel ?? buildCompoPlaceModeLabel()}**\n` +
+        `Deltas: **${params.deltaLabel ?? buildCompoPlaceDeltaLabel()}**\n` +
+      `Weight: **${params.inputWeight.toLocaleString("en-US")}**\n` +
+        `Bucket: **${params.bucket}**\n` +
+        params.refreshLine,
+    )
+    .addFields(
+      {
+        name: "Recommended",
+        value: formatPlacementRows(recommendedRows),
+        inline: false,
       },
-      select: {
-        tag: true,
-        shortName: true,
+      {
+        name: "Vacancy",
+        value: formatPlacementRows(vacancyRows),
+        inline: false,
       },
-    }),
-    playerCurrentService.listPlayerCurrentByTags(uniquePlayerTags),
-    prisma.fwaPlayerCatalog.findMany({
-      where: { playerTag: { in: uniquePlayerTags } },
-      select: {
-        playerTag: true,
-        latestTownHall: true,
+      {
+        name: "Composition",
+        value: formatPlacementRows(compositionRows),
+        inline: false,
       },
-    }),
-  ]);
-
-  const fillerTagSet = new Set(
-    fillerTags.map((tag) => normalizePlayerTag(tag)).filter((tag): tag is string => Boolean(tag)),
-  );
-  const lastSeenByTag = new Map<string, Date>();
-  for (const row of activityRows as Array<{ tag: string; lastSeenAt: Date }>) {
-    const tag = normalizePlayerTag(row.tag);
-    if (!tag || lastSeenByTag.has(tag)) continue;
-    lastSeenByTag.set(tag, row.lastSeenAt);
-  }
-  const warsMissedByTag = new Map<string, number>();
-  const warRows = inactiveWarSummary?.results ?? [];
-  for (const row of warRows) {
-    const tag = normalizePlayerTag(row.playerTag);
-    const missedWars = Math.trunc(Number(row.missedWars));
-    if (!tag || !Number.isFinite(missedWars) || missedWars <= 0) continue;
-    warsMissedByTag.set(tag, missedWars);
-  }
-  const linkedDiscordUserIdByTag = new Map<string, string>();
-  for (const row of linkedRows) {
-    const tag = normalizePlayerTag(row.playerTag);
-    const discordUserId = String(row.discordUserId ?? "").trim();
-    if (!tag || !discordUserId) continue;
-    linkedDiscordUserIdByTag.set(tag, discordUserId);
-  }
-  const shortNameByClanTag = buildTrackedClanShortNameMap(
-    trackedClanRows as Array<{ tag: string; shortName: string | null }>,
-  );
-  const townHallByTag = new Map<string, number | null>();
-  for (const [playerTag, playerCurrent] of playerCurrentByTag.entries()) {
-    const playerCurrentTownHall = normalizeTownHallLevel(playerCurrent.townHall);
-    if (playerCurrentTownHall !== null) {
-      townHallByTag.set(playerTag, playerCurrentTownHall);
-    }
-  }
-  for (const row of fwaCatalogRows as Array<{ playerTag: string; latestTownHall: unknown }>) {
-    const playerTag = normalizePlayerTag(row.playerTag);
-    if (!playerTag || townHallByTag.get(playerTag) !== undefined) continue;
-    townHallByTag.set(playerTag, normalizeTownHallLevel(row.latestTownHall));
-  }
-
-  const candidates = sameBucketMembers
-    .map((member) => {
-      const playerTag = normalizePlayerTag(member.playerTag);
-      if (!playerTag) return null;
-      const filler = fillerTagSet.has(playerTag);
-      const lastSeenAt = lastSeenByTag.get(playerTag) ?? null;
-      const daysInactive =
-        lastSeenAt !== null
-          ? Math.max(0, Math.floor((Date.now() - lastSeenAt.getTime()) / (24 * 60 * 60 * 1000)))
-          : null;
-      const inactiveByDays = daysInactive !== null && daysInactive >= 7;
-      const warsMissed = warsMissedByTag.get(playerTag) ?? null;
-      const inactiveByWars = warsMissed !== null && warsMissed > 0;
-      if (!filler && !inactiveByDays && !inactiveByWars) {
-        return null;
-      }
-      return {
-        clanName: member.clanName,
-        clanTag: member.clanTag,
-        playerTag,
-        playerName: member.playerName,
-        townHall:
-          normalizeTownHallLevel(member.townHall) ??
-          townHallByTag.get(playerTag) ??
-          null,
-        clanRole: normalizeClanMemberRole(playerCurrentByTag.get(playerTag)?.role ?? null),
-        weight: member.weight,
-        filler,
-        daysInactive,
-        warsMissed,
-        inactiveByDays,
-        inactiveByWars,
-        linkedDiscordUserId: linkedDiscordUserIdByTag.get(playerTag) ?? null,
-      } satisfies ReplaceCandidate;
-    })
-    .filter((candidate): candidate is ReplaceCandidate => candidate !== null)
-    .sort((a, b) => {
-      const aScore =
-        (a.filler ? 1 : 0) +
-        (a.inactiveByDays ? 1 : 0) +
-        (a.inactiveByWars ? 1 : 0);
-      const bScore =
-        (b.filler ? 1 : 0) +
-        (b.inactiveByDays ? 1 : 0) +
-        (b.inactiveByWars ? 1 : 0);
-      if (bScore !== aScore) return bScore - aScore;
-      if ((b.daysInactive ?? -1) !== (a.daysInactive ?? -1)) {
-        return (b.daysInactive ?? -1) - (a.daysInactive ?? -1);
-      }
-      if ((b.warsMissed ?? -1) !== (a.warsMissed ?? -1)) {
-        return (b.warsMissed ?? -1) - (a.warsMissed ?? -1);
-      }
-      if (b.weight !== a.weight) return b.weight - a.weight;
-      const clanCompare = a.clanName.localeCompare(b.clanName);
-      if (clanCompare !== 0) return clanCompare;
-      const nameCompare = a.playerName.localeCompare(b.playerName);
-      if (nameCompare !== 0) return nameCompare;
-      return a.playerTag.localeCompare(b.playerTag);
-    });
-
-  const metadataMayBeStale =
-    input.townHallEmojiByLevel.size === 0 ||
-    candidates.some(
-      (candidate) => candidate.townHall === null || (candidate.filler && candidate.clanRole === null),
     );
-
-  return {
-    rows: candidates.map((candidate) => {
-    const clanPrefix = buildReplaceClanPrefix({
-      clanName: candidate.clanName,
-      clanTag: candidate.clanTag,
-      shortNameByClanTag,
-    });
-    const reason = buildReplaceReasonText(candidate);
-    const mention = candidate.linkedDiscordUserId
-      ? ` <@${candidate.linkedDiscordUserId}>`
-      : "";
-    const crown =
-      candidate.filler && candidate.clanRole ? ":crown: " : "";
-    return `${clanPrefix} ${renderTownHallIcon(
-      candidate.townHall,
-      input.townHallEmojiByLevel,
-    )} ${candidate.weight.toLocaleString("en-US")} ${reason} - ${buildPlayerProfileMarkdownLink(
-      candidate.playerName,
-      candidate.playerTag,
-    )} ${crown}\`${candidate.playerTag}\`${mention}`;
-    }),
-    metadataMayBeStale,
-  };
-}
-
-/** Purpose: preserve the existing `/compo place` embed structure while swapping the source to persisted ACTUAL data. */
-function buildCompoPlaceBaseEmbed(params: {
-  inputWeight: number;
-  bucket: CompoWarDisplayBucket;
-  modeLabel?: string;
-  deltaLabel?: string;
-  recommended: PlacementCandidateWithDelta[];
-  vacancyList: PlacementCandidate[];
-  compositionList: PlacementCandidateWithDelta[];
-  refreshLine: string;
-  includeCoreSections?: boolean;
-}): EmbedBuilder {
-  const embed = buildCompoPlaceEmbedShell({
-    inputWeight: params.inputWeight,
-    bucket: params.bucket,
-    modeLabel: params.modeLabel,
-    deltaLabel: params.deltaLabel,
-    refreshLine: params.refreshLine,
-  });
-
-  if (params.includeCoreSections ?? true) {
-    embed.addFields(
-      ...buildCompoPlaceCoreFields({
-        bucket: params.bucket,
-        recommended: params.recommended,
-        vacancyList: params.vacancyList,
-        compositionList: params.compositionList,
-      }),
-    );
-  }
-
-  return embed;
-}
-
-function buildCompoPlaceEmbeds(params: {
-  inputWeight: number;
-  bucket: CompoWarDisplayBucket;
-  modeLabel?: string;
-  deltaLabel?: string;
-  recommended: PlacementCandidateWithDelta[];
-  vacancyList: PlacementCandidate[];
-  compositionList: PlacementCandidateWithDelta[];
-  replaceRows?: string[];
-  refreshLine: string;
-}): EmbedBuilder[] {
-  const safeEmbeds = buildSafeCompoPlaceEmbeds(params);
-  return safeEmbeds;
 }
 
 function buildPersistedRefreshLine(latestSourceSyncedAt: Date | null): string {
@@ -844,7 +241,6 @@ export class CompoPlaceService {
     inputWeight: number,
     bucket: CompoWarDisplayBucket,
     guildId?: string | null,
-    townHallEmojiByLevel: TownHallEmojiMap = new Map(),
   ): Promise<CompoPlaceReadResult> {
     const context = await loadCompoActualStateContext(guildId ?? null);
     if (context.trackedClanTags.length === 0) {
@@ -907,30 +303,21 @@ export class CompoPlaceService {
       });
 
     const recommended = compositionNeeds.filter((candidate) => candidate.hasVacancy);
-    const replaceRows = await buildReplaceRows({
-      guildId,
-      bucket,
-      clans: context.clans,
-      townHallEmojiByLevel,
-    });
-    const replaceMetadataNote =
-      replaceRows.metadataMayBeStale && replaceRows.rows.length > 0
-        ? "Some replacement metadata may be stale/missing."
-        : "";
 
     return {
-      content: replaceMetadataNote,
-      embeds: buildCompoPlaceEmbeds({
+      content: "",
+      embeds: [
+        buildCompoPlaceEmbed({
           inputWeight,
           bucket,
           recommended,
           vacancyList,
           compositionList: compositionNeeds,
-          replaceRows: replaceRows.rows,
           refreshLine: buildPersistedRefreshLine(context.latestSourceSyncedAt),
           modeLabel: buildCompoPlaceModeLabel(),
           deltaLabel: buildCompoPlaceDeltaLabel(),
         }),
+      ],
       trackedClanTags: context.trackedClanTags,
       eligibleClanTags: candidates.map((candidate) => candidate.clanTag),
       candidateCount: candidates.length,
@@ -945,7 +332,6 @@ export class CompoPlaceService {
     inputWeight: number,
     bucket: CompoWarDisplayBucket,
     guildId?: string | null,
-    townHallEmojiByLevel: TownHallEmojiMap = new Map(),
   ): Promise<CompoPlaceReadResult> {
     const tracked = await prisma.trackedClan.findMany({
       orderBy: { createdAt: "asc" },
@@ -963,11 +349,10 @@ export class CompoPlaceService {
         trackedClanTags,
       );
     }
-    return this.readPlace(inputWeight, bucket, guildId, townHallEmojiByLevel);
+    return this.readPlace(inputWeight, bucket, guildId);
   }
 }
 
-export const buildCompoPlaceEmbedForTest = buildCompoPlaceBaseEmbed;
-export const buildCompoPlaceEmbedsForTest = buildCompoPlaceEmbeds;
+export const buildCompoPlaceEmbedForTest = buildCompoPlaceEmbed;
 export const buildBucketDeltaByHeaderForTest = buildBucketDeltaByHeader;
 export const resolvePlacementWeightForTest = resolveActualCompoWeight;

--- a/tests/compoPlace.command.test.ts
+++ b/tests/compoPlace.command.test.ts
@@ -1,13 +1,11 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+﻿import { beforeEach, describe, expect, it, vi } from "vitest";
 import { EmbedBuilder } from "discord.js";
 import { Compo } from "../src/commands/Compo";
 import { CompoPlaceService } from "../src/services/CompoPlaceService";
 import { GoogleSheetsService } from "../src/services/GoogleSheetsService";
-import { emojiResolverService } from "../src/services/emoji/EmojiResolverService";
 
 function makeInteraction(weight: string) {
   const interaction: any = {
-    id: "interaction-1",
     commandName: "compo",
     guildId: "guild-1",
     user: { id: "user-1" },
@@ -27,20 +25,6 @@ function makeInteraction(weight: string) {
     },
   };
   return interaction;
-}
-
-function captureConsoleLogs() {
-  const captured: Array<{ level: "log" | "error" | "info"; text: string }> = [];
-  const logSpy = vi.spyOn(console, "log").mockImplementation((...args) => {
-    captured.push({ level: "log", text: args.map((value) => String(value)).join(" ") });
-  });
-  const errorSpy = vi.spyOn(console, "error").mockImplementation((...args) => {
-    captured.push({ level: "error", text: args.map((value) => String(value)).join(" ") });
-  });
-  const infoSpy = vi.spyOn(console, "info").mockImplementation((...args) => {
-    captured.push({ level: "info", text: args.map((value) => String(value)).join(" ") });
-  });
-  return { captured, logSpy, errorSpy, infoSpy };
 }
 
 function getComponentCustomIds(payload: unknown): string[] {
@@ -96,7 +80,6 @@ describe("/compo place command", () => {
   });
 
   it("uses the place service, keeps sheet access out of the command layer, and restores the place refresh button", async () => {
-    const { captured, logSpy, errorSpy, infoSpy } = captureConsoleLogs();
     const readPlaceSpy = vi
       .spyOn(CompoPlaceService.prototype, "readPlace")
       .mockResolvedValue({
@@ -105,14 +88,10 @@ describe("/compo place command", () => {
         trackedClanTags: ["#AAA111"],
         eligibleClanTags: ["#AAA111"],
         candidateCount: 1,
-      recommendedCount: 0,
-      vacancyCount: 0,
-      compositionCount: 1,
-    });
-    const fetchEmojiSpy = vi.spyOn(
-      emojiResolverService,
-      "fetchApplicationEmojiInventory",
-    );
+        recommendedCount: 0,
+        vacancyCount: 0,
+        compositionCount: 1,
+      });
     const getCompoLinkedSheetSpy = vi.spyOn(
       GoogleSheetsService.prototype,
       "getCompoLinkedSheet",
@@ -125,8 +104,7 @@ describe("/compo place command", () => {
     const interaction = makeInteraction("145k");
     await Compo.run({} as any, interaction as any, {} as any);
 
-    expect(readPlaceSpy).toHaveBeenCalledWith(145000, "TH15", "guild-1", expect.any(Map));
-    expect(fetchEmojiSpy).not.toHaveBeenCalled();
+    expect(readPlaceSpy).toHaveBeenCalledWith(145000, "TH15", "guild-1");
     expect(getCompoLinkedSheetSpy).not.toHaveBeenCalled();
     expect(readCompoLinkedValuesSpy).not.toHaveBeenCalled();
 
@@ -137,36 +115,6 @@ describe("/compo place command", () => {
       label: "Refresh Data",
       disabled: false,
     });
-
-    const deferAttemptIndex = captured.findIndex((entry) =>
-      entry.text.includes("stage=defer_attempt"),
-    );
-    const deferSuccessIndex = captured.findIndex((entry) =>
-      entry.text.includes("stage=defer_success"),
-    );
-    const responseSendAttemptIndex = captured.findIndex((entry) =>
-      entry.text.includes("stage=response_send_attempt"),
-    );
-    const responseSentSuccessIndex = captured.findIndex((entry) =>
-      entry.text.includes("stage=response_sent_success") &&
-      entry.text.includes("method=editReply"),
-    );
-    const placeReturnSuccessIndex = captured.findIndex((entry) =>
-      entry.text.includes("stage=place_return_success"),
-    );
-    expect(deferAttemptIndex).toBeGreaterThanOrEqual(0);
-    expect(deferSuccessIndex).toBeGreaterThanOrEqual(0);
-    expect(responseSendAttemptIndex).toBeGreaterThanOrEqual(0);
-    expect(responseSentSuccessIndex).toBeGreaterThanOrEqual(0);
-    expect(placeReturnSuccessIndex).toBeGreaterThanOrEqual(0);
-    expect(deferAttemptIndex).toBeLessThan(deferSuccessIndex);
-    expect(deferSuccessIndex).toBeLessThan(responseSendAttemptIndex);
-    expect(responseSendAttemptIndex).toBeLessThan(responseSentSuccessIndex);
-    expect(responseSentSuccessIndex).toBeLessThan(placeReturnSuccessIndex);
-
-    logSpy.mockRestore();
-    errorSpy.mockRestore();
-    infoSpy.mockRestore();
   });
 
   it("maps lower persisted weight buckets into the stable <=TH13 place bucket", async () => {
@@ -182,188 +130,16 @@ describe("/compo place command", () => {
         vacancyCount: 0,
         compositionCount: 0,
       });
-    const fetchEmojiSpy = vi.spyOn(
-      emojiResolverService,
-      "fetchApplicationEmojiInventory",
-    );
 
     const interaction = makeInteraction("100000");
     await Compo.run({} as any, interaction as any, {} as any);
 
-    expect(readPlaceSpy).toHaveBeenCalledWith(100000, "<=TH13", "guild-1", expect.any(Map));
-    expect(fetchEmojiSpy).not.toHaveBeenCalled();
+    expect(readPlaceSpy).toHaveBeenCalledWith(100000, "<=TH13", "guild-1");
     const payload = interaction.editReply.mock.calls.at(-1)?.[0];
     expect(getComponentCustomIds(payload)).toEqual(["compo-refresh:place:user-1:100000"]);
     expect(getFirstButtonState(payload)).toEqual({
       label: "Refresh Data",
       disabled: false,
     });
-  });
-
-  it("logs the raw run_catch error before the fallback response build when place throws", async () => {
-    const { captured, logSpy, errorSpy, infoSpy } = captureConsoleLogs();
-    const readPlaceSpy = vi
-      .spyOn(CompoPlaceService.prototype, "readPlace")
-      .mockRejectedValue(new Error("boom"));
-
-    const interaction = makeInteraction("145k");
-    await Compo.run({} as any, interaction as any, {} as any);
-
-    expect(readPlaceSpy).toHaveBeenCalled();
-    const runEntrySyncIndex = captured.findIndex(
-      (entry) =>
-        entry.level === "error" &&
-        entry.text.includes("stage=run_entry_sync"),
-    );
-    const runEntryIndex = captured.findIndex(
-      (entry) =>
-        entry.level === "log" &&
-        entry.text.includes("stage=run_entry command="),
-    );
-    const rawIndex = captured.findIndex(
-      (entry) =>
-        entry.level === "error" &&
-        (entry.text.includes("stage=place_error_raw") ||
-          entry.text.includes("stage=run_catch_raw")),
-    );
-    const fallbackReturnIndex = captured.findIndex(
-      (entry) =>
-        entry.level === "log" &&
-        entry.text.includes("stage=place_return_error_fallback"),
-    );
-    const fallbackBuildIndex = captured.findIndex(
-      (entry) =>
-        entry.level === "log" &&
-        entry.text.includes("stage=response_build") &&
-        entry.text.includes("reason=run_catch"),
-    );
-    const finallyIndex = captured.findIndex(
-      (entry) =>
-        entry.level === "log" &&
-        entry.text.includes("stage=place_finally"),
-    );
-    expect(runEntrySyncIndex).toBeGreaterThanOrEqual(0);
-    expect(runEntryIndex).toBeGreaterThanOrEqual(0);
-    expect(rawIndex).toBeGreaterThanOrEqual(0);
-    expect(fallbackReturnIndex).toBeGreaterThanOrEqual(0);
-    expect(fallbackBuildIndex).toBeGreaterThanOrEqual(0);
-    expect(finallyIndex).toBeGreaterThanOrEqual(0);
-    expect(runEntrySyncIndex).toBeLessThan(runEntryIndex);
-    expect(runEntryIndex).toBeLessThan(rawIndex);
-    expect(rawIndex).toBeLessThan(fallbackBuildIndex);
-    expect(fallbackReturnIndex).toBeLessThan(fallbackBuildIndex);
-    expect(fallbackBuildIndex).toBeLessThan(finallyIndex);
-
-    logSpy.mockRestore();
-    infoSpy.mockRestore();
-    errorSpy.mockRestore();
-  });
-
-  it("logs defer attempt, success, and defer failure details when deferReply rejects", async () => {
-    const { captured, logSpy, errorSpy, infoSpy } = captureConsoleLogs();
-    const deferError = Object.assign(new Error("defer failed"), {
-      name: "DiscordAPIError",
-      code: 40060,
-      status: 400,
-      rawError: { message: "already acknowledged" },
-      response: { data: { message: "already acknowledged" } },
-      requestBody: { json: { flags: 64 } },
-    });
-    const readPlaceSpy = vi
-      .spyOn(CompoPlaceService.prototype, "readPlace")
-      .mockResolvedValue({
-        content: "",
-        embeds: [new EmbedBuilder().setTitle("Compo Placement Suggestions")],
-        trackedClanTags: [],
-        eligibleClanTags: [],
-        candidateCount: 0,
-        recommendedCount: 0,
-        vacancyCount: 0,
-        compositionCount: 0,
-      });
-
-    const interaction = makeInteraction("145k");
-    interaction.deferReply.mockRejectedValueOnce(deferError);
-
-    await expect(Compo.run({} as any, interaction as any, {} as any)).rejects.toThrow(
-      "defer failed",
-    );
-
-    expect(readPlaceSpy).not.toHaveBeenCalled();
-    expect(captured.some((entry) => entry.text.includes("stage=defer_attempt"))).toBe(true);
-    expect(captured.some((entry) => entry.text.includes("stage=defer_failed"))).toBe(true);
-    const attemptIndex = captured.findIndex((entry) => entry.text.includes("stage=defer_attempt"));
-    const failedIndex = captured.findIndex((entry) => entry.text.includes("stage=defer_failed"));
-    expect(attemptIndex).toBeGreaterThanOrEqual(0);
-    expect(failedIndex).toBeGreaterThan(attemptIndex);
-
-    logSpy.mockRestore();
-    infoSpy.mockRestore();
-    errorSpy.mockRestore();
-  });
-
-  it("logs response_send_failed_header before the detailed payload dump when editReply rejects", async () => {
-    const { captured, logSpy, errorSpy, infoSpy } = captureConsoleLogs();
-    const sendError = Object.assign(new Error("embed failure"), {
-      name: "DiscordAPIError",
-      code: 50035,
-      status: 400,
-      rawError: {
-        message: "Invalid Form Body",
-        embeds: { _errors: [{ code: "BASE_TYPE_BAD_LENGTH", message: "too long" }] },
-      },
-      response: {
-        data: {
-          message: "Invalid Form Body",
-          embeds: { _errors: [{ code: "BASE_TYPE_BAD_LENGTH", message: "too long" }] },
-        },
-      },
-      requestBody: { json: { embeds: [{ title: "Too long" }] } },
-    });
-    const readPlaceSpy = vi
-      .spyOn(CompoPlaceService.prototype, "readPlace")
-      .mockResolvedValue({
-        content: "",
-        embeds: [new EmbedBuilder().setTitle("Compo Placement Suggestions")],
-        trackedClanTags: ["#AAA111"],
-        eligibleClanTags: ["#AAA111"],
-        candidateCount: 1,
-        recommendedCount: 0,
-        vacancyCount: 0,
-        compositionCount: 1,
-      });
-
-    const interaction = makeInteraction("145k");
-    interaction.editReply.mockRejectedValueOnce(sendError).mockResolvedValueOnce(undefined);
-
-    await Compo.run({} as any, interaction as any, {} as any);
-
-    expect(readPlaceSpy).toHaveBeenCalled();
-    const attemptIndex = captured.findIndex((entry) =>
-      entry.text.includes("stage=response_send_attempt"),
-    );
-    const headerIndex = captured.findIndex((entry) =>
-      entry.text.includes("stage=response_send_failed_header"),
-    );
-    const failedIndex = captured.findIndex((entry) =>
-      entry.text.includes("stage=response_send_failed") &&
-      !entry.text.includes("stage=response_send_failed_header"),
-    );
-    const fallbackIndex = captured.findIndex((entry) =>
-      entry.text.includes("stage=place_return_error_fallback"),
-    );
-    const buildIndex = captured.findIndex((entry) =>
-      entry.text.includes("stage=response_build") &&
-      entry.text.includes("reason=run_catch"),
-    );
-    expect(attemptIndex).toBeGreaterThanOrEqual(0);
-    expect(headerIndex).toBeGreaterThan(attemptIndex);
-    expect(failedIndex).toBeGreaterThan(headerIndex);
-    expect(fallbackIndex).toBeGreaterThan(failedIndex);
-    expect(buildIndex).toBeGreaterThan(fallbackIndex);
-
-    logSpy.mockRestore();
-    infoSpy.mockRestore();
-    errorSpy.mockRestore();
   });
 });

--- a/tests/compoPlace.refresh.test.ts
+++ b/tests/compoPlace.refresh.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+﻿import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   buildCompoRefreshCustomIdForTest,
   handleCompoRefreshButton,
@@ -73,7 +73,7 @@ describe("compo place refresh button behavior", () => {
 
     await handleCompoRefreshButton(interaction as any, {} as any);
 
-    expect(refreshPlaceSpy).toHaveBeenCalledWith(145000, "TH15", "guild-1", expect.any(Map));
+    expect(refreshPlaceSpy).toHaveBeenCalledWith(145000, "TH15", "guild-1");
     const loadingPayload = interaction.update.mock.calls[0]?.[0];
     expect(loadingPayload?.components?.length ?? 0).toBeGreaterThan(0);
     expect(

--- a/tests/compoPlace.service.test.ts
+++ b/tests/compoPlace.service.test.ts
@@ -1,14 +1,9 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+﻿import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GoogleSheetsService } from "../src/services/GoogleSheetsService";
-import { InactiveWarService } from "../src/services/InactiveWarService";
 import { FwaClanMembersSyncService } from "../src/services/fwa-feeds/FwaClanMembersSyncService";
-import { summarizeDiscordEmbedText } from "../src/helper/embedTextBudget";
 
 const prismaMock = vi.hoisted(() => ({
   trackedClan: {
-    findMany: vi.fn(),
-  },
-  fillerAccount: {
     findMany: vi.fn(),
   },
   fwaClanMemberCurrent: {
@@ -21,12 +16,6 @@ const prismaMock = vi.hoisted(() => ({
     findMany: vi.fn(),
   },
   playerCurrent: {
-    findMany: vi.fn(),
-  },
-  playerLink: {
-    findMany: vi.fn(),
-  },
-  playerActivity: {
     findMany: vi.fn(),
   },
   heatMapRef: {
@@ -44,15 +33,13 @@ vi.mock("../src/prisma", () => ({
 import {
   buildBucketDeltaByHeaderForTest,
   CompoPlaceService,
-  buildCompoPlaceEmbedsForTest,
   resolvePlacementWeightForTest,
 } from "../src/services/CompoPlaceService";
 
-function makeTrackedClan(tag: string, name: string, shortName: string | null = null) {
+function makeTrackedClan(tag: string, name: string) {
   return {
     tag,
     name,
-    shortName,
   };
 }
 
@@ -194,28 +181,14 @@ describe("CompoPlaceService", () => {
   beforeEach(() => {
     vi.restoreAllMocks();
     prismaMock.trackedClan.findMany.mockReset();
-    prismaMock.fillerAccount.findMany.mockReset();
     prismaMock.fwaClanMemberCurrent.findMany.mockReset();
     prismaMock.fwaTrackedClanWarRosterMemberCurrent.findMany.mockReset();
     prismaMock.fwaPlayerCatalog.findMany.mockReset();
     prismaMock.playerCurrent.findMany.mockReset();
-    prismaMock.playerLink.findMany.mockReset();
-    prismaMock.playerActivity.findMany.mockReset();
     prismaMock.heatMapRef.findMany.mockReset();
     prismaMock.weightInputDeferment.findMany.mockReset();
-    vi.spyOn(InactiveWarService.prototype, "listInactiveWarPlayers").mockResolvedValue({
-      results: [],
-      trackedTags: [],
-      trackedNameByTag: new Map(),
-      trackedBadgeByTag: new Map(),
-      warnings: [],
-      diagnosticNote: null,
-    });
     prismaMock.fwaPlayerCatalog.findMany.mockResolvedValue([]);
     prismaMock.playerCurrent.findMany.mockResolvedValue([]);
-    prismaMock.fillerAccount.findMany.mockResolvedValue([]);
-    prismaMock.playerLink.findMany.mockResolvedValue([]);
-    prismaMock.playerActivity.findMany.mockResolvedValue([]);
   });
 
   it("reads ACTUAL placement suggestions from persisted tracked clans, current members, and HeatMapRef without sheet services", async () => {
@@ -313,449 +286,6 @@ describe("CompoPlaceService", () => {
     expect(embed?.description).toContain("Deltas: **resolved roster vs HeatMapRef**");
     expect(embed?.fields?.find((field) => field.name === "Composition")?.value).toBe("None");
     expect(embed?.fields?.find((field) => field.name === "Recommended")?.value).toBe("None");
-  });
-
-  it("adds a Replace section for same-bucket filler candidates with clan short-name prefixes", async () => {
-    prismaMock.trackedClan.findMany.mockResolvedValue([
-      makeTrackedClan("AAA111", "Alpha Clan-war", "ALP"),
-    ]);
-    prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue([
-      {
-        clanTag: "#AAA111",
-        playerTag: "#P000002",
-        playerName: "Filler Alpha",
-        weight: 145000,
-        sourceSyncedAt: new Date("2026-04-10T16:30:00.000Z"),
-        townHall: null,
-      },
-    ]);
-    prismaMock.weightInputDeferment.findMany.mockResolvedValue([]);
-    prismaMock.fwaTrackedClanWarRosterMemberCurrent.findMany.mockResolvedValue([]);
-    prismaMock.heatMapRef.findMany.mockResolvedValue([makeHeatMapRef()]);
-    prismaMock.fillerAccount.findMany.mockResolvedValue([
-      { playerTag: "#P000002" },
-    ]);
-    prismaMock.playerCurrent.findMany.mockResolvedValue([
-      {
-        playerTag: "#P000002",
-        townHall: 16,
-        role: "leader",
-      },
-    ]);
-    prismaMock.playerActivity.findMany.mockResolvedValue([
-      { tag: "#P000002", lastSeenAt: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000) },
-    ]);
-    prismaMock.playerLink.findMany.mockImplementation(async (query: any) => {
-      const allowed = new Set<string>(query?.where?.playerTag?.in ?? []);
-      return [
-        {
-          playerTag: "#P000002",
-          discordUserId: "111111111111111111",
-          discordUsername: "Alpha One",
-          createdAt: new Date("2026-04-10T16:30:00.000Z"),
-        },
-      ].filter((row) => allowed.has(row.playerTag));
-    });
-    vi.mocked(InactiveWarService.prototype.listInactiveWarPlayers).mockResolvedValue({
-      results: [
-        {
-          clanTag: "#AAA111",
-          playerTag: "#P000002",
-          playerName: "Filler Alpha",
-          townHall: 16,
-          missedWars: 1,
-          participationWars: 3,
-          totalTrueStars: 0,
-          avgAttackDelay: null,
-          lateAttacks: 0,
-          warsAvailable: 3,
-          missedWarStates: [],
-        } as any,
-      ],
-      trackedTags: [],
-      trackedNameByTag: new Map(),
-      trackedBadgeByTag: new Map(),
-      warnings: [],
-      diagnosticNote: null,
-    });
-
-    const result = await new CompoPlaceService().readPlace(
-      145000,
-      "TH15",
-      "guild-1",
-      new Map([[16, "<:th16:12345678901234567>"]]),
-    );
-
-    const embed = result.embeds[0]?.toJSON();
-    const replaceField = embed?.fields?.find((field) => String(field.name).startsWith("Replace"));
-    expect(replaceField?.name).toBe("Replace 1/1");
-    expect(replaceField?.value).toContain("ALP <:th16:12345678901234567> 145,000");
-    expect(replaceField?.value).toContain(
-      "[Filler Alpha](<https://link.clashofclans.com/en/?action=OpenPlayerProfile&tag=P000002>) :crown: `#P000002`",
-    );
-  });
-
-  it("adds a crown for filler co-leader candidates", async () => {
-    prismaMock.trackedClan.findMany.mockResolvedValue([
-      makeTrackedClan("AAA111", "Alpha Clan-war", "ALP"),
-    ]);
-    prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue([
-      {
-        clanTag: "#AAA111",
-        playerTag: "#P000002",
-        playerName: "Filler CoLeader",
-        weight: 145000,
-        sourceSyncedAt: new Date("2026-04-10T16:30:00.000Z"),
-        townHall: null,
-      },
-    ]);
-    prismaMock.weightInputDeferment.findMany.mockResolvedValue([]);
-    prismaMock.fwaTrackedClanWarRosterMemberCurrent.findMany.mockResolvedValue([]);
-    prismaMock.heatMapRef.findMany.mockResolvedValue([makeHeatMapRef()]);
-    prismaMock.fillerAccount.findMany.mockResolvedValue([{ playerTag: "#P000002" }]);
-    prismaMock.playerCurrent.findMany.mockResolvedValue([
-      {
-        playerTag: "#P000002",
-        townHall: 16,
-        role: "coLeader",
-      },
-    ]);
-    prismaMock.playerActivity.findMany.mockResolvedValue([
-      { tag: "#P000002", lastSeenAt: new Date(Date.now() - 1 * 24 * 60 * 60 * 1000) },
-    ]);
-    prismaMock.playerLink.findMany.mockResolvedValue([
-      {
-        playerTag: "#P000002",
-        discordUserId: "444444444444444444",
-        discordUsername: "Bravo Two",
-        createdAt: new Date("2026-04-10T16:30:00.000Z"),
-      },
-    ]);
-    vi.mocked(InactiveWarService.prototype.listInactiveWarPlayers).mockResolvedValue({
-      results: [
-        {
-          clanTag: "#AAA111",
-          playerTag: "#P000002",
-          playerName: "Filler CoLeader",
-          townHall: 16,
-          missedWars: 1,
-          participationWars: 3,
-          totalTrueStars: 0,
-          avgAttackDelay: null,
-          lateAttacks: 0,
-          warsAvailable: 3,
-          missedWarStates: [],
-        } as any,
-      ],
-      trackedTags: [],
-      trackedNameByTag: new Map(),
-      trackedBadgeByTag: new Map(),
-      warnings: [],
-      diagnosticNote: null,
-    });
-
-    const result = await new CompoPlaceService().readPlace(
-      145000,
-      "TH15",
-      "guild-1",
-      new Map([[16, "<:th16:12345678901234567>"]]),
-    );
-
-    const embed = result.embeds[0]?.toJSON();
-    const replaceField = embed?.fields?.find((field) => String(field.name).startsWith("Replace"));
-    expect(replaceField?.name).toBe("Replace 1/1");
-    expect(replaceField?.value).toContain("ALP <:th16:12345678901234567> 145,000");
-    expect(replaceField?.value).toContain(
-      "[Filler CoLeader](<https://link.clashofclans.com/en/?action=OpenPlayerProfile&tag=P000002>) :crown: `#P000002`",
-    );
-  });
-
-  it("does not add a crown for inactive-only leaders", async () => {
-    prismaMock.trackedClan.findMany.mockResolvedValue([
-      makeTrackedClan("AAA111", "Alpha Clan-war", "ALP"),
-    ]);
-    prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue([
-      {
-        clanTag: "#AAA111",
-        playerTag: "#P000002",
-        playerName: "Inactive Leader",
-        weight: 145000,
-        sourceSyncedAt: new Date("2026-04-10T16:30:00.000Z"),
-        townHall: 15,
-      },
-    ]);
-    prismaMock.weightInputDeferment.findMany.mockResolvedValue([]);
-    prismaMock.fwaTrackedClanWarRosterMemberCurrent.findMany.mockResolvedValue([]);
-    prismaMock.heatMapRef.findMany.mockResolvedValue([makeHeatMapRef()]);
-    prismaMock.fillerAccount.findMany.mockResolvedValue([]);
-    prismaMock.playerCurrent.findMany.mockResolvedValue([
-      {
-        playerTag: "#P000002",
-        townHall: 15,
-        role: "coLeader",
-      },
-    ]);
-    prismaMock.playerActivity.findMany.mockResolvedValue([
-      { tag: "#P000002", lastSeenAt: new Date(Date.now() - 9 * 24 * 60 * 60 * 1000) },
-    ]);
-    prismaMock.playerLink.findMany.mockResolvedValue([
-      {
-        playerTag: "#P000002",
-        discordUserId: "111111111111111111",
-        discordUsername: "Alpha One",
-        createdAt: new Date("2026-04-10T16:30:00.000Z"),
-      },
-    ]);
-    vi.mocked(InactiveWarService.prototype.listInactiveWarPlayers).mockResolvedValue({
-      results: [
-        {
-          clanTag: "#AAA111",
-          playerTag: "#P000002",
-          playerName: "Inactive Leader",
-          townHall: 15,
-          missedWars: 1,
-          participationWars: 3,
-          totalTrueStars: 0,
-          avgAttackDelay: null,
-          lateAttacks: 0,
-          warsAvailable: 3,
-          missedWarStates: [],
-        } as any,
-      ],
-      trackedTags: [],
-      trackedNameByTag: new Map(),
-      trackedBadgeByTag: new Map(),
-      warnings: [],
-      diagnosticNote: null,
-    });
-
-    const result = await new CompoPlaceService().readPlace(
-      145000,
-      "TH15",
-      "guild-1",
-      new Map([[15, "<:th15:12345678901234567>"]]),
-    );
-
-    const embed = result.embeds[0]?.toJSON();
-    const replaceValue = embed?.fields?.find((field) => String(field.name).startsWith("Replace"))?.value ?? "";
-    expect(replaceValue).toContain("ALP <:th15:12345678901234567> 145,000");
-    expect(replaceValue).not.toContain(":crown: `#P000002`");
-  });
-
-  it("does not add a crown for filler members", async () => {
-    prismaMock.trackedClan.findMany.mockResolvedValue([
-      makeTrackedClan("AAA111", "Alpha Clan-war", "ALP"),
-    ]);
-    prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue([
-      {
-        clanTag: "#AAA111",
-        playerTag: "#P000002",
-        playerName: "Filler Member",
-        weight: 145000,
-        sourceSyncedAt: new Date("2026-04-10T16:30:00.000Z"),
-        townHall: 15,
-      },
-    ]);
-    prismaMock.weightInputDeferment.findMany.mockResolvedValue([]);
-    prismaMock.fwaTrackedClanWarRosterMemberCurrent.findMany.mockResolvedValue([]);
-    prismaMock.heatMapRef.findMany.mockResolvedValue([makeHeatMapRef()]);
-    prismaMock.fillerAccount.findMany.mockResolvedValue([{ playerTag: "#P000002" }]);
-    prismaMock.playerCurrent.findMany.mockResolvedValue([
-      {
-        playerTag: "#P000002",
-        townHall: 15,
-        role: "member",
-      },
-    ]);
-    prismaMock.playerActivity.findMany.mockResolvedValue([
-      { tag: "#P000002", lastSeenAt: new Date(Date.now() - 9 * 24 * 60 * 60 * 1000) },
-    ]);
-    prismaMock.playerLink.findMany.mockResolvedValue([
-      {
-        playerTag: "#P000002",
-        discordUserId: "111111111111111111",
-        discordUsername: "Alpha One",
-        createdAt: new Date("2026-04-10T16:30:00.000Z"),
-      },
-    ]);
-    vi.mocked(InactiveWarService.prototype.listInactiveWarPlayers).mockResolvedValue({
-      results: [
-        {
-          clanTag: "#AAA111",
-          playerTag: "#P000002",
-          playerName: "Filler Member",
-          townHall: 15,
-          missedWars: 1,
-          participationWars: 3,
-          totalTrueStars: 0,
-          avgAttackDelay: null,
-          lateAttacks: 0,
-          warsAvailable: 3,
-          missedWarStates: [],
-        } as any,
-      ],
-      trackedTags: [],
-      trackedNameByTag: new Map(),
-      trackedBadgeByTag: new Map(),
-      warnings: [],
-      diagnosticNote: null,
-    });
-
-    const result = await new CompoPlaceService().readPlace(
-      145000,
-      "TH15",
-      "guild-1",
-      new Map([[15, "<:th15:12345678901234567>"]]),
-    );
-
-    const embed = result.embeds[0]?.toJSON();
-    const replaceValue = embed?.fields?.find((field) => String(field.name).startsWith("Replace"))?.value ?? "";
-    expect(replaceValue).toContain("ALP <:th15:12345678901234567> 145,000");
-    expect(replaceValue).not.toContain(":crown: `#P000002`");
-  });
-
-  it("counts title, description, author, footer, and field text in the shared embed budget helper", () => {
-    const metrics = summarizeDiscordEmbedText(
-      {
-        title: "T".repeat(2000),
-        description: "D".repeat(1200),
-        author: { name: "A".repeat(400) },
-        footer: { text: "F".repeat(300) },
-        fields: [
-          {
-            name: "N".repeat(200),
-            value: "V".repeat(400),
-          },
-        ],
-      },
-    );
-
-    expect(metrics.titleLength).toBe(2000);
-    expect(metrics.descriptionLength).toBe(1200);
-    expect(metrics.authorNameLength).toBe(400);
-    expect(metrics.footerTextLength).toBe(300);
-    expect(metrics.maxFieldNameLength).toBe(200);
-    expect(metrics.maxFieldValueLength).toBe(400);
-    expect(metrics.estimatedTextLength).toBe(4500);
-  });
-
-  it("paginates Replace rows without cutting a player line mid-row", async () => {
-    const replaceRows = Array.from({ length: 70 }, (_, index) => {
-      const suffix = String(index + 1).padStart(6, "0");
-      const tag = `#P${suffix}`;
-      return `ALP <:th15:12345678901234567> 145,000 :man_standing: :zzz: 8d | :x: 1 - [Player ${
-        index + 1
-      }](<https://link.clashofclans.com/en/?action=OpenPlayerProfile&tag=%23P${suffix}>) \`${tag}\``;
-    });
-
-    const embeds = buildCompoPlaceEmbedsForTest({
-      inputWeight: 145000,
-      bucket: "TH15",
-      recommended: [],
-      vacancyList: [],
-      compositionList: [],
-      replaceRows,
-      refreshLine: "RAW Data last refreshed: <t:1744302600:F>",
-      modeLabel: "ACTUAL Auto-Detect",
-      deltaLabel: "resolved roster vs HeatMapRef",
-    });
-
-    const replaceFields = embeds.flatMap((embed) => {
-      const json = embed.toJSON();
-      return (json.fields ?? [])
-        .filter((field) => String(field.name).startsWith("Replace"))
-        .map((field) => ({
-          name: String(field.name),
-          value: String(field.value),
-        }));
-    });
-
-    expect(embeds.length).toBeGreaterThan(1);
-    expect(replaceFields.length).toBeGreaterThan(1);
-    expect(replaceFields.length).toBeGreaterThan(embeds.length);
-    expect(
-      embeds[0]?.toJSON().fields?.filter((field) => String(field.name).startsWith("Replace"))?.length ?? 0,
-    ).toBeGreaterThan(1);
-    expect(embeds.slice(1).every((embed) => {
-      const json = embed.toJSON();
-      return (json.fields ?? []).every((field) => String(field.name).startsWith("Replace"));
-    })).toBe(true);
-
-    for (const field of replaceFields) {
-      expect(field.value.length).toBeLessThanOrEqual(1024);
-      for (const line of field.value.split("\n")) {
-        expect(line).toContain("ALP <:th15:12345678901234567> 145,000 ");
-        expect(line).toContain(" - [");
-        expect(line).toContain("](<https://link.clashofclans.com/en/?action=OpenPlayerProfile&tag=");
-        expect(line).toMatch(/`#P[0-9A-Z]+`$/);
-      }
-    }
-
-    for (const embed of embeds) {
-      const metrics = summarizeDiscordEmbedText(embed.toJSON());
-      expect(metrics.estimatedTextLength).toBeLessThanOrEqual(4096);
-      expect(metrics.fieldCount).toBeLessThanOrEqual(25);
-      expect(metrics.maxFieldNameLength).toBeLessThanOrEqual(256);
-      expect(metrics.maxFieldValueLength).toBeLessThanOrEqual(1024);
-    }
-  });
-
-  it("falls back to the unknown Town Hall icon when no TH source exists", async () => {
-    prismaMock.trackedClan.findMany.mockResolvedValue([
-      makeTrackedClan("AAA111", "Alpha Clan-war", "ALP"),
-    ]);
-    prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue([
-      {
-        clanTag: "#AAA111",
-        playerTag: "#P000002",
-        playerName: "Unknown Town Hall",
-        weight: 145000,
-        sourceSyncedAt: new Date("2026-04-10T16:30:00.000Z"),
-        townHall: null,
-      },
-    ]);
-    prismaMock.weightInputDeferment.findMany.mockResolvedValue([]);
-    prismaMock.fwaTrackedClanWarRosterMemberCurrent.findMany.mockResolvedValue([]);
-    prismaMock.heatMapRef.findMany.mockResolvedValue([makeHeatMapRef()]);
-    prismaMock.fillerAccount.findMany.mockResolvedValue([{ playerTag: "#P000002" }]);
-    prismaMock.playerCurrent.findMany.mockResolvedValue([]);
-    prismaMock.playerActivity.findMany.mockResolvedValue([
-      { tag: "#P000002", lastSeenAt: new Date(Date.now() - 8 * 24 * 60 * 60 * 1000) },
-    ]);
-    prismaMock.playerLink.findMany.mockResolvedValue([]);
-    vi.mocked(InactiveWarService.prototype.listInactiveWarPlayers).mockResolvedValue({
-      results: [
-        {
-          clanTag: "#AAA111",
-          playerTag: "#P000002",
-          playerName: "Unknown Town Hall",
-          townHall: null,
-          missedWars: 1,
-          participationWars: 3,
-          totalTrueStars: 0,
-          avgAttackDelay: null,
-          lateAttacks: 0,
-          warsAvailable: 3,
-          missedWarStates: [],
-        } as any,
-      ],
-      trackedTags: [],
-      trackedNameByTag: new Map(),
-      trackedBadgeByTag: new Map(),
-      warnings: [],
-      diagnosticNote: null,
-    });
-
-    const result = await new CompoPlaceService().readPlace(
-      145000,
-      "TH15",
-      "guild-1",
-      new Map([[15, "<:th15:12345678901234567>"]]),
-    );
-
-    const embed = result.embeds[0]?.toJSON();
-    const replaceValue = embed?.fields?.find((field) => String(field.name).startsWith("Replace"))?.value ?? "";
-    expect(replaceValue).toContain("\u2754");
   });
 
   it("uses member weight, then deferred weight, then WAR effective weight, and ignores unresolved zero-weight rows", async () => {


### PR DESCRIPTION
Promote the stable pre-Replace /compo place implementation from the dev rollback branch onto main, while preserving the shared early defer behavior for all /compo subcommands.

Scope is intentionally limited to:
- src/commands/Compo.ts
- src/services/CompoPlaceService.ts
- tests/compoPlace.command.test.ts
- tests/compoPlace.refresh.test.ts
- tests/compoPlace.service.test.ts

Validation:
- npx vitest run tests/compoPlace.command.test.ts tests/compoPlace.refresh.test.ts tests/compoPlace.service.test.ts tests/compo.commandSheetRead.test.ts tests/compoWarState.command.test.ts
- npx tsc --noEmit