### PR TITLE
feat: add membership history backfill audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ The project is designed as a maintainable application, not a one-off bot script:
 - Uses bounded feed-sync/watch loops for external data ingestion and update timing.
 - Established Home accounts can receive a randomized, persisted pre-sync return DM when authoritative Home state is AWAY; UNKNOWN is suppressed, linked accounts for one user are grouped, exact sync timing is deliberately hidden, and normal replay is restart-safe/idempotent.
 - Supports mirror-mode staging via guarded prod-to-staging runtime snapshot sync.
+- Includes `npm run diagnose:membership-history-backfill`, a one-time strictly read-only historical evidence audit. It classifies recoverable guild/sync boundaries from persisted canonical owners, reports ambiguity and missing mappings, and prints diagnostic-only player streak and potential Home-tenure impact without writing data or consulting current-state tables as historical evidence.
 - Exposes `/livez` and `/healthz` for liveness/readiness checks.
 
 ### Clan management tooling

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "seed:fwa-layouts": "ts-node src/scripts/seedFwaLayouts.ts",
     "seed:heatmap-ref": "ts-node src/scripts/seedHeatMapRef.ts",
     "repair:fwa-ended-war": "ts-node src/scripts/repairEndedWarState.ts",
+    "diagnose:membership-history-backfill": "ts-node src/scripts/auditMembershipHistoryBackfill.ts",
     "sync:mirror": "ts-node src/scripts/mirrorSync.ts",
     "sync:fwa-feeds": "ts-node src/scripts/fwaFeedSync.ts",
     "start": "npm run build && npm run start:runtime",

--- a/src/scripts/auditMembershipHistoryBackfill.ts
+++ b/src/scripts/auditMembershipHistoryBackfill.ts
@@ -1,6 +1,11 @@
 import { prisma } from "../prisma";
 import { normalizeTag } from "../services/war-events/core";
-import { MembershipStreakService } from "../services/MembershipStreakService";
+import {
+  computeMembershipStreaksFromEvidence,
+  MembershipStreakService,
+  type MembershipBoundaryEvidence,
+  type MembershipStreakResult,
+} from "../services/MembershipStreakService";
 
 export const SCHEDULE_CORRELATION_THRESHOLD_MS = 24 * 60 * 60 * 1000;
 export const MAX_PREP_CLUSTER_SPREAD_MS = 2 * 60 * 60 * 1000;
@@ -22,6 +27,7 @@ export type AuditPointEvidence = {
   warStartTime: Date;
   opponentTag: string;
   isFwa: boolean;
+  identitySource?: "ClanPointsSync" | "WarPlanComplianceEvaluation";
 };
 
 export type AuditHistoryEvidence = {
@@ -112,6 +118,8 @@ export type AuditCycleReport = {
   latestSupportingEvidence: Date | null;
   rosterCompleteness: "COMPLETE" | "PARTIAL" | "UNKNOWN";
   expectedTeamSize: number | null;
+  expectedTeamSizesByClan: Record<string, number | null>;
+  perClanRosterCompleteness: Record<string, "COMPLETE" | "PARTIAL" | "UNKNOWN">;
   playerClanFacts: Array<{ playerTag: string; clanTag: string; source: string }>;
 };
 
@@ -165,11 +173,12 @@ function isFwa(value: unknown): boolean {
   return comparable(value) === "FWA";
 }
 
-/** Purpose: provide a stable key for one guild, sync number, and historical war identity. */
+/** Purpose: scope a historical war identity to its clan so alliance rosters do not conflict. */
 function warIdentityKey(point: AuditPointEvidence): string {
+  const clanTag = normalizeClanTag(point.clanTag);
   return point.warId !== null
-    ? `war:${point.warId}`
-    : `start:${point.warStartTime.getTime()}|opponent:${point.opponentTag}`;
+    ? `${clanTag}|war:${point.warId}`
+    : `${clanTag}|start:${point.warStartTime.getTime()}|opponent:${point.opponentTag}`;
 }
 
 /** Purpose: parse canonical participant tags from the supported archived WarLookup payload shape. */
@@ -256,13 +265,51 @@ function findScheduleCandidates(
 /** Purpose: map canonical histories to a points identity without nearest-time guessing. */
 function historyMatchesPoint(history: AuditHistoryEvidence, point: AuditPointEvidence): boolean {
   if (!isFwa(history.matchType)) return false;
-  if (history.warId === point.warId && point.warId !== null) return history.clanTag === point.clanTag;
+  if (history.warId === point.warId && point.warId !== null && normalizeClanTag(history.clanTag) === normalizeClanTag(point.clanTag)) {
+    return history.syncNumber === null || history.syncNumber === point.syncNumber;
+  }
   return (
     history.syncNumber === point.syncNumber &&
-    history.clanTag === point.clanTag &&
-    history.opponentTag === point.opponentTag &&
+    normalizeClanTag(history.clanTag) === normalizeClanTag(point.clanTag) &&
+    normalizeClanTag(history.opponentTag) === normalizeClanTag(point.opponentTag) &&
     history.warStartTime.getTime() === point.warStartTime.getTime()
   );
+}
+
+/** Purpose: identify persisted sync-number disagreement without allowing war identity to override it. */
+function hasPersistedSyncNumberDisagreement(
+  point: AuditPointEvidence,
+  histories: readonly AuditHistoryEvidence[],
+): boolean {
+  return point.warId !== null && histories.some((history) =>
+    isFwa(history.matchType) &&
+    history.warId === point.warId &&
+    normalizeClanTag(history.clanTag) === normalizeClanTag(point.clanTag) &&
+    history.syncNumber !== null &&
+    history.syncNumber !== point.syncNumber,
+  );
+}
+
+/** Purpose: detect conflicting persisted owners for one historical war and clan. */
+function hasConflictingPersistedOwners(points: readonly AuditPointEvidence[]): boolean {
+  const ownersByWarClan = new Map<string, Set<string>>();
+  for (const point of points) {
+    if (point.warId === null) continue;
+    const key = `${normalizeClanTag(point.clanTag)}|${point.warId}`;
+    const owners = ownersByWarClan.get(key) ?? new Set<string>();
+    owners.add(`${point.guildId}|${point.syncNumber}`);
+    ownersByWarClan.set(key, owners);
+  }
+  return [...ownersByWarClan.values()].some((owners) => owners.size > 1);
+}
+
+/** Purpose: apply persisted-owner conflict detection only to the current cycle identity. */
+function pointHasConflictingPersistedOwner(point: AuditPointEvidence, points: readonly AuditPointEvidence[]): boolean {
+  if (point.warId === null) return false;
+  const owners = new Set(points
+    .filter((candidate) => candidate.warId === point.warId && normalizeClanTag(candidate.clanTag) === normalizeClanTag(point.clanTag))
+    .map((candidate) => `${candidate.guildId}|${candidate.syncNumber}`));
+  return owners.size > 1;
 }
 
 /** Purpose: build one diagnostic report from already-normalized historical evidence. */
@@ -274,19 +321,20 @@ export function classifyAuditCycle(input: AuditCycleInput): AuditCycleReport {
   const mappedHistories = histories.filter((history) => points.some((point) => historyMatchesPoint(history, point)));
   const participation = input.participation.filter((row) =>
     row.guildId === guildId && mappedHistories.some((history) =>
-      history.warId === row.warId && history.clanTag === row.clanTag),
+      history.warId === row.warId && normalizeClanTag(history.clanTag) === normalizeClanTag(row.clanTag)),
   );
   const prepCluster = buildPrepCluster(mappedHistories.map((history) => history.prepStartTime).filter(isValidDate));
   const scheduledCandidates = findScheduleCandidates(guildId, prepCluster, input.schedules);
   const exactSnapshots = input.exactSnapshots.filter((row) =>
     row.guildId === guildId && input.syncCycleTime && row.syncTime.getTime() === input.syncCycleTime.getTime(),
   );
-  const historicalClanTags = new Set(points.map((point) => point.clanTag).filter(Boolean));
-  for (const history of mappedHistories) historicalClanTags.add(history.clanTag);
+  const historicalClanTags = new Set(points.map((point) => normalizeClanTag(point.clanTag)).filter(Boolean));
+  for (const history of mappedHistories) historicalClanTags.add(normalizeClanTag(history.clanTag));
   const perClanRosterPlayers = new Map<string, Set<string>>();
   const perClanRosterCounts: Record<string, number> = {};
   const playerClanFacts: Array<{ playerTag: string; clanTag: string; source: string }> = [];
   const playerClanSets = new Map<string, Set<string>>();
+  const participationFactKeys = new Set<string>();
   for (const row of participation) {
     const playerTag = normalizePlayerTag(row.playerTag);
     const clanTag = normalizeClanTag(row.clanTag);
@@ -298,14 +346,28 @@ export function classifyAuditCycle(input: AuditCycleInput): AuditCycleReport {
     const clans = playerClanSets.get(playerTag) ?? new Set<string>();
     clans.add(clanTag);
     playerClanSets.set(playerTag, clans);
-    playerClanFacts.push({ playerTag, clanTag, source: "ClanWarParticipation" });
+    const factKey = `${playerTag}|${clanTag}|ClanWarParticipation`;
+    if (!participationFactKeys.has(factKey)) {
+      participationFactKeys.add(factKey);
+      playerClanFacts.push({ playerTag, clanTag, source: "ClanWarParticipation" });
+    }
   }
   const conflicts = [...(input.explicitConflicts ?? [])];
-  const identityKeys = new Set(points.map(warIdentityKey));
-  if (identityKeys.size > 1) conflicts.push("conflicting_war_identities");
+  const identityKeysByClan = new Map<string, Set<string>>();
+  for (const point of points) {
+    const identities = identityKeysByClan.get(normalizeClanTag(point.clanTag)) ?? new Set<string>();
+    identities.add(warIdentityKey(point));
+    identityKeysByClan.set(normalizeClanTag(point.clanTag), identities);
+    if (hasPersistedSyncNumberDisagreement(point, histories)) conflicts.push("persisted_sync_number_disagreement");
+    if (pointHasConflictingPersistedOwner(point, points)) conflicts.push("conflicting_persisted_identity_sources");
+  }
+  if ([...identityKeysByClan.values()].some((identities) => identities.size > 1)) {
+    conflicts.push("conflicting_war_identities");
+  }
   for (const [playerTag, clans] of playerClanSets) {
     if (clans.size > 1) conflicts.push(`player_in_multiple_clans:${playerTag}`);
   }
+  const legacyRosterFacts: Array<{ playerTag: string; clanTag: string }> = [];
   const legacyEvidenceAvailable = participation.length === 0 && input.lookups.length > 0 && pointWarIds.size > 0;
   if (legacyEvidenceAvailable) {
     const factKeys = new Set<string>();
@@ -320,27 +382,60 @@ export function classifyAuditCycle(input: AuditCycleInput): AuditCycleReport {
         perClanRosterPlayers.set(clanTag, rosterPlayers);
         perClanRosterCounts[clanTag] = rosterPlayers.size;
         playerClanFacts.push({ playerTag, clanTag, source: "WarLookup.canonical.participants" });
+        legacyRosterFacts.push({ playerTag, clanTag });
       }
     }
   }
-  const expectedTeamSizes = [
-    ...mappedHistories.map((history) => normalizePositiveInteger(history.expectedTeamSize)),
-    ...input.lookups.map((lookup) => normalizePositiveInteger(lookup.expectedTeamSize)),
-  ]
-    .filter((value): value is number => value !== null);
-  const expectedTeamSize = expectedTeamSizes.length > 0 ? Math.max(...expectedTeamSizes) : null;
-  const rosterCompleteness = expectedTeamSize === null
+  const expectedTeamSizesByClan = new Map<string, Set<number>>();
+  for (const history of mappedHistories) {
+    const expectedSize = normalizePositiveInteger(history.expectedTeamSize);
+    if (expectedSize === null) continue;
+    const clanTag = normalizeClanTag(history.clanTag);
+    const sizes = expectedTeamSizesByClan.get(clanTag) ?? new Set<number>();
+    sizes.add(expectedSize);
+    expectedTeamSizesByClan.set(clanTag, sizes);
+  }
+  for (const lookup of input.lookups) {
+    const expectedSize = normalizePositiveInteger(lookup.expectedTeamSize);
+    if (expectedSize === null) continue;
+    const clanTag = normalizeClanTag(lookup.clanTag);
+    const sizes = expectedTeamSizesByClan.get(clanTag) ?? new Set<number>();
+    sizes.add(expectedSize);
+    expectedTeamSizesByClan.set(clanTag, sizes);
+  }
+  const expectedTeamSizesByClanRecord = Object.fromEntries([...historicalClanTags].sort((a, b) => a.localeCompare(b)).map((clanTag) => {
+    const sizes = expectedTeamSizesByClan.get(clanTag) ?? new Set<number>();
+    return [clanTag, sizes.size === 1 ? [...sizes][0] : null];
+  }));
+  for (const [clanTag, sizes] of expectedTeamSizesByClan) {
+    if (sizes.size > 1) conflicts.push(`conflicting_expected_team_sizes:${clanTag}`);
+  }
+  const perClanRosterCompleteness = Object.fromEntries([...historicalClanTags].sort((a, b) => a.localeCompare(b)).map((clanTag) => {
+    const expectedSize = expectedTeamSizesByClanRecord[clanTag];
+    const observedSize = perClanRosterCounts[clanTag] ?? 0;
+    const completeness = expectedSize === null
+      ? "UNKNOWN"
+      : observedSize === expectedSize ? "COMPLETE" : "PARTIAL";
+    return [clanTag, completeness];
+  })) as Record<string, "COMPLETE" | "PARTIAL" | "UNKNOWN">;
+  const expectedTeamSizes = Object.values(expectedTeamSizesByClanRecord).filter((value): value is number => value !== null);
+  const expectedTeamSize = expectedTeamSizes.length > 0 && new Set(expectedTeamSizes).size === 1
+    ? expectedTeamSizes[0]
+    : null;
+  const rosterCompleteness = Object.values(perClanRosterCompleteness).length === 0 || Object.values(perClanRosterCompleteness).every((value) => value === "UNKNOWN")
     ? "UNKNOWN"
-    : [...historicalClanTags].every((clanTag) => (perClanRosterCounts[clanTag] ?? 0) === expectedTeamSize)
+    : Object.values(perClanRosterCompleteness).every((value) => value === "COMPLETE")
       ? "COMPLETE"
       : "PARTIAL";
   const missingMappings = [...(input.missingParticipantWarMappings ?? [])];
   const normalizedRosterAvailable = participation.length > 0 && mappedHistories.length > 0;
+  const legacyRosterAvailable = legacyRosterFacts.length > 0;
+  const rosterEvidenceAvailable = normalizedRosterAvailable || legacyRosterAvailable;
   const exactCoverage = exactSnapshots.length > 0;
   let classification: AuditClassification;
   let candidateSyncTime: Date | null = null;
   let candidateSource: string | null = null;
-  if (conflicts.length > 0 && !input.syncCycleTime && !exactCoverage) {
+  if (conflicts.length > 0) {
     classification = "AMBIGUOUS";
   } else if (input.syncCycleTime && exactCoverage) {
     classification = "EXISTING_EXACT";
@@ -349,11 +444,17 @@ export function classifyAuditCycle(input: AuditCycleInput): AuditCycleReport {
   } else if (scheduledCandidates.length > 1) {
     classification = "AMBIGUOUS";
     conflicts.push("multiple_plausible_scheduled_sync_times");
-  } else if (scheduledCandidates.length === 1 && normalizedRosterAvailable && mappedHistories.length > 0) {
+  } else if (scheduledCandidates.length === 1 && rosterEvidenceAvailable && mappedHistories.length > 0) {
     classification = "SCHEDULED_SYNC_CANDIDATE";
     candidateSyncTime = scheduledCandidates[0].syncTime;
-    candidateSource = "ScheduledSyncPost.syncTime";
-  } else if (legacyEvidenceAvailable) {
+    candidateSource = legacyRosterAvailable && !normalizedRosterAvailable
+      ? "ScheduledSyncPost.syncTime+WarLookup.canonical.participants"
+      : "ScheduledSyncPost.syncTime";
+  } else if (legacyRosterAvailable && mappedHistories.length > 0 && prepCluster.center && !prepCluster.excessiveSpread) {
+    classification = "PREP_CLUSTER_CANDIDATE";
+    candidateSyncTime = prepCluster.center;
+    candidateSource = "ClanWarHistory.prepStartTime.median+WarLookup.canonical.participants";
+  } else if (legacyRosterAvailable) {
     classification = "LEGACY_WARLOOKUP_CANDIDATE";
     candidateSource = "WarLookup.canonical.participants";
   } else if (mappedHistories.length > 0 && prepCluster.center) {
@@ -406,6 +507,8 @@ export function classifyAuditCycle(input: AuditCycleInput): AuditCycleReport {
     latestSupportingEvidence,
     rosterCompleteness,
     expectedTeamSize,
+    expectedTeamSizesByClan: Object.fromEntries(Object.entries(expectedTeamSizesByClanRecord).sort(([a], [b]) => a.localeCompare(b))),
+    perClanRosterCompleteness: Object.fromEntries(Object.entries(perClanRosterCompleteness).sort(([a], [b]) => a.localeCompare(b))),
     playerClanFacts: playerClanFacts.sort((left, right) =>
       left.playerTag.localeCompare(right.playerTag) || left.clanTag.localeCompare(right.clanTag)),
   };
@@ -427,10 +530,11 @@ export function formatAuditSummary(reports: readonly AuditCycleReport[]): string
     "PREP_CLUSTER_CANDIDATE",
     "LEGACY_WARLOOKUP_CANDIDATE",
   ].includes(report.classification));
+  const candidateBoundaryReports = candidateReports.filter((report) => isValidDate(report.candidateSyncTime));
   const candidateFacts = candidateReports.reduce((sum, report) => sum + report.playerClanFacts.length, 0);
   const syncNumbers = reports.map((report) => report.syncNumber).sort((a, b) => a - b);
-  const safeDates = candidateReports.map((report) => report.candidateSyncTime).filter(isValidDate).sort((a, b) => a.getTime() - b.getTime());
-  const sortedCandidateReports = [...candidateReports].sort((a, b) => a.syncNumber - b.syncNumber || a.guildId.localeCompare(b.guildId));
+  const safeDates = candidateBoundaryReports.map((report) => report.candidateSyncTime).filter(isValidDate).sort((a, b) => a.getTime() - b.getTime());
+  const sortedCandidateReports = [...candidateBoundaryReports].sort((a, b) => a.syncNumber - b.syncNumber || a.guildId.localeCompare(b.guildId));
   const guilds = [...new Set(reports.map((report) => report.guildId))].sort((a, b) => a.localeCompare(b));
   const syncRange = syncNumbers.length > 0 ? `#${syncNumbers[0]} -> #${syncNumbers[syncNumbers.length - 1]}` : "none";
   return [
@@ -448,7 +552,7 @@ export function formatAuditSummary(reports: readonly AuditCycleReport[]): string
     `Ambiguous: ${count("AMBIGUOUS")}`,
     `Unrecoverable: ${count("UNRECOVERABLE")}`,
     "",
-    `Potential additional canonical boundaries: ${candidateReports.length}`,
+    `Potential additional canonical boundaries: ${candidateBoundaryReports.length}`,
     `Potential player-boundary membership facts: ${candidateFacts}`,
     `Earliest safely recoverable date: ${safeDates[0]?.toISOString() ?? "none"}`,
     `Earliest safely recoverable sync: ${sortedCandidateReports[0]?.syncNumber ? `#${sortedCandidateReports[0].syncNumber}` : "none"}`,
@@ -472,6 +576,7 @@ function normalizePoints(rows: any[]): AuditPointEvidence[] {
       warStartTime,
       opponentTag,
       isFwa: Boolean(row?.isFwa),
+      identitySource: "ClanPointsSync",
     }];
   });
 }
@@ -546,6 +651,33 @@ function normalizeLookups(rows: any[]): AuditLookupEvidence[] {
   });
 }
 
+/** Purpose: map compliance evaluations to canonical FWA histories as a secondary identity source. */
+function normalizeComplianceIdentities(rows: any[], histories: AuditHistoryEvidence[]): AuditPointEvidence[] {
+  return rows.flatMap((row) => {
+    const guildId = normalizeGuildId(row?.guildId);
+    const warId = normalizePositiveInteger(row?.warId);
+    if (!guildId || warId === null) return [];
+    const matchingHistories = histories.filter((history) =>
+      history.warId === warId &&
+      isFwa(history.matchType) &&
+      history.syncNumber !== null &&
+      isValidDate(history.warStartTime),
+    );
+    if (matchingHistories.length !== 1) return [];
+    const history = matchingHistories[0];
+    return [{
+      guildId,
+      syncNumber: history.syncNumber!,
+      clanTag: history.clanTag,
+      warId,
+      warStartTime: history.warStartTime,
+      opponentTag: history.opponentTag ?? "",
+      isFwa: true,
+      identitySource: "WarPlanComplianceEvaluation" as const,
+    }].filter((point) => Boolean(point.opponentTag));
+  });
+}
+
 /** Purpose: build candidate cycle inputs from all persisted read-only historical owners. */
 function buildCycleInputs(
   points: AuditPointEvidence[],
@@ -557,6 +689,24 @@ function buildCycleInputs(
   cycles: any[],
 ): AuditCycleInput[] {
   const identities = new Map<string, { guildId: string; syncNumber: number; points: AuditPointEvidence[]; syncCycleTime: Date | null }>();
+  const conflictingWarClanKeys = new Set<string>();
+  const ownersByWarClan = new Map<string, Set<string>>();
+  for (const point of points) {
+    if (point.warId === null) continue;
+    const key = `${normalizeClanTag(point.clanTag)}|${point.warId}`;
+    const owners = ownersByWarClan.get(key) ?? new Set<string>();
+    owners.add(`${point.guildId}|${point.syncNumber}`);
+    ownersByWarClan.set(key, owners);
+  }
+  for (const [key, owners] of ownersByWarClan) {
+    if (owners.size > 1) conflictingWarClanKeys.add(key);
+  }
+  // Keep this helper in the normalization path so future callers cannot accidentally drop owner conflicts.
+  if (hasConflictingPersistedOwners(points)) {
+    for (const [key, owners] of ownersByWarClan) {
+      if (owners.size > 1) conflictingWarClanKeys.add(key);
+    }
+  }
   for (const row of cycles) {
     const guildId = normalizeGuildId(row?.guildId);
     const syncNumber = normalizePositiveInteger(row?.syncNumber);
@@ -585,25 +735,28 @@ function buildCycleInputs(
     const pointWarIds = new Set(identity.points.map((point) => point.warId).filter((value): value is number => value !== null));
     const matchingHistories = histories.filter((history) => identity.points.some((point) => historyMatchesPoint(history, point)));
     const cycleParticipation = participation.filter((row) => row.guildId === identity.guildId && matchingHistories.some((history) =>
-      history.warId === row.warId && history.clanTag === row.clanTag));
+      history.warId === row.warId && normalizeClanTag(history.clanTag) === normalizeClanTag(row.clanTag)));
     const missingMappings = identity.points
       .filter((point) => !matchingHistories.some((history) => historyMatchesPoint(history, point)))
       .map((point) => `missing_history:${point.clanTag}`);
     for (const history of matchingHistories) {
-      if (!cycleParticipation.some((row) => row.warId === history.warId && row.clanTag === history.clanTag)) {
+      if (!cycleParticipation.some((row) => row.warId === history.warId && normalizeClanTag(row.clanTag) === normalizeClanTag(history.clanTag))) {
         missingMappings.push(`missing_participation:${history.clanTag}:${history.warId}`);
       }
     }
     const relevantLookups = lookups.filter((lookup) => pointWarIds.has(lookup.warId));
     const matchingLookups = relevantLookups.filter((lookup) => identity.points.some((point) =>
-      point.warId === lookup.warId && point.clanTag === lookup.clanTag));
+      point.warId === lookup.warId && normalizeClanTag(point.clanTag) === normalizeClanTag(lookup.clanTag)));
     const lookupOwnerKeys = new Set(relevantLookups.flatMap((lookup) =>
-      points.filter((point) => point.warId === lookup.warId && point.clanTag === lookup.clanTag)
+      points.filter((point) => point.warId === lookup.warId && normalizeClanTag(point.clanTag) === normalizeClanTag(lookup.clanTag))
         .map((point) => `${point.guildId}|${point.syncNumber}`),
     ));
     const historyOwnerKeys = new Set(matchingHistories.flatMap((history) =>
       points.filter((point) => historyMatchesPoint(history, point)).map((point) => `${point.guildId}|${point.syncNumber}`)));
     const explicitConflicts = [
+      ...(identity.points.some((point) => point.warId !== null && conflictingWarClanKeys.has(`${normalizeClanTag(point.clanTag)}|${point.warId}`))
+        ? ["conflicting_persisted_identity_sources"]
+        : []),
       ...(lookupOwnerKeys.size > 1 ? ["warlookup_maps_to_multiple_guild_sync_owners"] : []),
       ...(relevantLookups.length !== matchingLookups.length ? ["warlookup_clan_identity_mismatch"] : []),
       ...(historyOwnerKeys.size > 1 ? ["history_maps_to_multiple_guild_sync_owners"] : []),
@@ -629,7 +782,7 @@ function buildCycleInputs(
 
 /** Purpose: read every historical owner through an interface that exposes no mutation delegate. */
 async function readAuditInputs(db: ReadOnlyAuditDb): Promise<AuditCycleInput[]> {
-  const [cycles, rawSnapshots, rawSchedules, rawPoints, rawHistories, rawParticipation, rawLookups] = await Promise.all([
+  const [cycles, rawSnapshots, rawSchedules, rawPoints, rawHistories, rawParticipation, rawLookups, rawEvaluations] = await Promise.all([
     db.syncCycle.findMany({ orderBy: [{ guildId: "asc" }, { syncNumber: "asc" }] }),
     db.syncClanMemberSnapshot.findMany({ orderBy: [{ guildId: "asc" }, { syncTime: "asc" }, { clanTag: "asc" }, { playerTag: "asc" }] }),
     db.scheduledSyncPost.findMany({ orderBy: [{ guildId: "asc" }, { syncTime: "asc" }] }),
@@ -637,10 +790,15 @@ async function readAuditInputs(db: ReadOnlyAuditDb): Promise<AuditCycleInput[]> 
     db.clanWarHistory.findMany({ orderBy: [{ syncNumber: "asc" }, { warId: "asc" }, { clanTag: "asc" }] }),
     db.clanWarParticipation.findMany({ where: { matchType: "FWA" }, orderBy: [{ guildId: "asc" }, { warId: "asc" }, { playerTag: "asc" }] }),
     db.warLookup.findMany({ orderBy: [{ startTime: "asc" }, { warId: "asc" }] }),
+    db.warPlanComplianceEvaluation.findMany({
+      orderBy: [{ guildId: "asc" }, { warId: "asc" }],
+      select: { guildId: true, warId: true, warHistory: { select: { warId: true, syncNumber: true, matchType: true, clanTag: true, warStartTime: true, opponentTag: true } } },
+    }),
   ]);
+  const normalizedHistories = normalizeHistories(rawHistories);
   return buildCycleInputs(
-    normalizePoints(rawPoints),
-    normalizeHistories(rawHistories),
+    [...normalizePoints(rawPoints), ...normalizeComplianceIdentities(rawEvaluations, normalizedHistories)],
+    normalizedHistories,
     normalizeParticipation(rawParticipation),
     normalizeSchedules(rawSchedules),
     normalizeSnapshots(rawSnapshots),
@@ -672,7 +830,112 @@ function formatCycleRow(report: AuditCycleReport): string {
   ].join(" | ");
 }
 
-/** Purpose: compute read-only player streak and tenure diagnostics from current and candidate evidence. */
+type ProjectedPlayerEvidence = {
+  boundaries: Date[];
+  evidenceRows: MembershipBoundaryEvidence[];
+  coverageLimited: boolean;
+};
+
+/** Purpose: identify report classes that can contribute safe, timestamped candidate evidence. */
+function isTimestampedCandidate(report: AuditCycleReport): boolean {
+  return ["SCHEDULED_SYNC_CANDIDATE", "PREP_CLUSTER_CANDIDATE", "LEGACY_WARLOOKUP_CANDIDATE"].includes(report.classification) &&
+    isValidDate(report.candidateSyncTime);
+}
+
+/** Purpose: construct one fallback membership evidence row from candidate roster facts. */
+function buildCandidateEvidenceRow(
+  playerTag: string,
+  boundaryTime: Date,
+  facts: Array<{ playerTag: string; clanTag: string; source: string }>,
+): MembershipBoundaryEvidence {
+  const clanTags = [...new Set(facts.map((fact) => normalizeClanTag(fact.clanTag)).filter(Boolean))].sort((a, b) => a.localeCompare(b));
+  const fwa = clanTags.length === 0
+    ? { status: "UNKNOWN" as const, clanTag: null, clanTags: [], source: null }
+    : {
+        status: clanTags.length === 1 ? "RESOLVED" as const : "AMBIGUOUS" as const,
+        clanTag: clanTags.length === 1 ? clanTags[0] : null,
+        clanTags,
+        source: "FWA_WAR_PARTICIPATION_FALLBACK" as const,
+      };
+  return {
+    playerTag,
+    boundaryTime,
+    fwa,
+    alliance: {
+      positive: clanTags.length > 0,
+      clanTags,
+      ambiguous: clanTags.length > 1,
+      sources: clanTags.length > 0 ? ["FWA_EVIDENCE"] : [],
+    },
+  };
+}
+
+/** Purpose: merge candidate boundaries with service evidence while preserving exact snapshot precedence. */
+function buildProjectedPlayerEvidence(
+  playerTag: string,
+  currentBoundaries: readonly Date[],
+  currentRows: readonly MembershipBoundaryEvidence[],
+  reports: readonly AuditCycleReport[],
+): ProjectedPlayerEvidence {
+  const currentByTime = new Map(currentRows.map((row) => [row.boundaryTime.getTime(), row]));
+  const candidateFactsByTime = new Map<number, Array<{ playerTag: string; clanTag: string; source: string }>>();
+  const candidateReports = reports.filter(isTimestampedCandidate);
+  for (const report of candidateReports) {
+    const boundaryTime = report.candidateSyncTime!.getTime();
+    const facts = report.playerClanFacts.filter((fact) => fact.playerTag === playerTag);
+    const rows = candidateFactsByTime.get(boundaryTime) ?? [];
+    rows.push(...facts);
+    candidateFactsByTime.set(boundaryTime, rows);
+  }
+  const boundaryTimes = [...new Map([
+    ...currentBoundaries.map((boundaryTime) => [boundaryTime.getTime(), boundaryTime] as const),
+    ...candidateReports.map((report) => [report.candidateSyncTime!.getTime(), report.candidateSyncTime!] as const),
+  ]).values()].sort((left, right) => right.getTime() - left.getTime());
+  const evidenceRows = boundaryTimes.map((boundaryTime) => {
+    const current = currentByTime.get(boundaryTime.getTime());
+    if (current?.fwa.source === "SYNC_SNAPSHOT") return current;
+    const candidateFacts = candidateFactsByTime.get(boundaryTime.getTime()) ?? [];
+    if (candidateFacts.length > 0) return buildCandidateEvidenceRow(playerTag, boundaryTime, candidateFacts);
+    return current ?? buildCandidateEvidenceRow(playerTag, boundaryTime, []);
+  });
+  const coverageLimited = reports.some((report) =>
+    ["SCHEDULED_SYNC_CANDIDATE", "PREP_CLUSTER_CANDIDATE", "LEGACY_WARLOOKUP_CANDIDATE"].includes(report.classification) &&
+    report.playerClanFacts.some((fact) => fact.playerTag === playerTag) &&
+    !isValidDate(report.candidateSyncTime),
+  );
+  return { boundaries: boundaryTimes, evidenceRows, coverageLimited };
+}
+
+/** Purpose: format a streak value without presenting lower-bound evidence as exact. */
+function formatProjectedStreak(value: number, lowerBound: boolean): string {
+  return `${value}${lowerBound ? "+" : ""}`;
+}
+
+/** Purpose: replay one player's current and candidate evidence through the shared streak algorithm. */
+export function projectMembershipStreak(
+  playerTag: string,
+  current: {
+    boundaryTimes: readonly Date[];
+    evidenceRows: readonly MembershipBoundaryEvidence[];
+    boundaryHistoryTruncated: boolean;
+  },
+  reports: readonly AuditCycleReport[],
+): MembershipStreakResult {
+  const projectedEvidence = buildProjectedPlayerEvidence(
+    playerTag,
+    current.boundaryTimes,
+    current.evidenceRows,
+    reports,
+  );
+  return computeMembershipStreaksFromEvidence(
+    playerTag,
+    projectedEvidence.boundaries,
+    projectedEvidence.evidenceRows,
+    current.boundaryHistoryTruncated || projectedEvidence.coverageLimited,
+  );
+}
+
+/** Purpose: compute read-only player streak and tenure diagnostics from shared boundary semantics. */
 async function buildPlayerDiagnostics(
   db: ReadOnlyAuditDb,
   reports: readonly AuditCycleReport[],
@@ -703,11 +966,15 @@ async function buildPlayerDiagnostics(
     ].includes(report.classification));
     for (const result of current.streaks) {
       const home = homes.find((row) => normalizePlayerTag(row.playerTag) === result.playerTag);
-      const homeClanTag = normalizeClanTag(home?.clanTag);
-      const candidateFacts = candidateReports.flatMap((report) => report.playerClanFacts)
-        .filter((fact) => fact.playerTag === result.playerTag);
-      const sameHomeFacts = candidateFacts.filter((fact) => fact.clanTag === homeClanTag).length;
-      const allianceFacts = candidateFacts.length;
+      const projected = projectMembershipStreak(
+        result.playerTag,
+        {
+          boundaryTimes: current.boundaryTimes,
+          evidenceRows: current.evidenceByPlayer[result.playerTag] ?? [],
+          boundaryHistoryTruncated: current.boundaryHistoryTruncated,
+        },
+        candidateReports,
+      );
       const earliest = candidateReports
         .filter((report) => report.playerClanFacts.some((fact) => fact.playerTag === result.playerTag))
         .map((report) => report.candidateSyncTime)
@@ -716,17 +983,58 @@ async function buildPlayerDiagnostics(
       lines.push([
         `guild=${guildId}`,
         `player=${result.playerTag}`,
-        `current_clan_streak=${result.clanStreakSyncs}${result.clanStreakIsLowerBound ? "+" : ""}`,
-        `projected_clan_streak=${result.clanStreakSyncs + sameHomeFacts}`,
-        `current_alliance_streak=${result.allianceStreakSyncs}${result.allianceStreakIsLowerBound ? "+" : ""}`,
-        `projected_alliance_streak=${result.allianceStreakSyncs + allianceFacts}`,
-        `delta_clan=${sameHomeFacts}`,
-        `delta_alliance=${allianceFacts}`,
+        `current_clan_streak=${formatProjectedStreak(result.clanStreakSyncs, result.clanStreakIsLowerBound)}`,
+        `projected_clan_streak=${formatProjectedStreak(projected.clanStreakSyncs, projected.clanStreakIsLowerBound)}`,
+        `current_alliance_streak=${formatProjectedStreak(result.allianceStreakSyncs, result.allianceStreakIsLowerBound)}`,
+        `projected_alliance_streak_lower_bound=${formatProjectedStreak(projected.allianceStreakSyncs, true)}`,
+        `alliance_projection_coverage=LIMITED`,
+        `delta_clan=${projected.clanStreakSyncs - result.clanStreakSyncs}`,
+        `delta_alliance_lower_bound=${projected.allianceStreakSyncs - result.allianceStreakSyncs}`,
+        `prestart_home_contiguous_boundaries=${home ? buildHomeContinuity(candidateReports, home).reports.length : 0}`,
         `earliest_candidate_support=${earliest?.toISOString() ?? "none"}`,
       ].join(" "));
     }
   }
   return lines;
+}
+
+type HomeContinuity = {
+  reports: AuditCycleReport[];
+  stopReason: "NONE" | "GAP" | "ABSENT" | "UNKNOWN" | "CONFLICT";
+};
+
+/** Purpose: walk only safe pre-start candidate evidence backward for one active Home player. */
+function buildHomeContinuity(reports: readonly AuditCycleReport[], home: any): HomeContinuity {
+  const guildId = normalizeGuildId(home.guildId);
+  const playerTag = normalizePlayerTag(home.playerTag);
+  const clanTag = normalizeClanTag(home.clanTag);
+  const startedAt = new Date(home.startedAtSyncTime);
+  const candidateRows = reports
+    .filter((report) => report.guildId === guildId && isTimestampedCandidate(report))
+    .filter((report) => report.candidateSyncTime!.getTime() < startedAt.getTime())
+    .sort((left, right) => left.syncNumber - right.syncNumber);
+  const continuousRows: AuditCycleReport[] = [];
+  let stopReason: HomeContinuity["stopReason"] = "NONE";
+  for (let index = candidateRows.length - 1; index >= 0; index -= 1) {
+    const report = candidateRows[index];
+    if (report.conflicts.length > 0) {
+      stopReason = "CONFLICT";
+      break;
+    }
+    const followsContinuousRow = continuousRows.length === 0 || candidateRows[index + 1].syncNumber === report.syncNumber + 1;
+    if (!followsContinuousRow) {
+      stopReason = "GAP";
+      break;
+    }
+    const hasSameHomeFact = report.playerClanFacts.some((fact) => fact.playerTag === playerTag && fact.clanTag === clanTag);
+    if (hasSameHomeFact) {
+      continuousRows.unshift(report);
+      continue;
+    }
+    stopReason = report.perClanRosterCompleteness[clanTag] === "COMPLETE" ? "ABSENT" : "UNKNOWN";
+    break;
+  }
+  return { reports: continuousRows, stopReason };
 }
 
 /** Purpose: report theoretical Home tenure extension without mutating Home periods or asserting historical filler truth. */
@@ -737,38 +1045,20 @@ export function buildTenureDiagnostics(reports: readonly AuditCycleReport[], act
     `active Home player count: ${activeHomes.length}`,
   ];
   let sameHomeCount = 0;
+  let theoreticalBoundaryCount = 0;
   for (const home of [...activeHomes].sort((left, right) =>
     String(left.guildId).localeCompare(String(right.guildId)) || String(left.playerTag).localeCompare(String(right.playerTag)),
   )) {
     const guildId = normalizeGuildId(home.guildId);
     const playerTag = normalizePlayerTag(home.playerTag);
     const clanTag = normalizeClanTag(home.clanTag);
-    const candidateRows = reports
-      .filter((report) => report.guildId === guildId && [
-        "SCHEDULED_SYNC_CANDIDATE",
-        "PREP_CLUSTER_CANDIDATE",
-        "LEGACY_WARLOOKUP_CANDIDATE",
-      ].includes(report.classification))
-      .filter((report) => isValidDate(report.candidateSyncTime) && report.candidateSyncTime.getTime() < new Date(home.startedAtSyncTime).getTime())
-      .sort((left, right) => left.syncNumber - right.syncNumber);
-    let continuousRows: AuditCycleReport[] = [];
-    for (let index = candidateRows.length - 1; index >= 0; index -= 1) {
-      const report = candidateRows[index];
-      const hasSameHomeFact = report.playerClanFacts.some((fact) => fact.playerTag === playerTag && fact.clanTag === clanTag);
-      const followsContinuousRow = continuousRows.length === 0 || candidateRows[index + 1].syncNumber === report.syncNumber + 1;
-      if (!hasSameHomeFact || !followsContinuousRow) break;
-      continuousRows = [report, ...continuousRows];
-    }
-    if (continuousRows.length > 0) sameHomeCount += 1;
-    lines.push(`guild=${guildId} player=${playerTag} home=${clanTag} earliest_continuous_same_clan=${continuousRows[0]?.candidateSyncTime?.toISOString() ?? "none"} theoretical_extension_boundaries=${continuousRows.length}`);
+    const continuity = buildHomeContinuity(reports, home);
+    if (continuity.reports.length > 0) sameHomeCount += 1;
+    theoreticalBoundaryCount += continuity.reports.length;
+    lines.push(`guild=${guildId} player=${playerTag} home=${clanTag} earliest_continuous_same_clan=${continuity.reports[0]?.candidateSyncTime?.toISOString() ?? "none"} theoretical_extension_boundaries=${continuity.reports.length} stop_reason=${continuity.stopReason}`);
   }
   lines.splice(3, 0, `historical evidence shows same current Home before startedAtSyncTime: ${sameHomeCount}`);
-  lines.push(`boundaries by which Clan Tenure could theoretically extend: ${activeHomes.reduce((sum, home) => {
-    const guildId = normalizeGuildId(home.guildId);
-    const playerTag = normalizePlayerTag(home.playerTag);
-    const clanTag = normalizeClanTag(home.clanTag);
-    return sum + reports.filter((report) => report.guildId === guildId && report.playerClanFacts.some((fact) => fact.playerTag === playerTag && fact.clanTag === clanTag)).length;
-  }, 0)}`);
+  lines.push(`boundaries by which Clan Tenure could theoretically extend: ${theoreticalBoundaryCount}`);
   lines.push("Historical filler truth is incomplete before immutable SyncClanReadinessSnapshot capture; current filler registries were not consulted.");
   return lines;
 }

--- a/src/scripts/auditMembershipHistoryBackfill.ts
+++ b/src/scripts/auditMembershipHistoryBackfill.ts
@@ -1,0 +1,835 @@
+import { prisma } from "../prisma";
+import { normalizeTag } from "../services/war-events/core";
+import { MembershipStreakService } from "../services/MembershipStreakService";
+
+export const SCHEDULE_CORRELATION_THRESHOLD_MS = 24 * 60 * 60 * 1000;
+export const MAX_PREP_CLUSTER_SPREAD_MS = 2 * 60 * 60 * 1000;
+
+export type AuditClassification =
+  | "EXISTING_EXACT"
+  | "EXISTING_CYCLE_FALLBACK"
+  | "SCHEDULED_SYNC_CANDIDATE"
+  | "PREP_CLUSTER_CANDIDATE"
+  | "LEGACY_WARLOOKUP_CANDIDATE"
+  | "AMBIGUOUS"
+  | "UNRECOVERABLE";
+
+export type AuditPointEvidence = {
+  guildId: string;
+  syncNumber: number;
+  clanTag: string;
+  warId: number | null;
+  warStartTime: Date;
+  opponentTag: string;
+  isFwa: boolean;
+};
+
+export type AuditHistoryEvidence = {
+  warId: number;
+  syncNumber: number | null;
+  matchType: string | null;
+  clanTag: string;
+  opponentTag: string | null;
+  warStartTime: Date;
+  prepStartTime: Date | null;
+  warEndTime: Date | null;
+  expectedTeamSize?: number | null;
+};
+
+export type AuditParticipationEvidence = {
+  guildId: string;
+  warId: number;
+  clanTag: string;
+  playerTag: string;
+};
+
+export type AuditScheduleEvidence = {
+  id: string;
+  guildId: string;
+  syncTime: Date;
+  status: string;
+};
+
+export type AuditSnapshotEvidence = {
+  guildId: string;
+  syncTime: Date;
+  clanTag: string;
+  playerTag: string;
+};
+
+export type AuditLookupEvidence = {
+  warId: number;
+  clanTag: string;
+  startTime: Date;
+  payload: unknown;
+  expectedTeamSize?: number | null;
+};
+
+export type AuditCycleInput = {
+  guildId: string;
+  syncNumber: number;
+  syncCycleTime: Date | null;
+  points: AuditPointEvidence[];
+  histories: AuditHistoryEvidence[];
+  participation: AuditParticipationEvidence[];
+  schedules: AuditScheduleEvidence[];
+  exactSnapshots: AuditSnapshotEvidence[];
+  lookups: AuditLookupEvidence[];
+  missingParticipantWarMappings?: string[];
+  explicitConflicts?: string[];
+};
+
+export type AuditPrepCluster = {
+  min: Date | null;
+  max: Date | null;
+  center: Date | null;
+  spreadSeconds: number | null;
+  spreadMinutes: number | null;
+  excessiveSpread: boolean;
+};
+
+export type AuditCycleReport = {
+  guildId: string;
+  syncNumber: number;
+  classification: AuditClassification;
+  candidateSyncTime: Date | null;
+  candidateSource: string | null;
+  syncCycleExists: boolean;
+  exactSnapshotCoverage: boolean;
+  scheduledCandidateCount: number;
+  scheduledCandidateStatuses: string[];
+  scheduledCandidateDeltasSeconds: number[];
+  historicalParticipatingClanCount: number;
+  canonicalHistoryCount: number;
+  historiesWithPrepStartTime: number;
+  prepCluster: AuditPrepCluster;
+  participationDistinctClanCount: number;
+  participationDistinctPlayerCount: number;
+  perClanRosterCounts: Record<string, number>;
+  missingParticipantWarMappings: string[];
+  conflicts: string[];
+  earliestSupportingEvidence: Date | null;
+  latestSupportingEvidence: Date | null;
+  rosterCompleteness: "COMPLETE" | "PARTIAL" | "UNKNOWN";
+  expectedTeamSize: number | null;
+  playerClanFacts: Array<{ playerTag: string; clanTag: string; source: string }>;
+};
+
+export type ReadOnlyAuditDb = {
+  syncCycle: { findMany: (args?: any) => Promise<any[]>; groupBy: (args?: any) => Promise<any[]> };
+  syncClanMemberSnapshot: { findMany: (args?: any) => Promise<any[]>; groupBy: (args?: any) => Promise<any[]> };
+  scheduledSyncPost: { findMany: (args?: any) => Promise<any[]> };
+  clanPointsSync: { findMany: (args?: any) => Promise<any[]> };
+  clanWarHistory: { findMany: (args?: any) => Promise<any[]> };
+  clanWarParticipation: { findMany: (args?: any) => Promise<any[]> };
+  warLookup: { findMany: (args?: any) => Promise<any[]> };
+  clanHomeMembershipPeriod: { findMany: (args?: any) => Promise<any[]> };
+  syncClanReadinessSnapshot: { groupBy: (args?: any) => Promise<any[]> };
+  allianceClanMembershipInterval: { findMany: (args?: any) => Promise<any[]> };
+  warPlanComplianceEvaluation: { findMany: (args?: any) => Promise<any[]> };
+};
+
+/** Purpose: normalize a positive integer persisted by one of the historical owners. */
+function normalizePositiveInteger(value: unknown): number | null {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+/** Purpose: accept only finite persisted Date values for boundary calculations. */
+function isValidDate(value: unknown): value is Date {
+  return value instanceof Date && Number.isFinite(value.getTime());
+}
+
+/** Purpose: normalize a guild identifier before guild-scoped evidence joins. */
+function normalizeGuildId(value: unknown): string {
+  return String(value ?? "").trim();
+}
+
+/** Purpose: normalize a player identifier before deterministic fact grouping. */
+function normalizePlayerTag(value: unknown): string {
+  return normalizeTag(String(value ?? ""));
+}
+
+/** Purpose: normalize a clan identifier before historical owner comparisons. */
+function normalizeClanTag(value: unknown): string {
+  return normalizeTag(String(value ?? ""));
+}
+
+/** Purpose: normalize case-insensitive persisted FWA/match status values. */
+function comparable(value: unknown): string {
+  return String(value ?? "").trim().toUpperCase();
+}
+
+/** Purpose: identify canonical FWA history rows without trusting current-state registries. */
+function isFwa(value: unknown): boolean {
+  return comparable(value) === "FWA";
+}
+
+/** Purpose: provide a stable key for one guild, sync number, and historical war identity. */
+function warIdentityKey(point: AuditPointEvidence): string {
+  return point.warId !== null
+    ? `war:${point.warId}`
+    : `start:${point.warStartTime.getTime()}|opponent:${point.opponentTag}`;
+}
+
+/** Purpose: parse canonical participant tags from the supported archived WarLookup payload shape. */
+export function parseCanonicalParticipantTags(payload: unknown): string[] {
+  if (!payload || typeof payload !== "object") return [];
+  const root = payload as Record<string, unknown>;
+  const canonical = root.canonical && typeof root.canonical === "object"
+    ? root.canonical as Record<string, unknown>
+    : null;
+  const participants = canonical?.participants;
+  if (!Array.isArray(participants)) return [];
+  return [...new Set(
+    participants
+      .map((participant) => {
+        if (typeof participant === "string") return normalizePlayerTag(participant);
+        if (!participant || typeof participant !== "object") return "";
+        const row = participant as Record<string, unknown>;
+        return normalizePlayerTag(row.playerTag ?? row.tag ?? row.player_tag);
+      })
+      .filter(Boolean),
+  )].sort((a, b) => a.localeCompare(b));
+}
+
+/** Purpose: extract an explicitly persisted team-size expectation without hard-coding 50. */
+function parseCanonicalTeamSize(payload: unknown): number | null {
+  if (!payload || typeof payload !== "object") return null;
+  const root = payload as Record<string, unknown>;
+  const canonical = root.canonical && typeof root.canonical === "object"
+    ? root.canonical as Record<string, unknown>
+    : root;
+  return normalizePositiveInteger(canonical.teamSize ?? canonical.team_size ?? root.teamSize);
+}
+
+/** Purpose: derive a deterministic median-centered prep-time cluster and its spread. */
+export function buildPrepCluster(prepTimes: readonly Date[]): AuditPrepCluster {
+  const sorted = prepTimes
+    .filter(isValidDate)
+    .map((value) => value.getTime())
+    .sort((a, b) => a - b);
+  if (sorted.length === 0) {
+    return {
+      min: null,
+      max: null,
+      center: null,
+      spreadSeconds: null,
+      spreadMinutes: null,
+      excessiveSpread: false,
+    };
+  }
+  const min = sorted[0];
+  const max = sorted[sorted.length - 1];
+  const middle = Math.floor(sorted.length / 2);
+  const center = sorted.length % 2 === 0
+    ? Math.round((sorted[middle - 1] + sorted[middle]) / 2)
+    : sorted[middle];
+  const spreadMs = max - min;
+  return {
+    min: new Date(min),
+    max: new Date(max),
+    center: new Date(center),
+    spreadSeconds: Math.round(spreadMs / 1000),
+    spreadMinutes: Math.round(spreadMs / 60_000),
+    excessiveSpread: spreadMs > MAX_PREP_CLUSTER_SPREAD_MS,
+  };
+}
+
+/** Purpose: select only persisted schedule rows in the conservative prep-time neighborhood. */
+function findScheduleCandidates(
+  guildId: string,
+  prepCluster: AuditPrepCluster,
+  schedules: readonly AuditScheduleEvidence[],
+): AuditScheduleEvidence[] {
+  if (!prepCluster.center) return [];
+  return schedules
+    .filter((schedule) =>
+      schedule.guildId === guildId &&
+      !["CANCELLED", "REPLACED"].includes(comparable(schedule.status)) &&
+      isValidDate(schedule.syncTime) &&
+      Math.abs(schedule.syncTime.getTime() - prepCluster.center!.getTime()) <= SCHEDULE_CORRELATION_THRESHOLD_MS,
+    )
+    .sort((left, right) => left.syncTime.getTime() - right.syncTime.getTime() || left.id.localeCompare(right.id));
+}
+
+/** Purpose: map canonical histories to a points identity without nearest-time guessing. */
+function historyMatchesPoint(history: AuditHistoryEvidence, point: AuditPointEvidence): boolean {
+  if (!isFwa(history.matchType)) return false;
+  if (history.warId === point.warId && point.warId !== null) return history.clanTag === point.clanTag;
+  return (
+    history.syncNumber === point.syncNumber &&
+    history.clanTag === point.clanTag &&
+    history.opponentTag === point.opponentTag &&
+    history.warStartTime.getTime() === point.warStartTime.getTime()
+  );
+}
+
+/** Purpose: build one diagnostic report from already-normalized historical evidence. */
+export function classifyAuditCycle(input: AuditCycleInput): AuditCycleReport {
+  const guildId = normalizeGuildId(input.guildId);
+  const points = input.points.filter((point) => point.isFwa && point.guildId === guildId);
+  const histories = input.histories.filter((history) => isFwa(history.matchType));
+  const pointWarIds = new Set(points.map((point) => point.warId).filter((value): value is number => value !== null));
+  const mappedHistories = histories.filter((history) => points.some((point) => historyMatchesPoint(history, point)));
+  const participation = input.participation.filter((row) =>
+    row.guildId === guildId && mappedHistories.some((history) =>
+      history.warId === row.warId && history.clanTag === row.clanTag),
+  );
+  const prepCluster = buildPrepCluster(mappedHistories.map((history) => history.prepStartTime).filter(isValidDate));
+  const scheduledCandidates = findScheduleCandidates(guildId, prepCluster, input.schedules);
+  const exactSnapshots = input.exactSnapshots.filter((row) =>
+    row.guildId === guildId && input.syncCycleTime && row.syncTime.getTime() === input.syncCycleTime.getTime(),
+  );
+  const historicalClanTags = new Set(points.map((point) => point.clanTag).filter(Boolean));
+  for (const history of mappedHistories) historicalClanTags.add(history.clanTag);
+  const perClanRosterPlayers = new Map<string, Set<string>>();
+  const perClanRosterCounts: Record<string, number> = {};
+  const playerClanFacts: Array<{ playerTag: string; clanTag: string; source: string }> = [];
+  const playerClanSets = new Map<string, Set<string>>();
+  for (const row of participation) {
+    const playerTag = normalizePlayerTag(row.playerTag);
+    const clanTag = normalizeClanTag(row.clanTag);
+    if (!playerTag || !clanTag) continue;
+    const rosterPlayers = perClanRosterPlayers.get(clanTag) ?? new Set<string>();
+    rosterPlayers.add(playerTag);
+    perClanRosterPlayers.set(clanTag, rosterPlayers);
+    perClanRosterCounts[clanTag] = rosterPlayers.size;
+    const clans = playerClanSets.get(playerTag) ?? new Set<string>();
+    clans.add(clanTag);
+    playerClanSets.set(playerTag, clans);
+    playerClanFacts.push({ playerTag, clanTag, source: "ClanWarParticipation" });
+  }
+  const conflicts = [...(input.explicitConflicts ?? [])];
+  const identityKeys = new Set(points.map(warIdentityKey));
+  if (identityKeys.size > 1) conflicts.push("conflicting_war_identities");
+  for (const [playerTag, clans] of playerClanSets) {
+    if (clans.size > 1) conflicts.push(`player_in_multiple_clans:${playerTag}`);
+  }
+  const legacyEvidenceAvailable = participation.length === 0 && input.lookups.length > 0 && pointWarIds.size > 0;
+  if (legacyEvidenceAvailable) {
+    const factKeys = new Set<string>();
+    for (const lookup of input.lookups) {
+      for (const playerTag of parseCanonicalParticipantTags(lookup.payload)) {
+        const clanTag = normalizeClanTag(lookup.clanTag);
+        const key = `${playerTag}|${clanTag}`;
+        if (!clanTag || factKeys.has(key)) continue;
+        factKeys.add(key);
+        const rosterPlayers = perClanRosterPlayers.get(clanTag) ?? new Set<string>();
+        rosterPlayers.add(playerTag);
+        perClanRosterPlayers.set(clanTag, rosterPlayers);
+        perClanRosterCounts[clanTag] = rosterPlayers.size;
+        playerClanFacts.push({ playerTag, clanTag, source: "WarLookup.canonical.participants" });
+      }
+    }
+  }
+  const expectedTeamSizes = [
+    ...mappedHistories.map((history) => normalizePositiveInteger(history.expectedTeamSize)),
+    ...input.lookups.map((lookup) => normalizePositiveInteger(lookup.expectedTeamSize)),
+  ]
+    .filter((value): value is number => value !== null);
+  const expectedTeamSize = expectedTeamSizes.length > 0 ? Math.max(...expectedTeamSizes) : null;
+  const rosterCompleteness = expectedTeamSize === null
+    ? "UNKNOWN"
+    : [...historicalClanTags].every((clanTag) => (perClanRosterCounts[clanTag] ?? 0) === expectedTeamSize)
+      ? "COMPLETE"
+      : "PARTIAL";
+  const missingMappings = [...(input.missingParticipantWarMappings ?? [])];
+  const normalizedRosterAvailable = participation.length > 0 && mappedHistories.length > 0;
+  const exactCoverage = exactSnapshots.length > 0;
+  let classification: AuditClassification;
+  let candidateSyncTime: Date | null = null;
+  let candidateSource: string | null = null;
+  if (conflicts.length > 0 && !input.syncCycleTime && !exactCoverage) {
+    classification = "AMBIGUOUS";
+  } else if (input.syncCycleTime && exactCoverage) {
+    classification = "EXISTING_EXACT";
+  } else if (input.syncCycleTime && normalizedRosterAvailable) {
+    classification = "EXISTING_CYCLE_FALLBACK";
+  } else if (scheduledCandidates.length > 1) {
+    classification = "AMBIGUOUS";
+    conflicts.push("multiple_plausible_scheduled_sync_times");
+  } else if (scheduledCandidates.length === 1 && normalizedRosterAvailable && mappedHistories.length > 0) {
+    classification = "SCHEDULED_SYNC_CANDIDATE";
+    candidateSyncTime = scheduledCandidates[0].syncTime;
+    candidateSource = "ScheduledSyncPost.syncTime";
+  } else if (legacyEvidenceAvailable) {
+    classification = "LEGACY_WARLOOKUP_CANDIDATE";
+    candidateSource = "WarLookup.canonical.participants";
+  } else if (mappedHistories.length > 0 && prepCluster.center) {
+    if (prepCluster.excessiveSpread) {
+      classification = "AMBIGUOUS";
+      conflicts.push("excessive_prep_start_spread");
+    } else {
+      classification = "PREP_CLUSTER_CANDIDATE";
+      candidateSyncTime = prepCluster.center;
+      candidateSource = "ClanWarHistory.prepStartTime.median";
+    }
+  } else {
+    classification = "UNRECOVERABLE";
+  }
+  if (classification === "AMBIGUOUS" && scheduledCandidates.length > 1) {
+    candidateSyncTime = null;
+    candidateSource = null;
+  }
+  const evidenceTimes = [
+    ...points.flatMap((point) => [point.warStartTime]),
+    ...mappedHistories.flatMap((history) => [history.prepStartTime, history.warStartTime, history.warEndTime]),
+    ...participation.map((row) => mappedHistories.find((history) => history.warId === row.warId && history.clanTag === row.clanTag)?.warStartTime ?? null),
+    ...scheduledCandidates.map((schedule) => schedule.syncTime),
+  ].filter(isValidDate).map((value) => value.getTime());
+  const earliestSupportingEvidence = evidenceTimes.length > 0 ? new Date(Math.min(...evidenceTimes)) : null;
+  const latestSupportingEvidence = evidenceTimes.length > 0 ? new Date(Math.max(...evidenceTimes)) : null;
+  return {
+    guildId,
+    syncNumber: input.syncNumber,
+    classification,
+    candidateSyncTime,
+    candidateSource,
+    syncCycleExists: Boolean(input.syncCycleTime),
+    exactSnapshotCoverage: exactCoverage,
+    scheduledCandidateCount: scheduledCandidates.length,
+    scheduledCandidateStatuses: scheduledCandidates.map((schedule) => comparable(schedule.status)),
+    scheduledCandidateDeltasSeconds: scheduledCandidates.map((schedule) => prepCluster.center
+      ? Math.round((schedule.syncTime.getTime() - prepCluster.center.getTime()) / 1000)
+      : 0),
+    historicalParticipatingClanCount: historicalClanTags.size,
+    canonicalHistoryCount: mappedHistories.length,
+    historiesWithPrepStartTime: mappedHistories.filter((history) => isValidDate(history.prepStartTime)).length,
+    prepCluster,
+    participationDistinctClanCount: new Set(participation.map((row) => row.clanTag)).size,
+    participationDistinctPlayerCount: new Set(participation.map((row) => normalizePlayerTag(row.playerTag)).filter(Boolean)).size,
+    perClanRosterCounts: Object.fromEntries(Object.entries(perClanRosterCounts).sort(([a], [b]) => a.localeCompare(b))),
+    missingParticipantWarMappings: [...new Set(missingMappings)].sort((a, b) => a.localeCompare(b)),
+    conflicts: [...new Set(conflicts)].sort((a, b) => a.localeCompare(b)),
+    earliestSupportingEvidence,
+    latestSupportingEvidence,
+    rosterCompleteness,
+    expectedTeamSize,
+    playerClanFacts: playerClanFacts.sort((left, right) =>
+      left.playerTag.localeCompare(right.playerTag) || left.clanTag.localeCompare(right.clanTag)),
+  };
+}
+
+/** Purpose: classify all guild/sync identities in deterministic guild and sync-number order. */
+export function classifyAuditCycles(inputs: readonly AuditCycleInput[]): AuditCycleReport[] {
+  return [...inputs]
+    .map(classifyAuditCycle)
+    .sort((left, right) => left.guildId.localeCompare(right.guildId) || left.syncNumber - right.syncNumber);
+}
+
+/** Purpose: format the required compact audit summary before detailed cycle diagnostics. */
+export function formatAuditSummary(reports: readonly AuditCycleReport[]): string {
+  /** Purpose: count deterministic report classifications for the summary block. */
+  const count = (classification: AuditClassification) => reports.filter((report) => report.classification === classification).length;
+  const candidateReports = reports.filter((report) => [
+    "SCHEDULED_SYNC_CANDIDATE",
+    "PREP_CLUSTER_CANDIDATE",
+    "LEGACY_WARLOOKUP_CANDIDATE",
+  ].includes(report.classification));
+  const candidateFacts = candidateReports.reduce((sum, report) => sum + report.playerClanFacts.length, 0);
+  const syncNumbers = reports.map((report) => report.syncNumber).sort((a, b) => a - b);
+  const safeDates = candidateReports.map((report) => report.candidateSyncTime).filter(isValidDate).sort((a, b) => a.getTime() - b.getTime());
+  const sortedCandidateReports = [...candidateReports].sort((a, b) => a.syncNumber - b.syncNumber || a.guildId.localeCompare(b.guildId));
+  const guilds = [...new Set(reports.map((report) => report.guildId))].sort((a, b) => a.localeCompare(b));
+  const syncRange = syncNumbers.length > 0 ? `#${syncNumbers[0]} -> #${syncNumbers[syncNumbers.length - 1]}` : "none";
+  return [
+    "Historical Membership Backfill Audit",
+    "",
+    `Guild: ${guilds.length === 1 ? guilds[0] : guilds.length > 1 ? `${guilds.length} guilds` : "none"}`,
+    `Sync range: ${syncRange}`,
+    `Historical cycles found: ${reports.length}`,
+    "",
+    `Existing exact: ${count("EXISTING_EXACT")}`,
+    `Existing fallback cycles: ${count("EXISTING_CYCLE_FALLBACK")}`,
+    `Scheduled-sync candidates: ${count("SCHEDULED_SYNC_CANDIDATE")}`,
+    `Prep-cluster candidates: ${count("PREP_CLUSTER_CANDIDATE")}`,
+    `Legacy WarLookup candidates: ${count("LEGACY_WARLOOKUP_CANDIDATE")}`,
+    `Ambiguous: ${count("AMBIGUOUS")}`,
+    `Unrecoverable: ${count("UNRECOVERABLE")}`,
+    "",
+    `Potential additional canonical boundaries: ${candidateReports.length}`,
+    `Potential player-boundary membership facts: ${candidateFacts}`,
+    `Earliest safely recoverable date: ${safeDates[0]?.toISOString() ?? "none"}`,
+    `Earliest safely recoverable sync: ${sortedCandidateReports[0]?.syncNumber ? `#${sortedCandidateReports[0].syncNumber}` : "none"}`,
+  ].join("\n");
+}
+
+/** Purpose: normalize raw points rows into the canonical audit point identity. */
+function normalizePoints(rows: any[]): AuditPointEvidence[] {
+  return rows.flatMap((row) => {
+    const guildId = normalizeGuildId(row?.guildId);
+    const syncNumber = normalizePositiveInteger(row?.syncNum);
+    const clanTag = normalizeClanTag(row?.clanTag);
+    const warStartTime = row?.warStartTime;
+    const opponentTag = normalizeClanTag(row?.opponentTag);
+    if (!guildId || !syncNumber || !clanTag || !opponentTag || !isValidDate(warStartTime)) return [];
+    return [{
+      guildId,
+      syncNumber,
+      clanTag,
+      warId: normalizePositiveInteger(row?.warId),
+      warStartTime,
+      opponentTag,
+      isFwa: Boolean(row?.isFwa),
+    }];
+  });
+}
+
+/** Purpose: normalize canonical ended-war history rows for guild-independent identity matching. */
+function normalizeHistories(rows: any[]): AuditHistoryEvidence[] {
+  return rows.flatMap((row) => {
+    const warId = normalizePositiveInteger(row?.warId);
+    const clanTag = normalizeClanTag(row?.clanTag);
+    const warStartTime = row?.warStartTime;
+    if (!warId || !clanTag || !isValidDate(warStartTime)) return [];
+    return [{
+      warId,
+      syncNumber: normalizePositiveInteger(row?.syncNumber),
+      matchType: row?.matchType ?? null,
+      clanTag,
+      opponentTag: row?.opponentTag ? normalizeClanTag(row.opponentTag) : null,
+      warStartTime,
+      prepStartTime: isValidDate(row?.prepStartTime) ? row.prepStartTime : null,
+      warEndTime: isValidDate(row?.warEndTime) ? row.warEndTime : null,
+      expectedTeamSize: normalizePositiveInteger(row?.expectedTeamSize),
+    }];
+  });
+}
+
+/** Purpose: normalize participation rows into guild-scoped player/clan evidence. */
+function normalizeParticipation(rows: any[]): AuditParticipationEvidence[] {
+  return rows.flatMap((row) => {
+    const guildId = normalizeGuildId(row?.guildId);
+    const warId = normalizePositiveInteger(row?.warId);
+    const clanTag = normalizeClanTag(row?.clanTag);
+    const playerTag = normalizePlayerTag(row?.playerTag);
+    if (!guildId || !warId || !clanTag || !playerTag || !isFwa(row?.matchType)) return [];
+    return [{ guildId, warId, clanTag, playerTag }];
+  });
+}
+
+/** Purpose: normalize persisted scheduled-sync rows while retaining status for ambiguity diagnostics. */
+function normalizeSchedules(rows: any[]): AuditScheduleEvidence[] {
+  return rows.flatMap((row) => {
+    const id = String(row?.id ?? "").trim();
+    const guildId = normalizeGuildId(row?.guildId);
+    if (!id || !guildId || !isValidDate(row?.syncTime)) return [];
+    return [{ id, guildId, syncTime: row.syncTime, status: comparable(row.status) }];
+  });
+}
+
+/** Purpose: normalize immutable member snapshots for exact-coverage checks only. */
+function normalizeSnapshots(rows: any[]): AuditSnapshotEvidence[] {
+  return rows.flatMap((row) => {
+    const guildId = normalizeGuildId(row?.guildId);
+    const clanTag = normalizeClanTag(row?.clanTag);
+    const playerTag = normalizePlayerTag(row?.playerTag);
+    if (!guildId || !clanTag || !playerTag || !isValidDate(row?.syncTime)) return [];
+    return [{ guildId, syncTime: row.syncTime, clanTag, playerTag }];
+  });
+}
+
+/** Purpose: normalize archived WarLookup rows without using names to infer guild ownership. */
+function normalizeLookups(rows: any[]): AuditLookupEvidence[] {
+  return rows.flatMap((row) => {
+    const warId = normalizePositiveInteger(row?.warId);
+    const clanTag = normalizeClanTag(row?.clanTag);
+    if (!warId || !clanTag || !isValidDate(row?.startTime)) return [];
+    return [{
+      warId,
+      clanTag,
+      startTime: row.startTime,
+      payload: row.payload,
+      expectedTeamSize: parseCanonicalTeamSize(row.payload),
+    }];
+  });
+}
+
+/** Purpose: build candidate cycle inputs from all persisted read-only historical owners. */
+function buildCycleInputs(
+  points: AuditPointEvidence[],
+  histories: AuditHistoryEvidence[],
+  participation: AuditParticipationEvidence[],
+  schedules: AuditScheduleEvidence[],
+  snapshots: AuditSnapshotEvidence[],
+  lookups: AuditLookupEvidence[],
+  cycles: any[],
+): AuditCycleInput[] {
+  const identities = new Map<string, { guildId: string; syncNumber: number; points: AuditPointEvidence[]; syncCycleTime: Date | null }>();
+  for (const row of cycles) {
+    const guildId = normalizeGuildId(row?.guildId);
+    const syncNumber = normalizePositiveInteger(row?.syncNumber);
+    if (!guildId || !syncNumber) continue;
+    identities.set(`${guildId}|${syncNumber}`, {
+      guildId,
+      syncNumber,
+      points: [],
+      syncCycleTime: isValidDate(row?.syncTime) ? row.syncTime : null,
+    });
+  }
+  for (const point of points) {
+    const key = `${point.guildId}|${point.syncNumber}`;
+    const current = identities.get(key) ?? {
+      guildId: point.guildId,
+      syncNumber: point.syncNumber,
+      points: [],
+      syncCycleTime: null,
+    };
+    current.points.push(point);
+    identities.set(key, current);
+  }
+  return [...identities.values()].sort((left, right) =>
+    left.guildId.localeCompare(right.guildId) || left.syncNumber - right.syncNumber,
+  ).map((identity) => {
+    const pointWarIds = new Set(identity.points.map((point) => point.warId).filter((value): value is number => value !== null));
+    const matchingHistories = histories.filter((history) => identity.points.some((point) => historyMatchesPoint(history, point)));
+    const cycleParticipation = participation.filter((row) => row.guildId === identity.guildId && matchingHistories.some((history) =>
+      history.warId === row.warId && history.clanTag === row.clanTag));
+    const missingMappings = identity.points
+      .filter((point) => !matchingHistories.some((history) => historyMatchesPoint(history, point)))
+      .map((point) => `missing_history:${point.clanTag}`);
+    for (const history of matchingHistories) {
+      if (!cycleParticipation.some((row) => row.warId === history.warId && row.clanTag === history.clanTag)) {
+        missingMappings.push(`missing_participation:${history.clanTag}:${history.warId}`);
+      }
+    }
+    const relevantLookups = lookups.filter((lookup) => pointWarIds.has(lookup.warId));
+    const matchingLookups = relevantLookups.filter((lookup) => identity.points.some((point) =>
+      point.warId === lookup.warId && point.clanTag === lookup.clanTag));
+    const lookupOwnerKeys = new Set(relevantLookups.flatMap((lookup) =>
+      points.filter((point) => point.warId === lookup.warId && point.clanTag === lookup.clanTag)
+        .map((point) => `${point.guildId}|${point.syncNumber}`),
+    ));
+    const historyOwnerKeys = new Set(matchingHistories.flatMap((history) =>
+      points.filter((point) => historyMatchesPoint(history, point)).map((point) => `${point.guildId}|${point.syncNumber}`)));
+    const explicitConflicts = [
+      ...(lookupOwnerKeys.size > 1 ? ["warlookup_maps_to_multiple_guild_sync_owners"] : []),
+      ...(relevantLookups.length !== matchingLookups.length ? ["warlookup_clan_identity_mismatch"] : []),
+      ...(historyOwnerKeys.size > 1 ? ["history_maps_to_multiple_guild_sync_owners"] : []),
+    ];
+    const cycleLookups = lookupOwnerKeys.size === 1 && lookupOwnerKeys.has(`${identity.guildId}|${identity.syncNumber}`)
+      ? matchingLookups
+      : [];
+    return {
+      guildId: identity.guildId,
+      syncNumber: identity.syncNumber,
+      syncCycleTime: identity.syncCycleTime,
+      points: identity.points,
+      histories: matchingHistories,
+      participation: cycleParticipation,
+      schedules,
+      exactSnapshots: snapshots,
+      lookups: cycleLookups,
+      missingParticipantWarMappings: [...new Set(missingMappings)].sort((a, b) => a.localeCompare(b)),
+      explicitConflicts,
+    };
+  });
+}
+
+/** Purpose: read every historical owner through an interface that exposes no mutation delegate. */
+async function readAuditInputs(db: ReadOnlyAuditDb): Promise<AuditCycleInput[]> {
+  const [cycles, rawSnapshots, rawSchedules, rawPoints, rawHistories, rawParticipation, rawLookups] = await Promise.all([
+    db.syncCycle.findMany({ orderBy: [{ guildId: "asc" }, { syncNumber: "asc" }] }),
+    db.syncClanMemberSnapshot.findMany({ orderBy: [{ guildId: "asc" }, { syncTime: "asc" }, { clanTag: "asc" }, { playerTag: "asc" }] }),
+    db.scheduledSyncPost.findMany({ orderBy: [{ guildId: "asc" }, { syncTime: "asc" }] }),
+    db.clanPointsSync.findMany({ orderBy: [{ guildId: "asc" }, { syncNum: "asc" }, { clanTag: "asc" }] }),
+    db.clanWarHistory.findMany({ orderBy: [{ syncNumber: "asc" }, { warId: "asc" }, { clanTag: "asc" }] }),
+    db.clanWarParticipation.findMany({ where: { matchType: "FWA" }, orderBy: [{ guildId: "asc" }, { warId: "asc" }, { playerTag: "asc" }] }),
+    db.warLookup.findMany({ orderBy: [{ startTime: "asc" }, { warId: "asc" }] }),
+  ]);
+  return buildCycleInputs(
+    normalizePoints(rawPoints),
+    normalizeHistories(rawHistories),
+    normalizeParticipation(rawParticipation),
+    normalizeSchedules(rawSchedules),
+    normalizeSnapshots(rawSnapshots),
+    normalizeLookups(rawLookups),
+    cycles,
+  );
+}
+
+/** Purpose: render one deterministic per-cycle table row with no timing hidden from the audit. */
+function formatCycleRow(report: AuditCycleReport): string {
+  return [
+    report.guildId,
+    `#${report.syncNumber}`,
+    report.classification,
+    report.candidateSyncTime?.toISOString() ?? "-",
+    report.candidateSource ?? "-",
+    report.syncCycleExists ? "yes" : "no",
+    report.exactSnapshotCoverage ? "yes" : "no",
+    `${report.scheduledCandidateCount}(${report.scheduledCandidateStatuses.join(",") || "-"}/${report.scheduledCandidateDeltasSeconds.join(",") || "-"})`,
+    `${report.prepCluster.min?.toISOString() ?? "-"}..${report.prepCluster.max?.toISOString() ?? "-"}/${report.prepCluster.spreadSeconds ?? "-"}`,
+    String(report.historicalParticipatingClanCount),
+    String(report.canonicalHistoryCount),
+    String(report.participationDistinctClanCount),
+    String(report.participationDistinctPlayerCount),
+    `${report.rosterCompleteness}/${report.expectedTeamSize ?? "-"}`,
+    report.missingParticipantWarMappings.join(",") || "-",
+    report.conflicts.join(",") || "-",
+    `${report.earliestSupportingEvidence?.toISOString() ?? "-"}..${report.latestSupportingEvidence?.toISOString() ?? "-"}`,
+  ].join(" | ");
+}
+
+/** Purpose: compute read-only player streak and tenure diagnostics from current and candidate evidence. */
+async function buildPlayerDiagnostics(
+  db: ReadOnlyAuditDb,
+  reports: readonly AuditCycleReport[],
+  activeHomes: any[],
+): Promise<string[]> {
+  const lines = [
+    "",
+    "PLAYER IMPACT (projection is diagnostic only; no MembershipStreakService state was changed)",
+  ];
+  const homesByGuild = new Map<string, any[]>();
+  for (const home of activeHomes) {
+    const guildId = normalizeGuildId(home?.guildId);
+    if (!guildId) continue;
+    const rows = homesByGuild.get(guildId) ?? [];
+    rows.push(home);
+    homesByGuild.set(guildId, rows);
+  }
+  const streakService = new MembershipStreakService(db as any);
+  for (const guildId of [...homesByGuild.keys()].sort((a, b) => a.localeCompare(b))) {
+    const homes = homesByGuild.get(guildId) ?? [];
+    const playerTags = homes.map((home) => normalizePlayerTag(home.playerTag)).filter(Boolean).sort((a, b) => a.localeCompare(b));
+    if (playerTags.length === 0) continue;
+    const current = await streakService.getMembershipStreakBatchForPlayers({ guildId, playerTags });
+    const candidateReports = reports.filter((report) => report.guildId === guildId && [
+      "SCHEDULED_SYNC_CANDIDATE",
+      "PREP_CLUSTER_CANDIDATE",
+      "LEGACY_WARLOOKUP_CANDIDATE",
+    ].includes(report.classification));
+    for (const result of current.streaks) {
+      const home = homes.find((row) => normalizePlayerTag(row.playerTag) === result.playerTag);
+      const homeClanTag = normalizeClanTag(home?.clanTag);
+      const candidateFacts = candidateReports.flatMap((report) => report.playerClanFacts)
+        .filter((fact) => fact.playerTag === result.playerTag);
+      const sameHomeFacts = candidateFacts.filter((fact) => fact.clanTag === homeClanTag).length;
+      const allianceFacts = candidateFacts.length;
+      const earliest = candidateReports
+        .filter((report) => report.playerClanFacts.some((fact) => fact.playerTag === result.playerTag))
+        .map((report) => report.candidateSyncTime)
+        .filter(isValidDate)
+        .sort((left, right) => left.getTime() - right.getTime())[0];
+      lines.push([
+        `guild=${guildId}`,
+        `player=${result.playerTag}`,
+        `current_clan_streak=${result.clanStreakSyncs}${result.clanStreakIsLowerBound ? "+" : ""}`,
+        `projected_clan_streak=${result.clanStreakSyncs + sameHomeFacts}`,
+        `current_alliance_streak=${result.allianceStreakSyncs}${result.allianceStreakIsLowerBound ? "+" : ""}`,
+        `projected_alliance_streak=${result.allianceStreakSyncs + allianceFacts}`,
+        `delta_clan=${sameHomeFacts}`,
+        `delta_alliance=${allianceFacts}`,
+        `earliest_candidate_support=${earliest?.toISOString() ?? "none"}`,
+      ].join(" "));
+    }
+  }
+  return lines;
+}
+
+/** Purpose: report theoretical Home tenure extension without mutating Home periods or asserting historical filler truth. */
+export function buildTenureDiagnostics(reports: readonly AuditCycleReport[], activeHomes: any[]): string[] {
+  const lines = [
+    "",
+    "POTENTIAL HOME BACKDATE — NOT SAFE TO APPLY AUTOMATICALLY",
+    `active Home player count: ${activeHomes.length}`,
+  ];
+  let sameHomeCount = 0;
+  for (const home of [...activeHomes].sort((left, right) =>
+    String(left.guildId).localeCompare(String(right.guildId)) || String(left.playerTag).localeCompare(String(right.playerTag)),
+  )) {
+    const guildId = normalizeGuildId(home.guildId);
+    const playerTag = normalizePlayerTag(home.playerTag);
+    const clanTag = normalizeClanTag(home.clanTag);
+    const candidateRows = reports
+      .filter((report) => report.guildId === guildId && [
+        "SCHEDULED_SYNC_CANDIDATE",
+        "PREP_CLUSTER_CANDIDATE",
+        "LEGACY_WARLOOKUP_CANDIDATE",
+      ].includes(report.classification))
+      .filter((report) => isValidDate(report.candidateSyncTime) && report.candidateSyncTime.getTime() < new Date(home.startedAtSyncTime).getTime())
+      .sort((left, right) => left.syncNumber - right.syncNumber);
+    let continuousRows: AuditCycleReport[] = [];
+    for (let index = candidateRows.length - 1; index >= 0; index -= 1) {
+      const report = candidateRows[index];
+      const hasSameHomeFact = report.playerClanFacts.some((fact) => fact.playerTag === playerTag && fact.clanTag === clanTag);
+      const followsContinuousRow = continuousRows.length === 0 || candidateRows[index + 1].syncNumber === report.syncNumber + 1;
+      if (!hasSameHomeFact || !followsContinuousRow) break;
+      continuousRows = [report, ...continuousRows];
+    }
+    if (continuousRows.length > 0) sameHomeCount += 1;
+    lines.push(`guild=${guildId} player=${playerTag} home=${clanTag} earliest_continuous_same_clan=${continuousRows[0]?.candidateSyncTime?.toISOString() ?? "none"} theoretical_extension_boundaries=${continuousRows.length}`);
+  }
+  lines.splice(3, 0, `historical evidence shows same current Home before startedAtSyncTime: ${sameHomeCount}`);
+  lines.push(`boundaries by which Clan Tenure could theoretically extend: ${activeHomes.reduce((sum, home) => {
+    const guildId = normalizeGuildId(home.guildId);
+    const playerTag = normalizePlayerTag(home.playerTag);
+    const clanTag = normalizeClanTag(home.clanTag);
+    return sum + reports.filter((report) => report.guildId === guildId && report.playerClanFacts.some((fact) => fact.playerTag === playerTag && fact.clanTag === clanTag)).length;
+  }, 0)}`);
+  lines.push("Historical filler truth is incomplete before immutable SyncClanReadinessSnapshot capture; current filler registries were not consulted.");
+  return lines;
+}
+
+/** Purpose: print the complete audit in summary-first deterministic sections. */
+async function printAudit(
+  reports: readonly AuditCycleReport[],
+  activeHomes: any[],
+  db: ReadOnlyAuditDb,
+): Promise<void> {
+  console.log(formatAuditSummary(reports));
+  console.log("\nPer-cycle coverage");
+  console.log("guild | sync | classification | candidate_sync_time | candidate_source | cycle | exact_snapshot | schedules(statuses/delta_s) | prep(min..max/spread_s) | clans | histories | participation_clans | participation_players | roster(expected) | missing_mappings | conflicts | evidence(min..max)");
+  for (const report of reports) console.log(formatCycleRow(report));
+  console.log("\nAggregate per-clan coverage");
+  const clans = new Map<string, AuditCycleReport[]>();
+  for (const report of reports) {
+    for (const clanTag of Object.keys(report.perClanRosterCounts)) {
+      const rows = clans.get(clanTag) ?? [];
+      rows.push(report);
+      clans.set(clanTag, rows);
+    }
+  }
+  for (const clanTag of [...clans.keys()].sort((a, b) => a.localeCompare(b))) {
+    const rows = clans.get(clanTag)!;
+    const safe = rows.filter((row) => ["SCHEDULED_SYNC_CANDIDATE", "PREP_CLUSTER_CANDIDATE", "LEGACY_WARLOOKUP_CANDIDATE"].includes(row.classification));
+    console.log(`clan=${clanTag} first_recoverable_sync=${safe[0]?.syncNumber ?? "none"} last_recoverable_sync=${safe.at(-1)?.syncNumber ?? "none"} recoverable_cycles=${safe.length} complete_roster_cycles=${safe.filter((row) => row.rosterCompleteness === "COMPLETE").length} partial_or_missing_cycles=${safe.filter((row) => row.rosterCompleteness !== "COMPLETE").length}`);
+  }
+  console.log("\nCWL coverage limitation: this audit does not infer historical FWA absence or presence from current state; persisted CWL evidence was not used unless an unambiguous boundary owner is available.");
+  console.log((await buildPlayerDiagnostics(db, reports, activeHomes)).join("\n"));
+  console.log(buildTenureDiagnostics(reports, activeHomes).join("\n"));
+}
+
+/** Purpose: execute the one-off read-only historical membership backfill audit. */
+export async function runMembershipHistoryBackfillAudit(db: ReadOnlyAuditDb = prisma as unknown as ReadOnlyAuditDb): Promise<AuditCycleReport[]> {
+  console.log("READ ONLY — no database mutations will be performed.");
+  const [inputs, activeHomes] = await Promise.all([
+    readAuditInputs(db),
+    db.clanHomeMembershipPeriod.findMany({
+      where: { endedAtSyncTime: null },
+      orderBy: [{ guildId: "asc" }, { playerTag: "asc" }],
+      select: { guildId: true, playerTag: true, clanTag: true, startedAtSyncTime: true },
+    }),
+  ]);
+  const reports = classifyAuditCycles(inputs);
+  await printAudit(reports, activeHomes, db);
+  return reports;
+}
+
+/** Purpose: run the CLI entrypoint and convert any read failure into a nonzero process exit. */
+export async function main(): Promise<void> {
+  await runMembershipHistoryBackfillAudit();
+}
+
+if (require.main === module) {
+  main()
+    .catch((error) => {
+      console.error(error instanceof Error ? error.message : String(error));
+      process.exitCode = 1;
+    })
+    .finally(async () => {
+      await prisma.$disconnect();
+    });
+}

--- a/src/scripts/auditMembershipHistoryBackfill.ts
+++ b/src/scripts/auditMembershipHistoryBackfill.ts
@@ -443,6 +443,7 @@ export function classifyAuditCycle(input: AuditCycleInput): AuditCycleReport {
   const legacyRosterAvailable = legacyRosterFacts.length > 0;
   const rosterEvidenceAvailable = normalizedRosterAvailable || legacyRosterAvailable;
   const exactCoverage = exactSnapshots.length > 0;
+  if (prepCluster.excessiveSpread) conflicts.push("excessive_prep_start_spread");
   let classification: AuditClassification;
   let candidateSyncTime: Date | null = null;
   let candidateSource: string | null = null;
@@ -450,8 +451,10 @@ export function classifyAuditCycle(input: AuditCycleInput): AuditCycleReport {
     classification = "AMBIGUOUS";
   } else if (input.syncCycleTime && exactCoverage) {
     classification = "EXISTING_EXACT";
-  } else if (input.syncCycleTime && normalizedRosterAvailable) {
+  } else if (input.syncCycleTime && rosterEvidenceAvailable) {
     classification = "EXISTING_CYCLE_FALLBACK";
+  } else if (input.syncCycleTime) {
+    classification = "UNRECOVERABLE";
   } else if (scheduledCandidates.length > 1) {
     classification = "AMBIGUOUS";
     conflicts.push("multiple_plausible_scheduled_sync_times");
@@ -469,14 +472,9 @@ export function classifyAuditCycle(input: AuditCycleInput): AuditCycleReport {
     classification = "LEGACY_WARLOOKUP_CANDIDATE";
     candidateSource = "WarLookup.canonical.participants";
   } else if (mappedHistories.length > 0 && prepCluster.center) {
-    if (prepCluster.excessiveSpread) {
-      classification = "AMBIGUOUS";
-      conflicts.push("excessive_prep_start_spread");
-    } else {
-      classification = "PREP_CLUSTER_CANDIDATE";
-      candidateSyncTime = prepCluster.center;
-      candidateSource = "ClanWarHistory.prepStartTime.median";
-    }
+    classification = "PREP_CLUSTER_CANDIDATE";
+    candidateSyncTime = prepCluster.center;
+    candidateSource = "ClanWarHistory.prepStartTime.median";
   } else {
     classification = "UNRECOVERABLE";
   }
@@ -689,7 +687,7 @@ function normalizeComplianceIdentities(rows: any[], histories: AuditHistoryEvide
 }
 
 /** Purpose: build candidate cycle inputs from all persisted read-only historical owners. */
-function buildCycleInputs(
+export function buildCycleInputs(
   points: AuditPointEvidence[],
   histories: AuditHistoryEvidence[],
   participation: AuditParticipationEvidence[],
@@ -716,6 +714,21 @@ function buildCycleInputs(
     for (const [key, owners] of ownersByWarClan) {
       if (owners.size > 1) conflictingWarClanKeys.add(key);
     }
+  }
+  const partialTupleOwners = new Map<string, Set<string>>();
+  const partialTupleHasNullOwner = new Set<string>();
+  for (const point of points) {
+    const tupleKey = `${normalizeClanTag(point.clanTag)}|start:${point.warStartTime.getTime()}|opponent:${normalizeClanTag(point.opponentTag)}`;
+    const owners = partialTupleOwners.get(tupleKey) ?? new Set<string>();
+    owners.add(`${point.guildId}|${point.syncNumber}`);
+    partialTupleOwners.set(tupleKey, owners);
+    if (point.warId === null) partialTupleHasNullOwner.add(tupleKey);
+  }
+  const partialIdentityConflictOwners = new Set<string>();
+  for (const tupleKey of partialTupleHasNullOwner) {
+    const owners = partialTupleOwners.get(tupleKey) ?? new Set<string>();
+    if (owners.size <= 1) continue;
+    for (const owner of owners) partialIdentityConflictOwners.add(owner);
   }
   for (const row of cycles) {
     const guildId = normalizeGuildId(row?.guildId);
@@ -770,6 +783,9 @@ function buildCycleInputs(
       ...(lookupOwnerKeys.size > 1 ? ["warlookup_maps_to_multiple_guild_sync_owners"] : []),
       ...(relevantLookups.length !== matchingLookups.length ? ["warlookup_clan_identity_mismatch"] : []),
       ...(historyOwnerKeys.size > 1 ? ["history_maps_to_multiple_guild_sync_owners"] : []),
+      ...(partialIdentityConflictOwners.has(`${identity.guildId}|${identity.syncNumber}`)
+        ? ["conflicting_partial_war_identity_across_sync_buckets"]
+        : []),
     ];
     const cycleLookups = lookupOwnerKeys.size === 1 && lookupOwnerKeys.has(`${identity.guildId}|${identity.syncNumber}`)
       ? matchingLookups
@@ -817,8 +833,23 @@ async function readAuditInputs(db: ReadOnlyAuditDb): Promise<AuditCycleInput[]> 
   );
 }
 
-/** Purpose: render one deterministic per-cycle table row with no timing hidden from the audit. */
-function formatCycleRow(report: AuditCycleReport): string {
+/** Purpose: format deterministic per-clan observed/expected roster coverage. */
+export function formatPerClanRosterCoverage(report: AuditCycleReport): string {
+  const clans = new Set([
+    ...Object.keys(report.perClanRosterCounts),
+    ...Object.keys(report.expectedTeamSizesByClan),
+    ...Object.keys(report.perClanRosterCompleteness),
+  ]);
+  return [...clans].sort((left, right) => left.localeCompare(right)).map((clanTag) => {
+    const observed = report.perClanRosterCounts[clanTag] ?? 0;
+    const expected = report.expectedTeamSizesByClan[clanTag] ?? null;
+    const state = report.perClanRosterCompleteness[clanTag] ?? "UNKNOWN";
+    return `${clanTag}=${observed}/${expected ?? "?"}:${state}`;
+  }).join(",") || "-";
+}
+
+/** Purpose: format one deterministic per-cycle audit table row with per-clan roster coverage. */
+export function formatCycleRow(report: AuditCycleReport): string {
   return [
     report.guildId,
     `#${report.syncNumber}`,
@@ -833,7 +864,7 @@ function formatCycleRow(report: AuditCycleReport): string {
     String(report.canonicalHistoryCount),
     String(report.participationDistinctClanCount),
     String(report.participationDistinctPlayerCount),
-    `${report.rosterCompleteness}/${report.expectedTeamSize ?? "-"}`,
+    formatPerClanRosterCoverage(report),
     report.missingParticipantWarMappings.join(",") || "-",
     report.conflicts.join(",") || "-",
     `${report.earliestSupportingEvidence?.toISOString() ?? "-"}..${report.latestSupportingEvidence?.toISOString() ?? "-"}`,
@@ -1117,12 +1148,26 @@ async function printAudit(
 ): Promise<void> {
   console.log(formatAuditSummary(reports));
   console.log("\nPer-cycle coverage");
-  console.log("guild | sync | classification | candidate_sync_time | candidate_source | cycle | exact_snapshot | schedules(statuses/delta_s) | prep(min..max/spread_s) | clans | histories | participation_clans | participation_players | roster(expected) | missing_mappings | conflicts | evidence(min..max)");
+  console.log("guild | sync | classification | candidate_sync_time | candidate_source | cycle | exact_snapshot | schedules(statuses/delta_s) | prep(min..max/spread_s) | clans | histories | participation_clans | participation_players | per_clan_roster | missing_mappings | conflicts | evidence(min..max)");
   for (const report of reports) console.log(formatCycleRow(report));
   console.log("\nAggregate per-clan coverage");
+  for (const line of formatAggregatePerClanCoverage(reports)) console.log(line);
+
+  console.log("\nCWL coverage limitation: this audit does not infer historical FWA absence or presence from current state; persisted CWL evidence was not used unless an unambiguous boundary owner is available.");
+  console.log((await buildPlayerDiagnostics(db, reports, activeHomes)).join("\n"));
+  console.log(buildTenureDiagnostics(reports, activeHomes).join("\n"));
+}
+
+/** Purpose: format deterministic per-clan candidate coverage without dropping unknown clans. */
+export function formatAggregatePerClanCoverage(reports: readonly AuditCycleReport[]): string[] {
+  const lines: string[] = [];
   const clans = new Map<string, AuditCycleReport[]>();
   for (const report of reports) {
-    for (const clanTag of Object.keys(report.perClanRosterCounts)) {
+    for (const clanTag of new Set([
+      ...Object.keys(report.perClanRosterCounts),
+      ...Object.keys(report.expectedTeamSizesByClan),
+      ...Object.keys(report.perClanRosterCompleteness),
+    ])) {
       const rows = clans.get(clanTag) ?? [];
       rows.push(report);
       clans.set(clanTag, rows);
@@ -1130,12 +1175,13 @@ async function printAudit(
   }
   for (const clanTag of [...clans.keys()].sort((a, b) => a.localeCompare(b))) {
     const rows = clans.get(clanTag)!;
-    const safe = rows.filter((row) => ["SCHEDULED_SYNC_CANDIDATE", "PREP_CLUSTER_CANDIDATE", "LEGACY_WARLOOKUP_CANDIDATE"].includes(row.classification));
-    console.log(`clan=${clanTag} first_recoverable_sync=${safe[0]?.syncNumber ?? "none"} last_recoverable_sync=${safe.at(-1)?.syncNumber ?? "none"} recoverable_cycles=${safe.length} complete_roster_cycles=${safe.filter((row) => row.rosterCompleteness === "COMPLETE").length} partial_or_missing_cycles=${safe.filter((row) => row.rosterCompleteness !== "COMPLETE").length}`);
+    const safe = rows
+      .filter((row) => ["SCHEDULED_SYNC_CANDIDATE", "PREP_CLUSTER_CANDIDATE", "LEGACY_WARLOOKUP_CANDIDATE"].includes(row.classification))
+      .sort((left, right) => left.syncNumber - right.syncNumber);
+    const statusForClan = (row: AuditCycleReport) => row.perClanRosterCompleteness[clanTag] ?? "UNKNOWN";
+    lines.push(`clan=${clanTag} first_recoverable_sync=${safe[0]?.syncNumber ?? "none"} last_recoverable_sync=${safe.at(-1)?.syncNumber ?? "none"} candidate_cycles=${safe.length} complete_roster_cycles=${safe.filter((row) => statusForClan(row) === "COMPLETE").length} partial_roster_cycles=${safe.filter((row) => statusForClan(row) === "PARTIAL").length} unknown_roster_cycles=${safe.filter((row) => statusForClan(row) === "UNKNOWN").length}`);
   }
-  console.log("\nCWL coverage limitation: this audit does not infer historical FWA absence or presence from current state; persisted CWL evidence was not used unless an unambiguous boundary owner is available.");
-  console.log((await buildPlayerDiagnostics(db, reports, activeHomes)).join("\n"));
-  console.log(buildTenureDiagnostics(reports, activeHomes).join("\n"));
+  return lines;
 }
 
 /** Purpose: execute the one-off read-only historical membership backfill audit. */

--- a/src/scripts/auditMembershipHistoryBackfill.ts
+++ b/src/scripts/auditMembershipHistoryBackfill.ts
@@ -39,7 +39,6 @@ export type AuditHistoryEvidence = {
   warStartTime: Date;
   prepStartTime: Date | null;
   warEndTime: Date | null;
-  expectedTeamSize?: number | null;
 };
 
 export type AuditParticipationEvidence = {
@@ -68,7 +67,6 @@ export type AuditLookupEvidence = {
   clanTag: string;
   startTime: Date;
   payload: unknown;
-  expectedTeamSize?: number | null;
 };
 
 export type AuditCycleInput = {
@@ -100,6 +98,7 @@ export type AuditCycleReport = {
   classification: AuditClassification;
   candidateSyncTime: Date | null;
   candidateSource: string | null;
+  syncCycleTime: Date | null;
   syncCycleExists: boolean;
   exactSnapshotCoverage: boolean;
   scheduledCandidateCount: number;
@@ -178,7 +177,23 @@ function warIdentityKey(point: AuditPointEvidence): string {
   const clanTag = normalizeClanTag(point.clanTag);
   return point.warId !== null
     ? `${clanTag}|war:${point.warId}`
-    : `${clanTag}|start:${point.warStartTime.getTime()}|opponent:${point.opponentTag}`;
+    : `${clanTag}|start:${point.warStartTime.getTime()}|opponent:${normalizeClanTag(point.opponentTag)}`;
+}
+
+/** Purpose: compare the persisted tuple that makes a null-warId identity safely mergeable. */
+function sameCanonicalWarTuple(left: AuditPointEvidence, right: AuditPointEvidence): boolean {
+  return normalizeClanTag(left.clanTag) === normalizeClanTag(right.clanTag) &&
+    left.syncNumber === right.syncNumber &&
+    left.warStartTime.getTime() === right.warStartTime.getTime() &&
+    normalizeClanTag(left.opponentTag) === normalizeClanTag(right.opponentTag);
+}
+
+/** Purpose: reconcile a partial null-warId point with an equivalent canonical non-null identity. */
+function reconciledWarIdentityKey(point: AuditPointEvidence, points: readonly AuditPointEvidence[]): string {
+  if (point.warId !== null) return warIdentityKey(point);
+  const matchingNonNull = points.find((candidate) =>
+    candidate.warId !== null && sameCanonicalWarTuple(point, candidate));
+  return matchingNonNull ? warIdentityKey(matchingNonNull) : warIdentityKey(point);
 }
 
 /** Purpose: parse canonical participant tags from the supported archived WarLookup payload shape. */
@@ -202,14 +217,15 @@ export function parseCanonicalParticipantTags(payload: unknown): string[] {
   )].sort((a, b) => a.localeCompare(b));
 }
 
-/** Purpose: extract an explicitly persisted team-size expectation without hard-coding 50. */
+/** Purpose: extract only the authoritative team size persisted by the WarLookup writer. */
 function parseCanonicalTeamSize(payload: unknown): number | null {
   if (!payload || typeof payload !== "object") return null;
   const root = payload as Record<string, unknown>;
-  const canonical = root.canonical && typeof root.canonical === "object"
-    ? root.canonical as Record<string, unknown>
-    : root;
-  return normalizePositiveInteger(canonical.teamSize ?? canonical.team_size ?? root.teamSize);
+  const warMeta = root.warMeta && typeof root.warMeta === "object"
+    ? root.warMeta as Record<string, unknown>
+    : null;
+  if (String(warMeta?.teamSizeSource ?? "").trim().toLowerCase() !== "war_event_snapshot") return null;
+  return normalizePositiveInteger(warMeta?.teamSize);
 }
 
 /** Purpose: derive a deterministic median-centered prep-time cluster and its spread. */
@@ -317,7 +333,6 @@ export function classifyAuditCycle(input: AuditCycleInput): AuditCycleReport {
   const guildId = normalizeGuildId(input.guildId);
   const points = input.points.filter((point) => point.isFwa && point.guildId === guildId);
   const histories = input.histories.filter((history) => isFwa(history.matchType));
-  const pointWarIds = new Set(points.map((point) => point.warId).filter((value): value is number => value !== null));
   const mappedHistories = histories.filter((history) => points.some((point) => historyMatchesPoint(history, point)));
   const participation = input.participation.filter((row) =>
     row.guildId === guildId && mappedHistories.some((history) =>
@@ -334,7 +349,7 @@ export function classifyAuditCycle(input: AuditCycleInput): AuditCycleReport {
   const perClanRosterCounts: Record<string, number> = {};
   const playerClanFacts: Array<{ playerTag: string; clanTag: string; source: string }> = [];
   const playerClanSets = new Map<string, Set<string>>();
-  const participationFactKeys = new Set<string>();
+  const factKeys = new Set<string>();
   for (const row of participation) {
     const playerTag = normalizePlayerTag(row.playerTag);
     const clanTag = normalizeClanTag(row.clanTag);
@@ -346,9 +361,9 @@ export function classifyAuditCycle(input: AuditCycleInput): AuditCycleReport {
     const clans = playerClanSets.get(playerTag) ?? new Set<string>();
     clans.add(clanTag);
     playerClanSets.set(playerTag, clans);
-    const factKey = `${playerTag}|${clanTag}|ClanWarParticipation`;
-    if (!participationFactKeys.has(factKey)) {
-      participationFactKeys.add(factKey);
+    const factKey = `${playerTag}|${clanTag}`;
+    if (!factKeys.has(factKey)) {
+      factKeys.add(factKey);
       playerClanFacts.push({ playerTag, clanTag, source: "ClanWarParticipation" });
     }
   }
@@ -356,7 +371,7 @@ export function classifyAuditCycle(input: AuditCycleInput): AuditCycleReport {
   const identityKeysByClan = new Map<string, Set<string>>();
   for (const point of points) {
     const identities = identityKeysByClan.get(normalizeClanTag(point.clanTag)) ?? new Set<string>();
-    identities.add(warIdentityKey(point));
+    identities.add(reconciledWarIdentityKey(point, points));
     identityKeysByClan.set(normalizeClanTag(point.clanTag), identities);
     if (hasPersistedSyncNumberDisagreement(point, histories)) conflicts.push("persisted_sync_number_disagreement");
     if (pointHasConflictingPersistedOwner(point, points)) conflicts.push("conflicting_persisted_identity_sources");
@@ -368,15 +383,19 @@ export function classifyAuditCycle(input: AuditCycleInput): AuditCycleReport {
     if (clans.size > 1) conflicts.push(`player_in_multiple_clans:${playerTag}`);
   }
   const legacyRosterFacts: Array<{ playerTag: string; clanTag: string }> = [];
-  const legacyEvidenceAvailable = participation.length === 0 && input.lookups.length > 0 && pointWarIds.size > 0;
-  if (legacyEvidenceAvailable) {
-    const factKeys = new Set<string>();
-    for (const lookup of input.lookups) {
+  const participationIdentityKeys = new Set(
+    participation.map((row) => `${row.warId}|${normalizeClanTag(row.clanTag)}`),
+  );
+  for (const history of mappedHistories) {
+    const identityKey = `${history.warId}|${normalizeClanTag(history.clanTag)}`;
+    if (participationIdentityKeys.has(identityKey)) continue;
+    for (const lookup of input.lookups.filter((candidate) =>
+      candidate.warId === history.warId && normalizeClanTag(candidate.clanTag) === normalizeClanTag(history.clanTag))) {
       for (const playerTag of parseCanonicalParticipantTags(lookup.payload)) {
         const clanTag = normalizeClanTag(lookup.clanTag);
-        const key = `${playerTag}|${clanTag}`;
-        if (!clanTag || factKeys.has(key)) continue;
-        factKeys.add(key);
+        const factKey = `${playerTag}|${clanTag}`;
+        if (!clanTag || factKeys.has(factKey)) continue;
+        factKeys.add(factKey);
         const rosterPlayers = perClanRosterPlayers.get(clanTag) ?? new Set<string>();
         rosterPlayers.add(playerTag);
         perClanRosterPlayers.set(clanTag, rosterPlayers);
@@ -387,16 +406,8 @@ export function classifyAuditCycle(input: AuditCycleInput): AuditCycleReport {
     }
   }
   const expectedTeamSizesByClan = new Map<string, Set<number>>();
-  for (const history of mappedHistories) {
-    const expectedSize = normalizePositiveInteger(history.expectedTeamSize);
-    if (expectedSize === null) continue;
-    const clanTag = normalizeClanTag(history.clanTag);
-    const sizes = expectedTeamSizesByClan.get(clanTag) ?? new Set<number>();
-    sizes.add(expectedSize);
-    expectedTeamSizesByClan.set(clanTag, sizes);
-  }
   for (const lookup of input.lookups) {
-    const expectedSize = normalizePositiveInteger(lookup.expectedTeamSize);
+    const expectedSize = parseCanonicalTeamSize(lookup.payload);
     if (expectedSize === null) continue;
     const clanTag = normalizeClanTag(lookup.clanTag);
     const sizes = expectedTeamSizesByClan.get(clanTag) ?? new Set<number>();
@@ -487,6 +498,7 @@ export function classifyAuditCycle(input: AuditCycleInput): AuditCycleReport {
     classification,
     candidateSyncTime,
     candidateSource,
+    syncCycleTime: input.syncCycleTime,
     syncCycleExists: Boolean(input.syncCycleTime),
     exactSnapshotCoverage: exactCoverage,
     scheduledCandidateCount: scheduledCandidates.length,
@@ -597,7 +609,6 @@ function normalizeHistories(rows: any[]): AuditHistoryEvidence[] {
       warStartTime,
       prepStartTime: isValidDate(row?.prepStartTime) ? row.prepStartTime : null,
       warEndTime: isValidDate(row?.warEndTime) ? row.warEndTime : null,
-      expectedTeamSize: normalizePositiveInteger(row?.expectedTeamSize),
     }];
   });
 }
@@ -646,7 +657,6 @@ function normalizeLookups(rows: any[]): AuditLookupEvidence[] {
       clanTag,
       startTime: row.startTime,
       payload: row.payload,
-      expectedTeamSize: parseCanonicalTeamSize(row.payload),
     }];
   });
 }
@@ -875,12 +885,32 @@ function buildProjectedPlayerEvidence(
   playerTag: string,
   currentBoundaries: readonly Date[],
   currentRows: readonly MembershipBoundaryEvidence[],
+  currentIdentities: readonly { boundaryTime: Date; syncNumber: number }[],
   reports: readonly AuditCycleReport[],
 ): ProjectedPlayerEvidence {
   const currentByTime = new Map(currentRows.map((row) => [row.boundaryTime.getTime(), row]));
+  const currentTimeBySync = new Map(currentIdentities.map((identity) => [identity.syncNumber, identity.boundaryTime]));
   const candidateFactsByTime = new Map<number, Array<{ playerTag: string; clanTag: string; source: string }>>();
   const candidateReports = reports.filter(isTimestampedCandidate);
-  for (const report of candidateReports) {
+  const reportsBySync = new Map<number, AuditCycleReport>();
+  for (const report of reports) {
+    if (!reportsBySync.has(report.syncNumber)) reportsBySync.set(report.syncNumber, report);
+  }
+  const latestCurrentSync = currentIdentities.length > 0
+    ? Math.max(...currentIdentities.map((identity) => identity.syncNumber))
+    : null;
+  const candidateIsContiguous = (report: AuditCycleReport): boolean => {
+    if (latestCurrentSync === null) return true;
+    for (let syncNumber = latestCurrentSync - 1; syncNumber >= report.syncNumber; syncNumber -= 1) {
+      const intervening = reportsBySync.get(syncNumber);
+      if (intervening && (intervening.conflicts.length > 0 || ["AMBIGUOUS", "UNRECOVERABLE"].includes(intervening.classification))) return false;
+      if (currentTimeBySync.has(syncNumber)) continue;
+      if (!intervening || !isTimestampedCandidate(intervening) || intervening.conflicts.length > 0) return false;
+    }
+    return report.syncNumber < latestCurrentSync;
+  };
+  const usableCandidateReports = candidateReports.filter(candidateIsContiguous);
+  for (const report of usableCandidateReports) {
     const boundaryTime = report.candidateSyncTime!.getTime();
     const facts = report.playerClanFacts.filter((fact) => fact.playerTag === playerTag);
     const rows = candidateFactsByTime.get(boundaryTime) ?? [];
@@ -889,7 +919,7 @@ function buildProjectedPlayerEvidence(
   }
   const boundaryTimes = [...new Map([
     ...currentBoundaries.map((boundaryTime) => [boundaryTime.getTime(), boundaryTime] as const),
-    ...candidateReports.map((report) => [report.candidateSyncTime!.getTime(), report.candidateSyncTime!] as const),
+    ...usableCandidateReports.map((report) => [report.candidateSyncTime!.getTime(), report.candidateSyncTime!] as const),
   ]).values()].sort((left, right) => right.getTime() - left.getTime());
   const evidenceRows = boundaryTimes.map((boundaryTime) => {
     const current = currentByTime.get(boundaryTime.getTime());
@@ -898,11 +928,12 @@ function buildProjectedPlayerEvidence(
     if (candidateFacts.length > 0) return buildCandidateEvidenceRow(playerTag, boundaryTime, candidateFacts);
     return current ?? buildCandidateEvidenceRow(playerTag, boundaryTime, []);
   });
-  const coverageLimited = reports.some((report) =>
-    ["SCHEDULED_SYNC_CANDIDATE", "PREP_CLUSTER_CANDIDATE", "LEGACY_WARLOOKUP_CANDIDATE"].includes(report.classification) &&
-    report.playerClanFacts.some((fact) => fact.playerTag === playerTag) &&
-    !isValidDate(report.candidateSyncTime),
-  );
+  const coverageLimited = reports.some((report) => {
+    const relevant = report.playerClanFacts.some((fact) => fact.playerTag === playerTag);
+    if (!relevant && !["AMBIGUOUS", "UNRECOVERABLE"].includes(report.classification)) return false;
+    if (["AMBIGUOUS", "UNRECOVERABLE"].includes(report.classification)) return true;
+    return isTimestampedCandidate(report) && !usableCandidateReports.includes(report);
+  });
   return { boundaries: boundaryTimes, evidenceRows, coverageLimited };
 }
 
@@ -916,6 +947,7 @@ export function projectMembershipStreak(
   playerTag: string,
   current: {
     boundaryTimes: readonly Date[];
+    boundaryIdentities?: readonly { boundaryTime: Date; syncNumber: number }[];
     evidenceRows: readonly MembershipBoundaryEvidence[];
     boundaryHistoryTruncated: boolean;
   },
@@ -925,6 +957,7 @@ export function projectMembershipStreak(
     playerTag,
     current.boundaryTimes,
     current.evidenceRows,
+    current.boundaryIdentities ?? [],
     reports,
   );
   return computeMembershipStreaksFromEvidence(
@@ -959,24 +992,21 @@ async function buildPlayerDiagnostics(
     const playerTags = homes.map((home) => normalizePlayerTag(home.playerTag)).filter(Boolean).sort((a, b) => a.localeCompare(b));
     if (playerTags.length === 0) continue;
     const current = await streakService.getMembershipStreakBatchForPlayers({ guildId, playerTags });
-    const candidateReports = reports.filter((report) => report.guildId === guildId && [
-      "SCHEDULED_SYNC_CANDIDATE",
-      "PREP_CLUSTER_CANDIDATE",
-      "LEGACY_WARLOOKUP_CANDIDATE",
-    ].includes(report.classification));
+    const candidateReports = reports.filter((report) => report.guildId === guildId);
     for (const result of current.streaks) {
       const home = homes.find((row) => normalizePlayerTag(row.playerTag) === result.playerTag);
       const projected = projectMembershipStreak(
         result.playerTag,
         {
           boundaryTimes: current.boundaryTimes,
+          boundaryIdentities: current.boundaryIdentities,
           evidenceRows: current.evidenceByPlayer[result.playerTag] ?? [],
           boundaryHistoryTruncated: current.boundaryHistoryTruncated,
         },
         candidateReports,
       );
       const earliest = candidateReports
-        .filter((report) => report.playerClanFacts.some((fact) => fact.playerTag === result.playerTag))
+        .filter((report) => isTimestampedCandidate(report) && report.playerClanFacts.some((fact) => fact.playerTag === result.playerTag))
         .map((report) => report.candidateSyncTime)
         .filter(isValidDate)
         .sort((left, right) => left.getTime() - right.getTime())[0];
@@ -1000,29 +1030,45 @@ async function buildPlayerDiagnostics(
 
 type HomeContinuity = {
   reports: AuditCycleReport[];
-  stopReason: "NONE" | "GAP" | "ABSENT" | "UNKNOWN" | "CONFLICT";
+  startSyncNumber: number | null;
+  stopReason: "NONE" | "GAP" | "ABSENT" | "UNKNOWN" | "CONFLICT" | "START_ANCHOR_UNKNOWN";
 };
 
-/** Purpose: walk only safe pre-start candidate evidence backward for one active Home player. */
+/** Purpose: walk safe pre-start evidence backward from the canonical Home start sync without skipping boundaries. */
 function buildHomeContinuity(reports: readonly AuditCycleReport[], home: any): HomeContinuity {
   const guildId = normalizeGuildId(home.guildId);
   const playerTag = normalizePlayerTag(home.playerTag);
   const clanTag = normalizeClanTag(home.clanTag);
   const startedAt = new Date(home.startedAtSyncTime);
-  const candidateRows = reports
-    .filter((report) => report.guildId === guildId && isTimestampedCandidate(report))
-    .filter((report) => report.candidateSyncTime!.getTime() < startedAt.getTime())
-    .sort((left, right) => left.syncNumber - right.syncNumber);
+  const anchor = reports.find((report) =>
+    report.guildId === guildId &&
+    report.syncCycleTime instanceof Date &&
+    report.syncCycleTime.getTime() === startedAt.getTime());
+  if (!anchor) return { reports: [], startSyncNumber: null, stopReason: "START_ANCHOR_UNKNOWN" };
+  const reportsBySync = new Map<number, AuditCycleReport[]>();
+  for (const report of reports.filter((candidate) => candidate.guildId === guildId)) {
+    const rows = reportsBySync.get(report.syncNumber) ?? [];
+    rows.push(report);
+    reportsBySync.set(report.syncNumber, rows);
+  }
   const continuousRows: AuditCycleReport[] = [];
   let stopReason: HomeContinuity["stopReason"] = "NONE";
-  for (let index = candidateRows.length - 1; index >= 0; index -= 1) {
-    const report = candidateRows[index];
-    if (report.conflicts.length > 0) {
+  for (let expectedSync = anchor.syncNumber - 1; expectedSync > 0; expectedSync -= 1) {
+    const rows = reportsBySync.get(expectedSync) ?? [];
+    if (rows.length === 0) {
+      stopReason = "GAP";
+      break;
+    }
+    const report = rows[0];
+    if (rows.length > 1 || report.conflicts.length > 0 || report.classification === "AMBIGUOUS") {
       stopReason = "CONFLICT";
       break;
     }
-    const followsContinuousRow = continuousRows.length === 0 || candidateRows[index + 1].syncNumber === report.syncNumber + 1;
-    if (!followsContinuousRow) {
+    if (report.classification === "UNRECOVERABLE") {
+      stopReason = "UNKNOWN";
+      break;
+    }
+    if (!isTimestampedCandidate(report) || report.candidateSyncTime!.getTime() >= startedAt.getTime()) {
       stopReason = "GAP";
       break;
     }
@@ -1034,7 +1080,7 @@ function buildHomeContinuity(reports: readonly AuditCycleReport[], home: any): H
     stopReason = report.perClanRosterCompleteness[clanTag] === "COMPLETE" ? "ABSENT" : "UNKNOWN";
     break;
   }
-  return { reports: continuousRows, stopReason };
+  return { reports: continuousRows, startSyncNumber: anchor.syncNumber, stopReason };
 }
 
 /** Purpose: report theoretical Home tenure extension without mutating Home periods or asserting historical filler truth. */
@@ -1055,7 +1101,7 @@ export function buildTenureDiagnostics(reports: readonly AuditCycleReport[], act
     const continuity = buildHomeContinuity(reports, home);
     if (continuity.reports.length > 0) sameHomeCount += 1;
     theoreticalBoundaryCount += continuity.reports.length;
-    lines.push(`guild=${guildId} player=${playerTag} home=${clanTag} earliest_continuous_same_clan=${continuity.reports[0]?.candidateSyncTime?.toISOString() ?? "none"} theoretical_extension_boundaries=${continuity.reports.length} stop_reason=${continuity.stopReason}`);
+    lines.push(`guild=${guildId} player=${playerTag} home=${clanTag} home_start_sync=${continuity.startSyncNumber ?? "unknown"} earliest_continuous_same_clan=${continuity.reports[0]?.candidateSyncTime?.toISOString() ?? "none"} theoretical_extension_boundaries=${continuity.reports.length} stop_reason=${continuity.stopReason}`);
   }
   lines.splice(3, 0, `historical evidence shows same current Home before startedAtSyncTime: ${sameHomeCount}`);
   lines.push(`boundaries by which Clan Tenure could theoretically extend: ${theoreticalBoundaryCount}`);

--- a/src/services/MembershipStreakService.ts
+++ b/src/services/MembershipStreakService.ts
@@ -51,6 +51,7 @@ export type MembershipStreakBatchResult = {
   streaks: MembershipStreakResult[];
   boundaryTimes: Date[];
   boundaryHistoryTruncated: boolean;
+  evidenceByPlayer: MembershipBoundaryEvidenceByPlayer;
 };
 
 export type MembershipBoundaryEvidenceByPlayer = Record<string, MembershipBoundaryEvidence[]>;
@@ -337,12 +338,15 @@ function buildAllianceEvidence(
 }
 
 /** Purpose: compute bounded physical-clan and alliance streaks from boundary evidence. */
-function computeStreaks(
+export function computeMembershipStreaksFromEvidence(
   playerTag: string,
   boundaries: Date[],
-  evidenceByKey: Map<string, MembershipBoundaryEvidence>,
+  evidenceRows: MembershipBoundaryEvidence[],
   historyBoundReached: boolean,
 ): MembershipStreakResult {
+  const evidenceByKey = new Map(
+    evidenceRows.map((row) => [evidenceKey(playerTag, row.boundaryTime), row]),
+  );
   const latestBoundaryTime = boundaries[0] ?? null;
   const latest = latestBoundaryTime ? evidenceByKey.get(evidenceKey(playerTag, latestBoundaryTime)) : undefined;
 
@@ -414,16 +418,10 @@ export class MembershipStreakService {
   /** Purpose: return streaks and the same canonical boundary window through one bulk evidence load. */
   async getMembershipStreakBatchForPlayers(input: MembershipStreakInput): Promise<MembershipStreakBatchResult> {
     const loaded = await this.loadEvidence(input);
-    const evidenceMaps = new Map(
-      loaded.playerTags.map((playerTag) => [
-        playerTag,
-        new Map(loaded.evidenceByPlayer[playerTag].map((row) => [evidenceKey(playerTag, row.boundaryTime), row])),
-      ]),
-    );
-    const results = loaded.playerTags.map((playerTag) => computeStreaks(
+    const results = loaded.playerTags.map((playerTag) => computeMembershipStreaksFromEvidence(
       playerTag,
       loaded.boundaries,
-      evidenceMaps.get(playerTag)!,
+      loaded.evidenceByPlayer[playerTag],
       loaded.historyBoundReached,
     ));
     console.debug(
@@ -433,6 +431,7 @@ export class MembershipStreakService {
       streaks: results,
       boundaryTimes: [...loaded.boundaries],
       boundaryHistoryTruncated: loaded.boundaryHistoryTruncated,
+      evidenceByPlayer: loaded.evidenceByPlayer,
     };
   }
 

--- a/src/services/MembershipStreakService.ts
+++ b/src/services/MembershipStreakService.ts
@@ -50,6 +50,7 @@ export type MembershipStreakResult = {
 export type MembershipStreakBatchResult = {
   streaks: MembershipStreakResult[];
   boundaryTimes: Date[];
+  boundaryIdentities: Array<{ boundaryTime: Date; syncNumber: number }>;
   boundaryHistoryTruncated: boolean;
   evidenceByPlayer: MembershipBoundaryEvidenceByPlayer;
 };
@@ -107,6 +108,7 @@ type IntervalRow = {
 type LoadedEvidence = {
   playerTags: string[];
   boundaries: Date[];
+  boundaryIdentities: Array<{ boundaryTime: Date; syncNumber: number }>;
   evidenceByPlayer: MembershipBoundaryEvidenceByPlayer;
   historyBoundReached: boolean;
   boundaryHistoryTruncated: boolean;
@@ -430,6 +432,7 @@ export class MembershipStreakService {
     return {
       streaks: results,
       boundaryTimes: [...loaded.boundaries],
+      boundaryIdentities: [...loaded.boundaryIdentities],
       boundaryHistoryTruncated: loaded.boundaryHistoryTruncated,
       evidenceByPlayer: loaded.evidenceByPlayer,
     };
@@ -463,6 +466,7 @@ export class MembershipStreakService {
       return {
         playerTags,
         boundaries: [],
+        boundaryIdentities: [],
         evidenceByPlayer: {},
         historyBoundReached: false,
         boundaryHistoryTruncated: false,
@@ -531,6 +535,10 @@ export class MembershipStreakService {
 
     const cycles = normalizeCanonicalCycles(rawCycles);
     const boundedCycles = cycles.filter((cycle) => boundaryTimeSet.has(dateKey(cycle.syncTime)));
+    const boundaryIdentities = boundedCycles.map((cycle) => ({
+      boundaryTime: cycle.syncTime,
+      syncNumber: cycle.syncNumber,
+    }));
     const boundedCyclesBySyncNumber = new Map(boundedCycles.map((cycle) => [cycle.syncNumber, cycle]));
     const fallbackSyncNumbers = boundedCycles
       .filter((cycle) => !exactCaptureBoundarySet.has(dateKey(cycle.syncTime)))
@@ -662,6 +670,7 @@ export class MembershipStreakService {
     return {
       playerTags,
       boundaries,
+      boundaryIdentities,
       evidenceByPlayer,
       historyBoundReached: historyBoundReached || intervalHistoryBoundReached,
       boundaryHistoryTruncated,

--- a/tests/auditMembershipHistoryBackfill.test.ts
+++ b/tests/auditMembershipHistoryBackfill.test.ts
@@ -43,14 +43,25 @@ function boundaryEvidence(boundaryTime: Date, clanTag: string | null, status: "R
 }
 
 /** Purpose: build a candidate report with one optional historical player fact. */
-function candidateReport(syncNumber: number, candidateTime: Date, clanTag: string | null = "#HOME"): ReturnType<typeof classifyAuditCycle> {
+function candidateReport(syncNumber: number, candidateTime: Date, clanTag: string | null = "#HOME", syncCycleTime: Date | null = null): ReturnType<typeof classifyAuditCycle> {
   const historicalClanTag = clanTag ?? "#HOME";
   return classifyAuditCycle(input({
     syncNumber,
+    syncCycleTime,
     schedules: [],
     points: [point({ syncNumber, clanTag: historicalClanTag })],
     histories: [history({ syncNumber, clanTag: historicalClanTag, prepStartTime: candidateTime })],
     participation: clanTag ? [participation({ playerTag: "#PLAYER1", clanTag })] : [],
+  }));
+}
+
+/** Purpose: create an ambiguous historical report that retains a canonical candidate time. */
+function ambiguousReport(syncNumber: number, candidateTime: Date): ReturnType<typeof classifyAuditCycle> {
+  return classifyAuditCycle(input({
+    syncNumber,
+    schedules: [schedule({ syncTime: candidateTime })],
+    points: [point({ syncNumber }), point({ syncNumber, warId: 43 })],
+    histories: [history({ syncNumber }), history({ syncNumber, warId: 43 })],
   }));
 }
 
@@ -79,7 +90,20 @@ function history(overrides: Partial<AuditHistoryEvidence> = {}): AuditHistoryEvi
     warStartTime: warStart,
     prepStartTime: prep,
     warEndTime: new Date("2026-01-01T05:00:00.000Z"),
-    expectedTeamSize: 2,
+    ...overrides,
+  };
+}
+
+/** Purpose: build the real persisted WarLookup team-size and canonical participant shape. */
+function lookup(overrides: Partial<AuditLookupEvidence> = {}): AuditLookupEvidence {
+  return {
+    warId: 42,
+    clanTag: "#HOME",
+    startTime: warStart,
+    payload: {
+      warMeta: { teamSize: 2, teamSizeSource: "war_event_snapshot" },
+      canonical: { participants: ["#PLAYER1", "#PLAYER2"] },
+    },
     ...overrides,
   };
 }
@@ -134,25 +158,25 @@ describe("auditMembershipHistoryBackfill", () => {
     expect(classifyAuditCycle(input()).classification).toBe("SCHEDULED_SYNC_CANDIDATE");
     expect(classifyAuditCycle(input({ schedules: [] })).classification).toBe("PREP_CLUSTER_CANDIDATE");
     expect(classifyAuditCycle(input({
-      histories: [],
+      histories: [history({ prepStartTime: null })],
       participation: [],
       schedules: [],
       lookups: [{
         warId: 42,
         clanTag: "#HOME",
         startTime: warStart,
-        payload: { canonical: { participants: ["#PLAYER1", { tag: "#PLAYER2" }], teamSize: 2 } },
+        payload: { warMeta: { teamSize: 2, teamSizeSource: "war_event_snapshot" }, canonical: { participants: ["#PLAYER1", { tag: "#PLAYER2" }] } },
       } satisfies AuditLookupEvidence],
     })).classification).toBe("LEGACY_WARLOOKUP_CANDIDATE");
     const summary = formatAuditSummary([classifyAuditCycle(input({
-      histories: [],
+      histories: [history({ prepStartTime: null })],
       participation: [],
       schedules: [],
       lookups: [{
         warId: 42,
         clanTag: "#HOME",
         startTime: warStart,
-        payload: { canonical: { participants: ["#PLAYER1"] } },
+        payload: { warMeta: { teamSize: 2, teamSizeSource: "war_event_snapshot" }, canonical: { participants: ["#PLAYER1"] } },
       }],
     }))]);
     expect(summary).toContain("Potential additional canonical boundaries: 0");
@@ -186,6 +210,35 @@ describe("auditMembershipHistoryBackfill", () => {
     }));
     expect(conflictingSync.classification).toBe("AMBIGUOUS");
     expect(conflictingSync.conflicts).toContain("persisted_sync_number_disagreement");
+  });
+
+  it("merges a null ClanPointsSync warId with a matching compliance warId", () => {
+    const report = classifyAuditCycle(input({
+      points: [point({ warId: null })],
+      histories: [history()],
+      participation: [participation()],
+    }));
+    expect(report.classification).toBe("SCHEDULED_SYNC_CANDIDATE");
+    expect(report.conflicts).not.toContain("conflicting_war_identities");
+  });
+
+  it("fails closed for incompatible null-war tuples and conflicting persisted sizes", () => {
+    const nullTupleConflict = classifyAuditCycle(input({
+      points: [point({ warId: null }), point({ warId: null, opponentTag: "#OTHER" })],
+      histories: [history()],
+      participation: [participation()],
+    }));
+    expect(nullTupleConflict.classification).toBe("AMBIGUOUS");
+    expect(nullTupleConflict.conflicts).toContain("conflicting_war_identities");
+
+    const sizeConflict = classifyAuditCycle(input({
+      lookups: [
+        lookup({ payload: { warMeta: { teamSize: 50, teamSizeSource: "war_event_snapshot" }, canonical: { participants: [] } } }),
+        lookup({ payload: { warMeta: { teamSize: 40, teamSizeSource: "war_event_snapshot" }, canonical: { participants: [] } } }),
+      ],
+    }));
+    expect(sizeConflict.classification).toBe("AMBIGUOUS");
+    expect(sizeConflict.conflicts).toContain("conflicting_expected_team_sizes:#H0ME");
   });
 
   it("marks multiple schedules and excessive prep spread ambiguous", () => {
@@ -226,7 +279,7 @@ describe("auditMembershipHistoryBackfill", () => {
   });
 
   it("marks participation partial when persisted team-size evidence exceeds observed players", () => {
-    const report = classifyAuditCycle(input({ participation: [participation()] }));
+    const report = classifyAuditCycle(input({ participation: [participation()], lookups: [lookup()] }));
     expect(report.expectedTeamSize).toBe(2);
     expect(report.rosterCompleteness).toBe("PARTIAL");
     expect(report.participationDistinctPlayerCount).toBe(1);
@@ -234,7 +287,7 @@ describe("auditMembershipHistoryBackfill", () => {
 
   it("evaluates roster completeness independently for mixed historical team sizes", () => {
     const secondPoint = point({ clanTag: "#HOME2", warId: 43, opponentTag: "#OPPONENT2" });
-    const secondHistory = history({ clanTag: "#HOME2", warId: 43, opponentTag: "#OPPONENT2", expectedTeamSize: 40 });
+    const secondHistory = history({ clanTag: "#HOME2", warId: 43, opponentTag: "#OPPONENT2" });
     const firstRoster = Array.from({ length: 50 }, (_, index) => participation({ playerTag: `#A${String(index).padStart(3, "0")}` }));
     const secondRoster = Array.from({ length: 40 }, (_, index) => participation({
       playerTag: `#B${String(index).padStart(3, "0")}`,
@@ -243,13 +296,41 @@ describe("auditMembershipHistoryBackfill", () => {
     }));
     const report = classifyAuditCycle(input({
       points: [point(), secondPoint],
-      histories: [history({ expectedTeamSize: 50 }), secondHistory],
-      participation: [...firstRoster, ...secondRoster],
+      histories: [history(), secondHistory],
+      lookups: [
+        lookup({ payload: { warMeta: { teamSize: 50, teamSizeSource: "war_event_snapshot" }, canonical: { participants: firstRoster.map((row) => row.playerTag) } } }),
+        lookup({ warId: 43, clanTag: "#HOME2", payload: { warMeta: { teamSize: 40, teamSizeSource: "war_event_snapshot" }, canonical: { participants: secondRoster.map((row) => row.playerTag) } } }),
+      ],
+      participation: [],
     }));
     expect(report.expectedTeamSize).toBeNull();
     expect(report.expectedTeamSizesByClan).toEqual({ "#H0ME": 50, "#H0ME2": 40 });
     expect(report.perClanRosterCompleteness).toEqual({ "#H0ME": "COMPLETE", "#H0ME2": "COMPLETE" });
     expect(report.rosterCompleteness).toBe("COMPLETE");
+  });
+
+  it("keeps completeness UNKNOWN when WarLookup has no authoritative team size", () => {
+    const report = classifyAuditCycle(input({
+      participation: [participation(), participation({ playerTag: "#PLAYER2" })],
+      lookups: [lookup({ payload: { canonical: { participants: ["#PLAYER1", "#PLAYER2"] } } })],
+    }));
+    expect(report.expectedTeamSizesByClan).toEqual({ "#H0ME": null });
+    expect(report.perClanRosterCompleteness).toEqual({ "#H0ME": "UNKNOWN" });
+  });
+
+  it("uses normalized participation for one clan and WarLookup fallback for another", () => {
+    const secondPoint = point({ clanTag: "#HOME2", warId: 43, opponentTag: "#OPPONENT2" });
+    const report = classifyAuditCycle(input({
+      points: [point(), secondPoint],
+      histories: [history(), history({ clanTag: "#HOME2", warId: 43, opponentTag: "#OPPONENT2" })],
+      participation: [participation({ playerTag: "#PLAYER1" })],
+      lookups: [lookup({ warId: 43, clanTag: "#HOME2", payload: { canonical: { participants: ["#PLAYER2"] } } })],
+    }));
+    expect(report.playerClanFacts).toEqual([
+      { playerTag: "#PLAYER1", clanTag: "#H0ME", source: "ClanWarParticipation" },
+      { playerTag: "#PLAYER2", clanTag: "#H0ME2", source: "WarLookup.canonical.participants" },
+    ]);
+    expect(report.classification).toBe("SCHEDULED_SYNC_CANDIDATE");
   });
 
   it("does not treat an empty or malformed legacy payload as roster evidence", () => {
@@ -334,6 +415,7 @@ describe("auditMembershipHistoryBackfill", () => {
   it("replays candidate presence through contiguous shared streak semantics", () => {
     const projected = projectMembershipStreak("#PLAYER1", {
       boundaryTimes: [new Date("2026-03-03T00:00:00.000Z")],
+      boundaryIdentities: [{ boundaryTime: new Date("2026-03-03T00:00:00.000Z"), syncNumber: 12 }],
       evidenceRows: [boundaryEvidence(new Date("2026-03-03T00:00:00.000Z"), "#H0ME")],
       boundaryHistoryTruncated: false,
     }, [candidateReport(11, new Date("2026-03-02T00:00:00.000Z"))]);
@@ -343,6 +425,10 @@ describe("auditMembershipHistoryBackfill", () => {
   it("does not count candidate presence across unknown or authoritative absence", () => {
     const unknownGap = projectMembershipStreak("#PLAYER1", {
       boundaryTimes: [new Date("2026-03-03T00:00:00.000Z"), new Date("2026-03-02T00:00:00.000Z")],
+      boundaryIdentities: [
+        { boundaryTime: new Date("2026-03-03T00:00:00.000Z"), syncNumber: 12 },
+        { boundaryTime: new Date("2026-03-02T00:00:00.000Z"), syncNumber: 11 },
+      ],
       evidenceRows: [
         boundaryEvidence(new Date("2026-03-03T00:00:00.000Z"), "#H0ME"),
         boundaryEvidence(new Date("2026-03-02T00:00:00.000Z"), null),
@@ -352,6 +438,10 @@ describe("auditMembershipHistoryBackfill", () => {
     expect(unknownGap.clanStreakSyncs).toBe(1);
     const absence = projectMembershipStreak("#PLAYER1", {
       boundaryTimes: [new Date("2026-03-03T00:00:00.000Z"), new Date("2026-03-02T00:00:00.000Z")],
+      boundaryIdentities: [
+        { boundaryTime: new Date("2026-03-03T00:00:00.000Z"), syncNumber: 12 },
+        { boundaryTime: new Date("2026-03-02T00:00:00.000Z"), syncNumber: 11 },
+      ],
       evidenceRows: [
         boundaryEvidence(new Date("2026-03-03T00:00:00.000Z"), "#H0ME"),
         boundaryEvidence(new Date("2026-03-02T00:00:00.000Z"), null, "ABSENT"),
@@ -364,6 +454,7 @@ describe("auditMembershipHistoryBackfill", () => {
   it("extends only the alliance streak when candidate presence is in another clan", () => {
     const projected = projectMembershipStreak("#PLAYER1", {
       boundaryTimes: [new Date("2026-03-03T00:00:00.000Z")],
+      boundaryIdentities: [{ boundaryTime: new Date("2026-03-03T00:00:00.000Z"), syncNumber: 12 }],
       evidenceRows: [boundaryEvidence(new Date("2026-03-03T00:00:00.000Z"), "#H0ME")],
       boundaryHistoryTruncated: false,
     }, [candidateReport(11, new Date("2026-03-02T00:00:00.000Z"), "#OTHER")]);
@@ -374,6 +465,7 @@ describe("auditMembershipHistoryBackfill", () => {
   it("does not inflate a projection across a noncontiguous candidate run", () => {
     const projected = projectMembershipStreak("#PLAYER1", {
       boundaryTimes: [new Date("2026-03-04T00:00:00.000Z")],
+      boundaryIdentities: [{ boundaryTime: new Date("2026-03-04T00:00:00.000Z"), syncNumber: 13 }],
       evidenceRows: [boundaryEvidence(new Date("2026-03-04T00:00:00.000Z"), "#H0ME")],
       boundaryHistoryTruncated: false,
     }, [
@@ -382,6 +474,45 @@ describe("auditMembershipHistoryBackfill", () => {
       candidateReport(10, new Date("2026-03-01T00:00:00.000Z")),
     ]);
     expect(projected.clanStreakSyncs).toBe(2);
+  });
+
+  it("does not bridge an ambiguous intervening sync", () => {
+    const projected = projectMembershipStreak("#PLAYER1", {
+      boundaryTimes: [new Date("2026-03-04T00:00:00.000Z")],
+      boundaryIdentities: [{ boundaryTime: new Date("2026-03-04T00:00:00.000Z"), syncNumber: 451 }],
+      evidenceRows: [boundaryEvidence(new Date("2026-03-04T00:00:00.000Z"), "#H0ME")],
+      boundaryHistoryTruncated: false,
+    }, [
+      ambiguousReport(450, new Date("2026-03-03T00:00:00.000Z")),
+      candidateReport(449, new Date("2026-03-02T00:00:00.000Z")),
+    ]);
+    expect(projected.clanStreakSyncs).toBe(1);
+    expect(projected.clanStreakIsLowerBound).toBe(true);
+  });
+
+  it("does not bridge a missing intervening sync number", () => {
+    const projected = projectMembershipStreak("#PLAYER1", {
+      boundaryTimes: [new Date("2026-03-04T00:00:00.000Z")],
+      boundaryIdentities: [{ boundaryTime: new Date("2026-03-04T00:00:00.000Z"), syncNumber: 451 }],
+      evidenceRows: [boundaryEvidence(new Date("2026-03-04T00:00:00.000Z"), "#H0ME")],
+      boundaryHistoryTruncated: false,
+    }, [candidateReport(449, new Date("2026-03-02T00:00:00.000Z"))]);
+    expect(projected.clanStreakSyncs).toBe(1);
+    expect(projected.clanStreakIsLowerBound).toBe(true);
+  });
+
+  it("extends normally when every intervening sync is safe", () => {
+    const projected = projectMembershipStreak("#PLAYER1", {
+      boundaryTimes: [new Date("2026-03-04T00:00:00.000Z")],
+      boundaryIdentities: [{ boundaryTime: new Date("2026-03-04T00:00:00.000Z"), syncNumber: 451 }],
+      evidenceRows: [boundaryEvidence(new Date("2026-03-04T00:00:00.000Z"), "#H0ME")],
+      boundaryHistoryTruncated: false,
+    }, [
+      candidateReport(450, new Date("2026-03-03T00:00:00.000Z")),
+      candidateReport(449, new Date("2026-03-02T00:00:00.000Z")),
+    ]);
+    expect(projected.clanStreakSyncs).toBe(3);
+    expect(projected.clanStreakIsLowerBound).toBe(false);
   });
 
   it("does not accept an unambiguously unmapped WarLookup clan identity", () => {
@@ -420,9 +551,10 @@ describe("auditMembershipHistoryBackfill", () => {
   });
 
   it("does not include post-Home-start evidence in theoretical backdate boundaries", () => {
-    const before = classifyAuditCycle(input({ syncNumber: 20, schedules: [], points: [point({ syncNumber: 20 })], histories: [history({ syncNumber: 20, prepStartTime: new Date("2026-01-01T00:00:00.000Z") })] }));
-    const after = classifyAuditCycle(input({ syncNumber: 21, schedules: [], points: [point({ syncNumber: 21 })], histories: [history({ syncNumber: 21, prepStartTime: new Date("2026-01-03T00:00:00.000Z") })] }));
-    const tenure = buildTenureDiagnostics([before, after], [{
+    const anchor = classifyAuditCycle(input({ syncNumber: 20, syncCycleTime: new Date("2026-01-02T00:00:00.000Z") }));
+    const before = classifyAuditCycle(input({ syncNumber: 19, schedules: [], points: [point({ syncNumber: 19 })], histories: [history({ syncNumber: 19, prepStartTime: new Date("2026-01-01T00:00:00.000Z") })] }));
+    const after = classifyAuditCycle(input({ syncNumber: 21, syncCycleTime: new Date("2026-01-03T00:00:00.000Z"), schedules: [], points: [point({ syncNumber: 21 })], histories: [history({ syncNumber: 21, prepStartTime: new Date("2026-01-03T00:00:00.000Z") })] }));
+    const tenure = buildTenureDiagnostics([anchor, before, after], [{
       guildId: "guild-1",
       playerTag: "#PLAYER1",
       clanTag: "#HOME",
@@ -430,6 +562,32 @@ describe("auditMembershipHistoryBackfill", () => {
     }]);
     expect(tenure.join("\n")).toContain("theoretical_extension_boundaries=1");
     expect(tenure.join("\n")).not.toContain("theoretical_extension_boundaries=2");
+  });
+
+  it("anchors theoretical Home backdate continuity to the persisted start sync", () => {
+    const startTime = new Date("2026-05-01T00:00:00.000Z");
+    const make = (syncNumber: number, candidateTime: Date, syncCycleTime: Date | null = null, clanTag: string | null = "#HOME") =>
+      candidateReport(syncNumber, candidateTime, clanTag, syncCycleTime);
+    const anchor = classifyAuditCycle(input({ syncNumber: 500, syncCycleTime: startTime }));
+    const sync499 = make(499, new Date("2026-04-30T00:00:00.000Z"));
+    const sync498 = make(498, new Date("2026-04-29T00:00:00.000Z"));
+    const home = { guildId: "guild-1", playerTag: "#PLAYER1", clanTag: "#HOME", startedAtSyncTime: startTime };
+
+    const two = buildTenureDiagnostics([anchor, sync499, sync498], [home]).join("\n");
+    expect(two).toContain("home_start_sync=500");
+    expect(two).toContain("theoretical_extension_boundaries=2");
+
+    const only498 = buildTenureDiagnostics([anchor, sync498], [home]).join("\n");
+    expect(only498).toContain("theoretical_extension_boundaries=0");
+    expect(only498).toContain("stop_reason=GAP");
+
+    const unresolved499 = buildTenureDiagnostics([anchor, ambiguousReport(499, new Date("2026-04-30T00:00:00.000Z")), sync498], [home]).join("\n");
+    expect(unresolved499).toContain("theoretical_extension_boundaries=0");
+    expect(unresolved499).toContain("stop_reason=CONFLICT");
+
+    const unknownAnchor = buildTenureDiagnostics([sync499], [home]).join("\n");
+    expect(unknownAnchor).toContain("home_start_sync=unknown");
+    expect(unknownAnchor).toContain("stop_reason=START_ANCHOR_UNKNOWN");
   });
 
   it("uses only read delegates when executing the audit", async () => {

--- a/tests/auditMembershipHistoryBackfill.test.ts
+++ b/tests/auditMembershipHistoryBackfill.test.ts
@@ -4,6 +4,8 @@ import {
   buildTenureDiagnostics,
   classifyAuditCycle,
   classifyAuditCycles,
+  formatAuditSummary,
+  projectMembershipStreak,
   type AuditCycleInput,
   type AuditHistoryEvidence,
   type AuditLookupEvidence,
@@ -13,11 +15,46 @@ import {
   type ReadOnlyAuditDb,
   runMembershipHistoryBackfillAudit,
 } from "../src/scripts/auditMembershipHistoryBackfill";
+import type { MembershipBoundaryEvidence } from "../src/services/MembershipStreakService";
 
 const prep = new Date("2026-01-01T00:00:00.000Z");
 const sync = new Date("2026-01-01T02:00:00.000Z");
 const warStart = new Date("2026-01-01T03:00:00.000Z");
 
+/** Purpose: build exact or unknown boundary evidence for shared projection tests. */
+function boundaryEvidence(boundaryTime: Date, clanTag: string | null, status: "RESOLVED" | "ABSENT" | "UNKNOWN" = clanTag ? "RESOLVED" : "UNKNOWN"): MembershipBoundaryEvidence {
+  const clanTags = clanTag ? [clanTag] : [];
+  return {
+    playerTag: "#PLAYER1",
+    boundaryTime,
+    fwa: {
+      status,
+      clanTag: status === "RESOLVED" ? clanTag : null,
+      clanTags,
+      source: status === "ABSENT" || status === "RESOLVED" ? "SYNC_SNAPSHOT" : null,
+    },
+    alliance: {
+      positive: status === "RESOLVED",
+      clanTags,
+      ambiguous: false,
+      sources: status === "RESOLVED" ? ["FWA_EVIDENCE"] : [],
+    },
+  };
+}
+
+/** Purpose: build a candidate report with one optional historical player fact. */
+function candidateReport(syncNumber: number, candidateTime: Date, clanTag: string | null = "#HOME"): ReturnType<typeof classifyAuditCycle> {
+  const historicalClanTag = clanTag ?? "#HOME";
+  return classifyAuditCycle(input({
+    syncNumber,
+    schedules: [],
+    points: [point({ syncNumber, clanTag: historicalClanTag })],
+    histories: [history({ syncNumber, clanTag: historicalClanTag, prepStartTime: candidateTime })],
+    participation: clanTag ? [participation({ playerTag: "#PLAYER1", clanTag })] : [],
+  }));
+}
+
+/** Purpose: create a minimal persisted ClanPointsSync identity for audit fixtures. */
 function point(overrides: Partial<AuditPointEvidence> = {}): AuditPointEvidence {
   return {
     guildId: "guild-1",
@@ -31,6 +68,7 @@ function point(overrides: Partial<AuditPointEvidence> = {}): AuditPointEvidence 
   };
 }
 
+/** Purpose: create a canonical FWA war-history fixture with deterministic timestamps. */
 function history(overrides: Partial<AuditHistoryEvidence> = {}): AuditHistoryEvidence {
   return {
     warId: 42,
@@ -46,6 +84,7 @@ function history(overrides: Partial<AuditHistoryEvidence> = {}): AuditHistoryEvi
   };
 }
 
+/** Purpose: create one persisted historical player participation fact. */
 function participation(overrides: Partial<AuditParticipationEvidence> = {}): AuditParticipationEvidence {
   return {
     guildId: "guild-1",
@@ -56,6 +95,7 @@ function participation(overrides: Partial<AuditParticipationEvidence> = {}): Aud
   };
 }
 
+/** Purpose: create one persisted scheduled-sync correlation candidate. */
 function schedule(overrides: Partial<AuditScheduleEvidence> = {}): AuditScheduleEvidence {
   return {
     id: "schedule-1",
@@ -66,6 +106,7 @@ function schedule(overrides: Partial<AuditScheduleEvidence> = {}): AuditSchedule
   };
 }
 
+/** Purpose: compose a deterministic single-cycle audit fixture. */
 function input(overrides: Partial<AuditCycleInput> = {}): AuditCycleInput {
   return {
     guildId: "guild-1",
@@ -103,6 +144,48 @@ describe("auditMembershipHistoryBackfill", () => {
         payload: { canonical: { participants: ["#PLAYER1", { tag: "#PLAYER2" }], teamSize: 2 } },
       } satisfies AuditLookupEvidence],
     })).classification).toBe("LEGACY_WARLOOKUP_CANDIDATE");
+    const summary = formatAuditSummary([classifyAuditCycle(input({
+      histories: [],
+      participation: [],
+      schedules: [],
+      lookups: [{
+        warId: 42,
+        clanTag: "#HOME",
+        startTime: warStart,
+        payload: { canonical: { participants: ["#PLAYER1"] } },
+      }],
+    }))]);
+    expect(summary).toContain("Potential additional canonical boundaries: 0");
+    expect(summary).toContain("Potential player-boundary membership facts: 1");
+  });
+
+  it("accepts distinct war identities across alliance clans for scheduled and prep candidates", () => {
+    const secondPoint = point({ clanTag: "#HOME2", warId: 43, opponentTag: "#OPPONENT2" });
+    const secondHistory = history({ clanTag: "#HOME2", warId: 43, opponentTag: "#OPPONENT2" });
+    const secondParticipation = participation({ clanTag: "#HOME2", warId: 43, playerTag: "#PLAYER2" });
+    const multiClan = input({
+      points: [point(), secondPoint],
+      histories: [history(), secondHistory],
+      participation: [participation(), secondParticipation],
+    });
+    expect(classifyAuditCycle(multiClan).classification).toBe("SCHEDULED_SYNC_CANDIDATE");
+    expect(classifyAuditCycle({ ...multiClan, schedules: [] }).classification).toBe("PREP_CLUSTER_CANDIDATE");
+    expect(classifyAuditCycle(multiClan).conflicts).not.toContain("conflicting_war_identities");
+  });
+
+  it("rejects incompatible war identities for one clan and persisted sync disagreement", () => {
+    const conflictingWar = classifyAuditCycle(input({
+      points: [point(), point({ warId: 43 })],
+      histories: [history(), history({ warId: 43 })],
+    }));
+    expect(conflictingWar.classification).toBe("AMBIGUOUS");
+    expect(conflictingWar.conflicts).toContain("conflicting_war_identities");
+    const conflictingSync = classifyAuditCycle(input({
+      histories: [history({ syncNumber: 13 })],
+      schedules: [],
+    }));
+    expect(conflictingSync.classification).toBe("AMBIGUOUS");
+    expect(conflictingSync.conflicts).toContain("persisted_sync_number_disagreement");
   });
 
   it("marks multiple schedules and excessive prep spread ambiguous", () => {
@@ -114,6 +197,11 @@ describe("auditMembershipHistoryBackfill", () => {
       points: [point(), secondPoint],
       histories: [history(), history({ clanTag: "#HOME2", warId: 43, opponentTag: "#OPPONENT2", prepStartTime: new Date("2026-01-01T04:00:01.000Z") })],
     })).classification).toBe("AMBIGUOUS");
+    expect(classifyAuditCycle(input({
+      schedules: [],
+      points: [point(), secondPoint],
+      histories: [history(), history({ clanTag: "#HOME2", warId: 43, opponentTag: "#OPPONENT2", prepStartTime: new Date("2026-01-01T04:00:01.000Z") })],
+    })).conflicts).toContain("excessive_prep_start_spread");
   });
 
   it("marks a player observed in incompatible clans for one boundary ambiguous", () => {
@@ -142,6 +230,158 @@ describe("auditMembershipHistoryBackfill", () => {
     expect(report.expectedTeamSize).toBe(2);
     expect(report.rosterCompleteness).toBe("PARTIAL");
     expect(report.participationDistinctPlayerCount).toBe(1);
+  });
+
+  it("evaluates roster completeness independently for mixed historical team sizes", () => {
+    const secondPoint = point({ clanTag: "#HOME2", warId: 43, opponentTag: "#OPPONENT2" });
+    const secondHistory = history({ clanTag: "#HOME2", warId: 43, opponentTag: "#OPPONENT2", expectedTeamSize: 40 });
+    const firstRoster = Array.from({ length: 50 }, (_, index) => participation({ playerTag: `#A${String(index).padStart(3, "0")}` }));
+    const secondRoster = Array.from({ length: 40 }, (_, index) => participation({
+      playerTag: `#B${String(index).padStart(3, "0")}`,
+      clanTag: "#HOME2",
+      warId: 43,
+    }));
+    const report = classifyAuditCycle(input({
+      points: [point(), secondPoint],
+      histories: [history({ expectedTeamSize: 50 }), secondHistory],
+      participation: [...firstRoster, ...secondRoster],
+    }));
+    expect(report.expectedTeamSize).toBeNull();
+    expect(report.expectedTeamSizesByClan).toEqual({ "#H0ME": 50, "#H0ME2": 40 });
+    expect(report.perClanRosterCompleteness).toEqual({ "#H0ME": "COMPLETE", "#H0ME2": "COMPLETE" });
+    expect(report.rosterCompleteness).toBe("COMPLETE");
+  });
+
+  it("does not treat an empty or malformed legacy payload as roster evidence", () => {
+    const report = classifyAuditCycle(input({
+      histories: [],
+      participation: [],
+      schedules: [],
+      lookups: [{ warId: 42, clanTag: "#HOME", startTime: warStart, payload: { canonical: { participants: [] } } }],
+    }));
+    expect(report.classification).toBe("UNRECOVERABLE");
+    expect(report.playerClanFacts).toEqual([]);
+    expect(formatAuditSummary([report])).toContain("Potential additional canonical boundaries: 0");
+  });
+
+  it("uses an unambiguous compliance evaluation when ClanPointsSync is absent", async () => {
+    const rawHistory = {
+      warId: 501,
+      syncNumber: 77,
+      matchType: "FWA",
+      clanTag: "#HOME",
+      opponentTag: "#OPPONENT",
+      warStartTime: new Date("2026-02-01T03:00:00.000Z"),
+      prepStartTime: new Date("2026-02-01T00:00:00.000Z"),
+      warEndTime: new Date("2026-02-01T05:00:00.000Z"),
+    };
+    const reads = {
+      syncCycle: { findMany: vi.fn(async () => []), groupBy: vi.fn(async () => []) },
+      syncClanMemberSnapshot: { findMany: vi.fn(async () => []), groupBy: vi.fn(async () => []) },
+      scheduledSyncPost: { findMany: vi.fn(async () => []) },
+      clanPointsSync: { findMany: vi.fn(async () => []) },
+      clanWarHistory: { findMany: vi.fn(async () => [rawHistory]) },
+      clanWarParticipation: { findMany: vi.fn(async () => [{ guildId: "guild-1", warId: 501, clanTag: "#HOME", playerTag: "#PLAYER1", matchType: "FWA" }]) },
+      warLookup: { findMany: vi.fn(async () => []) },
+      warPlanComplianceEvaluation: { findMany: vi.fn(async () => [{
+        guildId: "guild-1",
+        warId: 501,
+        warHistory: rawHistory,
+      }]) },
+      clanHomeMembershipPeriod: { findMany: vi.fn(async () => []) },
+      syncClanReadinessSnapshot: { groupBy: vi.fn(async () => []) },
+      allianceClanMembershipInterval: { findMany: vi.fn(async () => []) },
+    } satisfies ReadOnlyAuditDb;
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const reports = await runMembershipHistoryBackfillAudit(reads);
+    log.mockRestore();
+    expect(reports).toHaveLength(1);
+    expect(reports[0].syncNumber).toBe(77);
+    expect(reports[0].classification).toBe("PREP_CLUSTER_CANDIDATE");
+  });
+
+  it("fails closed when ClanPointsSync and compliance identity disagree", async () => {
+    const rawHistory = {
+      warId: 502,
+      syncNumber: 78,
+      matchType: "FWA",
+      clanTag: "#HOME",
+      opponentTag: "#OPPONENT",
+      warStartTime: new Date("2026-02-02T03:00:00.000Z"),
+      prepStartTime: new Date("2026-02-02T00:00:00.000Z"),
+      warEndTime: new Date("2026-02-02T05:00:00.000Z"),
+    };
+    const reads = {
+      syncCycle: { findMany: vi.fn(async () => []), groupBy: vi.fn(async () => []) },
+      syncClanMemberSnapshot: { findMany: vi.fn(async () => []), groupBy: vi.fn(async () => []) },
+      scheduledSyncPost: { findMany: vi.fn(async () => []) },
+      clanPointsSync: { findMany: vi.fn(async () => [{ guildId: "guild-1", syncNum: 77, clanTag: "#HOME", warId: 502, warStartTime: rawHistory.warStartTime, opponentTag: "#OPPONENT", isFwa: true }]) },
+      clanWarHistory: { findMany: vi.fn(async () => [rawHistory]) },
+      clanWarParticipation: { findMany: vi.fn(async () => [{ guildId: "guild-1", warId: 502, clanTag: "#HOME", playerTag: "#PLAYER1", matchType: "FWA" }]) },
+      warLookup: { findMany: vi.fn(async () => []) },
+      warPlanComplianceEvaluation: { findMany: vi.fn(async () => [{ guildId: "guild-1", warId: 502, warHistory: rawHistory }]) },
+      clanHomeMembershipPeriod: { findMany: vi.fn(async () => []) },
+      syncClanReadinessSnapshot: { groupBy: vi.fn(async () => []) },
+      allianceClanMembershipInterval: { findMany: vi.fn(async () => []) },
+    } satisfies ReadOnlyAuditDb;
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const reports = await runMembershipHistoryBackfillAudit(reads);
+    log.mockRestore();
+    expect(reports.every((report) => report.classification === "AMBIGUOUS")).toBe(true);
+    expect(reports.every((report) => report.conflicts.includes("conflicting_persisted_identity_sources"))).toBe(true);
+  });
+
+  it("replays candidate presence through contiguous shared streak semantics", () => {
+    const projected = projectMembershipStreak("#PLAYER1", {
+      boundaryTimes: [new Date("2026-03-03T00:00:00.000Z")],
+      evidenceRows: [boundaryEvidence(new Date("2026-03-03T00:00:00.000Z"), "#H0ME")],
+      boundaryHistoryTruncated: false,
+    }, [candidateReport(11, new Date("2026-03-02T00:00:00.000Z"))]);
+    expect(projected.clanStreakSyncs).toBe(2);
+  });
+
+  it("does not count candidate presence across unknown or authoritative absence", () => {
+    const unknownGap = projectMembershipStreak("#PLAYER1", {
+      boundaryTimes: [new Date("2026-03-03T00:00:00.000Z"), new Date("2026-03-02T00:00:00.000Z")],
+      evidenceRows: [
+        boundaryEvidence(new Date("2026-03-03T00:00:00.000Z"), "#H0ME"),
+        boundaryEvidence(new Date("2026-03-02T00:00:00.000Z"), null),
+      ],
+      boundaryHistoryTruncated: false,
+    }, [candidateReport(11, new Date("2026-03-01T00:00:00.000Z"))]);
+    expect(unknownGap.clanStreakSyncs).toBe(1);
+    const absence = projectMembershipStreak("#PLAYER1", {
+      boundaryTimes: [new Date("2026-03-03T00:00:00.000Z"), new Date("2026-03-02T00:00:00.000Z")],
+      evidenceRows: [
+        boundaryEvidence(new Date("2026-03-03T00:00:00.000Z"), "#H0ME"),
+        boundaryEvidence(new Date("2026-03-02T00:00:00.000Z"), null, "ABSENT"),
+      ],
+      boundaryHistoryTruncated: false,
+    }, [candidateReport(11, new Date("2026-03-01T00:00:00.000Z"))]);
+    expect(absence.clanStreakSyncs).toBe(1);
+  });
+
+  it("extends only the alliance streak when candidate presence is in another clan", () => {
+    const projected = projectMembershipStreak("#PLAYER1", {
+      boundaryTimes: [new Date("2026-03-03T00:00:00.000Z")],
+      evidenceRows: [boundaryEvidence(new Date("2026-03-03T00:00:00.000Z"), "#H0ME")],
+      boundaryHistoryTruncated: false,
+    }, [candidateReport(11, new Date("2026-03-02T00:00:00.000Z"), "#OTHER")]);
+    expect(projected.clanStreakSyncs).toBe(1);
+    expect(projected.allianceStreakSyncs).toBe(2);
+  });
+
+  it("does not inflate a projection across a noncontiguous candidate run", () => {
+    const projected = projectMembershipStreak("#PLAYER1", {
+      boundaryTimes: [new Date("2026-03-04T00:00:00.000Z")],
+      evidenceRows: [boundaryEvidence(new Date("2026-03-04T00:00:00.000Z"), "#H0ME")],
+      boundaryHistoryTruncated: false,
+    }, [
+      candidateReport(12, new Date("2026-03-03T00:00:00.000Z")),
+      candidateReport(11, new Date("2026-03-02T00:00:00.000Z"), null),
+      candidateReport(10, new Date("2026-03-01T00:00:00.000Z")),
+    ]);
+    expect(projected.clanStreakSyncs).toBe(2);
   });
 
   it("does not accept an unambiguously unmapped WarLookup clan identity", () => {
@@ -177,6 +417,19 @@ describe("auditMembershipHistoryBackfill", () => {
       startedAtSyncTime: new Date("2026-01-02T00:00:00.000Z"),
     }]);
     expect(tenure.join("\n")).toContain("NOT SAFE TO APPLY AUTOMATICALLY");
+  });
+
+  it("does not include post-Home-start evidence in theoretical backdate boundaries", () => {
+    const before = classifyAuditCycle(input({ syncNumber: 20, schedules: [], points: [point({ syncNumber: 20 })], histories: [history({ syncNumber: 20, prepStartTime: new Date("2026-01-01T00:00:00.000Z") })] }));
+    const after = classifyAuditCycle(input({ syncNumber: 21, schedules: [], points: [point({ syncNumber: 21 })], histories: [history({ syncNumber: 21, prepStartTime: new Date("2026-01-03T00:00:00.000Z") })] }));
+    const tenure = buildTenureDiagnostics([before, after], [{
+      guildId: "guild-1",
+      playerTag: "#PLAYER1",
+      clanTag: "#HOME",
+      startedAtSyncTime: new Date("2026-01-02T00:00:00.000Z"),
+    }]);
+    expect(tenure.join("\n")).toContain("theoretical_extension_boundaries=1");
+    expect(tenure.join("\n")).not.toContain("theoretical_extension_boundaries=2");
   });
 
   it("uses only read delegates when executing the audit", async () => {

--- a/tests/auditMembershipHistoryBackfill.test.ts
+++ b/tests/auditMembershipHistoryBackfill.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   buildPrepCluster,
+  buildCycleInputs,
   buildTenureDiagnostics,
   classifyAuditCycle,
   classifyAuditCycles,
+  formatAggregatePerClanCoverage,
   formatAuditSummary,
+  formatCycleRow,
   projectMembershipStreak,
   type AuditCycleInput,
   type AuditHistoryEvidence,
@@ -152,6 +155,12 @@ describe("auditMembershipHistoryBackfill", () => {
       { guildId: "guild-1", syncTime: sync, clanTag: "#HOME", playerTag: "#PLAYER1" },
     ] })).classification).toBe("EXISTING_EXACT");
     expect(classifyAuditCycle(input({ syncCycleTime: sync })).classification).toBe("EXISTING_CYCLE_FALLBACK");
+    expect(classifyAuditCycle(input({ syncCycleTime: sync, participation: [], lookups: [lookup()] })).classification)
+      .toBe("EXISTING_CYCLE_FALLBACK");
+    expect(classifyAuditCycle(input({ syncCycleTime: sync, participation: [], lookups: [], schedules: [] })).classification)
+      .toBe("UNRECOVERABLE");
+    expect(formatAuditSummary([classifyAuditCycle(input({ syncCycleTime: sync, participation: [], lookups: [lookup()] }))]))
+      .toContain("Potential additional canonical boundaries: 0");
   });
 
   it("classifies scheduled, prep-cluster, and legacy candidates deterministically", () => {
@@ -241,6 +250,46 @@ describe("auditMembershipHistoryBackfill", () => {
     expect(sizeConflict.conflicts).toContain("conflicting_expected_team_sizes:#H0ME");
   });
 
+  it("propagates partial war identity conflicts across sync buckets", () => {
+    const cycles = [
+      { guildId: "guild-1", syncNumber: 499, syncTime: new Date("2026-02-01T00:00:00.000Z") },
+      { guildId: "guild-1", syncNumber: 500, syncTime: new Date("2026-02-02T00:00:00.000Z") },
+    ];
+    const reports = classifyAuditCycles(buildCycleInputs(
+      [point({ syncNumber: 499, warId: null }), point({ syncNumber: 500 })],
+      [history({ syncNumber: 500 })],
+      [],
+      [],
+      [],
+      [],
+      cycles,
+    ));
+    expect(reports.map((report) => report.classification)).toEqual(["AMBIGUOUS", "AMBIGUOUS"]);
+    expect(reports.every((report) => report.conflicts.includes("conflicting_partial_war_identity_across_sync_buckets"))).toBe(true);
+
+    const sameSync = classifyAuditCycles(buildCycleInputs(
+      [point({ warId: null }), point()],
+      [history()],
+      [],
+      [],
+      [],
+      [],
+      [{ guildId: "guild-1", syncNumber: 12, syncTime: sync }],
+    ));
+    expect(sameSync[0].classification).not.toBe("AMBIGUOUS");
+
+    const twoNullOwners = classifyAuditCycles(buildCycleInputs(
+      [point({ syncNumber: 499, warId: null }), point({ syncNumber: 500, warId: null })],
+      [],
+      [],
+      [],
+      [],
+      [],
+      cycles,
+    ));
+    expect(twoNullOwners.map((report) => report.classification)).toEqual(["AMBIGUOUS", "AMBIGUOUS"]);
+  });
+
   it("marks multiple schedules and excessive prep spread ambiguous", () => {
     expect(classifyAuditCycle(input({ schedules: [schedule(), schedule({ id: "schedule-2", syncTime: new Date("2026-01-01T04:00:00.000Z") })] })).classification)
       .toBe("AMBIGUOUS");
@@ -255,6 +304,17 @@ describe("auditMembershipHistoryBackfill", () => {
       points: [point(), secondPoint],
       histories: [history(), history({ clanTag: "#HOME2", warId: 43, opponentTag: "#OPPONENT2", prepStartTime: new Date("2026-01-01T04:00:01.000Z") })],
     })).conflicts).toContain("excessive_prep_start_spread");
+    const scheduledSpread = classifyAuditCycle(input({
+      points: [point(), secondPoint],
+      histories: [
+        history({ prepStartTime: new Date("2026-01-01T00:00:00.000Z") }),
+        history({ clanTag: "#HOME2", warId: 43, opponentTag: "#OPPONENT2", prepStartTime: new Date("2026-01-01T05:00:00.000Z") }),
+      ],
+      participation: [participation(), participation({ clanTag: "#HOME2", warId: 43 })],
+      schedules: [schedule({ syncTime: new Date("2026-01-01T02:30:00.000Z") })],
+    }));
+    expect(scheduledSpread.classification).toBe("AMBIGUOUS");
+    expect(scheduledSpread.conflicts).toContain("excessive_prep_start_spread");
   });
 
   it("marks a player observed in incompatible clans for one boundary ambiguous", () => {
@@ -307,6 +367,38 @@ describe("auditMembershipHistoryBackfill", () => {
     expect(report.expectedTeamSizesByClan).toEqual({ "#H0ME": 50, "#H0ME2": 40 });
     expect(report.perClanRosterCompleteness).toEqual({ "#H0ME": "COMPLETE", "#H0ME2": "COMPLETE" });
     expect(report.rosterCompleteness).toBe("COMPLETE");
+  });
+
+  it("reports per-clan completeness and retains zero-row unknown clans", () => {
+    const secondPoint = point({ clanTag: "#HOME2", warId: 43, opponentTag: "#OPPONENT2" });
+    const report = classifyAuditCycle(input({
+      points: [point(), secondPoint],
+      histories: [history(), history({ clanTag: "#HOME2", warId: 43, opponentTag: "#OPPONENT2" })],
+      participation: [
+        participation({ playerTag: "#A1" }),
+        participation({ playerTag: "#A2" }),
+        participation({ playerTag: "#B1", clanTag: "#HOME2", warId: 43 }),
+      ],
+      lookups: [
+        lookup({ payload: { warMeta: { teamSize: 2, teamSizeSource: "war_event_snapshot" }, canonical: { participants: [] } } }),
+        lookup({ warId: 43, clanTag: "#HOME2", payload: { warMeta: { teamSize: 2, teamSizeSource: "war_event_snapshot" }, canonical: { participants: [] } } }),
+      ],
+    }));
+    expect(report.perClanRosterCompleteness).toEqual({ "#H0ME": "COMPLETE", "#H0ME2": "PARTIAL" });
+    expect(formatCycleRow(report)).toContain("#H0ME=2/2:COMPLETE,#H0ME2=1/2:PARTIAL");
+
+    const unknownReport = classifyAuditCycle(input({
+      points: [point(), secondPoint],
+      histories: [history(), history({ clanTag: "#HOME2", warId: 43, opponentTag: "#OPPONENT2" })],
+      participation: [participation({ playerTag: "#A1" })],
+      lookups: [lookup({ payload: { warMeta: { teamSize: 1, teamSizeSource: "war_event_snapshot" }, canonical: { participants: [] } } })],
+    }));
+    expect(unknownReport.perClanRosterCounts["#H0ME2"]).toBeUndefined();
+    expect(unknownReport.perClanRosterCompleteness["#H0ME2"]).toBe("UNKNOWN");
+    expect(formatAggregatePerClanCoverage([unknownReport])).toEqual([
+      "clan=#H0ME first_recoverable_sync=12 last_recoverable_sync=12 candidate_cycles=1 complete_roster_cycles=1 partial_roster_cycles=0 unknown_roster_cycles=0",
+      "clan=#H0ME2 first_recoverable_sync=12 last_recoverable_sync=12 candidate_cycles=1 complete_roster_cycles=0 partial_roster_cycles=0 unknown_roster_cycles=1",
+    ]);
   });
 
   it("keeps completeness UNKNOWN when WarLookup has no authoritative team size", () => {

--- a/tests/auditMembershipHistoryBackfill.test.ts
+++ b/tests/auditMembershipHistoryBackfill.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  buildPrepCluster,
+  buildTenureDiagnostics,
+  classifyAuditCycle,
+  classifyAuditCycles,
+  type AuditCycleInput,
+  type AuditHistoryEvidence,
+  type AuditLookupEvidence,
+  type AuditParticipationEvidence,
+  type AuditPointEvidence,
+  type AuditScheduleEvidence,
+  type ReadOnlyAuditDb,
+  runMembershipHistoryBackfillAudit,
+} from "../src/scripts/auditMembershipHistoryBackfill";
+
+const prep = new Date("2026-01-01T00:00:00.000Z");
+const sync = new Date("2026-01-01T02:00:00.000Z");
+const warStart = new Date("2026-01-01T03:00:00.000Z");
+
+function point(overrides: Partial<AuditPointEvidence> = {}): AuditPointEvidence {
+  return {
+    guildId: "guild-1",
+    syncNumber: 12,
+    clanTag: "#HOME",
+    warId: 42,
+    warStartTime: warStart,
+    opponentTag: "#OPPONENT",
+    isFwa: true,
+    ...overrides,
+  };
+}
+
+function history(overrides: Partial<AuditHistoryEvidence> = {}): AuditHistoryEvidence {
+  return {
+    warId: 42,
+    syncNumber: 12,
+    matchType: "FWA",
+    clanTag: "#HOME",
+    opponentTag: "#OPPONENT",
+    warStartTime: warStart,
+    prepStartTime: prep,
+    warEndTime: new Date("2026-01-01T05:00:00.000Z"),
+    expectedTeamSize: 2,
+    ...overrides,
+  };
+}
+
+function participation(overrides: Partial<AuditParticipationEvidence> = {}): AuditParticipationEvidence {
+  return {
+    guildId: "guild-1",
+    warId: 42,
+    clanTag: "#HOME",
+    playerTag: "#PLAYER1",
+    ...overrides,
+  };
+}
+
+function schedule(overrides: Partial<AuditScheduleEvidence> = {}): AuditScheduleEvidence {
+  return {
+    id: "schedule-1",
+    guildId: "guild-1",
+    syncTime: sync,
+    status: "SCHEDULED",
+    ...overrides,
+  };
+}
+
+function input(overrides: Partial<AuditCycleInput> = {}): AuditCycleInput {
+  return {
+    guildId: "guild-1",
+    syncNumber: 12,
+    syncCycleTime: null,
+    points: [point()],
+    histories: [history()],
+    participation: [participation(), participation({ playerTag: "#PLAYER2" })],
+    schedules: [schedule()],
+    exactSnapshots: [],
+    lookups: [],
+    ...overrides,
+  };
+}
+
+describe("auditMembershipHistoryBackfill", () => {
+  it("classifies exact and cycle fallback evidence without using current-state tables", () => {
+    expect(classifyAuditCycle(input({ syncCycleTime: sync, exactSnapshots: [
+      { guildId: "guild-1", syncTime: sync, clanTag: "#HOME", playerTag: "#PLAYER1" },
+    ] })).classification).toBe("EXISTING_EXACT");
+    expect(classifyAuditCycle(input({ syncCycleTime: sync })).classification).toBe("EXISTING_CYCLE_FALLBACK");
+  });
+
+  it("classifies scheduled, prep-cluster, and legacy candidates deterministically", () => {
+    expect(classifyAuditCycle(input()).classification).toBe("SCHEDULED_SYNC_CANDIDATE");
+    expect(classifyAuditCycle(input({ schedules: [] })).classification).toBe("PREP_CLUSTER_CANDIDATE");
+    expect(classifyAuditCycle(input({
+      histories: [],
+      participation: [],
+      schedules: [],
+      lookups: [{
+        warId: 42,
+        clanTag: "#HOME",
+        startTime: warStart,
+        payload: { canonical: { participants: ["#PLAYER1", { tag: "#PLAYER2" }], teamSize: 2 } },
+      } satisfies AuditLookupEvidence],
+    })).classification).toBe("LEGACY_WARLOOKUP_CANDIDATE");
+  });
+
+  it("marks multiple schedules and excessive prep spread ambiguous", () => {
+    expect(classifyAuditCycle(input({ schedules: [schedule(), schedule({ id: "schedule-2", syncTime: new Date("2026-01-01T04:00:00.000Z") })] })).classification)
+      .toBe("AMBIGUOUS");
+    const secondPoint = point({ clanTag: "#HOME2", warId: 43, opponentTag: "#OPPONENT2" });
+    expect(classifyAuditCycle(input({
+      schedules: [],
+      points: [point(), secondPoint],
+      histories: [history(), history({ clanTag: "#HOME2", warId: 43, opponentTag: "#OPPONENT2", prepStartTime: new Date("2026-01-01T04:00:01.000Z") })],
+    })).classification).toBe("AMBIGUOUS");
+  });
+
+  it("marks a player observed in incompatible clans for one boundary ambiguous", () => {
+    const secondPoint = point({ clanTag: "#HOME2", warId: 43, opponentTag: "#OPPONENT2" });
+    const report = classifyAuditCycle(input({
+      schedules: [],
+      points: [point(), secondPoint],
+      histories: [history(), history({ clanTag: "#HOME2", warId: 43, opponentTag: "#OPPONENT2" })],
+      participation: [
+        participation(),
+        participation({ clanTag: "#HOME2", warId: 43 }),
+      ],
+    }));
+    expect(report.classification).toBe("AMBIGUOUS");
+    expect(report.conflicts).toContain("player_in_multiple_clans:#PLAYER1");
+  });
+
+  it("keeps missing participant mappings visible without converting a candidate to ambiguous", () => {
+    const report = classifyAuditCycle(input({ missingParticipantWarMappings: ["missing_participation:#HOME:42"] }));
+    expect(report.classification).toBe("SCHEDULED_SYNC_CANDIDATE");
+    expect(report.missingParticipantWarMappings).toEqual(["missing_participation:#HOME:42"]);
+  });
+
+  it("marks participation partial when persisted team-size evidence exceeds observed players", () => {
+    const report = classifyAuditCycle(input({ participation: [participation()] }));
+    expect(report.expectedTeamSize).toBe(2);
+    expect(report.rosterCompleteness).toBe("PARTIAL");
+    expect(report.participationDistinctPlayerCount).toBe(1);
+  });
+
+  it("does not accept an unambiguously unmapped WarLookup clan identity", () => {
+    const report = classifyAuditCycle(input({
+      histories: [],
+      participation: [],
+      schedules: [],
+      lookups: [{
+        warId: 42,
+        clanTag: "#OTHER",
+        startTime: warStart,
+        payload: { canonical: { participants: ["#PLAYER1"] } },
+      }],
+      explicitConflicts: ["warlookup_clan_identity_mismatch"],
+    }));
+    expect(report.classification).toBe("AMBIGUOUS");
+    expect(report.conflicts).toContain("warlookup_clan_identity_mismatch");
+  });
+
+  it("orders reports by guild and sync number and labels tenure as theoretical only", () => {
+    const reports = classifyAuditCycles([
+      input({ guildId: "guild-2", syncNumber: 2 }),
+      input({ guildId: "guild-1", syncNumber: 3 }),
+      input({ guildId: "guild-1", syncNumber: 1 }),
+    ]);
+    expect(reports.map((report) => `${report.guildId}:${report.syncNumber}`)).toEqual([
+      "guild-1:1", "guild-1:3", "guild-2:2",
+    ]);
+    const tenure = buildTenureDiagnostics(reports, [{
+      guildId: "guild-1",
+      playerTag: "#PLAYER1",
+      clanTag: "#HOME",
+      startedAtSyncTime: new Date("2026-01-02T00:00:00.000Z"),
+    }]);
+    expect(tenure.join("\n")).toContain("NOT SAFE TO APPLY AUTOMATICALLY");
+  });
+
+  it("uses only read delegates when executing the audit", async () => {
+    const reads = {
+      syncCycle: { findMany: vi.fn(async () => []), groupBy: vi.fn(async () => []) },
+      syncClanMemberSnapshot: { findMany: vi.fn(async () => []), groupBy: vi.fn(async () => []) },
+      scheduledSyncPost: { findMany: vi.fn(async () => []) },
+      clanPointsSync: { findMany: vi.fn(async () => []) },
+      clanWarHistory: { findMany: vi.fn(async () => []) },
+      clanWarParticipation: { findMany: vi.fn(async () => []) },
+      warLookup: { findMany: vi.fn(async () => []) },
+      clanHomeMembershipPeriod: { findMany: vi.fn(async () => []) },
+      syncClanReadinessSnapshot: { groupBy: vi.fn(async () => []) },
+      allianceClanMembershipInterval: { findMany: vi.fn(async () => []) },
+      warPlanComplianceEvaluation: { findMany: vi.fn(async () => []) },
+    } satisfies ReadOnlyAuditDb;
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    await expect(runMembershipHistoryBackfillAudit(reads)).resolves.toEqual([]);
+    expect(reads.syncCycle.findMany).toHaveBeenCalledOnce();
+    expect(reads.syncClanMemberSnapshot.findMany).toHaveBeenCalledOnce();
+    expect((reads as unknown as Record<string, unknown>).create).toBeUndefined();
+    expect((reads as unknown as Record<string, unknown>).update).toBeUndefined();
+    expect((reads as unknown as Record<string, unknown>).delete).toBeUndefined();
+    log.mockRestore();
+  });
+
+  it("reports prep cluster spread in seconds and minutes", () => {
+    const result = buildPrepCluster([prep, new Date(prep.getTime() + 90_000)]);
+    expect(result.spreadSeconds).toBe(90);
+    expect(result.spreadMinutes).toBe(2);
+  });
+});


### PR DESCRIPTION
Add a strictly read-only historical membership evidence audit with deterministic boundary classifications, ambiguity and missing-mapping diagnostics, and diagnostic-only player streak and Home-tenure impact reporting.

Validation: full suite 322 files / 4481 tests, ESLint 0 errors with existing warnings, npx tsc --noEmit, npx prisma validate, and git diff --check.