### PR TITLE
fix(link): chunk long list embeds cleanly

### DIFF
--- a/src/commands/Link.ts
+++ b/src/commands/Link.ts
@@ -159,6 +159,11 @@ function sanitizeTableText(input: string): string {
     .trim();
 }
 
+function sanitizeInlineCodeCell(input: string): string {
+  const normalized = sanitizeTableText(input);
+  return normalized.replace(/`/g, "ʼ").replace(/\u200B/g, "").trim();
+}
+
 function truncateWithEllipsis(input: string, maxLength: number): string {
   const normalized = sanitizeTableText(input);
   if (normalized.length <= maxLength) return normalized;
@@ -960,9 +965,11 @@ function formatAlignedInlineRow(
   widths: { playerName: number; value: number },
   statusPrefix: string,
 ): string {
-  const townHallLabel = formatLinkListTownHallLabel(row.townHall);
+  const townHallLabel = sanitizeInlineCodeCell(formatLinkListTownHallLabel(row.townHall));
   const playerName = rightAlign(
-    truncateWithEllipsis(row.playerName, MAX_PLAYER_NAME_CHARS),
+    sanitizeInlineCodeCell(
+      truncateWithEllipsis(row.playerName, MAX_PLAYER_NAME_CHARS),
+    ),
     widths.playerName,
   );
   const base = `${statusPrefix} \`${townHallLabel}\` \`${playerName}\``;
@@ -970,7 +977,9 @@ function formatAlignedInlineRow(
     return row.rightMarker ? `${base} ${row.rightMarker}` : base;
   }
   const displayValue = rightAlign(
-    row.displayValue.trim().length > 0 ? row.displayValue : WEIGHT_PLACEHOLDER,
+    sanitizeInlineCodeCell(
+      row.displayValue.trim().length > 0 ? row.displayValue : WEIGHT_PLACEHOLDER,
+    ),
     widths.value,
   );
   const line = `${base} \`${displayValue}\``;
@@ -1172,9 +1181,11 @@ async function buildLinkListView(input: {
   currentMembers.forEach((member, index) => {
     const playerTag = normalizePlayerTag(member.playerTag);
     if (!playerTag) return;
-    const playerName = truncateWithEllipsis(
-      sanitizeTableText(member.playerName) || "Unknown",
-      MAX_PLAYER_NAME_CHARS,
+    const playerName = sanitizeInlineCodeCell(
+      truncateWithEllipsis(
+        sanitizeInlineCodeCell(member.playerName) || "Unknown",
+        MAX_PLAYER_NAME_CHARS,
+      ),
     );
     const weightValue = weightByTag.get(playerTag) ?? null;
     const inactivityRow = inactivityByTag.get(playerTag) ?? null;
@@ -1183,30 +1194,34 @@ async function buildLinkListView(input: {
     const inactivityParticipationWars = inactivityRow?.participationWars ?? null;
     const link = linkByTag.get(playerTag);
     const linkedDisplayName = link
-      ? truncateWithEllipsis(
-          resolveLinkedUserDisplayName(
-            input.interaction,
-            link.discordUserId,
-            link.discordUsername,
+      ? sanitizeInlineCodeCell(
+          truncateWithEllipsis(
+            sanitizeInlineCodeCell(
+              resolveLinkedUserDisplayName(
+                input.interaction,
+                link.discordUserId,
+                link.discordUsername,
+              ),
+            ),
+            MAX_IDENTITY_CHARS,
           ),
-          MAX_IDENTITY_CHARS,
         )
       : null;
     const displayValue: string | null =
       sortMode === "discord"
-        ? linkedDisplayName ?? WEIGHT_PLACEHOLDER
+        ? sanitizeInlineCodeCell(linkedDisplayName ?? WEIGHT_PLACEHOLDER)
         : sortMode === "weight"
-          ? formatCompactWeightK(weightValue)
+          ? sanitizeInlineCodeCell(formatCompactWeightK(weightValue))
           : sortMode === "player-tags"
-            ? playerTag
+            ? sanitizeInlineCodeCell(playerTag)
             : sortMode === "player"
               ? null
               : sortMode === "clan-rank"
-                ? formatLinkListClanRole(member.role)
-                : formatInactivityMetricLabel({
+                ? sanitizeInlineCodeCell(formatLinkListClanRole(member.role))
+                : sanitizeInlineCodeCell(formatInactivityMetricLabel({
                     daysInactive: inactivityDays,
                     missedWars: inactivityMissedWars,
-                  });
+                  }));
     const discordSort =
       sortMode === "player-tags"
         ? playerTag

--- a/src/commands/Link.ts
+++ b/src/commands/Link.ts
@@ -77,6 +77,7 @@ const LINK_EMBED_SUPPORTED_CHANNEL_TYPES = [
 const EMBED_DESCRIPTION_LIMIT = 4096;
 const LINK_LIST_MAX_EMBEDS = 2;
 const LINK_LIST_MAX_TOTAL_DESCRIPTION_CHARS = 5200;
+const LINK_LIST_EMBED_DESCRIPTION_SAFE_LIMIT = 1500;
 const LINK_LIST_TRIM_SUFFIX_TEMPLATE =
   "...and {hiddenRows} more rows hidden. Use another sort/filter or Refresh Data.";
 const LINK_LIST_EMBED_COLOR = 0x5865f2;
@@ -395,11 +396,15 @@ function isLinkListRowLine(line: string): boolean {
   );
 }
 
-function chunkDescriptionLines(lines: string[]): DescriptionChunk[] {
+function chunkDescriptionLines(
+  lines: string[],
+  safeLimit = EMBED_DESCRIPTION_LIMIT,
+): DescriptionChunk[] {
   const chunks: DescriptionChunk[] = [];
   let currentLines: string[] = [];
   let currentCount = 0;
   let currentRowCount = 0;
+  const effectiveLimit = Math.max(1, Math.min(safeLimit, EMBED_DESCRIPTION_LIMIT));
 
   for (const rawLine of lines) {
     const line =
@@ -408,7 +413,7 @@ function chunkDescriptionLines(lines: string[]): DescriptionChunk[] {
         : `${rawLine.slice(0, EMBED_DESCRIPTION_LIMIT - 12)}...truncated`;
     const candidate = currentLines.length > 0 ? [...currentLines, line].join("\n") : line;
 
-    if (candidate.length <= EMBED_DESCRIPTION_LIMIT) {
+    if (candidate.length <= effectiveLimit) {
       currentLines.push(line);
       currentCount += 1;
       if (isLinkListRowLine(line)) currentRowCount += 1;
@@ -521,7 +526,7 @@ function buildDescriptionEmbeds(
   sortMode: LinkListSortMode,
 ): LinkListDescriptionRenderResult {
   const sortLabel = getLinkListSortModeLabel(sortMode);
-  const chunks = chunkDescriptionLines(lines);
+  const chunks = chunkDescriptionLines(lines, LINK_LIST_EMBED_DESCRIPTION_SAFE_LIMIT);
   if (chunks.length === 0) {
     const embeds = [
       new EmbedBuilder()
@@ -543,12 +548,11 @@ function buildDescriptionEmbeds(
   const totalRows = lines.filter((line) => isLinkListRowLine(line)).length;
   const trimmedChunks = trimLinkListDescriptionChunks(chunks);
   const embeds = trimmedChunks.chunks.map((chunk, index) => {
-    const embedTitle = index === 0 ? title : `${title} (cont. ${index + 1})`;
-    return new EmbedBuilder()
-      .setColor(LINK_LIST_EMBED_COLOR)
-      .setTitle(embedTitle)
-      .setFooter({ text: `Sort: ${sortLabel}` })
-      .setDescription(chunk.text);
+    const embed = new EmbedBuilder().setColor(LINK_LIST_EMBED_COLOR).setDescription(chunk.text);
+    if (index === 0) {
+      embed.setTitle(title).setFooter({ text: `Sort: ${sortLabel}` });
+    }
+    return embed;
   });
 
   if (embeds.length === 0) {

--- a/tests/link.command.run.test.ts
+++ b/tests/link.command.run.test.ts
@@ -2153,7 +2153,12 @@ describe("/link list sort button", () => {
     const rows = makeLinkListClanMembers({
       clanTag: "#PQL0289",
       count: 50,
-      playerNamePrefix: "Player",
+      playerNamePrefix: "Player With A Moderately Long Name For Chunking",
+    });
+    prismaMock.trackedClan.findUnique.mockResolvedValue({
+      tag: "#PQL0289",
+      name: "Tracked Alpha",
+      clanBadge: null,
     });
     prismaMock.playerLink.findMany.mockResolvedValue(
       rows.slice(0, 40).map((row, index) => ({
@@ -2191,6 +2196,11 @@ describe("/link list sort button", () => {
     expect(deferUpdate).toHaveBeenCalledTimes(1);
     expect(editReply).toHaveBeenCalledTimes(1);
     const payload = editReply.mock.calls[0]?.[0] as any;
+    expect(payload.embeds.length).toBe(2);
+    expect(payload.embeds[0].toJSON().title).toBe(
+      "Tracked Alpha #PQL0289",
+    );
+    expect(payload.embeds[1].toJSON().title).toBeUndefined();
     const description = payload.embeds
       .map((embed: { toJSON: () => any }) => embed.toJSON().description ?? "")
       .join("\n");
@@ -2199,6 +2209,12 @@ describe("/link list sort button", () => {
     expect(description).toContain("Linked Users: 40");
     expect(description).toContain("Unlinked users: 10");
     expect(renderedRows).toHaveLength(50);
+    expect(description).not.toMatch(/^[\u2705\u274C]\s+`?\d+`?\s*$/um);
+    expect(getInlineRowSegments(renderedRows[0] ?? "").playerName.trim()).toHaveLength(15);
+    expect(getInlineRowSegments(renderedRows[0] ?? "").value).toMatch(/^#[A-Z0-9]+$/u);
+    expect(getInlineRows(payload.embeds[1].toJSON().description ?? "")[0] ?? "").toMatch(
+      /^(?:[\u2705\u274C])\s+`[^`]+`\s+`[^`]+`(?:\s+`[^`]+`)?(?:\s+\u{1F9CD})?$/u,
+    );
     expect(
       payload.embeds.reduce(
         (sum: number, embed: { toJSON: () => any }) =>
@@ -2207,6 +2223,153 @@ describe("/link list sort button", () => {
       ),
     ).toBeLessThanOrEqual(5200);
     expect(description).not.toContain("...and");
+    const lastRow = getInlineRowSegments(renderedRows[renderedRows.length - 1] ?? "");
+    expect(lastRow.playerName.trim()).toHaveLength(15);
+    expect(lastRow.value.trim()).toMatch(/^#[A-Z0-9]+$/u);
+  }, 30000);
+
+  it("renders a realistic 50-member Discord Name view without aggressively trimming", async () => {
+    const rows = makeLinkListClanMembers({
+      clanTag: "#PQL0289",
+      count: 50,
+      playerNamePrefix: "Player With A Moderately Long Name For Chunking",
+    });
+    prismaMock.trackedClan.findUnique.mockResolvedValue({
+      tag: "#PQL0289",
+      name: "Tracked Alpha",
+      clanBadge: null,
+    });
+    prismaMock.playerLink.findMany.mockResolvedValue(
+      rows.slice(0, 40).map((row, index) => ({
+        playerTag: row.playerTag,
+        discordUserId: String(300000000000000000n + BigInt(index)),
+        discordUsername: `Linked ${index + 1}`,
+      })),
+    );
+    prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue(rows);
+
+    const deferUpdate = vi.fn().mockResolvedValue(undefined);
+    const editReply = vi.fn().mockResolvedValue(undefined);
+    const update = vi.fn().mockResolvedValue(undefined);
+    const reply = vi.fn().mockResolvedValue(undefined);
+    const interaction = {
+      customId: buildLinkListSortButtonCustomId(
+        "111111111111111111",
+        "#PQL0289",
+        "inactivity",
+      ),
+      user: { id: "111111111111111111" },
+      guildId: "guild-1",
+      guild: { members: { cache: new Map() } },
+      client: { users: { cache: new Map() } },
+      deferUpdate,
+      editReply,
+      update,
+      reply,
+      deferred: false,
+      replied: false,
+    };
+
+    await handleLinkListSortButton(interaction as any, { getClan: vi.fn() } as any);
+
+    expect(deferUpdate).toHaveBeenCalledTimes(1);
+    expect(editReply).toHaveBeenCalledTimes(1);
+    const payload = editReply.mock.calls[0]?.[0] as any;
+    expect(payload.embeds.length).toBe(2);
+    expect(payload.embeds[0].toJSON().title).toBe(
+      "Tracked Alpha #PQL0289",
+    );
+    expect(payload.embeds[1].toJSON().title).toBeUndefined();
+    const description = payload.embeds
+      .map((embed: { toJSON: () => any }) => embed.toJSON().description ?? "")
+      .join("\n");
+    const renderedRows = getInlineRows(description);
+    expect(renderedRows).toHaveLength(50);
+    expect(description).not.toMatch(/^[\u2705\u274C]\s+`?\d+`?\s*$/um);
+    expect(description).toContain("Linked Users: 40");
+    expect(description).toContain("Unlinked users: 10");
+    expect(payload.embeds[0].toJSON().footer?.text).toBe("Sort: Discord Name");
+    expect(payload.embeds[1].toJSON().footer).toBeUndefined();
+    expect(getInlineRowSegments(renderedRows[0] ?? "").playerName.trim()).toHaveLength(15);
+    expect(getInlineRowSegments(renderedRows[0] ?? "").value).toBe("Linked 1");
+    expect(getInlineRows(payload.embeds[1].toJSON().description ?? "")[0] ?? "").toMatch(
+      /^(?:[\u2705\u274C])\s+`[^`]+`\s+`[^`]+`(?:\s+`[^`]+`)?(?:\s+\u{1F9CD})?$/u,
+    );
+    const lastRow = getInlineRowSegments(renderedRows[renderedRows.length - 1] ?? "");
+    expect(lastRow.playerName.trim()).toHaveLength(15);
+    expect(lastRow.value.length).toBeGreaterThan(0);
+  }, 30000);
+
+  it("renders a realistic 50-member Weight view without aggressively trimming", async () => {
+    const rows = makeLinkListClanMembers({
+      clanTag: "#PQL0289",
+      count: 50,
+      playerNamePrefix: "Player With A Moderately Long Name For Chunking",
+    });
+    prismaMock.trackedClan.findUnique.mockResolvedValue({
+      tag: "#PQL0289",
+      name: "Tracked Alpha",
+      clanBadge: null,
+    });
+    prismaMock.playerLink.findMany.mockResolvedValue(
+      rows.slice(0, 40).map((row, index) => ({
+        playerTag: row.playerTag,
+        discordUserId: String(300000000000000000n + BigInt(index)),
+        discordUsername: `Linked ${index + 1}`,
+      })),
+    );
+    prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue(rows);
+
+    const deferUpdate = vi.fn().mockResolvedValue(undefined);
+    const editReply = vi.fn().mockResolvedValue(undefined);
+    const update = vi.fn().mockResolvedValue(undefined);
+    const reply = vi.fn().mockResolvedValue(undefined);
+    const interaction = {
+      customId: buildLinkListSortButtonCustomId(
+        "111111111111111111",
+        "#PQL0289",
+        "discord",
+      ),
+      user: { id: "111111111111111111" },
+      guildId: "guild-1",
+      guild: { members: { cache: new Map() } },
+      client: { users: { cache: new Map() } },
+      deferUpdate,
+      editReply,
+      update,
+      reply,
+      deferred: false,
+      replied: false,
+    };
+
+    await handleLinkListSortButton(interaction as any, { getClan: vi.fn() } as any);
+
+    expect(deferUpdate).toHaveBeenCalledTimes(1);
+    expect(editReply).toHaveBeenCalledTimes(1);
+    const payload = editReply.mock.calls[0]?.[0] as any;
+    expect(payload.embeds.length).toBe(2);
+    expect(payload.embeds[0].toJSON().title).toBe(
+      "Tracked Alpha #PQL0289",
+    );
+    expect(payload.embeds[1].toJSON().title).toBeUndefined();
+    const description = payload.embeds
+      .map((embed: { toJSON: () => any }) => embed.toJSON().description ?? "")
+      .join("\n");
+    const renderedRows = getInlineRows(description);
+    expect(renderedRows).toHaveLength(50);
+    expect(description).not.toMatch(/^[\u2705\u274C]\s+`?\d+`?\s*$/um);
+    expect(description).toContain("Linked Users: 40");
+    expect(description).toContain("Unlinked users: 10");
+    expect(payload.embeds[0].toJSON().footer?.text).toBe("Sort: Weight Desc");
+    expect(payload.embeds[1].toJSON().footer).toBeUndefined();
+    expect(getInlineRowSegments(renderedRows[0] ?? "").playerName.trim()).toHaveLength(15);
+    expect(getInlineRowSegments(renderedRows[0] ?? "").value).not.toBe("");
+    expect(getInlineRows(payload.embeds[1].toJSON().description ?? "")[0] ?? "").toMatch(
+      /^(?:[\u2705\u274C])\s+`[^`]+`\s+`[^`]+`(?:\s+`[^`]+`)?(?:\s+\u{1F9CD})?$/u,
+    );
+    const lastRow = getInlineRowSegments(renderedRows[renderedRows.length - 1] ?? "");
+    expect(lastRow.playerName.trim()).toHaveLength(15);
+    expect(lastRow.value.length).toBeGreaterThan(0);
   }, 30000);
 
   it("trims oversized Player Tags views instead of throwing", async () => {

--- a/tests/link.command.run.test.ts
+++ b/tests/link.command.run.test.ts
@@ -1387,6 +1387,58 @@ describe("/link run", () => {
     expect(description).not.toContain("``");
   });
 
+  it("escapes backticks in /link list inline-code cells", async () => {
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      {
+        playerTag: "#PYLQ0289",
+        discordUserId: "111111111111111111",
+        discordUsername: "Discord ` Nick",
+        createdAt: new Date("2026-03-15T09:07:00.000Z"),
+      },
+    ]);
+    prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue([
+      {
+        playerTag: "#PYLQ0289",
+        playerName: "WIZEX`",
+        townHall: 18,
+        rank: 18,
+        weight: 145000,
+        sourceSyncedAt: new Date("2026-03-21T09:07:00.000Z"),
+      },
+      {
+        playerTag: "#QGRJ2222",
+        playerName: "Plain Member",
+        townHall: 17,
+        rank: 17,
+        weight: 132000,
+        sourceSyncedAt: new Date("2026-03-21T09:07:00.000Z"),
+      },
+    ]);
+    const interaction = makeInteraction({
+      subcommand: "list",
+      clanTag: "#PQL0289",
+    });
+
+    await Link.run({} as any, interaction as any, {} as any);
+
+    const payload = interaction.editReply.mock.calls[0]?.[0] as any;
+    const description = String(payload.embeds[0].toJSON().description ?? "");
+    const rows = getInlineRows(description);
+
+    expect(rows).toHaveLength(2);
+    rows.forEach((row) => {
+      expect(row).not.toMatch(/^[\u2705\u274C]\s+`?\d+`?\s*$/u);
+      const segments = getInlineRowSegments(row);
+      expect(segments.playerName).not.toContain("`");
+      expect(segments.value).not.toContain("`");
+    });
+    expect(description).toContain("WIZEXʼ");
+    expect(description).toContain("Discord ʼ Nick");
+    expect(description).toContain("Plain Member");
+    expect(description).not.toContain("`WIZEX`");
+    expect(description).not.toContain("`Discord ` Nick`");
+  });
+
   it("falls back to persisted discord username when guild display name is unavailable", async () => {
     prismaMock.playerLink.findMany.mockResolvedValue([
       {


### PR DESCRIPTION
replace raw backticks in player and display values to prevent blank rendered rows

preserve compact link list layout and role-based clan role view