### PR TITLE
feat: add targeted war event poll api

### DIFF
--- a/src/services/WarEventLogService.ts
+++ b/src/services/WarEventLogService.ts
@@ -633,6 +633,11 @@ type PollSyncContext = {
   activeSync: number | null;
 };
 
+export type WarEventPollClanResult = {
+  processed: boolean;
+  warEnded: boolean;
+};
+
 type CocWarOutageState = {
   failureStreak: number;
   recoveryStreak: number;
@@ -1535,11 +1540,7 @@ export class WarEventLogService {
   }): Promise<void> {
     const sendBattleDaySwapReminders =
       input?.sendBattleDaySwapReminders === true;
-    const previousSync = await this.syncResolution.getLatestPersistedSyncBaseline();
-    const syncContext: PollSyncContext = {
-      previousSync,
-      activeSync: previousSync === null ? null : previousSync + 1,
-    };
+    const syncContext = await this.buildPollSyncContext();
     const targets = await this.listPollTargets();
     const maintenanceOverGuildIds = new Set<string>();
     for (const target of targets) {
@@ -1581,6 +1582,49 @@ export class WarEventLogService {
           `[war-plan-violation] event=reconcile_failed error=${formatError(err)}`,
         );
       });
+  }
+
+  /** Purpose: derive the shared poll sync context without widening the global poll loop. */
+  private async buildPollSyncContext(): Promise<PollSyncContext> {
+    const previousSync = await this.syncResolution.getLatestPersistedSyncBaseline();
+    return {
+      previousSync,
+      activeSync: previousSync === null ? null : previousSync + 1,
+    };
+  }
+
+  /** Purpose: reconcile one tracked clan through the authoritative poll worker. */
+  async pollClan(input: {
+    guildId: string;
+    clanTag: string;
+    sendBattleDaySwapReminders?: boolean;
+  }): Promise<WarEventPollClanResult> {
+    const guildId = String(input.guildId ?? "").trim();
+    const clanTag = normalizeTag(input.clanTag);
+    if (!guildId || !clanTag) {
+      return { processed: false, warEnded: false };
+    }
+
+    const subscription = await this.findSubscriptionByGuildAndTag(
+      guildId,
+      clanTag,
+    );
+    if (!subscription) {
+      return { processed: false, warEnded: false };
+    }
+
+    const syncContext = await this.buildPollSyncContext();
+    const warEnded = await this.processSubscription(
+      guildId,
+      clanTag,
+      syncContext,
+      {
+        sendBattleDaySwapReminders:
+          input.sendBattleDaySwapReminders === true,
+      },
+    );
+
+    return { processed: true, warEnded };
   }
 
   private async listPollTargets(): Promise<PollTarget[]> {

--- a/tests/warEventLog.pollClan.test.ts
+++ b/tests/warEventLog.pollClan.test.ts
@@ -1,0 +1,136 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { WarEventLogService } from "../src/services/WarEventLogService";
+
+const prismaMock = vi.hoisted(() => ({
+  $queryRaw: vi.fn(),
+  trackedClan: {
+    findMany: vi.fn(),
+    findUnique: vi.fn(),
+  },
+  currentWar: {
+    findFirst: vi.fn(),
+    findMany: vi.fn(),
+    upsert: vi.fn(),
+  },
+  clanNotifyConfig: {
+    findMany: vi.fn(),
+    findUnique: vi.fn(),
+  },
+}));
+
+vi.mock("../src/prisma", () => ({
+  prisma: prismaMock,
+}));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  prismaMock.$queryRaw.mockResolvedValue([]);
+  prismaMock.trackedClan.findMany.mockResolvedValue([]);
+  prismaMock.trackedClan.findUnique.mockResolvedValue(null);
+  prismaMock.currentWar.findFirst.mockResolvedValue(null);
+  prismaMock.currentWar.findMany.mockResolvedValue([]);
+  prismaMock.currentWar.upsert.mockResolvedValue({});
+  prismaMock.clanNotifyConfig.findMany.mockResolvedValue([]);
+  prismaMock.clanNotifyConfig.findUnique.mockResolvedValue(null);
+});
+
+describe("WarEventLogService.pollClan", () => {
+  it("normalizes input and delegates to the same per-clan poll worker", async () => {
+    const service = new WarEventLogService(
+      { channels: { fetch: vi.fn() } } as any,
+      {} as any,
+    );
+    const findSpy = vi
+      .spyOn(service as any, "findSubscriptionByGuildAndTag")
+      .mockResolvedValue({ guildId: "guild-1", clanTag: "#AAA111" });
+    const syncSpy = vi
+      .spyOn(service as any, "buildPollSyncContext")
+      .mockResolvedValue({ previousSync: 41, activeSync: 42 });
+    const processSpy = vi
+      .spyOn(service as any, "processSubscription")
+      .mockResolvedValue(true);
+    const pollSpy = vi.spyOn(service as any, "poll");
+    const refreshSpy = vi.spyOn(service as any, "refreshBattleDayPosts");
+    const dispatchSpy = vi.spyOn(service as any, "dispatchDetectedEvent");
+
+    const result = await service.pollClan({
+      guildId: " guild-1 ",
+      clanTag: " aaa111 ",
+      sendBattleDaySwapReminders: false,
+    });
+
+    expect(result).toEqual({ processed: true, warEnded: true });
+    expect(findSpy).toHaveBeenCalledTimes(1);
+    expect(findSpy).toHaveBeenCalledWith("guild-1", "#AAA111");
+    expect(syncSpy).toHaveBeenCalledTimes(1);
+    expect(processSpy).toHaveBeenCalledTimes(1);
+    expect(processSpy).toHaveBeenCalledWith(
+      "guild-1",
+      "#AAA111",
+      { previousSync: 41, activeSync: 42 },
+      { sendBattleDaySwapReminders: false },
+    );
+    expect(pollSpy).not.toHaveBeenCalled();
+    expect(refreshSpy).not.toHaveBeenCalled();
+    expect(dispatchSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns a no-op when the CurrentWar row is missing", async () => {
+    const service = new WarEventLogService(
+      { channels: { fetch: vi.fn() } } as any,
+      {} as any,
+    );
+    const processSpy = vi.spyOn(service as any, "processSubscription");
+    const syncSpy = vi.spyOn(service as any, "buildPollSyncContext");
+    const pollSpy = vi.spyOn(service as any, "poll");
+    const refreshSpy = vi.spyOn(service as any, "refreshBattleDayPosts");
+
+    const result = await service.pollClan({
+      guildId: "guild-1",
+      clanTag: "#aaa111",
+    });
+
+    expect(result).toEqual({ processed: false, warEnded: false });
+    expect(processSpy).not.toHaveBeenCalled();
+    expect(syncSpy).not.toHaveBeenCalled();
+    expect(pollSpy).not.toHaveBeenCalled();
+    expect(refreshSpy).not.toHaveBeenCalled();
+    expect(prismaMock.$queryRaw).toHaveBeenCalledTimes(1);
+    expect(prismaMock.trackedClan.findMany).not.toHaveBeenCalled();
+    expect(prismaMock.currentWar.findMany).not.toHaveBeenCalled();
+    expect(prismaMock.clanNotifyConfig.findMany).not.toHaveBeenCalled();
+  });
+
+  it("keeps duplicate-event handling inside the underlying worker", async () => {
+    const service = new WarEventLogService(
+      { channels: { fetch: vi.fn() } } as any,
+      {} as any,
+    );
+    const findSpy = vi
+      .spyOn(service as any, "findSubscriptionByGuildAndTag")
+      .mockResolvedValue({ guildId: "guild-1", clanTag: "#AAA111" });
+    const syncSpy = vi
+      .spyOn(service as any, "buildPollSyncContext")
+      .mockResolvedValue({ previousSync: 41, activeSync: 42 });
+    const processSpy = vi
+      .spyOn(service as any, "processSubscription")
+      .mockResolvedValue(false);
+    const pollSpy = vi.spyOn(service as any, "poll");
+    const refreshSpy = vi.spyOn(service as any, "refreshBattleDayPosts");
+
+    await service.pollClan({
+      guildId: "guild-1",
+      clanTag: "#AAA111",
+    });
+
+    expect(findSpy).toHaveBeenCalledTimes(1);
+    expect(syncSpy).toHaveBeenCalledTimes(1);
+    expect(processSpy).toHaveBeenCalledTimes(1);
+    expect(pollSpy).not.toHaveBeenCalled();
+    expect(refreshSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Task 1 of a minimal three-task fix.
- Adds a targeted `pollClan` API on `WarEventLogService` that normalizes the guild/clan inputs, checks for one tracked `CurrentWar` row, and reuses the existing per-clan processing worker.
- Keeps the global `poll()` loop and refresh fan-out untouched.

## Validation
- `npx vitest run tests/warEventLog.pollClan.test.ts`
- `npm test`
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`
- `git diff --check`

## Notes
- This PR contains no `/fwa match` behavior change yet.