### PR TITLE
feat(raids): add overview offense metrics

### DIFF
--- a/src/services/RaidDashboardService.ts
+++ b/src/services/RaidDashboardService.ts
@@ -85,6 +85,8 @@ export type RaidDashboardClanRow = RaidTrackedClanDisplayRow & RaidDashboardCoun
   defaultLayoutCount: number | null;
   raidIntelDefenderUpgrades: number | null;
   maxDefenseAttacksUsed: number | null;
+  offensiveDistrictsDestroyed: number | null;
+  offensiveAverageAttacksPerCompletedRaid: number | null;
   intelGradeScore: number;
   raidIntelMarks?: RaidIntelDistrictLayoutMarkRecord[];
   openDefenseSections?: RaidDashboardDefenseSection[];
@@ -496,6 +498,107 @@ function calculateCompletedRaidsFromAttackLog(
   }
 
   return sawUsableLog ? completed : null;
+}
+
+function calculateAttackCountFromRaidLogEntry(
+  entry: Record<string, unknown>,
+  districts: RaidDashboardDistrictRow[],
+): number | null {
+  const aggregateAttackCount = normalizeNonNegativeInt(
+    entry.attackCount ?? entry.attacks ?? entry.attacksUsed,
+  );
+  if (aggregateAttackCount !== null) {
+    return aggregateAttackCount;
+  }
+
+  const districtAttackCounts = districts
+    .map((district) => district.attackCount)
+    .filter((attackCount): attackCount is number => attackCount !== null);
+  if (districtAttackCounts.length > 0) {
+    return districtAttackCounts.reduce((sum, attackCount) => sum + attackCount, 0);
+  }
+
+  return null;
+}
+
+function calculateCurrentOffensiveDistrictsDestroyed(
+  attackLog: ClanCapitalRaidSeason["attackLog"],
+): number | null {
+  if (!Array.isArray(attackLog) || attackLog.length <= 0) {
+    return null;
+  }
+
+  let sawCompletedRaid = false;
+  for (const entry of attackLog) {
+    const state = normalizeRaidAttackLogEntryState(entry);
+    if (!state.started) continue;
+    if (state.complete === false) {
+      const value = entry as Record<string, unknown>;
+      const districts = Array.isArray(value.districts)
+        ? value.districts
+            .map((district: unknown) => normalizeRaidDistrictRow(district))
+            .filter((district: RaidDashboardDistrictRow | null): district is RaidDashboardDistrictRow => district !== null)
+        : [];
+      return districts.reduce(
+        (sum: number, district: RaidDashboardDistrictRow) =>
+          sum + (isDistrictFullyDestroyed(district) === true ? 1 : 0),
+        0,
+      );
+    }
+    if (state.complete === true) {
+      sawCompletedRaid = true;
+    }
+  }
+
+  return sawCompletedRaid ? 9 : null;
+}
+
+function calculateAverageAttacksPerCompletedRaid(
+  attackLog: ClanCapitalRaidSeason["attackLog"],
+): number | null {
+  if (!Array.isArray(attackLog) || attackLog.length <= 0) {
+    return null;
+  }
+
+  let completedCount = 0;
+  let totalAttacks = 0;
+  let sawUsableRaid = false;
+  for (const entry of attackLog) {
+    const state = normalizeRaidAttackLogEntryState(entry);
+    if (!state.usable || state.complete !== true) continue;
+    sawUsableRaid = true;
+    const value = entry as Record<string, unknown>;
+    const districts = Array.isArray(value.districts)
+      ? value.districts
+          .map((district: unknown) => normalizeRaidDistrictRow(district))
+          .filter((district: RaidDashboardDistrictRow | null): district is RaidDashboardDistrictRow => district !== null)
+      : [];
+    const attackCount = calculateAttackCountFromRaidLogEntry(value, districts);
+    if (attackCount === null) continue;
+    completedCount += 1;
+    totalAttacks += attackCount;
+  }
+
+  return sawUsableRaid && completedCount > 0 ? totalAttacks / completedCount : null;
+}
+
+function formatRaidDashboardAverageAttacksPerCompletedRaid(value: number | null): string {
+  if (value === null) {
+    return "—";
+  }
+
+  const rounded = Math.round(value * 10) / 10;
+  return Number.isInteger(rounded) ? String(rounded) : rounded.toFixed(1);
+}
+
+function buildRaidDashboardOverviewOffenseLine(row: RaidDashboardClanRow): string {
+  const totalAttacks = row.attacksCompleted === null ? "—" : String(row.attacksCompleted);
+  const destroyedDistricts =
+    row.offensiveDistrictsDestroyed === null ? "—" : String(row.offensiveDistrictsDestroyed);
+  const averageAttacks = formatRaidDashboardAverageAttacksPerCompletedRaid(
+    row.offensiveAverageAttacksPerCompletedRaid,
+  );
+  return `- 🗡 ${totalAttacks} 🏠 ${destroyedDistricts}/9 📈 ${averageAttacks} att/raid`;
 }
 
 function buildRaidDistrictLabel(row: RaidDashboardDistrictRow): string {
@@ -1370,6 +1473,12 @@ async function loadRaidDashboardRowsFromSourceRows(input: {
       }
       return Math.max(...values);
     })();
+    const offensiveDistrictsDestroyed = calculateCurrentOffensiveDistrictsDestroyed(
+      snapshot.activeSeason?.attackLog,
+    );
+    const offensiveAverageAttacksPerCompletedRaid = calculateAverageAttacksPerCompletedRaid(
+      snapshot.activeSeason?.attackLog,
+    );
     const openDefenseSections = snapshot.activeSeason
       ? normalizeDefenseSections(snapshot.activeSeason, metadataByTag).filter(
           (section) => section.joinType === "open",
@@ -1382,6 +1491,8 @@ async function loadRaidDashboardRowsFromSourceRows(input: {
       defaultLayoutCount,
       raidIntelDefenderUpgrades,
       maxDefenseAttacksUsed,
+      offensiveDistrictsDestroyed,
+      offensiveAverageAttacksPerCompletedRaid,
       intelGradeScore,
       raidIntelMarks,
       hasOngoingRaid: snapshot.counts.hasOngoingRaid,
@@ -1580,6 +1691,7 @@ export function buildRaidDashboardOverviewDescription(rows: RaidDashboardClanRow
     if (intelLine) {
       lines.push(intelLine);
     }
+    lines.push(buildRaidDashboardOverviewOffenseLine(row));
     for (const section of row.openDefenseSections ?? []) {
       const text = buildRaidDashboardOverviewOpenDefenseSectionText(section);
       if (text) {

--- a/tests/raidDashboard.service.test.ts
+++ b/tests/raidDashboard.service.test.ts
@@ -519,6 +519,9 @@ describe("RaidDashboardService", () => {
     expect(overview).not.toContain("- 🏘️");
     expect(overview).not.toContain("🛡️");
     expect(overview).not.toContain("GM, SP, GQ");
+    expect(overview).toContain("🗡");
+    expect(overview).toMatch(/🏠.*\/9/);
+    expect(overview).toContain("att/raid");
   });
 
   it("omits the defense shield metric when the active season defense counts are unknown", () => {
@@ -562,6 +565,181 @@ describe("RaidDashboardService", () => {
     const titleLine = overview.split("\n").find((line) => line.includes("[Alpha Raid]"));
     expect(titleLine).toContain("🛡️46");
     expect(titleLine).toContain("`#2QG2C08UP`");
+  });
+
+  it("renders offensive overview metrics from the active raid attack log and hides intel after the first clear", async () => {
+    prismaMock.raidTrackedClan.findMany.mockResolvedValueOnce([
+      {
+        clanTag: "2QG2C08UP",
+        name: "Alpha Raid",
+        upgrades: 2210,
+        joinType: "open",
+        createdAt: new Date("2026-05-01T00:00:00.000Z"),
+        updatedAt: new Date("2026-05-08T11:00:00.000Z"),
+      },
+    ]);
+
+    const activeSeason = {
+      startTime: "2026-05-08T00:00:00.000Z",
+      endTime: "2026-05-11T00:00:00.000Z",
+      members: [{ attacks: 6 }, { attacks: 5 }],
+      attackLog: [
+        {
+          defender: { name: "Open One", tag: "#OPEN1" },
+          attackCount: 24,
+          districtCount: 9,
+          districtsDestroyed: 9,
+          districts: [
+            {
+              name: "Capital Hall",
+              districtHallLevel: 5,
+              attackCount: 24,
+              destructionPercent: 100,
+              stars: 3,
+            },
+          ],
+        },
+        {
+          defender: { name: "Open Two", tag: "#OPEN2" },
+          attacksUsed: 25,
+          districtCount: 9,
+          districtsDestroyed: 9,
+          districts: [
+            {
+              name: "Capital Hall",
+              districtHallLevel: 5,
+              attackCount: 25,
+              destructionPercent: 100,
+              stars: 3,
+            },
+          ],
+        },
+        {
+          defender: { name: "Current Raid", tag: "#CURRENT" },
+          attackCount: 42,
+          districtCount: 9,
+          districtsDestroyed: 7,
+          districts: [
+            {
+              name: "Capital Hall",
+              districtHallLevel: 5,
+              attackCount: 3,
+              destructionPercent: 100,
+              stars: 3,
+            },
+            {
+              name: "Wizard Valley",
+              districtHallLevel: 4,
+              attackCount: 3,
+              destructionPercent: 100,
+              stars: 3,
+            },
+            {
+              name: "Balloon Lagoon",
+              districtHallLevel: 5,
+              attackCount: 3,
+              destructionPercent: 100,
+              stars: 3,
+            },
+            {
+              name: "Barbarian Camp",
+              districtHallLevel: 5,
+              attackCount: 3,
+              destructionPercent: 100,
+              stars: 3,
+            },
+            {
+              name: "Golem Quarry",
+              districtHallLevel: 5,
+              attackCount: 3,
+              destructionPercent: 100,
+              stars: 3,
+            },
+            {
+              name: "Dragon Cliffs",
+              districtHallLevel: 5,
+              attackCount: 3,
+              destructionPercent: 100,
+              stars: 3,
+            },
+            {
+              name: "Skeleton Park",
+              districtHallLevel: 4,
+              attackCount: 3,
+              destructionPercent: 100,
+              stars: 3,
+            },
+            {
+              name: "Builders Workshop",
+              districtHallLevel: 5,
+              attackCount: 3,
+              destructionPercent: 50,
+              stars: 1,
+            },
+            {
+              name: "Capital Peak",
+              districtHallLevel: 10,
+              attackCount: 3,
+              destructionPercent: 0,
+              stars: 0,
+            },
+          ],
+        },
+      ],
+      defenseLog: [],
+      raidsCompleted: null,
+    };
+
+    const cocService = {
+      getClanCapitalRaidSeasons: vi.fn(async () => [activeSeason]),
+      getClan: vi.fn(),
+    };
+
+    const rows = await listRaidDashboardRows({
+      cocService: cocService as any,
+      guildId: "guild-1",
+    });
+
+    expect(rows[0]?.offensiveDistrictsDestroyed).toBe(7);
+    expect(rows[0]?.offensiveAverageAttacksPerCompletedRaid).toBe(24.5);
+    expect(rows[0]?.raidsCompleted).toBe(2);
+
+    const overview = buildRaidDashboardOverviewDescription(rows);
+    expect(overview).toContain("🗡 11");
+    expect(overview).toMatch(/🏠.*7\/9/);
+    expect(overview).toContain("📈 24.5 att/raid");
+    expect(overview).not.toContain("- 🏘️");
+  });
+
+  it("renders the offensive overview line when intel is hidden after the first completed raid", () => {
+    const overview = buildRaidDashboardOverviewDescription([
+      {
+        clanTag: "2RVGJYLC0",
+        clanName: "Bravo Raid",
+        upgrades: null,
+        joinType: "closed",
+        createdAt: new Date("2026-05-02T00:00:00.000Z"),
+        updatedAt: new Date("2026-05-08T11:30:00.000Z"),
+        attacksCompleted: null,
+        attacksMax: null,
+        hasOngoingRaid: false,
+        raidsCompleted: 1,
+        defaultLayoutCount: 0,
+        intelGradeScore: 0,
+        maxDefenseAttacksUsed: null,
+        offensiveDistrictsDestroyed: null,
+        offensiveAverageAttacksPerCompletedRaid: null,
+        raidIntelMarks: [
+          { districtName: "Dragon Cliffs", layoutGrade: "CUSTOM_EASY" },
+          { districtName: "Balloon Lagoon", layoutGrade: "CUSTOM_MEDIUM" },
+          { districtName: "Wizard Valley", layoutGrade: "CUSTOM_HARD" },
+        ],
+      } as any,
+    ]);
+
+    expect(overview).not.toContain("- 🏘️");
+    expect(overview).toContain("- 🗡 — 🏠 —/9 📈 — att/raid");
+    expect(overview).not.toContain("GM, SP, GQ");
   });
 
   it("sorts overview rows by ongoing status, raids completed, and default layout count", async () => {


### PR DESCRIPTION
show total attacks, current raid district progress, and attacks per completed raid

derive offensive metrics from active raid season data without new state