### PR TITLE
fix(fwa): persist manual bases checklist completions

### DIFF
--- a/src/services/FwaMatchChecklistStateService.ts
+++ b/src/services/FwaMatchChecklistStateService.ts
@@ -626,6 +626,12 @@ async function buildFwaMatchBasesRenderStateForGuild(params: {
       Boolean(currentBaseSwap) &&
       currentBaseSwapStatus === TRACKED_MESSAGE_STATUS.COMPLETED &&
       !issueSummary.hasIssues;
+    const hasSafeCurrentWarIdentity = Boolean(
+      activeCurrentWar &&
+        (activeCurrentWar.warId !== null ||
+          (activeCurrentWar.startTime instanceof Date &&
+            Number.isFinite(activeCurrentWar.startTime.getTime()))),
+    );
     const baseSwapSource = currentBaseSwap
       ? currentBaseSwapCompleted
         ? "base_swap_completed"
@@ -636,20 +642,35 @@ async function buildFwaMatchBasesRenderStateForGuild(params: {
         ? "no_match"
         : "no_sync";
     const exactCompletion =
-      currentBaseSwapCompleted || issueSummary.hasIssues || !rowSyncIdentity
+      currentBaseSwapCompleted || issueSummary.hasIssues
         ? null
-        : await trackedMessageService
-            .findLatestFwaMatchChecklistBasesCompletionForClan({
-              guildId: params.guildId,
-              clanTag,
-              warId: activeCurrentWar?.warId ?? null,
-              warStartTime: activeCurrentWar?.startTime ?? null,
-              opponentTag: activeCurrentWar?.opponentTag ?? null,
-              syncMessageId: rowSyncIdentity,
-            })
-            .catch(() => null);
+        : rowSyncIdentity
+          ? await trackedMessageService
+              .findLatestFwaMatchChecklistBasesCompletionForClan({
+                guildId: params.guildId,
+                clanTag,
+                warId: activeCurrentWar?.warId ?? null,
+                warStartTime: activeCurrentWar?.startTime ?? null,
+                opponentTag: activeCurrentWar?.opponentTag ?? null,
+                syncMessageId: rowSyncIdentity,
+              })
+              .catch(() => null)
+          : hasSafeCurrentWarIdentity
+            ? await trackedMessageService
+                .findLatestFwaMatchChecklistBasesCompletionForClan({
+                  guildId: params.guildId,
+                  clanTag,
+                  warId: activeCurrentWar?.warId ?? null,
+                  warStartTime: activeCurrentWar?.startTime ?? null,
+                  opponentTag: activeCurrentWar?.opponentTag ?? null,
+                })
+                .catch(() => null)
+            : null;
     const fallbackCompletion =
-      currentBaseSwapCompleted || exactCompletion || issueSummary.hasIssues || !rowSyncIdentity
+      currentBaseSwapCompleted ||
+      exactCompletion ||
+      issueSummary.hasIssues ||
+      (!hasSafeCurrentWarIdentity && !rowSyncIdentity)
         ? null
         : await trackedMessageService
             .findLatestActiveFwaMatchChecklistBasesCompletionForClan({

--- a/src/services/TrackedMessageService.ts
+++ b/src/services/TrackedMessageService.ts
@@ -4019,6 +4019,12 @@ export class TrackedMessageService {
           logPersistenceFailure(row, "current_war_identity_mismatch", checked);
           return false;
         }
+
+        if (!syncReferenceId && currentWar && currentWarIsExplicitlyInactive) {
+          logPersistenceFailure(row, "current_war_inactive", checked);
+          return false;
+        }
+
         const activeBaseSwap = await this.findLatestActiveFwaBaseSwapTrackedMessageForClan({
           guildId: tracked.guildId,
           clanTag: row.clanTag,

--- a/src/services/TrackedMessageService.ts
+++ b/src/services/TrackedMessageService.ts
@@ -3884,6 +3884,7 @@ export class TrackedMessageService {
           prepStartTime: Date | null;
           startTime: Date | null;
           endTime: Date | null;
+          state: string | null;
         }
       >();
       if (!syncReferenceId && sourceRows.length > 0) {
@@ -3910,6 +3911,7 @@ export class TrackedMessageService {
               prepStartTime: true,
               startTime: true,
               endTime: true,
+              state: true,
             },
           }).catch(() => []);
           for (const currentWar of currentWarRows) {
@@ -3921,6 +3923,7 @@ export class TrackedMessageService {
               prepStartTime: currentWar.prepStartTime ?? null,
               startTime: currentWar.startTime ?? null,
               endTime: currentWar.endTime ?? null,
+              state: currentWar.state ?? null,
             });
           }
         }
@@ -3957,16 +3960,65 @@ export class TrackedMessageService {
         existingBaselines: existingReactionBaselines,
       });
       const handledChangeRowTags = new Set<string>();
+      const persistenceFailureKeys = new Set<string>();
+      const resolvedWarIdentityByClanTag = new Map<
+        string,
+        {
+          warId: string | number | null;
+          warStartTime: Date | null;
+          opponentTag: string | null;
+        }
+      >();
+
+      const logPersistenceFailure = (
+        row: FwaMatchChecklistTrackedRow,
+        reason: string,
+        checked: boolean,
+      ): void => {
+        const failureKey = `${normalizeChecklistClanTag(row.clanTag)}:${reason}`;
+        if (persistenceFailureKeys.has(failureKey)) return;
+        persistenceFailureKeys.add(failureKey);
+        console.warn(
+          `[fwa_checklist_bases_persistence] guildId=${tracked.guildId} messageId=${message.id} clanTag=${normalizeChecklistClanTag(row.clanTag)} checked=${checked} reason=${reason} rowWarId=${normalizeWarIdText(row.warId ?? null) ?? "missing"} rowWarStartTimeIso=${row.warStartTimeIso ?? "missing"} rowOpponentTag=${normalizeChecklistClanTag(row.opponentTag ?? "") || "missing"} currentWarId=${normalizeWarIdText(currentWarByClanTag.get(normalizeChecklistClanTag(row.clanTag))?.warId ?? null) ?? "missing"} syncMessageId=${syncReferenceId ?? "missing"}`,
+        );
+      };
 
       const persistBasesCheckedStateForRow = async (
         row: FwaMatchChecklistTrackedRow,
         checked: boolean,
       ): Promise<boolean> => {
-        const warStartTime = row.warStartTimeIso ? new Date(row.warStartTimeIso) : null;
-        const hasWarIdentity = Boolean(row.warId || row.opponentTag || warStartTime);
-        const currentWar = syncReferenceId
-          ? null
-          : currentWarByClanTag.get(normalizeChecklistClanTag(row.clanTag)) ?? null;
+        const clanTag = normalizeChecklistClanTag(row.clanTag);
+        const rowWarId = normalizeWarIdText(row.warId ?? null);
+        const parsedRowWarStartTime = row.warStartTimeIso ? new Date(row.warStartTimeIso) : null;
+        const rowWarStartTime =
+          parsedRowWarStartTime instanceof Date && Number.isFinite(parsedRowWarStartTime.getTime())
+            ? parsedRowWarStartTime
+            : null;
+        const rowOpponentTag = normalizeChecklistClanTag(row.opponentTag ?? "") || null;
+        const rowHasSafeWarIdentity = Boolean(rowWarId || rowWarStartTime);
+        const currentWar = currentWarByClanTag.get(clanTag) ?? null;
+        const currentWarId = normalizeWarIdText(currentWar?.warId ?? null);
+        const currentWarStartTime =
+          currentWar?.startTime instanceof Date && Number.isFinite(currentWar.startTime.getTime())
+            ? currentWar.startTime
+            : null;
+        const currentWarOpponentTag = normalizeChecklistClanTag(currentWar?.opponentTag ?? "") || null;
+        const currentWarHasSafeIdentity = Boolean(currentWarId || currentWarStartTime);
+        const currentWarIsExplicitlyInactive = ["notinwar", "not_in_war", "not in war"].includes(
+          String(currentWar?.state ?? "").trim().toLowerCase(),
+        );
+        const identityConflicts = Boolean(
+          !syncReferenceId &&
+            currentWar &&
+            (Boolean(rowWarId) && rowWarId !== currentWarId ||
+              Boolean(rowWarStartTime) &&
+                (currentWarStartTime === null || rowWarStartTime?.getTime() !== currentWarStartTime.getTime()) ||
+              Boolean(rowOpponentTag) && rowOpponentTag !== currentWarOpponentTag),
+        );
+        if (identityConflicts) {
+          logPersistenceFailure(row, "current_war_identity_mismatch", checked);
+          return false;
+        }
         const activeBaseSwap = await this.findLatestActiveFwaBaseSwapTrackedMessageForClan({
           guildId: tracked.guildId,
           clanTag: row.clanTag,
@@ -3987,27 +4039,61 @@ export class TrackedMessageService {
             String(row.matchType ?? "").trim() || null,
           );
           if (issueSummary.hasIssues) {
+            logPersistenceFailure(row, "base_swap_issues", checked);
             return false;
           }
         }
-        await this.setFwaMatchChecklistBasesCompletion({
-          guildId: tracked.guildId,
-          channelId: tracked.channelId,
-          createdByUserId: metadata.createdByUserId,
-          clanTag: row.clanTag,
-          clanName: null,
-          ...(hasWarIdentity
+        const resolvedWarIdentity =
+          !syncReferenceId && currentWarHasSafeIdentity && !currentWarIsExplicitlyInactive
             ? {
-                warId: row.warId ?? null,
-                warStartTime,
-                opponentTag: row.opponentTag ?? null,
+                warId: currentWar?.warId ?? null,
+                warStartTime: currentWarStartTime,
+                opponentTag: currentWar?.opponentTag ?? null,
               }
-            : {
-              syncReferenceId,
-            }),
-          checked,
-        });
-        return true;
+            : rowHasSafeWarIdentity
+              ? {
+                  warId: row.warId ?? null,
+                  warStartTime: rowWarStartTime,
+                  opponentTag: row.opponentTag ?? null,
+                }
+              : null;
+        if (resolvedWarIdentity) {
+          resolvedWarIdentityByClanTag.set(clanTag, resolvedWarIdentity);
+        }
+        if (!resolvedWarIdentity && !syncReferenceId) {
+          logPersistenceFailure(row, "no_safe_war_or_sync_identity", checked);
+          return false;
+        }
+        let persisted = false;
+        try {
+          persisted = await this.setFwaMatchChecklistBasesCompletion({
+            guildId: tracked.guildId,
+            channelId: tracked.channelId,
+            createdByUserId: metadata.createdByUserId,
+            clanTag: row.clanTag,
+            clanName: null,
+            ...(resolvedWarIdentity
+              ? {
+                  warId: resolvedWarIdentity.warId,
+                  warStartTime: resolvedWarIdentity.warStartTime,
+                  opponentTag: resolvedWarIdentity.opponentTag,
+                }
+              : {
+                  syncReferenceId,
+                }),
+            checked,
+          });
+        } catch (err) {
+          logPersistenceFailure(row, "completion_write_error", checked);
+          console.debug(
+            `[fwa_checklist_bases_persistence] guildId=${tracked.guildId} messageId=${message.id} clanTag=${clanTag} reason=completion_write_error_detail error=${formatError(err)}`,
+          );
+          return false;
+        }
+        if (!persisted) {
+          logPersistenceFailure(row, "completion_write_returned_false", checked);
+        }
+        return persisted;
       };
 
       const changedRowTag = change
@@ -4041,15 +4127,17 @@ export class TrackedMessageService {
               persisted &&
               reactionChange.reactorUserId
             ) {
+              const resolvedWarIdentity = resolvedWarIdentityByClanTag.get(changedRowTag) ?? null;
               const warStartTime =
-                matchedRow.warStartTimeIso
+                resolvedWarIdentity?.warStartTime ??
+                (matchedRow.warStartTimeIso
                   ? new Date(matchedRow.warStartTimeIso)
                   : await resolveChecklistWarStartTimeFromCurrentWar({
                       guildId: tracked.guildId,
                       clanTag: matchedRow.clanTag,
                       warId: matchedRow.warId ?? null,
                       opponentTag: matchedRow.opponentTag ?? null,
-                    });
+                    }));
               await repWorkActivityService.recordBasesChecklistChecked({
                 guildId: tracked.guildId,
                 discordUserId: reactionChange.reactorUserId,
@@ -4057,9 +4145,9 @@ export class TrackedMessageService {
                 syncMessageId: normalizeTrackedMessageId(tracked.referenceId ?? null),
                 sourceMessageId: message.id,
                 sourceTrackedMessageId: tracked.id,
-                warId: matchedRow.warId ?? null,
+                warId: resolvedWarIdentity?.warId ?? matchedRow.warId ?? null,
                 warStartTime,
-                opponentTag: matchedRow.opponentTag ?? null,
+                opponentTag: resolvedWarIdentity?.opponentTag ?? matchedRow.opponentTag ?? null,
                 eventAt: new Date(),
                 metadata: {
                   source: "fwa_match_checklist",

--- a/tests/fwaBasesChecklistReminder.service.test.ts
+++ b/tests/fwaBasesChecklistReminder.service.test.ts
@@ -26,7 +26,7 @@ vi.mock("../src/services/FwaMatchChecklistStateService", () => ({
   buildFwaMatchChecklistRenderStateForGuild: renderStateMock.build,
 }));
 
-import { trackedMessageService } from "../src/services/TrackedMessageService";
+import { TrackedMessageService, trackedMessageService } from "../src/services/TrackedMessageService";
 import {
   BASES_CHECKLIST_REMINDER_OFFSETS_HOURS,
   findPendingFwaBasesChecklistReminderCandidates,
@@ -790,6 +790,74 @@ describe("fwa bases checklist reminder service", () => {
     await expect(
       findPendingFwaBasesChecklistReminderCandidates({
         now: new Date("2026-05-26T19:00:00.000Z"),
+      }),
+    ).resolves.toEqual([]);
+  });
+
+  it("suppresses a manual no-sync reminder through the real completion lookup seam", async () => {
+    const currentWarStartTime = new Date("2026-05-26T18:00:00.000Z");
+    prismaMock.currentWar.findMany.mockResolvedValueOnce([
+      {
+        guildId: "guild-1",
+        clanTag: "#PYPY",
+        warId: 1001,
+        opponentTag: "#OPP1",
+        prepStartTime: new Date("2026-05-26T12:00:00.000Z"),
+        startTime: currentWarStartTime,
+        endTime: new Date("2026-05-27T18:00:00.000Z"),
+        state: "preparation",
+      },
+    ]);
+    renderStateMock.build.mockResolvedValueOnce({
+      viewType: "Bases",
+      rows: [
+        {
+          clanTag: "#PYPY",
+          compactCopyLine: "Alpha | ⚫ | ❌ Bases not checked",
+          badgeEmojiId: "111",
+          badgeEmojiName: "alpha",
+          badgeEmojiInline: "<:alpha:111>",
+          warId: 1001,
+          opponentTag: "#OPP1",
+          warStartTimeIso: currentWarStartTime.toISOString(),
+        },
+      ],
+      expiresAt: currentWarStartTime,
+    });
+    const completionRow = {
+      id: "manual-completion-1",
+      guildId: "guild-1",
+      channelId: "channel-1",
+      messageId:
+        "fwa_match_checklist_bases_completion|guild=guild-1|clan=#PYPY|war=1001|opponent=OPP1|start=2026-05-26T18:00:00.000Z",
+      featureType: "FWA_MATCH_CHECKLIST",
+      status: "ACTIVE",
+      referenceId: null,
+      clanTag: "#PYPY",
+      createdAt: new Date("2026-05-26T15:00:00.000Z"),
+      expiresAt: null,
+      metadata: {
+        kind: "bases_completion",
+        createdByUserId: "user-1",
+        createdAtIso: "2026-05-26T15:00:00.000Z",
+        clanTag: "#PYPY",
+        clanName: "Alpha Clan",
+        checked: true,
+        warId: "1001",
+        opponentTag: "OPP1",
+        warStartTimeIso: currentWarStartTime.toISOString(),
+      },
+    };
+    prismaMock.trackedMessage.findUnique.mockImplementation(async ({ where }: any) =>
+      where?.messageId === completionRow.messageId ? completionRow : null,
+    );
+    vi.mocked(trackedMessageService.findLatestActiveFwaMatchChecklistBasesCompletionForClan).mockImplementation(
+      (params) => new TrackedMessageService().findLatestActiveFwaMatchChecklistBasesCompletionForClan(params),
+    );
+
+    await expect(
+      findPendingFwaBasesChecklistReminderCandidates({
+        now: new Date("2026-05-26T15:00:00.000Z"),
       }),
     ).resolves.toEqual([]);
   });

--- a/tests/fwaBasesChecklistReminderScheduler.test.ts
+++ b/tests/fwaBasesChecklistReminderScheduler.test.ts
@@ -45,7 +45,7 @@ vi.mock("../src/prisma", () => ({
   prisma: prismaMock,
 }));
 
-import { trackedMessageService } from "../src/services/TrackedMessageService";
+import { TrackedMessageService, trackedMessageService } from "../src/services/TrackedMessageService";
 
 type ClientLike = {
   channels: {
@@ -216,6 +216,61 @@ describe("FwaBasesChecklistReminderSchedulerService", () => {
     });
     expect(trackedMessageService.claimFwaBasesChecklistReminderMarker).not.toHaveBeenCalled();
     expect(client.channels.fetch).not.toHaveBeenCalled();
+    expect(send).not.toHaveBeenCalled();
+    expect(dozzleLogMock.info).toHaveBeenCalledWith(
+      expect.stringContaining("reason=bases_completion_exists"),
+    );
+  });
+
+  it("suppresses a candidate created before a manual completion using the real final lookup", async () => {
+    plannerMocks.findPending.mockResolvedValue([makeCandidate({ syncMessageId: null })]);
+    const completionMessageId =
+      "fwa_match_checklist_bases_completion|guild=guild-1|clan=ABC|war=1001|opponent=OPP1|start=2026-05-26T18:00:00.000Z";
+    prismaMock.trackedMessage.findUnique.mockImplementation(async ({ where }: any) =>
+      where?.messageId === completionMessageId
+        ? {
+            id: "completion-1",
+            guildId: "guild-1",
+            channelId: "channel-1",
+            messageId: completionMessageId,
+            featureType: "FWA_MATCH_CHECKLIST",
+            status: "ACTIVE",
+            referenceId: null,
+            clanTag: "#ABC",
+            createdAt: new Date("2026-05-26T15:01:00.000Z"),
+            expiresAt: null,
+            metadata: {
+              kind: "bases_completion",
+              createdByUserId: "user-1",
+              createdAtIso: "2026-05-26T15:01:00.000Z",
+              clanTag: "#ABC",
+              clanName: "Alpha Clan",
+              checked: true,
+              warId: "1001",
+              opponentTag: "OPP1",
+              warStartTimeIso: "2026-05-26T18:00:00.000Z",
+            },
+          }
+        : null,
+    );
+    vi.mocked(trackedMessageService.findLatestActiveFwaMatchChecklistBasesCompletionForClan).mockImplementation(
+      (params) => new TrackedMessageService().findLatestActiveFwaMatchChecklistBasesCompletionForClan(params),
+    );
+    await expect(
+      new TrackedMessageService().findLatestActiveFwaMatchChecklistBasesCompletionForClan({
+        guildId: "guild-1",
+        clanTag: "#ABC",
+        warId: 1001,
+        opponentTag: "#OPP1",
+        warStartTime: new Date("2026-05-26T18:00:00.000Z"),
+      }),
+    ).resolves.toBeTruthy();
+    const { client, send } = makeClient();
+    const scheduler = await createScheduler(client);
+
+    const counts = await scheduler.runCycle(new Date("2026-05-26T15:02:00.000Z").getTime());
+
+    expect(counts).toMatchObject({ evaluated: 1, sent: 0, skipped: 1 });
     expect(send).not.toHaveBeenCalled();
     expect(dozzleLogMock.info).toHaveBeenCalledWith(
       expect.stringContaining("reason=bases_completion_exists"),

--- a/tests/fwaMatchChecklist.state.test.ts
+++ b/tests/fwaMatchChecklist.state.test.ts
@@ -1212,6 +1212,69 @@ describe("FwaMatchChecklistStateService checklist expiry", () => {
     expect(state.rows[0].compactCopyLine).toContain("Bases checked and all good");
   });
 
+  it("renders an exact current-war Bases completion without a sync root", async () => {
+    const currentWarStartTime = new Date("2026-05-13T18:00:00.000Z");
+    prismaMock.trackedClan.findMany.mockResolvedValue([
+      { tag: "#PYPY", clanBadge: "<:rr:111>", name: "Alpha", shortName: "A" },
+    ]);
+    prismaMock.currentWar.findMany.mockResolvedValue([
+      {
+        clanTag: "#PYPY",
+        warId: 1001,
+        prepStartTime: new Date("2026-05-13T13:00:00.000Z"),
+        startTime: currentWarStartTime,
+        endTime: new Date("2026-05-14T18:00:00.000Z"),
+        opponentTag: "#OPP1",
+        matchType: "FWA",
+        inferredMatchType: null,
+        outcome: null,
+        state: "preparation",
+      },
+    ]);
+    vi.mocked(trackedMessageService.resolveLatestActiveSyncPost).mockResolvedValue(null);
+    vi.mocked(trackedMessageService.resolveLatestRelevantSyncPostForClanWar).mockResolvedValue(null);
+    vi.mocked(trackedMessageService.findLatestActiveFwaBaseSwapTrackedMessageForClan).mockResolvedValue(null);
+    vi.mocked(trackedMessageService.findLatestFwaMatchChecklistBasesCompletionForClan).mockResolvedValue({
+      id: "completion-1",
+      guildId: "guild-1",
+      channelId: "channel-1",
+      messageId: "completion-current-war",
+      referenceId: null,
+      clanTag: "#PYPY",
+      createdAt: new Date("2026-05-13T17:00:00.000Z"),
+      expiresAt: null,
+      metadata: {
+        kind: "bases_completion",
+        createdByUserId: "user-1",
+        createdAtIso: "2026-05-13T17:00:00.000Z",
+        clanTag: "#PYPY",
+        clanName: "Alpha",
+        checked: true,
+        warId: "1001",
+        opponentTag: "OPP1",
+        warStartTimeIso: currentWarStartTime.toISOString(),
+      },
+    } as any);
+
+    const state = await buildFwaMatchChecklistRenderStateForGuild({
+      cocService: { getCurrentWar: vi.fn().mockResolvedValue(null) } as any,
+      guildId: "guild-1",
+      client: {} as any,
+      viewType: "Bases",
+    });
+
+    expect(state.referenceId).toBeNull();
+    expect(state.rows[0].basesStatus).toBe("all_good");
+    expect(state.rows[0].compactCopyLine).toContain("✅ Bases checked and all good");
+    expect(trackedMessageService.findLatestFwaMatchChecklistBasesCompletionForClan).toHaveBeenCalledWith({
+      guildId: "guild-1",
+      clanTag: "#PYPY",
+      warId: 1001,
+      warStartTime: currentWarStartTime,
+      opponentTag: "#OPP1",
+    });
+  });
+
   it("ignores stale current-war timing and falls back to the provided sync+48h expiry", async () => {
     prismaMock.currentWar.findMany.mockResolvedValue([
       {

--- a/tests/trackedMessage.fwaChecklist.test.ts
+++ b/tests/trackedMessage.fwaChecklist.test.ts
@@ -3062,6 +3062,59 @@ describe("fwa checklist tracked messages", () => {
     expect(edit.mock.calls.at(-1)?.[0]?.content).toContain("❌ Bases not checked");
   });
 
+  it("fails closed when a manual checklist row belongs to an inactive CurrentWar", async () => {
+    const tracked = makeManualBasesTrackedChecklistRow();
+    tracked.metadata.rows[0].warId = 1001;
+    tracked.metadata.rows[0].opponentTag = "#OPP1";
+    tracked.metadata.rows[0].warStartTimeIso = "2026-06-13T18:00:00.000Z";
+    prismaMock.trackedMessage.findUnique.mockResolvedValue(tracked as any);
+    prismaMock.trackedClan.findMany.mockResolvedValue([
+      { tag: "#PYPY", clanBadge: "<:alpha:111>", name: "Alpha", shortName: "A" },
+    ]);
+    prismaMock.currentWar.findMany.mockResolvedValue([
+      {
+        clanTag: "#PYPY",
+        warId: 1001,
+        startTime: new Date("2026-06-13T18:00:00.000Z"),
+        opponentTag: "#OPP1",
+        state: "notInWar",
+      },
+    ]);
+    vi.mocked(trackedMessageService.resolveLatestActiveSyncPost).mockResolvedValue(null);
+    const setCompletion = vi.spyOn(trackedMessageService, "setFwaMatchChecklistBasesCompletion");
+    const recordBasesChecklistChecked = vi.spyOn(
+      repWorkActivityService,
+      "recordBasesChecklistChecked",
+    );
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const edit = vi.fn().mockResolvedValue(undefined);
+
+    await expect(
+      trackedMessageService.refreshFwaMatchChecklistMessage(
+        {
+          id: tracked.messageId,
+          reactions: {
+            cache: new Map([[
+              "alpha",
+              { emoji: { id: "111", name: "alpha" }, count: 2, me: true },
+            ]]),
+          },
+          edit,
+        } as any,
+        {
+          kind: "add",
+          reactorUserId: "user-2",
+          reaction: { emoji: { id: "111", name: "alpha" }, count: 2 },
+        },
+      ),
+    ).resolves.toBe(true);
+
+    expect(setCompletion).not.toHaveBeenCalled();
+    expect(recordBasesChecklistChecked).not.toHaveBeenCalled();
+    expect(edit.mock.calls.at(-1)?.[0]?.content).not.toContain("all good");
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("reason=current_war_inactive"));
+  });
+
   it("does not record rep-work activity when the completion write returns false", async () => {
     prismaMock.trackedMessage.findUnique.mockResolvedValue(makeBasesTrackedChecklistRow());
     const setCompletion = vi

--- a/tests/trackedMessage.fwaChecklist.test.ts
+++ b/tests/trackedMessage.fwaChecklist.test.ts
@@ -126,6 +126,27 @@ function makeBasesTrackedChecklistRow() {
   };
 }
 
+function makeManualBasesTrackedChecklistRow() {
+  const tracked = makeBasesTrackedChecklistRow();
+  return {
+    ...tracked,
+    referenceId: null,
+    metadata: {
+      ...tracked.metadata,
+      referenceId: null,
+      rows: tracked.metadata.rows.map((row) => ({
+        ...row,
+        warId: null,
+        opponentTag: null,
+        warStartTimeIso: null,
+      })),
+      warId: null,
+      opponentTag: null,
+      warStartTimeIso: null,
+    },
+  };
+}
+
 function makeSkippedThenActiveBasesTrackedChecklistRow() {
   const active = makeBasesTrackedChecklistRow();
   return {
@@ -765,6 +786,106 @@ describe("fwa checklist tracked messages", () => {
         }),
       }),
     );
+  });
+
+  it("returns false without creating a completion when no war or sync identity is usable", async () => {
+    await expect(
+      trackedMessageService.setFwaMatchChecklistBasesCompletion({
+        guildId: "guild-1",
+        channelId: "channel-1",
+        createdByUserId: "user-1",
+        clanTag: "#PYPY",
+        clanName: "Alpha",
+        checked: true,
+      }),
+    ).resolves.toBe(false);
+    expect(prismaMock.trackedMessage.upsert).not.toHaveBeenCalled();
+  });
+
+  it("persists and rerenders a manual no-sync Bases reaction against the active CurrentWar", async () => {
+    const tracked = makeManualBasesTrackedChecklistRow();
+    const currentWarStartTime = new Date("2026-06-13T18:00:00.000Z");
+    let completionRow: any = null;
+    prismaMock.trackedMessage.findUnique.mockImplementation(async ({ where }: any) => {
+      if (where?.messageId === tracked.messageId) return tracked;
+      if (where?.messageId === completionRow?.messageId) return completionRow;
+      return null;
+    });
+    prismaMock.trackedMessage.upsert.mockImplementation(async ({ create, update, where }: any) => {
+      completionRow = {
+        id: "manual-completion-1",
+        ...create,
+        ...update,
+        messageId: where.messageId,
+        referenceId: create.referenceId ?? update.referenceId ?? null,
+        createdAt: new Date("2026-06-13T17:30:00.000Z"),
+        expiresAt: null,
+      };
+      return completionRow;
+    });
+    prismaMock.trackedMessage.update.mockResolvedValue(tracked as any);
+    prismaMock.trackedClan.findMany.mockResolvedValue([
+      { tag: "#PYPY", clanBadge: "<:alpha:111>", name: "Alpha", shortName: "A" },
+    ]);
+    prismaMock.currentWar.findMany.mockResolvedValue([
+      {
+        clanTag: "#PYPY",
+        warId: 1001,
+        prepStartTime: new Date("2026-06-13T13:00:00.000Z"),
+        startTime: currentWarStartTime,
+        endTime: new Date("2026-06-14T18:00:00.000Z"),
+        opponentTag: "#OPP1",
+        matchType: "fwa",
+        inferredMatchType: "fwa",
+        outcome: null,
+        state: "preparation",
+      },
+    ]);
+    vi.mocked(trackedMessageService.resolveLatestActiveSyncPost).mockResolvedValue(null);
+    vi.spyOn(trackedMessageService, "findLatestActiveFwaBaseSwapTrackedMessageForClan").mockResolvedValue(null);
+    const edit = vi.fn().mockResolvedValue(undefined);
+
+    await expect(
+      trackedMessageService.refreshFwaMatchChecklistMessage(
+        {
+          id: tracked.messageId,
+          client: {} as any,
+          reactions: {
+            cache: new Map([
+              ["alpha", { emoji: { id: "111", name: "alpha" }, count: 2, me: true }],
+            ]),
+          },
+          edit,
+        } as any,
+        {
+          kind: "add",
+          reactorUserId: "user-2",
+          reaction: { emoji: { id: "111", name: "alpha" }, count: 2 },
+        },
+      ),
+    ).resolves.toBe(true);
+
+    expect(completionRow).toMatchObject({
+      referenceId: null,
+      messageId:
+        "fwa_match_checklist_bases_completion|guild=guild-1|clan=#PYPY|war=1001|opponent=OPP1|start=2026-06-13T18:00:00.000Z",
+      metadata: expect.objectContaining({
+        checked: true,
+        warId: "1001",
+        opponentTag: "OPP1",
+        warStartTimeIso: currentWarStartTime.toISOString(),
+      }),
+    });
+    await expect(
+      trackedMessageService.findLatestFwaMatchChecklistBasesCompletionForClan({
+        guildId: "guild-1",
+        clanTag: "#PYPY",
+        warId: 1001,
+        warStartTime: currentWarStartTime,
+        opponentTag: "#OPP1",
+      }),
+    ).resolves.toMatchObject({ messageId: completionRow.messageId });
+    expect(edit.mock.calls.at(-1)?.[0]?.content).toContain("✅ Bases checked and all good");
   });
 
   it("falls back to sync-scoped bases completion after war identity becomes known", async () => {
@@ -2895,6 +3016,83 @@ describe("fwa checklist tracked messages", () => {
     );
     expect(edit.mock.calls.at(-1)?.[0]?.content).toContain("✅ Bases checked and all good");
     expect(edit.mock.calls.at(-1)?.[0]?.content).not.toContain("❌ Bases not checked");
+  });
+
+  it("fails closed when a manual checklist row conflicts with CurrentWar identity", async () => {
+    const tracked = makeManualBasesTrackedChecklistRow();
+    tracked.metadata.rows[0].warId = 9999;
+    tracked.metadata.rows[0].opponentTag = "#OLDOPP";
+    tracked.metadata.rows[0].warStartTimeIso = "2026-06-12T18:00:00.000Z";
+    prismaMock.trackedMessage.findUnique.mockResolvedValue(tracked as any);
+    prismaMock.trackedClan.findMany.mockResolvedValue([
+      { tag: "#PYPY", clanBadge: "<:alpha:111>", name: "Alpha", shortName: "A" },
+    ]);
+    prismaMock.currentWar.findMany.mockResolvedValue([
+      {
+        clanTag: "#PYPY",
+        warId: 1001,
+        startTime: new Date("2026-06-13T18:00:00.000Z"),
+        opponentTag: "#OPP1",
+        state: "preparation",
+      },
+    ]);
+    vi.mocked(trackedMessageService.resolveLatestActiveSyncPost).mockResolvedValue(null);
+    vi.spyOn(trackedMessageService, "findLatestActiveFwaBaseSwapTrackedMessageForClan").mockResolvedValue(null);
+    const setCompletion = vi.spyOn(trackedMessageService, "setFwaMatchChecklistBasesCompletion");
+    const edit = vi.fn().mockResolvedValue(undefined);
+
+    await expect(
+      trackedMessageService.refreshFwaMatchChecklistMessage(
+        {
+          id: tracked.messageId,
+          reactions: {
+            cache: new Map([["alpha", { emoji: { id: "111", name: "alpha" }, count: 2, me: true }]]),
+          },
+          edit,
+        } as any,
+        {
+          kind: "add",
+          reactorUserId: "user-2",
+          reaction: { emoji: { id: "111", name: "alpha" }, count: 2 },
+        },
+      ),
+    ).resolves.toBe(true);
+
+    expect(setCompletion).not.toHaveBeenCalled();
+    expect(edit.mock.calls.at(-1)?.[0]?.content).toContain("❌ Bases not checked");
+  });
+
+  it("does not record rep-work activity when the completion write returns false", async () => {
+    prismaMock.trackedMessage.findUnique.mockResolvedValue(makeBasesTrackedChecklistRow());
+    const setCompletion = vi
+      .spyOn(trackedMessageService, "setFwaMatchChecklistBasesCompletion")
+      .mockResolvedValue(false);
+    vi.spyOn(trackedMessageService, "findLatestActiveFwaBaseSwapTrackedMessageForClan").mockResolvedValue(null);
+    const recordBasesChecklistChecked = vi.spyOn(
+      repWorkActivityService,
+      "recordBasesChecklistChecked",
+    );
+    const edit = vi.fn().mockResolvedValue(undefined);
+
+    await expect(
+      trackedMessageService.refreshFwaMatchChecklistMessage(
+        {
+          id: "bases-message-1",
+          reactions: {
+            cache: new Map([["alpha", { emoji: { id: "111", name: "alpha" }, count: 2, me: true }]]),
+          },
+          edit,
+        } as any,
+        {
+          kind: "add",
+          reactorUserId: "user-2",
+          reaction: { emoji: { id: "111", name: "alpha" }, count: 2 },
+        },
+      ),
+    ).resolves.toBe(true);
+
+    expect(setCompletion).toHaveBeenCalledTimes(1);
+    expect(recordBasesChecklistChecked).not.toHaveBeenCalled();
   });
 
   it("ignores skipped bases rows when a badge reaction is added", async () => {


### PR DESCRIPTION
Use safe CurrentWar identity for no-sync badge reactions, render exact current-war completions, and suppress reminders after successful writes.