### PR TITLE
fix: preserve exact same-war todo attack progress

### DIFF
--- a/docs/diagnostics/stale-war-attacks-after-1685.md
+++ b/docs/diagnostics/stale-war-attacks-after-1685.md
@@ -4,14 +4,16 @@
 
 The sampled mismatch **predates the authoritative correction**.
 
-I can confirm that the affected `TodoPlayerSnapshot` rows were still stale when I sampled them, and that the corresponding `WarAttacks.attackOrder = 0` rows later reached `attacksUsed = 2`. What I **cannot** confirm yet is whether a later todo refresh happened after that write.
+I can confirm that the affected `TodoPlayerSnapshot` rows were still stale when I sampled them, and that the corresponding `WarAttacks.attackOrder = 0` rows later reached `attacksUsed = 2`. What I **cannot** confirm from production alone is whether a later todo refresh happened after that write.
 
-So the diagnosis is still **unresolved**:
+That leaves the production timeline unresolved:
 
 - propagation delay remains possible
 - durable confidence-preservation staleness remains possible
 - those two explanations stay indistinguishable until a post-write refresh is observed or reproduced
 - I should not call this a confirmed "normal propagation window"
+
+The code path itself is now reproduced and fixed in tests: the canonical same-identity merge was preserving the live-verified owner and the existing `warAttacksUsed` value even when exact same-war `WarAttacks` had already reached `2`. The fix threads exact attack provenance into the todo write decision and lets the snapshot advance monotonically to `2/2` without downgrading ownership confidence.
 
 ## Production evidence
 
@@ -73,26 +75,33 @@ I should not claim the next war is safe until I either observe one or prove the 
 
 ## Classification
 
-No A-F defect classification yet.
+Defect class: **F**
 
-The current evidence does not prove a durable failure.
+The proven defect is the durable confidence-preservation branch in `buildTodoWarOwnerDecision()`:
 
-The focused regression test reproduces the same retained-ended same-identity path in `buildTodoWarOwnerDecision()`: the canonical tracked-roster merge preserves the live-verified row and leaves `warAttacksUsed = 0` even when the same-war `WarAttacks` row has reached `2`.
+- `canonicalAttemptIsSameIdentity` preserved the live-verified owner correctly
+- the same branch also preserved `warAttacksUsed` from the existing row instead of the exact same-war `WarAttacks` count
+- that left the snapshot at `0/2` even though the authoritative attack row had already reached `2`
 
-If a later production refresh is observed and it still leaves the row at `0/2`, then the defect should be classified with the original A-F scale and the exact confidence-preservation branch is `canonicalAttemptIsSameIdentity` inside `persistTodoSnapshotWrite()`.
+The fixed invariant is:
+
+- same-war exact `WarAttacks` progress may advance the mutable WAR attack count
+- verified owner identity stays live-protected
+- monotonic progress never decreases once `2` has been observed
+- non-exact or stale fallback evidence still cannot override a verified owner
 
 ## Confidence
 
-Confidence: **66%**
+Confidence: **84%**
 
 Why not higher:
 
 - the sampled snapshot is definitely stale
 - the authoritative `WarAttacks` correction is definitely later
-- but a post-write todo refresh has not been observed yet
+- production still did not show a post-write todo refresh for the sampled players
 
 Why not lower:
 
 - the production rows and logs agree on the ordering
 - the reminder path already uses the corrected `WarAttacks` rows directly
-- the stale sample therefore cannot be called a confirmed normal propagation window
+- the focused regression test now reproduces the stale branch and proves the corrected same-war refresh advances the snapshot to `2/2`

--- a/src/services/TodoSnapshotService.ts
+++ b/src/services/TodoSnapshotService.ts
@@ -2917,7 +2917,7 @@ export class TodoSnapshotService {
           ) {
             verifiedOwnerClearedCount += 1;
           }
-          if (writeDecision.attackProgressIncreased) {
+          if (writeDecision.exactSameWarAttackProgressIncreased) {
             exactSameWarAttackProgressCount += 1;
             if (exactSameWarAttackProgressSamples.length < 5) {
               exactSameWarAttackProgressSamples.push(
@@ -3890,7 +3890,7 @@ type TodoWarOwnerWriteDecision = {
   finalState: TodoWarOwnerSnapshotState;
   existingWarAttacksUsed: number;
   finalWarAttacksUsed: number;
-  attackProgressIncreased: boolean;
+  exactSameWarAttackProgressIncreased: boolean;
   preservationMode:
     | "attempted"
     | "preserved_existing_verified"
@@ -4090,18 +4090,31 @@ function finalizeTodoWarOwnerDecision(input: {
   finalState: TodoWarOwnerSnapshotState;
   existingWarAttacksUsed: number;
   attackProgressSource: TodoWarAttackProgressSource;
+  resolutionSource: WarOwnerResolutionSource;
   baseDecision: Omit<
     TodoWarOwnerWriteDecision,
-    "finalState" | "existingWarAttacksUsed" | "finalWarAttacksUsed" | "attackProgressIncreased"
+    | "finalState"
+    | "existingWarAttacksUsed"
+    | "finalWarAttacksUsed"
+    | "exactSameWarAttackProgressIncreased"
   >;
 }): TodoWarOwnerWriteDecision {
   const finalWarAttacksUsed = clampInt(input.finalState.warAttacksUsed ?? 0, 0, 2);
+  const sameWarIdentity =
+    input.baseDecision.existingWarIdentity !== null &&
+    input.baseDecision.attemptedWarIdentity !== null &&
+    input.baseDecision.existingWarIdentity.clanTag === input.baseDecision.attemptedWarIdentity.clanTag &&
+    input.baseDecision.existingWarIdentity.warId !== null &&
+    input.baseDecision.attemptedWarIdentity.warId !== null &&
+    input.baseDecision.existingWarIdentity.warId === input.baseDecision.attemptedWarIdentity.warId;
   return {
     ...input.baseDecision,
     finalState: input.finalState,
     existingWarAttacksUsed: input.existingWarAttacksUsed,
     finalWarAttacksUsed,
-    attackProgressIncreased:
+    exactSameWarAttackProgressIncreased:
+      input.resolutionSource === "canonical_tracked_roster" &&
+      sameWarIdentity &&
       input.attackProgressSource === "exact_war_attacks" &&
       finalWarAttacksUsed > input.existingWarAttacksUsed,
   };
@@ -4212,6 +4225,7 @@ function buildTodoWarOwnerDecision(input: {
         }),
         existingWarAttacksUsed,
         attackProgressSource: input.attackProgressSource,
+        resolutionSource: input.resolutionSource,
         baseDecision: {
           preservationMode: "preserved_existing_verified",
           suppressionReason: "stale",
@@ -4240,6 +4254,7 @@ function buildTodoWarOwnerDecision(input: {
       },
       existingWarAttacksUsed,
       attackProgressSource: input.attackProgressSource,
+      resolutionSource: input.resolutionSource,
       baseDecision: {
         preservationMode: "attempted",
         suppressionReason: null,
@@ -4266,6 +4281,7 @@ function buildTodoWarOwnerDecision(input: {
       }),
       existingWarAttacksUsed,
       attackProgressSource: input.attackProgressSource,
+      resolutionSource: input.resolutionSource,
       baseDecision: {
         preservationMode: "preserved_existing_verified",
         suppressionReason: "stale",
@@ -4286,6 +4302,7 @@ function buildTodoWarOwnerDecision(input: {
       }),
       existingWarAttacksUsed,
       attackProgressSource: input.attackProgressSource,
+      resolutionSource: input.resolutionSource,
       baseDecision: {
         preservationMode: "preserved_existing_verified",
         suppressionReason: "stale",
@@ -4308,6 +4325,7 @@ function buildTodoWarOwnerDecision(input: {
       }),
       existingWarAttacksUsed,
       attackProgressSource: input.attackProgressSource,
+      resolutionSource: input.resolutionSource,
       baseDecision: {
         preservationMode: "attempted",
         suppressionReason: null,
@@ -4333,6 +4351,7 @@ function buildTodoWarOwnerDecision(input: {
         }),
         existingWarAttacksUsed,
         attackProgressSource: input.attackProgressSource,
+        resolutionSource: input.resolutionSource,
         baseDecision: {
           preservationMode: "preserved_existing_verified",
           suppressionReason: "stale",
@@ -4352,6 +4371,7 @@ function buildTodoWarOwnerDecision(input: {
       },
       existingWarAttacksUsed,
       attackProgressSource: input.attackProgressSource,
+      resolutionSource: input.resolutionSource,
       baseDecision: {
         preservationMode: "attempted",
         suppressionReason: null,
@@ -4372,6 +4392,7 @@ function buildTodoWarOwnerDecision(input: {
       }),
       existingWarAttacksUsed,
       attackProgressSource: input.attackProgressSource,
+      resolutionSource: input.resolutionSource,
       baseDecision: {
         preservationMode: "preserved_existing_verified",
         suppressionReason: "stale",
@@ -4396,6 +4417,7 @@ function buildTodoWarOwnerDecision(input: {
       }),
       existingWarAttacksUsed,
       attackProgressSource: input.attackProgressSource,
+      resolutionSource: input.resolutionSource,
       baseDecision: {
         preservationMode: "preserved_existing_verified",
         suppressionReason,
@@ -4416,6 +4438,7 @@ function buildTodoWarOwnerDecision(input: {
       }),
       existingWarAttacksUsed,
       attackProgressSource: input.attackProgressSource,
+      resolutionSource: input.resolutionSource,
       baseDecision: {
         preservationMode: "preserved_existing_bootstrap",
         suppressionReason: "lower_confidence",
@@ -4431,6 +4454,7 @@ function buildTodoWarOwnerDecision(input: {
     finalState: attemptedState,
     existingWarAttacksUsed,
     attackProgressSource: input.attackProgressSource,
+    resolutionSource: input.resolutionSource,
     baseDecision: {
       preservationMode: "attempted",
       suppressionReason: null,

--- a/src/services/TodoSnapshotService.ts
+++ b/src/services/TodoSnapshotService.ts
@@ -307,6 +307,8 @@ type WarOwnerCandidateSource =
 
 type TodoWarOwnerSource = "LIVE_VERIFIED" | "PERSISTED_FALLBACK" | "NONE";
 
+type TodoWarAttackProgressSource = "exact_war_attacks" | "non_exact";
+
 type WarOwnerCandidateEntry = {
   clanTag: string;
   sources: Set<WarOwnerCandidateSource>;
@@ -2720,6 +2722,10 @@ export class TodoSnapshotService {
             warPhase,
             warEndsAt,
           };
+      const attackProgressSource: TodoWarAttackProgressSource =
+        canonicalRosterExactAttackState || trackedWarMemberExactAttackState
+          ? "exact_war_attacks"
+          : "non_exact";
       const warDecision = buildTodoWarOwnerDecision({
         existing: existing ?? null,
         attemptedState: attemptedWarState,
@@ -2730,6 +2736,7 @@ export class TodoSnapshotService {
           : bootstrapLiveVerified
             ? "live_verified"
             : warOwnerResolution.resolvedSource,
+        attackProgressSource,
       });
       const finalWarState = warDecision.finalState;
 
@@ -2823,6 +2830,7 @@ export class TodoSnapshotService {
           attemptedState: attemptedWarState,
           attemptedObservationAt: now,
           resolutionSource: warOwnerResolution.resolvedSource,
+          attackProgressSource,
         },
       });
     }
@@ -3886,6 +3894,7 @@ type TodoSnapshotWriteOperation = {
     attemptedState: TodoWarOwnerSnapshotState;
     attemptedObservationAt: Date;
     resolutionSource: WarOwnerResolutionSource;
+    attackProgressSource: TodoWarAttackProgressSource;
   };
 };
 
@@ -3969,7 +3978,10 @@ function buildTodoWarOwnerCanonicalMergeState(input: {
     warId: number | null;
     verifiedAt: Date | null;
   } | null;
+  attackProgressSource: TodoWarAttackProgressSource;
 }): TodoWarOwnerSnapshotState {
+  const existingWarAttacksUsed = clampInt(input.existing.warAttacksUsed ?? 0, 0, 2);
+  const attemptedWarAttacksUsed = clampInt(input.attemptedState.warAttacksUsed, 0, 2);
   return {
     warClanTag: input.attemptedState.warClanTag,
     warClanName: input.attemptedState.warClanName,
@@ -3979,7 +3991,10 @@ function buildTodoWarOwnerCanonicalMergeState(input: {
     warOwnerWarId: input.attemptedState.warOwnerWarId,
     warOwnerVerifiedAt: input.existingIdentity?.verifiedAt ?? null,
     warActive: Boolean(input.existing.warActive),
-    warAttacksUsed: clampInt(input.existing.warAttacksUsed ?? 0, 0, 2),
+    warAttacksUsed:
+      input.attackProgressSource === "exact_war_attacks"
+        ? Math.max(existingWarAttacksUsed, attemptedWarAttacksUsed)
+        : existingWarAttacksUsed,
     warAttacksMax: clampInt(input.existing.warAttacksMax ?? 2, 0, 2) || 2,
     warPhase: input.existing.warPhase ?? null,
     warEndsAt: input.existing.warEndsAt ?? null,
@@ -4016,6 +4031,7 @@ async function persistTodoSnapshotWrite(input: {
       attemptedObservationAt: input.write.warDecisionInput.attemptedObservationAt,
       currentWarByClanTag: input.currentWarByClanTag,
       resolutionSource: input.write.warDecisionInput.resolutionSource,
+      attackProgressSource: input.write.warDecisionInput.attackProgressSource,
     });
     const guardedUpdate = applyTodoWarOwnerStateToSnapshotData(
       input.write.update,
@@ -4040,6 +4056,7 @@ function buildTodoWarOwnerDecision(input: {
   attemptedObservationAt: Date;
   currentWarByClanTag: Map<string, TodoTrackedCurrentWarRow>;
   resolutionSource: WarOwnerResolutionSource;
+  attackProgressSource: TodoWarAttackProgressSource;
 }): TodoWarOwnerWriteDecision {
   const existing = input.existing ?? null;
   const attemptedState = input.attemptedState;
@@ -4213,6 +4230,7 @@ function buildTodoWarOwnerDecision(input: {
         attemptedState,
         existingConfidence,
         existingIdentity,
+        attackProgressSource: input.attackProgressSource,
       }),
       preservationMode: "attempted",
       suppressionReason: null,

--- a/src/services/TodoSnapshotService.ts
+++ b/src/services/TodoSnapshotService.ts
@@ -1943,9 +1943,11 @@ export class TodoSnapshotService {
     let staleWriteSuppressedCount = 0;
     let verifiedOwnerReplacedCount = 0;
     let verifiedOwnerClearedCount = 0;
+    let exactSameWarAttackProgressCount = 0;
     const warOwnerResolutionAmbiguousSamples: string[] = [];
     const warOwnerResolutionUnresolvedCanonicalSamples: string[] = [];
     const warOwnerResolutionStaleCorrectionSamples: string[] = [];
+    const exactSameWarAttackProgressSamples: string[] = [];
 
     for (const playerTag of normalizedTags) {
       const existing = existingByTag.get(playerTag) ?? null;
@@ -2915,6 +2917,20 @@ export class TodoSnapshotService {
           ) {
             verifiedOwnerClearedCount += 1;
           }
+          if (writeDecision.attackProgressIncreased) {
+            exactSameWarAttackProgressCount += 1;
+            if (exactSameWarAttackProgressSamples.length < 5) {
+              exactSameWarAttackProgressSamples.push(
+                [
+                  `player_tag=${write.where.playerTag}`,
+                  `clan_tag=${writeDecision.finalState.warClanTag ?? "none"}`,
+                  `war_id=${writeDecision.finalState.warOwnerWarId ?? "none"}`,
+                  `previous_attacks_used=${writeDecision.existingWarAttacksUsed}`,
+                  `final_attacks_used=${writeDecision.finalWarAttacksUsed}`,
+                ].join(" "),
+              );
+            }
+          }
         },
       );
     } catch (err) {
@@ -2925,7 +2941,7 @@ export class TodoSnapshotService {
     }
 
     console.info(
-      `[todo-snapshot] event=todo_war_owner_resolution_summary player_count=${warOwnerResolutionPlayerCount} multi_candidate_player_count=${warOwnerResolutionMultiplePersistedCount} live_confirmed_count=${warOwnerResolutionLiveConfirmedCount} verified_continuity_preserved_count=${verifiedContinuityPreservedCount} lower_confidence_write_suppressed_count=${lowerConfidenceWriteSuppressedCount} stale_write_suppressed_count=${staleWriteSuppressedCount} verified_owner_replaced_count=${verifiedOwnerReplacedCount} verified_owner_cleared_count=${verifiedOwnerClearedCount} stale_correction_count=${warOwnerResolutionStaleCorrectionCount} degraded_fallback_count=${warOwnerResolutionDegradedFallbackCount} authoritative_clear_count=${warOwnerResolutionAuthoritativeClearCount} ambiguous_live_match_count=${warOwnerResolutionAmbiguousLiveCount} unresolved_count=${warOwnerResolutionUnresolvedCount} unresolved_canonical_count=${warOwnerResolutionUnresolvedCanonicalCount} tracked_authoritative_count=${trackedRosterAuthoritativeCount} tracked_legacy_fallback_count=${trackedRosterLegacyFallbackCount} tracked_stale_identity_rejected_count=${trackedRosterStaleIdentityRejectedCount} tracked_roster_inactive_rejected_count=${trackedRosterInactiveRejectedCount} tracked_ambiguous_count=${trackedRosterAmbiguousCount} tracked_owner_corrected_count=${trackedRosterOwnerCorrectedCount} tracked_retained_ended_count=${trackedRosterRetainedEndedCount} tracked_roster_canonical_write_count=${trackedRosterCanonicalWriteCount} tracked_roster_canonical_write_suppressed_stale_count=${trackedRosterCanonicalWriteSuppressedStaleCount} tracked_roster_preloaded_live_confirmed_count=${trackedRosterPreloadedLiveConfirmedCount} tracked_roster_preloaded_live_rejected_count=${trackedRosterPreloadedLiveRejectedCount}`,
+      `[todo-snapshot] event=todo_war_owner_resolution_summary player_count=${warOwnerResolutionPlayerCount} multi_candidate_player_count=${warOwnerResolutionMultiplePersistedCount} live_confirmed_count=${warOwnerResolutionLiveConfirmedCount} verified_continuity_preserved_count=${verifiedContinuityPreservedCount} lower_confidence_write_suppressed_count=${lowerConfidenceWriteSuppressedCount} stale_write_suppressed_count=${staleWriteSuppressedCount} verified_owner_replaced_count=${verifiedOwnerReplacedCount} verified_owner_cleared_count=${verifiedOwnerClearedCount} exact_same_war_attack_progress_count=${exactSameWarAttackProgressCount} stale_correction_count=${warOwnerResolutionStaleCorrectionCount} degraded_fallback_count=${warOwnerResolutionDegradedFallbackCount} authoritative_clear_count=${warOwnerResolutionAuthoritativeClearCount} ambiguous_live_match_count=${warOwnerResolutionAmbiguousLiveCount} unresolved_count=${warOwnerResolutionUnresolvedCount} unresolved_canonical_count=${warOwnerResolutionUnresolvedCanonicalCount} tracked_authoritative_count=${trackedRosterAuthoritativeCount} tracked_legacy_fallback_count=${trackedRosterLegacyFallbackCount} tracked_stale_identity_rejected_count=${trackedRosterStaleIdentityRejectedCount} tracked_roster_inactive_rejected_count=${trackedRosterInactiveRejectedCount} tracked_ambiguous_count=${trackedRosterAmbiguousCount} tracked_owner_corrected_count=${trackedRosterOwnerCorrectedCount} tracked_retained_ended_count=${trackedRosterRetainedEndedCount} tracked_roster_canonical_write_count=${trackedRosterCanonicalWriteCount} tracked_roster_canonical_write_suppressed_stale_count=${trackedRosterCanonicalWriteSuppressedStaleCount} tracked_roster_preloaded_live_confirmed_count=${trackedRosterPreloadedLiveConfirmedCount} tracked_roster_preloaded_live_rejected_count=${trackedRosterPreloadedLiveRejectedCount}`,
     );
     if (warOwnerResolutionAmbiguousSamples.length > 0) {
       console.warn(
@@ -2945,6 +2961,11 @@ export class TodoSnapshotService {
     if (trackedRosterCanonicalWriteSuppressedSamples.length > 0) {
       console.warn(
         `[todo-snapshot] event=tracked_roster_canonical_write_suppressed sample_count=${trackedRosterCanonicalWriteSuppressedSamples.length} sample_matches=${trackedRosterCanonicalWriteSuppressedSamples.join("|")}`,
+      );
+    }
+    if (exactSameWarAttackProgressSamples.length > 0) {
+      console.info(
+        `[todo-snapshot] event=todo_war_owner_resolution_exact_same_war_attack_progress sample_count=${exactSameWarAttackProgressSamples.length} sample_matches=${exactSameWarAttackProgressSamples.join("|")}`,
       );
     }
 
@@ -3867,6 +3888,9 @@ type TodoWarOwnerSnapshotState = {
 
 type TodoWarOwnerWriteDecision = {
   finalState: TodoWarOwnerSnapshotState;
+  existingWarAttacksUsed: number;
+  finalWarAttacksUsed: number;
+  attackProgressIncreased: boolean;
   preservationMode:
     | "attempted"
     | "preserved_existing_verified"
@@ -3982,10 +4006,14 @@ function buildTodoWarOwnerCanonicalMergeState(input: {
 }): TodoWarOwnerSnapshotState {
   const existingWarAttacksUsed = clampInt(input.existing.warAttacksUsed ?? 0, 0, 2);
   const attemptedWarAttacksUsed = clampInt(input.attemptedState.warAttacksUsed, 0, 2);
+  const existingWarClanName = sanitizeDisplayText(input.existing.warClanName ?? "") || null;
+  const attemptedWarClanName = sanitizeDisplayText(input.attemptedState.warClanName ?? "") || null;
+  const existingWarPosition = toPositiveWarPosition(input.existing.warPosition ?? null);
+  const attemptedWarPosition = toPositiveWarPosition(input.attemptedState.warPosition ?? null);
   return {
     warClanTag: input.attemptedState.warClanTag,
-    warClanName: input.attemptedState.warClanName,
-    warPosition: input.attemptedState.warPosition,
+    warClanName: attemptedWarClanName ?? existingWarClanName,
+    warPosition: attemptedWarPosition ?? existingWarPosition,
     warSourceUpdatedAt: input.attemptedState.warSourceUpdatedAt,
     warOwnerSource: input.existingConfidence,
     warOwnerWarId: input.attemptedState.warOwnerWarId,
@@ -4013,6 +4041,14 @@ function getTodoWarOwnerFreshnessMs(input: {
     return input.lastUpdatedAt.getTime();
   }
   return null;
+}
+
+function toPositiveWarPosition(input: unknown): number | null {
+  const value = toFiniteIntOrNull(input);
+  if (value === null || value <= 0) {
+    return null;
+  }
+  return value;
 }
 
 async function persistTodoSnapshotWrite(input: {
@@ -4050,6 +4086,27 @@ async function persistTodoSnapshotWrite(input: {
   });
 }
 
+function finalizeTodoWarOwnerDecision(input: {
+  finalState: TodoWarOwnerSnapshotState;
+  existingWarAttacksUsed: number;
+  attackProgressSource: TodoWarAttackProgressSource;
+  baseDecision: Omit<
+    TodoWarOwnerWriteDecision,
+    "finalState" | "existingWarAttacksUsed" | "finalWarAttacksUsed" | "attackProgressIncreased"
+  >;
+}): TodoWarOwnerWriteDecision {
+  const finalWarAttacksUsed = clampInt(input.finalState.warAttacksUsed ?? 0, 0, 2);
+  return {
+    ...input.baseDecision,
+    finalState: input.finalState,
+    existingWarAttacksUsed: input.existingWarAttacksUsed,
+    finalWarAttacksUsed,
+    attackProgressIncreased:
+      input.attackProgressSource === "exact_war_attacks" &&
+      finalWarAttacksUsed > input.existingWarAttacksUsed,
+  };
+}
+
 function buildTodoWarOwnerDecision(input: {
   existing: TodoSnapshotRecord | null;
   attemptedState: TodoWarOwnerSnapshotState;
@@ -4076,6 +4133,7 @@ function buildTodoWarOwnerDecision(input: {
     : null;
   const existingFreshnessMs = getTodoWarOwnerFreshnessMs(existing);
   const attemptedFreshnessMs = input.attemptedObservationAt.getTime();
+  const existingWarAttacksUsed = clampInt(existing?.warAttacksUsed ?? 0, 0, 2);
 
   const existingWarClanTag = normalizeClanTag(existing?.warClanTag ?? "");
   const existingCurrentWar = existingWarClanTag
@@ -4146,22 +4204,26 @@ function buildTodoWarOwnerDecision(input: {
 
   if (input.resolutionSource === "authoritative_clear") {
     if (existing && existingFreshnessMs !== null && attemptedFreshnessMs < existingFreshnessMs) {
-      return {
+      return finalizeTodoWarOwnerDecision({
         finalState: buildTodoWarOwnerPreservedState({
           existing,
           existingConfidence,
           existingIdentity,
         }),
-        preservationMode: "preserved_existing_verified",
-        suppressionReason: "stale",
-        existingConfidence,
-        attemptedConfidence,
-        existingWarIdentity: existingIdentity,
-        attemptedWarIdentity: attemptedIdentity,
-      };
+        existingWarAttacksUsed,
+        attackProgressSource: input.attackProgressSource,
+        baseDecision: {
+          preservationMode: "preserved_existing_verified",
+          suppressionReason: "stale",
+          existingConfidence,
+          attemptedConfidence,
+          existingWarIdentity: existingIdentity,
+          attemptedWarIdentity: attemptedIdentity,
+        },
+      });
     }
 
-    return {
+    return finalizeTodoWarOwnerDecision({
       finalState: {
         warClanTag: null,
         warClanName: null,
@@ -4176,13 +4238,17 @@ function buildTodoWarOwnerDecision(input: {
         warPhase: null,
         warEndsAt: null,
       },
-      preservationMode: "attempted",
-      suppressionReason: null,
-      existingConfidence,
-      attemptedConfidence,
-      existingWarIdentity: existingIdentity,
-      attemptedWarIdentity: attemptedIdentity,
-    };
+      existingWarAttacksUsed,
+      attackProgressSource: input.attackProgressSource,
+      baseDecision: {
+        preservationMode: "attempted",
+        suppressionReason: null,
+        existingConfidence,
+        attemptedConfidence,
+        existingWarIdentity: existingIdentity,
+        attemptedWarIdentity: attemptedIdentity,
+      },
+    });
   }
 
   if (
@@ -4192,39 +4258,47 @@ function buildTodoWarOwnerDecision(input: {
     (existingFreshnessMs === null || attemptedFreshnessMs < existingFreshnessMs) &&
     existing
   ) {
-    return {
+    return finalizeTodoWarOwnerDecision({
       finalState: buildTodoWarOwnerPreservedState({
         existing,
         existingConfidence,
         existingIdentity,
       }),
-      preservationMode: "preserved_existing_verified",
-      suppressionReason: "stale",
-      existingConfidence,
-      attemptedConfidence,
-      existingWarIdentity: existingIdentity,
-      attemptedWarIdentity: attemptedIdentity,
-    };
+      existingWarAttacksUsed,
+      attackProgressSource: input.attackProgressSource,
+      baseDecision: {
+        preservationMode: "preserved_existing_verified",
+        suppressionReason: "stale",
+        existingConfidence,
+        attemptedConfidence,
+        existingWarIdentity: existingIdentity,
+        attemptedWarIdentity: attemptedIdentity,
+      },
+    });
   }
 
   if (canonicalAttemptIsStale && existing) {
-    return {
+    return finalizeTodoWarOwnerDecision({
       finalState: buildTodoWarOwnerPreservedState({
         existing,
         existingConfidence,
         existingIdentity,
       }),
-      preservationMode: "preserved_existing_verified",
-      suppressionReason: "stale",
-      existingConfidence,
-      attemptedConfidence,
-      existingWarIdentity: existingIdentity,
-      attemptedWarIdentity: attemptedIdentity,
-    };
+      existingWarAttacksUsed,
+      attackProgressSource: input.attackProgressSource,
+      baseDecision: {
+        preservationMode: "preserved_existing_verified",
+        suppressionReason: "stale",
+        existingConfidence,
+        attemptedConfidence,
+        existingWarIdentity: existingIdentity,
+        attemptedWarIdentity: attemptedIdentity,
+      },
+    });
   }
 
   if (canonicalAttemptIsSameIdentity && existing) {
-    return {
+    return finalizeTodoWarOwnerDecision({
       finalState: buildTodoWarOwnerCanonicalMergeState({
         existing,
         attemptedState,
@@ -4232,13 +4306,17 @@ function buildTodoWarOwnerDecision(input: {
         existingIdentity,
         attackProgressSource: input.attackProgressSource,
       }),
-      preservationMode: "attempted",
-      suppressionReason: null,
-      existingConfidence,
-      attemptedConfidence,
-      existingWarIdentity: existingIdentity,
-      attemptedWarIdentity: attemptedIdentity,
-    };
+      existingWarAttacksUsed,
+      attackProgressSource: input.attackProgressSource,
+      baseDecision: {
+        preservationMode: "attempted",
+        suppressionReason: null,
+        existingConfidence,
+        attemptedConfidence,
+        existingWarIdentity: existingIdentity,
+        attemptedWarIdentity: attemptedIdentity,
+      },
+    });
   }
 
   if (canonicalAttemptIsDifferentIdentity && existing) {
@@ -4247,50 +4325,62 @@ function buildTodoWarOwnerDecision(input: {
       existingFreshnessMs !== null &&
       attemptedFreshnessMs < existingFreshnessMs
     ) {
-      return {
+      return finalizeTodoWarOwnerDecision({
         finalState: buildTodoWarOwnerPreservedState({
           existing,
           existingConfidence,
           existingIdentity,
         }),
+        existingWarAttacksUsed,
+        attackProgressSource: input.attackProgressSource,
+        baseDecision: {
+          preservationMode: "preserved_existing_verified",
+          suppressionReason: "stale",
+          existingConfidence,
+          attemptedConfidence,
+          existingWarIdentity: existingIdentity,
+          attemptedWarIdentity: attemptedIdentity,
+        },
+      });
+    }
+
+    return finalizeTodoWarOwnerDecision({
+      finalState: {
+        ...attemptedState,
+        warOwnerSource: "PERSISTED_FALLBACK",
+        warOwnerVerifiedAt: null,
+      },
+      existingWarAttacksUsed,
+      attackProgressSource: input.attackProgressSource,
+      baseDecision: {
+        preservationMode: "attempted",
+        suppressionReason: null,
+        existingConfidence,
+        attemptedConfidence,
+        existingWarIdentity: existingIdentity,
+        attemptedWarIdentity: attemptedIdentity,
+      },
+    });
+  }
+
+  if (existingVerifiedStaleLowerConfidence && existing) {
+    return finalizeTodoWarOwnerDecision({
+      finalState: buildTodoWarOwnerPreservedState({
+        existing,
+        existingConfidence,
+        existingIdentity,
+      }),
+      existingWarAttacksUsed,
+      attackProgressSource: input.attackProgressSource,
+      baseDecision: {
         preservationMode: "preserved_existing_verified",
         suppressionReason: "stale",
         existingConfidence,
         attemptedConfidence,
         existingWarIdentity: existingIdentity,
         attemptedWarIdentity: attemptedIdentity,
-      };
-    }
-
-    return {
-      finalState: {
-        ...attemptedState,
-        warOwnerSource: "PERSISTED_FALLBACK",
-        warOwnerVerifiedAt: null,
       },
-      preservationMode: "attempted",
-      suppressionReason: null,
-      existingConfidence,
-      attemptedConfidence,
-      existingWarIdentity: existingIdentity,
-      attemptedWarIdentity: attemptedIdentity,
-    };
-  }
-
-  if (existingVerifiedStaleLowerConfidence && existing) {
-    return {
-      finalState: buildTodoWarOwnerPreservedState({
-        existing,
-        existingConfidence,
-        existingIdentity,
-      }),
-      preservationMode: "preserved_existing_verified",
-      suppressionReason: "stale",
-      existingConfidence,
-      attemptedConfidence,
-      existingWarIdentity: existingIdentity,
-      attemptedWarIdentity: attemptedIdentity,
-    };
+    });
   }
 
   if (existingVerifiedContinuity && attemptedConfidence !== "LIVE_VERIFIED" && existing) {
@@ -4298,46 +4388,58 @@ function buildTodoWarOwnerDecision(input: {
       existing.lastUpdatedAt.getTime() > input.attemptedObservationAt.getTime()
         ? "stale"
         : "lower_confidence";
-    return {
+    return finalizeTodoWarOwnerDecision({
       finalState: buildTodoWarOwnerPreservedState({
         existing,
         existingConfidence,
         existingIdentity,
       }),
-      preservationMode: "preserved_existing_verified",
-      suppressionReason,
-      existingConfidence,
-      attemptedConfidence,
-      existingWarIdentity: existingIdentity,
-      attemptedWarIdentity: attemptedIdentity,
-    };
+      existingWarAttacksUsed,
+      attackProgressSource: input.attackProgressSource,
+      baseDecision: {
+        preservationMode: "preserved_existing_verified",
+        suppressionReason,
+        existingConfidence,
+        attemptedConfidence,
+        existingWarIdentity: existingIdentity,
+        attemptedWarIdentity: attemptedIdentity,
+      },
+    });
   }
 
   if (existingBootstrapProtectedFallback) {
-    return {
+    return finalizeTodoWarOwnerDecision({
       finalState: buildTodoWarOwnerPreservedState({
         existing,
         existingConfidence,
         existingIdentity,
       }),
-      preservationMode: "preserved_existing_bootstrap",
-      suppressionReason: "lower_confidence",
+      existingWarAttacksUsed,
+      attackProgressSource: input.attackProgressSource,
+      baseDecision: {
+        preservationMode: "preserved_existing_bootstrap",
+        suppressionReason: "lower_confidence",
+        existingConfidence,
+        attemptedConfidence,
+        existingWarIdentity: existingIdentity,
+        attemptedWarIdentity: attemptedIdentity,
+      },
+    });
+  }
+
+  return finalizeTodoWarOwnerDecision({
+    finalState: attemptedState,
+    existingWarAttacksUsed,
+    attackProgressSource: input.attackProgressSource,
+    baseDecision: {
+      preservationMode: "attempted",
+      suppressionReason: null,
       existingConfidence,
       attemptedConfidence,
       existingWarIdentity: existingIdentity,
       attemptedWarIdentity: attemptedIdentity,
-    };
-  }
-
-  return {
-    finalState: attemptedState,
-    preservationMode: "attempted",
-    suppressionReason: null,
-    existingConfidence,
-    attemptedConfidence,
-    existingWarIdentity: existingIdentity,
-    attemptedWarIdentity: attemptedIdentity,
-  };
+    },
+  });
 }
 
 /** Purpose: build a consistent unresolved WAR owner result for guarded fallbacks. */

--- a/tests/todoSnapshot.service.test.ts
+++ b/tests/todoSnapshot.service.test.ts
@@ -5877,7 +5877,7 @@ describe("TodoSnapshotService", () => {
     );
   });
 
-  it("retains a live-verified retained-ended snapshot at 0/2 when the canonical same-war merge runs", async () => {
+  it("advances a live-verified retained-ended snapshot to 2/2 when the canonical same-war merge sees exact WarAttacks", async () => {
     const twcClanTag = "#29PCQGUV0";
     const playerTag = "#PYLQ0289";
     const verifiedAt = new Date("2026-03-26T00:02:00.000Z");
@@ -5994,7 +5994,7 @@ describe("TodoSnapshotService", () => {
       warOwnerWarId: 1002,
       warOwnerVerifiedAt: verifiedAt,
       warActive: true,
-      warAttacksUsed: 0,
+      warAttacksUsed: 2,
       warPhase: "battle day",
       warEndsAt,
       warSourceUpdatedAt: attemptedAt,

--- a/tests/todoSnapshot.service.test.ts
+++ b/tests/todoSnapshot.service.test.ts
@@ -2644,6 +2644,7 @@ describe("TodoSnapshotService", () => {
     prismaMock.cwlRoundMemberHistory.findMany.mockResolvedValue([]);
     prismaMock.cwlPlayerClanSeason.findMany.mockResolvedValue([]);
     prismaMock.botSetting.findMany.mockResolvedValue([]);
+    const consoleInfoSpy = vi.spyOn(console, "info").mockImplementation(() => undefined);
     const cocService = {
       getPlayerRaw: vi.fn().mockResolvedValue(null),
       getCurrentWar: vi.fn().mockResolvedValue(null),
@@ -6023,23 +6024,35 @@ describe("TodoSnapshotService", () => {
       warMemberAttacksUsed?: number | null;
       warAttacksRows?: Array<Record<string, unknown>>;
       txExistingWarAttacksUsedOverride?: number;
+      clanTag?: string;
+      playerTag?: string;
+      playerName?: string;
+      existingClanTag?: string;
+      attemptedClanTag?: string;
+      existingWarId?: number;
+      attemptedWarId?: number;
+      includeExistingSnapshot?: boolean;
     }): Promise<Record<string, unknown>> {
-      const twcClanTag = "#29PCQGUV0";
-      const playerTag = "#PYLQ0289";
+      const clanTag = input.clanTag ?? "#29PCQGUV0";
+      const playerTag = input.playerTag ?? "#PYLQ0289";
+      const playerName = input.playerName ?? "Party Blizzard";
+      const existingClanTag = input.existingClanTag ?? clanTag;
+      const attemptedClanTag = input.attemptedClanTag ?? clanTag;
+      const existingWarId = input.existingWarId ?? 1002;
+      const attemptedWarId = input.attemptedWarId ?? existingWarId;
       const verifiedAt = new Date("2026-03-26T00:02:00.000Z");
       const attemptedAt = new Date("2026-03-26T12:06:00.000Z");
       const warEndsAt = new Date("2026-03-26T12:00:00.000Z");
-      const warId = 1002;
       const existingRow = buildSnapshotRow({
         playerTag,
-        playerName: "Party Blizzard",
-        clanTag: twcClanTag,
-        clanName: "TheWiseCowboys",
+        playerName,
+        clanTag: existingClanTag,
+        clanName: input.trackedClanName ?? "TheWiseCowboys",
         warActive: true,
-        warClanTag: twcClanTag,
-        warClanName: input.existingWarClanName ?? "TheWiseCowboys",
+        warClanTag: existingClanTag,
+        warClanName: input.existingWarClanName ?? (input.trackedClanName ?? "TheWiseCowboys"),
         warOwnerSource: "LIVE_VERIFIED",
-        warOwnerWarId: warId,
+        warOwnerWarId: existingWarId,
         warOwnerVerifiedAt: verifiedAt,
         warPosition: input.existingWarPosition ?? 8,
         warAttacksUsed: input.existingWarAttacksUsed,
@@ -6050,7 +6063,8 @@ describe("TodoSnapshotService", () => {
         lastUpdatedAt: verifiedAt,
         updatedAt: verifiedAt,
       });
-      const snapshotRows: Record<string, unknown>[] = [existingRow];
+      const snapshotRows: Record<string, unknown>[] =
+        input.includeExistingSnapshot === false ? [] : [existingRow];
       installMutableTodoSnapshotStore(snapshotRows);
       if (input.txExistingWarAttacksUsedOverride !== undefined) {
         txMock.todoPlayerSnapshot.findUnique.mockResolvedValue({
@@ -6063,8 +6077,8 @@ describe("TodoSnapshotService", () => {
       prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue([
         {
           playerTag,
-          clanTag: twcClanTag,
-          playerName: "Party Blizzard",
+          clanTag: attemptedClanTag,
+          playerName,
           sourceSyncedAt: verifiedAt,
         },
       ]);
@@ -6074,7 +6088,7 @@ describe("TodoSnapshotService", () => {
           : [
               {
                 playerTag,
-                clanTag: twcClanTag,
+                clanTag: attemptedClanTag,
                 position: input.attemptedWarPosition ?? 8,
                 attacks: input.warMemberAttacksUsed,
                 sourceSyncedAt: attemptedAt,
@@ -6083,8 +6097,8 @@ describe("TodoSnapshotService", () => {
       );
       prismaMock.fwaTrackedClanWarRosterCurrent.findMany.mockResolvedValue([
         {
-          clanTag: twcClanTag,
-          sourceWarId: warId,
+          clanTag: attemptedClanTag,
+          sourceWarId: attemptedWarId,
           sourceWarStartTime: new Date("2026-03-25T12:00:00.000Z"),
           sourceWarEndTime: warEndsAt,
           sourceWarState: "notInWar",
@@ -6093,17 +6107,17 @@ describe("TodoSnapshotService", () => {
       ]);
       prismaMock.fwaTrackedClanWarRosterMemberCurrent.findMany.mockResolvedValue([
         {
-          clanTag: twcClanTag,
+          clanTag: attemptedClanTag,
           playerTag,
           position: input.attemptedWarPosition ?? 8,
-          playerName: "Party Blizzard",
+          playerName,
           townHall: 15,
         },
       ]);
       prismaMock.currentWar.findMany.mockResolvedValue([
         {
-          clanTag: twcClanTag,
-          warId,
+          clanTag: attemptedClanTag,
+          warId: attemptedWarId,
           state: "notInWar",
           startTime: new Date("2026-03-25T12:00:00.000Z"),
           endTime: warEndsAt,
@@ -6113,8 +6127,8 @@ describe("TodoSnapshotService", () => {
       prismaMock.warAttacks.findMany.mockResolvedValue(
         input.warAttacksRows ?? [
           {
-            warId,
-            clanTag: twcClanTag,
+            warId: attemptedWarId,
+            clanTag: attemptedClanTag,
             warStartTime: new Date("2026-03-25T12:00:00.000Z"),
             playerTag,
             playerPosition: input.attemptedWarPosition ?? 8,
@@ -6129,7 +6143,7 @@ describe("TodoSnapshotService", () => {
       );
       prismaMock.trackedClan.findMany.mockResolvedValue([
         {
-          tag: twcClanTag,
+          tag: attemptedClanTag,
           name: input.trackedClanName === undefined ? "TheWiseCowboys" : input.trackedClanName,
         },
       ]);
@@ -6153,6 +6167,52 @@ describe("TodoSnapshotService", () => {
 
       expect(cocService.getCurrentWar).not.toHaveBeenCalled();
       return getTodoSnapshotUpsertUpdateForPlayer(playerTag);
+    }
+
+    async function captureRetainedEndedExactSameWarTelemetrySnapshot(input: {
+      existingWarAttacksUsed: number;
+      attemptedWarAttacksUsed: number;
+      existingWarClanName?: string | null;
+      attemptedWarClanName?: string | null;
+      existingWarPosition?: number | null;
+      attemptedWarPosition?: number | null;
+      trackedClanName?: string | null;
+      warMemberAttacksUsed?: number | null;
+      warAttacksRows?: Array<Record<string, unknown>>;
+      txExistingWarAttacksUsedOverride?: number;
+      clanTag?: string;
+      playerTag?: string;
+      playerName?: string;
+      existingClanTag?: string;
+      attemptedClanTag?: string;
+      existingWarId?: number;
+      attemptedWarId?: number;
+      includeExistingSnapshot?: boolean;
+    }): Promise<{
+      update: Record<string, unknown>;
+      summaryLine: string;
+      sampleLine: string | null;
+      messages: string[];
+    }> {
+      const consoleInfoSpy = vi.spyOn(console, "info").mockImplementation(() => undefined);
+      try {
+        const update = await refreshRetainedEndedExactSameWarSnapshot(input);
+        const messages = getConsoleMessages(consoleInfoSpy);
+        const summaryLine = getSingleConsoleMessage(consoleInfoSpy, (message) =>
+          message.includes("event=todo_war_owner_resolution_summary"),
+        );
+        const sampleMessages = messages.filter((message) =>
+          message.includes("event=todo_war_owner_resolution_exact_same_war_attack_progress"),
+        );
+        return {
+          update,
+          summaryLine,
+          sampleLine: sampleMessages[0] ?? null,
+          messages,
+        };
+      } finally {
+        consoleInfoSpy.mockRestore();
+      }
     }
 
     it.each([
@@ -6263,19 +6323,15 @@ describe("TodoSnapshotService", () => {
       });
     });
 
-    it("reports bounded exact same-war healing samples in the summary", async () => {
+    it("reports bounded canonical exact same-war healing samples in the summary", async () => {
       const warEndsAt = new Date("2026-03-26T12:00:00.000Z");
       const attemptedAt = new Date("2026-03-26T12:06:00.000Z");
       const verifiedAt = new Date("2026-03-26T00:02:00.000Z");
-      const exactCases = [
-        { clanTag: "#29PCQGUV0", warId: 1002 },
-        { clanTag: "#2RYGLU2UY", warId: 1003 },
-        { clanTag: "#QGRJ2222", warId: 1004 },
-        { clanTag: "#LQQ99UV8", warId: 1005 },
-        { clanTag: "#2QG2C08UP", warId: 1006 },
-        { clanTag: "#VUVU2222", warId: 1007 },
-      ].map((entry, index) => ({
-        ...entry,
+      const clanTag = "#29PCQGUV0";
+      const warId = 1002;
+      const exactCases = Array.from({ length: 6 }, (_, index) => ({
+        clanTag,
+        warId,
         playerTag: buildValidPlayerTag(index),
         playerName: `Player ${index + 1}`,
         position: index + 1,
@@ -6285,10 +6341,10 @@ describe("TodoSnapshotService", () => {
           playerTag: entry.playerTag,
           playerName: entry.playerName,
           clanTag: entry.clanTag,
-          clanName: entry.clanTag === "#29PCQGUV0" ? "TheWiseCowboys" : `Clan ${entry.position}`,
+          clanName: "TheWiseCowboys",
           warActive: true,
           warClanTag: entry.clanTag,
-          warClanName: entry.clanTag === "#29PCQGUV0" ? "TheWiseCowboys" : `Clan ${entry.position}`,
+          warClanName: "TheWiseCowboys",
           warOwnerSource: "LIVE_VERIFIED",
           warOwnerWarId: entry.warId,
           warOwnerVerifiedAt: verifiedAt,
@@ -6315,14 +6371,16 @@ describe("TodoSnapshotService", () => {
       );
       prismaMock.fwaWarMemberCurrent.findMany.mockResolvedValue([]);
       prismaMock.fwaTrackedClanWarRosterCurrent.findMany.mockResolvedValue(
-        exactCases.map((entry) => ({
-          clanTag: entry.clanTag,
-          sourceWarId: entry.warId,
-          sourceWarStartTime: new Date("2026-03-25T12:00:00.000Z"),
-          sourceWarEndTime: warEndsAt,
-          sourceWarState: "notInWar",
-          sourceCurrentWarUpdatedAt: attemptedAt,
-        })),
+        [
+          {
+            clanTag,
+            sourceWarId: warId,
+            sourceWarStartTime: new Date("2026-03-25T12:00:00.000Z"),
+            sourceWarEndTime: warEndsAt,
+            sourceWarState: "notInWar",
+            sourceCurrentWarUpdatedAt: attemptedAt,
+          },
+        ],
       );
       prismaMock.fwaTrackedClanWarRosterMemberCurrent.findMany.mockResolvedValue(
         exactCases.map((entry) => ({
@@ -6334,14 +6392,16 @@ describe("TodoSnapshotService", () => {
         })),
       );
       prismaMock.currentWar.findMany.mockResolvedValue(
-        exactCases.map((entry) => ({
-          clanTag: entry.clanTag,
-          warId: entry.warId,
-          state: "notInWar",
-          startTime: new Date("2026-03-25T12:00:00.000Z"),
-          endTime: warEndsAt,
-          updatedAt: attemptedAt,
-        })),
+        [
+          {
+            clanTag,
+            warId,
+            state: "notInWar",
+            startTime: new Date("2026-03-25T12:00:00.000Z"),
+            endTime: warEndsAt,
+            updatedAt: attemptedAt,
+          },
+        ],
       );
       prismaMock.warAttacks.findMany.mockResolvedValue(
         exactCases.map((entry) => ({
@@ -6359,10 +6419,7 @@ describe("TodoSnapshotService", () => {
         })),
       );
       prismaMock.trackedClan.findMany.mockResolvedValue(
-        exactCases.map((entry, index) => ({
-          tag: entry.clanTag,
-          name: index === 0 ? "TheWiseCowboys" : `Clan ${index + 1}`,
-        })),
+        [{ tag: clanTag, name: "TheWiseCowboys" }],
       );
       prismaMock.raidTrackedClan.findMany.mockResolvedValue([]);
       prismaMock.cwlTrackedClan.findMany.mockResolvedValue([]);
@@ -6371,12 +6428,12 @@ describe("TodoSnapshotService", () => {
       prismaMock.cwlRoundMemberHistory.findMany.mockResolvedValue([]);
       prismaMock.cwlPlayerClanSeason.findMany.mockResolvedValue([]);
       prismaMock.botSetting.findMany.mockResolvedValue([]);
-      const consoleInfoSpy = vi.spyOn(console, "info").mockImplementation(() => undefined);
       const cocService = {
         getPlayerRaw: vi.fn().mockResolvedValue(null),
         getCurrentWar: vi.fn().mockResolvedValue(null),
       };
 
+      const consoleInfoSpy = vi.spyOn(console, "info").mockImplementation(() => undefined);
       await todoSnapshotService.refreshSnapshotsForPlayerTags({
         playerTags: exactCases.map((entry) => entry.playerTag),
         cocService: cocService as any,
@@ -6391,13 +6448,70 @@ describe("TodoSnapshotService", () => {
       );
       const exactCountMatch = summaryLine.match(/exact_same_war_attack_progress_count=(\d+)/);
       expect(exactCountMatch).not.toBeNull();
-      expect(Number(exactCountMatch?.[1] ?? -1)).toBeGreaterThanOrEqual(5);
+      expect(Number(exactCountMatch?.[1] ?? -1)).toBe(6);
       expect(sampleLine).toContain("sample_count=5");
       expect(sampleLine.match(/player_tag=/g)).toHaveLength(5);
       expect(sampleLine).toContain("previous_attacks_used=0");
       expect(sampleLine).toContain("final_attacks_used=2");
       expect(cocService.getCurrentWar).not.toHaveBeenCalled();
       consoleInfoSpy.mockRestore();
+    });
+
+    it.each([
+      {
+        label: "canonical same-war exact 0 to 2 increments the count",
+        existingWarAttacksUsed: 0,
+        attemptedWarAttacksUsed: 2,
+        expectedCount: 1,
+      },
+      {
+        label: "canonical same-war exact 1 to 2 increments the count",
+        existingWarAttacksUsed: 1,
+        attemptedWarAttacksUsed: 2,
+        expectedCount: 1,
+      },
+      {
+        label: "canonical same-war exact 2 to 1 does not increment the count",
+        existingWarAttacksUsed: 2,
+        attemptedWarAttacksUsed: 1,
+        expectedCount: 0,
+      },
+      {
+        label: "different war ID with exact WarAttacks does not increment the count",
+        existingWarAttacksUsed: 1,
+        attemptedWarAttacksUsed: 2,
+        attemptedWarId: 1003,
+        expectedCount: 0,
+      },
+      {
+        label: "different clan with exact WarAttacks does not increment the count",
+        existingWarAttacksUsed: 1,
+        attemptedWarAttacksUsed: 2,
+        existingClanTag: "#29PCQGUV0",
+        attemptedClanTag: "#2RYGLU2UY",
+        trackedClanName: "Other Clan",
+        expectedCount: 0,
+      },
+      {
+        label: "a newly created exact snapshot does not increment the count",
+        existingWarAttacksUsed: 0,
+        attemptedWarAttacksUsed: 2,
+        includeExistingSnapshot: false,
+        expectedCount: 0,
+      },
+    ])("$label", async ({ expectedCount, ...input }) => {
+      const result = await captureRetainedEndedExactSameWarTelemetrySnapshot(input as any);
+      const exactCountMatch = result.summaryLine.match(/exact_same_war_attack_progress_count=(\d+)/);
+      expect(exactCountMatch).not.toBeNull();
+      expect(Number(exactCountMatch?.[1] ?? -1)).toBe(expectedCount);
+
+      if (expectedCount > 0) {
+        expect(result.sampleLine).toContain("sample_count=1");
+        expect(result.sampleLine).toContain(`previous_attacks_used=${input.existingWarAttacksUsed}`);
+        expect(result.sampleLine).toContain(`final_attacks_used=${input.attemptedWarAttacksUsed}`);
+      } else {
+        expect(result.sampleLine).toBeNull();
+      }
     });
 
     it("bases exact healing counts on the final transaction decision instead of the pre-transaction snapshot", async () => {
@@ -6607,6 +6721,7 @@ describe("TodoSnapshotService", () => {
     prismaMock.cwlRoundMemberHistory.findMany.mockResolvedValue([]);
     prismaMock.cwlPlayerClanSeason.findMany.mockResolvedValue([]);
     prismaMock.botSetting.findMany.mockResolvedValue([]);
+    const consoleInfoSpy = vi.spyOn(console, "info").mockImplementation(() => undefined);
     const cocService = {
       getPlayerRaw: vi.fn().mockResolvedValue(null),
       getCurrentWar: vi.fn().mockResolvedValue(null),
@@ -6618,6 +6733,15 @@ describe("TodoSnapshotService", () => {
       nowMs: Date.UTC(2026, 2, 26, 0, 0, 30, 0),
     });
 
+    const summaryLine = getSingleConsoleMessage(consoleInfoSpy, (message) =>
+      message.includes("event=todo_war_owner_resolution_summary"),
+    );
+    expect(summaryLine).toContain("exact_same_war_attack_progress_count=0");
+    expect(
+      getConsoleMessages(consoleInfoSpy).some((message) =>
+        message.includes("event=todo_war_owner_resolution_exact_same_war_attack_progress"),
+      ),
+    ).toBe(false);
     expect(cocService.getCurrentWar).not.toHaveBeenCalled();
     expect(prismaMock.todoPlayerSnapshot.upsert).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -6638,6 +6762,7 @@ describe("TodoSnapshotService", () => {
         }),
       }),
     );
+    consoleInfoSpy.mockRestore();
   });
 
   it("authoritatively clears a verified Rocky Road WAR owner when the live lineup excludes the player", async () => {

--- a/tests/todoSnapshot.service.test.ts
+++ b/tests/todoSnapshot.service.test.ts
@@ -2644,7 +2644,6 @@ describe("TodoSnapshotService", () => {
     prismaMock.cwlRoundMemberHistory.findMany.mockResolvedValue([]);
     prismaMock.cwlPlayerClanSeason.findMany.mockResolvedValue([]);
     prismaMock.botSetting.findMany.mockResolvedValue([]);
-    const consoleInfoSpy = vi.spyOn(console, "info").mockImplementation(() => undefined);
     const cocService = {
       getPlayerRaw: vi.fn().mockResolvedValue(null),
       getCurrentWar: vi.fn().mockResolvedValue(null),

--- a/tests/todoSnapshot.service.test.ts
+++ b/tests/todoSnapshot.service.test.ts
@@ -5881,7 +5881,7 @@ describe("TodoSnapshotService", () => {
     const twcClanTag = "#29PCQGUV0";
     const playerTag = "#PYLQ0289";
     const verifiedAt = new Date("2026-03-26T00:02:00.000Z");
-    const attemptedAt = new Date("2026-03-26T00:06:00.000Z");
+    const attemptedAt = new Date("2026-03-26T12:06:00.000Z");
     const warEndsAt = new Date("2026-03-26T12:00:00.000Z");
 
     const snapshotRows: Record<string, unknown>[] = [
@@ -6009,6 +6009,518 @@ describe("TodoSnapshotService", () => {
         },
       }),
     );
+  });
+
+  describe("retained-ended exact same-war reconciliation", () => {
+    async function refreshRetainedEndedExactSameWarSnapshot(input: {
+      existingWarAttacksUsed: number;
+      attemptedWarAttacksUsed: number;
+      existingWarClanName?: string | null;
+      attemptedWarClanName?: string | null;
+      existingWarPosition?: number | null;
+      attemptedWarPosition?: number | null;
+      trackedClanName?: string | null;
+      warMemberAttacksUsed?: number | null;
+      warAttacksRows?: Array<Record<string, unknown>>;
+      txExistingWarAttacksUsedOverride?: number;
+    }): Promise<Record<string, unknown>> {
+      const twcClanTag = "#29PCQGUV0";
+      const playerTag = "#PYLQ0289";
+      const verifiedAt = new Date("2026-03-26T00:02:00.000Z");
+      const attemptedAt = new Date("2026-03-26T12:06:00.000Z");
+      const warEndsAt = new Date("2026-03-26T12:00:00.000Z");
+      const warId = 1002;
+      const existingRow = buildSnapshotRow({
+        playerTag,
+        playerName: "Party Blizzard",
+        clanTag: twcClanTag,
+        clanName: "TheWiseCowboys",
+        warActive: true,
+        warClanTag: twcClanTag,
+        warClanName: input.existingWarClanName ?? "TheWiseCowboys",
+        warOwnerSource: "LIVE_VERIFIED",
+        warOwnerWarId: warId,
+        warOwnerVerifiedAt: verifiedAt,
+        warPosition: input.existingWarPosition ?? 8,
+        warAttacksUsed: input.existingWarAttacksUsed,
+        warPhase: "battle day",
+        warEndsAt,
+        warSourceUpdatedAt: verifiedAt,
+        clanMembershipObservedAt: verifiedAt,
+        lastUpdatedAt: verifiedAt,
+        updatedAt: verifiedAt,
+      });
+      const snapshotRows: Record<string, unknown>[] = [existingRow];
+      installMutableTodoSnapshotStore(snapshotRows);
+      if (input.txExistingWarAttacksUsedOverride !== undefined) {
+        txMock.todoPlayerSnapshot.findUnique.mockResolvedValue({
+          ...existingRow,
+          warAttacksUsed: input.txExistingWarAttacksUsedOverride,
+        });
+      }
+
+      prismaMock.playerCurrent.findMany.mockResolvedValue([]);
+      prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue([
+        {
+          playerTag,
+          clanTag: twcClanTag,
+          playerName: "Party Blizzard",
+          sourceSyncedAt: verifiedAt,
+        },
+      ]);
+      prismaMock.fwaWarMemberCurrent.findMany.mockResolvedValue(
+        input.warMemberAttacksUsed === undefined
+          ? []
+          : [
+              {
+                playerTag,
+                clanTag: twcClanTag,
+                position: input.attemptedWarPosition ?? 8,
+                attacks: input.warMemberAttacksUsed,
+                sourceSyncedAt: attemptedAt,
+              },
+            ],
+      );
+      prismaMock.fwaTrackedClanWarRosterCurrent.findMany.mockResolvedValue([
+        {
+          clanTag: twcClanTag,
+          sourceWarId: warId,
+          sourceWarStartTime: new Date("2026-03-25T12:00:00.000Z"),
+          sourceWarEndTime: warEndsAt,
+          sourceWarState: "notInWar",
+          sourceCurrentWarUpdatedAt: attemptedAt,
+        },
+      ]);
+      prismaMock.fwaTrackedClanWarRosterMemberCurrent.findMany.mockResolvedValue([
+        {
+          clanTag: twcClanTag,
+          playerTag,
+          position: input.attemptedWarPosition ?? 8,
+          playerName: "Party Blizzard",
+          townHall: 15,
+        },
+      ]);
+      prismaMock.currentWar.findMany.mockResolvedValue([
+        {
+          clanTag: twcClanTag,
+          warId,
+          state: "notInWar",
+          startTime: new Date("2026-03-25T12:00:00.000Z"),
+          endTime: warEndsAt,
+          updatedAt: attemptedAt,
+        },
+      ]);
+      prismaMock.warAttacks.findMany.mockResolvedValue(
+        input.warAttacksRows ?? [
+          {
+            warId,
+            clanTag: twcClanTag,
+            warStartTime: new Date("2026-03-25T12:00:00.000Z"),
+            playerTag,
+            playerPosition: input.attemptedWarPosition ?? 8,
+            attacksUsed: input.attemptedWarAttacksUsed,
+            attackOrder: 0,
+            attackNumber: 0,
+            defenderPosition: null,
+            stars: 0,
+            attackSeenAt: attemptedAt,
+          },
+        ],
+      );
+      prismaMock.trackedClan.findMany.mockResolvedValue([
+        {
+          tag: twcClanTag,
+          name: input.trackedClanName === undefined ? "TheWiseCowboys" : input.trackedClanName,
+        },
+      ]);
+      prismaMock.raidTrackedClan.findMany.mockResolvedValue([]);
+      prismaMock.cwlTrackedClan.findMany.mockResolvedValue([]);
+      prismaMock.currentCwlRound.findMany.mockResolvedValue([]);
+      prismaMock.cwlRoundMemberCurrent.findMany.mockResolvedValue([]);
+      prismaMock.cwlRoundMemberHistory.findMany.mockResolvedValue([]);
+      prismaMock.cwlPlayerClanSeason.findMany.mockResolvedValue([]);
+      prismaMock.botSetting.findMany.mockResolvedValue([]);
+      const cocService = {
+        getPlayerRaw: vi.fn().mockResolvedValue(null),
+        getCurrentWar: vi.fn().mockResolvedValue(null),
+      };
+
+      await todoSnapshotService.refreshSnapshotsForPlayerTags({
+        playerTags: [playerTag],
+        cocService: cocService as any,
+        nowMs: attemptedAt.getTime(),
+      });
+
+      expect(cocService.getCurrentWar).not.toHaveBeenCalled();
+      return getTodoSnapshotUpsertUpdateForPlayer(playerTag);
+    }
+
+    it.each([
+      {
+        label: "0 to 2",
+        existingWarAttacksUsed: 0,
+        attemptedWarAttacksUsed: 2,
+        expectedWarAttacksUsed: 2,
+      },
+      {
+        label: "1 to 2",
+        existingWarAttacksUsed: 1,
+        attemptedWarAttacksUsed: 2,
+        expectedWarAttacksUsed: 2,
+      },
+      {
+        label: "2 stays 2 when attempted 1 arrives",
+        existingWarAttacksUsed: 2,
+        attemptedWarAttacksUsed: 1,
+        expectedWarAttacksUsed: 2,
+      },
+      {
+        label: "preserves stronger verified metadata when attempted canonical metadata is missing or invalid",
+        existingWarAttacksUsed: 1,
+        attemptedWarAttacksUsed: 2,
+        existingWarClanName: "TheWiseCowboys",
+        attemptedWarClanName: "",
+        existingWarPosition: 8,
+        attemptedWarPosition: 0,
+        trackedClanName: null,
+        expectedWarAttacksUsed: 2,
+        expectedWarClanName: "TheWiseCowboys",
+        expectedWarPosition: 8,
+      },
+    ])("$label", async (input) => {
+      const update = await refreshRetainedEndedExactSameWarSnapshot(input as any);
+
+      expect(update).toMatchObject({
+        warClanTag: "#29PCQGUV0",
+        warOwnerSource: "LIVE_VERIFIED",
+        warOwnerWarId: 1002,
+        warOwnerVerifiedAt: new Date("2026-03-26T00:02:00.000Z"),
+        warActive: true,
+        warAttacksUsed: input.expectedWarAttacksUsed,
+        warPhase: "battle day",
+        warEndsAt: new Date("2026-03-26T12:00:00.000Z"),
+      });
+      if (input.expectedWarClanName !== undefined) {
+        expect(update).toMatchObject({
+          warClanName: input.expectedWarClanName,
+        });
+      }
+      if (input.expectedWarPosition !== undefined) {
+        expect(update).toMatchObject({
+          warPosition: input.expectedWarPosition,
+        });
+      }
+    });
+
+    it("keeps exact same-war progress monotonic when the exact attack row regresses", async () => {
+      const update = await refreshRetainedEndedExactSameWarSnapshot({
+        existingWarAttacksUsed: 2,
+        attemptedWarAttacksUsed: 1,
+      });
+
+      expect(update).toMatchObject({
+        warAttacksUsed: 2,
+        warOwnerSource: "LIVE_VERIFIED",
+        warOwnerWarId: 1002,
+        warOwnerVerifiedAt: new Date("2026-03-26T00:02:00.000Z"),
+      });
+    });
+
+    it("does not advance a live-verified retained-ended snapshot from a non-exact raw attack count", async () => {
+      const update = await refreshRetainedEndedExactSameWarSnapshot({
+        existingWarAttacksUsed: 1,
+        attemptedWarAttacksUsed: 2,
+        warMemberAttacksUsed: 2,
+        warAttacksRows: [],
+      });
+
+      expect(update).toMatchObject({
+        warAttacksUsed: 1,
+        warOwnerSource: "LIVE_VERIFIED",
+        warOwnerWarId: 1002,
+        warOwnerVerifiedAt: new Date("2026-03-26T00:02:00.000Z"),
+      });
+    });
+
+    it("keeps verified metadata when the attempted canonical name and position are missing", async () => {
+      const update = await refreshRetainedEndedExactSameWarSnapshot({
+        existingWarAttacksUsed: 1,
+        attemptedWarAttacksUsed: 2,
+        existingWarClanName: "TheWiseCowboys",
+        attemptedWarClanName: null,
+        existingWarPosition: 8,
+        attemptedWarPosition: null,
+        trackedClanName: null,
+      });
+
+      expect(update).toMatchObject({
+        warClanName: "TheWiseCowboys",
+        warPosition: 8,
+        warAttacksUsed: 2,
+        warOwnerSource: "LIVE_VERIFIED",
+        warOwnerWarId: 1002,
+        warOwnerVerifiedAt: new Date("2026-03-26T00:02:00.000Z"),
+      });
+    });
+
+    it("reports bounded exact same-war healing samples in the summary", async () => {
+      const warEndsAt = new Date("2026-03-26T12:00:00.000Z");
+      const attemptedAt = new Date("2026-03-26T12:06:00.000Z");
+      const verifiedAt = new Date("2026-03-26T00:02:00.000Z");
+      const exactCases = [
+        { clanTag: "#29PCQGUV0", warId: 1002 },
+        { clanTag: "#2RYGLU2UY", warId: 1003 },
+        { clanTag: "#QGRJ2222", warId: 1004 },
+        { clanTag: "#LQQ99UV8", warId: 1005 },
+        { clanTag: "#2QG2C08UP", warId: 1006 },
+        { clanTag: "#VUVU2222", warId: 1007 },
+      ].map((entry, index) => ({
+        ...entry,
+        playerTag: buildValidPlayerTag(index),
+        playerName: `Player ${index + 1}`,
+        position: index + 1,
+      }));
+      const existingRows = exactCases.map((entry) =>
+        buildSnapshotRow({
+          playerTag: entry.playerTag,
+          playerName: entry.playerName,
+          clanTag: entry.clanTag,
+          clanName: entry.clanTag === "#29PCQGUV0" ? "TheWiseCowboys" : `Clan ${entry.position}`,
+          warActive: true,
+          warClanTag: entry.clanTag,
+          warClanName: entry.clanTag === "#29PCQGUV0" ? "TheWiseCowboys" : `Clan ${entry.position}`,
+          warOwnerSource: "LIVE_VERIFIED",
+          warOwnerWarId: entry.warId,
+          warOwnerVerifiedAt: verifiedAt,
+          warPosition: entry.position,
+          warAttacksUsed: 0,
+          warPhase: "battle day",
+          warEndsAt,
+          warSourceUpdatedAt: verifiedAt,
+          clanMembershipObservedAt: verifiedAt,
+          lastUpdatedAt: verifiedAt,
+          updatedAt: verifiedAt,
+        }),
+      );
+
+      installMutableTodoSnapshotStore(existingRows);
+      prismaMock.playerCurrent.findMany.mockResolvedValue([]);
+      prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue(
+        exactCases.map((entry) => ({
+          playerTag: entry.playerTag,
+          clanTag: entry.clanTag,
+          playerName: entry.playerName,
+          sourceSyncedAt: verifiedAt,
+        })),
+      );
+      prismaMock.fwaWarMemberCurrent.findMany.mockResolvedValue([]);
+      prismaMock.fwaTrackedClanWarRosterCurrent.findMany.mockResolvedValue(
+        exactCases.map((entry) => ({
+          clanTag: entry.clanTag,
+          sourceWarId: entry.warId,
+          sourceWarStartTime: new Date("2026-03-25T12:00:00.000Z"),
+          sourceWarEndTime: warEndsAt,
+          sourceWarState: "notInWar",
+          sourceCurrentWarUpdatedAt: attemptedAt,
+        })),
+      );
+      prismaMock.fwaTrackedClanWarRosterMemberCurrent.findMany.mockResolvedValue(
+        exactCases.map((entry) => ({
+          clanTag: entry.clanTag,
+          playerTag: entry.playerTag,
+          position: entry.position,
+          playerName: entry.playerName,
+          townHall: 15,
+        })),
+      );
+      prismaMock.currentWar.findMany.mockResolvedValue(
+        exactCases.map((entry) => ({
+          clanTag: entry.clanTag,
+          warId: entry.warId,
+          state: "notInWar",
+          startTime: new Date("2026-03-25T12:00:00.000Z"),
+          endTime: warEndsAt,
+          updatedAt: attemptedAt,
+        })),
+      );
+      prismaMock.warAttacks.findMany.mockResolvedValue(
+        exactCases.map((entry) => ({
+          warId: entry.warId,
+          clanTag: entry.clanTag,
+          warStartTime: new Date("2026-03-25T12:00:00.000Z"),
+          playerTag: entry.playerTag,
+          playerPosition: entry.position,
+          attacksUsed: 2,
+          attackOrder: 0,
+          attackNumber: 0,
+          defenderPosition: null,
+          stars: 0,
+          attackSeenAt: attemptedAt,
+        })),
+      );
+      prismaMock.trackedClan.findMany.mockResolvedValue(
+        exactCases.map((entry, index) => ({
+          tag: entry.clanTag,
+          name: index === 0 ? "TheWiseCowboys" : `Clan ${index + 1}`,
+        })),
+      );
+      prismaMock.raidTrackedClan.findMany.mockResolvedValue([]);
+      prismaMock.cwlTrackedClan.findMany.mockResolvedValue([]);
+      prismaMock.currentCwlRound.findMany.mockResolvedValue([]);
+      prismaMock.cwlRoundMemberCurrent.findMany.mockResolvedValue([]);
+      prismaMock.cwlRoundMemberHistory.findMany.mockResolvedValue([]);
+      prismaMock.cwlPlayerClanSeason.findMany.mockResolvedValue([]);
+      prismaMock.botSetting.findMany.mockResolvedValue([]);
+      const consoleInfoSpy = vi.spyOn(console, "info").mockImplementation(() => undefined);
+      const cocService = {
+        getPlayerRaw: vi.fn().mockResolvedValue(null),
+        getCurrentWar: vi.fn().mockResolvedValue(null),
+      };
+
+      await todoSnapshotService.refreshSnapshotsForPlayerTags({
+        playerTags: exactCases.map((entry) => entry.playerTag),
+        cocService: cocService as any,
+        nowMs: attemptedAt.getTime(),
+      });
+
+      const summaryLine = getSingleConsoleMessage(consoleInfoSpy, (message) =>
+        message.includes("event=todo_war_owner_resolution_summary"),
+      );
+      const sampleLine = getSingleConsoleMessage(consoleInfoSpy, (message) =>
+        message.includes("event=todo_war_owner_resolution_exact_same_war_attack_progress"),
+      );
+      const exactCountMatch = summaryLine.match(/exact_same_war_attack_progress_count=(\d+)/);
+      expect(exactCountMatch).not.toBeNull();
+      expect(Number(exactCountMatch?.[1] ?? -1)).toBeGreaterThanOrEqual(5);
+      expect(sampleLine).toContain("sample_count=5");
+      expect(sampleLine.match(/player_tag=/g)).toHaveLength(5);
+      expect(sampleLine).toContain("previous_attacks_used=0");
+      expect(sampleLine).toContain("final_attacks_used=2");
+      expect(cocService.getCurrentWar).not.toHaveBeenCalled();
+      consoleInfoSpy.mockRestore();
+    });
+
+    it("bases exact healing counts on the final transaction decision instead of the pre-transaction snapshot", async () => {
+      const twcClanTag = "#29PCQGUV0";
+      const playerTag = "#PYLQ0289";
+      const warEndsAt = new Date("2026-03-26T12:00:00.000Z");
+      const attemptedAt = new Date("2026-03-26T12:06:00.000Z");
+      const verifiedAt = new Date("2026-03-26T00:02:00.000Z");
+      const warId = 1002;
+      const existingRow = buildSnapshotRow({
+        playerTag,
+        playerName: "Party Blizzard",
+        clanTag: twcClanTag,
+        clanName: "TheWiseCowboys",
+        warActive: true,
+        warClanTag: twcClanTag,
+        warClanName: "TheWiseCowboys",
+        warOwnerSource: "LIVE_VERIFIED",
+        warOwnerWarId: warId,
+        warOwnerVerifiedAt: verifiedAt,
+        warPosition: 8,
+        warAttacksUsed: 0,
+        warPhase: "battle day",
+        warEndsAt,
+        warSourceUpdatedAt: verifiedAt,
+        clanMembershipObservedAt: verifiedAt,
+        lastUpdatedAt: verifiedAt,
+        updatedAt: verifiedAt,
+      });
+
+      installMutableTodoSnapshotStore([existingRow]);
+      txMock.todoPlayerSnapshot.findUnique.mockResolvedValue({
+        ...existingRow,
+        warAttacksUsed: 2,
+        lastUpdatedAt: attemptedAt,
+        updatedAt: attemptedAt,
+      });
+      prismaMock.playerCurrent.findMany.mockResolvedValue([]);
+      prismaMock.fwaClanMemberCurrent.findMany.mockResolvedValue([
+        {
+          playerTag,
+          clanTag: twcClanTag,
+          playerName: "Party Blizzard",
+          sourceSyncedAt: verifiedAt,
+        },
+      ]);
+      prismaMock.fwaWarMemberCurrent.findMany.mockResolvedValue([]);
+      prismaMock.fwaTrackedClanWarRosterCurrent.findMany.mockResolvedValue([
+        {
+          clanTag: twcClanTag,
+          sourceWarId: warId,
+          sourceWarStartTime: new Date("2026-03-25T12:00:00.000Z"),
+          sourceWarEndTime: warEndsAt,
+          sourceWarState: "notInWar",
+          sourceCurrentWarUpdatedAt: attemptedAt,
+        },
+      ]);
+      prismaMock.fwaTrackedClanWarRosterMemberCurrent.findMany.mockResolvedValue([
+        {
+          clanTag: twcClanTag,
+          playerTag,
+          position: 8,
+          playerName: "Party Blizzard",
+          townHall: 15,
+        },
+      ]);
+      prismaMock.currentWar.findMany.mockResolvedValue([
+        {
+          clanTag: twcClanTag,
+          warId,
+          state: "notInWar",
+          startTime: new Date("2026-03-25T12:00:00.000Z"),
+          endTime: warEndsAt,
+          updatedAt: attemptedAt,
+        },
+      ]);
+      prismaMock.warAttacks.findMany.mockResolvedValue([
+        {
+          warId,
+          clanTag: twcClanTag,
+          warStartTime: new Date("2026-03-25T12:00:00.000Z"),
+          playerTag,
+          playerPosition: 8,
+          attacksUsed: 2,
+          attackOrder: 0,
+          attackNumber: 0,
+          defenderPosition: null,
+          stars: 0,
+          attackSeenAt: attemptedAt,
+        },
+      ]);
+      prismaMock.trackedClan.findMany.mockResolvedValue([
+        { tag: twcClanTag, name: "TheWiseCowboys" },
+      ]);
+      prismaMock.raidTrackedClan.findMany.mockResolvedValue([]);
+      prismaMock.cwlTrackedClan.findMany.mockResolvedValue([]);
+      prismaMock.currentCwlRound.findMany.mockResolvedValue([]);
+      prismaMock.cwlRoundMemberCurrent.findMany.mockResolvedValue([]);
+      prismaMock.cwlRoundMemberHistory.findMany.mockResolvedValue([]);
+      prismaMock.cwlPlayerClanSeason.findMany.mockResolvedValue([]);
+      prismaMock.botSetting.findMany.mockResolvedValue([]);
+      const consoleInfoSpy = vi.spyOn(console, "info").mockImplementation(() => undefined);
+      const cocService = {
+        getPlayerRaw: vi.fn().mockResolvedValue(null),
+        getCurrentWar: vi.fn().mockResolvedValue(null),
+      };
+
+      await todoSnapshotService.refreshSnapshotsForPlayerTags({
+        playerTags: [playerTag],
+        cocService: cocService as any,
+        nowMs: attemptedAt.getTime(),
+      });
+
+      const summaryLine = getSingleConsoleMessage(consoleInfoSpy, (message) =>
+        message.includes("event=todo_war_owner_resolution_summary"),
+      );
+      expect(summaryLine).toContain("exact_same_war_attack_progress_count=0");
+      expect(getConsoleMessages(consoleInfoSpy).some((message) =>
+        message.includes("event=todo_war_owner_resolution_exact_same_war_attack_progress"),
+      )).toBe(false);
+      expect(cocService.getCurrentWar).not.toHaveBeenCalled();
+      consoleInfoSpy.mockRestore();
+    });
   });
 
   it("keeps a legacy identity-null tracked roster row from bypassing an existing live verified owner", async () => {


### PR DESCRIPTION
Thread exact same-war WarAttacks provenance into the todo write decision so live-verified retained-ended snapshots can advance warAttacksUsed to 2/2 without weakening owner confidence.