### PR TITLE
fix(activity): reconcile linked player clan departures

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ Cadence defaults and cost controls:
 - `Clans.json`: every 6 hours
 - tracked-clan `Members.json`: every 15 minutes (minimum source freshness respected)
 - `WarMembers.json`: distributed sweep ticks every 15 minutes with bounded chunk size/concurrency
+- The active 30-minute activity-observe cycle reconciles linked-player `PlayerCurrent` state: tracked-clan departures are immediate, stale external/clanless/unknown rows use a 60-minute freshness gate, and no more than 100 extra linked-player refreshes run per cycle; current tracked members are not fetched twice.
 - tracked-clan `Wars.json` watch: 5-minute cadence only inside active per-clan windows, starts 5 minutes before sync time, stops once update is acquired
 - optional global `Wars.json` sweep: disabled by default, configurable and chunked
 - command paths remain DB-first; `/compo state mode:war`, `/compo state mode:actual`, and `/compo place` now read persisted feed-backed state instead of relying on hot-path sheet reads

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -24,8 +24,9 @@ npm start
 - `CLASHKING_API_TOKEN` - bearer token for private ClashKing API (if required).
 
 Behavior:
-- `/accounts` resolves linked accounts from persisted `PlayerLink` and local player activity only.
+- `/accounts` renders from persisted `PlayerLink`, `PlayerCurrent`, FWA current-membership, and activity state; opening it remains DB-only.
 - Activity observe loop checks unresolved tracked-member links via ClashKing at most once every 6 hours and caches matches in `PlayerLink`.
+- Each active 30-minute activity-observe cycle performs bounded linked-player `PlayerCurrent` reconciliation: detected tracked-clan departures are refreshed immediately, while stale external, confirmed-clanless, and unknown-membership rows use the default 60-minute freshness threshold. It allows at most 100 extra linked-player refreshes per cycle and does not fetch current tracked members twice.
 
 ## Optional War Event Poll Setting
 - `WAR_EVENT_LOG_POLL_INTERVAL_MINUTES` - interval for war-state event listener polling (default: `15` minutes).

--- a/src/listeners/ready.ts
+++ b/src/listeners/ready.ts
@@ -787,6 +787,7 @@ export default (client: Client, cocService: CoCService): void => {
         refreshSucceeded: 0,
         refreshFailed: 0,
         deferredByBatchBound: 0,
+        unknownMembershipCandidates: 0,
         failedTrackedClanTags: [],
       };
       await runWithCoCQueueContext(
@@ -888,7 +889,7 @@ export default (client: Client, cocService: CoCService): void => {
         },
       );
       dozzleLog.info(
-        `[activity-observe] event=activity_observe_cycle_summary source=activity_observe_cycle activity_observe_cycle_id=${activityObserveCycleId} scheduled_at_ms=${scheduledAtMs} observed_clan_count=${observedClanCount} live_clan_fetch_count=${liveClanFetchCount} linked_players_considered=${linkedPlayerCurrentReconcile.linkedPlayersConsidered} linked_players_already_observed_skipped=${linkedPlayerCurrentReconcile.alreadyObservedTrackedPlayersSkipped} linked_player_departure_candidates=${linkedPlayerCurrentReconcile.departureCandidates} linked_player_stale_outside_or_clanless_candidates=${linkedPlayerCurrentReconcile.staleOutsideOrClanlessCandidates} linked_player_refresh_attempted=${linkedPlayerCurrentReconcile.refreshAttempted} linked_player_refresh_succeeded=${linkedPlayerCurrentReconcile.refreshSucceeded} linked_player_refresh_failed=${linkedPlayerCurrentReconcile.refreshFailed} linked_player_refresh_deferred=${linkedPlayerCurrentReconcile.deferredByBatchBound} linked_player_failed_clan_count=${linkedPlayerCurrentReconcile.failedTrackedClanTags.length} duration_ms=${Date.now() - observedCycleStartedAtMs}`,
+        `[activity-observe] event=activity_observe_cycle_summary source=activity_observe_cycle activity_observe_cycle_id=${activityObserveCycleId} scheduled_at_ms=${scheduledAtMs} observed_clan_count=${observedClanCount} live_clan_fetch_count=${liveClanFetchCount} linked_players_considered=${linkedPlayerCurrentReconcile.linkedPlayersConsidered} linked_players_already_observed_skipped=${linkedPlayerCurrentReconcile.alreadyObservedTrackedPlayersSkipped} linked_player_departure_candidates=${linkedPlayerCurrentReconcile.departureCandidates} linked_player_unknown_membership_candidates=${linkedPlayerCurrentReconcile.unknownMembershipCandidates} linked_player_stale_outside_or_clanless_candidates=${linkedPlayerCurrentReconcile.staleOutsideOrClanlessCandidates} linked_player_refresh_attempted=${linkedPlayerCurrentReconcile.refreshAttempted} linked_player_refresh_succeeded=${linkedPlayerCurrentReconcile.refreshSucceeded} linked_player_refresh_failed=${linkedPlayerCurrentReconcile.refreshFailed} linked_player_refresh_deferred=${linkedPlayerCurrentReconcile.deferredByBatchBound} linked_player_failed_clan_count=${linkedPlayerCurrentReconcile.failedTrackedClanTags.length} duration_ms=${Date.now() - observedCycleStartedAtMs}`,
       );
     };
 

--- a/src/listeners/ready.ts
+++ b/src/listeners/ready.ts
@@ -81,6 +81,10 @@ import {
 } from "../services/CoCRequestQueueService";
 import { PollCycleGuardService } from "../services/PollCycleGuardService";
 import { unlinkedMemberAlertService } from "../services/UnlinkedMemberAlertService";
+import {
+  linkedPlayerCurrentReconcileService,
+  type LinkedPlayerCurrentReconcileResult,
+} from "../services/LinkedPlayerCurrentReconcileService";
 import { runWithCoCQueueContext } from "../services/CoCQueueContext";
 import { dozzleLog } from "../helper/dozzleLogger";
 import {
@@ -630,6 +634,10 @@ export default (client: Client, cocService: CoCService): void => {
 
     const observeTrackedClans = async (activityObserveCycleId: string, scheduledAtMs: number): Promise<{
       trackedClanCount: number;
+      configuredTrackedClanTags: string[];
+      successfullyObservedTrackedClanTags: string[];
+      observedTrackedClans: Array<{ clanTag: string; memberTags: string[] }>;
+      failedTrackedClanTags: string[];
       observedTags: string[];
       observedPlayerCurrent: Array<{
         playerTag: string;
@@ -660,6 +668,10 @@ export default (client: Client, cocService: CoCService): void => {
         );
         return {
           trackedClanCount: 0,
+          configuredTrackedClanTags: [],
+          successfullyObservedTrackedClanTags: [],
+          observedTrackedClans: [],
+          failedTrackedClanTags: [],
           observedTags: [],
           observedPlayerCurrent: [],
           observedFwaClans: [],
@@ -667,6 +679,9 @@ export default (client: Client, cocService: CoCService): void => {
       }
 
       const observedMemberTags = new Set<string>();
+      const successfullyObservedTrackedClanTags: string[] = [];
+      const observedTrackedClans: Array<{ clanTag: string; memberTags: string[] }> = [];
+      const failedTrackedClanTags: string[] = [];
       const observedPlayerCurrentByTag = new Map<
         string,
         { clanTag: string | null; townHall: number | null }
@@ -690,6 +705,11 @@ export default (client: Client, cocService: CoCService): void => {
           for (const memberTag of observedClan.memberTags) {
             observedMemberTags.add(memberTag);
           }
+          successfullyObservedTrackedClanTags.push(trackedClan.tag);
+          observedTrackedClans.push({
+            clanTag: trackedClan.tag,
+            memberTags: observedClan.memberTags,
+          });
           for (const entry of observedClan.observedPlayerCurrent ?? []) {
             const playerTag = String(entry?.playerTag ?? "").trim();
             if (!playerTag || observedPlayerCurrentByTag.has(playerTag)) {
@@ -709,6 +729,7 @@ export default (client: Client, cocService: CoCService): void => {
             members: observedClan.members,
           });
         } catch (err) {
+          failedTrackedClanTags.push(trackedClan.tag);
           console.error(
             `observeClan failed for ${trackedClan.tag}: ${formatError(err)}`
           );
@@ -717,6 +738,10 @@ export default (client: Client, cocService: CoCService): void => {
 
       return {
         trackedClanCount: dbTracked.length,
+        configuredTrackedClanTags: trackedTags,
+        successfullyObservedTrackedClanTags,
+        observedTrackedClans,
+        failedTrackedClanTags,
         observedTags: [...observedMemberTags],
         observedPlayerCurrent: [...observedPlayerCurrentByTag.entries()].map(
           ([playerTag, value]) => ({
@@ -753,6 +778,17 @@ export default (client: Client, cocService: CoCService): void => {
       const observedCycleStartedAtMs = Date.now();
       let observedClanCount = 0;
       let liveClanFetchCount = 0;
+      let linkedPlayerCurrentReconcile: LinkedPlayerCurrentReconcileResult = {
+        linkedPlayersConsidered: 0,
+        alreadyObservedTrackedPlayersSkipped: 0,
+        departureCandidates: 0,
+        staleOutsideOrClanlessCandidates: 0,
+        refreshAttempted: 0,
+        refreshSucceeded: 0,
+        refreshFailed: 0,
+        deferredByBatchBound: 0,
+        failedTrackedClanTags: [],
+      };
       await runWithCoCQueueContext(
         {
           priority: "background",
@@ -772,6 +808,20 @@ export default (client: Client, cocService: CoCService): void => {
               const observed = await observeTrackedClans(activityObserveCycleId, scheduledAtMs);
               observedClanCount = observed.trackedClanCount;
               liveClanFetchCount = observed.observedFwaClans.length;
+              try {
+                linkedPlayerCurrentReconcile = await linkedPlayerCurrentReconcileService.reconcile({
+                  configuredTrackedClanTags: observed.configuredTrackedClanTags,
+                  successfullyObservedTrackedClanTags: observed.successfullyObservedTrackedClanTags,
+                  observedTrackedClans: observed.observedTrackedClans,
+                  failedTrackedClanTags: observed.failedTrackedClanTags,
+                  cocService,
+                  now: new Date(scheduledAtMs),
+                });
+              } catch (err) {
+                console.error(
+                  `[activity-observe] event=linked_player_current_reconcile_failed error=${formatError(err)}`,
+                );
+              }
               try {
                 const backfill = await backfillMissingDiscordUsernamesForClanMembers({
                   memberTagsInOrder: observed.observedTags,
@@ -838,7 +888,7 @@ export default (client: Client, cocService: CoCService): void => {
         },
       );
       dozzleLog.info(
-        `[activity-observe] event=activity_observe_cycle_summary source=activity_observe_cycle activity_observe_cycle_id=${activityObserveCycleId} scheduled_at_ms=${scheduledAtMs} observed_clan_count=${observedClanCount} live_clan_fetch_count=${liveClanFetchCount} duration_ms=${Date.now() - observedCycleStartedAtMs}`,
+        `[activity-observe] event=activity_observe_cycle_summary source=activity_observe_cycle activity_observe_cycle_id=${activityObserveCycleId} scheduled_at_ms=${scheduledAtMs} observed_clan_count=${observedClanCount} live_clan_fetch_count=${liveClanFetchCount} linked_players_considered=${linkedPlayerCurrentReconcile.linkedPlayersConsidered} linked_players_already_observed_skipped=${linkedPlayerCurrentReconcile.alreadyObservedTrackedPlayersSkipped} linked_player_departure_candidates=${linkedPlayerCurrentReconcile.departureCandidates} linked_player_stale_outside_or_clanless_candidates=${linkedPlayerCurrentReconcile.staleOutsideOrClanlessCandidates} linked_player_refresh_attempted=${linkedPlayerCurrentReconcile.refreshAttempted} linked_player_refresh_succeeded=${linkedPlayerCurrentReconcile.refreshSucceeded} linked_player_refresh_failed=${linkedPlayerCurrentReconcile.refreshFailed} linked_player_refresh_deferred=${linkedPlayerCurrentReconcile.deferredByBatchBound} linked_player_failed_clan_count=${linkedPlayerCurrentReconcile.failedTrackedClanTags.length} duration_ms=${Date.now() - observedCycleStartedAtMs}`,
       );
     };
 

--- a/src/services/AccountRowsService.ts
+++ b/src/services/AccountRowsService.ts
@@ -116,8 +116,9 @@ function resolveAccountClanState(input: {
 }): "known" | "no_clan" | "unknown" {
   const currentClanTag = sanitizeDisplayText(input.playerCurrent?.currentClanTag);
   const activityClanTag = sanitizeDisplayText(input.playerActivity?.clanTag);
-  if (currentClanTag || activityClanTag) return "known";
+  if (currentClanTag) return "known";
   if (isConfirmedClanlessSource(input.playerCurrent?.lastSource)) return "no_clan";
+  if (activityClanTag) return "known";
   return "unknown";
 }
 
@@ -260,8 +261,11 @@ export async function buildAccountsRows(input: {
             : null,
         });
     const fwaCatalogRow = fwaCatalogByTag.get(tag) ?? null;
-    const isTrackedFwaClan = Boolean(clanTag && trackedClanNameByTag.has(clanTag));
-    const trackedClanSortOrder = clanTag ? trackedClanSortOrderByTag.get(clanTag) ?? null : null;
+    const isTrackedFwaClan = Boolean(
+      clanState === "known" && clanTag && trackedClanNameByTag.has(clanTag),
+    );
+    const trackedClanSortOrder =
+      clanState === "known" && clanTag ? trackedClanSortOrderByTag.get(clanTag) ?? null : null;
 
     return {
       tag,

--- a/src/services/AccountRowsService.ts
+++ b/src/services/AccountRowsService.ts
@@ -1,6 +1,9 @@
 import { prisma } from "../prisma";
 import { resolveEffectivePlayerWeight } from "../helper/effectiveWeightResolution";
-import { playerCurrentService } from "./PlayerCurrentService";
+import {
+  isAuthoritativeLivePlayerCurrentSource,
+  playerCurrentService,
+} from "./PlayerCurrentService";
 import { listOpenDeferredWeightsByClanAndPlayerTags } from "./WeightInputDefermentService";
 import { normalizeClashTagInput } from "../helper/clashTag";
 
@@ -105,11 +108,6 @@ function pickPreferredFwaMemberRow(
   })[0] ?? null;
 }
 
-function isConfirmedClanlessSource(source: string | null | undefined): boolean {
-  const normalized = sanitizeDisplayText(source)?.toLowerCase() ?? null;
-  return normalized === "accounts-refresh" || normalized === "live_refresh";
-}
-
 function resolveAccountClanState(input: {
   playerCurrent: PlayerCurrentSnapshot | null;
   playerActivity: { clanTag: string | null; clanName: string | null } | null;
@@ -117,7 +115,7 @@ function resolveAccountClanState(input: {
   const currentClanTag = sanitizeDisplayText(input.playerCurrent?.currentClanTag);
   const activityClanTag = sanitizeDisplayText(input.playerActivity?.clanTag);
   if (currentClanTag) return "known";
-  if (isConfirmedClanlessSource(input.playerCurrent?.lastSource)) return "no_clan";
+  if (isAuthoritativeLivePlayerCurrentSource(input.playerCurrent?.lastSource)) return "no_clan";
   if (activityClanTag) return "known";
   return "unknown";
 }

--- a/src/services/LinkedPlayerCurrentReconcileService.ts
+++ b/src/services/LinkedPlayerCurrentReconcileService.ts
@@ -1,0 +1,227 @@
+import { prisma } from "../prisma";
+import { dozzleLog } from "../helper/dozzleLogger";
+import { normalizeClanTag, normalizePlayerTag } from "./PlayerLinkService";
+import {
+  playerCurrentService,
+  type PlayerCurrentLike,
+} from "./PlayerCurrentService";
+
+/** Routine outside/clanless maintenance runs at roughly twice the default 30-minute observe cadence. */
+export const DEFAULT_LINKED_PLAYER_RECONCILE_FRESHNESS_MS = 60 * 60 * 1000;
+export const DEFAULT_LINKED_PLAYER_RECONCILE_BATCH_SIZE = 100;
+
+export type LinkedPlayerObservedTrackedClan = {
+  clanTag: string;
+  memberTags: string[];
+};
+
+export type LinkedPlayerCurrentReconcileInput = {
+  configuredTrackedClanTags: string[];
+  successfullyObservedTrackedClanTags: string[];
+  observedTrackedClans: LinkedPlayerObservedTrackedClan[];
+  failedTrackedClanTags: string[];
+  cocService: Pick<{ getPlayerRaw: (tag: string) => Promise<unknown> }, "getPlayerRaw"> | null;
+  now?: Date;
+  freshnessMs?: number;
+  batchSize?: number;
+};
+
+export type LinkedPlayerCurrentReconcileResult = {
+  linkedPlayersConsidered: number;
+  alreadyObservedTrackedPlayersSkipped: number;
+  departureCandidates: number;
+  staleOutsideOrClanlessCandidates: number;
+  refreshAttempted: number;
+  refreshSucceeded: number;
+  refreshFailed: number;
+  deferredByBatchBound: number;
+  failedTrackedClanTags: string[];
+};
+
+type Candidate = {
+  playerTag: string;
+  priority: 0 | 1 | 2;
+  lastFetchedAtMs: number;
+};
+
+function normalizePositiveDuration(input: unknown, fallback: number): number {
+  const parsed = Math.trunc(Number(input));
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function isConfirmedClanless(record: PlayerCurrentLike): boolean {
+  const source = String(record.lastSource ?? "").trim().toLowerCase();
+  return source === "live_refresh" || source === "accounts-refresh";
+}
+
+function isStale(record: PlayerCurrentLike | null, now: Date, freshnessMs: number): boolean {
+  if (!record?.lastFetchedAt) return true;
+  return now.getTime() - record.lastFetchedAt.getTime() >= freshnessMs;
+}
+
+function compareCandidates(left: Candidate, right: Candidate): number {
+  if (left.priority !== right.priority) return left.priority - right.priority;
+  if (left.priority === 2 && left.lastFetchedAtMs !== right.lastFetchedAtMs) {
+    return left.lastFetchedAtMs - right.lastFetchedAtMs;
+  }
+  return left.playerTag.localeCompare(right.playerTag, undefined, { sensitivity: "base" });
+}
+
+function emptyResult(failedTrackedClanTags: string[] = []): LinkedPlayerCurrentReconcileResult {
+  return {
+    linkedPlayersConsidered: 0,
+    alreadyObservedTrackedPlayersSkipped: 0,
+    departureCandidates: 0,
+    staleOutsideOrClanlessCandidates: 0,
+    refreshAttempted: 0,
+    refreshSucceeded: 0,
+    refreshFailed: 0,
+    deferredByBatchBound: 0,
+    failedTrackedClanTags,
+  };
+}
+
+function logResult(result: LinkedPlayerCurrentReconcileResult): void {
+  dozzleLog.info(
+    `[activity-observe] event=linked_player_current_reconcile linked_players_considered=${result.linkedPlayersConsidered} already_observed_tracked_players_skipped=${result.alreadyObservedTrackedPlayersSkipped} departure_candidates=${result.departureCandidates} stale_outside_or_clanless_candidates=${result.staleOutsideOrClanlessCandidates} refresh_attempted=${result.refreshAttempted} refresh_succeeded=${result.refreshSucceeded} refresh_failed=${result.refreshFailed} deferred_by_batch_bound=${result.deferredByBatchBound} failed_tracked_clan_tags=${result.failedTrackedClanTags.join(",") || "none"}`,
+  );
+}
+
+/** Purpose: reconcile linked PlayerCurrent rows after the activity cycle has observed tracked rosters. */
+export class LinkedPlayerCurrentReconcileService {
+  async reconcile(
+    input: LinkedPlayerCurrentReconcileInput,
+  ): Promise<LinkedPlayerCurrentReconcileResult> {
+    const configuredTrackedClanTags = new Set(
+      input.configuredTrackedClanTags.map((tag) => normalizeClanTag(tag)).filter(Boolean),
+    );
+    const successfullyObservedTrackedClanTags = new Set(
+      input.successfullyObservedTrackedClanTags
+        .map((tag) => normalizeClanTag(tag))
+        .filter((tag) => configuredTrackedClanTags.has(tag)),
+    );
+    const failedTrackedClanTags = [
+      ...new Set(input.failedTrackedClanTags.map((tag) => normalizeClanTag(tag)).filter(Boolean)),
+    ].sort();
+
+    const linkedRows = await prisma.playerLink.findMany({
+      where: { discordUserId: { not: null } },
+      select: { playerTag: true, discordUserId: true },
+    });
+    const linkedTags = [
+      ...new Set(
+        linkedRows
+          .filter((row) => String(row.discordUserId ?? "").trim().length > 0)
+          .map((row) => normalizePlayerTag(row.playerTag))
+          .filter(Boolean),
+      ),
+    ];
+    if (linkedTags.length === 0) {
+      const result = emptyResult(failedTrackedClanTags);
+      logResult(result);
+      return result;
+    }
+
+    const playerCurrentByTag = await playerCurrentService.listPlayerCurrentByTags(linkedTags);
+    const observedMemberTags = new Set<string>();
+    const observedMemberTagsByClanTag = new Map<string, Set<string>>();
+    for (const observed of input.observedTrackedClans) {
+      const clanTag = normalizeClanTag(observed.clanTag);
+      if (!clanTag || !successfullyObservedTrackedClanTags.has(clanTag)) continue;
+      const memberTags = observedMemberTagsByClanTag.get(clanTag) ?? new Set<string>();
+      for (const tag of observed.memberTags) {
+        const playerTag = normalizePlayerTag(tag);
+        if (!playerTag) continue;
+        memberTags.add(playerTag);
+        observedMemberTags.add(playerTag);
+      }
+      observedMemberTagsByClanTag.set(clanTag, memberTags);
+    }
+
+    const now = input.now ?? new Date();
+    const freshnessMs = normalizePositiveDuration(
+      input.freshnessMs,
+      DEFAULT_LINKED_PLAYER_RECONCILE_FRESHNESS_MS,
+    );
+    const batchSize = normalizePositiveDuration(
+      input.batchSize,
+      DEFAULT_LINKED_PLAYER_RECONCILE_BATCH_SIZE,
+    );
+    const candidates: Candidate[] = [];
+    let alreadyObservedTrackedPlayersSkipped = 0;
+    let departureCandidates = 0;
+    let staleOutsideOrClanlessCandidates = 0;
+
+    for (const playerTag of linkedTags) {
+      if (observedMemberTags.has(playerTag)) {
+        alreadyObservedTrackedPlayersSkipped += 1;
+        continue;
+      }
+
+      const current = playerCurrentByTag.get(playerTag) ?? null;
+      const currentClanTag = normalizeClanTag(current?.currentClanTag ?? "");
+      if (current && currentClanTag && successfullyObservedTrackedClanTags.has(currentClanTag)) {
+        const observedMembers = observedMemberTagsByClanTag.get(currentClanTag) ?? new Set<string>();
+        if (!observedMembers.has(playerTag)) {
+          candidates.push({
+            playerTag,
+            priority: 0,
+            lastFetchedAtMs: current.lastFetchedAt?.getTime() ?? Number.NEGATIVE_INFINITY,
+          });
+          departureCandidates += 1;
+          continue;
+        }
+      }
+
+      const isMissingPlayerCurrent = !current;
+      const isOutsideTrackedClans = Boolean(
+        current && currentClanTag && !configuredTrackedClanTags.has(currentClanTag),
+      );
+      const isConfirmedClanlessCandidate = Boolean(current && !currentClanTag && isConfirmedClanless(current));
+      if (
+        (isMissingPlayerCurrent || isOutsideTrackedClans || isConfirmedClanlessCandidate) &&
+        isStale(current, now, freshnessMs)
+      ) {
+        candidates.push({
+          playerTag,
+          priority: current ? 2 : 1,
+          lastFetchedAtMs: current?.lastFetchedAt?.getTime() ?? Number.NEGATIVE_INFINITY,
+        });
+        if (current) staleOutsideOrClanlessCandidates += 1;
+      }
+    }
+
+    candidates.sort(compareCandidates);
+    const selectedCandidates = candidates.slice(0, batchSize);
+    const deferredByBatchBound = Math.max(0, candidates.length - selectedCandidates.length);
+    let refreshSucceeded = 0;
+    let refreshFailed = 0;
+    if (selectedCandidates.length > 0) {
+      const refresh = await playerCurrentService.refreshCurrentPlayersFromLiveTags({
+        playerTags: selectedCandidates.map((candidate) => candidate.playerTag),
+        cocService: input.cocService,
+        concurrency: 4,
+        source: "live_refresh",
+        now,
+      });
+      refreshSucceeded = refresh.successCount;
+      refreshFailed = refresh.failedPlayerTags.length;
+    }
+
+    const result: LinkedPlayerCurrentReconcileResult = {
+      linkedPlayersConsidered: linkedTags.length,
+      alreadyObservedTrackedPlayersSkipped,
+      departureCandidates,
+      staleOutsideOrClanlessCandidates,
+      refreshAttempted: selectedCandidates.length,
+      refreshSucceeded,
+      refreshFailed,
+      deferredByBatchBound,
+      failedTrackedClanTags,
+    };
+    logResult(result);
+    return result;
+  }
+}
+
+export const linkedPlayerCurrentReconcileService = new LinkedPlayerCurrentReconcileService();

--- a/src/services/LinkedPlayerCurrentReconcileService.ts
+++ b/src/services/LinkedPlayerCurrentReconcileService.ts
@@ -2,6 +2,7 @@ import { prisma } from "../prisma";
 import { dozzleLog } from "../helper/dozzleLogger";
 import { normalizeClanTag, normalizePlayerTag } from "./PlayerLinkService";
 import {
+  isAuthoritativeLivePlayerCurrentSource,
   playerCurrentService,
   type PlayerCurrentLike,
 } from "./PlayerCurrentService";
@@ -35,6 +36,7 @@ export type LinkedPlayerCurrentReconcileResult = {
   refreshSucceeded: number;
   refreshFailed: number;
   deferredByBatchBound: number;
+  unknownMembershipCandidates: number;
   failedTrackedClanTags: string[];
 };
 
@@ -47,11 +49,6 @@ type Candidate = {
 function normalizePositiveDuration(input: unknown, fallback: number): number {
   const parsed = Math.trunc(Number(input));
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
-}
-
-function isConfirmedClanless(record: PlayerCurrentLike): boolean {
-  const source = String(record.lastSource ?? "").trim().toLowerCase();
-  return source === "live_refresh" || source === "accounts-refresh";
 }
 
 function isStale(record: PlayerCurrentLike | null, now: Date, freshnessMs: number): boolean {
@@ -77,13 +74,14 @@ function emptyResult(failedTrackedClanTags: string[] = []): LinkedPlayerCurrentR
     refreshSucceeded: 0,
     refreshFailed: 0,
     deferredByBatchBound: 0,
+    unknownMembershipCandidates: 0,
     failedTrackedClanTags,
   };
 }
 
 function logResult(result: LinkedPlayerCurrentReconcileResult): void {
   dozzleLog.info(
-    `[activity-observe] event=linked_player_current_reconcile linked_players_considered=${result.linkedPlayersConsidered} already_observed_tracked_players_skipped=${result.alreadyObservedTrackedPlayersSkipped} departure_candidates=${result.departureCandidates} stale_outside_or_clanless_candidates=${result.staleOutsideOrClanlessCandidates} refresh_attempted=${result.refreshAttempted} refresh_succeeded=${result.refreshSucceeded} refresh_failed=${result.refreshFailed} deferred_by_batch_bound=${result.deferredByBatchBound} failed_tracked_clan_tags=${result.failedTrackedClanTags.join(",") || "none"}`,
+    `[activity-observe] event=linked_player_current_reconcile linked_players_considered=${result.linkedPlayersConsidered} already_observed_tracked_players_skipped=${result.alreadyObservedTrackedPlayersSkipped} departure_candidates=${result.departureCandidates} unknown_membership_candidates=${result.unknownMembershipCandidates} stale_outside_or_clanless_candidates=${result.staleOutsideOrClanlessCandidates} refresh_attempted=${result.refreshAttempted} refresh_succeeded=${result.refreshSucceeded} refresh_failed=${result.refreshFailed} deferred_by_batch_bound=${result.deferredByBatchBound} failed_tracked_clan_tags=${result.failedTrackedClanTags.join(",") || "none"}`,
   );
 }
 
@@ -151,6 +149,7 @@ export class LinkedPlayerCurrentReconcileService {
     let alreadyObservedTrackedPlayersSkipped = 0;
     let departureCandidates = 0;
     let staleOutsideOrClanlessCandidates = 0;
+    let unknownMembershipCandidates = 0;
 
     for (const playerTag of linkedTags) {
       if (observedMemberTags.has(playerTag)) {
@@ -174,20 +173,33 @@ export class LinkedPlayerCurrentReconcileService {
       }
 
       const isMissingPlayerCurrent = !current;
+      const isUnknownMembership = Boolean(
+        current &&
+        !currentClanTag &&
+        !isAuthoritativeLivePlayerCurrentSource(current.lastSource),
+      );
       const isOutsideTrackedClans = Boolean(
         current && currentClanTag && !configuredTrackedClanTags.has(currentClanTag),
       );
-      const isConfirmedClanlessCandidate = Boolean(current && !currentClanTag && isConfirmedClanless(current));
+      const isConfirmedClanlessCandidate = Boolean(
+        current &&
+        !currentClanTag &&
+        isAuthoritativeLivePlayerCurrentSource(current.lastSource),
+      );
       if (
-        (isMissingPlayerCurrent || isOutsideTrackedClans || isConfirmedClanlessCandidate) &&
+        (isMissingPlayerCurrent || isUnknownMembership || isOutsideTrackedClans || isConfirmedClanlessCandidate) &&
         isStale(current, now, freshnessMs)
       ) {
         candidates.push({
           playerTag,
-          priority: current ? 2 : 1,
+          priority: isMissingPlayerCurrent || isUnknownMembership ? 1 : 2,
           lastFetchedAtMs: current?.lastFetchedAt?.getTime() ?? Number.NEGATIVE_INFINITY,
         });
-        if (current) staleOutsideOrClanlessCandidates += 1;
+        if (isUnknownMembership) {
+          unknownMembershipCandidates += 1;
+        } else if (current) {
+          staleOutsideOrClanlessCandidates += 1;
+        }
       }
     }
 
@@ -217,6 +229,7 @@ export class LinkedPlayerCurrentReconcileService {
       refreshSucceeded,
       refreshFailed,
       deferredByBatchBound,
+      unknownMembershipCandidates,
       failedTrackedClanTags,
     };
     logResult(result);

--- a/src/services/PlayerCurrentService.ts
+++ b/src/services/PlayerCurrentService.ts
@@ -38,6 +38,12 @@ export type PlayerCurrentResolutionSource =
   | "accounts-refresh"
   | "missing";
 
+/** Purpose: identify PlayerCurrent sources that represent a full live player API observation. */
+export function isAuthoritativeLivePlayerCurrentSource(source: unknown): boolean {
+  const normalized = String(source ?? "").trim().toLowerCase();
+  return normalized === "live_refresh" || normalized === "accounts-refresh" || normalized === "activity_observe";
+}
+
 export type PlayerCurrentRefreshPolicy = "missing_only" | "missing_or_stale";
 
 export type PlayerCurrentLike = {

--- a/tests/accountRows.service.test.ts
+++ b/tests/accountRows.service.test.ts
@@ -345,6 +345,46 @@ describe("AccountRowsService", () => {
     });
   });
 
+  it("keeps a live-confirmed clanless PlayerCurrent row from inheriting stale PlayerActivity clan data", async () => {
+    playerCurrentServiceMock.listPlayerCurrentByTags.mockResolvedValue(
+      new Map([
+        [
+          "#PYLQ0289",
+          {
+            playerTag: "#PYLQ0289",
+            playerName: "Clanless Alpha",
+            townHall: 16,
+            currentClanTag: null,
+            currentClanName: null,
+            currentWeight: null,
+            lastSource: "live_refresh",
+          },
+        ],
+      ]),
+    );
+    prismaMock.playerActivity.findMany.mockResolvedValue([
+      { tag: "#PYLQ0289", name: "Clanless Alpha", clanTag: "#CLANA", clanName: "Clan A" },
+    ]);
+    prismaMock.trackedClan.findMany.mockResolvedValue([
+      { tag: "#CLANA", name: "Clan A" },
+    ]);
+
+    const rows = await buildAccountsRows({
+      guildId: "guild-1",
+      linkedNameByTag: new Map([["#PYLQ0289", "Clanless Alpha"]]),
+      tags: ["#PYLQ0289"],
+    });
+
+    expect(rows[0]).toEqual(
+      expect.objectContaining({
+        clanTag: null,
+        clanName: null,
+        clanState: "no_clan",
+        isTrackedFwaClan: false,
+      }),
+    );
+  });
+
   it("uses the freshest current FWA membership row during a transient cross-clan overlap", async () => {
     playerCurrentServiceMock.listPlayerCurrentByTags.mockResolvedValue(
       new Map([

--- a/tests/accountRows.service.test.ts
+++ b/tests/accountRows.service.test.ts
@@ -357,7 +357,7 @@ describe("AccountRowsService", () => {
             currentClanTag: null,
             currentClanName: null,
             currentWeight: null,
-            lastSource: "live_refresh",
+            lastSource: "activity_observe",
           },
         ],
       ]),

--- a/tests/linkedPlayerCurrentReconcile.service.test.ts
+++ b/tests/linkedPlayerCurrentReconcile.service.test.ts
@@ -1,0 +1,275 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const prismaMock = vi.hoisted(() => ({
+  playerLink: {
+    findMany: vi.fn(),
+  },
+}));
+
+const playerCurrentServiceMock = vi.hoisted(() => ({
+  listPlayerCurrentByTags: vi.fn(),
+  refreshCurrentPlayersFromLiveTags: vi.fn(),
+}));
+
+vi.mock("../src/prisma", () => ({
+  prisma: prismaMock,
+}));
+
+vi.mock("../src/helper/dozzleLogger", () => ({
+  dozzleLog: {
+    info: vi.fn(),
+  },
+}));
+
+vi.mock("../src/services/PlayerCurrentService", () => ({
+  playerCurrentService: playerCurrentServiceMock,
+}));
+
+vi.mock("../src/services/PlayerLinkService", () => ({
+  normalizeClanTag: (input: string) => String(input ?? "").trim().toUpperCase(),
+  normalizePlayerTag: (input: string) => String(input ?? "").trim().toUpperCase(),
+}));
+
+import {
+  DEFAULT_LINKED_PLAYER_RECONCILE_BATCH_SIZE,
+  LinkedPlayerCurrentReconcileService,
+} from "../src/services/LinkedPlayerCurrentReconcileService";
+
+const NOW = new Date("2026-08-11T12:00:00.000Z");
+
+function makeCurrent(input: {
+  playerTag: string;
+  currentClanTag: string | null;
+  lastSource?: string;
+  lastFetchedAt?: Date | null;
+}): any {
+  return {
+    playerTag: input.playerTag,
+    playerName: "Cached Player",
+    townHall: 16,
+    currentClanTag: input.currentClanTag,
+    currentClanName: input.currentClanTag ? "Cached Clan" : null,
+    trophies: 6000,
+    builderTrophies: 4000,
+    warStars: 100,
+    expLevel: 200,
+    role: "member",
+    leagueName: "Legend League",
+    currentWeight: null,
+    currentWeightSource: null,
+    currentWeightMeasuredAt: null,
+    achievementsJson: null,
+    lastSeenAt: input.lastFetchedAt ?? new Date("2026-06-01T00:00:00.000Z"),
+    lastFetchedAt: input.lastFetchedAt ?? new Date("2026-06-01T00:00:00.000Z"),
+    lastSource: input.lastSource ?? "activity_observe",
+    createdAt: new Date("2026-06-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-06-01T00:00:00.000Z"),
+    source: "player_current",
+    liveRefreshInvoked: false,
+  };
+}
+
+function configureLinkedRows(rows: any[]): void {
+  prismaMock.playerLink.findMany.mockResolvedValue(
+    rows.map((row) => ({ playerTag: row.playerTag, discordUserId: "discord-1" })),
+  );
+  playerCurrentServiceMock.listPlayerCurrentByTags.mockResolvedValue(
+    new Map(rows.map((row) => [row.playerTag, row.current === null ? null : row.current ?? row])),
+  );
+  playerCurrentServiceMock.refreshCurrentPlayersFromLiveTags.mockImplementation(
+    async (input: { playerTags: string[] }) => ({
+      playerCount: input.playerTags.length,
+      successCount: input.playerTags.length,
+      failedPlayerTags: [],
+    }),
+  );
+}
+
+function baseInput(overrides: Record<string, unknown> = {}): any {
+  return {
+    configuredTrackedClanTags: ["#CLANA"],
+    successfullyObservedTrackedClanTags: ["#CLANA"],
+    observedTrackedClans: [{ clanTag: "#CLANA", memberTags: [] }],
+    failedTrackedClanTags: [],
+    cocService: { getPlayerRaw: vi.fn() },
+    now: NOW,
+    ...overrides,
+  };
+}
+
+describe("LinkedPlayerCurrentReconcileService", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    prismaMock.playerLink.findMany.mockResolvedValue([]);
+    playerCurrentServiceMock.listPlayerCurrentByTags.mockResolvedValue(new Map());
+    playerCurrentServiceMock.refreshCurrentPlayersFromLiveTags.mockResolvedValue({
+      playerCount: 0,
+      successCount: 0,
+      failedPlayerTags: [],
+    });
+  });
+
+  it("refreshes a linked departure from tracked FWA into a non-FWA clan", async () => {
+    const playerTag = "#PLAYERA";
+    configureLinkedRows([
+      { playerTag, current: makeCurrent({ playerTag, currentClanTag: "#CLANA" }) },
+    ]);
+
+    const result = await new LinkedPlayerCurrentReconcileService().reconcile(baseInput());
+
+    expect(result).toMatchObject({
+      linkedPlayersConsidered: 1,
+      departureCandidates: 1,
+      refreshAttempted: 1,
+      refreshSucceeded: 1,
+    });
+    expect(playerCurrentServiceMock.refreshCurrentPlayersFromLiveTags).toHaveBeenCalledWith(
+      expect.objectContaining({
+        playerTags: [playerTag],
+        source: "live_refresh",
+        now: NOW,
+      }),
+    );
+  });
+
+  it("refreshes a tracked departure that is now clanless", async () => {
+    const playerTag = "#PLAYERB";
+    configureLinkedRows([
+      { playerTag, current: makeCurrent({ playerTag, currentClanTag: "#CLANA" }) },
+    ]);
+
+    const result = await new LinkedPlayerCurrentReconcileService().reconcile(baseInput());
+
+    expect(result.departureCandidates).toBe(1);
+    expect(playerCurrentServiceMock.refreshCurrentPlayersFromLiveTags).toHaveBeenCalledWith(
+      expect.objectContaining({ playerTags: [playerTag], source: "live_refresh" }),
+    );
+  });
+
+  it("refreshes stale movement between non-FWA clans", async () => {
+    const playerTag = "#PLAYERC";
+    configureLinkedRows([
+      { playerTag, current: makeCurrent({ playerTag, currentClanTag: "#CLANX" }) },
+    ]);
+
+    const result = await new LinkedPlayerCurrentReconcileService().reconcile(
+      baseInput({
+        configuredTrackedClanTags: ["#CLANA"],
+        successfullyObservedTrackedClanTags: ["#CLANA"],
+      }),
+    );
+
+    expect(result.staleOutsideOrClanlessCandidates).toBe(1);
+    expect(playerCurrentServiceMock.refreshCurrentPlayersFromLiveTags).toHaveBeenCalledWith(
+      expect.objectContaining({ playerTags: [playerTag] }),
+    );
+  });
+
+  it("refreshes stale confirmed-clanless rows that now have a non-FWA clan", async () => {
+    const playerTag = "#PLAYERD";
+    configureLinkedRows([
+      {
+        playerTag,
+        current: makeCurrent({
+          playerTag,
+          currentClanTag: null,
+          lastSource: "live_refresh",
+        }),
+      },
+    ]);
+
+    const result = await new LinkedPlayerCurrentReconcileService().reconcile(baseInput());
+
+    expect(result.staleOutsideOrClanlessCandidates).toBe(1);
+    expect(playerCurrentServiceMock.refreshCurrentPlayersFromLiveTags).toHaveBeenCalledWith(
+      expect.objectContaining({ playerTags: [playerTag] }),
+    );
+  });
+
+  it("refreshes missing PlayerCurrent rows and skips recently refreshed outside rows", async () => {
+    const missingTag = "#PLAYERE";
+    const freshTag = "#PLAYERF";
+    configureLinkedRows([
+      { playerTag: missingTag, current: null },
+      {
+        playerTag: freshTag,
+        current: makeCurrent({
+          playerTag: freshTag,
+          currentClanTag: "#CLANX",
+          lastFetchedAt: new Date("2026-08-11T11:30:00.000Z"),
+        }),
+      },
+    ]);
+
+    const result = await new LinkedPlayerCurrentReconcileService().reconcile(baseInput());
+
+    expect(result.refreshAttempted).toBe(1);
+    expect(playerCurrentServiceMock.refreshCurrentPlayersFromLiveTags).toHaveBeenCalledWith(
+      expect.objectContaining({ playerTags: [missingTag] }),
+    );
+  });
+
+  it("does not re-fetch linked players already observed in a tracked roster", async () => {
+    const playerTag = "#PLAYERG";
+    configureLinkedRows([
+      { playerTag, current: makeCurrent({ playerTag, currentClanTag: "#CLANA" }) },
+    ]);
+
+    const result = await new LinkedPlayerCurrentReconcileService().reconcile(
+      baseInput({ observedTrackedClans: [{ clanTag: "#CLANA", memberTags: [playerTag] }] }),
+    );
+
+    expect(result.alreadyObservedTrackedPlayersSkipped).toBe(1);
+    expect(result.refreshAttempted).toBe(0);
+    expect(playerCurrentServiceMock.refreshCurrentPlayersFromLiveTags).not.toHaveBeenCalled();
+  });
+
+  it("does not infer departure from a tracked clan whose observation failed", async () => {
+    const playerTag = "#PLAYERH";
+    configureLinkedRows([
+      { playerTag, current: makeCurrent({ playerTag, currentClanTag: "#CLANA" }) },
+    ]);
+
+    const result = await new LinkedPlayerCurrentReconcileService().reconcile(
+      baseInput({
+        successfullyObservedTrackedClanTags: [],
+        observedTrackedClans: [],
+        failedTrackedClanTags: ["#CLANA"],
+      }),
+    );
+
+    expect(result.departureCandidates).toBe(0);
+    expect(result.refreshAttempted).toBe(0);
+    expect(result.failedTrackedClanTags).toEqual(["#CLANA"]);
+  });
+
+  it("prioritizes departures before routine stale maintenance and reports the batch deferral", async () => {
+    const departureTags = ["#PLAYERI", "#PLAYERJ"];
+    const routineTag = "#PLAYERK";
+    configureLinkedRows([
+      ...departureTags.map((playerTag) => ({
+        playerTag,
+        current: makeCurrent({ playerTag, currentClanTag: "#CLANA" }),
+      })),
+      {
+        playerTag: routineTag,
+        current: makeCurrent({ playerTag: routineTag, currentClanTag: "#CLANX" }),
+      },
+    ]);
+
+    const result = await new LinkedPlayerCurrentReconcileService().reconcile(
+      baseInput({ batchSize: 2 }),
+    );
+
+    expect(result.departureCandidates).toBe(2);
+    expect(result.staleOutsideOrClanlessCandidates).toBe(1);
+    expect(result.deferredByBatchBound).toBe(1);
+    expect(playerCurrentServiceMock.refreshCurrentPlayersFromLiveTags).toHaveBeenCalledWith(
+      expect.objectContaining({ playerTags: departureTags }),
+    );
+  });
+
+  it("uses the default bounded maintenance batch", async () => {
+    expect(DEFAULT_LINKED_PLAYER_RECONCILE_BATCH_SIZE).toBe(100);
+  });
+});

--- a/tests/linkedPlayerCurrentReconcile.service.test.ts
+++ b/tests/linkedPlayerCurrentReconcile.service.test.ts
@@ -22,6 +22,10 @@ vi.mock("../src/helper/dozzleLogger", () => ({
 }));
 
 vi.mock("../src/services/PlayerCurrentService", () => ({
+  isAuthoritativeLivePlayerCurrentSource: (source: unknown) =>
+    ["live_refresh", "accounts-refresh", "activity_observe"].includes(
+      String(source ?? "").trim().toLowerCase(),
+    ),
   playerCurrentService: playerCurrentServiceMock,
 }));
 
@@ -207,6 +211,50 @@ describe("LinkedPlayerCurrentReconcileService", () => {
     expect(playerCurrentServiceMock.refreshCurrentPlayersFromLiveTags).toHaveBeenCalledWith(
       expect.objectContaining({ playerTags: [missingTag] }),
     );
+  });
+
+  it("refreshes stale existing unknown-membership rows", async () => {
+    const unknownTag = "#PLAYERUNKNOWN";
+    configureLinkedRows([
+      {
+        playerTag: unknownTag,
+        current: makeCurrent({
+          playerTag: unknownTag,
+          currentClanTag: null,
+          lastSource: "fwa_player_catalog",
+          lastFetchedAt: new Date("2026-08-11T10:00:00.000Z"),
+        }),
+      },
+    ]);
+
+    const result = await new LinkedPlayerCurrentReconcileService().reconcile(baseInput());
+
+    expect(result.unknownMembershipCandidates).toBe(1);
+    expect(result.staleOutsideOrClanlessCandidates).toBe(0);
+    expect(playerCurrentServiceMock.refreshCurrentPlayersFromLiveTags).toHaveBeenCalledWith(
+      expect.objectContaining({ playerTags: [unknownTag] }),
+    );
+  });
+
+  it("does not refresh a recently fetched unknown-membership row", async () => {
+    const unknownTag = "#PLAYERUNKNOWNFRESH";
+    configureLinkedRows([
+      {
+        playerTag: unknownTag,
+        current: makeCurrent({
+          playerTag: unknownTag,
+          currentClanTag: null,
+          lastSource: "todo_snapshot",
+          lastFetchedAt: new Date("2026-08-11T11:30:00.000Z"),
+        }),
+      },
+    ]);
+
+    const result = await new LinkedPlayerCurrentReconcileService().reconcile(baseInput());
+
+    expect(result.unknownMembershipCandidates).toBe(0);
+    expect(result.refreshAttempted).toBe(0);
+    expect(playerCurrentServiceMock.refreshCurrentPlayersFromLiveTags).not.toHaveBeenCalled();
   });
 
   it("does not re-fetch linked players already observed in a tracked roster", async () => {

--- a/tests/playerCurrent.service.test.ts
+++ b/tests/playerCurrent.service.test.ts
@@ -195,6 +195,64 @@ describe("PlayerCurrentService", () => {
     );
   });
 
+  it("persists external-clan and clanless results through the bounded live-tag refresh path", async () => {
+    prismaMock.playerCurrent.findMany.mockResolvedValueOnce([
+      makeCurrentRow({
+        playerTag: "#PYLQ0289",
+        currentClanTag: "#CLANA",
+        currentClanName: "Tracked A",
+      }),
+      makeCurrentRow({
+        playerTag: "#QGRJ2222",
+        currentClanTag: "#CLANA",
+        currentClanName: "Tracked A",
+      }),
+    ]);
+    const cocService = {
+      getPlayerRaw: vi.fn(async (tag: string) =>
+        tag === "#PYLQ0289"
+          ? makeLivePlayer({
+              tag,
+              clan: { tag: "#2QG2C08UP", name: "External X" },
+            })
+          : makeLivePlayer({ tag, clan: null }),
+      ),
+    } as any;
+
+    const result = await playerCurrentService.refreshCurrentPlayersFromLiveTags({
+      playerTags: ["#PYLQ0289", "#QGRJ2222"],
+      cocService,
+      source: "live_refresh",
+      now: new Date("2026-08-11T12:00:00.000Z"),
+    });
+
+    expect(result).toEqual({
+      playerCount: 2,
+      successCount: 2,
+      failedPlayerTags: [],
+    });
+    expect(prismaMock.playerCurrent.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { playerTag: "#PYLQ0289" },
+        create: expect.objectContaining({
+          currentClanTag: "#2QG2C08UP",
+          currentClanName: "External X",
+          lastSource: "live_refresh",
+        }),
+      }),
+    );
+    expect(prismaMock.playerCurrent.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { playerTag: "#QGRJ2222" },
+        create: expect.objectContaining({
+          currentClanTag: null,
+          currentClanName: null,
+          lastSource: "live_refresh",
+        }),
+      }),
+    );
+  });
+
   it("falls back to legacy league when leagueTier is missing", async () => {
     prismaMock.playerCurrent.findMany.mockResolvedValueOnce([]);
     prismaMock.fwaPlayerCatalog.findMany.mockResolvedValueOnce([]);

--- a/tests/playerCurrent.service.test.ts
+++ b/tests/playerCurrent.service.test.ts
@@ -14,7 +14,10 @@ vi.mock("../src/prisma", () => ({
   prisma: prismaMock,
 }));
 
-import { playerCurrentService } from "../src/services/PlayerCurrentService";
+import {
+  isAuthoritativeLivePlayerCurrentSource,
+  playerCurrentService,
+} from "../src/services/PlayerCurrentService";
 import { todoSnapshotService } from "../src/services/TodoSnapshotService";
 
 function makeCurrentRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
@@ -42,6 +45,22 @@ function makeCurrentRow(overrides: Record<string, unknown> = {}): Record<string,
     ...overrides,
   };
 }
+
+describe("isAuthoritativeLivePlayerCurrentSource", () => {
+  it.each(["live_refresh", "accounts-refresh", "activity_observe"])(
+    "accepts %s as a live observation",
+    (source) => {
+      expect(isAuthoritativeLivePlayerCurrentSource(source)).toBe(true);
+    },
+  );
+
+  it.each(["fwa_player_catalog", "todo_snapshot", "missing", null, undefined])(
+    "does not accept %s as a live observation",
+    (source) => {
+      expect(isAuthoritativeLivePlayerCurrentSource(source)).toBe(false);
+    },
+  );
+});
 
 function makeLivePlayer(overrides: Record<string, unknown> = {}): Record<string, unknown> {
   return {

--- a/tests/ready.listener.test.ts
+++ b/tests/ready.listener.test.ts
@@ -1,7 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const autoRoleStart = vi.hoisted(() => vi.fn(() => ({ started: true })));
-const observeLoopStart = vi.hoisted(() => vi.fn(() => new Promise<void>(() => undefined)));
+const observeLoopArgs = vi.hoisted(() => ({ current: null as any }));
+const observeLoopStart = vi.hoisted(() =>
+  vi.fn((args: any) => {
+    observeLoopArgs.current = args;
+    return { started: true };
+  }),
+);
 const reminderStart = vi.hoisted(() => vi.fn(() => ({ started: true })));
 const userActivityReminderStart = vi.hoisted(() => vi.fn(() => ({ started: true })));
 const fwaFeedStart = vi.hoisted(() => vi.fn());
@@ -52,6 +58,27 @@ const prismaMock = vi.hoisted(() => ({
 const isActivePollingModeMock = vi.hoisted(() => vi.fn(() => true));
 const isMirrorPollingModeMock = vi.hoisted(() => vi.fn(() => false));
 const resolvePollingModeMock = vi.hoisted(() => vi.fn(() => "active"));
+const activityObserveClanDetailedMock = vi.hoisted(() =>
+  vi.fn().mockResolvedValue({
+    clanTag: "#CLAN",
+    clanName: "Clan",
+    memberTags: [],
+    members: [],
+  }),
+);
+const linkedPlayerCurrentReconcileMock = vi.hoisted(() => ({
+  reconcile: vi.fn().mockResolvedValue({
+    linkedPlayersConsidered: 0,
+    alreadyObservedTrackedPlayersSkipped: 0,
+    departureCandidates: 0,
+    staleOutsideOrClanlessCandidates: 0,
+    refreshAttempted: 0,
+    refreshSucceeded: 0,
+    refreshFailed: 0,
+    deferredByBatchBound: 0,
+    failedTrackedClanTags: [],
+  }),
+}));
 
 vi.mock("../src/Commands", () => ({
   Commands: [],
@@ -153,13 +180,12 @@ vi.mock("../src/services/SettingsService", () => ({
 
 vi.mock("../src/services/ActivityService", () => ({
   ActivityService: vi.fn().mockImplementation(() => ({
-    observeClanDetailed: vi.fn().mockResolvedValue({
-      clanTag: "#CLAN",
-      clanName: "Clan",
-      memberTags: [],
-      members: [],
-    }),
+    observeClanDetailed: activityObserveClanDetailedMock,
   })),
+}));
+
+vi.mock("../src/services/LinkedPlayerCurrentReconcileService", () => ({
+  linkedPlayerCurrentReconcileService: linkedPlayerCurrentReconcileMock,
 }));
 
 vi.mock("../src/services/WarEventLogService", () => ({
@@ -364,6 +390,14 @@ import ready from "../src/listeners/ready";
 describe("ready listener startup", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    observeLoopArgs.current = null;
+    activityObserveClanDetailedMock.mockReset();
+    activityObserveClanDetailedMock.mockResolvedValue({
+      clanTag: "#CLAN",
+      clanName: "Clan",
+      memberTags: [],
+      members: [],
+    });
     isActivePollingModeMock.mockReturnValue(true);
     resolvePollingModeMock.mockReturnValue("active");
     statusServiceMock.markStarted.mockResolvedValue({});
@@ -374,6 +408,7 @@ describe("ready listener startup", () => {
     botStartupStatusService.markPhase("ready_start", { test: true });
     prismaMock.trackedMessage.findMany.mockResolvedValue([]);
     prismaMock.trackedMessage.findFirst.mockResolvedValue(null);
+    prismaMock.trackedClan.findMany.mockResolvedValue([]);
   });
 
   afterEach(() => {
@@ -553,6 +588,35 @@ describe("ready listener startup", () => {
         metadata: expect.objectContaining({
           started: true,
         }),
+      }),
+    );
+  });
+
+  it("passes successful and failed tracked-clan coverage to linked-player reconciliation", async () => {
+    prismaMock.trackedClan.findMany.mockResolvedValue([
+      { tag: "#CLANA", name: "Clan A", logChannelId: null },
+      { tag: "#CLANB", name: "Clan B", logChannelId: null },
+    ]);
+    activityObserveClanDetailedMock
+      .mockResolvedValueOnce({
+        clanTag: "#CLANA",
+        clanName: "Clan A",
+        memberTags: ["#PYLQ0289"],
+        members: [{ playerTag: "#PYLQ0289", playerName: "Alpha" }],
+        observedPlayerCurrent: [],
+      })
+      .mockRejectedValueOnce(new Error("Clan B unavailable"));
+
+    await runStartup();
+    await observeLoopArgs.current.runObservedCycle(123);
+
+    expect(linkedPlayerCurrentReconcileMock.reconcile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        configuredTrackedClanTags: ["#CLANA", "#CLANB"],
+        successfullyObservedTrackedClanTags: ["#CLANA"],
+        observedTrackedClans: [{ clanTag: "#CLANA", memberTags: ["#PYLQ0289"] }],
+        failedTrackedClanTags: ["#CLANB"],
+        now: new Date(123),
       }),
     );
   });

--- a/tests/ready.listener.test.ts
+++ b/tests/ready.listener.test.ts
@@ -76,6 +76,7 @@ const linkedPlayerCurrentReconcileMock = vi.hoisted(() => ({
     refreshSucceeded: 0,
     refreshFailed: 0,
     deferredByBatchBound: 0,
+    unknownMembershipCandidates: 0,
     failedTrackedClanTags: [],
   }),
 }));


### PR DESCRIPTION
Keep linked PlayerCurrent rows current after tracked-roster departures by using the existing activity-observe cycle and bounded live player refreshes. Preserve DB-only /accounts rendering and suppress stale activity clan fallback after a live-confirmed clanless refresh.