### PR TITLE
fix(autorole): discover uncached tracked role holders

### DIFF
--- a/docs/diagnostics/autorole-stale-clan-role-diagnosis.md
+++ b/docs/diagnostics/autorole-stale-clan-role-diagnosis.md
@@ -8,14 +8,14 @@ Three separate behaviors are involved:
 
 - `/accounts` is a read-path issue caused by stale persisted player state and stale activity fallback.
 - Targeted user refresh is a live-refresh / delay-flow issue whose historical production execution cannot be proven from retained logs.
-- Tracked-clan role refresh is a candidate-discovery issue for cache-absent current holders.
+- Tracked-clan role refresh is a confirmed candidate-discovery issue for cache-absent current holders.
 - Guild-wide and scheduled refresh preserve a stale positive tracked-clan role because they merge live positive evidence over persisted player state and do not treat roster absence as authoritative negative evidence for a specific clan.
 
 Confidence:
 
 - `/accounts` stale read-path diagnosis: ~97%
 - guild-wide stale-positive preservation: ~92%
-- tracked-clan role candidate omission: ~96%
+- tracked-clan role candidate omission: confirmed / ~99%
 - historical targeted-user execution: unresolved / low confidence
 
 ## `/accounts`
@@ -49,24 +49,26 @@ This confirms the intended user-scope behavior without claiming that the histori
 
 ## Tracked-clan role refresh
 
-Tracked-clan role refresh does not rely on stale persisted `PlayerCurrent` for departed players.
+Tracked-clan role refresh is a confirmed candidate-discovery root cause for cache-absent current holders.
 
 Current role-holder discovery currently begins from `guild.members.cache`.
 
 That means a role holder who is absent from the initial cache and absent from the current live roster is never discovered.
 
-The confirmed temporary reproduction showed:
+The confirmed temporary reproduction observed:
 
-- the user was absent from `currentHolderIds`
-- the user was absent from candidate ids
+- `currentHolderIds` was empty
+- candidate ids were empty
 - `guild.members.fetch(userId)` was never called
 - the user was never evaluated
 - no pending-removal row was created
 - the role was neither removed nor queued
 
-This is a candidate-discovery defect in role-scoped refresh.
+This is a candidate-discovery defect in role-scoped refresh and is separate from stale `PlayerCurrent` in guild-wide or scheduled refresh.
 
 ## Guild-wide and scheduled refresh
+
+Stale `PlayerCurrent` definitively explains why the latest guild-wide or scheduled refresh preserved the affected Rising Dawn role.
 
 Guild refresh loads persisted `PlayerCurrent`.
 
@@ -74,9 +76,9 @@ It merges positive live tracked-clan roster observations over that persisted sta
 
 It does not use live roster absence as authoritative negative evidence for a specific tracked clan.
 
-A stale positive `PlayerCurrent.currentClanTag` can therefore survive.
+The role-scoped outcome is governed by candidate discovery and live roster evidence.
 
-That is why the latest guild-wide or scheduled refresh preserved the affected Rising Dawn role.
+Historical targeted-user execution remains unknown because retained logs are unavailable.
 
 ## Architecture and ownership
 
@@ -100,6 +102,7 @@ The eventual implementation must:
 - retain the `removeStaleManagedRoles` opt-in gate
 - abort before role writes when required clan or guild-member data is incomplete
 - leave `PlayerCurrentService` and `AutoRoleApplyService` unchanged unless tests prove otherwise
+- add a permanent regression test for cache-absent tracked-clan holder discovery in role refresh
 
 ## Reproduced outcomes
 

--- a/docs/diagnostics/autorole-stale-clan-role-diagnosis.md
+++ b/docs/diagnostics/autorole-stale-clan-role-diagnosis.md
@@ -8,14 +8,14 @@ Three separate behaviors are involved:
 
 - `/accounts` is a read-path issue caused by stale persisted player state and stale activity fallback.
 - Targeted user refresh is a live-refresh / delay-flow issue whose historical production execution cannot be proven from retained logs.
-- Tracked-clan role refresh is a confirmed candidate-discovery issue for cache-absent current holders.
+- Tracked-clan role refresh is a candidate-discovery issue for cache-absent current holders.
 - Guild-wide and scheduled refresh preserve a stale positive tracked-clan role because they merge live positive evidence over persisted player state and do not treat roster absence as authoritative negative evidence for a specific clan.
 
 Confidence:
 
 - `/accounts` stale read-path diagnosis: ~97%
 - guild-wide stale-positive preservation: ~92%
-- tracked-clan role candidate omission: confirmed / ~99%
+- tracked-clan role candidate omission: ~96%
 - historical targeted-user execution: unresolved / low confidence
 
 ## `/accounts`
@@ -49,26 +49,24 @@ This confirms the intended user-scope behavior without claiming that the histori
 
 ## Tracked-clan role refresh
 
-Tracked-clan role refresh is a confirmed candidate-discovery root cause for cache-absent current holders.
+Tracked-clan role refresh does not rely on stale persisted `PlayerCurrent` for departed players.
 
 Current role-holder discovery currently begins from `guild.members.cache`.
 
 That means a role holder who is absent from the initial cache and absent from the current live roster is never discovered.
 
-The confirmed temporary reproduction observed:
+The confirmed temporary reproduction showed:
 
-- `currentHolderIds` was empty
-- candidate ids were empty
+- the user was absent from `currentHolderIds`
+- the user was absent from candidate ids
 - `guild.members.fetch(userId)` was never called
 - the user was never evaluated
 - no pending-removal row was created
 - the role was neither removed nor queued
 
-This is a candidate-discovery defect in role-scoped refresh and is separate from stale `PlayerCurrent` in guild-wide or scheduled refresh.
+This is a candidate-discovery defect in role-scoped refresh.
 
 ## Guild-wide and scheduled refresh
-
-Stale `PlayerCurrent` definitively explains why the latest guild-wide or scheduled refresh preserved the affected Rising Dawn role.
 
 Guild refresh loads persisted `PlayerCurrent`.
 
@@ -76,9 +74,9 @@ It merges positive live tracked-clan roster observations over that persisted sta
 
 It does not use live roster absence as authoritative negative evidence for a specific tracked clan.
 
-The role-scoped outcome is governed by candidate discovery and live roster evidence.
+A stale positive `PlayerCurrent.currentClanTag` can therefore survive.
 
-Historical targeted-user execution remains unknown because retained logs are unavailable.
+That is why the latest guild-wide or scheduled refresh preserved the affected Rising Dawn role.
 
 ## Architecture and ownership
 
@@ -102,7 +100,6 @@ The eventual implementation must:
 - retain the `removeStaleManagedRoles` opt-in gate
 - abort before role writes when required clan or guild-member data is incomplete
 - leave `PlayerCurrentService` and `AutoRoleApplyService` unchanged unless tests prove otherwise
-- add a permanent regression test for cache-absent tracked-clan holder discovery in role refresh
 
 ## Reproduced outcomes
 

--- a/src/services/AutoRoleRefreshService.ts
+++ b/src/services/AutoRoleRefreshService.ts
@@ -1362,7 +1362,6 @@ async function loadTrackedLeadRoleRefreshState(input: {
   guildId?: string;
   roleId: string;
   guild: Guild;
-  membersById: Map<string, AutoRoleGuildMemberLike>;
   cocService?: CoCService | null;
   telemetry?: AutoRoleRefreshTelemetry | null;
 }): Promise<TrackedLeadRoleRefreshState | null> {
@@ -2837,7 +2836,6 @@ export class AutoRoleRefreshService {
           guildId: input.guildId,
           roleId: input.scope.discordRoleId,
           guild: input.guild,
-          membersById: getGuildCachedMembersMap(input.guild),
           cocService: input.cocService ?? null,
           telemetry: input.telemetry ?? null,
         });

--- a/src/services/AutoRoleRefreshService.ts
+++ b/src/services/AutoRoleRefreshService.ts
@@ -299,6 +299,133 @@ async function loadGuildMembersByIdsAllowPartial(input: {
   };
 }
 
+function logRoleHolderDiscovery(input: {
+  guildId: string;
+  roleId: string;
+  subtype: RoleScopeDiscoverySubtype;
+  guildMemberCount: number;
+  initialCachedCount: number;
+  fullFetchRequired: boolean;
+  hydratedCount: number;
+  holderCount: number;
+  candidateCount: number;
+  cacheCoverageComplete: boolean;
+  action: "continue" | "abort_before_apply";
+  reason?: string | null;
+  error?: unknown;
+}): void {
+  const message =
+    `[autorole] event=role_holder_discovery guild_id=${input.guildId} target_role=${input.roleId} subtype=${input.subtype} guild_member_count=${input.guildMemberCount} initial_cached_count=${input.initialCachedCount} full_fetch_required=${input.fullFetchRequired ? "true" : "false"} hydrated_count=${input.hydratedCount} holder_count=${input.holderCount} candidate_count=${input.candidateCount} completeness_status=${input.cacheCoverageComplete ? "complete" : "incomplete"} action=${input.action}` +
+    (input.reason ? ` reason=${input.reason}` : "") +
+    (input.error !== undefined ? ` error=${formatError(input.error)}` : "");
+  if (input.action === "abort_before_apply") {
+    dozzleLog.warn(message);
+    return;
+  }
+  dozzleLog.info(message);
+}
+
+async function loadCompleteGuildMembersForRoleRefresh(input: {
+  guild: Guild;
+  guildId: string;
+  roleId: string;
+  subtype: RoleScopeDiscoverySubtype;
+  telemetry?: AutoRoleRefreshTelemetry | null;
+}): Promise<RoleScopeGuildMemberLoadState> {
+  const cachedMembersById = getGuildCachedMembersMap(input.guild);
+  const cachedMemberCount = cachedMembersById.size;
+  const guildMemberCount = Math.trunc(Number(input.guild.memberCount ?? cachedMemberCount));
+  const cacheCoverageComplete = guildMemberCount <= cachedMemberCount;
+  if (cacheCoverageComplete) {
+    return {
+      membersById: cachedMembersById,
+      cachedMemberCount,
+      hydratedMemberCount: cachedMemberCount,
+      guildMemberCount,
+      cacheCoverageComplete: true,
+      fullFetchRequired: false,
+    };
+  }
+
+  let fetchedMembers: unknown;
+  try {
+    fetchedMembers = await input.guild.members.fetch();
+  } catch (error) {
+    logRoleHolderDiscovery({
+      guildId: input.guildId,
+      roleId: input.roleId,
+      subtype: input.subtype,
+      guildMemberCount,
+      initialCachedCount: cachedMemberCount,
+      fullFetchRequired: true,
+      hydratedCount: 0,
+      holderCount: 0,
+      candidateCount: 0,
+      cacheCoverageComplete: false,
+      action: "abort_before_apply",
+      reason: "full_member_fetch_failed",
+      error,
+    });
+    throw new Error(
+      `Tracked ${input.subtype === "tracked_clan" ? "clan" : "lead"} role refresh requires a complete guild member fetch.`,
+    );
+  }
+
+  let membersById: Map<string, AutoRoleGuildMemberLike>;
+  try {
+    membersById = memberCollectionToMap(fetchedMembers as AutoRoleMemberCollectionLike);
+  } catch (error) {
+    logRoleHolderDiscovery({
+      guildId: input.guildId,
+      roleId: input.roleId,
+      subtype: input.subtype,
+      guildMemberCount,
+      initialCachedCount: cachedMemberCount,
+      fullFetchRequired: true,
+      hydratedCount: 0,
+      holderCount: 0,
+      candidateCount: 0,
+      cacheCoverageComplete: false,
+      action: "abort_before_apply",
+      reason: "full_member_fetch_unusable",
+      error,
+    });
+    throw new Error(
+      `Tracked ${input.subtype === "tracked_clan" ? "clan" : "lead"} role refresh requires a usable complete guild member fetch.`,
+    );
+  }
+
+  const hydratedMemberCount = membersById.size;
+  if (hydratedMemberCount < guildMemberCount) {
+    logRoleHolderDiscovery({
+      guildId: input.guildId,
+      roleId: input.roleId,
+      subtype: input.subtype,
+      guildMemberCount,
+      initialCachedCount: cachedMemberCount,
+      fullFetchRequired: true,
+      hydratedCount: hydratedMemberCount,
+      holderCount: 0,
+      candidateCount: 0,
+      cacheCoverageComplete: false,
+      action: "abort_before_apply",
+      reason: "full_member_fetch_incomplete",
+    });
+    throw new Error(
+      `Tracked ${input.subtype === "tracked_clan" ? "clan" : "lead"} role refresh requires a complete guild member fetch, but Discord returned only ${hydratedMemberCount}/${guildMemberCount} members.`,
+    );
+  }
+
+  return {
+    membersById,
+    cachedMemberCount,
+    hydratedMemberCount,
+    guildMemberCount,
+    cacheCoverageComplete: true,
+    fullFetchRequired: true,
+  };
+}
+
 function mergeTrackedClanPlayerCurrentOverlay(input: {
   baseByTag: Map<string, PlayerCurrentLike>;
   overlayByTag: Map<string, PlayerCurrentLike>;
@@ -983,6 +1110,17 @@ type TrackedFwaClanRefreshState = {
   failedClanTags: string[];
 };
 
+type RoleScopeDiscoverySubtype = "tracked_clan" | "tracked_lead";
+
+type RoleScopeGuildMemberLoadState = {
+  membersById: Map<string, AutoRoleGuildMemberLike>;
+  cachedMemberCount: number;
+  hydratedMemberCount: number;
+  guildMemberCount: number;
+  cacheCoverageComplete: boolean;
+  fullFetchRequired: boolean;
+};
+
 type TrackedLeadRoleRefreshState = {
   requestedClanCount: number;
   configuredClanTags: string[];
@@ -1000,8 +1138,12 @@ type TrackedLeadRoleRefreshState = {
   membersById: Map<string, AutoRoleGuildMemberLike>;
   candidateUserIds: Set<string>;
   loadedCandidateUserIds: Set<string>;
+  currentHolderCount: number;
   cachedMemberCount: number;
+  hydratedMemberCount: number;
   guildMemberCount: number;
+  cacheCoverageComplete: boolean;
+  fullFetchRequired: boolean;
   targetedFetchRequestedCount: number;
   targetedFetchSucceededCount: number;
   targetedFetchFailedCount: number;
@@ -1026,8 +1168,12 @@ type TrackedClanRoleRefreshState = {
   candidateUserIds: Set<string>;
   membersById: Map<string, AutoRoleGuildMemberLike>;
   loadedCandidateUserIds: Set<string>;
+  currentHolderCount: number;
   cachedMemberCount: number;
+  hydratedMemberCount: number;
   guildMemberCount: number;
+  cacheCoverageComplete: boolean;
+  fullFetchRequired: boolean;
   targetedFetchRequestedCount: number;
   targetedFetchSucceededCount: number;
   targetedFetchFailedCount: number;
@@ -1249,7 +1395,14 @@ async function loadTrackedLeadRoleRefreshState(input: {
     return null;
   }
 
-  const cachedMembersById = input.membersById;
+  const guildMembers = await loadCompleteGuildMembersForRoleRefresh({
+    guild: input.guild,
+    guildId: input.guildId ?? "",
+    roleId,
+    subtype: "tracked_lead",
+    telemetry: input.telemetry,
+  });
+  const cachedMembersById = guildMembers.membersById;
   const currentHolderIds = collectCurrentRoleHolders(cachedMembersById, new Set([roleId]));
   const failedClanTags = new Set<string>();
   const configuredClanTags = new Set<string>();
@@ -1365,6 +1518,7 @@ async function loadTrackedLeadRoleRefreshState(input: {
     });
   }
 
+  const currentHolderCount = currentHolderIds.size;
   const leaderLinkedAccountsByUserId = await loadLinkedAccountsForPlayerTags({
     playerTags: [...leaderMemberTags],
   });
@@ -1373,12 +1527,12 @@ async function loadTrackedLeadRoleRefreshState(input: {
     candidateUserIds.add(userId);
   }
 
-  const memberSource = await loadGuildMembersByIdsAllowPartial({
-    guild: input.guild,
-    userIds: candidateUserIds,
-  });
-  const membersById = memberSource.membersById;
-  const loadedCandidateUserIds = new Set<string>(membersById.keys());
+  const loadedCandidateUserIds = new Set<string>();
+  for (const userId of candidateUserIds) {
+    if (cachedMembersById.has(userId)) {
+      loadedCandidateUserIds.add(userId);
+    }
+  }
   const linkedAccountsByUserId = await loadLinkedAccountsForGuildMemberIds({
     guildMemberIds: [...loadedCandidateUserIds],
   });
@@ -1397,14 +1551,18 @@ async function loadTrackedLeadRoleRefreshState(input: {
     },
     playerCurrentByTag,
     linkedAccountsByUserId,
-    membersById,
+    membersById: cachedMembersById,
     candidateUserIds,
     loadedCandidateUserIds,
-    cachedMemberCount: cachedMembersById.size,
-    guildMemberCount: input.guild.memberCount,
-    targetedFetchRequestedCount: memberSource.targetedFetchRequestedCount,
-    targetedFetchSucceededCount: memberSource.targetedFetchSucceededCount,
-    targetedFetchFailedCount: memberSource.targetedFetchFailedCount,
+    currentHolderCount,
+    cachedMemberCount: guildMembers.cachedMemberCount,
+    hydratedMemberCount: guildMembers.hydratedMemberCount,
+    guildMemberCount: guildMembers.guildMemberCount,
+    cacheCoverageComplete: guildMembers.cacheCoverageComplete,
+    fullFetchRequired: guildMembers.fullFetchRequired,
+    targetedFetchRequestedCount: 0,
+    targetedFetchSucceededCount: 0,
+    targetedFetchFailedCount: 0,
     clanFetchCount,
     failedClanTags: [...failedClanTags].sort(),
   };
@@ -1446,7 +1604,14 @@ async function loadTrackedClanRoleRefreshState(input: {
     throw new Error("Tracked clan role refresh requires CoC clan data.");
   }
 
-  const cachedMembersById = getGuildCachedMembersMap(input.guild);
+  const guildMembers = await loadCompleteGuildMembersForRoleRefresh({
+    guild: input.guild,
+    guildId: input.guildId ?? "",
+    roleId,
+    subtype: "tracked_clan",
+    telemetry: input.telemetry,
+  });
+  const cachedMembersById = guildMembers.membersById;
   const currentHolderIds = collectCurrentRoleHolders(cachedMembersById, new Set([roleId]));
   const failedClanTags = new Set<string>();
   const configuredClanTags = new Set<string>();
@@ -1489,7 +1654,7 @@ async function loadTrackedClanRoleRefreshState(input: {
   const fwaMemberTags = new Set<string>();
   const candidatePlayerTags = new Set<string>();
   let clanFetchCount = 0;
-  const cachedMemberCount = cachedMembersById.size;
+  const currentHolderCount = currentHolderIds.size;
 
   for (const lookup of successfulLookups) {
     clanFetchCount += 1;
@@ -1577,12 +1742,12 @@ async function loadTrackedClanRoleRefreshState(input: {
     candidateUserIds.add(userId);
   }
 
-  const memberSource = await loadGuildMembersByIdsAllowPartial({
-    guild: input.guild,
-    userIds: candidateUserIds,
-  });
-  const membersById = memberSource.membersById;
-  const loadedCandidateUserIds = new Set<string>(membersById.keys());
+  const loadedCandidateUserIds = new Set<string>();
+  for (const userId of candidateUserIds) {
+    if (cachedMembersById.has(userId)) {
+      loadedCandidateUserIds.add(userId);
+    }
+  }
 
   const linkedAccountsByUserId = await loadLinkedAccountsForGuildMemberIds({
     guildMemberIds: [...loadedCandidateUserIds],
@@ -1603,13 +1768,17 @@ async function loadTrackedClanRoleRefreshState(input: {
     playerCurrentByTag,
     linkedAccountsByUserId,
     candidateUserIds,
-    membersById,
+    membersById: cachedMembersById,
     loadedCandidateUserIds,
-    cachedMemberCount,
-    guildMemberCount: input.guild.memberCount,
-    targetedFetchRequestedCount: memberSource.targetedFetchRequestedCount,
-    targetedFetchSucceededCount: memberSource.targetedFetchSucceededCount,
-    targetedFetchFailedCount: memberSource.targetedFetchFailedCount,
+    currentHolderCount,
+    cachedMemberCount: guildMembers.cachedMemberCount,
+    hydratedMemberCount: guildMembers.hydratedMemberCount,
+    guildMemberCount: guildMembers.guildMemberCount,
+    cacheCoverageComplete: guildMembers.cacheCoverageComplete,
+    fullFetchRequired: guildMembers.fullFetchRequired,
+    targetedFetchRequestedCount: 0,
+    targetedFetchSucceededCount: 0,
+    targetedFetchFailedCount: 0,
     clanFetchCount,
     failedClanTags: [...failedClanTags].sort(),
   };
@@ -2573,8 +2742,6 @@ export class AutoRoleRefreshService {
       }
 
       if (input.scope.kind === "role") {
-        const roleMembersById = getGuildCachedMembersMap(input.guild);
-        const roleCacheCoverageComplete = input.guild.memberCount <= roleMembersById.size;
         const clanRoleState = await loadTrackedClanRoleRefreshState({
           guildId: input.guildId,
           roleId: input.scope.discordRoleId,
@@ -2606,17 +2773,28 @@ export class AutoRoleRefreshService {
             throw error;
           }
 
-          const currentHolderCount = collectCurrentRoleHolders(
-            clanRoleState.membersById,
-            new Set([input.scope.discordRoleId]),
-          ).size;
-          const visitorRoleAdditionsSuppressed = visitorRoleConfigured && !roleCacheCoverageComplete;
+          const currentHolderCount = clanRoleState.currentHolderCount;
+          const candidateCount = clanRoleState.loadedCandidateUserIds.size;
+          logRoleHolderDiscovery({
+            guildId: input.guildId,
+            roleId: input.scope.discordRoleId,
+            subtype: "tracked_clan",
+            guildMemberCount: clanRoleState.guildMemberCount,
+            initialCachedCount: clanRoleState.cachedMemberCount,
+            fullFetchRequired: clanRoleState.fullFetchRequired,
+            hydratedCount: clanRoleState.hydratedMemberCount,
+            holderCount: currentHolderCount,
+            candidateCount,
+            cacheCoverageComplete: clanRoleState.cacheCoverageComplete,
+            action: "continue",
+          });
+          const visitorRoleAdditionsSuppressed = visitorRoleConfigured && !clanRoleState.cacheCoverageComplete;
           const memberSourceSummary = buildMemberSourceSummary({
             scope: input.scope,
             guildMemberCount: clanRoleState.guildMemberCount,
             cachedMemberCount: clanRoleState.cachedMemberCount,
-            cacheCoverageComplete: roleCacheCoverageComplete,
-            candidateUserCount: clanRoleState.candidateUserIds.size,
+            cacheCoverageComplete: clanRoleState.cacheCoverageComplete,
+            candidateUserCount: candidateCount,
             targetedFetchRequestedCount: clanRoleState.targetedFetchRequestedCount,
             targetedFetchSucceededCount: clanRoleState.targetedFetchSucceededCount,
             targetedFetchFailedCount: clanRoleState.targetedFetchFailedCount,
@@ -2625,15 +2803,15 @@ export class AutoRoleRefreshService {
             trackedClanOverlayCount: clanRoleState.playerCurrentByTag.size,
           });
           dozzleLog.info(
-            `[autorole] event=refresh_start guild_id=${input.guildId} scope=${input.scope.kind} target_role=${input.scope.discordRoleId} clan_role_clans=${clanRoleState.trackedClans.length} current_holders=${currentHolderCount} linked_users=${clanRoleState.linkedAccountsByUserId.size} managed_roles=${managedRoleIds.size} clan_member_tags=${clanRoleState.trackedMembershipScope.fwaMemberTags.size} clan_fetches=${clanRoleState.clanFetchCount} player_current_tags=${clanRoleState.playerCurrentByTag.size} member_fetch_mode=targeted`,
+            `[autorole] event=refresh_start guild_id=${input.guildId} scope=${input.scope.kind} target_role=${input.scope.discordRoleId} clan_role_clans=${clanRoleState.trackedClans.length} current_holders=${currentHolderCount} linked_users=${clanRoleState.linkedAccountsByUserId.size} managed_roles=${managedRoleIds.size} clan_member_tags=${clanRoleState.trackedMembershipScope.fwaMemberTags.size} clan_fetches=${clanRoleState.clanFetchCount} player_current_tags=${clanRoleState.playerCurrentByTag.size} member_fetch_mode=${clanRoleState.fullFetchRequired ? "full_fetch" : "cache_complete"}`,
           );
 
           const result = await runRefreshPass({
-          guildId: input.guildId,
-          scope: input.scope,
-          runTrigger: input.runContext.trigger,
-          guild: input.guild,
-          snapshot,
+            guildId: input.guildId,
+            scope: input.scope,
+            runTrigger: input.runContext.trigger,
+            guild: input.guild,
+            snapshot,
             trackedClans: clanRoleState.trackedClans,
             membersById: clanRoleState.membersById,
             linkedAccountsByUserId: clanRoleState.linkedAccountsByUserId,
@@ -2659,7 +2837,7 @@ export class AutoRoleRefreshService {
           guildId: input.guildId,
           roleId: input.scope.discordRoleId,
           guild: input.guild,
-          membersById: roleMembersById,
+          membersById: getGuildCachedMembersMap(input.guild),
           cocService: input.cocService ?? null,
           telemetry: input.telemetry ?? null,
         });
@@ -2687,17 +2865,28 @@ export class AutoRoleRefreshService {
             throw error;
           }
 
-          const currentHolderCount = collectCurrentRoleHolders(
-            roleMembersById,
-            new Set([input.scope.discordRoleId]),
-          ).size;
-          const visitorRoleAdditionsSuppressed = visitorRoleConfigured && !roleCacheCoverageComplete;
+          const currentHolderCount = leadRoleState.currentHolderCount;
+          const candidateCount = leadRoleState.loadedCandidateUserIds.size;
+          logRoleHolderDiscovery({
+            guildId: input.guildId,
+            roleId: input.scope.discordRoleId,
+            subtype: "tracked_lead",
+            guildMemberCount: leadRoleState.guildMemberCount,
+            initialCachedCount: leadRoleState.cachedMemberCount,
+            fullFetchRequired: leadRoleState.fullFetchRequired,
+            hydratedCount: leadRoleState.hydratedMemberCount,
+            holderCount: currentHolderCount,
+            candidateCount,
+            cacheCoverageComplete: leadRoleState.cacheCoverageComplete,
+            action: "continue",
+          });
+          const visitorRoleAdditionsSuppressed = visitorRoleConfigured && !leadRoleState.cacheCoverageComplete;
           const memberSourceSummary = buildMemberSourceSummary({
             scope: input.scope,
             guildMemberCount: leadRoleState.guildMemberCount,
             cachedMemberCount: leadRoleState.cachedMemberCount,
-            cacheCoverageComplete: roleCacheCoverageComplete,
-            candidateUserCount: leadRoleState.candidateUserIds.size,
+            cacheCoverageComplete: leadRoleState.cacheCoverageComplete,
+            candidateUserCount: candidateCount,
             targetedFetchRequestedCount: leadRoleState.targetedFetchRequestedCount,
             targetedFetchSucceededCount: leadRoleState.targetedFetchSucceededCount,
             targetedFetchFailedCount: leadRoleState.targetedFetchFailedCount,
@@ -2706,7 +2895,7 @@ export class AutoRoleRefreshService {
             trackedClanOverlayCount: leadRoleState.playerCurrentByTag.size,
           });
           dozzleLog.info(
-            `[autorole] event=refresh_start guild_id=${input.guildId} scope=${input.scope.kind} target_role=${input.scope.discordRoleId} lead_clans=${leadRoleState.trackedClans.length} current_holders=${currentHolderCount} linked_users=${leadRoleState.linkedAccountsByUserId.size} managed_roles=${managedRoleIds.size} lead_member_tags=${leadRoleState.trackedMembershipScope.fwaMemberTags.size} clan_fetches=${leadRoleState.clanFetchCount} player_current_tags=${leadRoleState.playerCurrentByTag.size}`,
+            `[autorole] event=refresh_start guild_id=${input.guildId} scope=${input.scope.kind} target_role=${input.scope.discordRoleId} lead_clans=${leadRoleState.trackedClans.length} current_holders=${currentHolderCount} linked_users=${leadRoleState.linkedAccountsByUserId.size} managed_roles=${managedRoleIds.size} lead_member_tags=${leadRoleState.trackedMembershipScope.fwaMemberTags.size} clan_fetches=${leadRoleState.clanFetchCount} player_current_tags=${leadRoleState.playerCurrentByTag.size} member_fetch_mode=${leadRoleState.fullFetchRequired ? "full_fetch" : "cache_complete"}`,
           );
 
           const result = await runRefreshPass({

--- a/tests/autorole.refresh.service.test.ts
+++ b/tests/autorole.refresh.service.test.ts
@@ -164,6 +164,26 @@ function makeGuild(members: Map<string, GuildMemberLike>, roleIds: string[] = []
   } as any;
 }
 
+function makeRoleRefreshGuild(input: {
+  initialMembers: Map<string, GuildMemberLike>;
+  fullMembers: Map<string, GuildMemberLike>;
+  roleIds?: string[];
+  memberCount?: number;
+}) {
+  const guild = makeGuild(
+    input.initialMembers,
+    input.roleIds ?? [],
+    input.memberCount ?? input.fullMembers.size,
+  );
+  guild.members.fetch = vi.fn(async (discordUserId?: string) => {
+    if (typeof discordUserId === "string") {
+      return input.fullMembers.get(discordUserId) ?? null;
+    }
+    return input.fullMembers;
+  });
+  return guild;
+}
+
 function makeConfig(overrides: Record<string, unknown> = {}) {
   return {
     id: "config-1",
@@ -2122,7 +2142,7 @@ describe("AutoRoleRefreshService", () => {
       cocService: cocService as any,
     });
 
-    expect(guild.members.fetch).not.toHaveBeenCalledWith();
+    expect(guild.members.fetch).not.toHaveBeenCalled();
     expect(cocService.getClan).toHaveBeenCalledTimes(1);
     expect(cocService.getClan).toHaveBeenCalledWith(clanTag);
     expect(cocService.getPlayerRaw).not.toHaveBeenCalled();
@@ -2142,7 +2162,12 @@ describe("AutoRoleRefreshService", () => {
     const clanTag = "#2QG2C08UP";
     const staleHolderId = "111111111111111111";
     const staleHolder = makeMember(staleHolderId, [clanRoleId]);
-    const guild = makeGuild(new Map([[staleHolderId, staleHolder]]));
+    const guild = makeRoleRefreshGuild({
+      initialMembers: new Map(),
+      fullMembers: new Map([[staleHolderId, staleHolder]]),
+      roleIds: [clanRoleId],
+      memberCount: 1,
+    });
     const cocService = {
       getClan: vi.fn(async (tag: string) => {
         if (tag === clanTag) {
@@ -2175,9 +2200,9 @@ describe("AutoRoleRefreshService", () => {
       }),
     ).rejects.toThrow("Tracked clan fetch failed");
 
-    expect(guild.members.fetch.mock.calls.some((args: unknown[]) => args.length === 0)).toBe(false);
     expect(cocService.getClan).toHaveBeenCalledTimes(1);
     expect(cocService.getClan).toHaveBeenCalledWith(clanTag);
+    expect(guild.members.fetch.mock.calls.filter((args: unknown[]) => args.length === 0)).toHaveLength(1);
     expect(cocService.getPlayerRaw).not.toHaveBeenCalled();
     expect(staleHolder.roles.remove).not.toHaveBeenCalled();
     expect(prismaMock.autoRoleMemberState.upsert).not.toHaveBeenCalled();
@@ -2192,23 +2217,133 @@ describe("AutoRoleRefreshService", () => {
     );
   });
 
-  it("keeps tracked-clan clan role refresh partial when one targeted member fetch rate limits", async () => {
+  it("creates and later clears pending removal for an uncached stale tracked-clan holder", async () => {
     const clanRoleId = "333333333333333333";
     const clanTag = "#2QG2C08UP";
-    const successUserId = "111111111111111111";
-    const rateLimitedUserId = "444444444444444444";
-    const successUser = makeMember(successUserId);
-    const rateLimitedUser = makeMember(rateLimitedUserId);
-    const guild = makeGuild(new Map(), [], 2);
-    const rateLimitError = new Error("Request with opcode 8 was rate limited. Retry after 12 seconds.");
-    guild.members.fetch = vi.fn(async (discordUserId?: string) => {
-      if (discordUserId === successUserId) {
-        return successUser;
-      }
-      if (discordUserId === rateLimitedUserId) {
-        throw rateLimitError;
-      }
-      return null;
+    const staleHolderId = "111111111111111111";
+    const staleHolder = makeMember(staleHolderId, [clanRoleId]);
+    const fullMembers = new Map<string, GuildMemberLike>([[staleHolderId, staleHolder]]);
+    const guild = makeRoleRefreshGuild({
+      initialMembers: new Map(),
+      fullMembers,
+      roleIds: [clanRoleId],
+      memberCount: 1,
+    });
+    const firstNow = new Date("2026-05-01T12:00:00.000Z");
+    const secondNow = new Date("2026-05-02T12:01:00.000Z");
+    const cocService = {
+      getClan: vi.fn(async (tag: string) => {
+        if (tag === clanTag) {
+          return {
+            tag: clanTag,
+            name: "Tracked Clan",
+            members: [],
+          };
+        }
+        throw new Error(`unexpected clan lookup ${tag}`);
+      }),
+      getPlayerRaw: vi.fn(),
+    };
+
+    prismaMock.playerLink.findMany.mockImplementation(async ({ where }: any) => {
+      return filterPlayerLinkRows(
+        [
+          makeLinkedAccount({
+            playerTag: "#OLD111",
+            discordUserId: staleHolderId,
+            playerName: "Stale Holder",
+          }),
+        ],
+        where,
+      );
+    });
+    prismaMock.trackedClan.findMany.mockResolvedValue([
+      { tag: clanTag, name: "Tracked Clan", shortName: "TC", clanRoleId, leadRoleId: null },
+    ]);
+    prismaMock.autoRolePendingRemoval.findMany
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          ruleId: "rule-1",
+          discordRoleId: clanRoleId,
+          firstMissingAt: firstNow,
+          lastCheckedAt: firstNow,
+        },
+      ] as any);
+    vi.spyOn(autoRoleService, "getGuildStateSnapshot").mockResolvedValue({
+      config: makeConfig({
+        applyNicknames: false,
+        removeStaleManagedRoles: true,
+        clanRoleRemovalDelayMinutes: 1440,
+      }),
+      rules: [
+        makeRule({
+          type: AutoRoleRuleType.CLAN,
+          targetValue: clanTag,
+          discordRoleId: clanRoleId,
+        }),
+      ],
+      exclusions: { users: [], roles: [] },
+    } as any);
+
+    const firstResult = await autoRoleRefreshService.refreshRole({
+      guild,
+      guildId: "111111111111111111",
+      discordRoleId: clanRoleId,
+      cocService: cocService as any,
+      now: firstNow,
+    });
+
+    expect(guild.members.fetch.mock.calls.filter((args: unknown[]) => args.length === 0)).toHaveLength(1);
+    expect(cocService.getClan).toHaveBeenCalledTimes(1);
+    expect(cocService.getPlayerRaw).not.toHaveBeenCalled();
+    expect(staleHolder.roles.remove).not.toHaveBeenCalled();
+    expect(prismaMock.autoRolePendingRemoval.upsert).toHaveBeenCalledTimes(1);
+    expect(prismaMock.autoRolePendingRemoval.deleteMany).not.toHaveBeenCalled();
+    expect(firstResult).toMatchObject({
+      evaluatedCount: 1,
+      addedCount: 0,
+      removedCount: 0,
+      failedCount: 0,
+    });
+
+    const secondResult = await autoRoleRefreshService.refreshRole({
+      guild,
+      guildId: "111111111111111111",
+      discordRoleId: clanRoleId,
+      cocService: cocService as any,
+      now: secondNow,
+    });
+
+    expect(guild.members.fetch.mock.calls.filter((args: unknown[]) => args.length === 0)).toHaveLength(2);
+    expect(staleHolder.roles.remove).toHaveBeenCalledWith(clanRoleId);
+    expect(secondResult).toMatchObject({
+      evaluatedCount: 1,
+      addedCount: 0,
+      removedCount: 1,
+      failedCount: 0,
+    });
+    expect(prismaMock.autoRolePendingRemoval.deleteMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          guildId: "111111111111111111",
+          discordUserId: staleHolderId,
+          discordRoleId: { in: [clanRoleId] },
+        }),
+      }),
+    );
+  });
+
+  it("hydrates a current tracked-clan member from the full guild fetch and keeps the role", async () => {
+    const clanRoleId = "333333333333333333";
+    const clanTag = "#2QG2C08UP";
+    const liveMemberId = "111111111111111111";
+    const liveMember = makeMember(liveMemberId);
+    const guild = makeRoleRefreshGuild({
+      initialMembers: new Map(),
+      fullMembers: new Map([[liveMemberId, liveMember]]),
+      roleIds: [clanRoleId],
+      memberCount: 1,
     });
     const cocService = {
       getClan: vi.fn(async (tag: string) => {
@@ -2219,16 +2354,9 @@ describe("AutoRoleRefreshService", () => {
             members: [
               makeClanMember({
                 tag: "#PYLQ0289",
-                name: "Linked Member",
+                name: "Live Member",
                 role: "member",
                 townHallLevel: 16,
-                leagueName: "Legend League",
-              }),
-              makeClanMember({
-                tag: "#QGRJ2222",
-                name: "Rate Limited Member",
-                role: "member",
-                townHallLevel: 15,
                 leagueName: "Legend League",
               }),
             ],
@@ -2244,13 +2372,8 @@ describe("AutoRoleRefreshService", () => {
         [
           makeLinkedAccount({
             playerTag: "#PYLQ0289",
-            discordUserId: successUserId,
-            playerName: "Linked Member",
-          }),
-          makeLinkedAccount({
-            playerTag: "#QGRJ2222",
-            discordUserId: rateLimitedUserId,
-            playerName: "Rate Limited Member",
+            discordUserId: liveMemberId,
+            playerName: "Live Member",
           }),
         ],
         where,
@@ -2264,7 +2387,13 @@ describe("AutoRoleRefreshService", () => {
         applyNicknames: false,
         removeStaleManagedRoles: true,
       }),
-      rules: [],
+      rules: [
+        makeRule({
+          type: AutoRoleRuleType.CLAN,
+          targetValue: clanTag,
+          discordRoleId: clanRoleId,
+        }),
+      ],
       exclusions: { users: [], roles: [] },
     } as any);
 
@@ -2275,19 +2404,11 @@ describe("AutoRoleRefreshService", () => {
       cocService: cocService as any,
     });
 
+    expect(guild.members.fetch.mock.calls.filter((args: unknown[]) => args.length === 0)).toHaveLength(1);
     expect(cocService.getClan).toHaveBeenCalledTimes(1);
     expect(cocService.getPlayerRaw).not.toHaveBeenCalled();
-    expect(guild.members.fetch.mock.calls.some((args: unknown[]) => args.length === 0)).toBe(false);
-    expect(guild.members.fetch).toHaveBeenCalledWith(successUserId);
-    expect(guild.members.fetch).toHaveBeenCalledWith(rateLimitedUserId);
-    expect(successUser.roles.add).toHaveBeenCalledWith(clanRoleId);
-    expect(rateLimitedUser.roles.add).not.toHaveBeenCalledWith(clanRoleId);
-    expect(result.memberSourceSummary).toMatchObject({
-      memberSourceMode: "partial_candidates",
-      targetedFetchRequestedCount: 2,
-      targetedFetchSucceededCount: 1,
-      targetedFetchFailedCount: 1,
-    });
+    expect(liveMember.roles.add).toHaveBeenCalledWith(clanRoleId);
+    expect(prismaMock.autoRolePendingRemoval.upsert).not.toHaveBeenCalled();
     expect(result).toMatchObject({
       evaluatedCount: 1,
       addedCount: 1,
@@ -2295,15 +2416,100 @@ describe("AutoRoleRefreshService", () => {
       skippedCount: 0,
       failedCount: 0,
     });
-    expect(prismaMock.autoRoleMemberState.upsert).toHaveBeenCalledTimes(1);
-    expect(prismaMock.autoRoleSyncRun.update).toHaveBeenCalledWith(
-      expect.objectContaining({
-        where: { id: "run-1" },
-        data: expect.objectContaining({
-          status: "COMPLETED",
-        }),
+  });
+
+  it("aborts tracked-clan clan role refresh when the full guild fetch throws", async () => {
+    const clanRoleId = "333333333333333333";
+    const clanTag = "#2QG2C08UP";
+    const guild = makeGuild(new Map(), [clanRoleId], 1);
+    guild.members.fetch = vi.fn(async () => {
+      throw new Error("full member fetch failed");
+    });
+    const cocService = {
+      getClan: vi.fn(),
+      getPlayerRaw: vi.fn(),
+    };
+
+    prismaMock.playerLink.findMany.mockResolvedValue([]);
+    prismaMock.trackedClan.findMany.mockResolvedValue([
+      { tag: clanTag, name: "Tracked Clan", shortName: "TC", clanRoleId, leadRoleId: null },
+    ]);
+    vi.spyOn(autoRoleService, "getGuildStateSnapshot").mockResolvedValue({
+      config: makeConfig({
+        applyNicknames: false,
+        removeStaleManagedRoles: true,
       }),
-    );
+      rules: [
+        makeRule({
+          type: AutoRoleRuleType.CLAN,
+          targetValue: clanTag,
+          discordRoleId: clanRoleId,
+        }),
+      ],
+      exclusions: { users: [], roles: [] },
+    } as any);
+
+    await expect(
+      autoRoleRefreshService.refreshRole({
+        guild,
+        guildId: "111111111111111111",
+        discordRoleId: clanRoleId,
+        cocService: cocService as any,
+      }),
+    ).rejects.toThrow("complete guild member fetch");
+
+    expect(cocService.getClan).not.toHaveBeenCalled();
+    expect(guild.members.fetch.mock.calls.filter((args: unknown[]) => args.length === 0)).toHaveLength(1);
+    expect(prismaMock.autoRolePendingRemoval.upsert).not.toHaveBeenCalled();
+    expect(prismaMock.autoRoleMemberState.upsert).not.toHaveBeenCalled();
+    expect(guild.members.fetch).not.toHaveBeenCalledWith("111111111111111111");
+  });
+
+  it("aborts tracked-clan clan role refresh when the full guild fetch remains incomplete", async () => {
+    const clanRoleId = "333333333333333333";
+    const clanTag = "#2QG2C08UP";
+    const staleHolderId = "111111111111111111";
+    const staleHolder = makeMember(staleHolderId, [clanRoleId]);
+    const guild = makeGuild(new Map(), [clanRoleId], 2);
+    guild.members.fetch = vi.fn(async () => new Map([[staleHolderId, staleHolder]]));
+    const cocService = {
+      getClan: vi.fn(),
+      getPlayerRaw: vi.fn(),
+    };
+
+    prismaMock.playerLink.findMany.mockResolvedValue([]);
+    prismaMock.trackedClan.findMany.mockResolvedValue([
+      { tag: clanTag, name: "Tracked Clan", shortName: "TC", clanRoleId, leadRoleId: null },
+    ]);
+    vi.spyOn(autoRoleService, "getGuildStateSnapshot").mockResolvedValue({
+      config: makeConfig({
+        applyNicknames: false,
+        removeStaleManagedRoles: true,
+      }),
+      rules: [
+        makeRule({
+          type: AutoRoleRuleType.CLAN,
+          targetValue: clanTag,
+          discordRoleId: clanRoleId,
+        }),
+      ],
+      exclusions: { users: [], roles: [] },
+    } as any);
+
+    await expect(
+      autoRoleRefreshService.refreshRole({
+        guild,
+        guildId: "111111111111111111",
+        discordRoleId: clanRoleId,
+        cocService: cocService as any,
+      }),
+    ).rejects.toThrow("Discord returned only 1/2 members");
+
+    expect(cocService.getClan).not.toHaveBeenCalled();
+    expect(guild.members.fetch.mock.calls.filter((args: unknown[]) => args.length === 0)).toHaveLength(1);
+    expect(staleHolder.roles.remove).not.toHaveBeenCalled();
+    expect(prismaMock.autoRolePendingRemoval.upsert).not.toHaveBeenCalled();
+    expect(prismaMock.autoRoleMemberState.upsert).not.toHaveBeenCalled();
   });
 
   it("refreshes a tracked-clan lead role from the owning clan profile without player fanout", async () => {
@@ -2439,23 +2645,25 @@ describe("AutoRoleRefreshService", () => {
     });
   });
 
-  it("fetches an uncached linked co-leader and skips a stale linked lead candidate without aborting the refresh", async () => {
+  it("creates and later clears pending removal for an uncached stale tracked-clan lead holder", async () => {
     const leadRoleId = "222222222222222222";
     const clanTag = "#2QG2C08UP";
-    const coLeaderUserId = "333333333333333333";
-    const staleUserId = "444444444444444444";
-    const coLeaderUser = makeMember(coLeaderUserId);
-    const staleUser = makeMember(staleUserId);
-    const guild = makeGuild(new Map(), [], 2);
-    guild.members.fetch = vi.fn(async (discordUserId?: string) => {
-      if (discordUserId === coLeaderUserId) {
-        return coLeaderUser;
-      }
-      if (discordUserId === staleUserId) {
-        throw new Error("member missing from guild");
-      }
-      return null;
+    const staleHolderId = "111111111111111111";
+    const leaderUserId = "333333333333333333";
+    const staleHolder = makeMember(staleHolderId, [leadRoleId]);
+    const leaderUser = makeMember(leaderUserId);
+    const fullMembers = new Map<string, GuildMemberLike>([
+      [staleHolderId, staleHolder],
+      [leaderUserId, leaderUser],
+    ]);
+    const guild = makeRoleRefreshGuild({
+      initialMembers: new Map(),
+      fullMembers,
+      roleIds: [leadRoleId],
+      memberCount: 2,
     });
+    const firstNow = new Date("2026-05-03T12:00:00.000Z");
+    const secondNow = new Date("2026-05-04T12:01:00.000Z");
     const cocService = {
       getClan: vi.fn(async (tag: string) => {
         if (tag === clanTag) {
@@ -2463,13 +2671,6 @@ describe("AutoRoleRefreshService", () => {
             tag: clanTag,
             name: "Lead Clan",
             members: [
-              makeClanMember({
-                tag: "#GRJQ2222",
-                name: "CoLeader Player",
-                role: "coLeader",
-                townHallLevel: 15,
-                leagueName: "Master League I",
-              }),
               makeClanMember({
                 tag: "#QGRJ2222",
                 name: "Leader Player",
@@ -2489,54 +2690,80 @@ describe("AutoRoleRefreshService", () => {
       return filterPlayerLinkRows(
         [
           makeLinkedAccount({
-            playerTag: "#GRJQ2222",
-            discordUserId: coLeaderUserId,
-            playerName: "CoLeader Player",
+            playerTag: "#PYLQ0289",
+            discordUserId: staleHolderId,
+            playerName: "Stale Holder",
           }),
           makeLinkedAccount({
             playerTag: "#QGRJ2222",
-            discordUserId: staleUserId,
-            playerName: "Stale Leader Player",
+            discordUserId: leaderUserId,
+            playerName: "Leader Player",
           }),
         ],
         where,
       );
     });
     prismaMock.trackedClan.findMany.mockResolvedValue([{ tag: clanTag, name: "Lead Clan", shortName: "LC", leadRoleId }]);
+    prismaMock.autoRolePendingRemoval.findMany
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          ruleId: "rule-1",
+          discordRoleId: leadRoleId,
+          firstMissingAt: firstNow,
+          lastCheckedAt: firstNow,
+        },
+      ] as any);
     vi.spyOn(autoRoleService, "getGuildStateSnapshot").mockResolvedValue({
       config: makeConfig({
         applyNicknames: false,
         removeStaleManagedRoles: true,
+        clanRoleRemovalDelayMinutes: 1440,
       }),
-      rules: [],
+      rules: [
+        makeRule({
+          type: AutoRoleRuleType.CLAN,
+          targetValue: clanTag,
+          discordRoleId: leadRoleId,
+        }),
+      ],
       exclusions: { users: [], roles: [] },
     } as any);
 
-    const result = await autoRoleRefreshService.refreshRole({
+    const firstResult = await autoRoleRefreshService.refreshRole({
       guild,
       guildId: "111111111111111111",
       discordRoleId: leadRoleId,
       cocService: cocService as any,
+      now: firstNow,
     });
 
-    expect(guild.members.fetch.mock.calls.some((args: unknown[]) => args.length === 0)).toBe(false);
-    expect(guild.members.fetch).toHaveBeenCalledWith(coLeaderUserId);
-    expect(guild.members.fetch).toHaveBeenCalledWith(staleUserId);
-    expect(playerCurrentService.resolveCurrentPlayersForTags).not.toHaveBeenCalled();
-    expect(playerCurrentService.refreshCurrentPlayersFromLiveTags).not.toHaveBeenCalled();
-    expect(coLeaderUser.roles.add).toHaveBeenCalledWith(leadRoleId);
-    expect(staleUser.roles.add).not.toHaveBeenCalledWith(leadRoleId);
-    expect(result.memberSourceSummary).toMatchObject({
-      memberSourceMode: "partial_candidates",
-      targetedFetchRequestedCount: 2,
-      targetedFetchSucceededCount: 1,
-      targetedFetchFailedCount: 1,
-    });
-    expect(result).toMatchObject({
-      evaluatedCount: 1,
+    expect(guild.members.fetch.mock.calls.filter((args: unknown[]) => args.length === 0)).toHaveLength(1);
+    expect(cocService.getClan).toHaveBeenCalledTimes(1);
+    expect(cocService.getPlayerRaw).not.toHaveBeenCalled();
+    expect(staleHolder.roles.remove).not.toHaveBeenCalled();
+    expect(prismaMock.autoRolePendingRemoval.upsert).toHaveBeenCalledTimes(1);
+    expect(firstResult).toMatchObject({
+      evaluatedCount: 2,
       addedCount: 1,
       removedCount: 0,
-      skippedCount: 0,
+      failedCount: 0,
+    });
+
+    const secondResult = await autoRoleRefreshService.refreshRole({
+      guild,
+      guildId: "111111111111111111",
+      discordRoleId: leadRoleId,
+      cocService: cocService as any,
+      now: secondNow,
+    });
+
+    expect(guild.members.fetch.mock.calls.filter((args: unknown[]) => args.length === 0)).toHaveLength(2);
+    expect(staleHolder.roles.remove).toHaveBeenCalledWith(leadRoleId);
+    expect(secondResult).toMatchObject({
+      evaluatedCount: 2,
+      addedCount: 0,
+      removedCount: 1,
       failedCount: 0,
     });
   });
@@ -2546,7 +2773,12 @@ describe("AutoRoleRefreshService", () => {
     const clanTag = "#2QG2C08UP";
     const currentHolderId = "111111111111111111";
     const currentHolder = makeMember(currentHolderId, [leadRoleId]);
-    const guild = makeGuild(new Map([[currentHolderId, currentHolder]]));
+    const guild = makeRoleRefreshGuild({
+      initialMembers: new Map(),
+      fullMembers: new Map([[currentHolderId, currentHolder]]),
+      roleIds: [leadRoleId],
+      memberCount: 1,
+    });
     const cocService = {
       getClan: vi.fn(async (tag: string) => {
         if (tag === clanTag) {
@@ -2581,6 +2813,7 @@ describe("AutoRoleRefreshService", () => {
 
     expect(cocService.getClan).toHaveBeenCalledTimes(1);
     expect(cocService.getClan).toHaveBeenCalledWith(clanTag);
+    expect(guild.members.fetch.mock.calls.filter((args: unknown[]) => args.length === 0)).toHaveLength(1);
     expect(playerCurrentService.resolveCurrentPlayersForTags).not.toHaveBeenCalled();
     expect(playerCurrentService.refreshCurrentPlayersFromLiveTags).not.toHaveBeenCalled();
     expect(currentHolder.roles.remove).not.toHaveBeenCalled();


### PR DESCRIPTION
## Root cause
- Current tracked-clan and tracked-lead role holders were being discovered from an incomplete Discord cache.
- If a holder was missing from the initial cache and not part of the live roster, role refresh could miss that user entirely.

## Solution
- Hydrate the complete guild member collection once before role-holder discovery.
- Both tracked-clan roles and tracked-lead roles use the shared complete-member loader.
- Incomplete or failed hydration aborts before evaluation and application.
- Candidate discovery, removal delay, `removeStaleManagedRoles`, and clan-fetch abort-before-apply behavior remain unchanged.
- No `PlayerCurrent` values are written from roster absence.

## Regression coverage
- Added permanent tests for uncached stale tracked-clan holders and uncached stale tracked-lead holders.
- Added permanent tests for full-fetch failure and incomplete-fetch aborts.

## Validation
- `npx vitest run tests\\autorole.refresh.service.test.ts -t "uncached stale tracked-clan"`
- `npx vitest run tests\\autorole.refresh.service.test.ts`
- `git diff --check`
- `npm run lint`
- `npm test`
- `npm run build`