### PR TITLE
Fix targeted /fwa match mail reconciliation race

### DIFF
--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -4360,37 +4360,96 @@ function mailStatusTitleForState(state: WarStateForSync): string {
   return "War Ended";
 }
 
-async function upsertCurrentWarHistoryAndGetWarId(params: {
+type WarMailCurrentWarIdentityRow = {
+  warId: number | null;
+  startTime: Date | null;
+  opponentTag: string | null;
+  state: string | null;
+};
+
+type WarMailResolvedCurrentWarIdentity = {
+  warId: number;
+  startTime: Date;
+  opponentTag: string;
+};
+
+function isActiveWarMailState(
+  state: string | null | undefined,
+): state is "preparation" | "inWar" {
+  const normalized = String(state ?? "").trim();
+  return normalized === "preparation" || normalized === "inWar";
+}
+
+function resolveExactCurrentWarMailIdentityForRow(
+  row: WarMailCurrentWarIdentityRow | null | undefined,
+  input: {
+    liveWarState: WarStateForSync;
+    liveWarStartMs: number | null;
+    liveOpponentTag: string | null;
+  },
+): WarMailResolvedCurrentWarIdentity | null {
+  if (input.liveWarState === "notInWar") return null;
+  if (!row || !isActiveWarMailState(row.state)) return null;
+  if (input.liveWarStartMs === null || input.liveOpponentTag === null) return null;
+
+  const rowWarId = toComparableSyncNumber(row.warId ?? null);
+  const rowStartMs = toWarStartMs(row.startTime);
+  const rowOpponentTag = normalizeTag(String(row.opponentTag ?? ""));
+  if (
+    rowWarId === null ||
+    rowWarId <= 0 ||
+    rowStartMs === null ||
+    rowStartMs !== Math.trunc(input.liveWarStartMs) ||
+    rowOpponentTag !== input.liveOpponentTag
+  ) {
+    return null;
+  }
+
+  return {
+    warId: rowWarId,
+    startTime: row.startTime!,
+    opponentTag: rowOpponentTag,
+  };
+}
+
+async function readExactCurrentWarIdentityForTag(params: {
   guildId: string;
   normalizedTag: string;
-  warStartMs: number | null;
-  warEndMs: number | null;
-  currentSync: number | null;
-  matchType: "FWA" | "BL" | "MM" | "UNKNOWN";
-  expectedOutcome: "WIN" | "LOSE" | "UNKNOWN" | null;
-  clanName: string;
-  opponentName: string;
-  opponentTag: string;
-  war: Awaited<ReturnType<CoCService["getCurrentWar"]>>;
-}): Promise<number | null> {
-  const resolvedWarStartMs =
-    params.warStartMs !== null && Number.isFinite(params.warStartMs)
-      ? params.warStartMs
-      : parseCocApiTime(params.war?.startTime);
-  return getCurrentWarIdForClan(
-    params.guildId,
-    params.normalizedTag,
-    resolvedWarStartMs !== null && Number.isFinite(resolvedWarStartMs)
-      ? resolvedWarStartMs
-      : null,
-  );
+  liveWarState: WarStateForSync;
+  liveWarStartMs: number | null;
+  liveOpponentTag: string | null;
+}): Promise<WarMailResolvedCurrentWarIdentity | null> {
+  if (!params.guildId || !params.normalizedTag) return null;
+  const current = await prisma.currentWar.findUnique({
+    where: {
+      clanTag_guildId: {
+        guildId: params.guildId,
+        clanTag: `#${params.normalizedTag}`,
+      },
+    },
+    select: {
+      warId: true,
+      startTime: true,
+      opponentTag: true,
+      state: true,
+    },
+  });
+  return resolveExactCurrentWarMailIdentityForRow(current, {
+    liveWarState: params.liveWarState,
+    liveWarStartMs: params.liveWarStartMs,
+    liveOpponentTag: params.liveOpponentTag,
+  });
 }
+
+export const resolveExactCurrentWarMailIdentityForTagForTest =
+  resolveExactCurrentWarMailIdentityForRow;
 
 async function getCurrentWarIdForClan(
   guildId: string,
   normalizedTag: string,
   _warStartMs: number | null,
 ): Promise<number | null> {
+  if (!guildId || !normalizedTag) return null;
   const current = await prisma.currentWar.findUnique({
     where: {
       clanTag_guildId: {
@@ -4403,6 +4462,79 @@ async function getCurrentWarIdForClan(
   return current?.warId ?? null;
 }
 
+export const targetedWarMailIdentityResolver = {
+  /** Purpose: resolve a war-mail identity only after targeted one-clan reconciliation. */
+  async resolve(params: {
+    client: Client | null | undefined;
+    cocService: CoCService;
+    guildId: string;
+    normalizedTag: string;
+    liveWarState: WarStateForSync;
+    liveWarStartMs: number | null;
+    liveOpponentTag: string | null;
+    currentWarRow: WarMailCurrentWarIdentityRow | null;
+  }): Promise<WarMailResolvedCurrentWarIdentity | null> {
+    const normalizedGuildId = String(params.guildId ?? "").trim();
+    const normalizedTag = normalizeTag(params.normalizedTag);
+    if (!normalizedGuildId || !normalizedTag) {
+      return null;
+    }
+    const initialExact = resolveExactCurrentWarMailIdentityForRow(
+      params.currentWarRow,
+      {
+        liveWarState: params.liveWarState,
+        liveWarStartMs: params.liveWarStartMs,
+        liveOpponentTag: params.liveOpponentTag,
+      },
+    );
+    if (initialExact) return initialExact;
+
+    if (
+      !params.client ||
+      params.liveWarState === "notInWar" ||
+      params.liveWarStartMs === null ||
+      params.liveOpponentTag === null
+    ) {
+      return null;
+    }
+
+    const warEvents = new WarEventLogService(params.client, params.cocService);
+    try {
+      const result = await warEvents.pollClan({
+        guildId: normalizedGuildId,
+        clanTag: normalizedTag,
+        sendBattleDaySwapReminders: false,
+      });
+      if (!result.processed) {
+        console.warn(
+          `[fwa-mail] event=targeted_war_reconcile guild=${normalizedGuildId} clan=#${normalizedTag} result=not_processed`,
+        );
+        return null;
+      }
+    } catch (error) {
+      console.warn(
+        `[fwa-mail] event=targeted_war_reconcile guild=${normalizedGuildId} clan=#${normalizedTag} result=failed error=${formatError(error)}`,
+      );
+      return null;
+    }
+
+    const reread = await readExactCurrentWarIdentityForTag({
+      guildId: normalizedGuildId,
+      normalizedTag,
+      liveWarState: params.liveWarState,
+      liveWarStartMs: params.liveWarStartMs,
+      liveOpponentTag: params.liveOpponentTag,
+    });
+    if (!reread) {
+      console.warn(
+        `[fwa-mail] event=targeted_war_reconcile guild=${normalizedGuildId} clan=#${normalizedTag} result=unresolved`,
+      );
+      return null;
+    }
+    return reread;
+  },
+};
+
 async function buildWarMailEmbedForTag(
   cocService: CoCService,
   guildId: string,
@@ -4411,6 +4543,7 @@ async function buildWarMailEmbedForTag(
     fetchReason?: PointsApiFetchReason;
     routine?: boolean;
     revisionOverride?: MatchRevisionFields | null;
+    targetedWarReconcileClient?: Client | null;
   },
 ): Promise<{
   embed: EmbedBuilder;
@@ -4481,8 +4614,28 @@ async function buildWarMailEmbedForTag(
     currentWarStartTime: subscription?.startTime ?? null,
     currentWarOpponentTag: subscription?.opponentTag ?? null,
   });
-  const warIdForSync = syncIdentity.warId;
-  const warStartTimeForSync = syncIdentity.warStartTime;
+  const resolvedCurrentWarIdentity = await targetedWarMailIdentityResolver.resolve(
+    {
+      client: options?.targetedWarReconcileClient ?? null,
+      cocService,
+      guildId,
+      normalizedTag,
+      liveWarState: warState,
+      liveWarStartMs: parseCocApiTime(war?.startTime),
+      liveOpponentTag: opponentTag || null,
+      currentWarRow: subscription,
+    },
+  );
+  const syncIdentityForRender = resolvedCurrentWarIdentity
+    ? buildActiveWarSyncIdentity({
+        warState,
+        warId: resolvedCurrentWarIdentity.warId,
+        warStartTime: resolvedCurrentWarIdentity.startTime,
+        opponentTag: resolvedCurrentWarIdentity.opponentTag,
+      })
+    : syncIdentity;
+  const warIdForSync = syncIdentityForRender.warId;
+  const warStartTimeForSync = syncIdentityForRender.warStartTime;
   const warIdForSyncNumber =
     warIdForSync !== null && Number.isFinite(Number(warIdForSync))
       ? Math.trunc(Number(warIdForSync))
@@ -4492,12 +4645,12 @@ async function buildWarMailEmbedForTag(
     clanTag: normalizedTag,
     opponentTag,
     warState,
-    currentWarId: subscription?.warId ?? null,
-    currentWarStartTime: subscription?.startTime ?? null,
-    currentWarOpponentTag: subscription?.opponentTag ?? null,
+    currentWarId: syncIdentityForRender.warId ?? null,
+    currentWarStartTime: syncIdentityForRender.warStartTime ?? null,
+    currentWarOpponentTag: syncIdentityForRender.opponentTag ?? null,
     activeWarId: warIdForSync,
     activeWarStartTime: warStartTimeForSync,
-    activeOpponentTag: syncIdentity.opponentTag ?? opponentTag,
+    activeOpponentTag: syncIdentityForRender.opponentTag ?? opponentTag,
     existingMatchType:
       (subscription?.matchType as
         | "FWA"
@@ -4548,7 +4701,7 @@ async function buildWarMailEmbedForTag(
     })
     .catch(() => null);
   const syncResolution = resolveActiveWarSyncNumber({
-    identity: syncIdentity,
+    identity: syncIdentityForRender,
     latestPersistedSyncNumber: sourceSync,
     sameWarPersistedSyncNumber: syncRow?.syncNum ?? null,
   });
@@ -4844,27 +4997,18 @@ async function buildWarMailEmbedForTag(
   const fallbackWarStartMs = subscription?.startTime
     ? subscription.startTime.getTime()
     : null;
-  const effectiveWarStartMs = warStartMs ?? fallbackWarStartMs;
+  const effectiveWarStartMs =
+    syncIdentityForRender.warStartTime?.getTime() ?? warStartMs ?? fallbackWarStartMs;
   const liveExpectedOutcome =
     matchType === "FWA" ? (outcome ?? "UNKNOWN") : null;
   const remainingText = formatDiscordRelativeMs(
     warState === "preparation" ? effectiveWarStartMs : battleTargetMs,
   );
-  const warId =
-    (await upsertCurrentWarHistoryAndGetWarId({
-      guildId,
-      normalizedTag,
-      warStartMs: effectiveWarStartMs,
-      warEndMs: battleTargetMs,
-      currentSync: resolvedCurrentSyncNum,
-      matchType,
-      expectedOutcome: liveExpectedOutcome,
-      clanName,
-      opponentName: effectiveOpponentName,
-      opponentTag: effectiveOpponentTag,
-      war,
-    })) ??
-    (await getCurrentWarIdForClan(guildId, normalizedTag, effectiveWarStartMs));
+  const warId = syncIdentityForRender.warId
+    ? Math.trunc(Number(syncIdentityForRender.warId))
+    : null;
+  const effectiveOpponentTagForRender =
+    syncIdentityForRender.opponentTag ?? effectiveOpponentTag;
   let displayClanStars = war?.clan?.stars ?? null;
   let displayOpponentStars = war?.opponent?.stars ?? null;
   let displayClanDestruction = war?.clan?.destructionPercentage ?? null;
@@ -4927,7 +5071,7 @@ async function buildWarMailEmbedForTag(
   embed.addFields(
     {
       name: "Opponent",
-      value: `${effectiveOpponentName} (${effectiveOpponentTag ? `#${effectiveOpponentTag}` : "unknown"})`,
+      value: `${effectiveOpponentName} (${effectiveOpponentTagForRender ? `#${effectiveOpponentTagForRender}` : "unknown"})`,
       inline: false,
     },
     {
@@ -4982,7 +5126,7 @@ async function buildWarMailEmbedForTag(
     mailChannelId: trackedConfig.mailChannelId,
     clanRoleId: trackedConfig.clanRoleId,
     warId,
-    opponentTag: effectiveOpponentTag || null,
+    opponentTag: effectiveOpponentTagForRender || null,
     warStartMs: effectiveWarStartMs,
     freezeRefresh,
     unavailableReasons,
@@ -8157,6 +8301,7 @@ async function showWarMailPreview(
   const rendered = await buildWarMailEmbedForTag(cocService, guildId, tag, {
     fetchReason: "pre_fwa_validation",
     revisionOverride: revisionOverride ?? null,
+    targetedWarReconcileClient: interaction.client,
   });
   const mailSendGate = rendered.mailRevisionDecision;
   if (
@@ -8643,6 +8788,7 @@ async function handleFwaMailConfirmAction(
     {
       fetchReason: "pre_fwa_validation",
       revisionOverride: payload.revisionOverride ?? null,
+      targetedWarReconcileClient: interaction.client,
     },
   );
   if (!rendered.mailChannelId || rendered.unavailableReasons.length > 0) {

--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -4360,12 +4360,25 @@ function mailStatusTitleForState(state: WarStateForSync): string {
   return "War Ended";
 }
 
-type WarMailCurrentWarIdentityRow = {
-  warId: number | null;
-  startTime: Date | null;
-  opponentTag: string | null;
-  state: string | null;
-};
+const warMailCurrentWarRenderSelect = Prisma.validator<Prisma.CurrentWarSelect>()({
+  warId: true,
+  matchType: true,
+  inferredMatchType: true,
+  outcome: true,
+  fwaPoints: true,
+  opponentFwaPoints: true,
+  startTime: true,
+  state: true,
+  endTime: true,
+  opponentTag: true,
+  opponentName: true,
+  clanStars: true,
+  opponentStars: true,
+});
+
+type WarMailCurrentWarRenderRow = Prisma.CurrentWarGetPayload<{
+  select: typeof warMailCurrentWarRenderSelect;
+}>;
 
 type WarMailResolvedCurrentWarIdentity = {
   warId: number;
@@ -4381,7 +4394,7 @@ function isActiveWarMailState(
 }
 
 function resolveExactCurrentWarMailIdentityForRow(
-  row: WarMailCurrentWarIdentityRow | null | undefined,
+  row: WarMailCurrentWarRenderRow | null | undefined,
   input: {
     liveWarState: WarStateForSync;
     liveWarStartMs: number | null;
@@ -4412,34 +4425,24 @@ function resolveExactCurrentWarMailIdentityForRow(
   };
 }
 
-async function readExactCurrentWarIdentityForTag(params: {
+async function loadWarMailCurrentWarRenderRow(params: {
   guildId: string;
   normalizedTag: string;
-  liveWarState: WarStateForSync;
-  liveWarStartMs: number | null;
-  liveOpponentTag: string | null;
-}): Promise<WarMailResolvedCurrentWarIdentity | null> {
+}): Promise<WarMailCurrentWarRenderRow | null> {
   if (!params.guildId || !params.normalizedTag) return null;
-  const current = await prisma.currentWar.findUnique({
+  return prisma.currentWar.findUnique({
     where: {
       clanTag_guildId: {
         guildId: params.guildId,
         clanTag: `#${params.normalizedTag}`,
       },
     },
-    select: {
-      warId: true,
-      startTime: true,
-      opponentTag: true,
-      state: true,
-    },
-  });
-  return resolveExactCurrentWarMailIdentityForRow(current, {
-    liveWarState: params.liveWarState,
-    liveWarStartMs: params.liveWarStartMs,
-    liveOpponentTag: params.liveOpponentTag,
+    select: warMailCurrentWarRenderSelect,
   });
 }
+
+export const loadWarMailCurrentWarRenderRowForTest =
+  loadWarMailCurrentWarRenderRow;
 
 export const resolveExactCurrentWarMailIdentityForTagForTest =
   resolveExactCurrentWarMailIdentityForRow;
@@ -4472,12 +4475,21 @@ export const targetedWarMailIdentityResolver = {
     liveWarState: WarStateForSync;
     liveWarStartMs: number | null;
     liveOpponentTag: string | null;
-    currentWarRow: WarMailCurrentWarIdentityRow | null;
-  }): Promise<WarMailResolvedCurrentWarIdentity | null> {
+    activeWarSyncIdentity: ActiveWarSyncIdentity;
+    currentWarRow: WarMailCurrentWarRenderRow | null;
+  }): Promise<{
+    identity: WarMailResolvedCurrentWarIdentity | null;
+    currentWarRow: WarMailCurrentWarRenderRow | null;
+    reconciled: boolean;
+  }> {
     const normalizedGuildId = String(params.guildId ?? "").trim();
     const normalizedTag = normalizeTag(params.normalizedTag);
     if (!normalizedGuildId || !normalizedTag) {
-      return null;
+      return {
+        identity: null,
+        currentWarRow: params.currentWarRow,
+        reconciled: false,
+      };
     }
     const initialExact = resolveExactCurrentWarMailIdentityForRow(
       params.currentWarRow,
@@ -4487,15 +4499,29 @@ export const targetedWarMailIdentityResolver = {
         liveOpponentTag: params.liveOpponentTag,
       },
     );
-    if (initialExact) return initialExact;
+    if (initialExact) {
+      return {
+        identity: initialExact,
+        currentWarRow: params.currentWarRow,
+        reconciled: false,
+      };
+    }
 
     if (
       !params.client ||
       params.liveWarState === "notInWar" ||
       params.liveWarStartMs === null ||
-      params.liveOpponentTag === null
+      params.liveOpponentTag === null ||
+      (params.activeWarSyncIdentity.warId !== null &&
+        params.activeWarSyncIdentity.warId !== undefined &&
+        Number.isFinite(Number(params.activeWarSyncIdentity.warId)) &&
+        Math.trunc(Number(params.activeWarSyncIdentity.warId)) > 0)
     ) {
-      return null;
+      return {
+        identity: null,
+        currentWarRow: params.currentWarRow,
+        reconciled: false,
+      };
     }
 
     const warEvents = new WarEventLogService(params.client, params.cocService);
@@ -4509,18 +4535,28 @@ export const targetedWarMailIdentityResolver = {
         console.warn(
           `[fwa-mail] event=targeted_war_reconcile guild=${normalizedGuildId} clan=#${normalizedTag} result=not_processed`,
         );
-        return null;
+        return {
+          identity: null,
+          currentWarRow: params.currentWarRow,
+          reconciled: false,
+        };
       }
     } catch (error) {
       console.warn(
         `[fwa-mail] event=targeted_war_reconcile guild=${normalizedGuildId} clan=#${normalizedTag} result=failed error=${formatError(error)}`,
       );
-      return null;
+      return {
+        identity: null,
+        currentWarRow: params.currentWarRow,
+        reconciled: false,
+      };
     }
 
-    const reread = await readExactCurrentWarIdentityForTag({
+    const rereadRow = await loadWarMailCurrentWarRenderRow({
       guildId: normalizedGuildId,
       normalizedTag,
+    });
+    const reread = resolveExactCurrentWarMailIdentityForRow(rereadRow, {
       liveWarState: params.liveWarState,
       liveWarStartMs: params.liveWarStartMs,
       liveOpponentTag: params.liveOpponentTag,
@@ -4529,11 +4565,99 @@ export const targetedWarMailIdentityResolver = {
       console.warn(
         `[fwa-mail] event=targeted_war_reconcile guild=${normalizedGuildId} clan=#${normalizedTag} result=unresolved`,
       );
-      return null;
+      return {
+        identity: null,
+        currentWarRow: params.currentWarRow,
+        reconciled: false,
+      };
     }
-    return reread;
+    return {
+      identity: reread,
+      currentWarRow: rereadRow,
+      reconciled: true,
+    };
   },
 };
+
+export const resolveWarMailCurrentWarRenderContextForTest =
+  targetedWarMailIdentityResolver.resolve;
+
+type WarMailCurrentWarRenderState = {
+  warId: number | null;
+  matchType: "FWA" | "BL" | "MM" | "SKIP" | null;
+  inferredMatchType: boolean | null;
+  outcome: "WIN" | "LOSE" | null;
+  fwaPoints: number | null;
+  opponentFwaPoints: number | null;
+  startTime: Date | null;
+  endTime: Date | null;
+  opponentTag: string | null;
+  opponentName: string | null;
+  clanStars: number | null;
+  opponentStars: number | null;
+};
+
+function buildWarMailCurrentWarRenderState(
+  currentWarRow: WarMailCurrentWarRenderRow | null,
+): WarMailCurrentWarRenderState {
+  if (!currentWarRow) {
+    return {
+      warId: null,
+      matchType: null,
+      inferredMatchType: null,
+      outcome: null,
+      fwaPoints: null,
+      opponentFwaPoints: null,
+      startTime: null,
+      endTime: null,
+      opponentTag: null,
+      opponentName: null,
+      clanStars: null,
+      opponentStars: null,
+    };
+  }
+
+  return {
+    warId:
+      currentWarRow.warId !== null && Number.isFinite(Number(currentWarRow.warId))
+        ? Math.trunc(Number(currentWarRow.warId))
+        : null,
+    matchType: (currentWarRow.matchType as "FWA" | "BL" | "MM" | "SKIP" | null) ?? null,
+    inferredMatchType: Boolean(currentWarRow.inferredMatchType),
+    outcome: (currentWarRow.outcome as "WIN" | "LOSE" | null) ?? null,
+    fwaPoints:
+      currentWarRow.fwaPoints !== null &&
+      currentWarRow.fwaPoints !== undefined &&
+      Number.isFinite(Number(currentWarRow.fwaPoints))
+        ? Number(currentWarRow.fwaPoints)
+        : null,
+    opponentFwaPoints:
+      currentWarRow.opponentFwaPoints !== null &&
+      currentWarRow.opponentFwaPoints !== undefined &&
+      Number.isFinite(Number(currentWarRow.opponentFwaPoints))
+        ? Number(currentWarRow.opponentFwaPoints)
+        : null,
+    startTime: currentWarRow.startTime ?? null,
+    endTime: currentWarRow.endTime ?? null,
+    opponentTag: normalizeTag(String(currentWarRow.opponentTag ?? "")),
+    opponentName: sanitizeClanName(String(currentWarRow.opponentName ?? "")),
+    clanStars:
+      currentWarRow.clanStars !== null &&
+      currentWarRow.clanStars !== undefined &&
+      Number.isFinite(Number(currentWarRow.clanStars))
+        ? Number(currentWarRow.clanStars)
+        : null,
+    opponentStars:
+      currentWarRow.opponentStars !== null &&
+      currentWarRow.opponentStars !== undefined &&
+      Number.isFinite(Number(currentWarRow.opponentStars))
+        ? Number(currentWarRow.opponentStars)
+        : null,
+  };
+}
+
+export const buildWarMailCurrentWarRenderStateForTest =
+  buildWarMailCurrentWarRenderState;
 
 async function buildWarMailEmbedForTag(
   cocService: CoCService,
@@ -4581,51 +4705,39 @@ async function buildWarMailEmbedForTag(
     sanitizeClanName(String(war?.clan?.name ?? "")) ??
     `#${normalizedTag}`;
 
-  const subscription = await prisma.currentWar.findUnique({
-    where: {
-      clanTag_guildId: {
-        guildId,
-        clanTag: `#${normalizedTag}`,
-      },
-    },
-    select: {
-      warId: true,
-      matchType: true,
-      inferredMatchType: true,
-      outcome: true,
-      fwaPoints: true,
-      opponentFwaPoints: true,
-      startTime: true,
-      state: true,
-      endTime: true,
-      opponentTag: true,
-      opponentName: true,
-      clanStars: true,
-      opponentStars: true,
-    },
+  const initialCurrentWar = await loadWarMailCurrentWarRenderRow({
+    guildId,
+    normalizedTag,
   });
+  let currentWarForRender = initialCurrentWar;
 
   const syncIdentity = resolveCurrentWarSyncIdentity({
     clanTag: tag,
     warState,
     liveWarStartTime: war?.startTime ?? null,
     liveOpponentTag: opponentTag || null,
-    currentWarId: subscription?.warId ?? null,
-    currentWarStartTime: subscription?.startTime ?? null,
-    currentWarOpponentTag: subscription?.opponentTag ?? null,
+    currentWarId: currentWarForRender?.warId ?? null,
+    currentWarStartTime: currentWarForRender?.startTime ?? null,
+    currentWarOpponentTag: currentWarForRender?.opponentTag ?? null,
   });
-  const resolvedCurrentWarIdentity = await targetedWarMailIdentityResolver.resolve(
-    {
-      client: options?.targetedWarReconcileClient ?? null,
-      cocService,
-      guildId,
-      normalizedTag,
-      liveWarState: warState,
-      liveWarStartMs: parseCocApiTime(war?.startTime),
-      liveOpponentTag: opponentTag || null,
-      currentWarRow: subscription,
-    },
+  const reconciledContext = await targetedWarMailIdentityResolver.resolve({
+    client: options?.targetedWarReconcileClient ?? null,
+    cocService,
+    guildId,
+    normalizedTag,
+    liveWarState: warState,
+    liveWarStartMs: parseCocApiTime(war?.startTime),
+    liveOpponentTag: opponentTag || null,
+    activeWarSyncIdentity: syncIdentity,
+    currentWarRow: currentWarForRender,
+  });
+  if (reconciledContext.currentWarRow) {
+    currentWarForRender = reconciledContext.currentWarRow;
+  }
+  const currentWarRenderState = buildWarMailCurrentWarRenderState(
+    currentWarForRender,
   );
+  const resolvedCurrentWarIdentity = reconciledContext.identity;
   const syncIdentityForRender = resolvedCurrentWarIdentity
     ? buildActiveWarSyncIdentity({
         warState,
@@ -4651,15 +4763,8 @@ async function buildWarMailEmbedForTag(
     activeWarId: warIdForSync,
     activeWarStartTime: warStartTimeForSync,
     activeOpponentTag: syncIdentityForRender.opponentTag ?? opponentTag,
-    existingMatchType:
-      (subscription?.matchType as
-        | "FWA"
-        | "BL"
-        | "MM"
-        | "SKIP"
-        | null
-        | undefined) ?? null,
-    existingInferredMatchType: subscription?.inferredMatchType ?? null,
+    existingMatchType: currentWarRenderState.matchType,
+    existingInferredMatchType: currentWarRenderState.inferredMatchType ?? null,
   });
   let appliedResolution = chooseMatchTypeResolution({
     confirmedCurrent: fallbackResolution.confirmedCurrent,
@@ -4668,37 +4773,34 @@ async function buildWarMailEmbedForTag(
     unconfirmedCurrent: fallbackResolution.unconfirmedCurrent,
   });
   let inferredMatchType =
-    appliedResolution?.inferred ?? Boolean(subscription?.inferredMatchType);
+    appliedResolution?.inferred ??
+    Boolean(currentWarRenderState.inferredMatchType);
   let matchType: "FWA" | "BL" | "MM" | "UNKNOWN" =
     appliedResolution?.matchType === "SKIP"
       ? "UNKNOWN"
       : (appliedResolution?.matchType ?? "UNKNOWN");
-  let outcome =
-    (subscription?.outcome as "WIN" | "LOSE" | null | undefined) ?? null;
-  const fallbackOpponentTag = normalizeTag(
-    String(subscription?.opponentTag ?? ""),
-  );
+  let outcome = currentWarRenderState.outcome;
+  const fallbackOpponentTag = currentWarRenderState.opponentTag ?? null;
   const effectiveOpponentTag = opponentTag || fallbackOpponentTag;
   const effectiveOpponentName = opponentTag
     ? opponentName
-    : (sanitizeClanName(String(subscription?.opponentName ?? "")) ??
-      opponentName);
+    : (currentWarRenderState.opponentName ?? opponentName);
   const hasLiveWar = warState !== "notInWar" && Boolean(opponentTag);
   const hasStoredWarIdentity = Boolean(
-    (subscription?.warId !== null &&
-      subscription?.warId !== undefined &&
-      Number.isFinite(Number(subscription.warId))) ||
-      subscription?.startTime,
+    (currentWarRenderState.warId !== null &&
+      currentWarRenderState.warId !== undefined &&
+      Number.isFinite(Number(currentWarRenderState.warId))) ||
+      currentWarRenderState.startTime,
   );
   const freezeRefresh =
     !hasLiveWar && hasStoredWarIdentity && Boolean(effectiveOpponentTag);
   const syncRow = await pointsSyncService
     .getCurrentSyncForClan({
       guildId,
-      clanTag: normalizedTag,
-      warId: warIdForSync,
-      warStartTime: warStartTimeForSync,
-    })
+        clanTag: normalizedTag,
+        warId: warIdForSync,
+        warStartTime: warStartTimeForSync,
+      })
     .catch(() => null);
   const syncResolution = resolveActiveWarSyncNumber({
     identity: syncIdentityForRender,
@@ -4733,7 +4835,7 @@ async function buildWarMailEmbedForTag(
         preferredAllowedReason: options?.fetchReason ?? "mail_refresh",
         warState,
         warStartTime: warStartTimeForSync,
-        warEndTime: subscription?.endTime ?? null,
+        warEndTime: currentWarRenderState.endTime ?? null,
         currentSyncNumber: resolvedCurrentSyncNum,
         lifecycle,
         activeWarId: warIdForSync,
@@ -4806,9 +4908,10 @@ async function buildWarMailEmbedForTag(
     primaryBalance = primarySnapshot?.balance ?? null;
     opponentBalance = opponentSnapshot?.balance ?? null;
   } else {
-    primaryBalance = subscription?.fwaPoints ?? syncRow?.clanPoints ?? null;
+    primaryBalance =
+      currentWarRenderState.fwaPoints ?? syncRow?.clanPoints ?? null;
     opponentBalance =
-      subscription?.opponentFwaPoints ?? syncRow?.opponentPoints ?? null;
+      currentWarRenderState.opponentFwaPoints ?? syncRow?.opponentPoints ?? null;
   }
   const siteCurrentFromPrimary = Boolean(
     opponentTag &&
@@ -4834,9 +4937,9 @@ async function buildWarMailEmbedForTag(
     const activeWarInference = buildActiveWarMatchInferenceOptions({
       warState,
       clanAttacksUsed: war?.clan?.attacks ?? null,
-      clanStars: war?.clan?.stars ?? subscription?.clanStars ?? null,
+      clanStars: war?.clan?.stars ?? currentWarRenderState.clanStars ?? null,
       opponentStars:
-        war?.opponent?.stars ?? subscription?.opponentStars ?? null,
+        war?.opponent?.stars ?? currentWarRenderState.opponentStars ?? null,
     });
     pointsInference = toMatchTypeResolutionFromPointsInference(
       inferMatchTypeFromPointsSnapshots(primarySnapshot, opponentSnapshot, {
@@ -4852,8 +4955,8 @@ async function buildWarMailEmbedForTag(
         opponentNotFoundExplicitly: opponentSnapshot?.notFound === true,
         hasSameWarExplicitFwaConfirmation: hasSameWarExplicitFwaConfirmation({
           fallbackResolution,
-          currentWarStartTime: subscription?.startTime ?? null,
-          currentWarOpponentTag: subscription?.opponentTag ?? null,
+          currentWarStartTime: currentWarRenderState.startTime ?? null,
+          currentWarOpponentTag: currentWarRenderState.opponentTag ?? null,
           activeWarStartTime: getWarStartDateForSync(null, war),
           activeOpponentTag: opponentTag,
         }),
@@ -4865,7 +4968,8 @@ async function buildWarMailEmbedForTag(
       unconfirmedCurrent: guardedFallbackResolution.unconfirmedCurrent,
     });
     inferredMatchType =
-      appliedResolution?.inferred ?? Boolean(subscription?.inferredMatchType);
+      appliedResolution?.inferred ??
+      Boolean(currentWarRenderState.inferredMatchType);
     matchType =
       appliedResolution?.matchType === "SKIP"
         ? "UNKNOWN"
@@ -4875,7 +4979,7 @@ async function buildWarMailEmbedForTag(
         stage: "mail_embed",
         clanTag: normalizedTag,
         opponentTag,
-        warId: subscription?.warId ?? null,
+        warId: currentWarRenderState.warId ?? null,
         source: appliedResolution.source,
         matchType: appliedResolution.matchType,
         inferred: appliedResolution.inferred,
@@ -4994,8 +5098,8 @@ async function buildWarMailEmbedForTag(
 
   const battleTargetMs = parseCocApiTime(war?.endTime);
   const warStartMs = parseCocApiTime(war?.startTime);
-  const fallbackWarStartMs = subscription?.startTime
-    ? subscription.startTime.getTime()
+  const fallbackWarStartMs = currentWarRenderState.startTime
+    ? currentWarRenderState.startTime.getTime()
     : null;
   const effectiveWarStartMs =
     syncIdentityForRender.warStartTime?.getTime() ?? warStartMs ?? fallbackWarStartMs;
@@ -5021,14 +5125,14 @@ async function buildWarMailEmbedForTag(
   if (freezeRefresh) {
     const finalResult = await history.getWarEndResultSnapshot({
       clanTag: normalizedTag,
-      opponentTag: effectiveOpponentTag,
-      fallbackClanStars: subscription?.clanStars ?? null,
-      fallbackOpponentStars: subscription?.opponentStars ?? null,
-      warStartTime: subscription?.startTime ?? null,
+      opponentTag: effectiveOpponentTag ?? opponentTag,
+      fallbackClanStars: currentWarRenderState.clanStars ?? null,
+      fallbackOpponentStars: currentWarRenderState.opponentStars ?? null,
+      warStartTime: currentWarRenderState.startTime ?? null,
     });
     const endedAtMs =
       finalResult.warEndTime?.getTime() ??
-      subscription?.endTime?.getTime() ??
+      currentWarRenderState.endTime?.getTime() ??
       battleTargetMs ??
       null;
     displayClanStars = finalResult.clanStars;

--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -4386,11 +4386,60 @@ type WarMailResolvedCurrentWarIdentity = {
   opponentTag: string;
 };
 
+type WarMailCurrentWarRowClassification = {
+  samePhysicalWar: boolean;
+  exactIdentity: WarMailResolvedCurrentWarIdentity | null;
+};
+
 function isActiveWarMailState(
   state: string | null | undefined,
 ): state is "preparation" | "inWar" {
   const normalized = String(state ?? "").trim();
   return normalized === "preparation" || normalized === "inWar";
+}
+
+function classifyWarMailCurrentWarRow(
+  row: WarMailCurrentWarRenderRow | null | undefined,
+  input: {
+    liveWarState: WarStateForSync;
+    liveWarStartMs: number | null;
+    liveOpponentTag: string | null;
+  },
+): WarMailCurrentWarRowClassification {
+  if (input.liveWarState === "notInWar") {
+    return { samePhysicalWar: false, exactIdentity: null };
+  }
+  if (!row || !isActiveWarMailState(row.state)) {
+    return { samePhysicalWar: false, exactIdentity: null };
+  }
+  if (input.liveWarStartMs === null || input.liveOpponentTag === null) {
+    return { samePhysicalWar: false, exactIdentity: null };
+  }
+
+  const rowStartMs = toWarStartMs(row.startTime);
+  const rowOpponentTag = normalizeTag(String(row.opponentTag ?? ""));
+  const samePhysicalWar =
+    rowStartMs !== null &&
+    rowStartMs === Math.trunc(input.liveWarStartMs) &&
+    rowOpponentTag === input.liveOpponentTag;
+  if (!samePhysicalWar) {
+    return { samePhysicalWar: false, exactIdentity: null };
+  }
+
+  const rowWarId = toComparableSyncNumber(row.warId ?? null);
+  const exactIdentity =
+    rowWarId !== null && rowWarId > 0
+      ? {
+          warId: rowWarId,
+          startTime: row.startTime!,
+          opponentTag: rowOpponentTag,
+        }
+      : null;
+
+  return {
+    samePhysicalWar: true,
+    exactIdentity,
+  };
 }
 
 function resolveExactCurrentWarMailIdentityForRow(
@@ -4401,28 +4450,7 @@ function resolveExactCurrentWarMailIdentityForRow(
     liveOpponentTag: string | null;
   },
 ): WarMailResolvedCurrentWarIdentity | null {
-  if (input.liveWarState === "notInWar") return null;
-  if (!row || !isActiveWarMailState(row.state)) return null;
-  if (input.liveWarStartMs === null || input.liveOpponentTag === null) return null;
-
-  const rowWarId = toComparableSyncNumber(row.warId ?? null);
-  const rowStartMs = toWarStartMs(row.startTime);
-  const rowOpponentTag = normalizeTag(String(row.opponentTag ?? ""));
-  if (
-    rowWarId === null ||
-    rowWarId <= 0 ||
-    rowStartMs === null ||
-    rowStartMs !== Math.trunc(input.liveWarStartMs) ||
-    rowOpponentTag !== input.liveOpponentTag
-  ) {
-    return null;
-  }
-
-  return {
-    warId: rowWarId,
-    startTime: row.startTime!,
-    opponentTag: rowOpponentTag,
-  };
+  return classifyWarMailCurrentWarRow(row, input).exactIdentity;
 }
 
 async function loadWarMailCurrentWarRenderRow(params: {
@@ -4443,6 +4471,9 @@ async function loadWarMailCurrentWarRenderRow(params: {
 
 export const loadWarMailCurrentWarRenderRowForTest =
   loadWarMailCurrentWarRenderRow;
+
+export const classifyWarMailCurrentWarRowForTest =
+  classifyWarMailCurrentWarRow;
 
 export const resolveExactCurrentWarMailIdentityForTagForTest =
   resolveExactCurrentWarMailIdentityForRow;
@@ -4491,7 +4522,7 @@ export const targetedWarMailIdentityResolver = {
         reconciled: false,
       };
     }
-    const initialExact = resolveExactCurrentWarMailIdentityForRow(
+    const initialClassification = classifyWarMailCurrentWarRow(
       params.currentWarRow,
       {
         liveWarState: params.liveWarState,
@@ -4499,6 +4530,7 @@ export const targetedWarMailIdentityResolver = {
         liveOpponentTag: params.liveOpponentTag,
       },
     );
+    const initialExact = initialClassification.exactIdentity;
     if (initialExact) {
       return {
         identity: initialExact,
@@ -4506,6 +4538,9 @@ export const targetedWarMailIdentityResolver = {
         reconciled: false,
       };
     }
+    const initialRenderableRow = initialClassification.samePhysicalWar
+      ? params.currentWarRow
+      : null;
 
     if (
       !params.client ||
@@ -4519,7 +4554,7 @@ export const targetedWarMailIdentityResolver = {
     ) {
       return {
         identity: null,
-        currentWarRow: params.currentWarRow,
+        currentWarRow: initialRenderableRow,
         reconciled: false,
       };
     }
@@ -4537,7 +4572,7 @@ export const targetedWarMailIdentityResolver = {
         );
         return {
           identity: null,
-          currentWarRow: params.currentWarRow,
+          currentWarRow: initialRenderableRow,
           reconciled: false,
         };
       }
@@ -4547,7 +4582,7 @@ export const targetedWarMailIdentityResolver = {
       );
       return {
         identity: null,
-        currentWarRow: params.currentWarRow,
+        currentWarRow: initialRenderableRow,
         reconciled: false,
       };
     }
@@ -4567,7 +4602,7 @@ export const targetedWarMailIdentityResolver = {
       );
       return {
         identity: null,
-        currentWarRow: params.currentWarRow,
+        currentWarRow: initialRenderableRow,
         reconciled: false,
       };
     }
@@ -4709,16 +4744,15 @@ async function buildWarMailEmbedForTag(
     guildId,
     normalizedTag,
   });
-  let currentWarForRender = initialCurrentWar;
 
   const syncIdentity = resolveCurrentWarSyncIdentity({
     clanTag: tag,
     warState,
     liveWarStartTime: war?.startTime ?? null,
     liveOpponentTag: opponentTag || null,
-    currentWarId: currentWarForRender?.warId ?? null,
-    currentWarStartTime: currentWarForRender?.startTime ?? null,
-    currentWarOpponentTag: currentWarForRender?.opponentTag ?? null,
+    currentWarId: initialCurrentWar?.warId ?? null,
+    currentWarStartTime: initialCurrentWar?.startTime ?? null,
+    currentWarOpponentTag: initialCurrentWar?.opponentTag ?? null,
   });
   const reconciledContext = await targetedWarMailIdentityResolver.resolve({
     client: options?.targetedWarReconcileClient ?? null,
@@ -4729,14 +4763,10 @@ async function buildWarMailEmbedForTag(
     liveWarStartMs: parseCocApiTime(war?.startTime),
     liveOpponentTag: opponentTag || null,
     activeWarSyncIdentity: syncIdentity,
-    currentWarRow: currentWarForRender,
+    currentWarRow: initialCurrentWar,
   });
-  if (reconciledContext.currentWarRow) {
-    currentWarForRender = reconciledContext.currentWarRow;
-  }
-  const currentWarRenderState = buildWarMailCurrentWarRenderState(
-    currentWarForRender,
-  );
+  const currentWarForRender = reconciledContext.currentWarRow;
+  const currentWarRenderState = buildWarMailCurrentWarRenderState(currentWarForRender);
   const resolvedCurrentWarIdentity = reconciledContext.identity;
   const syncIdentityForRender = resolvedCurrentWarIdentity
     ? buildActiveWarSyncIdentity({

--- a/src/services/WarEventLogService.ts
+++ b/src/services/WarEventLogService.ts
@@ -633,9 +633,103 @@ type PollSyncContext = {
   activeSync: number | null;
 };
 
+type ReconciliationRelease = () => void;
+type ReconciliationMode = "global" | "targeted";
+
+/** Purpose: coordinate active and scheduled war reconciliation work within one Node process. */
+class WarReconciliationCoordinator {
+  private activeMode: ReconciliationMode | null = null;
+  private readonly globalWaiters: Array<(release: ReconciliationRelease) => void> =
+    [];
+
+  /** Purpose: run one global reconciliation at a time while waiting for any active targeted reconciliation. */
+  async runGlobal<T>(work: () => Promise<T>): Promise<T> {
+    const release = await this.acquireGlobal();
+    try {
+      return await work();
+    } finally {
+      release();
+    }
+  }
+
+  /** Purpose: attempt targeted reconciliation once and skip immediately if any reconciliation is already active or queued. */
+  async runTargeted<T>(work: () => Promise<T>): Promise<
+    | { acquired: true; value: T }
+    | { acquired: false }
+  > {
+    const release = this.tryAcquireTargeted();
+    if (!release) {
+      return { acquired: false };
+    }
+
+    try {
+      return { acquired: true, value: await work() };
+    } finally {
+      release();
+    }
+  }
+
+  /** Purpose: queue a global reconciliation until the coordinator becomes free. */
+  private acquireGlobal(): Promise<ReconciliationRelease> {
+    return new Promise((resolve) => {
+      if (this.activeMode === null && this.globalWaiters.length === 0) {
+        this.activeMode = "global";
+        resolve(this.createRelease());
+        return;
+      }
+
+      this.globalWaiters.push(resolve);
+    });
+  }
+
+  /** Purpose: grab the coordinator only when no reconciliation is active or already waiting. */
+  private tryAcquireTargeted(): ReconciliationRelease | null {
+    if (this.activeMode !== null || this.globalWaiters.length > 0) {
+      return null;
+    }
+
+    this.activeMode = "targeted";
+    return this.createRelease();
+  }
+
+  /** Purpose: release the current reconciliation and hand the coordinator to the next queued global run. */
+  private createRelease(): ReconciliationRelease {
+    let released = false;
+    return () => {
+      if (released) {
+        return;
+      }
+      released = true;
+
+      const next = this.globalWaiters.shift();
+      if (next) {
+        this.activeMode = "global";
+        next(this.createRelease());
+        return;
+      }
+
+      this.activeMode = null;
+    };
+  }
+
+  /** Purpose: clear coordinator state for isolated tests. */
+  resetForTest(): void {
+    this.activeMode = null;
+    this.globalWaiters.length = 0;
+  }
+}
+
+const reconciliationCoordinator = new WarReconciliationCoordinator();
+
+/** Purpose: clear the module-scoped reconciliation coordinator between isolated tests. */
+export const resetWarReconciliationCoordinatorForTest = (): void => {
+  reconciliationCoordinator.resetForTest();
+};
+
 export type WarEventPollClanResult = {
   processed: boolean;
   warEnded: boolean;
+  skippedReason?: "reconciliation_in_flight";
 };
 
 type CocWarOutageState = {
@@ -1538,50 +1632,52 @@ export class WarEventLogService {
     sendBattleDaySwapReminders?: boolean;
     currentWarSnapshotCycleContext?: CurrentWarSnapshotCycleContext;
   }): Promise<void> {
-    const sendBattleDaySwapReminders =
-      input?.sendBattleDaySwapReminders === true;
-    const syncContext = await this.buildPollSyncContext();
-    const targets = await this.listPollTargets();
-    const maintenanceOverGuildIds = new Set<string>();
-    for (const target of targets) {
-      await this.ensureCurrentWarBaseline(target);
-      await this.processSubscription(
-        target.guildId,
-        target.clanTag,
-        syncContext,
-        {
-          sendBattleDaySwapReminders,
-          maintenanceOverGuildIds,
-          currentWarSnapshotCycleContext: input?.currentWarSnapshotCycleContext ?? null,
-        },
-      ).catch((err) => {
-        console.error(
-          `[war-events] process failed guild=${target.guildId} clan=${target.clanTag} error=${formatError(
-            err,
-          )}`,
-        );
-      });
-    }
-    for (const guildId of maintenanceOverGuildIds) {
-      await fireBattleDayTransitionWar24hRemindersForGuild({
-        client: this.client,
-        guildId,
-        nowMs: Date.now(),
-        triggerSource: "maintenance_over",
-      }).catch((err) => {
-        console.error(
-          `[reminders] battle_day_maintenance_over_failed guild=${guildId} trigger=maintenance_over error=${formatError(err)}`,
-        );
-      });
-    }
+    await reconciliationCoordinator.runGlobal(async () => {
+      const sendBattleDaySwapReminders =
+        input?.sendBattleDaySwapReminders === true;
+      const syncContext = await this.buildPollSyncContext();
+      const targets = await this.listPollTargets();
+      const maintenanceOverGuildIds = new Set<string>();
+      for (const target of targets) {
+        await this.ensureCurrentWarBaseline(target);
+        await this.processSubscription(
+          target.guildId,
+          target.clanTag,
+          syncContext,
+          {
+            sendBattleDaySwapReminders,
+            maintenanceOverGuildIds,
+            currentWarSnapshotCycleContext: input?.currentWarSnapshotCycleContext ?? null,
+          },
+        ).catch((err) => {
+          console.error(
+            `[war-events] process failed guild=${target.guildId} clan=${target.clanTag} error=${formatError(
+              err,
+            )}`,
+          );
+        });
+      }
+      for (const guildId of maintenanceOverGuildIds) {
+        await fireBattleDayTransitionWar24hRemindersForGuild({
+          client: this.client,
+          guildId,
+          nowMs: Date.now(),
+          triggerSource: "maintenance_over",
+        }).catch((err) => {
+          console.error(
+            `[reminders] battle_day_maintenance_over_failed guild=${guildId} trigger=maintenance_over error=${formatError(err)}`,
+          );
+        });
+      }
 
-    await this.warPlanViolations
-      .reconcileDueEvaluations({ limit: 20 })
-      .catch((err) => {
-        console.error(
-          `[war-plan-violation] event=reconcile_failed error=${formatError(err)}`,
-        );
-      });
+      await this.warPlanViolations
+        .reconcileDueEvaluations({ limit: 20 })
+        .catch((err) => {
+          console.error(
+            `[war-plan-violation] event=reconcile_failed error=${formatError(err)}`,
+          );
+        });
+    });
   }
 
   /** Purpose: derive the shared poll sync context without widening the global poll loop. */
@@ -1605,26 +1701,41 @@ export class WarEventLogService {
       return { processed: false, warEnded: false };
     }
 
-    const subscription = await this.findSubscriptionByGuildAndTag(
-      guildId,
-      clanTag,
-    );
-    if (!subscription) {
-      return { processed: false, warEnded: false };
+    const targeted = await reconciliationCoordinator.runTargeted(async () => {
+      const subscription = await this.findSubscriptionByGuildAndTag(
+        guildId,
+        clanTag,
+      );
+      if (!subscription) {
+        return { processed: false, warEnded: false };
+      }
+
+      const syncContext = await this.buildPollSyncContext();
+      const warEnded = await this.processSubscription(
+        guildId,
+        clanTag,
+        syncContext,
+        {
+          sendBattleDaySwapReminders:
+            input.sendBattleDaySwapReminders === true,
+        },
+      );
+
+      return { processed: true, warEnded };
+    });
+
+    if (!targeted.acquired) {
+      console.warn(
+        `[war-events] event=reconciliation_skipped source=poll_clan reason=in_flight guild=${guildId} clan=${clanTag}`,
+      );
+      return {
+        processed: false,
+        warEnded: false,
+        skippedReason: "reconciliation_in_flight",
+      };
     }
 
-    const syncContext = await this.buildPollSyncContext();
-    const warEnded = await this.processSubscription(
-      guildId,
-      clanTag,
-      syncContext,
-      {
-        sendBattleDaySwapReminders:
-          input.sendBattleDaySwapReminders === true,
-      },
-    );
-
-    return { processed: true, warEnded };
+    return targeted.value;
   }
 
   private async listPollTargets(): Promise<PollTarget[]> {

--- a/tests/fwaTargetedWarReconcile.logic.test.ts
+++ b/tests/fwaTargetedWarReconcile.logic.test.ts
@@ -4,6 +4,8 @@ const prismaMock = vi.hoisted(() => ({
   currentWar: {
     findUnique: vi.fn(),
     findMany: vi.fn(),
+    update: vi.fn(),
+    upsert: vi.fn(),
   },
 }));
 
@@ -26,15 +28,63 @@ vi.mock("../src/services/WarEventLogService", () => ({
 }));
 
 import {
+  buildWarMailCurrentWarRenderStateForTest,
+  loadWarMailCurrentWarRenderRowForTest,
   resolveExactCurrentWarMailIdentityForTagForTest,
-  targetedWarMailIdentityResolver,
+  resolveWarMailCurrentWarRenderContextForTest,
 } from "../src/commands/Fwa";
+
+const liveStartMs = new Date("2026-07-12T15:22:26.000Z").getTime();
+const liveStartTime = new Date("2026-07-12T15:22:26.000Z");
+const staleStartTime = new Date("2026-07-11T15:22:26.000Z");
+
+function buildRenderRow(overrides: Record<string, unknown> = {}) {
+  return {
+    warId: 1000610,
+    matchType: "FWA",
+    inferredMatchType: true,
+    outcome: "WIN",
+    fwaPoints: 111,
+    opponentFwaPoints: 99,
+    startTime: liveStartTime,
+    state: "preparation",
+    endTime: new Date("2026-07-12T18:22:26.000Z"),
+    opponentTag: "#LYPLQQUC",
+    opponentName: "Old Opponent",
+    clanStars: 30,
+    opponentStars: 27,
+    ...overrides,
+  } as any;
+}
+
+function buildActiveIdentity(overrides: Record<string, unknown> = {}) {
+  return {
+    warState: "preparation",
+    warId: null,
+    warStartTime: null,
+    opponentTag: null,
+    positivelyResolved: false,
+    ...overrides,
+  } as any;
+}
+
+function expectNoMutatingWrites(): void {
+  expect(prismaMock.currentWar.update).not.toHaveBeenCalled();
+  expect(prismaMock.currentWar.upsert).not.toHaveBeenCalled();
+}
+
+function expectNoGlobalPolls(): void {
+  expect(warEventLogServiceMock.poll).not.toHaveBeenCalled();
+  expect(warEventLogServiceMock.refreshBattleDayPosts).not.toHaveBeenCalled();
+}
 
 describe("fwa targeted war-mail identity reconciliation", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     prismaMock.currentWar.findUnique.mockResolvedValue(null);
     prismaMock.currentWar.findMany.mockResolvedValue([]);
+    prismaMock.currentWar.update.mockResolvedValue({});
+    prismaMock.currentWar.upsert.mockResolvedValue({});
     warEventLogServiceMock.pollClan.mockResolvedValue({
       processed: true,
       warEnded: false,
@@ -45,102 +95,154 @@ describe("fwa targeted war-mail identity reconciliation", () => {
     vi.restoreAllMocks();
   });
 
-  it("accepts only an exact active CurrentWar reread with a positive war id", () => {
-    const exact = resolveExactCurrentWarMailIdentityForTagForTest(
-      {
-        warId: 1000610,
-        startTime: new Date("2026-07-12T15:22:26.000Z"),
-        opponentTag: "#LYPLQQUC",
-        state: "preparation",
-      },
-      {
-        liveWarState: "preparation",
-        liveWarStartMs: new Date("2026-07-12T15:22:26.000Z").getTime(),
-        liveOpponentTag: "LYPLQQUC",
-      },
-    );
+  it("loads the shared render-row select for the exact clan row", async () => {
+    prismaMock.currentWar.findUnique.mockResolvedValueOnce(null);
 
-    expect(exact).toEqual({
-      warId: 1000610,
-      startTime: new Date("2026-07-12T15:22:26.000Z"),
-      opponentTag: "LYPLQQUC",
+    const result = await loadWarMailCurrentWarRenderRowForTest({
+      guildId: " guild-1 ",
+      normalizedTag: "LYPLQQUC",
+    });
+
+    expect(result).toBeNull();
+    expect(prismaMock.currentWar.findUnique).toHaveBeenCalledWith({
+      where: {
+        clanTag_guildId: {
+          guildId: " guild-1 ",
+          clanTag: "#LYPLQQUC",
+        },
+      },
+      select: expect.objectContaining({
+        warId: true,
+        matchType: true,
+        inferredMatchType: true,
+        outcome: true,
+        fwaPoints: true,
+        opponentFwaPoints: true,
+        startTime: true,
+        state: true,
+        endTime: true,
+        opponentTag: true,
+        opponentName: true,
+        clanStars: true,
+        opponentStars: true,
+      }),
     });
   });
 
-  it("rejects a reread when the state, war id, start, or opponent do not match exactly", () => {
-    const rejected = resolveExactCurrentWarMailIdentityForTagForTest(
-      {
-        warId: 0,
-        startTime: new Date("2026-07-12T15:22:26.000Z"),
-        opponentTag: "#OLDTAG",
-        state: "notInWar",
-      },
-      {
+  it("accepts an already exact active CurrentWar row without polling", async () => {
+    const exactRow = buildRenderRow({
+      warId: 1000610,
+      state: "preparation",
+      opponentTag: "#LYPLQQUC",
+      opponentName: "Exact Opponent",
+      inferredMatchType: false,
+      outcome: null,
+      fwaPoints: 120,
+      opponentFwaPoints: 108,
+      clanStars: 28,
+      opponentStars: 26,
+    });
+    expect(
+      resolveExactCurrentWarMailIdentityForTagForTest(exactRow, {
         liveWarState: "preparation",
-        liveWarStartMs: new Date("2026-07-12T15:22:26.000Z").getTime(),
+        liveWarStartMs: liveStartMs,
         liveOpponentTag: "LYPLQQUC",
-      },
-    );
+      }),
+    ).toEqual({
+      warId: 1000610,
+      startTime: liveStartTime,
+      opponentTag: "LYPLQQUC",
+    });
 
-    expect(rejected).toBeNull();
-  });
-
-  it("returns the current-war identity without polling when the row is already exact", async () => {
-    const result = await targetedWarMailIdentityResolver.resolve({
+    const result = await resolveWarMailCurrentWarRenderContextForTest({
       client: { channels: { fetch: vi.fn() } } as any,
       cocService: {} as any,
-      guildId: " guild-1 ",
-      normalizedTag: " #lyplqquc ",
+      guildId: "guild-1",
+      normalizedTag: "LYPLQQUC",
       liveWarState: "preparation",
-      liveWarStartMs: new Date("2026-07-12T15:22:26.000Z").getTime(),
+      liveWarStartMs: liveStartMs,
       liveOpponentTag: "LYPLQQUC",
-      currentWarRow: {
-        warId: 1000610,
-        startTime: new Date("2026-07-12T15:22:26.000Z"),
-        opponentTag: "#LYPLQQUC",
-        state: "preparation",
-      },
+      activeWarSyncIdentity: buildActiveIdentity({
+        warId: "1000610",
+        warStartTime: liveStartTime,
+        opponentTag: "LYPLQQUC",
+        positivelyResolved: true,
+      }),
+      currentWarRow: exactRow,
     });
 
     expect(result).toEqual({
-      warId: 1000610,
-      startTime: new Date("2026-07-12T15:22:26.000Z"),
-      opponentTag: "LYPLQQUC",
+      identity: {
+        warId: 1000610,
+        startTime: liveStartTime,
+        opponentTag: "LYPLQQUC",
+      },
+      currentWarRow: exactRow,
+      reconciled: false,
     });
     expect(warEventLogServiceMock.pollClan).not.toHaveBeenCalled();
-    expect(warEventLogServiceMock.poll).not.toHaveBeenCalled();
-    expect(warEventLogServiceMock.refreshBattleDayPosts).not.toHaveBeenCalled();
-    expect(prismaMock.currentWar.findUnique).not.toHaveBeenCalled();
+    expectNoGlobalPolls();
+    expectNoMutatingWrites();
   });
 
-  it("reconciles one clan through pollClan and rereads only the exact CurrentWar row", async () => {
-    prismaMock.currentWar.findUnique.mockResolvedValueOnce({
-      warId: 1000610,
-      startTime: new Date("2026-07-12T15:22:26.000Z"),
-      opponentTag: "#LYPLQQUC",
+  it("reconciles a stale row through pollClan and replaces the render row with the fresh exact row", async () => {
+    const staleRow = buildRenderRow({
+      warId: 1000609,
+      matchType: "FWA",
+      inferredMatchType: true,
+      outcome: "WIN",
+      fwaPoints: 211,
+      opponentFwaPoints: 198,
+      startTime: staleStartTime,
       state: "preparation",
+      endTime: new Date("2026-07-11T18:22:26.000Z"),
+      opponentTag: "#OLDTAG",
+      opponentName: "Old Opponent",
+      clanStars: 31,
+      opponentStars: 29,
     });
+    const freshRow = buildRenderRow({
+      warId: 1000610,
+      matchType: "MM",
+      inferredMatchType: false,
+      outcome: null,
+      fwaPoints: null,
+      opponentFwaPoints: null,
+      startTime: liveStartTime,
+      state: "preparation",
+      endTime: null,
+      opponentTag: "#LYPLQQUC",
+      opponentName: "Fresh Opponent",
+      clanStars: 17,
+      opponentStars: 14,
+    });
+    prismaMock.currentWar.findUnique.mockResolvedValueOnce(freshRow);
 
-    const result = await targetedWarMailIdentityResolver.resolve({
+    const result = await resolveWarMailCurrentWarRenderContextForTest({
       client: { channels: { fetch: vi.fn() } } as any,
       cocService: {} as any,
-      guildId: " guild-1 ",
-      normalizedTag: " #lyplqquc ",
+      guildId: "guild-1",
+      normalizedTag: "LYPLQQUC",
       liveWarState: "preparation",
-      liveWarStartMs: new Date("2026-07-12T15:22:26.000Z").getTime(),
+      liveWarStartMs: liveStartMs,
       liveOpponentTag: "LYPLQQUC",
-      currentWarRow: {
+      activeWarSyncIdentity: buildActiveIdentity({
         warId: null,
-        startTime: null,
-        opponentTag: null,
-        state: "preparation",
-      },
+        warStartTime: liveStartTime,
+        opponentTag: "LYPLQQUC",
+        positivelyResolved: true,
+      }),
+      currentWarRow: staleRow,
     });
 
     expect(result).toEqual({
-      warId: 1000610,
-      startTime: new Date("2026-07-12T15:22:26.000Z"),
-      opponentTag: "LYPLQQUC",
+      identity: {
+        warId: 1000610,
+        startTime: liveStartTime,
+        opponentTag: "LYPLQQUC",
+      },
+      currentWarRow: freshRow,
+      reconciled: true,
     });
     expect(warEventLogServiceMock.pollClan).toHaveBeenCalledTimes(1);
     expect(warEventLogServiceMock.pollClan).toHaveBeenCalledWith({
@@ -151,41 +253,322 @@ describe("fwa targeted war-mail identity reconciliation", () => {
     expect(warEventLogServiceMock.poll).not.toHaveBeenCalled();
     expect(warEventLogServiceMock.refreshBattleDayPosts).not.toHaveBeenCalled();
     expect(prismaMock.currentWar.findUnique).toHaveBeenCalledTimes(1);
-    expect(prismaMock.currentWar.findUnique).toHaveBeenCalledWith({
-      where: {
-        clanTag_guildId: {
-          guildId: "guild-1",
-          clanTag: "#LYPLQQUC",
-        },
-      },
-      select: {
-        warId: true,
-        startTime: true,
-        opponentTag: true,
-        state: true,
-      },
+    expectNoMutatingWrites();
+
+    const freshState = buildWarMailCurrentWarRenderStateForTest(
+      result.currentWarRow,
+    );
+    expect(freshState).toMatchObject({
+      warId: 1000610,
+      matchType: "MM",
+      inferredMatchType: false,
+      outcome: null,
+      fwaPoints: null,
+      opponentFwaPoints: null,
+      opponentTag: "LYPLQQUC",
+      opponentName: "Fresh Opponent",
+      clanStars: 17,
+      opponentStars: 14,
     });
+    expect(freshState.matchType).not.toBe(staleRow.matchType);
+    expect(freshState.inferredMatchType).not.toBe(Boolean(staleRow.inferredMatchType));
+    expect(freshState.outcome).not.toBe(staleRow.outcome);
+    expect(freshState.fwaPoints).not.toBe(staleRow.fwaPoints);
+    expect(freshState.opponentFwaPoints).not.toBe(staleRow.opponentFwaPoints);
+    expect(freshState.clanStars).not.toBe(staleRow.clanStars);
+    expect(freshState.opponentStars).not.toBe(staleRow.opponentStars);
   });
 
-  it("returns a no-op when the one-clan poll does not materialize a matching CurrentWar row", async () => {
-    warEventLogServiceMock.pollClan.mockResolvedValueOnce({
-      processed: false,
-      warEnded: false,
-    });
+  it.each([
+    ["poll throws", async () => {
+      warEventLogServiceMock.pollClan.mockRejectedValueOnce(new Error("poll boom"));
+    }],
+    ["processed false", async () => {
+      warEventLogServiceMock.pollClan.mockResolvedValueOnce({
+        processed: false,
+        warEnded: false,
+      });
+    }],
+    ["missing reread", async () => {
+      prismaMock.currentWar.findUnique.mockResolvedValueOnce(null);
+    }],
+    ["reread ID null", async () => {
+      prismaMock.currentWar.findUnique.mockResolvedValueOnce(
+        buildRenderRow({ warId: null }),
+      );
+    }],
+    ["reread ID zero", async () => {
+      prismaMock.currentWar.findUnique.mockResolvedValueOnce(
+        buildRenderRow({ warId: 0 }),
+      );
+    }],
+    ["reread ID negative", async () => {
+      prismaMock.currentWar.findUnique.mockResolvedValueOnce(
+        buildRenderRow({ warId: -7 }),
+      );
+    }],
+    ["reread start differs", async () => {
+      prismaMock.currentWar.findUnique.mockResolvedValueOnce(
+        buildRenderRow({ startTime: staleStartTime }),
+      );
+    }],
+    ["reread opponent differs", async () => {
+      prismaMock.currentWar.findUnique.mockResolvedValueOnce(
+        buildRenderRow({ opponentTag: "#ANOTHER" }),
+      );
+    }],
+    ["reread state is notInWar", async () => {
+      prismaMock.currentWar.findUnique.mockResolvedValueOnce(
+        buildRenderRow({ state: "notInWar" }),
+      );
+    }],
+  ])(
+    "fails closed when %s",
+    async (
+      _label,
+      setup,
+    ) => {
+      const staleRow = buildRenderRow({
+        warId: null,
+        state: "preparation",
+        opponentTag: "#OLDTAG",
+        opponentName: "Old Opponent",
+        startTime: staleStartTime,
+      });
+      await setup();
 
-    const result = await targetedWarMailIdentityResolver.resolve({
+      const result = await resolveWarMailCurrentWarRenderContextForTest({
+        client: { channels: { fetch: vi.fn() } } as any,
+        cocService: {} as any,
+        guildId: "guild-1",
+        normalizedTag: "LYPLQQUC",
+        liveWarState: "preparation",
+        liveWarStartMs: liveStartMs,
+        liveOpponentTag: "LYPLQQUC",
+        activeWarSyncIdentity: buildActiveIdentity({
+          warId: null,
+          warStartTime: liveStartTime,
+          opponentTag: "LYPLQQUC",
+          positivelyResolved: true,
+        }),
+        currentWarRow: staleRow,
+      });
+
+      expect(result.identity).toBeNull();
+      expect(result.currentWarRow).toBe(staleRow);
+      expect(result.reconciled).toBe(false);
+      expect(warEventLogServiceMock.pollClan).toHaveBeenCalledTimes(1);
+      expect(warEventLogServiceMock.poll).not.toHaveBeenCalled();
+      expect(warEventLogServiceMock.refreshBattleDayPosts).not.toHaveBeenCalled();
+      expectNoMutatingWrites();
+    },
+  );
+
+  it.each([
+    ["missing live start", null, "LYPLQQUC"],
+    ["missing live opponent", liveStartMs, null],
+    ["live state is notInWar", liveStartMs, "LYPLQQUC"],
+    ["interactive client absent", liveStartMs, "LYPLQQUC"],
+  ])(
+    "does not poll when %s",
+    async (label, testLiveStartMs, testOpponentTag) => {
+      const staleRow = buildRenderRow({
+        warId: null,
+        state: "preparation",
+        opponentTag: "#OLDTAG",
+        opponentName: "Old Opponent",
+        startTime: staleStartTime,
+      });
+      const result = await resolveWarMailCurrentWarRenderContextForTest({
+        client: label === "interactive client absent" ? null : { channels: { fetch: vi.fn() } } as any,
+        cocService: {} as any,
+        guildId: "guild-1",
+        normalizedTag: "LYPLQQUC",
+        liveWarState: label === "live state is notInWar" ? "notInWar" : "preparation",
+        liveWarStartMs: testLiveStartMs,
+        liveOpponentTag: label === "missing live opponent" ? null : testOpponentTag,
+        activeWarSyncIdentity: buildActiveIdentity({
+          warId: null,
+          warStartTime: liveStartTime,
+          opponentTag: "LYPLQQUC",
+          positivelyResolved: false,
+        }),
+        currentWarRow: staleRow,
+      });
+
+      expect(result.identity).toBeNull();
+      expect(result.currentWarRow).toBe(staleRow);
+      expect(result.reconciled).toBe(false);
+      expect(warEventLogServiceMock.pollClan).not.toHaveBeenCalled();
+      expectNoGlobalPolls();
+      expectNoMutatingWrites();
+    },
+  );
+
+  it("preserves the fail-closed render row when no usable positive identity exists", async () => {
+    const staleRow = buildRenderRow({
+      warId: null,
+      state: "preparation",
+      opponentTag: "#OLDTAG",
+      opponentName: "Old Opponent",
+      startTime: staleStartTime,
+      matchType: "FWA",
+      inferredMatchType: true,
+      outcome: "WIN",
+      fwaPoints: 200,
+      opponentFwaPoints: 170,
+      clanStars: 31,
+      opponentStars: 30,
+    });
+    const result = await resolveWarMailCurrentWarRenderContextForTest({
       client: { channels: { fetch: vi.fn() } } as any,
       cocService: {} as any,
       guildId: "guild-1",
-      normalizedTag: "2RYGLU2UY",
+      normalizedTag: "LYPLQQUC",
       liveWarState: "preparation",
-      liveWarStartMs: new Date("2026-07-12T15:22:26.000Z").getTime(),
+      liveWarStartMs: liveStartMs,
       liveOpponentTag: "LYPLQQUC",
-      currentWarRow: null,
+      activeWarSyncIdentity: buildActiveIdentity({
+        warId: null,
+        warStartTime: liveStartTime,
+        opponentTag: "LYPLQQUC",
+        positivelyResolved: false,
+      }),
+      currentWarRow: staleRow,
     });
 
-    expect(result).toBeNull();
+    expect(result.identity).toBeNull();
+    expect(result.currentWarRow).toBe(staleRow);
+    expect(result.reconciled).toBe(false);
     expect(warEventLogServiceMock.pollClan).toHaveBeenCalledTimes(1);
-    expect(prismaMock.currentWar.findUnique).not.toHaveBeenCalled();
+    expectNoGlobalPolls();
+    expectNoMutatingWrites();
+  });
+
+  it("exposes the fresh row's render state rather than the stale row's values", () => {
+    const staleRow = buildRenderRow({
+      warId: 1000609,
+      matchType: "FWA",
+      inferredMatchType: true,
+      outcome: "WIN",
+      fwaPoints: 400,
+      opponentFwaPoints: 380,
+      startTime: staleStartTime,
+      endTime: new Date("2026-07-11T18:22:26.000Z"),
+      opponentTag: "#OLDTAG",
+      opponentName: "Old Opponent",
+      clanStars: 42,
+      opponentStars: 35,
+    });
+    const freshRow = buildRenderRow({
+      warId: 1000610,
+      matchType: "MM",
+      inferredMatchType: false,
+      outcome: null,
+      fwaPoints: null,
+      opponentFwaPoints: null,
+      startTime: liveStartTime,
+      endTime: null,
+      opponentTag: "#LYPLQQUC",
+      opponentName: "Fresh Opponent",
+      clanStars: 18,
+      opponentStars: 12,
+    });
+
+    const staleState = buildWarMailCurrentWarRenderStateForTest(staleRow);
+    const freshState = buildWarMailCurrentWarRenderStateForTest(freshRow);
+
+    expect(staleState).toMatchObject({
+      warId: 1000609,
+      matchType: "FWA",
+      inferredMatchType: true,
+      outcome: "WIN",
+      fwaPoints: 400,
+      opponentFwaPoints: 380,
+      opponentTag: "OLDTAG",
+      opponentName: "Old Opponent",
+      clanStars: 42,
+      opponentStars: 35,
+    });
+    expect(freshState).toMatchObject({
+      warId: 1000610,
+      matchType: "MM",
+      inferredMatchType: false,
+      outcome: null,
+      fwaPoints: null,
+      opponentFwaPoints: null,
+      opponentTag: "LYPLQQUC",
+      opponentName: "Fresh Opponent",
+      clanStars: 18,
+      opponentStars: 12,
+    });
+    expect(freshState.matchType).not.toBe(staleState.matchType);
+    expect(freshState.inferredMatchType).not.toBe(staleState.inferredMatchType);
+    expect(freshState.outcome).not.toBe(staleState.outcome);
+    expect(freshState.fwaPoints).not.toBe(staleState.fwaPoints);
+    expect(freshState.opponentFwaPoints).not.toBe(staleState.opponentFwaPoints);
+    expect(freshState.clanStars).not.toBe(staleState.clanStars);
+    expect(freshState.opponentStars).not.toBe(staleState.opponentStars);
+  });
+
+  it("accepts the exact reread row when the live state is active and the reread remains exact", async () => {
+    const exactRow = buildRenderRow({
+      warId: 1000610,
+      matchType: "MM",
+      inferredMatchType: false,
+      outcome: null,
+      fwaPoints: null,
+      opponentFwaPoints: null,
+      startTime: liveStartTime,
+      state: "preparation",
+      endTime: null,
+      opponentTag: "#LYPLQQUC",
+      opponentName: "Fresh Opponent",
+      clanStars: 18,
+      opponentStars: 12,
+    });
+    prismaMock.currentWar.findUnique.mockResolvedValueOnce(exactRow);
+
+    const reread = await resolveWarMailCurrentWarRenderContextForTest({
+      client: { channels: { fetch: vi.fn() } } as any,
+      cocService: {} as any,
+      guildId: "guild-1",
+      normalizedTag: "LYPLQQUC",
+      liveWarState: "preparation",
+      liveWarStartMs: liveStartMs,
+      liveOpponentTag: "LYPLQQUC",
+      activeWarSyncIdentity: buildActiveIdentity({
+        warId: null,
+        warStartTime: liveStartTime,
+        opponentTag: "LYPLQQUC",
+        positivelyResolved: true,
+      }),
+      currentWarRow: buildRenderRow({
+        warId: null,
+        matchType: "FWA",
+        inferredMatchType: true,
+        outcome: "WIN",
+        fwaPoints: 100,
+        opponentFwaPoints: 90,
+        startTime: staleStartTime,
+        state: "preparation",
+        endTime: new Date("2026-07-11T18:22:26.000Z"),
+        opponentTag: "#OLDTAG",
+        opponentName: "Old Opponent",
+        clanStars: 40,
+        opponentStars: 38,
+      }),
+    });
+
+    expect(reread.identity).toEqual({
+      warId: 1000610,
+      startTime: liveStartTime,
+      opponentTag: "LYPLQQUC",
+    });
+    expect(reread.currentWarRow).toBe(exactRow);
+    expect(reread.reconciled).toBe(true);
+    expect(warEventLogServiceMock.pollClan).toHaveBeenCalledTimes(1);
+    expect(prismaMock.currentWar.update).not.toHaveBeenCalled();
+    expect(prismaMock.currentWar.upsert).not.toHaveBeenCalled();
   });
 });

--- a/tests/fwaTargetedWarReconcile.logic.test.ts
+++ b/tests/fwaTargetedWarReconcile.logic.test.ts
@@ -1,0 +1,191 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const prismaMock = vi.hoisted(() => ({
+  currentWar: {
+    findUnique: vi.fn(),
+    findMany: vi.fn(),
+  },
+}));
+
+const warEventLogServiceMock = vi.hoisted(() => ({
+  pollClan: vi.fn(),
+  poll: vi.fn(),
+  refreshBattleDayPosts: vi.fn(),
+}));
+
+vi.mock("../src/prisma", () => ({
+  prisma: prismaMock,
+}));
+
+vi.mock("../src/services/WarEventLogService", () => ({
+  WarEventLogService: class {
+    pollClan = warEventLogServiceMock.pollClan;
+    poll = warEventLogServiceMock.poll;
+    refreshBattleDayPosts = warEventLogServiceMock.refreshBattleDayPosts;
+  },
+}));
+
+import {
+  resolveExactCurrentWarMailIdentityForTagForTest,
+  targetedWarMailIdentityResolver,
+} from "../src/commands/Fwa";
+
+describe("fwa targeted war-mail identity reconciliation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prismaMock.currentWar.findUnique.mockResolvedValue(null);
+    prismaMock.currentWar.findMany.mockResolvedValue([]);
+    warEventLogServiceMock.pollClan.mockResolvedValue({
+      processed: true,
+      warEnded: false,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("accepts only an exact active CurrentWar reread with a positive war id", () => {
+    const exact = resolveExactCurrentWarMailIdentityForTagForTest(
+      {
+        warId: 1000610,
+        startTime: new Date("2026-07-12T15:22:26.000Z"),
+        opponentTag: "#LYPLQQUC",
+        state: "preparation",
+      },
+      {
+        liveWarState: "preparation",
+        liveWarStartMs: new Date("2026-07-12T15:22:26.000Z").getTime(),
+        liveOpponentTag: "LYPLQQUC",
+      },
+    );
+
+    expect(exact).toEqual({
+      warId: 1000610,
+      startTime: new Date("2026-07-12T15:22:26.000Z"),
+      opponentTag: "LYPLQQUC",
+    });
+  });
+
+  it("rejects a reread when the state, war id, start, or opponent do not match exactly", () => {
+    const rejected = resolveExactCurrentWarMailIdentityForTagForTest(
+      {
+        warId: 0,
+        startTime: new Date("2026-07-12T15:22:26.000Z"),
+        opponentTag: "#OLDTAG",
+        state: "notInWar",
+      },
+      {
+        liveWarState: "preparation",
+        liveWarStartMs: new Date("2026-07-12T15:22:26.000Z").getTime(),
+        liveOpponentTag: "LYPLQQUC",
+      },
+    );
+
+    expect(rejected).toBeNull();
+  });
+
+  it("returns the current-war identity without polling when the row is already exact", async () => {
+    const result = await targetedWarMailIdentityResolver.resolve({
+      client: { channels: { fetch: vi.fn() } } as any,
+      cocService: {} as any,
+      guildId: " guild-1 ",
+      normalizedTag: " #lyplqquc ",
+      liveWarState: "preparation",
+      liveWarStartMs: new Date("2026-07-12T15:22:26.000Z").getTime(),
+      liveOpponentTag: "LYPLQQUC",
+      currentWarRow: {
+        warId: 1000610,
+        startTime: new Date("2026-07-12T15:22:26.000Z"),
+        opponentTag: "#LYPLQQUC",
+        state: "preparation",
+      },
+    });
+
+    expect(result).toEqual({
+      warId: 1000610,
+      startTime: new Date("2026-07-12T15:22:26.000Z"),
+      opponentTag: "LYPLQQUC",
+    });
+    expect(warEventLogServiceMock.pollClan).not.toHaveBeenCalled();
+    expect(warEventLogServiceMock.poll).not.toHaveBeenCalled();
+    expect(warEventLogServiceMock.refreshBattleDayPosts).not.toHaveBeenCalled();
+    expect(prismaMock.currentWar.findUnique).not.toHaveBeenCalled();
+  });
+
+  it("reconciles one clan through pollClan and rereads only the exact CurrentWar row", async () => {
+    prismaMock.currentWar.findUnique.mockResolvedValueOnce({
+      warId: 1000610,
+      startTime: new Date("2026-07-12T15:22:26.000Z"),
+      opponentTag: "#LYPLQQUC",
+      state: "preparation",
+    });
+
+    const result = await targetedWarMailIdentityResolver.resolve({
+      client: { channels: { fetch: vi.fn() } } as any,
+      cocService: {} as any,
+      guildId: " guild-1 ",
+      normalizedTag: " #lyplqquc ",
+      liveWarState: "preparation",
+      liveWarStartMs: new Date("2026-07-12T15:22:26.000Z").getTime(),
+      liveOpponentTag: "LYPLQQUC",
+      currentWarRow: {
+        warId: null,
+        startTime: null,
+        opponentTag: null,
+        state: "preparation",
+      },
+    });
+
+    expect(result).toEqual({
+      warId: 1000610,
+      startTime: new Date("2026-07-12T15:22:26.000Z"),
+      opponentTag: "LYPLQQUC",
+    });
+    expect(warEventLogServiceMock.pollClan).toHaveBeenCalledTimes(1);
+    expect(warEventLogServiceMock.pollClan).toHaveBeenCalledWith({
+      guildId: "guild-1",
+      clanTag: "LYPLQQUC",
+      sendBattleDaySwapReminders: false,
+    });
+    expect(warEventLogServiceMock.poll).not.toHaveBeenCalled();
+    expect(warEventLogServiceMock.refreshBattleDayPosts).not.toHaveBeenCalled();
+    expect(prismaMock.currentWar.findUnique).toHaveBeenCalledTimes(1);
+    expect(prismaMock.currentWar.findUnique).toHaveBeenCalledWith({
+      where: {
+        clanTag_guildId: {
+          guildId: "guild-1",
+          clanTag: "#LYPLQQUC",
+        },
+      },
+      select: {
+        warId: true,
+        startTime: true,
+        opponentTag: true,
+        state: true,
+      },
+    });
+  });
+
+  it("returns a no-op when the one-clan poll does not materialize a matching CurrentWar row", async () => {
+    warEventLogServiceMock.pollClan.mockResolvedValueOnce({
+      processed: false,
+      warEnded: false,
+    });
+
+    const result = await targetedWarMailIdentityResolver.resolve({
+      client: { channels: { fetch: vi.fn() } } as any,
+      cocService: {} as any,
+      guildId: "guild-1",
+      normalizedTag: "2RYGLU2UY",
+      liveWarState: "preparation",
+      liveWarStartMs: new Date("2026-07-12T15:22:26.000Z").getTime(),
+      liveOpponentTag: "LYPLQQUC",
+      currentWarRow: null,
+    });
+
+    expect(result).toBeNull();
+    expect(warEventLogServiceMock.pollClan).toHaveBeenCalledTimes(1);
+    expect(prismaMock.currentWar.findUnique).not.toHaveBeenCalled();
+  });
+});

--- a/tests/fwaTargetedWarReconcile.logic.test.ts
+++ b/tests/fwaTargetedWarReconcile.logic.test.ts
@@ -78,6 +78,23 @@ function expectNoGlobalPolls(): void {
   expect(warEventLogServiceMock.refreshBattleDayPosts).not.toHaveBeenCalled();
 }
 
+function expectNullWarMailRenderState(row: unknown): void {
+  expect(buildWarMailCurrentWarRenderStateForTest(row as any)).toEqual({
+    warId: null,
+    matchType: null,
+    inferredMatchType: null,
+    outcome: null,
+    fwaPoints: null,
+    opponentFwaPoints: null,
+    startTime: null,
+    endTime: null,
+    opponentTag: null,
+    opponentName: null,
+    clanStars: null,
+    opponentStars: null,
+  });
+}
+
 describe("fwa targeted war-mail identity reconciliation", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -279,90 +296,149 @@ describe("fwa targeted war-mail identity reconciliation", () => {
     expect(freshState.opponentStars).not.toBe(staleRow.opponentStars);
   });
 
-  it.each([
-    ["poll throws", async () => {
-      warEventLogServiceMock.pollClan.mockRejectedValueOnce(new Error("poll boom"));
-    }],
-    ["processed false", async () => {
-      warEventLogServiceMock.pollClan.mockResolvedValueOnce({
-        processed: false,
-        warEnded: false,
-      });
-    }],
-    ["missing reread", async () => {
-      prismaMock.currentWar.findUnique.mockResolvedValueOnce(null);
-    }],
-    ["reread ID null", async () => {
-      prismaMock.currentWar.findUnique.mockResolvedValueOnce(
-        buildRenderRow({ warId: null }),
-      );
-    }],
-    ["reread ID zero", async () => {
-      prismaMock.currentWar.findUnique.mockResolvedValueOnce(
-        buildRenderRow({ warId: 0 }),
-      );
-    }],
-    ["reread ID negative", async () => {
-      prismaMock.currentWar.findUnique.mockResolvedValueOnce(
-        buildRenderRow({ warId: -7 }),
-      );
-    }],
-    ["reread start differs", async () => {
-      prismaMock.currentWar.findUnique.mockResolvedValueOnce(
-        buildRenderRow({ startTime: staleStartTime }),
-      );
-    }],
-    ["reread opponent differs", async () => {
-      prismaMock.currentWar.findUnique.mockResolvedValueOnce(
-        buildRenderRow({ opponentTag: "#ANOTHER" }),
-      );
-    }],
-    ["reread state is notInWar", async () => {
-      prismaMock.currentWar.findUnique.mockResolvedValueOnce(
-        buildRenderRow({ state: "notInWar" }),
-      );
-    }],
-  ])(
-    "fails closed when %s",
-    async (
-      _label,
-      setup,
-    ) => {
-      const staleRow = buildRenderRow({
+  it("returns null row and fail-closed render state when a stale row poll throws", async () => {
+    const staleRow = buildRenderRow({
+      warId: null,
+      state: "preparation",
+      opponentTag: "#OLDTAG",
+      opponentName: "Old Opponent",
+      startTime: staleStartTime,
+      matchType: "FWA",
+      inferredMatchType: true,
+      outcome: "WIN",
+      fwaPoints: 200,
+      opponentFwaPoints: 170,
+      endTime: new Date("2026-07-11T18:22:26.000Z"),
+      clanStars: 31,
+      opponentStars: 30,
+    });
+    warEventLogServiceMock.pollClan.mockRejectedValueOnce(new Error("poll boom"));
+
+    const result = await resolveWarMailCurrentWarRenderContextForTest({
+      client: { channels: { fetch: vi.fn() } } as any,
+      cocService: {} as any,
+      guildId: "guild-1",
+      normalizedTag: "LYPLQQUC",
+      liveWarState: "preparation",
+      liveWarStartMs: liveStartMs,
+      liveOpponentTag: "LYPLQQUC",
+      activeWarSyncIdentity: buildActiveIdentity({
         warId: null,
-        state: "preparation",
-        opponentTag: "#OLDTAG",
-        opponentName: "Old Opponent",
+        warStartTime: liveStartTime,
+        opponentTag: "LYPLQQUC",
+        positivelyResolved: true,
+      }),
+      currentWarRow: staleRow,
+    });
+
+    expect(result.identity).toBeNull();
+    expect(result.currentWarRow).toBeNull();
+    expect(result.reconciled).toBe(false);
+    expect(warEventLogServiceMock.pollClan).toHaveBeenCalledTimes(1);
+    expect(warEventLogServiceMock.poll).not.toHaveBeenCalled();
+    expect(warEventLogServiceMock.refreshBattleDayPosts).not.toHaveBeenCalled();
+    expectNoMutatingWrites();
+    expectNullWarMailRenderState(result.currentWarRow);
+  });
+
+  it("returns null row and fail-closed render state when a stale row poll is not processed", async () => {
+    const staleRow = buildRenderRow({
+      warId: null,
+      state: "preparation",
+      opponentTag: "#OLDTAG",
+      opponentName: "Old Opponent",
+      startTime: staleStartTime,
+      matchType: "FWA",
+      inferredMatchType: true,
+      outcome: "WIN",
+      fwaPoints: 200,
+      opponentFwaPoints: 170,
+      endTime: new Date("2026-07-11T18:22:26.000Z"),
+      clanStars: 31,
+      opponentStars: 30,
+    });
+    warEventLogServiceMock.pollClan.mockResolvedValueOnce({
+      processed: false,
+      warEnded: false,
+    });
+
+    const result = await resolveWarMailCurrentWarRenderContextForTest({
+      client: { channels: { fetch: vi.fn() } } as any,
+      cocService: {} as any,
+      guildId: "guild-1",
+      normalizedTag: "LYPLQQUC",
+      liveWarState: "preparation",
+      liveWarStartMs: liveStartMs,
+      liveOpponentTag: "LYPLQQUC",
+      activeWarSyncIdentity: buildActiveIdentity({
+        warId: null,
+        warStartTime: liveStartTime,
+        opponentTag: "LYPLQQUC",
+        positivelyResolved: true,
+      }),
+      currentWarRow: staleRow,
+    });
+
+    expect(result.identity).toBeNull();
+    expect(result.currentWarRow).toBeNull();
+    expect(result.reconciled).toBe(false);
+    expect(warEventLogServiceMock.pollClan).toHaveBeenCalledTimes(1);
+    expect(warEventLogServiceMock.poll).not.toHaveBeenCalled();
+    expect(warEventLogServiceMock.refreshBattleDayPosts).not.toHaveBeenCalled();
+    expectNoMutatingWrites();
+    expectNullWarMailRenderState(result.currentWarRow);
+  });
+
+  it("returns null row when a stale row reread is mismatched", async () => {
+    const staleRow = buildRenderRow({
+      warId: null,
+      state: "preparation",
+      opponentTag: "#OLDTAG",
+      opponentName: "Old Opponent",
+      startTime: staleStartTime,
+      matchType: "FWA",
+      inferredMatchType: true,
+      outcome: "WIN",
+      fwaPoints: 200,
+      opponentFwaPoints: 170,
+      endTime: new Date("2026-07-11T18:22:26.000Z"),
+      clanStars: 31,
+      opponentStars: 30,
+    });
+    prismaMock.currentWar.findUnique.mockResolvedValueOnce(
+      buildRenderRow({
+        warId: 1000610,
         startTime: staleStartTime,
-      });
-      await setup();
+        opponentTag: "#ANOTHER",
+      }),
+    );
 
-      const result = await resolveWarMailCurrentWarRenderContextForTest({
-        client: { channels: { fetch: vi.fn() } } as any,
-        cocService: {} as any,
-        guildId: "guild-1",
-        normalizedTag: "LYPLQQUC",
-        liveWarState: "preparation",
-        liveWarStartMs: liveStartMs,
-        liveOpponentTag: "LYPLQQUC",
-        activeWarSyncIdentity: buildActiveIdentity({
-          warId: null,
-          warStartTime: liveStartTime,
-          opponentTag: "LYPLQQUC",
-          positivelyResolved: true,
-        }),
-        currentWarRow: staleRow,
-      });
+    const result = await resolveWarMailCurrentWarRenderContextForTest({
+      client: { channels: { fetch: vi.fn() } } as any,
+      cocService: {} as any,
+      guildId: "guild-1",
+      normalizedTag: "LYPLQQUC",
+      liveWarState: "preparation",
+      liveWarStartMs: liveStartMs,
+      liveOpponentTag: "LYPLQQUC",
+      activeWarSyncIdentity: buildActiveIdentity({
+        warId: null,
+        warStartTime: liveStartTime,
+        opponentTag: "LYPLQQUC",
+        positivelyResolved: true,
+      }),
+      currentWarRow: staleRow,
+    });
 
-      expect(result.identity).toBeNull();
-      expect(result.currentWarRow).toBe(staleRow);
-      expect(result.reconciled).toBe(false);
-      expect(warEventLogServiceMock.pollClan).toHaveBeenCalledTimes(1);
-      expect(warEventLogServiceMock.poll).not.toHaveBeenCalled();
-      expect(warEventLogServiceMock.refreshBattleDayPosts).not.toHaveBeenCalled();
-      expectNoMutatingWrites();
-    },
-  );
+    expect(result.identity).toBeNull();
+    expect(result.currentWarRow).toBeNull();
+    expect(result.reconciled).toBe(false);
+    expect(warEventLogServiceMock.pollClan).toHaveBeenCalledTimes(1);
+    expect(warEventLogServiceMock.poll).not.toHaveBeenCalled();
+    expect(warEventLogServiceMock.refreshBattleDayPosts).not.toHaveBeenCalled();
+    expectNoMutatingWrites();
+    expectNullWarMailRenderState(result.currentWarRow);
+  });
 
   it.each([
     ["missing live start", null, "LYPLQQUC"],
@@ -397,29 +473,33 @@ describe("fwa targeted war-mail identity reconciliation", () => {
       });
 
       expect(result.identity).toBeNull();
-      expect(result.currentWarRow).toBe(staleRow);
+      expect(result.currentWarRow).toBeNull();
       expect(result.reconciled).toBe(false);
       expect(warEventLogServiceMock.pollClan).not.toHaveBeenCalled();
       expectNoGlobalPolls();
       expectNoMutatingWrites();
+      expectNullWarMailRenderState(result.currentWarRow);
     },
   );
 
-  it("preserves the fail-closed render row when no usable positive identity exists", async () => {
-    const staleRow = buildRenderRow({
+  it("retains a same-war row with a missing ID when poll fails", async () => {
+    const sameWarRowMissingId = buildRenderRow({
       warId: null,
       state: "preparation",
-      opponentTag: "#OLDTAG",
-      opponentName: "Old Opponent",
-      startTime: staleStartTime,
+      opponentTag: "#LYPLQQUC",
+      opponentName: "Fresh Opponent",
+      startTime: liveStartTime,
       matchType: "FWA",
       inferredMatchType: true,
       outcome: "WIN",
       fwaPoints: 200,
       opponentFwaPoints: 170,
+      endTime: new Date("2026-07-12T18:22:26.000Z"),
       clanStars: 31,
       opponentStars: 30,
     });
+    warEventLogServiceMock.pollClan.mockRejectedValueOnce(new Error("poll boom"));
+
     const result = await resolveWarMailCurrentWarRenderContextForTest({
       client: { channels: { fetch: vi.fn() } } as any,
       cocService: {} as any,
@@ -434,15 +514,30 @@ describe("fwa targeted war-mail identity reconciliation", () => {
         opponentTag: "LYPLQQUC",
         positivelyResolved: false,
       }),
-      currentWarRow: staleRow,
+      currentWarRow: sameWarRowMissingId,
     });
 
     expect(result.identity).toBeNull();
-    expect(result.currentWarRow).toBe(staleRow);
+    expect(result.currentWarRow).toBe(sameWarRowMissingId);
     expect(result.reconciled).toBe(false);
     expect(warEventLogServiceMock.pollClan).toHaveBeenCalledTimes(1);
-    expectNoGlobalPolls();
+    expect(warEventLogServiceMock.poll).not.toHaveBeenCalled();
+    expect(warEventLogServiceMock.refreshBattleDayPosts).not.toHaveBeenCalled();
     expectNoMutatingWrites();
+    expect(buildWarMailCurrentWarRenderStateForTest(result.currentWarRow)).toMatchObject({
+      warId: null,
+      matchType: "FWA",
+      inferredMatchType: true,
+      outcome: "WIN",
+      fwaPoints: 200,
+      opponentFwaPoints: 170,
+      startTime: liveStartTime,
+      endTime: new Date("2026-07-12T18:22:26.000Z"),
+      opponentTag: "LYPLQQUC",
+      opponentName: "Fresh Opponent",
+      clanStars: 31,
+      opponentStars: 30,
+    });
   });
 
   it("exposes the fresh row's render state rather than the stale row's values", () => {

--- a/tests/warEventLog.coordinator.test.ts
+++ b/tests/warEventLog.coordinator.test.ts
@@ -1,0 +1,335 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  WarEventLogService,
+  resetWarReconciliationCoordinatorForTest,
+} from "../src/services/WarEventLogService";
+
+const prismaMock = vi.hoisted(() => ({
+  $queryRaw: vi.fn(),
+  trackedClan: {
+    findMany: vi.fn(),
+    findUnique: vi.fn(),
+  },
+  currentWar: {
+    findFirst: vi.fn(),
+    findMany: vi.fn(),
+    upsert: vi.fn(),
+  },
+  clanNotifyConfig: {
+    findMany: vi.fn(),
+    findUnique: vi.fn(),
+  },
+}));
+
+vi.mock("../src/prisma", () => ({
+  prisma: prismaMock,
+}));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetWarReconciliationCoordinatorForTest();
+  prismaMock.$queryRaw.mockResolvedValue([]);
+  prismaMock.trackedClan.findMany.mockResolvedValue([]);
+  prismaMock.trackedClan.findUnique.mockResolvedValue(null);
+  prismaMock.currentWar.findFirst.mockResolvedValue(null);
+  prismaMock.currentWar.findMany.mockResolvedValue([]);
+  prismaMock.currentWar.upsert.mockResolvedValue({});
+  prismaMock.clanNotifyConfig.findMany.mockResolvedValue([]);
+  prismaMock.clanNotifyConfig.findUnique.mockResolvedValue(null);
+});
+
+function makeDeferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+async function flushTick(): Promise<void> {
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+}
+
+function makeService(): WarEventLogService {
+  return new WarEventLogService(
+    { channels: { fetch: vi.fn() } } as any,
+    {} as any,
+  );
+}
+
+function stubTargetedPollBody(service: WarEventLogService, buildSyncGate?: Promise<unknown>) {
+  const findSubscriptionSpy = vi
+    .spyOn(service as any, "findSubscriptionByGuildAndTag")
+    .mockResolvedValue({ guildId: "guild-1", clanTag: "#AAA111" });
+  const buildSyncSpy = vi
+    .spyOn(service as any, "buildPollSyncContext")
+    .mockImplementation(async () => {
+      if (buildSyncGate) {
+        await buildSyncGate;
+      }
+      return { previousSync: 41, activeSync: 42 };
+    });
+  const processSpy = vi
+    .spyOn(service as any, "processSubscription")
+    .mockResolvedValue(true);
+  return { findSubscriptionSpy, buildSyncSpy, processSpy };
+}
+
+describe("WarEventLogService reconciliation coordinator", () => {
+  it("skips targeted reconciliation while a global poll is waiting and logs the skip", async () => {
+    const service = makeService();
+    const buildSyncGate = makeDeferred<void>();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const buildSyncSpy = vi
+      .spyOn(service as any, "buildPollSyncContext")
+      .mockImplementation(async () => {
+        await buildSyncGate.promise;
+        return { previousSync: 41, activeSync: 42 };
+      });
+    const listTargetsSpy = vi
+      .spyOn(service as any, "listPollTargets")
+      .mockResolvedValue([]);
+    const reconcileSpy = vi
+      .spyOn((service as any).warPlanViolations, "reconcileDueEvaluations")
+      .mockResolvedValue({
+        requestedLimit: 20,
+        processedCount: 0,
+        completedCount: 0,
+        insufficientDataCount: 0,
+        failedCount: 0,
+        skippedCount: 0,
+        durationMs: 0,
+      });
+    const findSubscriptionSpy = vi.spyOn(
+      service as any,
+      "findSubscriptionByGuildAndTag",
+    );
+    const processSpy = vi.spyOn(service as any, "processSubscription");
+
+    const globalPoll = service.poll();
+    await flushTick();
+
+    const targetedResult = await service.pollClan({
+      guildId: " guild-1 ",
+      clanTag: " aaa111 ",
+    });
+
+    expect(targetedResult).toEqual({
+      processed: false,
+      warEnded: false,
+      skippedReason: "reconciliation_in_flight",
+    });
+    expect(warnSpy).toHaveBeenCalledWith(
+      "[war-events] event=reconciliation_skipped source=poll_clan reason=in_flight guild=guild-1 clan=#AAA111",
+    );
+    expect(findSubscriptionSpy).not.toHaveBeenCalled();
+    expect(processSpy).not.toHaveBeenCalled();
+
+    buildSyncGate.resolve();
+    await globalPoll;
+    expect(buildSyncSpy).toHaveBeenCalledTimes(1);
+    expect(listTargetsSpy).toHaveBeenCalledTimes(1);
+    expect(reconcileSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips a second targeted reconciliation while one targeted worker is active", async () => {
+    const service = makeService();
+    const buildSyncGate = makeDeferred<void>();
+    const { findSubscriptionSpy, buildSyncSpy, processSpy } =
+      stubTargetedPollBody(service, buildSyncGate.promise);
+
+    const firstTargeted = service.pollClan({
+      guildId: "guild-1",
+      clanTag: "#AAA111",
+    });
+    await Promise.resolve();
+
+    const secondTargeted = await service.pollClan({
+      guildId: "guild-1",
+      clanTag: "#AAA111",
+    });
+
+    expect(secondTargeted).toEqual({
+      processed: false,
+      warEnded: false,
+      skippedReason: "reconciliation_in_flight",
+    });
+    expect(findSubscriptionSpy).toHaveBeenCalledTimes(1);
+    expect(buildSyncSpy).toHaveBeenCalledTimes(1);
+    expect(processSpy).not.toHaveBeenCalled();
+
+    buildSyncGate.resolve();
+    await expect(firstTargeted).resolves.toEqual({
+      processed: true,
+      warEnded: true,
+    });
+    expect(processSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("makes a global poll wait for an active targeted reconciliation", async () => {
+    const service = makeService();
+    const buildSyncGate = makeDeferred<void>();
+    const targetedBuildSpy = vi
+      .spyOn(service as any, "buildPollSyncContext")
+      .mockImplementation(async () => {
+        await buildSyncGate.promise;
+        return { previousSync: 41, activeSync: 42 };
+      });
+    const findSubscriptionSpy = vi
+      .spyOn(service as any, "findSubscriptionByGuildAndTag")
+      .mockResolvedValue({ guildId: "guild-1", clanTag: "#AAA111" });
+    const processSpy = vi
+      .spyOn(service as any, "processSubscription")
+      .mockResolvedValue(true);
+    const listTargetsSpy = vi
+      .spyOn(service as any, "listPollTargets")
+      .mockResolvedValue([]);
+    const reconcileSpy = vi
+      .spyOn((service as any).warPlanViolations, "reconcileDueEvaluations")
+      .mockResolvedValue({
+        requestedLimit: 20,
+        processedCount: 0,
+        completedCount: 0,
+        insufficientDataCount: 0,
+        failedCount: 0,
+        skippedCount: 0,
+        durationMs: 0,
+      });
+
+    const targetedPoll = service.pollClan({
+      guildId: "guild-1",
+      clanTag: "#AAA111",
+    });
+    await flushTick();
+
+    const globalPoll = service.poll();
+    await flushTick();
+
+    expect(targetedBuildSpy).toHaveBeenCalledTimes(1);
+    expect(findSubscriptionSpy).toHaveBeenCalledTimes(1);
+    expect(processSpy).not.toHaveBeenCalled();
+    expect(listTargetsSpy).not.toHaveBeenCalled();
+    expect(reconcileSpy).not.toHaveBeenCalled();
+
+    buildSyncGate.resolve();
+    await expect(targetedPoll).resolves.toEqual({
+      processed: true,
+      warEnded: true,
+    });
+
+    await globalPoll;
+    expect(targetedBuildSpy).toHaveBeenCalledTimes(2);
+    expect(listTargetsSpy).toHaveBeenCalledTimes(1);
+    expect(reconcileSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("releases the coordinator after a targeted reconciliation throws", async () => {
+    const service = makeService();
+    const findSubscriptionSpy = vi
+      .spyOn(service as any, "findSubscriptionByGuildAndTag")
+      .mockResolvedValue({ guildId: "guild-1", clanTag: "#AAA111" });
+    const buildSyncSpy = vi
+      .spyOn(service as any, "buildPollSyncContext")
+      .mockRejectedValueOnce(new Error("targeted boom"))
+      .mockResolvedValueOnce({ previousSync: 41, activeSync: 42 });
+    const processSpy = vi
+      .spyOn(service as any, "processSubscription")
+      .mockResolvedValue(true);
+
+    await expect(
+      service.pollClan({
+        guildId: "guild-1",
+        clanTag: "#AAA111",
+      }),
+    ).rejects.toThrow("targeted boom");
+
+    await expect(
+      service.pollClan({
+        guildId: "guild-1",
+        clanTag: "#AAA111",
+      }),
+    ).resolves.toEqual({
+      processed: true,
+      warEnded: true,
+    });
+    expect(findSubscriptionSpy).toHaveBeenCalledTimes(2);
+    expect(buildSyncSpy).toHaveBeenCalledTimes(2);
+    expect(processSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("releases the coordinator after a global reconciliation throws", async () => {
+    const service = makeService();
+    const buildSyncSpy = vi
+      .spyOn(service as any, "buildPollSyncContext")
+      .mockRejectedValueOnce(new Error("global boom"))
+      .mockResolvedValueOnce({ previousSync: 41, activeSync: 42 });
+    const findSubscriptionSpy = vi
+      .spyOn(service as any, "findSubscriptionByGuildAndTag")
+      .mockResolvedValue({ guildId: "guild-1", clanTag: "#AAA111" });
+    const processSpy = vi
+      .spyOn(service as any, "processSubscription")
+      .mockResolvedValue(true);
+
+    await expect(service.poll()).rejects.toThrow("global boom");
+    await expect(
+      service.pollClan({
+        guildId: "guild-1",
+        clanTag: "#AAA111",
+      }),
+    ).resolves.toEqual({
+      processed: true,
+      warEnded: true,
+    });
+
+    expect(buildSyncSpy).toHaveBeenCalledTimes(2);
+    expect(findSubscriptionSpy).toHaveBeenCalledTimes(1);
+    expect(processSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("shares the same coordinator across separate service instances", async () => {
+    const serviceA = makeService();
+    const serviceB = makeService();
+    const buildSyncGate = makeDeferred<void>();
+    const targetedA = stubTargetedPollBody(serviceA, buildSyncGate.promise);
+    const targetedBFindSpy = vi
+      .spyOn(serviceB as any, "findSubscriptionByGuildAndTag")
+      .mockResolvedValue({ guildId: "guild-1", clanTag: "#AAA111" });
+    const targetedBBuildSpy = vi.spyOn(serviceB as any, "buildPollSyncContext");
+    const targetedBProcessSpy = vi.spyOn(serviceB as any, "processSubscription");
+
+    const inFlight = serviceA.pollClan({
+      guildId: "guild-1",
+      clanTag: "#AAA111",
+    });
+    await flushTick();
+
+    const skipped = await serviceB.pollClan({
+      guildId: "guild-1",
+      clanTag: "#AAA111",
+    });
+
+    expect(skipped).toEqual({
+      processed: false,
+      warEnded: false,
+      skippedReason: "reconciliation_in_flight",
+    });
+    expect(targetedA.findSubscriptionSpy).toHaveBeenCalledTimes(1);
+    expect(targetedA.buildSyncSpy).toHaveBeenCalledTimes(1);
+    expect(targetedA.processSpy).not.toHaveBeenCalled();
+    expect(targetedBFindSpy).not.toHaveBeenCalled();
+    expect(targetedBBuildSpy).not.toHaveBeenCalled();
+    expect(targetedBProcessSpy).not.toHaveBeenCalled();
+
+    buildSyncGate.resolve();
+    await expect(inFlight).resolves.toEqual({
+      processed: true,
+      warEnded: true,
+    });
+  });
+});


### PR DESCRIPTION
Task 3 of 3 in the minimal three-task FWA mail fix.

This follow-up adds a shared module-scoped reconciliation coordinator so targeted and global war reconciliations are mutually exclusive within one Node process.

Scope:
- `WarEventLogService.poll()` now acquires the shared coordinator and waits for any active targeted reconciliation
- `WarEventLogService.pollClan()` attempts the same coordinator, skips immediately when reconciliation is already in flight, and logs the skip
- existing per-clan reconciliation logic remains unchanged once the coordinator is acquired
- no `/fwa match` behavior change yet; the final send-guard task remains separate
