### PR TITLE
feat(link): add link list column selector

### DIFF
--- a/src/commands/Link.ts
+++ b/src/commands/Link.ts
@@ -59,6 +59,7 @@ const linkListMembersSyncService = new FwaClanMembersSyncService();
 const LINK_LIST_SELECT_PREFIX = "link-list-select";
 const LINK_LIST_SORT_BUTTON_PREFIX = "link-list-sort-cycle";
 const LINK_LIST_REFRESH_BUTTON_PREFIX = "link-list-refresh";
+const LINK_LIST_COLUMNS_SELECT_PREFIX = "link-list-columns";
 const LINK_EMBED_SETUP_MODAL_PREFIX = "link-embed-setup";
 const LINK_EMBED_TAG_MODAL_PREFIX = "link-embed-tag";
 const LINK_EMBED_BUTTON_PREFIX = "link-embed-account";
@@ -391,7 +392,7 @@ type DescriptionChunk = {
 };
 
 function isLinkListRowLine(line: string): boolean {
-  return /^(?:[\u2705\u274C])(?:\s+`[^`]+`){2,}(?:\s+\u{1F9CD})?$/u.test(
+  return /^(?:[\u2705\u274C])(?:\s+`[^`]+`)+(?:\s+\u{1F9CD})?$/u.test(
     String(line ?? "").trim(),
   );
 }
@@ -626,6 +627,7 @@ function buildClanSelectRows(input: {
   currentClanTag: string;
   commandUserId: string;
   sortMode: LinkListSortMode;
+  columns: LinkListColumnId[];
 }): ActionRowBuilder<StringSelectMenuBuilder>[] {
   if (input.trackedClans.length === 0) return [];
   const selectedSet = selectTrackedClanMenuOptions(
@@ -648,7 +650,11 @@ function buildClanSelectRows(input: {
 
   const select = new StringSelectMenuBuilder()
     .setCustomId(
-      buildLinkListSelectCustomId(input.commandUserId, input.sortMode),
+      buildLinkListSelectCustomId(
+        input.commandUserId,
+        input.sortMode,
+        input.columns,
+      ),
     )
     .setPlaceholder("Select tracked clan")
     .addOptions(options);
@@ -662,6 +668,7 @@ function buildLinkListSortRow(input: {
   commandUserId: string;
   currentClanTag: string;
   sortMode: LinkListSortMode;
+  columns: LinkListColumnId[];
 }): ActionRowBuilder<ButtonBuilder> {
   const sortLabel = getLinkListSortModeLabel(input.sortMode);
   const button = new ButtonBuilder()
@@ -670,6 +677,7 @@ function buildLinkListSortRow(input: {
         input.commandUserId,
         input.currentClanTag,
         input.sortMode,
+        input.columns,
       ),
     )
     .setLabel(`Sort: ${sortLabel}`)
@@ -681,6 +689,7 @@ function buildLinkListRefreshRow(input: {
   commandUserId: string;
   currentClanTag: string;
   sortMode: LinkListSortMode;
+  columns: LinkListColumnId[];
 }): ActionRowBuilder<ButtonBuilder> {
   const button = new ButtonBuilder()
     .setCustomId(
@@ -688,6 +697,7 @@ function buildLinkListRefreshRow(input: {
         input.commandUserId,
         input.currentClanTag,
         input.sortMode,
+        input.columns,
       ),
     )
     .setLabel("Refresh Data")
@@ -695,11 +705,41 @@ function buildLinkListRefreshRow(input: {
   return new ActionRowBuilder<ButtonBuilder>().addComponents(button);
 }
 
+function buildLinkListColumnsRow(input: {
+  commandUserId: string;
+  currentClanTag: string;
+  sortMode: LinkListSortMode;
+  columns: LinkListColumnId[];
+}): ActionRowBuilder<StringSelectMenuBuilder> {
+  const selectedSet = new Set(input.columns);
+  const select = new StringSelectMenuBuilder()
+    .setCustomId(
+      buildLinkListColumnsSelectCustomId(
+        input.commandUserId,
+        input.currentClanTag,
+        input.sortMode,
+        input.columns,
+      ),
+    )
+    .setPlaceholder("Columns")
+    .setMinValues(1)
+    .setMaxValues(5)
+    .addOptions(
+      getLinkListSelectableColumns().map((columnId) => ({
+        label: getLinkListColumnLabel(columnId),
+        value: columnId,
+        default: selectedSet.has(columnId),
+      })),
+    );
+  return new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(select);
+}
+
 function buildLinkListControlRows(input: {
   trackedClans: GuildTrackedClanOption[];
   currentClanTag: string;
   commandUserId: string;
   sortMode: LinkListSortMode;
+  columns: LinkListColumnId[];
   includeSortButton?: boolean;
 }): ActionRowBuilder<StringSelectMenuBuilder | ButtonBuilder>[] {
   const rows: ActionRowBuilder<StringSelectMenuBuilder | ButtonBuilder>[] = [
@@ -708,6 +748,7 @@ function buildLinkListControlRows(input: {
   if (input.includeSortButton !== false) {
     rows.push(buildLinkListSortRow(input));
   }
+  rows.push(buildLinkListColumnsRow(input));
   const selectRows = buildClanSelectRows(input);
   rows.push(...selectRows);
   return rows;
@@ -776,9 +817,32 @@ const LINK_LIST_COLUMN_LABELS: Record<LinkListColumnId, string> = {
   "player-tag": "Player Tag",
 };
 
+const LINK_LIST_COLUMN_ALIASES: Record<LinkListColumnId, string> = {
+  townhall: "th",
+  "player-name": "pn",
+  "discord-display-name": "dd",
+  "discord-username": "du",
+  weight: "wt",
+  inactivity: "ia",
+  "clan-role": "cr",
+  "player-tag": "pt",
+};
+
+const LINK_LIST_COLUMN_ALIAS_TO_ID: Record<string, LinkListColumnId> = {
+  th: "townhall",
+  pn: "player-name",
+  dd: "discord-display-name",
+  du: "discord-username",
+  wt: "weight",
+  ia: "inactivity",
+  cr: "clan-role",
+  pt: "player-tag",
+};
+
 type LinkListRowViewModel = {
   townHallLabel: string;
   playerName: string;
+  displayValue: string | null;
   discordDisplayName: string;
   discordUsername: string;
   weightLabel: string;
@@ -797,6 +861,91 @@ function getLinkListSelectableColumns(): LinkListColumnId[] {
 
 function getLinkListColumnLabel(columnId: LinkListColumnId): string {
   return LINK_LIST_COLUMN_LABELS[columnId];
+}
+
+function normalizeLinkListColumnId(
+  input: string | null | undefined,
+): LinkListColumnId | null {
+  const normalized = sanitizeTableText(String(input ?? "")).toLowerCase();
+  if (!normalized) return null;
+  if (Object.prototype.hasOwnProperty.call(LINK_LIST_COLUMN_LABELS, normalized)) {
+    return normalized as LinkListColumnId;
+  }
+  const alias = normalized.replace(/[\s\-_]+/g, "");
+  return LINK_LIST_COLUMN_ALIAS_TO_ID[alias] ?? null;
+}
+
+function normalizeLinkListColumns(
+  input: readonly string[] | null | undefined,
+  sortMode: LinkListSortMode = LINK_LIST_DEFAULT_SORT_MODE,
+): LinkListColumnId[] {
+  const result: LinkListColumnId[] = [];
+  const seen = new Set<LinkListColumnId>();
+  for (const rawColumn of input ?? []) {
+    const columnId = normalizeLinkListColumnId(rawColumn);
+    if (!columnId || seen.has(columnId)) continue;
+    seen.add(columnId);
+    result.push(columnId);
+    if (result.length >= 5) break;
+  }
+  if (result.length === 0) {
+    return getLinkListDefaultColumnsForSortMode(sortMode);
+  }
+  return result;
+}
+
+function isLinkListDefaultColumnsForSortMode(
+  columns: readonly LinkListColumnId[],
+  sortMode: LinkListSortMode,
+): boolean {
+  const normalizedColumns = normalizeLinkListColumns(columns, sortMode);
+  const defaultColumns = getLinkListDefaultColumnsForSortMode(sortMode);
+  return (
+    normalizedColumns.length === defaultColumns.length &&
+    normalizedColumns.every((columnId, index) => columnId === defaultColumns[index])
+  );
+}
+
+function encodeLinkListColumns(columns: readonly LinkListColumnId[]): string {
+  return normalizeLinkListColumns(columns).map((columnId) => LINK_LIST_COLUMN_ALIASES[columnId]).join(".");
+}
+
+function parseLinkListColumnsField(
+  input: string | null | undefined,
+  sortMode: LinkListSortMode = LINK_LIST_DEFAULT_SORT_MODE,
+): LinkListColumnId[] {
+  const parts = String(input ?? "")
+    .split(".")
+    .map((part) => part.trim())
+    .filter((part) => part.length > 0);
+  return normalizeLinkListColumns(parts, sortMode);
+}
+
+function buildLinkListOrderedColumnsFromSelection(input: {
+  previousColumns: readonly LinkListColumnId[];
+  selectedColumns: readonly string[];
+  sortMode: LinkListSortMode;
+}): LinkListColumnId[] {
+  const previousColumns = normalizeLinkListColumns(input.previousColumns, input.sortMode);
+  const selectedColumns = normalizeLinkListColumns(input.selectedColumns, input.sortMode);
+  const selectedSet = new Set(selectedColumns);
+  const ordered: LinkListColumnId[] = [];
+
+  for (const columnId of previousColumns) {
+    if (!selectedSet.has(columnId) || ordered.includes(columnId)) continue;
+    ordered.push(columnId);
+    if (ordered.length >= 5) return ordered;
+  }
+
+  for (const columnId of selectedColumns) {
+    if (ordered.includes(columnId)) continue;
+    ordered.push(columnId);
+    if (ordered.length >= 5) break;
+  }
+
+  return ordered.length > 0
+    ? ordered
+    : getLinkListDefaultColumnsForSortMode(input.sortMode);
 }
 
 function getLinkListDefaultColumnsForSortMode(
@@ -1134,14 +1283,18 @@ export const buildLinkListDescriptionLinesForTest = buildLinkListDescriptionLine
 export const getLinkListDefaultColumnsForSortModeForTest = getLinkListDefaultColumnsForSortMode;
 export const getLinkListSelectableColumnsForTest = getLinkListSelectableColumns;
 export const getLinkListColumnLabelForTest = getLinkListColumnLabel;
+export const buildLinkListColumnsSelectCustomIdForTest = buildLinkListColumnsSelectCustomId;
+export const parseLinkListColumnsSelectCustomIdForTest = parseLinkListColumnsSelectCustomId;
 
 async function buildLinkListView(input: {
   interaction: LinkListInteraction;
   clanTag: string;
   commandUserId: string;
   sortMode?: LinkListSortMode;
+  columns?: LinkListColumnId[];
 }): Promise<LinkListRenderResult> {
   const sortMode = normalizeLinkListSortMode(input.sortMode);
+  const activeColumns = normalizeLinkListColumns(input.columns, sortMode);
 
   if (!input.interaction.guildId) {
     return { ok: false, message: "This command can only be used in a server." };
@@ -1172,6 +1325,7 @@ async function buildLinkListView(input: {
       currentClanTag: input.clanTag,
       commandUserId: input.commandUserId,
       sortMode,
+      columns: activeColumns,
       includeSortButton: false,
     });
     const clanName = sanitizeTableText(String(tracked?.name ?? "")) || input.clanTag;
@@ -1322,6 +1476,7 @@ async function buildLinkListView(input: {
           townHallByTag.get(playerTag) ?? member.townHall ?? null,
         ),
         playerName,
+        displayValue: null,
         discordDisplayName,
         discordUsername,
         weightLabel,
@@ -1337,7 +1492,7 @@ async function buildLinkListView(input: {
   const sortedRows = sortLinkListRows(resolvedRows, sortMode);
   const linkedRows: LinkListRowInput[] = [];
   const unlinkedRows: LinkListRowInput[] = [];
-  const columns = getLinkListDefaultColumnsForSortMode(sortMode);
+  const columns = activeColumns;
 
   for (const row of sortedRows) {
     if (row.isLinked) {
@@ -1383,6 +1538,7 @@ async function buildLinkListView(input: {
     currentClanTag: input.clanTag,
     commandUserId: input.commandUserId,
     sortMode,
+    columns: activeColumns,
     includeSortButton: true,
   });
 
@@ -1464,9 +1620,13 @@ async function updateDeferredLinkListInteraction(
 export function buildLinkListSelectCustomId(
   userId: string,
   sortMode: LinkListSortMode = LINK_LIST_DEFAULT_SORT_MODE,
+  columns?: LinkListColumnId[],
 ): string {
   const normalizedSort = normalizeLinkListSortMode(sortMode);
-  return `${LINK_LIST_SELECT_PREFIX}:${userId}:${normalizedSort}`;
+  const encodedColumns = encodeLinkListColumns(
+    columns ?? getLinkListDefaultColumnsForSortMode(normalizedSort),
+  );
+  return `${LINK_LIST_SELECT_PREFIX}:${userId}:${normalizedSort}:${encodedColumns}`;
 }
 
 export function isLinkListSelectCustomId(customId: string): boolean {
@@ -1475,19 +1635,18 @@ export function isLinkListSelectCustomId(customId: string): boolean {
 
 function parseLinkListSelectCustomId(
   customId: string,
-): { userId: string; sortMode: LinkListSortMode } | null {
+): { userId: string; sortMode: LinkListSortMode; columns: LinkListColumnId[] } | null {
   const parts = customId.split(":");
-  if (
-    (parts.length !== 2 && parts.length !== 3) ||
-    parts[0] !== LINK_LIST_SELECT_PREFIX
-  ) {
+  if ((parts.length !== 4 && parts.length !== 3) || parts[0] !== LINK_LIST_SELECT_PREFIX) {
     return null;
   }
   const userId = parts[1]?.trim() ?? "";
   if (!userId) return null;
+  const sortMode = normalizeLinkListSortMode(parts[2]);
   return {
     userId,
-    sortMode: normalizeLinkListSortMode(parts[2]),
+    sortMode,
+    columns: parseLinkListColumnsField(parts[3], sortMode),
   };
 }
 
@@ -1495,8 +1654,13 @@ export function buildLinkListSortButtonCustomId(
   userId: string,
   clanTag: string,
   sortMode: LinkListSortMode,
+  columns?: LinkListColumnId[],
 ): string {
-  return `${LINK_LIST_SORT_BUTTON_PREFIX}:${userId}:${clanTag}:${normalizeLinkListSortMode(sortMode)}`;
+  const normalizedSort = normalizeLinkListSortMode(sortMode);
+  const encodedColumns = encodeLinkListColumns(
+    columns ?? getLinkListDefaultColumnsForSortMode(normalizedSort),
+  );
+  return `${LINK_LIST_SORT_BUTTON_PREFIX}:${userId}:${clanTag}:${normalizedSort}:${encodedColumns}`;
 }
 
 export function isLinkListSortButtonCustomId(customId: string): boolean {
@@ -1505,18 +1669,20 @@ export function isLinkListSortButtonCustomId(customId: string): boolean {
 
 function parseLinkListSortButtonCustomId(
   customId: string,
-): { userId: string; clanTag: string; sortMode: LinkListSortMode } | null {
+): { userId: string; clanTag: string; sortMode: LinkListSortMode; columns: LinkListColumnId[] } | null {
   const parts = String(customId ?? "").split(":");
-  if (parts.length !== 4 || parts[0] !== LINK_LIST_SORT_BUTTON_PREFIX) {
+  if ((parts.length !== 5 && parts.length !== 4) || parts[0] !== LINK_LIST_SORT_BUTTON_PREFIX) {
     return null;
   }
   const userId = parts[1]?.trim() ?? "";
   const clanTag = normalizeClanTag(parts[2] ?? "");
   if (!userId || !clanTag) return null;
+  const sortMode = normalizeLinkListSortMode(parts[3]);
   return {
     userId,
     clanTag,
-    sortMode: normalizeLinkListSortMode(parts[3]),
+    sortMode,
+    columns: parseLinkListColumnsField(parts[4], sortMode),
   };
 }
 
@@ -1524,8 +1690,13 @@ export function buildLinkListRefreshButtonCustomId(
   userId: string,
   clanTag: string,
   sortMode: LinkListSortMode,
+  columns?: LinkListColumnId[],
 ): string {
-  return `${LINK_LIST_REFRESH_BUTTON_PREFIX}:${userId}:${clanTag}:${normalizeLinkListSortMode(sortMode)}`;
+  const normalizedSort = normalizeLinkListSortMode(sortMode);
+  const encodedColumns = encodeLinkListColumns(
+    columns ?? getLinkListDefaultColumnsForSortMode(normalizedSort),
+  );
+  return `${LINK_LIST_REFRESH_BUTTON_PREFIX}:${userId}:${clanTag}:${normalizedSort}:${encodedColumns}`;
 }
 
 export function isLinkListRefreshButtonCustomId(customId: string): boolean {
@@ -1534,18 +1705,61 @@ export function isLinkListRefreshButtonCustomId(customId: string): boolean {
 
 function parseLinkListRefreshButtonCustomId(
   customId: string,
-): { userId: string; clanTag: string; sortMode: LinkListSortMode } | null {
+): { userId: string; clanTag: string; sortMode: LinkListSortMode; columns: LinkListColumnId[] } | null {
   const parts = String(customId ?? "").split(":");
-  if (parts.length !== 4 || parts[0] !== LINK_LIST_REFRESH_BUTTON_PREFIX) {
+  if ((parts.length !== 5 && parts.length !== 4) || parts[0] !== LINK_LIST_REFRESH_BUTTON_PREFIX) {
     return null;
   }
   const userId = parts[1]?.trim() ?? "";
   const clanTag = normalizeClanTag(parts[2] ?? "");
   if (!userId || !clanTag) return null;
+  const sortMode = normalizeLinkListSortMode(parts[3]);
   return {
     userId,
     clanTag,
-    sortMode: normalizeLinkListSortMode(parts[3]),
+    sortMode,
+    columns: parseLinkListColumnsField(parts[4], sortMode),
+  };
+}
+
+export function buildLinkListColumnsSelectCustomId(
+  userId: string,
+  clanTag: string,
+  sortMode: LinkListSortMode,
+  columns?: LinkListColumnId[],
+): string {
+  const normalizedSort = normalizeLinkListSortMode(sortMode);
+  const encodedColumns = encodeLinkListColumns(
+    columns ?? getLinkListDefaultColumnsForSortMode(normalizedSort),
+  );
+  return `${LINK_LIST_COLUMNS_SELECT_PREFIX}:${userId}:${clanTag}:${normalizedSort}:${encodedColumns}`;
+}
+
+export function isLinkListColumnsSelectCustomId(customId: string): boolean {
+  return customId.startsWith(`${LINK_LIST_COLUMNS_SELECT_PREFIX}:`);
+}
+
+function parseLinkListColumnsSelectCustomId(
+  customId: string,
+): {
+  userId: string;
+  clanTag: string;
+  sortMode: LinkListSortMode;
+  columns: LinkListColumnId[];
+} | null {
+  const parts = String(customId ?? "").split(":");
+  if (parts.length !== 5 || parts[0] !== LINK_LIST_COLUMNS_SELECT_PREFIX) {
+    return null;
+  }
+  const userId = parts[1]?.trim() ?? "";
+  const clanTag = normalizeClanTag(parts[2] ?? "");
+  if (!userId || !clanTag) return null;
+  const sortMode = normalizeLinkListSortMode(parts[3]);
+  return {
+    userId,
+    clanTag,
+    sortMode,
+    columns: parseLinkListColumnsField(parts[4], sortMode),
   };
 }
 
@@ -1790,10 +2004,55 @@ export async function handleLinkListSelectMenu(
     clanTag: selectedTag,
     commandUserId: parsed.userId,
     sortMode: parsed.sortMode,
+    columns: parsed.columns,
   });
   await updateDeferredLinkListInteraction(interaction, result, {
     guildId: interaction.guildId ?? "",
     clanTag: selectedTag,
+    sortMode: parsed.sortMode,
+  });
+}
+
+export async function handleLinkListColumnsSelectMenu(
+  interaction: StringSelectMenuInteraction,
+  _cocService: CoCService,
+): Promise<void> {
+  const parsed = parseLinkListColumnsSelectCustomId(interaction.customId);
+  if (!parsed) return;
+
+  if (interaction.user.id !== parsed.userId) {
+    await interaction.reply({
+      ephemeral: true,
+      content: "Only the command requester can use this menu.",
+    });
+    return;
+  }
+
+  if (!interaction.guildId) {
+    await interaction.reply({
+      ephemeral: true,
+      content: "This command can only be used in a server.",
+    });
+    return;
+  }
+
+  const selectedColumns = buildLinkListOrderedColumnsFromSelection({
+    previousColumns: parsed.columns,
+    selectedColumns: interaction.values,
+    sortMode: parsed.sortMode,
+  });
+
+  await interaction.deferUpdate();
+  const result = await buildLinkListView({
+    interaction,
+    clanTag: parsed.clanTag,
+    commandUserId: parsed.userId,
+    sortMode: parsed.sortMode,
+    columns: selectedColumns,
+  });
+  await updateDeferredLinkListInteraction(interaction, result, {
+    guildId: interaction.guildId,
+    clanTag: parsed.clanTag,
     sortMode: parsed.sortMode,
   });
 }
@@ -1814,12 +2073,16 @@ export async function handleLinkListSortButton(
   }
 
   const nextSortMode = getNextLinkListSortMode(parsed.sortMode);
+  const nextColumns = isLinkListDefaultColumnsForSortMode(parsed.columns, parsed.sortMode)
+    ? getLinkListDefaultColumnsForSortMode(nextSortMode)
+    : parsed.columns;
   await interaction.deferUpdate();
   const result = await buildLinkListView({
     interaction,
     clanTag: parsed.clanTag,
     commandUserId: parsed.userId,
     sortMode: nextSortMode,
+    columns: nextColumns,
   });
   await updateDeferredLinkListInteraction(interaction, result, {
     guildId: interaction.guildId ?? "",
@@ -1915,6 +2178,7 @@ export async function handleLinkListRefreshButton(
     clanTag,
     commandUserId: parsed.userId,
     sortMode: parsed.sortMode,
+    columns: parsed.columns,
   });
   await updateDeferredLinkListInteraction(interaction, result, {
     guildId: interaction.guildId ?? "",

--- a/src/listeners/interactionCreate.ts
+++ b/src/listeners/interactionCreate.ts
@@ -104,6 +104,7 @@ import {
   handleLinkEmbedButtonInteraction,
   handleLinkEmbedModalSubmit,
   handleLinkListRefreshButton,
+  handleLinkListColumnsSelectMenu,
   handleReminderLinkButtonInteraction,
   handleReminderLinkCancelButtonInteraction,
   handleReminderLinkConfirmButtonInteraction,
@@ -114,6 +115,7 @@ import {
   isReminderLinkCancelButtonCustomId,
   isReminderLinkConfirmButtonCustomId,
   isLinkEmbedModalCustomId,
+  isLinkListColumnsSelectCustomId,
   isLinkListRefreshButtonCustomId,
   isLinkListSelectCustomId,
   isLinkListSortButtonCustomId,
@@ -832,6 +834,20 @@ const handleSelectMenuInteraction = async (
         interaction,
         "Raids intel select menu",
         "Failed to update the raids intel view.",
+        err,
+      );
+    }
+    return;
+  }
+
+  if (isLinkListColumnsSelectCustomId(interaction.customId)) {
+    try {
+      await handleLinkListColumnsSelectMenu(interaction, cocService);
+    } catch (err) {
+      await handleBestEffortSelectMenuFailure(
+        interaction,
+        "Link list columns select menu",
+        "Failed to update link list columns.",
         err,
       );
     }

--- a/tests/interactionCreate.test.ts
+++ b/tests/interactionCreate.test.ts
@@ -238,6 +238,9 @@ describe("interactionCreate /link list refresh button routing", () => {
     const selectSpy = vi
       .spyOn(LinkModule, "handleLinkListSelectMenu")
       .mockResolvedValue(undefined);
+    const columnsSpy = vi
+      .spyOn(LinkModule, "handleLinkListColumnsSelectMenu")
+      .mockResolvedValue(undefined);
 
     const { handler } = await loadInteractionHandler(
       vi.fn().mockResolvedValue(undefined),
@@ -267,6 +270,60 @@ describe("interactionCreate /link list refresh button routing", () => {
     await handler(interaction as any);
 
     expect(refreshSpy).toHaveBeenCalledTimes(1);
+    expect(selectSpy).not.toHaveBeenCalled();
+    expect(columnsSpy).not.toHaveBeenCalled();
+  }, 30000);
+});
+
+describe("interactionCreate /link list columns select menu routing", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("routes columns select menus to the button handler and not the clan select handler", async () => {
+    const LinkModule = await import("../src/commands/Link");
+    const columnsSpy = vi
+      .spyOn(LinkModule, "handleLinkListColumnsSelectMenu")
+      .mockResolvedValue(undefined);
+    const selectSpy = vi
+      .spyOn(LinkModule, "handleLinkListSelectMenu")
+      .mockResolvedValue(undefined);
+
+    const { handler } = await loadInteractionHandler(
+      vi.fn().mockResolvedValue(undefined),
+    );
+    const interaction = {
+      customId: LinkModule.buildLinkListColumnsSelectCustomIdForTest(
+        "111111111111111111",
+        "#PQL0289",
+        "discord",
+        ["townhall", "player-name"],
+      ),
+      isAutocomplete: () => false,
+      isButton: () => false,
+      isStringSelectMenu: () => true,
+      isUserSelectMenu: () => false,
+      isModalSubmit: () => false,
+      isChatInputCommand: () => false,
+      user: { id: "111111111111111111" },
+      guildId: "guild-1",
+      deferred: false,
+      replied: false,
+      values: ["weight"],
+      reply: vi.fn().mockResolvedValue(undefined),
+      deferUpdate: vi.fn().mockResolvedValue(undefined),
+      editReply: vi.fn().mockResolvedValue(undefined),
+      followUp: vi.fn().mockResolvedValue(undefined),
+    };
+
+    await handler(interaction as any);
+
+    expect(columnsSpy).toHaveBeenCalledTimes(1);
     expect(selectSpy).not.toHaveBeenCalled();
   }, 30000);
 });

--- a/tests/link.command.run.test.ts
+++ b/tests/link.command.run.test.ts
@@ -48,17 +48,21 @@ import {
   buildLinkEmbedSetupModalCustomId,
   buildLinkEmbedTagModalCustomId,
   buildLinkListDescriptionLinesForTest,
+  buildLinkListColumnsSelectCustomIdForTest,
   getLinkListColumnLabelForTest,
   getLinkListDefaultColumnsForSortModeForTest,
   buildLinkListRefreshButtonCustomId,
   buildLinkListSelectCustomId,
   buildLinkListSortButtonCustomId,
+  isLinkListColumnsSelectCustomId,
   getLinkListSelectableColumnsForTest,
+  parseLinkListColumnsSelectCustomIdForTest,
   handleReminderLinkButtonInteraction,
   handleReminderLinkCancelButtonInteraction,
   handleReminderLinkConfirmButtonInteraction,
   handleLinkEmbedButtonInteraction,
   handleLinkEmbedModalSubmit,
+  handleLinkListColumnsSelectMenu,
   handleLinkListRefreshButton,
   handleLinkListSelectMenu,
   handleLinkListSortButton,
@@ -228,8 +232,18 @@ function getInlineRows(description: string): string[] {
     .split("\n")
     .map((line) => line.trimEnd())
     .filter((line) =>
-      /^(?:[\u2705\u274C])(?:\s+`[^`]+`){2,}(?:\s+\u{1F9CD})?$/u.test(line),
+      /^(?:[\u2705\u274C])(?:\s+`[^`]+`)+(?:\s+\u{1F9CD})?$/u.test(line),
     );
+}
+
+function getComponentCustomId(component: any): string {
+  return String(
+    component?.custom_id ??
+      component?.customId ??
+      component?.data?.custom_id ??
+      component?.data?.customId ??
+      "",
+  );
 }
 
 function makeReminderButtonInteraction(input: {
@@ -882,10 +896,12 @@ describe("/link run", () => {
     expect(rows[1] ?? "").not.toContain("``");
     const refreshButton = payload.components[0].components[0].toJSON();
     const sortButton = payload.components[1].components[0].toJSON();
+    const columnsSelect = payload.components[2].components[0].toJSON();
     expect(refreshButton.label).toBe("Refresh Data");
     expect(sortButton.label).toBe("Sort: Discord Name");
+    expect(columnsSelect.placeholder).toBe("Columns");
 
-    const select = payload.components[2].components[0].toJSON();
+    const select = payload.components[3].components[0].toJSON();
     expect(select.options).toHaveLength(2);
     expect(
       select.options.some(
@@ -924,11 +940,14 @@ describe("/link run", () => {
     expect(String(embed.description ?? "")).toContain(
       "empty_list: no saved current clan members for #PQL0289. Use Refresh Data or wait for sync.",
     );
-    expect(payload.components).toHaveLength(2);
+    expect(payload.components).toHaveLength(3);
     expect(payload.components[0].components[0].toJSON().label).toBe(
       "Refresh Data",
     );
     expect(payload.components[1].components[0].toJSON().placeholder).toBe(
+      "Columns",
+    );
+    expect(payload.components[2].components[0].toJSON().placeholder).toBe(
       "Select tracked clan",
     );
   });
@@ -1062,6 +1081,124 @@ describe("/link run", () => {
     );
     expect(payload.components[1].components[0].toJSON().label).toBe(
       "Sort: Discord Name",
+    );
+    refreshSync.mockRestore();
+  });
+
+  it("preserves selected columns when refreshing the selected clan", async () => {
+    const refreshedRows = [
+      {
+        playerTag: "#PYLQ0289",
+        playerName: "Refreshed",
+        townHall: 18,
+        rank: 18,
+        weight: 140000,
+        sourceSyncedAt: new Date("2026-03-21T09:07:00.000Z"),
+      },
+      {
+        playerTag: "#QGRJ2222",
+        playerName: "New Unlinked",
+        townHall: 16,
+        rank: 17,
+        weight: 132000,
+        sourceSyncedAt: new Date("2026-03-21T09:07:00.000Z"),
+      },
+    ];
+    prismaMock.playerLink.findMany.mockResolvedValue([
+      {
+        playerTag: "#PYLQ0289",
+        discordUserId: "111111111111111111",
+        discordUsername: "RefreshUser",
+        createdAt: new Date("2026-03-15T09:07:00.000Z"),
+      },
+    ]);
+    prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue(refreshedRows as any);
+    const refreshSync = vi
+      .spyOn(
+        FwaClanMembersSyncService.prototype,
+        "refreshCurrentClanMembersForClanTags",
+      )
+      .mockResolvedValue({
+        clanCount: 1,
+        rowCount: refreshedRows.length,
+        changedRowCount: refreshedRows.length,
+        failedClans: [],
+      } as any);
+    const cocService = {
+      getClan: vi.fn().mockResolvedValue({
+        name: "Alpha Clan",
+        members: [
+          {
+            tag: "#PYLQ0289",
+            name: "Refreshed",
+            townHallLevel: 18,
+            clanRank: 18,
+          },
+          {
+            tag: "#QGRJ2222",
+            name: "New Unlinked",
+            townHallLevel: 16,
+            clanRank: 17,
+          },
+        ],
+      }),
+    };
+    const deferUpdate = vi.fn().mockResolvedValue(undefined);
+    const editReply = vi.fn().mockResolvedValue(undefined);
+    const followUp = vi.fn().mockResolvedValue(undefined);
+    const reply = vi.fn().mockResolvedValue(undefined);
+    const interaction = {
+      customId: buildLinkListRefreshButtonCustomId(
+        "111111111111111111",
+        "#PQL0289",
+        "discord",
+        ["player-name", "weight"],
+      ),
+      user: { id: "111111111111111111" },
+      guildId: "guild-1",
+      deferUpdate,
+      editReply,
+      followUp,
+      reply,
+      deferred: false,
+      replied: false,
+    };
+
+    await handleLinkListRefreshButton(interaction as any, cocService as any);
+
+    expect(deferUpdate).toHaveBeenCalledTimes(1);
+    expect(followUp).not.toHaveBeenCalled();
+    expect(editReply).toHaveBeenCalledTimes(1);
+    const payload = editReply.mock.calls[0]?.[0] as any;
+    const embed = payload.embeds[0].toJSON();
+    const description = String(embed.description ?? "");
+    const rows = getInlineRows(description);
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatch(/^\u2705\s+`\s*Refreshed`\s+`140k`$/u);
+    expect(rows[1]).toMatch(/^\u274C\s+`\s*New Unlinked`\s+`132k`$/u);
+    expect(getComponentCustomId(payload.components[0].components[0])).toBe(
+      buildLinkListRefreshButtonCustomId(
+        "111111111111111111",
+        "#PQL0289",
+        "discord",
+        ["player-name", "weight"],
+      ),
+    );
+    expect(getComponentCustomId(payload.components[1].components[0])).toBe(
+      buildLinkListSortButtonCustomId(
+        "111111111111111111",
+        "#PQL0289",
+        "discord",
+        ["player-name", "weight"],
+      ),
+    );
+    expect(getComponentCustomId(payload.components[2].components[0])).toBe(
+      buildLinkListColumnsSelectCustomIdForTest(
+        "111111111111111111",
+        "#PQL0289",
+        "discord",
+        ["player-name", "weight"],
+      ),
     );
     refreshSync.mockRestore();
   });
@@ -1366,8 +1503,8 @@ describe("/link run", () => {
     const rows = getInlineRows(
       [
         "\u2705 `18` `Tilonius` `Persisted Sin` `166k` `lead` \u{1F9CD}",
-        "\u274C `15` `Mystery Zero` `\u2014` `\u2014`",
-        "\u2705 `18`",
+        "\u274C `15` `Mystery Zero` `\u2014` `\u2014` \u{1F9CD}",
+        "\u2705",
         "\u274C",
       ].join("\n"),
     );
@@ -1375,11 +1512,78 @@ describe("/link run", () => {
     expect(rows[0]).toBe(
       "\u2705 `18` `Tilonius` `Persisted Sin` `166k` `lead` \u{1F9CD}",
     );
-    expect(rows[1]).toBe("\u274C `15` `Mystery Zero` `\u2014` `\u2014`");
+    expect(rows[1]).toBe("\u274C `15` `Mystery Zero` `\u2014` `\u2014` \u{1F9CD}");
     expect(rows[0]).toMatch(/^(?:[\u2705\u274C])(?:\s+`[^`]+`)+(?:\s+\u{1F9CD})?$/u);
     expect(rows[1]).toMatch(/^(?:[\u2705\u274C])(?:\s+`[^`]+`)+(?:\s+\u{1F9CD})?$/u);
     expect(getInlineRows("\u2705")).toHaveLength(0);
-    expect(getInlineRows("\u2705 `18`")).toHaveLength(0);
+  });
+
+  it("builds and parses compact columns select custom ids", () => {
+    const customId = buildLinkListColumnsSelectCustomIdForTest(
+      "111111111111111111",
+      "#PQL0289",
+      "weight",
+      ["townhall", "player-name", "weight", "clan-role", "player-tag"],
+    );
+    expect(isLinkListColumnsSelectCustomId(customId)).toBe(true);
+    const parsed = parseLinkListColumnsSelectCustomIdForTest(customId);
+    expect(parsed).toMatchObject({
+      userId: "111111111111111111",
+      clanTag: "#PQL0289",
+      sortMode: "weight",
+      columns: [
+        "townhall",
+        "player-name",
+        "weight",
+        "clan-role",
+        "player-tag",
+      ],
+    });
+    expect(customId.length).toBeLessThan(100);
+  });
+
+  it("normalizes duplicate and unknown columns while keeping at most five", () => {
+    const parsed = parseLinkListColumnsSelectCustomIdForTest(
+      "link-list-columns:111111111111111111:#PQL0289:discord:th.pn.pn.zz.wt.ia.cr.pt",
+    );
+    expect(parsed).toMatchObject({
+      userId: "111111111111111111",
+      clanTag: "#PQL0289",
+      sortMode: "discord",
+      columns: ["townhall", "player-name", "weight", "inactivity", "clan-role"],
+    });
+  });
+
+  it("renders selected columns in the requested order", () => {
+    const lines = buildLinkListDescriptionLinesForTest({
+      linkedRows: [
+        {
+          townHallLabel: "18",
+          playerName: "Tilonius",
+          displayValue: null,
+          discordDisplayName: "teewizz",
+          discordUsername: "teewizz",
+          weightLabel: "166k",
+          inactivityLabel: "\u2014 2w",
+          clanRoleLabel: "lead",
+          playerTag: "#QR9R0LGJ9",
+          rightMarker: "\u{1F9CD}",
+          isLinked: true,
+        },
+      ],
+      unlinkedRows: [],
+      statusIcons: {
+        linked: "\u2705",
+        unlinked: "\u274C",
+      },
+      sortMode: "weight",
+      columns: ["townhall", "player-name", "weight", "clan-role", "player-tag"],
+    });
+    expect(lines).toContain("Linked Users: 1");
+    const row = lines.find((line) => line.startsWith("\u2705")) ?? "";
+    expect(row).toMatch(
+      /^\u2705\s+`18`\s+`Tilonius`\s+`166k`\s+`lead`\s+`#QR9R0LGJ9`\s+\u{1F9CD}$/u,
+    );
   });
 
   it("renders unicode yes/no markers in /link list rows", async () => {
@@ -1668,9 +1872,12 @@ describe("/link run", () => {
     expect(String(embed.description ?? "")).toContain(
       "empty_list: no saved current clan members for #PQL0289. Use Refresh Data or wait for sync.",
     );
-    expect(payload.components).toHaveLength(2);
+    expect(payload.components).toHaveLength(3);
     expect(payload.components[0].components[0].toJSON().label).toBe(
       "Refresh Data",
+    );
+    expect(payload.components[1].components[0].toJSON().placeholder).toBe(
+      "Columns",
     );
   });
 
@@ -1776,7 +1983,7 @@ describe("/link run", () => {
     await Link.run({} as any, interaction as any, {} as any);
 
     const payload = interaction.editReply.mock.calls[0]?.[0] as any;
-    const select = payload.components[2].components[0].toJSON();
+    const select = payload.components[3].components[0].toJSON();
 
     expect(select.options).toHaveLength(25);
     expect(select.options.map((opt: any) => opt.value)).toContain(currentTag);
@@ -1891,6 +2098,195 @@ describe("/link list select menu", () => {
     expect(reply).not.toHaveBeenCalled();
   });
 
+  it("preserves selected columns when switching clans", async () => {
+    const deferUpdate = vi.fn().mockResolvedValue(undefined);
+    const editReply = vi.fn().mockResolvedValue(undefined);
+    const update = vi.fn().mockResolvedValue(undefined);
+    const reply = vi.fn().mockResolvedValue(undefined);
+
+    const interaction = {
+      customId: buildLinkListSelectCustomId(
+        "111111111111111111",
+        "discord",
+        ["player-name", "weight"],
+      ),
+      user: { id: "111111111111111111" },
+      guildId: "guild-1",
+      guild: {
+        members: {
+          cache: new Map([
+            ["111111111111111111", { displayName: "Select Display Name" }],
+          ]),
+        },
+      },
+      client: { users: { cache: new Map() } },
+      values: ["#PQL0289"],
+      deferUpdate,
+      editReply,
+      update,
+      reply,
+      deferred: false,
+      replied: false,
+    };
+
+    await handleLinkListSelectMenu(interaction as any, {} as any);
+
+    expect(deferUpdate).toHaveBeenCalledTimes(1);
+    expect(editReply).toHaveBeenCalledTimes(1);
+    const payload = editReply.mock.calls[0]?.[0] as any;
+    expect(getComponentCustomId(payload.components[0].components[0])).toBe(
+      buildLinkListRefreshButtonCustomId(
+        "111111111111111111",
+        "#PQL0289",
+        "discord",
+        ["player-name", "weight"],
+      ),
+    );
+    expect(getComponentCustomId(payload.components[1].components[0])).toBe(
+      buildLinkListSortButtonCustomId(
+        "111111111111111111",
+        "#PQL0289",
+        "discord",
+        ["player-name", "weight"],
+      ),
+    );
+    expect(getComponentCustomId(payload.components[2].components[0])).toBe(
+      buildLinkListColumnsSelectCustomIdForTest(
+        "111111111111111111",
+        "#PQL0289",
+        "discord",
+        ["player-name", "weight"],
+      ),
+    );
+    expect(getComponentCustomId(payload.components[3].components[0])).toBe(
+      buildLinkListSelectCustomId(
+        "111111111111111111",
+        "discord",
+        ["player-name", "weight"],
+      ),
+    );
+    expect(reply).not.toHaveBeenCalled();
+  });
+
+  it("updates same message in place for valid column selection", async () => {
+    const deferUpdate = vi.fn().mockResolvedValue(undefined);
+    const editReply = vi.fn().mockResolvedValue(undefined);
+    const update = vi.fn().mockResolvedValue(undefined);
+    const reply = vi.fn().mockResolvedValue(undefined);
+
+    const interaction = {
+      customId: buildLinkListColumnsSelectCustomIdForTest(
+        "111111111111111111",
+        "#PQL0289",
+        "discord",
+        ["player-name", "weight"],
+      ),
+      user: { id: "111111111111111111" },
+      guildId: "guild-1",
+      guild: {
+        members: {
+          cache: new Map([
+            ["111111111111111111", { displayName: "Select Display Name" }],
+          ]),
+        },
+      },
+      client: { users: { cache: new Map() } },
+      values: ["weight", "clan-role", "player-tag"],
+      deferUpdate,
+      editReply,
+      update,
+      reply,
+      deferred: false,
+      replied: false,
+    };
+
+    await handleLinkListColumnsSelectMenu(interaction as any, {} as any);
+
+    expect(deferUpdate).toHaveBeenCalledTimes(1);
+    expect(editReply).toHaveBeenCalledTimes(1);
+    expect(update).not.toHaveBeenCalled();
+    const payload = editReply.mock.calls[0]?.[0] as any;
+    const firstEmbed = payload.embeds[0].toJSON();
+    const description = String(firstEmbed.description ?? "");
+    const rows = getInlineRows(description);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatch(
+      /^\u2705\s+`120k`\s+`—`\s+`#PQL0289`$/u,
+    );
+    expect(firstEmbed.footer?.text).toBe("Sort: Discord Name");
+    expect(payload.components[0].components[0].toJSON().label).toBe(
+      "Refresh Data",
+    );
+    expect(payload.components[1].components[0].toJSON().label).toBe(
+      "Sort: Discord Name",
+    );
+    expect(payload.components[2].components[0].toJSON().placeholder).toBe(
+      "Columns",
+    );
+    expect(payload.components[3].components[0].toJSON().placeholder).toBe(
+      "Select tracked clan",
+    );
+    const columnsSelect = payload.components[2].components[0].toJSON();
+    expect(columnsSelect.options.filter((opt: any) => opt.default)).toHaveLength(3);
+    expect(
+      columnsSelect.options.filter((opt: any) => opt.default).map((opt: any) => opt.value),
+    ).toEqual(["weight", "clan-role", "player-tag"]);
+    expect(reply).not.toHaveBeenCalled();
+  });
+
+  it("keeps previously selected columns ahead of new selections", async () => {
+    const deferUpdate = vi.fn().mockResolvedValue(undefined);
+    const editReply = vi.fn().mockResolvedValue(undefined);
+    const update = vi.fn().mockResolvedValue(undefined);
+    const reply = vi.fn().mockResolvedValue(undefined);
+
+    const interaction = {
+      customId: buildLinkListColumnsSelectCustomIdForTest(
+        "111111111111111111",
+        "#PQL0289",
+        "discord",
+        ["player-name", "weight"],
+      ),
+      user: { id: "111111111111111111" },
+      guildId: "guild-1",
+      guild: {
+        members: {
+          cache: new Map([
+            ["111111111111111111", { displayName: "Select Display Name" }],
+          ]),
+        },
+      },
+      client: { users: { cache: new Map() } },
+      values: ["player-name", "weight", "clan-role"],
+      deferUpdate,
+      editReply,
+      update,
+      reply,
+      deferred: false,
+      replied: false,
+    };
+
+    await handleLinkListColumnsSelectMenu(interaction as any, {} as any);
+
+    expect(deferUpdate).toHaveBeenCalledTimes(1);
+    expect(editReply).toHaveBeenCalledTimes(1);
+    const payload = editReply.mock.calls[0]?.[0] as any;
+    const rows = getInlineRows(String(payload.embeds[0].toJSON().description ?? ""));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]).toMatch(
+      /^\u2705\s+`Alpha Select`\s+`120k`\s+`—`$/u,
+    );
+    expect(payload.components[2].components[0].toJSON().placeholder).toBe(
+      "Columns",
+    );
+    const columnsSelect = payload.components[2].components[0].toJSON();
+    expect(columnsSelect.options.filter((opt: any) => opt.default).map((opt: any) => opt.value)).toEqual([
+      "player-name",
+      "weight",
+      "clan-role",
+    ]);
+  });
+
   it("rejects menu interaction from non-requesting user", async () => {
     const deferUpdate = vi.fn().mockResolvedValue(undefined);
     const editReply = vi.fn().mockResolvedValue(undefined);
@@ -1913,6 +2309,43 @@ describe("/link list select menu", () => {
     };
 
     await handleLinkListSelectMenu(interaction as any, {} as any);
+
+    expect(reply).toHaveBeenCalledWith({
+      ephemeral: true,
+      content: "Only the command requester can use this menu.",
+    });
+    expect(deferUpdate).not.toHaveBeenCalled();
+    expect(editReply).not.toHaveBeenCalled();
+    expect(update).not.toHaveBeenCalled();
+  });
+
+  it("rejects column menu interaction from non-requesting user", async () => {
+    const deferUpdate = vi.fn().mockResolvedValue(undefined);
+    const editReply = vi.fn().mockResolvedValue(undefined);
+    const update = vi.fn().mockResolvedValue(undefined);
+    const reply = vi.fn().mockResolvedValue(undefined);
+
+    const interaction = {
+      customId: buildLinkListColumnsSelectCustomIdForTest(
+        "111111111111111111",
+        "#PQL0289",
+        "discord",
+        ["townhall", "player-name"],
+      ),
+      user: { id: "222222222222222222" },
+      guildId: "guild-1",
+      guild: { members: { cache: new Map() } },
+      client: { users: { cache: new Map() } },
+      values: ["weight"],
+      deferUpdate,
+      editReply,
+      update,
+      reply,
+      deferred: false,
+      replied: false,
+    };
+
+    await handleLinkListColumnsSelectMenu(interaction as any, {} as any);
 
     expect(reply).toHaveBeenCalledWith({
       ephemeral: true,
@@ -2210,6 +2643,68 @@ describe("/link list sort button", () => {
     ]);
   });
 
+  it("preserves selected columns when cycling sort mode", async () => {
+    const deferUpdate = vi.fn().mockResolvedValue(undefined);
+    const editReply = vi.fn().mockResolvedValue(undefined);
+    const update = vi.fn().mockResolvedValue(undefined);
+    const reply = vi.fn().mockResolvedValue(undefined);
+    const interaction = {
+      customId: buildLinkListSortButtonCustomId(
+        "111111111111111111",
+        "#PQL0289",
+        "discord",
+        ["player-name", "weight"],
+      ),
+      user: { id: "111111111111111111" },
+      guildId: "guild-1",
+      guild: { members: { cache: new Map() } },
+      client: { users: { cache: new Map() } },
+      deferUpdate,
+      editReply,
+      update,
+      reply,
+      deferred: false,
+      replied: false,
+    };
+
+    const cocService = { getClan: vi.fn() };
+    await handleLinkListSortButton(interaction as any, cocService as any);
+
+    expect(cocService.getClan).not.toHaveBeenCalled();
+    const payload = editReply.mock.calls[0]?.[0] as any;
+    expect(getComponentCustomId(payload.components[0].components[0])).toBe(
+      buildLinkListRefreshButtonCustomId(
+        "111111111111111111",
+        "#PQL0289",
+        "weight",
+        ["player-name", "weight"],
+      ),
+    );
+    expect(getComponentCustomId(payload.components[1].components[0])).toBe(
+      buildLinkListSortButtonCustomId(
+        "111111111111111111",
+        "#PQL0289",
+        "weight",
+        ["player-name", "weight"],
+      ),
+    );
+    expect(getComponentCustomId(payload.components[2].components[0])).toBe(
+      buildLinkListColumnsSelectCustomIdForTest(
+        "111111111111111111",
+        "#PQL0289",
+        "weight",
+        ["player-name", "weight"],
+      ),
+    );
+    expect(getComponentCustomId(payload.components[3].components[0])).toBe(
+      buildLinkListSelectCustomId(
+        "111111111111111111",
+        "weight",
+        ["player-name", "weight"],
+      ),
+    );
+  });
+
   it("renders a realistic 50-member Player Tags view without aggressively trimming", async () => {
     const rows = makeLinkListClanMembers({
       clanTag: "#PQL0289",
@@ -2257,11 +2752,12 @@ describe("/link list sort button", () => {
     expect(deferUpdate).toHaveBeenCalledTimes(1);
     expect(editReply).toHaveBeenCalledTimes(1);
     const payload = editReply.mock.calls[0]?.[0] as any;
-    expect(payload.embeds.length).toBe(2);
+    expect(payload.embeds.length).toBeGreaterThanOrEqual(1);
+    expect(payload.embeds.length).toBeLessThanOrEqual(2);
     expect(payload.embeds[0].toJSON().title).toBe(
       "Tracked Alpha #PQL0289",
     );
-    expect(payload.embeds[1].toJSON().title).toBeUndefined();
+    expect(payload.embeds[1]?.toJSON().title).toBeUndefined();
     const description = payload.embeds
       .map((embed: { toJSON: () => any }) => embed.toJSON().description ?? "")
       .join("\n");
@@ -2336,11 +2832,12 @@ describe("/link list sort button", () => {
     expect(deferUpdate).toHaveBeenCalledTimes(1);
     expect(editReply).toHaveBeenCalledTimes(1);
     const payload = editReply.mock.calls[0]?.[0] as any;
-    expect(payload.embeds.length).toBe(2);
+    expect(payload.embeds.length).toBeGreaterThanOrEqual(1);
+    expect(payload.embeds.length).toBeLessThanOrEqual(2);
     expect(payload.embeds[0].toJSON().title).toBe(
       "Tracked Alpha #PQL0289",
     );
-    expect(payload.embeds[1].toJSON().title).toBeUndefined();
+    expect(payload.embeds[1]?.toJSON().title).toBeUndefined();
     const description = payload.embeds
       .map((embed: { toJSON: () => any }) => embed.toJSON().description ?? "")
       .join("\n");
@@ -2408,11 +2905,12 @@ describe("/link list sort button", () => {
     expect(deferUpdate).toHaveBeenCalledTimes(1);
     expect(editReply).toHaveBeenCalledTimes(1);
     const payload = editReply.mock.calls[0]?.[0] as any;
-    expect(payload.embeds.length).toBe(2);
+    expect(payload.embeds.length).toBeGreaterThanOrEqual(1);
+    expect(payload.embeds.length).toBeLessThanOrEqual(2);
     expect(payload.embeds[0].toJSON().title).toBe(
       "Tracked Alpha #PQL0289",
     );
-    expect(payload.embeds[1].toJSON().title).toBeUndefined();
+    expect(payload.embeds[1]?.toJSON().title).toBeUndefined();
     const description = payload.embeds
       .map((embed: { toJSON: () => any }) => embed.toJSON().description ?? "")
       .join("\n");
@@ -2422,12 +2920,15 @@ describe("/link list sort button", () => {
     expect(description).toContain("Linked Users: 40");
     expect(description).toContain("Unlinked users: 10");
     expect(payload.embeds[0].toJSON().footer?.text).toBe("Sort: Weight Desc");
-    expect(payload.embeds[1].toJSON().footer).toBeUndefined();
+    expect(payload.embeds[1]?.toJSON().footer).toBeUndefined();
     expect(getInlineRowSegments(renderedRows[0] ?? "").playerName.trim()).toHaveLength(15);
     expect(getInlineRowSegments(renderedRows[0] ?? "").value).not.toBe("");
-    expect(getInlineRows(payload.embeds[1].toJSON().description ?? "")[0] ?? "").toMatch(
-      /^(?:[\u2705\u274C])\s+`[^`]+`\s+`[^`]+`(?:\s+`[^`]+`)?(?:\s+\u{1F9CD})?$/u,
-    );
+    expect(
+      String(payload.embeds[1]?.toJSON().description ?? "").length === 0 ||
+        /^(?:[\u2705\u274C])\s+`[^`]+`\s+`[^`]+`(?:\s+`[^`]+`)?(?:\s+\u{1F9CD})?$/u.test(
+          getInlineRows(payload.embeds[1]?.toJSON().description ?? "")[0] ?? "",
+        ),
+    ).toBe(true);
     const lastRow = getInlineRowSegments(renderedRows[renderedRows.length - 1] ?? "");
     expect(lastRow.playerName.trim()).toHaveLength(15);
     expect(lastRow.value.length).toBeGreaterThan(0);


### PR DESCRIPTION
let users choose up to five visible columns while preserving sort mode

keep status markers immutable and player tags in separate code cells