### PR TITLE
Guard FWA mail confirmation against war-identity changes

### DIFF
--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -5270,6 +5270,131 @@ async function buildWarMailEmbedForTag(
   };
 }
 
+type FwaMailConfirmExpectedIdentity = Readonly<{
+  guildId: string;
+  clanTag: string;
+  warId: number;
+  startTime: Date;
+  opponentTag: string;
+}>;
+
+let buildWarMailEmbedForTagForConfirm = buildWarMailEmbedForTag;
+
+export function setFwaMailPreviewPayloadForTest(
+  key: string,
+  payload: FwaMailPreviewPayload | null,
+): void {
+  const normalizedKey = String(key ?? "").trim();
+  if (!normalizedKey) return;
+  if (!payload) {
+    fwaMailPreviewPayloads.delete(normalizedKey);
+    return;
+  }
+  fwaMailPreviewPayloads.set(normalizedKey, payload);
+}
+
+export function setFwaMailConfirmRendererForTest(
+  renderer: typeof buildWarMailEmbedForTag | null,
+): void {
+  buildWarMailEmbedForTagForConfirm = renderer ?? buildWarMailEmbedForTag;
+}
+
+function buildFwaMailConfirmExpectedIdentity(params: {
+  guildId: string;
+  clanTag: string;
+  warId: number | null | undefined;
+  startTime: Date | null | undefined;
+  opponentTag: string | null | undefined;
+}): FwaMailConfirmExpectedIdentity | null {
+  const guildId = String(params.guildId ?? "").trim();
+  const clanTag = normalizeTag(params.clanTag);
+  const warId =
+    params.warId !== null &&
+    params.warId !== undefined &&
+    Number.isFinite(params.warId)
+      ? Math.trunc(params.warId)
+      : null;
+  const startTime =
+    params.startTime instanceof Date &&
+    Number.isFinite(params.startTime.getTime())
+      ? new Date(params.startTime.getTime())
+      : null;
+  const opponentTag = normalizeTag(String(params.opponentTag ?? ""));
+  if (!guildId || !clanTag || !warId || !startTime || !opponentTag) {
+    return null;
+  }
+  return Object.freeze({
+    guildId,
+    clanTag,
+    warId,
+    startTime,
+    opponentTag,
+  });
+}
+
+async function rereadExactCurrentWarForFwaMailConfirm(
+  identity: FwaMailConfirmExpectedIdentity,
+): Promise<WarMailCurrentWarRenderRow | null> {
+  const row = await loadWarMailCurrentWarRenderRow({
+    guildId: identity.guildId,
+    normalizedTag: identity.clanTag,
+  });
+  if (!row || !isActiveWarMailState(row.state)) return null;
+  const rowWarId = toComparableSyncNumber(row.warId ?? null);
+  const rowStartTimeMs = toWarStartMs(row.startTime);
+  const rowOpponentTag = normalizeTag(String(row.opponentTag ?? ""));
+  if (
+    rowWarId !== identity.warId ||
+    rowStartTimeMs !== identity.startTime.getTime() ||
+    rowOpponentTag !== identity.opponentTag
+  ) {
+    return null;
+  }
+  return row;
+}
+
+async function updateExactCurrentWarAfterFwaMailConfirm(params: {
+  identity: FwaMailConfirmExpectedIdentity;
+  channelId: string;
+  currentWarState: CurrentWarConfirmedState | null;
+}): Promise<number> {
+  const result = await prisma.currentWar.updateMany({
+    where: {
+      guildId: params.identity.guildId,
+      clanTag: `#${params.identity.clanTag}`,
+      warId: params.identity.warId,
+      startTime: params.identity.startTime,
+      opponentTag: `#${params.identity.opponentTag}`,
+      state: {
+        in: ["preparation", "inWar"],
+      },
+    },
+    data: {
+      channelId: params.channelId,
+      matchType: params.currentWarState?.matchType ?? null,
+      inferredMatchType: params.currentWarState?.inferredMatchType ?? true,
+      outcome: params.currentWarState?.outcome ?? null,
+      updatedAt: new Date(),
+    },
+  });
+  return result.count;
+}
+
+function logWarMailCompensationFailure(params: {
+  guildId: string;
+  clanTag: string;
+  warId: number;
+  startTime: Date;
+  opponentTag: string;
+  channelId: string;
+  messageId: string;
+  error: unknown;
+}): void {
+  console.error(
+    `[fwa-mail] event=war_mail_compensation_failed guild=${params.guildId} clan=#${params.clanTag} war_id=${params.warId} war_start=${params.startTime.toISOString()} opponent=#${params.opponentTag} channel_id=${params.channelId} message_id=${params.messageId} error=${formatError(params.error)}`,
+  );
+}
+
 type ResolveLiveWarMailStatusParams = {
   client: Client | null | undefined;
   guildId: string | null;
@@ -8906,19 +9031,29 @@ async function handleFwaMailConfirmAction(
     });
     return;
   }
+  const normalizedGuildId = String(payload.guildId ?? "").trim();
+  const normalizedClanTag = normalizeTag(payload.tag);
+  if (!normalizedGuildId || !normalizedClanTag) {
+    await interaction.reply({
+      ephemeral: true,
+      content:
+        "Cannot send mail because the active war changed. Please run /fwa match again.",
+    });
+    return;
+  }
   await interaction.deferUpdate();
   await interaction
     .editReply({
       content: "Sending war mail... please wait.",
       embeds: [],
       components: [],
-    })
+  })
     .catch(() => undefined);
   const cocService = new CoCService();
-  const rendered = await buildWarMailEmbedForTag(
+  const rendered = await buildWarMailEmbedForTagForConfirm(
     cocService,
-    payload.guildId,
-    payload.tag,
+    normalizedGuildId,
+    normalizedClanTag,
     {
       fetchReason: "pre_fwa_validation",
       revisionOverride: payload.revisionOverride ?? null,
@@ -8974,9 +9109,9 @@ async function handleFwaMailConfirmAction(
       shouldRedirectToFwaMatchForMailGateReason(mailSendGate.mailBlockedReason)
     ) {
       const handoff = await prepareMailGateResumeMatchPayloadForTag({
-        guildId: payload.guildId,
+        guildId: normalizedGuildId,
         userId: parsed.userId,
-        tag: payload.tag,
+        tag: normalizedClanTag,
         sourceMatchPayloadKey: payload.sourceMatchPayloadKey,
         client: interaction.client,
       });
@@ -9029,9 +9164,43 @@ async function handleFwaMailConfirmAction(
     Number.isFinite(rendered.warStartMs)
       ? new Date(Math.trunc(rendered.warStartMs))
       : null;
+  const exactCurrentWarIdentity = buildFwaMailConfirmExpectedIdentity({
+    guildId: normalizedGuildId,
+    clanTag: normalizedClanTag,
+    warId: renderedWarIdNumber,
+    startTime: renderedWarStartTime,
+    opponentTag: rendered.opponentTag ?? null,
+  });
+  if (!exactCurrentWarIdentity) {
+    await interaction.editReply({
+      content:
+        "Cannot send mail because the active war changed. Please run /fwa match again.",
+      embeds: [],
+      components: [],
+    });
+    return;
+  }
+  if (
+    !(await rereadExactCurrentWarForFwaMailConfirm(exactCurrentWarIdentity))
+  ) {
+    await interaction.editReply({
+      content:
+        "Cannot send mail because the active war changed. Please run /fwa match again.",
+      embeds: [],
+      components: [],
+    });
+    return;
+  }
+  const confirmedCurrentWarState = buildCurrentWarConfirmedState({
+    warId: renderedWarIdNumber,
+    warStartMs: rendered.warStartMs ?? null,
+    opponentTag: rendered.opponentTag ?? null,
+    matchType: rendered.matchType,
+    expectedOutcome: rendered.expectedOutcome,
+  });
   const postKey = buildWarMailPollKey(
-    payload.guildId,
-    payload.tag,
+    normalizedGuildId,
+    normalizedClanTag,
     renderedWarIdNumber,
     rendered.warStartMs,
   );
@@ -9048,55 +9217,33 @@ async function handleFwaMailConfirmAction(
       ? []
       : buildWarMailPostedComponents(postKey),
   });
-  const confirmedCurrentWarState = buildCurrentWarConfirmedState({
-    warId: renderedWarIdNumber,
-    warStartMs: rendered.warStartMs ?? null,
-    opponentTag: rendered.opponentTag ?? null,
-    matchType: rendered.matchType,
-    expectedOutcome: rendered.expectedOutcome,
-  });
-  await prisma.currentWar.upsert({
-    where: {
-      clanTag_guildId: {
-        guildId: payload.guildId,
-        clanTag: `#${normalizeTag(payload.tag)}`,
-      },
-    },
-    create: {
-      guildId: payload.guildId,
-      clanTag: `#${normalizeTag(payload.tag)}`,
-      channelId: channel.id,
-      notify: false,
-      warId: confirmedCurrentWarState?.warId ?? renderedWarIdNumber ?? null,
-      ...(confirmedCurrentWarState?.startTime
-        ? { startTime: confirmedCurrentWarState.startTime }
-        : {}),
-      ...(confirmedCurrentWarState?.opponentTag
-        ? { opponentTag: confirmedCurrentWarState.opponentTag }
-        : {}),
-      ...(confirmedCurrentWarState?.matchType
-        ? { matchType: confirmedCurrentWarState.matchType }
-        : {}),
-      inferredMatchType: confirmedCurrentWarState?.inferredMatchType ?? true,
-      outcome: confirmedCurrentWarState?.outcome ?? null,
-    },
-    update: {
-      channelId: channel.id,
-      warId: confirmedCurrentWarState?.warId ?? renderedWarIdNumber ?? null,
-      ...(confirmedCurrentWarState?.startTime
-        ? { startTime: confirmedCurrentWarState.startTime }
-        : {}),
-      ...(confirmedCurrentWarState?.opponentTag
-        ? { opponentTag: confirmedCurrentWarState.opponentTag }
-        : {}),
-      ...(confirmedCurrentWarState?.matchType
-        ? { matchType: confirmedCurrentWarState.matchType }
-        : {}),
-      inferredMatchType: confirmedCurrentWarState?.inferredMatchType ?? true,
-      outcome: confirmedCurrentWarState?.outcome ?? null,
-      updatedAt: new Date(),
-    },
-  });
+  const updatedCount = await updateExactCurrentWarAfterFwaMailConfirm({
+    identity: exactCurrentWarIdentity,
+    channelId: channel.id,
+    currentWarState: confirmedCurrentWarState,
+  }).catch(() => 0);
+  if (updatedCount !== 1) {
+    const deleteError = await sent.delete().catch((error: unknown) => error);
+    if (deleteError) {
+      logWarMailCompensationFailure({
+        guildId: exactCurrentWarIdentity.guildId,
+        clanTag: exactCurrentWarIdentity.clanTag,
+        warId: exactCurrentWarIdentity.warId,
+        startTime: exactCurrentWarIdentity.startTime,
+        opponentTag: exactCurrentWarIdentity.opponentTag,
+        channelId: channel.id,
+        messageId: sent.id,
+        error: deleteError,
+      });
+    }
+    await interaction.editReply({
+      content:
+        "The active war changed while mail was being sent, so the mail was cancelled. Please run /fwa match again.",
+      embeds: [],
+      components: [],
+    });
+    return;
+  }
   const nowMs = Date.now();
   const renderedWarIdText =
     renderedWarIdNumber !== null ? String(renderedWarIdNumber) : null;
@@ -9108,8 +9255,8 @@ async function handleFwaMailConfirmAction(
       : null;
   const checkpointSyncRow = await pointsSyncService
     .getCurrentSyncForClan({
-      guildId: payload.guildId,
-      clanTag: payload.tag,
+      guildId: normalizedGuildId,
+      clanTag: normalizedClanTag,
       warId: renderedWarIdText,
       warStartTime: checkpointWarStartTime,
     })
@@ -9127,8 +9274,8 @@ async function handleFwaMailConfirmAction(
     renderedWarIdNumber !== null
       ? await warMailLifecycleService
           .getLifecycleForWar({
-            guildId: payload.guildId,
-            clanTag: payload.tag,
+            guildId: normalizedGuildId,
+            clanTag: normalizedClanTag,
             warId: renderedWarIdNumber,
             warStartTime: renderedWarStartTime,
             opponentTag: rendered.opponentTag ?? null,
@@ -9160,8 +9307,8 @@ async function handleFwaMailConfirmAction(
     startWarMailPolling(interaction.client, postKey);
   }
   await persistActiveWarMailLifecycle({
-    guildId: payload.guildId,
-    clanTag: payload.tag,
+    guildId: normalizedGuildId,
+    clanTag: normalizedClanTag,
     warId: Number(renderedWarIdNumber),
     warStartTime: renderedWarStartTime,
     opponentTag: rendered.opponentTag ?? null,
@@ -9170,9 +9317,9 @@ async function handleFwaMailConfirmAction(
     postedAt: new Date(nowMs),
   });
   await repWorkActivityService.recordMailSent({
-    guildId: payload.guildId,
+    guildId: normalizedGuildId,
     discordUserId: parsed.userId,
-    clanTag: `#${normalizeTag(payload.tag)}`,
+    clanTag: `#${normalizedClanTag}`,
     sourceMessageId: sent.id,
     sourceTrackedMessageId: payload.sourceMessageId ?? null,
     warId: renderedWarIdText,
@@ -9190,8 +9337,8 @@ async function handleFwaMailConfirmAction(
   });
   await pointsSyncService
     .markConfirmedByClanMail({
-      guildId: payload.guildId,
-      clanTag: payload.tag,
+      guildId: normalizedGuildId,
+      clanTag: normalizedClanTag,
       warId: renderedWarIdText,
       warStartTime: checkpointWarStartTime,
       matchType: rendered.matchType,
@@ -9201,8 +9348,8 @@ async function handleFwaMailConfirmAction(
     })
     .catch(() => undefined);
   const existingMailConfig = await getCurrentWarMailConfig(
-    payload.guildId,
-    payload.tag,
+    normalizedGuildId,
+    normalizedClanTag,
   );
   const nextMailConfig: MatchMailConfig = {
     ...existingMailConfig,
@@ -9228,16 +9375,16 @@ async function handleFwaMailConfirmAction(
         : null,
   };
   await saveCurrentWarMailConfig({
-    guildId: payload.guildId,
-    tag: payload.tag,
+    guildId: normalizedGuildId,
+    tag: normalizedClanTag,
     channelId: channel.id,
     mailConfig: nextMailConfig,
   });
   await new WarEventLogService(interaction.client, cocService)
-    .refreshCurrentNotifyPost(payload.guildId, payload.tag)
+    .refreshCurrentNotifyPost(normalizedGuildId, normalizedClanTag)
     .catch((err) => {
       console.error(
-        `[fwa-mail] notify refresh after mail send failed guild=${payload.guildId} clan=#${normalizeTag(payload.tag)} error=${formatError(err)}`,
+        `[fwa-mail] notify refresh after mail send failed guild=${normalizedGuildId} clan=#${normalizedClanTag} error=${formatError(err)}`,
       );
     });
   if (payload.sourceMatchPayloadKey) {
@@ -9246,7 +9393,7 @@ async function handleFwaMailConfirmAction(
     );
     if (sourcePayload) {
       const nextDraftByTag = { ...sourcePayload.revisionDraftByTag };
-      delete nextDraftByTag[normalizeTag(payload.tag)];
+      delete nextDraftByTag[normalizedClanTag];
       fwaMatchCopyPayloads.set(payload.sourceMatchPayloadKey, {
         ...sourcePayload,
         revisionDraftByTag: nextDraftByTag,

--- a/src/commands/Fwa.ts
+++ b/src/commands/Fwa.ts
@@ -5320,7 +5320,14 @@ function buildFwaMailConfirmExpectedIdentity(params: {
       ? new Date(params.startTime.getTime())
       : null;
   const opponentTag = normalizeTag(String(params.opponentTag ?? ""));
-  if (!guildId || !clanTag || !warId || !startTime || !opponentTag) {
+  if (
+    !guildId ||
+    !clanTag ||
+    warId === null ||
+    warId <= 0 ||
+    !startTime ||
+    !opponentTag
+  ) {
     return null;
   }
   return Object.freeze({
@@ -5358,6 +5365,15 @@ async function updateExactCurrentWarAfterFwaMailConfirm(params: {
   channelId: string;
   currentWarState: CurrentWarConfirmedState | null;
 }): Promise<number> {
+  const data: Prisma.CurrentWarUpdateManyMutationInput = {
+    channelId: params.channelId,
+    inferredMatchType: params.currentWarState?.inferredMatchType ?? true,
+    outcome: params.currentWarState?.outcome ?? null,
+    updatedAt: new Date(),
+  };
+  if (params.currentWarState?.matchType != null) {
+    data.matchType = params.currentWarState?.matchType;
+  }
   const result = await prisma.currentWar.updateMany({
     where: {
       guildId: params.identity.guildId,
@@ -5369,15 +5385,24 @@ async function updateExactCurrentWarAfterFwaMailConfirm(params: {
         in: ["preparation", "inWar"],
       },
     },
-    data: {
-      channelId: params.channelId,
-      matchType: params.currentWarState?.matchType ?? null,
-      inferredMatchType: params.currentWarState?.inferredMatchType ?? true,
-      outcome: params.currentWarState?.outcome ?? null,
-      updatedAt: new Date(),
-    },
+    data,
   });
   return result.count;
+}
+
+function logWarMailGuardUpdateFailure(params: {
+  guildId: string;
+  clanTag: string;
+  warId: number;
+  startTime: Date;
+  opponentTag: string;
+  channelId: string;
+  messageId: string;
+  error: unknown;
+}): void {
+  console.error(
+    `[fwa-mail] event=war_mail_guard_update_failed guild=${params.guildId} clan=#${params.clanTag} war_id=${params.warId} war_start=${params.startTime.toISOString()} opponent=#${params.opponentTag} channel_id=${params.channelId} message_id=${params.messageId} error=${formatError(params.error)}`,
+  );
 }
 
 function logWarMailCompensationFailure(params: {
@@ -9217,11 +9242,25 @@ async function handleFwaMailConfirmAction(
       ? []
       : buildWarMailPostedComponents(postKey),
   });
-  const updatedCount = await updateExactCurrentWarAfterFwaMailConfirm({
-    identity: exactCurrentWarIdentity,
-    channelId: channel.id,
-    currentWarState: confirmedCurrentWarState,
-  }).catch(() => 0);
+  let updatedCount = 0;
+  try {
+    updatedCount = await updateExactCurrentWarAfterFwaMailConfirm({
+      identity: exactCurrentWarIdentity,
+      channelId: channel.id,
+      currentWarState: confirmedCurrentWarState,
+    });
+  } catch (error) {
+    logWarMailGuardUpdateFailure({
+      guildId: exactCurrentWarIdentity.guildId,
+      clanTag: exactCurrentWarIdentity.clanTag,
+      warId: exactCurrentWarIdentity.warId,
+      startTime: exactCurrentWarIdentity.startTime,
+      opponentTag: exactCurrentWarIdentity.opponentTag,
+      channelId: channel.id,
+      messageId: sent.id,
+      error,
+    });
+  }
   if (updatedCount !== 1) {
     const deleteError = await sent.delete().catch((error: unknown) => error);
     if (deleteError) {

--- a/tests/fwaMailConfirm.command.test.ts
+++ b/tests/fwaMailConfirm.command.test.ts
@@ -1,0 +1,435 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { EmbedBuilder } from "discord.js";
+import {
+  buildFwaMailConfirmCustomId,
+  buildFwaMailConfirmNoPingCustomId,
+} from "../src/commands/fwa/customIds";
+import {
+  handleFwaMailConfirmButton,
+  handleFwaMailConfirmNoPingButton,
+  setFwaMailConfirmRendererForTest,
+  setFwaMailPreviewPayloadForTest,
+} from "../src/commands/Fwa";
+import { prisma } from "../src/prisma";
+import { WarEventLogService } from "../src/services/WarEventLogService";
+
+const prismaMock = vi.hoisted(() => ({
+  currentWar: {
+    findUnique: vi.fn(),
+    update: vi.fn(),
+    updateMany: vi.fn(),
+    upsert: vi.fn(),
+  },
+  trackedClan: {
+    findUnique: vi.fn(),
+    update: vi.fn(),
+  },
+}));
+
+vi.mock("../src/prisma", () => ({
+  prisma: prismaMock,
+}));
+
+const pointsSyncMock = vi.hoisted(() => ({
+  getCurrentSyncForClan: vi.fn(),
+  markConfirmedByClanMail: vi.fn(),
+}));
+
+vi.mock("../src/services/PointsSyncService", () => ({
+  PointsSyncService: vi.fn().mockImplementation(() => pointsSyncMock),
+}));
+
+const lifecycleMock = vi.hoisted(() => ({
+  getLifecycleForWar: vi.fn(),
+  markPosted: vi.fn(),
+}));
+
+vi.mock("../src/services/WarMailLifecycleService", () => ({
+  WarMailLifecycleService: vi
+    .fn()
+    .mockImplementation(() => lifecycleMock),
+}));
+
+const repWorkActivityMock = vi.hoisted(() => ({
+  recordMailSent: vi.fn(),
+}));
+
+vi.mock("../src/services/RepWorkActivityService", () => ({
+  repWorkActivityService: repWorkActivityMock,
+}));
+
+const cocServiceMock = vi.hoisted(() => ({
+  getCurrentWar: vi.fn(),
+}));
+
+vi.mock("../src/services/CoCService", () => ({
+  CoCService: vi.fn().mockImplementation(() => cocServiceMock),
+}));
+
+function buildRenderedMail(overrides?: Partial<{
+  mailChannelId: string | null;
+  clanRoleId: string | null;
+  warId: number | null;
+  opponentTag: string | null;
+  warStartMs: number | null;
+  freezeRefresh: boolean;
+  matchType: "FWA" | "BL" | "MM" | "UNKNOWN";
+  expectedOutcome: "WIN" | "LOSE" | "UNKNOWN" | null;
+  unavailableReasons: string[];
+  planText: string;
+  mailBlockedReason: string | null;
+}>) {
+  return {
+    embed: new EmbedBuilder().setTitle("Mail preview"),
+    planText: overrides?.planText ?? "Plan body",
+    inferredMatchType: false,
+    mailChannelId: overrides?.mailChannelId ?? "mail-channel-1",
+    clanRoleId: overrides?.clanRoleId ?? "123456789",
+    warId: overrides?.warId ?? 1000110,
+    opponentTag: overrides?.opponentTag ?? "2LYPLQQUC",
+    warStartMs:
+      overrides?.warStartMs ?? new Date("2026-07-12T15:22:26.000Z").getTime(),
+    freezeRefresh: overrides?.freezeRefresh ?? false,
+    unavailableReasons: overrides?.unavailableReasons ?? [],
+    matchType: overrides?.matchType ?? "FWA",
+    expectedOutcome: overrides?.expectedOutcome ?? "WIN",
+    mailRevisionDecision: {
+      mailBlockedReason: overrides?.mailBlockedReason ?? null,
+    },
+  } as any;
+}
+
+function buildCurrentWarRow(overrides?: Partial<Record<string, unknown>>) {
+  return {
+    warId: 1000110,
+    state: "preparation",
+    startTime: new Date("2026-07-12T15:22:26.000Z"),
+    opponentTag: "#2LYPLQQUC",
+    matchType: "FWA",
+    inferredMatchType: false,
+    outcome: "WIN",
+    fwaPoints: null,
+    opponentFwaPoints: null,
+    endTime: null,
+    opponentName: "Opponent",
+    clanStars: null,
+    opponentStars: null,
+    ...overrides,
+  } as any;
+}
+
+function createInteraction(params: {
+  customId: string;
+  send: ReturnType<typeof vi.fn>;
+}) {
+  const editReply = vi.fn().mockResolvedValue(undefined);
+  const reply = vi.fn().mockResolvedValue(undefined);
+  const deleteReply = vi.fn().mockResolvedValue(undefined);
+  const followUp = vi.fn().mockResolvedValue(undefined);
+  return {
+    customId: params.customId,
+    user: { id: "owner-1" },
+    guildId: "guild-1",
+    channelId: "command-channel-1",
+    inGuild: () => true,
+    memberPermissions: {
+      has: () => true,
+    },
+    message: { embeds: [] },
+    client: {
+      channels: {
+        fetch: vi.fn().mockResolvedValue({
+          id: "mail-channel-1",
+          isTextBased: () => true,
+          send: params.send,
+          messages: { fetch: vi.fn() },
+        }),
+      },
+    },
+    deferUpdate: vi.fn().mockResolvedValue(undefined),
+    editReply,
+    reply,
+    deleteReply,
+    followUp,
+  } as any;
+}
+
+async function seedConfirmPayloadAndRenderer(input?: {
+  previewKey?: string;
+  rendered?: ReturnType<typeof buildRenderedMail>;
+  currentWarRow?: ReturnType<typeof buildCurrentWarRow>;
+}) {
+  const previewKey = input?.previewKey ?? "preview-key";
+  setFwaMailPreviewPayloadForTest(previewKey, {
+    userId: "owner-1",
+    guildId: "guild-1",
+    tag: "R80L8VYG",
+    revisionOverride: null,
+  });
+  setFwaMailConfirmRendererForTest(async () => input?.rendered ?? buildRenderedMail());
+  prismaMock.currentWar.findUnique.mockResolvedValueOnce(
+    input?.currentWarRow ?? buildCurrentWarRow(),
+  );
+  return previewKey;
+}
+
+describe("fwa mail confirm button", () => {
+  let refreshNotifySpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    refreshNotifySpy = vi
+      .spyOn(WarEventLogService.prototype, "refreshCurrentNotifyPost")
+      .mockResolvedValue(undefined);
+    vi.spyOn(globalThis, "setInterval").mockImplementation((() => 1) as any);
+  });
+
+  afterEach(() => {
+    setFwaMailConfirmRendererForTest(null);
+    setFwaMailPreviewPayloadForTest("preview-key", null);
+    setFwaMailPreviewPayloadForTest("preview-no-ping", null);
+    refreshNotifySpy.mockRestore();
+    vi.restoreAllMocks();
+  });
+
+  it("fails closed when the active war changes before send", async () => {
+    const previewKey = await seedConfirmPayloadAndRenderer({
+      currentWarRow: buildCurrentWarRow({
+        warId: 1000999,
+        opponentTag: "#2OLDTAG",
+      }),
+    });
+    prismaMock.currentWar.updateMany.mockResolvedValueOnce({ count: 1 });
+    const send = vi.fn();
+    const interaction = createInteraction({
+      customId: buildFwaMailConfirmCustomId("owner-1", previewKey),
+      send,
+    });
+
+    await handleFwaMailConfirmButton(interaction as any);
+
+    expect(interaction.deferUpdate).toHaveBeenCalledTimes(1);
+    expect(send).not.toHaveBeenCalled();
+    expect(prisma.currentWar.update).not.toHaveBeenCalled();
+    expect(prisma.currentWar.updateMany).not.toHaveBeenCalled();
+    expect(prisma.currentWar.upsert).not.toHaveBeenCalled();
+    expect(pointsSyncMock.getCurrentSyncForClan).not.toHaveBeenCalled();
+    expect(lifecycleMock.markPosted).not.toHaveBeenCalled();
+    expect(repWorkActivityMock.recordMailSent).not.toHaveBeenCalled();
+    expect(pointsSyncMock.markConfirmedByClanMail).not.toHaveBeenCalled();
+    expect(prismaMock.trackedClan.update).not.toHaveBeenCalled();
+    expect(refreshNotifySpy).not.toHaveBeenCalled();
+    expect(globalThis.setInterval).not.toHaveBeenCalled();
+
+    expect(interaction.editReply).toHaveBeenLastCalledWith({
+      content:
+        "Cannot send mail because the active war changed. Please run /fwa match again.",
+      embeds: [],
+      components: [],
+    });
+    expect(prismaMock.currentWar.findUnique).toHaveBeenCalledWith({
+      where: {
+        clanTag_guildId: {
+          guildId: "guild-1",
+          clanTag: "#R80L8VYG",
+        },
+      },
+      select: expect.objectContaining({
+        state: true,
+        warId: true,
+        startTime: true,
+        opponentTag: true,
+      }),
+    });
+  });
+
+  it("cancels when the active war changes after send but before the guarded update", async () => {
+    const previewKey = await seedConfirmPayloadAndRenderer();
+    prismaMock.currentWar.updateMany.mockResolvedValueOnce({ count: 0 });
+    const sentMessage = {
+      id: "sent-1",
+      delete: vi.fn().mockResolvedValue(undefined),
+    };
+    const send = vi.fn().mockResolvedValue(sentMessage);
+    const interaction = createInteraction({
+      customId: buildFwaMailConfirmCustomId("owner-1", previewKey),
+      send,
+    });
+
+    await handleFwaMailConfirmButton(interaction as any);
+
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(sentMessage.delete).toHaveBeenCalledTimes(1);
+    expect(prisma.currentWar.update).not.toHaveBeenCalled();
+    expect(prisma.currentWar.updateMany).toHaveBeenCalledTimes(1);
+    expect(prisma.currentWar.upsert).not.toHaveBeenCalled();
+    expect(lifecycleMock.markPosted).not.toHaveBeenCalled();
+    expect(repWorkActivityMock.recordMailSent).not.toHaveBeenCalled();
+    expect(pointsSyncMock.markConfirmedByClanMail).not.toHaveBeenCalled();
+    expect(prismaMock.trackedClan.update).not.toHaveBeenCalled();
+    expect(refreshNotifySpy).not.toHaveBeenCalled();
+    expect(globalThis.setInterval).not.toHaveBeenCalled();
+
+    expect(interaction.editReply).toHaveBeenLastCalledWith({
+      content:
+        "The active war changed while mail was being sent, so the mail was cancelled. Please run /fwa match again.",
+      embeds: [],
+      components: [],
+    });
+  });
+
+  it("logs compensation failures when deleting a stale send fails", async () => {
+    const previewKey = await seedConfirmPayloadAndRenderer();
+    prismaMock.currentWar.updateMany.mockResolvedValueOnce({ count: 0 });
+    const sentMessage = {
+      id: "sent-1",
+      delete: vi.fn().mockRejectedValue(new Error("unknown message")),
+    };
+    const send = vi.fn().mockResolvedValue(sentMessage);
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const interaction = createInteraction({
+      customId: buildFwaMailConfirmCustomId("owner-1", previewKey),
+      send,
+    });
+
+    await handleFwaMailConfirmButton(interaction as any);
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "[fwa-mail] event=war_mail_compensation_failed guild=guild-1 clan=#R80L8VYG war_id=1000110 war_start=2026-07-12T15:22:26.000Z opponent=#2LYPLQQUC channel_id=mail-channel-1 message_id=sent-1",
+      ),
+    );
+    expect(prisma.currentWar.update).not.toHaveBeenCalled();
+    expect(prisma.currentWar.upsert).not.toHaveBeenCalled();
+    expect(interaction.editReply).toHaveBeenLastCalledWith({
+      content:
+        "The active war changed while mail was being sent, so the mail was cancelled. Please run /fwa match again.",
+      embeds: [],
+      components: [],
+    });
+  });
+
+  it("sends and records the pinging confirmation on the success path", async () => {
+    const previewKey = await seedConfirmPayloadAndRenderer({
+      currentWarRow: buildCurrentWarRow(),
+    });
+    prismaMock.currentWar.updateMany.mockResolvedValueOnce({ count: 1 });
+    prismaMock.trackedClan.findUnique.mockResolvedValueOnce({
+      mailConfig: null,
+    });
+    prismaMock.trackedClan.update.mockResolvedValueOnce({});
+    pointsSyncMock.getCurrentSyncForClan.mockResolvedValueOnce(null);
+    pointsSyncMock.markConfirmedByClanMail.mockResolvedValueOnce(undefined);
+    lifecycleMock.getLifecycleForWar.mockResolvedValueOnce(null);
+    lifecycleMock.markPosted.mockResolvedValueOnce(undefined);
+    repWorkActivityMock.recordMailSent.mockResolvedValueOnce(undefined);
+    const sentMessage = {
+      id: "sent-1",
+      delete: vi.fn().mockResolvedValue(undefined),
+    };
+    const send = vi.fn().mockResolvedValue(sentMessage);
+    const interaction = createInteraction({
+      customId: buildFwaMailConfirmCustomId("owner-1", previewKey),
+      send,
+    });
+
+    await handleFwaMailConfirmButton(interaction as any);
+
+    const pingSendPayload = send.mock.calls[0]?.[0] as
+      | {
+          content?: string;
+          allowedMentions?: { roles?: string[] } | undefined;
+          embeds?: unknown[];
+          components?: unknown[];
+        }
+      | undefined;
+    expect(pingSendPayload?.content ?? "").toContain("<@&123456789>");
+    expect(pingSendPayload?.allowedMentions).toEqual({ roles: ["123456789"] });
+    expect(pingSendPayload?.embeds?.[0]).toEqual(expect.any(EmbedBuilder));
+    expect(pingSendPayload?.components).toEqual(expect.any(Array));
+    expect(prisma.currentWar.updateMany).toHaveBeenCalledWith({
+      where: {
+        guildId: "guild-1",
+        clanTag: "#R80L8VYG",
+        warId: 1000110,
+        startTime: new Date("2026-07-12T15:22:26.000Z"),
+        opponentTag: "#2LYPLQQUC",
+        state: {
+          in: ["preparation", "inWar"],
+        },
+      },
+      data: {
+        channelId: "mail-channel-1",
+        matchType: "FWA",
+        inferredMatchType: false,
+        outcome: "WIN",
+        updatedAt: expect.any(Date),
+      },
+    });
+    expect(prisma.currentWar.update).not.toHaveBeenCalled();
+    expect(prisma.currentWar.upsert).not.toHaveBeenCalled();
+    expect(lifecycleMock.markPosted).toHaveBeenCalledTimes(1);
+    expect(repWorkActivityMock.recordMailSent).toHaveBeenCalledTimes(1);
+    expect(pointsSyncMock.markConfirmedByClanMail).toHaveBeenCalledTimes(1);
+    expect(prismaMock.trackedClan.update).toHaveBeenCalledTimes(1);
+    expect(refreshNotifySpy).toHaveBeenCalledTimes(1);
+    expect(globalThis.setInterval).toHaveBeenCalledTimes(1);
+    expect(sentMessage.delete).not.toHaveBeenCalled();
+    expect(interaction.deleteReply).toHaveBeenCalledTimes(1);
+    expect(interaction.followUp).toHaveBeenCalledTimes(1);
+  });
+
+  it("sends without pinging on the no-ping confirmation path", async () => {
+    const previewKey = "preview-no-ping";
+    setFwaMailPreviewPayloadForTest(previewKey, {
+      userId: "owner-1",
+      guildId: "guild-1",
+      tag: "R80L8VYG",
+      revisionOverride: null,
+    });
+    setFwaMailConfirmRendererForTest(async () => buildRenderedMail());
+    prismaMock.currentWar.findUnique.mockResolvedValueOnce(buildCurrentWarRow());
+    prismaMock.currentWar.updateMany.mockResolvedValueOnce({ count: 1 });
+    prismaMock.trackedClan.findUnique.mockResolvedValueOnce({
+      mailConfig: null,
+    });
+    prismaMock.trackedClan.update.mockResolvedValueOnce({});
+    pointsSyncMock.getCurrentSyncForClan.mockResolvedValueOnce(null);
+    pointsSyncMock.markConfirmedByClanMail.mockResolvedValueOnce(undefined);
+    lifecycleMock.getLifecycleForWar.mockResolvedValueOnce(null);
+    lifecycleMock.markPosted.mockResolvedValueOnce(undefined);
+    repWorkActivityMock.recordMailSent.mockResolvedValueOnce(undefined);
+    const sentMessage = {
+      id: "sent-2",
+      delete: vi.fn().mockResolvedValue(undefined),
+    };
+    const send = vi.fn().mockResolvedValue(sentMessage);
+    const interaction = createInteraction({
+      customId: buildFwaMailConfirmNoPingCustomId("owner-1", previewKey),
+      send,
+    });
+
+    await handleFwaMailConfirmNoPingButton(interaction as any);
+
+    const noPingPayload = send.mock.calls[0]?.[0] as
+      | {
+          content?: string;
+          allowedMentions?: { roles?: string[] } | undefined;
+          embeds?: unknown[];
+          components?: unknown[];
+        }
+      | undefined;
+    expect(noPingPayload?.content ?? "").not.toContain("<@&123456789>");
+    expect(noPingPayload?.allowedMentions).toBeUndefined();
+    expect(noPingPayload?.embeds?.[0]).toEqual(expect.any(EmbedBuilder));
+    expect(noPingPayload?.components).toEqual(expect.any(Array));
+    expect(prisma.currentWar.update).not.toHaveBeenCalled();
+    expect(prisma.currentWar.upsert).not.toHaveBeenCalled();
+    expect(interaction.followUp).toHaveBeenCalledTimes(1);
+    const followUpContent = String(
+      (interaction.followUp.mock.calls[0]?.[0] as { content?: string } | undefined)
+        ?.content ?? "",
+    );
+    expect(followUpContent).toContain("without ping");
+  });
+});

--- a/tests/fwaMailConfirm.command.test.ts
+++ b/tests/fwaMailConfirm.command.test.ts
@@ -175,9 +175,17 @@ async function seedConfirmPayloadAndRenderer(input?: {
 
 describe("fwa mail confirm button", () => {
   let refreshNotifySpy: ReturnType<typeof vi.spyOn>;
+  let pollSpy: ReturnType<typeof vi.spyOn>;
+  let refreshBattleDayPostsSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    pollSpy = vi.spyOn(WarEventLogService.prototype, "poll").mockResolvedValue(
+      undefined,
+    );
+    refreshBattleDayPostsSpy = vi
+      .spyOn(WarEventLogService.prototype, "refreshBattleDayPosts")
+      .mockResolvedValue(undefined);
     refreshNotifySpy = vi
       .spyOn(WarEventLogService.prototype, "refreshCurrentNotifyPost")
       .mockResolvedValue(undefined);
@@ -188,9 +196,47 @@ describe("fwa mail confirm button", () => {
     setFwaMailConfirmRendererForTest(null);
     setFwaMailPreviewPayloadForTest("preview-key", null);
     setFwaMailPreviewPayloadForTest("preview-no-ping", null);
+    pollSpy.mockRestore();
+    refreshBattleDayPostsSpy.mockRestore();
     refreshNotifySpy.mockRestore();
     vi.restoreAllMocks();
   });
+
+  it.each([0, -1])(
+    "blocks invalid war ID %s before send",
+    async (invalidWarId) => {
+      const previewKey = await seedConfirmPayloadAndRenderer({
+        rendered: buildRenderedMail({ warId: invalidWarId }),
+      });
+      const send = vi.fn();
+      const interaction = createInteraction({
+        customId: buildFwaMailConfirmCustomId("owner-1", previewKey),
+        send,
+      });
+
+      await handleFwaMailConfirmButton(interaction as any);
+
+      expect(send).not.toHaveBeenCalled();
+      expect(prisma.currentWar.updateMany).not.toHaveBeenCalled();
+      expect(prisma.currentWar.update).not.toHaveBeenCalled();
+      expect(prisma.currentWar.upsert).not.toHaveBeenCalled();
+      expect(pointsSyncMock.getCurrentSyncForClan).not.toHaveBeenCalled();
+      expect(lifecycleMock.markPosted).not.toHaveBeenCalled();
+      expect(repWorkActivityMock.recordMailSent).not.toHaveBeenCalled();
+      expect(pointsSyncMock.markConfirmedByClanMail).not.toHaveBeenCalled();
+      expect(prismaMock.trackedClan.update).not.toHaveBeenCalled();
+      expect(pollSpy).not.toHaveBeenCalled();
+      expect(refreshBattleDayPostsSpy).not.toHaveBeenCalled();
+      expect(refreshNotifySpy).not.toHaveBeenCalled();
+      expect(globalThis.setInterval).not.toHaveBeenCalled();
+      expect(interaction.editReply).toHaveBeenLastCalledWith({
+        content:
+          "Cannot send mail because the active war changed. Please run /fwa match again.",
+        embeds: [],
+        components: [],
+      });
+    },
+  );
 
   it("fails closed when the active war changes before send", async () => {
     const previewKey = await seedConfirmPayloadAndRenderer({
@@ -214,12 +260,14 @@ describe("fwa mail confirm button", () => {
     expect(prisma.currentWar.updateMany).not.toHaveBeenCalled();
     expect(prisma.currentWar.upsert).not.toHaveBeenCalled();
     expect(pointsSyncMock.getCurrentSyncForClan).not.toHaveBeenCalled();
-    expect(lifecycleMock.markPosted).not.toHaveBeenCalled();
-    expect(repWorkActivityMock.recordMailSent).not.toHaveBeenCalled();
-    expect(pointsSyncMock.markConfirmedByClanMail).not.toHaveBeenCalled();
-    expect(prismaMock.trackedClan.update).not.toHaveBeenCalled();
-    expect(refreshNotifySpy).not.toHaveBeenCalled();
-    expect(globalThis.setInterval).not.toHaveBeenCalled();
+      expect(lifecycleMock.markPosted).not.toHaveBeenCalled();
+      expect(repWorkActivityMock.recordMailSent).not.toHaveBeenCalled();
+      expect(pointsSyncMock.markConfirmedByClanMail).not.toHaveBeenCalled();
+      expect(prismaMock.trackedClan.update).not.toHaveBeenCalled();
+      expect(pollSpy).not.toHaveBeenCalled();
+      expect(refreshBattleDayPostsSpy).not.toHaveBeenCalled();
+      expect(refreshNotifySpy).not.toHaveBeenCalled();
+      expect(globalThis.setInterval).not.toHaveBeenCalled();
 
     expect(interaction.editReply).toHaveBeenLastCalledWith({
       content:
@@ -267,9 +315,52 @@ describe("fwa mail confirm button", () => {
     expect(repWorkActivityMock.recordMailSent).not.toHaveBeenCalled();
     expect(pointsSyncMock.markConfirmedByClanMail).not.toHaveBeenCalled();
     expect(prismaMock.trackedClan.update).not.toHaveBeenCalled();
+    expect(pollSpy).not.toHaveBeenCalled();
+    expect(refreshBattleDayPostsSpy).not.toHaveBeenCalled();
     expect(refreshNotifySpy).not.toHaveBeenCalled();
     expect(globalThis.setInterval).not.toHaveBeenCalled();
 
+    expect(interaction.editReply).toHaveBeenLastCalledWith({
+      content:
+        "The active war changed while mail was being sent, so the mail was cancelled. Please run /fwa match again.",
+      embeds: [],
+      components: [],
+    });
+  });
+
+  it("logs guarded-update failures and cancels cleanly", async () => {
+    const previewKey = await seedConfirmPayloadAndRenderer();
+    prismaMock.currentWar.updateMany.mockRejectedValueOnce(new Error("db boom"));
+    const sentMessage = {
+      id: "sent-guard-fail",
+      delete: vi.fn().mockResolvedValue(undefined),
+    };
+    const send = vi.fn().mockResolvedValue(sentMessage);
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const interaction = createInteraction({
+      customId: buildFwaMailConfirmCustomId("owner-1", previewKey),
+      send,
+    });
+
+    await handleFwaMailConfirmButton(interaction as any);
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "[fwa-mail] event=war_mail_guard_update_failed guild=guild-1 clan=#R80L8VYG war_id=1000110 war_start=2026-07-12T15:22:26.000Z opponent=#2LYPLQQUC channel_id=mail-channel-1 message_id=sent-guard-fail",
+      ),
+    );
+    expect(sentMessage.delete).toHaveBeenCalledTimes(1);
+    expect(prisma.currentWar.update).not.toHaveBeenCalled();
+    expect(prisma.currentWar.upsert).not.toHaveBeenCalled();
+    expect(pointsSyncMock.getCurrentSyncForClan).not.toHaveBeenCalled();
+    expect(lifecycleMock.markPosted).not.toHaveBeenCalled();
+    expect(repWorkActivityMock.recordMailSent).not.toHaveBeenCalled();
+    expect(pointsSyncMock.markConfirmedByClanMail).not.toHaveBeenCalled();
+    expect(prismaMock.trackedClan.update).not.toHaveBeenCalled();
+    expect(pollSpy).not.toHaveBeenCalled();
+    expect(refreshBattleDayPostsSpy).not.toHaveBeenCalled();
+    expect(refreshNotifySpy).not.toHaveBeenCalled();
+    expect(globalThis.setInterval).not.toHaveBeenCalled();
     expect(interaction.editReply).toHaveBeenLastCalledWith({
       content:
         "The active war changed while mail was being sent, so the mail was cancelled. Please run /fwa match again.",
@@ -301,12 +392,66 @@ describe("fwa mail confirm button", () => {
     );
     expect(prisma.currentWar.update).not.toHaveBeenCalled();
     expect(prisma.currentWar.upsert).not.toHaveBeenCalled();
+    expect(pollSpy).not.toHaveBeenCalled();
+    expect(refreshBattleDayPostsSpy).not.toHaveBeenCalled();
     expect(interaction.editReply).toHaveBeenLastCalledWith({
       content:
         "The active war changed while mail was being sent, so the mail was cancelled. Please run /fwa match again.",
       embeds: [],
       components: [],
     });
+  });
+
+  it("omits matchType from the guarded update when the rendered match is UNKNOWN", async () => {
+    const previewKey = await seedConfirmPayloadAndRenderer({
+      rendered: buildRenderedMail({
+        matchType: "UNKNOWN",
+        expectedOutcome: "UNKNOWN",
+      }),
+    });
+    prismaMock.currentWar.updateMany.mockResolvedValueOnce({ count: 1 });
+    prismaMock.trackedClan.findUnique.mockResolvedValueOnce({
+      mailConfig: null,
+    });
+    prismaMock.trackedClan.update.mockResolvedValueOnce({});
+    pointsSyncMock.getCurrentSyncForClan.mockResolvedValueOnce(null);
+    pointsSyncMock.markConfirmedByClanMail.mockResolvedValueOnce(undefined);
+    lifecycleMock.getLifecycleForWar.mockResolvedValueOnce(null);
+    lifecycleMock.markPosted.mockResolvedValueOnce(undefined);
+    repWorkActivityMock.recordMailSent.mockResolvedValueOnce(undefined);
+    const sentMessage = {
+      id: "sent-unknown",
+      delete: vi.fn().mockResolvedValue(undefined),
+    };
+    const send = vi.fn().mockResolvedValue(sentMessage);
+    const interaction = createInteraction({
+      customId: buildFwaMailConfirmCustomId("owner-1", previewKey),
+      send,
+    });
+
+    await handleFwaMailConfirmButton(interaction as any);
+
+    const updateCall = prismaMock.currentWar.updateMany.mock.calls[0]?.[0] as
+      | { data?: Record<string, unknown> }
+      | undefined;
+    expect(updateCall?.data).toMatchObject({
+      channelId: "mail-channel-1",
+      inferredMatchType: true,
+      outcome: null,
+      updatedAt: expect.any(Date),
+    });
+    expect(updateCall?.data).not.toHaveProperty("matchType");
+    expect(sentMessage.delete).not.toHaveBeenCalled();
+    expect(prisma.currentWar.update).not.toHaveBeenCalled();
+    expect(prisma.currentWar.upsert).not.toHaveBeenCalled();
+    expect(lifecycleMock.markPosted).toHaveBeenCalledTimes(1);
+    expect(repWorkActivityMock.recordMailSent).toHaveBeenCalledTimes(1);
+    expect(pointsSyncMock.markConfirmedByClanMail).toHaveBeenCalledTimes(1);
+    expect(prismaMock.trackedClan.update).toHaveBeenCalledTimes(1);
+    expect(pollSpy).not.toHaveBeenCalled();
+    expect(refreshBattleDayPostsSpy).not.toHaveBeenCalled();
+    expect(refreshNotifySpy).toHaveBeenCalledTimes(1);
+    expect(globalThis.setInterval).toHaveBeenCalledTimes(1);
   });
 
   it("sends and records the pinging confirmation on the success path", async () => {


### PR DESCRIPTION
## Summary
This draft keeps the `/fwa mail confirm` send path fail-closed when the active war changes after the final rerender.

It adds:
- an exact pre-send reread that requires the same `guildId`, normalized `clanTag`, positive `warId`, exact `startTime`, and normalized `opponentTag` before `channel.send()`;
- a guarded post-send `currentWar.updateMany()` that only updates `channelId`, `matchType`, `inferredMatchType`, `outcome`, and `updatedAt`;
- best-effort message deletion plus cancellation if the guarded update does not affect exactly one row;
- focused command tests for ping and no-ping confirmation flows.

This keeps the mail confirmation path from creating or overwriting war identity, while leaving the `/fwa match` flow unchanged in this task.

## Validation
- `npx vitest run tests/fwaMailConfirm.command.test.ts`
- `npx vitest run tests/fwaTargetedWarReconcile.logic.test.ts tests/fwaWarIdentityRace.logic.test.ts tests/fwaMailDownstream.logic.test.ts`
- `npm test` (passed; a second full run also passed after an unrelated scheduler flake was rerun in isolation)
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`
- `git diff --check`
