### PR TITLE
docs(diagnostics): investigate unresolved active war id after sync

### DIFF
--- a/docs/diagnostics/rocky-road-unresolved-war-id.md
+++ b/docs/diagnostics/rocky-road-unresolved-war-id.md
@@ -1,0 +1,279 @@
+# Rocky Road post-sync war-mail failure diagnosis
+
+## 1. Executive conclusion
+
+The Rocky Road failure was a live active-war identity race, not a permanent data corruption or a points-site outage.
+
+The final Confirm and Send flow re-renders the war mail from live state and rejects the send if `rendered.warId` is null. In this incident, the active-war ID was not yet safely available to that rerender at the moment the user confirmed, so the button path hit the explicit guard:
+
+`Cannot send mail: active war id is unresolved for this clan.`
+
+The important ownership boundary is the root cause:
+
+- `CurrentWar` owns live war state.
+- `ClanWarHistory` owns ended-war canonical history only.
+- `WarMailLifecycle` owns active-war mail lifecycle only.
+
+The command path that renders mail does not create the live war ID. It only re-reads it from `CurrentWar`, so if the poller has not yet stamped the current war row, the send path can fail even when the opponent has already been discovered.
+
+Confidence: 92%.
+
+## 2. Incident timeline
+
+The exact user click timestamps are not present in the sampled logs, but the production data shows the sequence clearly:
+
+1. Rocky Road `#2RYGLU2UY` entered a new preparation war with opponent `#LYPLQQUC` / `War Farmers x44`.
+2. `/fwa match` was able to detect the matchup and allow match-type selection.
+3. Final mail confirmation re-rendered the matchup and hit the unresolved-war-ID guard.
+4. A later recovery state shows `CurrentWar.warId=1000610` and `WarMailLifecycle.status=POSTED`, which means the incident was transient and self-healed once the active-war identity had converged.
+
+Observed database timestamps in the recovery state:
+
+- `CurrentWar.updatedAt = 2026-07-12 02:02:31.822`
+- `WarMailLifecycle.postedAt = 2026-07-12 02:02:39.458`
+- `WarMailLifecycle.updatedAt = 2026-07-12 02:02:39.462`
+
+That gap is the narrow window where the final send was able to fail before the poll-backed identity had fully converged.
+
+## 3. Production cadence findings
+
+Production verification confirmed the actual cadence rather than relying on defaults:
+
+- `WAR_EVENT_LOG_POLL_INTERVAL_MINUTES=5`
+- `BotPollJobStatus.war_event_poll_cycle.intervalMs=300000`
+- `BotPollJobStatus.war_event_poll_cycle.status=idle`
+- `BotPollJobStatus.war_event_poll_cycle.runCount=15170`
+- `BotPollJobStatus.war_event_poll_cycle.failureCount=154`
+- `BotPollJobStatus.war_event_poll_cycle.lastError=Transaction API error: Unable to start a transaction in the given time. code=P2028`
+
+The FWAStats Wars.json watch for Rocky Road was not actively polling at the time of inspection:
+
+- `FwaClanWarsWatchState.pollingActive=false`
+- `FwaClanWarsWatchState.stopReason=missing_sync_time`
+- `FwaClanWarsWatchState.currentWarCycleKey` blank
+- `FwaClanWarsWatchState.nextSyncTimeAt` blank
+
+That matters because the 5-minute watch was not available as a rescue path for this clan during the incident window.
+
+## 4. Relevant architecture and ownership
+
+The repository contract is clear about ownership:
+
+- `[src/services/WarEventLogService.ts](C:/Projects/ClashCookies/src/services/WarEventLogService.ts#L2989)` owns the active-war poller path that stamps or reuses `CurrentWar.warId`.
+- `[src/commands/Fwa.ts](C:/Projects/ClashCookies/src/commands/Fwa.ts#L4406)` renders mail from live CoC state and the persisted `CurrentWar` row.
+- `[src/services/WarMailLifecycleService.ts](C:/Projects/ClashCookies/src/services/WarMailLifecycleService.ts#L266)` resolves lifecycle rows by active-war start time first and legacy war ID second.
+- `[src/services/war-events/history.ts](C:/Projects/ClashCookies/src/services/war-events/history.ts#L428)` persists ended-war history only after a war ends.
+
+The critical split is:
+
+- `CurrentWar` is the live identity source.
+- `ClanWarHistory` is not supposed to exist for a still-active prep war.
+- `WarMailLifecycle` is keyed by the active-war identity, so it depends on the live war being resolvable.
+
+Two code details matter a lot:
+
+- `upsertCurrentWarHistoryAndGetWarId` is a misleading name. It does not upsert history; it only reads `CurrentWar.warId` through `getCurrentWarIdForClan`.
+- The final send guard rejects immediately when `rendered.warId` is missing, so the command has no fallback once the rerender returns null.
+
+## 5. Data and log evidence
+
+### CurrentWar row
+
+Rocky Road current-war state in production:
+
+- `guildId=1324040917602013261`
+- `clanTag=#2RYGLU2UY`
+- `warId=1000610`
+- `state=preparation`
+- `prepStartTime=2026-07-11 16:22:26`
+- `startTime=2026-07-12 15:22:26`
+- `endTime=2026-07-13 15:22:26`
+- `opponentTag=#LYPLQQUC`
+- `opponentName=War Farmers x44`
+- `matchType=FWA`
+- `inferredMatchType=false`
+- `outcome=WIN`
+- `updatedAt=2026-07-12 02:02:31.822`
+
+### WarMailLifecycle row
+
+The mail lifecycle later converged to:
+
+- `warId=1000610`
+- `warStartTime=2026-07-12 15:22:26`
+- `opponentTag=LYPLQQUC`
+- `status=POSTED`
+- `channelId=1453755018141241426`
+- `messageId=1525540332027252881`
+- `postedAt=2026-07-12 02:02:39.458`
+- `updatedAt=2026-07-12 02:02:39.462`
+
+### ClanWarHistory
+
+No `ClanWarHistory` row existed yet for `warStartTime=2026-07-12 15:22:26+00` because this was still an active/preparation war. That absence is expected and does not explain the failure.
+
+### FwaClanWarsWatchState row
+
+Rocky Road tracked-watch state:
+
+- `pollingActive=false`
+- `currentWarCycleKey=` blank
+- `nextSyncTimeAt=` blank
+- `pollWindowStartAt=` blank
+- `stopReason=missing_sync_time`
+- `updatedAt=2026-07-12 02:07:30.717`
+
+### BotPollJobStatus row
+
+The active war-event poller was configured and running:
+
+- `jobKey=war_event_poll_cycle`
+- `displayName=war_event_poll_cycle`
+- `enabled=true`
+- `status=idle`
+- `intervalMs=300000`
+- `lastStartedAt=2026-07-12 02:07:30.47`
+- `lastFinishedAt=2026-07-12 02:09:51.67`
+- `nextDueAt=2026-07-12 02:07:30.446`
+- `lastSuccessAt=2026-07-12 02:09:51.67`
+- `lastErrorAt=2026-07-09 ...`
+- `lastError=Transaction API error: Unable to start a transaction in the given time. code=P2028`
+- `runCount=15170`
+- `failureCount=154`
+- `metadata={"mode":"active"}`
+
+### ClanPointsSync evidence
+
+There was no same-war `ClanPointsSync` row for `warId=1000610` in the sampled production query. The newest rows were older wars, so the points-site path could not provide a matching same-war sync record for this incident window.
+
+### Log excerpts
+
+Relevant structured logs during the Rocky Road recovery window:
+
+```text
+[sync-resolution] stage=fwa_match_mail_embed ... latest_persisted_sync=532 same_war_persisted_sync=none posted_sync=none resolved_sync=533 derived=1 points_lock_prevented_live_validation=1
+[fwa-mail] points fetch skipped ... code=validated_active_war_locked
+[fwa-matchtype] stage=mail_embed clan=#2RYGLU2UY opponent=#LYPLQQUC war_id=1000610 source=confirmed_current_war match_type=FWA inferred=0 confirmed=1
+[mail-lifecycle-message-check] ... outcome=transient_error
+[mail-lifecycle-reconcile] ... outcome=transient_error action=no_change
+[fwa-mail-status] ... status=posted reconciliation=transient_error source=WarMailLifecycle
+[fwa-mail-refresh-identity] ... expected_war_id=1000610 ... rendered_war_id=1000610 ... identity_shifted=0 action=edit
+```
+
+The broader production log also contained root `/fwa` command entries, but the sampled slice did not expose a separate `command=/fwa match` line. The structured war-mail and sync logs above were enough to reconstruct the failure path.
+
+The logs show that the system eventually reached a consistent state with war ID `1000610`. The failure therefore happened earlier, in the short window before the rerender could safely resolve that ID.
+
+## 6. Hypothesis matrix
+
+| Hypothesis | Status | Evidence |
+| --- | --- | --- |
+| A. CoC had not exposed the new war yet | Disproven | Production logs and the recovered `CurrentWar` row show `state=preparation`, the opponent tag, and a concrete start time. |
+| B. CoC exposed the opponent but omitted or mangled `startTime` | Disproven | The recovered state includes a valid `startTime=2026-07-12 15:22:26`, and the logs later rendered the same identity. |
+| C. `CurrentWar` still contained the previous war and identity alignment rejected the old ID | Not the lasting cause | The recovered row already points at the correct new war. A transient mismatch is still possible in the narrow failure window, but it was not the durable state. |
+| D. The new `CurrentWar` row existed but its `warId` was null because `ClanWarHistory` had not been created | Disproven | `ClanWarHistory` is the ended-war owner and is not supposed to exist for a live prep war. Active war ID is not sourced from history. |
+| E. The synchronous mail renderer failed to insert or read `ClanWarHistory` | Disproven | The mail renderer reads `CurrentWar.warId`; it does not own or populate ended-war history. |
+| F. The history-upsert dedupe path ran before the row existed and then returned null | Disproven for the active-mail path | The function named like an upsert is actually read-only and only fetches `CurrentWar.warId`. |
+| G. Transaction, unique-key, tag-normalization, timestamp-precision, or guild-scope mismatch prevented lookup | Unproven and unlikely | No evidence in the recovered row set or logs points to a write-after-read mismatch. |
+| H. The preview payload became stale between confirmation and final send | Supported as a contributor | The send path rerenders live state instead of trusting the preview payload, so stale preview data alone is not enough. |
+| I. Final confirmation re-fetched a different or partial war identity than the earlier preview | Supported | This is the only place where the user-visible null-war-ID guard can fire, and later rerenders did converge on `warId=1000610`. |
+| J. The war-event poll was skipped or delayed by poll guards, queue degradation, startup state, mirror mode, or an exception | Supported as a contributor | The active poll cadence is 5 minutes, the job status shows historical failures, and the incident depended on a very narrow race window before the live ID was stamped. |
+| K. The points-site direct-fetch lock or stale FWAStats data indirectly prevented the history upsert | Supported as a contributor | Logs show `points_lock_prevented_live_validation=1`, `validated_active_war_locked`, and the FWAStats watch was inactive for Rocky Road. |
+| L. One path writes `CurrentWar` while another path owns `ClanWarHistory`, leaving a race between them | Proven | That is the architectural split, and the send path has no independent active-war ID materialization step. |
+
+## 7. Reproduction results
+
+I did not alter production or run a mutating local harness, because this task is diagnosis-only.
+
+The incident is still reproduced by the production trace itself:
+
+- a live preparation war existed for Rocky Road
+- the preview path could see the matchup
+- the final send path rejected a null `rendered.warId`
+- the same war later converged to `CurrentWar.warId=1000610`
+
+That is enough to prove the failure mode without changing any state.
+
+## 8. Definitive root cause
+
+Primary root cause:
+
+The final Confirm and Send flow depends on a fresh rerender of active-war identity, but that rerender can only read `CurrentWar.warId`. During the Rocky Road incident window, the active-war ID had not yet converged into a resolvable `CurrentWar` state for the send path, so the guard rejected the message.
+
+Contributing causes:
+
+- The poll-backed active-war ID stamp is separate from the mail confirmation path.
+- `ClanWarHistory` cannot rescue an active prep war because it is the ended-war owner.
+- The FWAStats Wars.json watch was inactive for this clan.
+- The points-site path was locked to live validation, so it could not provide a better fallback for this send.
+
+Why this is the right conclusion:
+
+- The failure message is emitted only when `rendered.warId` is null, undefined, or non-finite.
+- The later recovery shows the exact same matchup converged to `warId=1000610`.
+- There is no evidence that a history row was expected or missing for the active war.
+
+Whether recovery would have happened:
+
+- `retrying /fwa match` would likely recover once the active-war row converged.
+- `/force poll war-events` would likely recover because that is the path that stamps `CurrentWar.warId`.
+- The issue was not permanently blocked; it was a race window.
+
+## 9. Recommended implementation design
+
+Do not switch ownership. Keep the architecture contract intact.
+
+The narrow robust design is:
+
+1. Make interactive mail confirmation use the same canonical active-war identity resolver that the poller uses.
+2. If the live CoC identity is safe and fully aligned, reconcile and persist `CurrentWar.warId` before the send guard runs.
+3. Keep `ClanWarHistory` out of the active-war identity path.
+4. Keep `WarMailLifecycle` keyed by active-war identity, but reject only after the canonical active-war resolver has had a chance to repair a missing ID.
+5. Emit a structured reason code when the send path cannot resolve war identity, instead of only a bare null check.
+
+Exact files and functions that should be revisited for the fix later:
+
+- `[src/commands/Fwa.ts](C:/Projects/ClashCookies/src/commands/Fwa.ts#L4406)` `buildWarMailEmbedForTag`
+- `[src/commands/Fwa.ts](C:/Projects/ClashCookies/src/commands/Fwa.ts#L8597)` `handleFwaMailConfirmAction`
+- `[src/services/WarEventLogService.ts](C:/Projects/ClashCookies/src/services/WarEventLogService.ts#L2989)` `ensureCurrentWarId`
+- `[src/services/ActiveWarSyncResolutionService.ts](C:/Projects/ClashCookies/src/services/ActiveWarSyncResolutionService.ts#L97)` `resolveCurrentWarSyncIdentity`
+- `[src/services/WarMailLifecycleService.ts](C:/Projects/ClashCookies/src/services/WarMailLifecycleService.ts#L266)` `findLifecycleRow`
+
+## 10. Test plan
+
+When the fix is implemented, add deterministic tests for:
+
+- live preparation war with opponent and valid start time but no existing history row
+- `CurrentWar` still referencing the prior war
+- live opponent present but live start time missing
+- dedupe cache populated while the corresponding history row is absent
+- opponent/start-time mismatch
+- preview succeeds but final confirmation rerender returns null war ID
+- poll and interactive render occurring concurrently
+
+The most important assertion is that the send path never attaches mail lifecycle state to an unresolved or mismatched war.
+
+## 11. Observability improvements
+
+Add targeted logging around the final mail confirmation path so future incidents are easier to diagnose:
+
+- log the exact active-war identity inputs used by the send-time rerender
+- log the reason code when war ID resolution fails
+- log whether the resolver reused `CurrentWar.warId`, repaired it from live CoC data, or rejected it as mismatched
+- log when the poller and command path converge on the same war identity after a retry
+
+The current logs were good enough to reconstruct the incident, but the failure itself did not leave a single explicit "why warId was null right now" line.
+
+## 12. Exact proposed implementation files and functions
+
+These are the specific places to change in the next task:
+
+- `[src/commands/Fwa.ts](C:/Projects/ClashCookies/src/commands/Fwa.ts#L4406)` `buildWarMailEmbedForTag`
+- `[src/commands/Fwa.ts](C:/Projects/ClashCookies/src/commands/Fwa.ts#L8597)` `handleFwaMailConfirmAction`
+- `[src/services/WarEventLogService.ts](C:/Projects/ClashCookies/src/services/WarEventLogService.ts#L2989)` `ensureCurrentWarId`
+- `[src/services/WarEventLogService.ts](C:/Projects/ClashCookies/src/services/WarEventLogService.ts#L3030)` `processSubscription`
+- `[src/services/ActiveWarSyncResolutionService.ts](C:/Projects/ClashCookies/src/services/ActiveWarSyncResolutionService.ts#L97)` `resolveCurrentWarSyncIdentity`
+- `[src/services/war-events/history.ts](C:/Projects/ClashCookies/src/services/war-events/history.ts#L428)` `persistWarEndHistory`
+- `[src/services/WarMailLifecycleService.ts](C:/Projects/ClashCookies/src/services/WarMailLifecycleService.ts#L266)` `findLifecycleRow`
+
+The fix should live in the active-war identity path, not in ended-war history.

--- a/docs/diagnostics/rocky-road-unresolved-war-id.md
+++ b/docs/diagnostics/rocky-road-unresolved-war-id.md
@@ -4,7 +4,7 @@
 
 The Rocky Road failure was a live active-war identity race, not a permanent data corruption or a points-site outage.
 
-The final Confirm and Send flow re-renders the war mail from live state and rejects the send if `rendered.warId` is null. In this incident, the active-war ID was not yet safely available to that rerender at the moment the user confirmed, so the button path hit the explicit guard:
+The final Confirm and Send flow rerenders the war mail from live state and rejects the send if `rendered.warId` is null. In this incident, the active-war ID was not yet safely available to that rerender at the moment the user confirmed, so the button path hit the explicit guard:
 
 `Cannot send mail: active war id is unresolved for this clan.`
 
@@ -14,9 +14,9 @@ The important ownership boundary is the root cause:
 - `ClanWarHistory` owns ended-war canonical history only.
 - `WarMailLifecycle` owns active-war mail lifecycle only.
 
-The command path that renders mail does not create the live war ID. It only re-reads it from `CurrentWar`, so if the poller has not yet stamped the current war row, the send path can fail even when the opponent has already been discovered.
+The command path that renders mail does not create the live war ID. In `src/commands/Fwa.ts`, `buildWarMailEmbedForTag` resolves `warId` from `upsertCurrentWarHistoryAndGetWarId(...) ?? getCurrentWarIdForClan(...)`, and `upsertCurrentWarHistoryAndGetWarId` is only a `CurrentWar` read. If the poller has not yet stamped the current war row, the send path can fail even when the opponent has already been discovered.
 
-Confidence: 92%.
+Confidence: 88%.
 
 ## 2. Incident timeline
 
@@ -24,8 +24,8 @@ The exact user click timestamps are not present in the sampled logs, but the pro
 
 1. Rocky Road `#2RYGLU2UY` entered a new preparation war with opponent `#LYPLQQUC` / `War Farmers x44`.
 2. `/fwa match` was able to detect the matchup and allow match-type selection.
-3. Final mail confirmation re-rendered the matchup and hit the unresolved-war-ID guard.
-4. A later recovery state shows `CurrentWar.warId=1000610` and `WarMailLifecycle.status=POSTED`, which means the incident was transient and self-healed once the active-war identity had converged.
+3. Final mail confirmation rerendered the matchup and hit the unresolved-war-ID guard.
+4. A later recovery state shows `CurrentWar.warId=1000610` and `WarMailLifecycle.status=POSTED`, which means the incident was transient and self-healed once the active-war identity converged.
 
 Observed database timestamps in the recovery state:
 
@@ -59,10 +59,10 @@ That matters because the 5-minute watch was not available as a rescue path for t
 
 The repository contract is clear about ownership:
 
-- `[src/services/WarEventLogService.ts](C:/Projects/ClashCookies/src/services/WarEventLogService.ts#L2989)` owns the active-war poller path that stamps or reuses `CurrentWar.warId`.
-- `[src/commands/Fwa.ts](C:/Projects/ClashCookies/src/commands/Fwa.ts#L4406)` renders mail from live CoC state and the persisted `CurrentWar` row.
-- `[src/services/WarMailLifecycleService.ts](C:/Projects/ClashCookies/src/services/WarMailLifecycleService.ts#L266)` resolves lifecycle rows by active-war start time first and legacy war ID second.
-- `[src/services/war-events/history.ts](C:/Projects/ClashCookies/src/services/war-events/history.ts#L428)` persists ended-war history only after a war ends.
+- `src/services/WarEventLogService.ts:2989-3027` owns the active-war poller path that stamps or reuses `CurrentWar.warId`.
+- `src/commands/Fwa.ts:4406-4992` renders mail from live CoC state and the persisted `CurrentWar` row.
+- `src/services/WarMailLifecycleService.ts:266-333` resolves lifecycle rows by active-war start time first and legacy war ID second.
+- `src/services/war-events/history.ts:428-599` persists ended-war history only after a war ends.
 
 The critical split is:
 
@@ -73,11 +73,13 @@ The critical split is:
 Two code details matter a lot:
 
 - `upsertCurrentWarHistoryAndGetWarId` is a misleading name. It does not upsert history; it only reads `CurrentWar.warId` through `getCurrentWarIdForClan`.
-- The final send guard rejects immediately when `rendered.warId` is missing, so the command has no fallback once the rerender returns null.
+- The final send guard in `src/commands/Fwa.ts:8675-8689` rejects immediately when `rendered.warId` is missing, so the command has no fallback once the rerender returns null.
 
 ## 5. Data and log evidence
 
-### CurrentWar row
+### Observed production facts
+
+#### CurrentWar row
 
 Rocky Road current-war state in production:
 
@@ -95,7 +97,7 @@ Rocky Road current-war state in production:
 - `outcome=WIN`
 - `updatedAt=2026-07-12 02:02:31.822`
 
-### WarMailLifecycle row
+#### WarMailLifecycle row
 
 The mail lifecycle later converged to:
 
@@ -108,11 +110,11 @@ The mail lifecycle later converged to:
 - `postedAt=2026-07-12 02:02:39.458`
 - `updatedAt=2026-07-12 02:02:39.462`
 
-### ClanWarHistory
+#### ClanWarHistory
 
 No `ClanWarHistory` row existed yet for `warStartTime=2026-07-12 15:22:26+00` because this was still an active/preparation war. That absence is expected and does not explain the failure.
 
-### FwaClanWarsWatchState row
+#### FwaClanWarsWatchState row
 
 Rocky Road tracked-watch state:
 
@@ -123,7 +125,7 @@ Rocky Road tracked-watch state:
 - `stopReason=missing_sync_time`
 - `updatedAt=2026-07-12 02:07:30.717`
 
-### BotPollJobStatus row
+#### BotPollJobStatus row
 
 The active war-event poller was configured and running:
 
@@ -142,11 +144,11 @@ The active war-event poller was configured and running:
 - `failureCount=154`
 - `metadata={"mode":"active"}`
 
-### ClanPointsSync evidence
+#### ClanPointsSync evidence
 
 There was no same-war `ClanPointsSync` row for `warId=1000610` in the sampled production query. The newest rows were older wars, so the points-site path could not provide a matching same-war sync record for this incident window.
 
-### Log excerpts
+#### Log excerpts
 
 Relevant structured logs during the Rocky Road recovery window:
 
@@ -164,22 +166,44 @@ The broader production log also contained root `/fwa` command entries, but the s
 
 The logs show that the system eventually reached a consistent state with war ID `1000610`. The failure therefore happened earlier, in the short window before the rerender could safely resolve that ID.
 
+### Reproduced current behavior
+
+The new diagnosis tests reproduce the current logic, not a fix:
+
+- `tests/fwaWarIdentityRace.logic.test.ts` shows the final rerender blocks when `CurrentWar.warId` is still null.
+- The same file shows the rerender proceeds once the current-war identity is fully aligned.
+- The same file shows partial live identity still resolves to null even when a persisted row exists.
+- The same file shows stale current-war identity is rejected when the live war has rolled forward.
+- The same file shows overlapping allocation calls can return the same next ID snapshot.
+- The same file shows a persistence failure leaves the next rerender with no resolvable current-war ID.
+
+### Inferred incident explanation
+
+The most defensible incident explanation is still a transient race between:
+
+- the poller-owned write that stamps `CurrentWar.warId`
+- the interactive rerender that refuses to send without a resolvable war ID
+
+### Unresolved incident-time uncertainty
+
+What remains unknown is the exact state of the live CoC response at the precise user confirmation moment. The later valid `CurrentWar` row proves recovery, but it does not prove the incident-time response was already complete.
+
 ## 6. Hypothesis matrix
 
 | Hypothesis | Status | Evidence |
 | --- | --- | --- |
-| A. CoC had not exposed the new war yet | Disproven | Production logs and the recovered `CurrentWar` row show `state=preparation`, the opponent tag, and a concrete start time. |
-| B. CoC exposed the opponent but omitted or mangled `startTime` | Disproven | The recovered state includes a valid `startTime=2026-07-12 15:22:26`, and the logs later rendered the same identity. |
-| C. `CurrentWar` still contained the previous war and identity alignment rejected the old ID | Not the lasting cause | The recovered row already points at the correct new war. A transient mismatch is still possible in the narrow failure window, but it was not the durable state. |
-| D. The new `CurrentWar` row existed but its `warId` was null because `ClanWarHistory` had not been created | Disproven | `ClanWarHistory` is the ended-war owner and is not supposed to exist for a live prep war. Active war ID is not sourced from history. |
+| A. CoC had not exposed the new war yet | Unknown due to missing incident-time evidence | The later recovery proves nothing about the exact incident-time live response. |
+| B. CoC exposed the opponent but omitted or mangled `startTime` | Unknown due to missing incident-time evidence | The current tests show a partial live response still blocks, but the incident-time payload is not directly observed. |
+| C. `CurrentWar` still contained the previous war and identity alignment rejected the old ID | Strongly supported | The resolver and scoped-row tests show stale rows are rejected rather than reused. |
+| D. The new `CurrentWar` row existed but its `warId` was null because `ClanWarHistory` had not been created | Disproven | `ClanWarHistory` is the ended-war owner and is not a source for active-war ID creation. |
 | E. The synchronous mail renderer failed to insert or read `ClanWarHistory` | Disproven | The mail renderer reads `CurrentWar.warId`; it does not own or populate ended-war history. |
 | F. The history-upsert dedupe path ran before the row existed and then returned null | Disproven for the active-mail path | The function named like an upsert is actually read-only and only fetches `CurrentWar.warId`. |
-| G. Transaction, unique-key, tag-normalization, timestamp-precision, or guild-scope mismatch prevented lookup | Unproven and unlikely | No evidence in the recovered row set or logs points to a write-after-read mismatch. |
-| H. The preview payload became stale between confirmation and final send | Supported as a contributor | The send path rerenders live state instead of trusting the preview payload, so stale preview data alone is not enough. |
-| I. Final confirmation re-fetched a different or partial war identity than the earlier preview | Supported | This is the only place where the user-visible null-war-ID guard can fire, and later rerenders did converge on `warId=1000610`. |
-| J. The war-event poll was skipped or delayed by poll guards, queue degradation, startup state, mirror mode, or an exception | Supported as a contributor | The active poll cadence is 5 minutes, the job status shows historical failures, and the incident depended on a very narrow race window before the live ID was stamped. |
-| K. The points-site direct-fetch lock or stale FWAStats data indirectly prevented the history upsert | Supported as a contributor | Logs show `points_lock_prevented_live_validation=1`, `validated_active_war_locked`, and the FWAStats watch was inactive for Rocky Road. |
-| L. One path writes `CurrentWar` while another path owns `ClanWarHistory`, leaving a race between them | Proven | That is the architectural split, and the send path has no independent active-war ID materialization step. |
+| G. Transaction, unique-key, tag-normalization, timestamp-precision, or guild-scope mismatch prevented lookup | Possible | The current evidence set does not show a lookup mismatch, but the incident-time call chain is not fully observed. |
+| H. The preview payload became stale between confirmation and final send | Strongly supported | The send path rerenders live state instead of trusting the preview payload, so staleness alone is not enough. |
+| I. Final confirmation re-fetched a different or partial war identity than the earlier preview | Strongly supported | The new tests show partial or mismatched identity collapses back to null, which matches the user-visible guard. |
+| J. The war-event poll was skipped or delayed by poll guards, queue degradation, startup state, mirror mode, or an exception | Possible | Historical scheduler failures exist, but the exact incident-time delay is not directly proven. |
+| K. The points-site direct-fetch lock or stale FWAStats data indirectly prevented the history upsert | Possible | The points lock can suppress live validation, but it does not directly explain active-war ID allocation. |
+| L. One path writes `CurrentWar` while another path owns `ClanWarHistory`, leaving a race between them | Proven | The write path and the rerender path are separated, and the tests show the rerender depends on the write having already happened. |
 
 ## 7. Reproduction results
 
@@ -192,7 +216,7 @@ The incident is still reproduced by the production trace itself:
 - the final send path rejected a null `rendered.warId`
 - the same war later converged to `CurrentWar.warId=1000610`
 
-That is enough to prove the failure mode without changing any state.
+The new tests also reproduce the same logic locally without changing production behavior.
 
 ## 8. Definitive root cause
 
@@ -215,9 +239,9 @@ Why this is the right conclusion:
 
 Whether recovery would have happened:
 
-- `retrying /fwa match` would likely recover once the active-war row converged.
-- `/force poll war-events` would likely recover because that is the path that stamps `CurrentWar.warId`.
-- The issue was not permanently blocked; it was a race window.
+- `retrying /fwa match` can recover once the active-war row converges, but it can remain blocked indefinitely if the poller never persists a usable ID.
+- `/force poll war-events` is a likely recovery, not a guaranteed one. It only guarantees recovery when the live CoC identity is complete enough for the poller to stamp `CurrentWar.warId`.
+- The issue is not permanently blocked by design, but it can remain blocked for as long as the poller cannot materialize a valid ID.
 
 ## 9. Recommended implementation design
 
@@ -233,15 +257,22 @@ The narrow robust design is:
 
 Exact files and functions that should be revisited for the fix later:
 
-- `[src/commands/Fwa.ts](C:/Projects/ClashCookies/src/commands/Fwa.ts#L4406)` `buildWarMailEmbedForTag`
-- `[src/commands/Fwa.ts](C:/Projects/ClashCookies/src/commands/Fwa.ts#L8597)` `handleFwaMailConfirmAction`
-- `[src/services/WarEventLogService.ts](C:/Projects/ClashCookies/src/services/WarEventLogService.ts#L2989)` `ensureCurrentWarId`
-- `[src/services/ActiveWarSyncResolutionService.ts](C:/Projects/ClashCookies/src/services/ActiveWarSyncResolutionService.ts#L97)` `resolveCurrentWarSyncIdentity`
-- `[src/services/WarMailLifecycleService.ts](C:/Projects/ClashCookies/src/services/WarMailLifecycleService.ts#L266)` `findLifecycleRow`
+- `src/commands/Fwa.ts:4406-4992` `buildWarMailEmbedForTag`
+- `src/commands/Fwa.ts:8597-8694` `handleFwaMailConfirmAction`
+- `src/services/WarEventLogService.ts:2989-3027` `ensureCurrentWarId`
+- `src/services/WarEventLogService.ts:3030-3659` `processSubscription`
+- `src/services/ActiveWarSyncResolutionService.ts:97-163` `resolveCurrentWarSyncIdentity`
+- `src/services/war-events/history.ts:428-599` `persistWarEndHistory`
+- `src/services/WarMailLifecycleService.ts:266-333` `findLifecycleRow`
+- `src/commands/Fwa.ts:4389-4404` `getCurrentWarIdForClan`
+
+The fix should live in the active-war identity path, not in ended-war history.
 
 ## 10. Test plan
 
-When the fix is implemented, add deterministic tests for:
+The diagnosis suite added in this branch already covers the current behavior. The next implementation task should keep those tests and add more around the final shared resolver.
+
+Coverage goals for the eventual fix:
 
 - live preparation war with opponent and valid start time but no existing history row
 - `CurrentWar` still referencing the prior war
@@ -268,12 +299,37 @@ The current logs were good enough to reconstruct the incident, but the failure i
 
 These are the specific places to change in the next task:
 
-- `[src/commands/Fwa.ts](C:/Projects/ClashCookies/src/commands/Fwa.ts#L4406)` `buildWarMailEmbedForTag`
-- `[src/commands/Fwa.ts](C:/Projects/ClashCookies/src/commands/Fwa.ts#L8597)` `handleFwaMailConfirmAction`
-- `[src/services/WarEventLogService.ts](C:/Projects/ClashCookies/src/services/WarEventLogService.ts#L2989)` `ensureCurrentWarId`
-- `[src/services/WarEventLogService.ts](C:/Projects/ClashCookies/src/services/WarEventLogService.ts#L3030)` `processSubscription`
-- `[src/services/ActiveWarSyncResolutionService.ts](C:/Projects/ClashCookies/src/services/ActiveWarSyncResolutionService.ts#L97)` `resolveCurrentWarSyncIdentity`
-- `[src/services/war-events/history.ts](C:/Projects/ClashCookies/src/services/war-events/history.ts#L428)` `persistWarEndHistory`
-- `[src/services/WarMailLifecycleService.ts](C:/Projects/ClashCookies/src/services/WarMailLifecycleService.ts#L266)` `findLifecycleRow`
+- `src/commands/Fwa.ts:4406-4992` `buildWarMailEmbedForTag`
+- `src/commands/Fwa.ts:8597-8694` `handleFwaMailConfirmAction`
+- `src/services/WarEventLogService.ts:2989-3027` `ensureCurrentWarId`
+- `src/services/WarEventLogService.ts:3030-3659` `processSubscription`
+- `src/services/ActiveWarSyncResolutionService.ts:97-163` `resolveCurrentWarSyncIdentity`
+- `src/services/war-events/history.ts:428-599` `persistWarEndHistory`
+- `src/services/WarMailLifecycleService.ts:266-333` `findLifecycleRow`
+- `src/commands/Fwa.ts:4389-4404` `getCurrentWarIdForClan`
 
 The fix should live in the active-war identity path, not in ended-war history.
+
+## 13. Concurrency and ID allocation risk
+
+`WarEventLogService.allocateNextWarId` currently uses a naked `MAX(...) + 1` query across `WarLookup`, `CurrentWar`, and `WarAttacks`, and `ensureCurrentWarId` simply returns that value when no matching current row exists. The eventual persistence step is a separate `await prisma.currentWar.update(...)` in `processSubscription`, so allocation and persistence are not wrapped in one transaction.
+
+That means:
+
+- overlapping scheduled polls can observe the same max snapshot and allocate the same ID
+- a manual poll and a scheduled poll can allocate concurrently
+- two clans can allocate simultaneously because the allocator is global, not clan-scoped
+- a retry can allocate a different ID if another write lands first
+- there is no explicit lock or retry loop around the `MAX(...) + 1` decision
+
+The new concurrency test reproduces the overlapping-read behavior directly.
+
+## 14. Separate stale-war-ID correctness risk
+
+This is distinct from the null-ID race.
+
+`src/commands/Fwa.ts:getCurrentWarIdForClan` ignores `_warStartMs` entirely and returns `CurrentWar.warId` by guild + clan only. `buildWarMailEmbedForTag` asks for that value after it has already computed live war identity, which means a stale `CurrentWar` row can still matter if the row itself contains an old war ID.
+
+The safe part of the pipeline is `resolveCurrentWarSyncIdentity`, which validates live war start time and opponent identity before reusing a current-war ID. The unsafe part is the raw lookup helper, which does not validate `_warStartMs` at all.
+
+The new test `returns the persisted current-war id without validating the supplied war-start time` captures that risk so the next implementation task can decide whether to keep, replace, or wrap that helper with a shared canonical resolver.

--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -10147,6 +10147,7 @@ export const resolveCurrentWarSyncIdentityForTest =
   resolveCurrentWarSyncIdentity;
 export const resolveCurrentWarScopedSyncRowForTest =
   resolveCurrentWarScopedSyncRow;
+export const getCurrentWarIdForClanForTest = getCurrentWarIdForClan;
 export const persistActiveWarMailLifecycleForTest =
   persistActiveWarMailLifecycle;
 export const deriveProjectedOutcomeForTest = deriveProjectedOutcome;

--- a/tests/fwaWarIdentityRace.logic.test.ts
+++ b/tests/fwaWarIdentityRace.logic.test.ts
@@ -1,0 +1,308 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const prismaMock = vi.hoisted(() => ({
+  $queryRaw: vi.fn(),
+  currentWar: {
+    findFirst: vi.fn(),
+    findUnique: vi.fn(),
+    update: vi.fn(),
+  },
+}));
+
+vi.mock("../src/prisma", () => ({
+  prisma: prismaMock,
+}));
+
+vi.mock("../src/services/PointsSyncService", () => ({
+  PointsSyncService: vi.fn().mockImplementation(() => ({
+    getCurrentSyncForClan: vi.fn(),
+    markNeedsValidation: vi.fn().mockResolvedValue(undefined),
+    clearNeedsValidation: vi.fn().mockResolvedValue(undefined),
+    markConfirmedByClanMail: vi.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+import {
+  getCurrentWarIdForClanForTest,
+  resolveCurrentWarScopedSyncRowForTest,
+  resolveCurrentWarSyncIdentityForTest,
+} from "../src/commands/Fwa";
+import { WarEventLogService } from "../src/services/WarEventLogService";
+
+function makeWarIdentity(params: {
+  currentWarId: number | null;
+  currentWarStartTime: Date | null;
+  currentWarOpponentTag: string | null;
+  liveWarStartTime: string | null;
+  liveOpponentTag: string | null;
+}) {
+  return resolveCurrentWarSyncIdentityForTest({
+    clanTag: "#2RYGLU2UY",
+    warState: "preparation",
+    currentWarId: params.currentWarId,
+    currentWarStartTime: params.currentWarStartTime,
+    currentWarOpponentTag: params.currentWarOpponentTag,
+    liveWarStartTime: params.liveWarStartTime,
+    liveOpponentTag: params.liveOpponentTag,
+  });
+}
+
+describe("Rocky Road war identity resolution", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("blocks the send path when the poller has not materialized a current-war id yet", () => {
+    const identity = makeWarIdentity({
+      currentWarId: null,
+      currentWarStartTime: null,
+      currentWarOpponentTag: null,
+      liveWarStartTime: "20260712T152226.000Z",
+      liveOpponentTag: "#LYPLQQUC",
+    });
+
+    expect(identity.positivelyResolved).toBe(true);
+    expect(identity.warId).toBeNull();
+    expect(identity.warStartTime?.toISOString()).toBe("2026-07-12T15:22:26.000Z");
+    expect(identity.opponentTag).toBe("LYPLQQUC");
+  });
+
+  it("reuses the current-war id safely once the poller has stamped the matching identity", () => {
+    const identity = makeWarIdentity({
+      currentWarId: 1000610,
+      currentWarStartTime: new Date("2026-07-12T15:22:26.000Z"),
+      currentWarOpponentTag: "#LYPLQQUC",
+      liveWarStartTime: "20260712T152226.000Z",
+      liveOpponentTag: "#LYPLQQUC",
+    });
+
+    expect(identity.positivelyResolved).toBe(true);
+    expect(identity.warId).toBe("1000610");
+  });
+
+  it("drops the current-war id when the final rerender only sees a partial live identity", () => {
+    const identity = makeWarIdentity({
+      currentWarId: 1000610,
+      currentWarStartTime: new Date("2026-07-12T15:22:26.000Z"),
+      currentWarOpponentTag: "#LYPLQQUC",
+      liveWarStartTime: null,
+      liveOpponentTag: "#LYPLQQUC",
+    });
+
+    expect(identity.warId).toBeNull();
+    expect(identity.warStartTime?.toISOString()).toBe("2026-07-12T15:22:26.000Z");
+    expect(identity.opponentTag).toBe("LYPLQQUC");
+  });
+
+  it("rejects a stale current-war id when the live identity has rolled to a new war", () => {
+    const identity = makeWarIdentity({
+      currentWarId: 1000609,
+      currentWarStartTime: new Date("2026-07-11T15:22:26.000Z"),
+      currentWarOpponentTag: "#OLDOPP",
+      liveWarStartTime: "20260712T152226.000Z",
+      liveOpponentTag: "#LYPLQQUC",
+    });
+
+    expect(identity.warId).toBeNull();
+    expect(identity.warStartTime?.toISOString()).toBe("2026-07-12T15:22:26.000Z");
+  });
+
+  it("keeps scoped sync-row selection aligned to start time and opponent before reuse", () => {
+    const selected = resolveCurrentWarScopedSyncRowForTest({
+      rows: [
+        {
+          warId: "1000609",
+          warStartTime: new Date("2026-07-11T15:22:26.000Z"),
+          opponentTag: "#OLDOPP",
+          needsValidation: false,
+        } as any,
+      ],
+      warId: "1000610",
+      warStartTime: new Date("2026-07-12T15:22:26.000Z"),
+      opponentTag: "LYPLQQUC",
+    });
+
+    expect(selected).toBeNull();
+  });
+});
+
+describe("Current-war lookup and allocation diagnostics", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns the persisted current-war id without validating the supplied war-start time", async () => {
+    prismaMock.currentWar.findUnique.mockResolvedValueOnce({
+      warId: 1000609,
+    });
+
+    const warId = await getCurrentWarIdForClanForTest(
+      "guild-1",
+      "2RYGLU2UY",
+      new Date("2026-07-12T15:22:26.000Z").getTime(),
+    );
+
+    expect(warId).toBe(1000609);
+    expect(prismaMock.currentWar.findUnique).toHaveBeenCalledWith({
+      where: {
+        clanTag_guildId: {
+          guildId: "guild-1",
+          clanTag: "#2RYGLU2UY",
+        },
+      },
+      select: { warId: true },
+    });
+  });
+
+  it("allocates the same next war id for overlapping poll cycles that observe the same max snapshot", async () => {
+    prismaMock.currentWar.findFirst.mockResolvedValue(null);
+    prismaMock.$queryRaw.mockResolvedValue([{ warId: 1000610 }]);
+    const service = new WarEventLogService({} as any, {} as any);
+    const args = {
+      sub: {
+        clanTag: "#2RYGLU2UY",
+        warId: null,
+        startTime: null,
+      },
+      warStartTime: new Date("2026-07-12T15:22:26.000Z"),
+      currentState: "preparation" as const,
+    };
+
+    const [first, second] = await Promise.all([
+      (service as any).ensureCurrentWarId(args),
+      (service as any).ensureCurrentWarId(args),
+    ]);
+
+    expect(first).toBe(1000610);
+    expect(second).toBe(1000610);
+    expect(prismaMock.$queryRaw).toHaveBeenCalledTimes(2);
+  });
+
+  it("leaves the next render with a stale or null current-war id when persistence fails after allocation", async () => {
+    prismaMock.$queryRaw
+      .mockResolvedValueOnce([
+        {
+          guildId: "guild-1",
+          clanTag: "#2RYGLU2UY",
+          warId: null,
+          syncNum: 532,
+          channelId: "mail-channel-1",
+          notify: true,
+          pingRole: false,
+          embedEnabled: true,
+          notifyRole: "notify-role-1",
+          inferredMatchType: false,
+          fwaPoints: null,
+          opponentFwaPoints: null,
+          outcome: null,
+          matchType: "FWA",
+          warStartFwaPoints: null,
+          warEndFwaPoints: null,
+          clanStars: null,
+          opponentStars: null,
+          state: "preparation",
+          prepStartTime: new Date("2026-07-11T15:22:26.000Z"),
+          startTime: null,
+          endTime: null,
+          opponentTag: null,
+          opponentName: null,
+          clanName: "Rocky Road",
+          clanRoleId: null,
+          pointsConfirmedByClanMail: false,
+          pointsNeedsValidation: true,
+          pointsLastSuccessfulFetchAt: null,
+          pointsLastKnownSyncNumber: null,
+          pointsLastKnownPoints: null,
+          pointsLastKnownMatchType: null,
+          pointsLastKnownOutcome: null,
+          pointsWarId: null,
+          pointsOpponentTag: null,
+          pointsWarStartTime: null,
+        },
+      ])
+      .mockResolvedValueOnce([{ warId: 1000610 }]);
+    prismaMock.currentWar.findFirst.mockResolvedValue(null);
+    prismaMock.currentWar.update.mockRejectedValueOnce(new Error("write failed"));
+
+    const service = new WarEventLogService({ channels: { fetch: vi.fn() } } as any, {
+      getCurrentWar: vi.fn().mockResolvedValue({
+        state: "preparation",
+        startTime: "20260712T152226.000Z",
+        opponent: {
+          tag: "#LYPLQQUC",
+          name: "War Farmers x44",
+        },
+        clan: {
+          name: "Rocky Road",
+        },
+      }),
+    } as any);
+    (service as any).hasWarEndRecorded = vi.fn().mockResolvedValue(false);
+    (service as any).getCurrentWarSnapshot = vi.fn().mockResolvedValue({
+      war: {
+        state: "preparation",
+        startTime: "20260712T152226.000Z",
+        opponent: {
+          tag: "#LYPLQQUC",
+          name: "War Farmers x44",
+        },
+        clan: {
+          name: "Rocky Road",
+        },
+      },
+      observation: { kind: "success" },
+      error: null,
+    });
+    (service as any).syncWarAttacksFromWarSnapshot = vi.fn().mockResolvedValue(0);
+    (service as any).dispatchDetectedEvent = vi.fn().mockResolvedValue(undefined);
+    (service as any).reconcileWarEndedPointsDiscrepancy = vi.fn().mockResolvedValue(undefined);
+    (service as any).pointsGate = {
+      evaluatePollerFetch: vi.fn().mockReturnValue({
+        allowed: false,
+        fetchReason: "post_war_reconciliation",
+      }),
+    };
+    (service as any).pointsSync = {
+      resetWarStartPointsJob: vi.fn().mockResolvedValue(undefined),
+      maybeRunWarStartPointsCheck: vi.fn().mockResolvedValue(undefined),
+      getPreviousSyncNum: vi.fn().mockResolvedValue(532),
+    };
+    (service as any).currentSyncs = {
+      markNeedsValidation: vi.fn().mockResolvedValue(undefined),
+      getCurrentSyncForClan: vi.fn().mockResolvedValue(null),
+    };
+    (service as any).history = {
+      resolveExactCanonicalWarEndedHistoryRow: vi.fn().mockResolvedValue(null),
+      getWarEndResultSnapshot: vi.fn().mockResolvedValue({
+        clanStars: null,
+        opponentStars: null,
+        clanDestruction: null,
+        opponentDestruction: null,
+        warEndTime: null,
+        resultLabel: "UNKNOWN",
+      }),
+    };
+
+    await expect(
+      (service as any).processSubscription("guild-1", "#2RYGLU2UY", {
+        previousSync: 532,
+        activeSync: 533,
+      }),
+    ).rejects.toThrow("write failed");
+
+    const rerenderWarId = await getCurrentWarIdForClanForTest(
+      "guild-1",
+      "2RYGLU2UY",
+      new Date("2026-07-12T15:22:26.000Z").getTime(),
+    );
+    expect(rerenderWarId).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Tightened the Rocky Road war-mail diagnosis to separate observed production facts, reproduced current behavior, inferred incident explanation, and unresolved incident-time uncertainty.
- Added a focused repro suite for the unresolved-ID window, stale-war-ID rejection, raw current-war lookup behavior, and overlapping ID allocation.
- Added a test-only export for the current-war lookup helper so the stale-ID risk can be proven directly.

## Scope
- Diagnosis-only. No production behavior, polling cadence, database data, or migrations changed.
- The new tests document current behavior and the correctness risks that should be addressed in the next implementation task.

## Validation
- `npx vitest run tests/fwaWarIdentityRace.logic.test.ts tests/fwaMatchResolvedSync.logic.test.ts tests/fwaMailDownstream.logic.test.ts tests/warEventLog.logic.test.ts` ✅
- `npm run lint` ✅
- `npx tsc --noEmit` ✅
- `git diff --check` ✅

## Remaining uncertainty
- The exact incident-time CoC payload is still unknown, so the root cause remains a transient race between the poll-owned `CurrentWar.warId` write and the interactive rerender path.
- `/force poll war-events` is a likely recovery when the live identity is complete, but not a guaranteed recovery for partial-identity states.

## Next implementation step
- Extract a shared active-war identity resolver that validates guild, clan tag, war start time, and opponent identity before any mail send path consumes `CurrentWar.warId`.