### PR TITLE
fix: make membership history audit production-safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The project is designed as a maintainable application, not a one-off bot script:
 - Uses bounded feed-sync/watch loops for external data ingestion and update timing.
 - Established Home accounts can receive a randomized, persisted pre-sync return DM when authoritative Home state is AWAY; UNKNOWN is suppressed, linked accounts for one user are grouped, exact sync timing is deliberately hidden, and normal replay is restart-safe/idempotent.
 - Supports mirror-mode staging via guarded prod-to-staging runtime snapshot sync.
-- Includes `npm run diagnose:membership-history-backfill`, a one-time strictly read-only historical evidence audit. It classifies recoverable guild/sync boundaries from persisted canonical owners, reports ambiguity and missing mappings, and prints diagnostic-only player streak and potential Home-tenure impact without writing data or consulting current-state tables as historical evidence.
+- Includes `npm run diagnose:membership-history-backfill`, a one-time strictly read-only historical evidence audit that executes the compiled `dist/scripts/auditMembershipHistoryBackfill.js` artifact. Production deploys build `dist` normally; for a local/manual checkout, run the normal build (`npm run build` or `yarn build`) first so the diagnostic does not run against a missing or stale artifact. It classifies recoverable guild/sync boundaries from persisted canonical owners, reports ambiguity and missing mappings, and prints diagnostic-only player streak and potential Home-tenure impact without writing data or consulting current-state tables as historical evidence.
 - Exposes `/livez` and `/healthz` for liveness/readiness checks.
 
 ### Clan management tooling

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "seed:fwa-layouts": "ts-node src/scripts/seedFwaLayouts.ts",
     "seed:heatmap-ref": "ts-node src/scripts/seedHeatMapRef.ts",
     "repair:fwa-ended-war": "ts-node src/scripts/repairEndedWarState.ts",
-    "diagnose:membership-history-backfill": "ts-node src/scripts/auditMembershipHistoryBackfill.ts",
+    "diagnose:membership-history-backfill": "node dist/scripts/auditMembershipHistoryBackfill.js",
     "sync:mirror": "ts-node src/scripts/mirrorSync.ts",
     "sync:fwa-feeds": "ts-node src/scripts/fwaFeedSync.ts",
     "start": "npm run build && npm run start:runtime",

--- a/src/scripts/auditMembershipHistoryBackfill.ts
+++ b/src/scripts/auditMembershipHistoryBackfill.ts
@@ -9,6 +9,7 @@ import {
 
 export const SCHEDULE_CORRELATION_THRESHOLD_MS = 24 * 60 * 60 * 1000;
 export const MAX_PREP_CLUSTER_SPREAD_MS = 2 * 60 * 60 * 1000;
+export const AUDIT_WAR_ID_BATCH_SIZE = 500;
 
 export type AuditClassification =
   | "EXISTING_EXACT"
@@ -542,6 +543,13 @@ export function formatAuditSummary(reports: readonly AuditCycleReport[]): string
   ].includes(report.classification));
   const candidateBoundaryReports = candidateReports.filter((report) => isValidDate(report.candidateSyncTime));
   const candidateFacts = candidateReports.reduce((sum, report) => sum + report.playerClanFacts.length, 0);
+  const conflictCounts = new Map<string, number>();
+  for (const reason of reports.flatMap((report) => report.conflicts)) {
+    conflictCounts.set(reason, (conflictCounts.get(reason) ?? 0) + 1);
+  }
+  const conflictLines = [...conflictCounts.entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([reason, count]) => `${reason}: ${count}`);
   const syncNumbers = reports.map((report) => report.syncNumber).sort((a, b) => a - b);
   const safeDates = candidateBoundaryReports.map((report) => report.candidateSyncTime).filter(isValidDate).sort((a, b) => a.getTime() - b.getTime());
   const sortedCandidateReports = [...candidateBoundaryReports].sort((a, b) => a.syncNumber - b.syncNumber || a.guildId.localeCompare(b.guildId));
@@ -561,6 +569,9 @@ export function formatAuditSummary(reports: readonly AuditCycleReport[]): string
     `Legacy WarLookup candidates: ${count("LEGACY_WARLOOKUP_CANDIDATE")}`,
     `Ambiguous: ${count("AMBIGUOUS")}`,
     `Unrecoverable: ${count("UNRECOVERABLE")}`,
+    "",
+    "Conflict reasons:",
+    ...(conflictLines.length > 0 ? conflictLines : ["none"]),
     "",
     `Potential additional canonical boundaries: ${candidateBoundaryReports.length}`,
     `Potential player-boundary membership facts: ${candidateFacts}`,
@@ -755,7 +766,6 @@ export function buildCycleInputs(
   return [...identities.values()].sort((left, right) =>
     left.guildId.localeCompare(right.guildId) || left.syncNumber - right.syncNumber,
   ).map((identity) => {
-    const pointWarIds = new Set(identity.points.map((point) => point.warId).filter((value): value is number => value !== null));
     const matchingHistories = histories.filter((history) => identity.points.some((point) => historyMatchesPoint(history, point)));
     const cycleParticipation = participation.filter((row) => row.guildId === identity.guildId && matchingHistories.some((history) =>
       history.warId === row.warId && normalizeClanTag(history.clanTag) === normalizeClanTag(row.clanTag)));
@@ -767,11 +777,13 @@ export function buildCycleInputs(
         missingMappings.push(`missing_participation:${history.clanTag}:${history.warId}`);
       }
     }
-    const relevantLookups = lookups.filter((lookup) => pointWarIds.has(lookup.warId));
-    const matchingLookups = relevantLookups.filter((lookup) => identity.points.some((point) =>
-      point.warId === lookup.warId && normalizeClanTag(point.clanTag) === normalizeClanTag(lookup.clanTag)));
+    const canonicalWarIds = new Set(matchingHistories.map((history) => history.warId));
+    const relevantLookups = lookups.filter((lookup) => canonicalWarIds.has(lookup.warId));
+    const matchingLookups = relevantLookups.filter((lookup) => matchingHistories.some((history) =>
+      history.warId === lookup.warId && normalizeClanTag(history.clanTag) === normalizeClanTag(lookup.clanTag)));
     const lookupOwnerKeys = new Set(relevantLookups.flatMap((lookup) =>
-      points.filter((point) => point.warId === lookup.warId && normalizeClanTag(point.clanTag) === normalizeClanTag(lookup.clanTag))
+      points.filter((point) => histories.some((history) =>
+        history.warId === lookup.warId && historyMatchesPoint(history, point)))
         .map((point) => `${point.guildId}|${point.syncNumber}`),
     ));
     const historyOwnerKeys = new Set(matchingHistories.flatMap((history) =>
@@ -806,28 +818,89 @@ export function buildCycleInputs(
   });
 }
 
+/** Purpose: split canonical war IDs into deterministic bounded Prisma IN batches. */
+function chunkWarIds(warIds: readonly number[]): number[][] {
+  const sorted = [...new Set(warIds)].sort((left, right) => left - right);
+  const chunks: number[][] = [];
+  for (let index = 0; index < sorted.length; index += AUDIT_WAR_ID_BATCH_SIZE) {
+    chunks.push(sorted.slice(index, index + AUDIT_WAR_ID_BATCH_SIZE));
+  }
+  return chunks;
+}
+
+/** Purpose: load only canonical-war-scoped evidence in bounded bulk batches. */
+async function readCanonicalWarRows(
+  warIds: readonly number[],
+  readChunk: (warIds: string[]) => Promise<any[]>,
+): Promise<any[]> {
+  const rows: any[] = [];
+  for (const chunk of chunkWarIds(warIds)) rows.push(...await readChunk(chunk.map(String)));
+  return rows;
+}
+
 /** Purpose: read every historical owner through an interface that exposes no mutation delegate. */
 async function readAuditInputs(db: ReadOnlyAuditDb): Promise<AuditCycleInput[]> {
-  const [cycles, rawSnapshots, rawSchedules, rawPoints, rawHistories, rawParticipation, rawLookups, rawEvaluations] = await Promise.all([
-    db.syncCycle.findMany({ orderBy: [{ guildId: "asc" }, { syncNumber: "asc" }] }),
-    db.syncClanMemberSnapshot.findMany({ orderBy: [{ guildId: "asc" }, { syncTime: "asc" }, { clanTag: "asc" }, { playerTag: "asc" }] }),
-    db.scheduledSyncPost.findMany({ orderBy: [{ guildId: "asc" }, { syncTime: "asc" }] }),
-    db.clanPointsSync.findMany({ orderBy: [{ guildId: "asc" }, { syncNum: "asc" }, { clanTag: "asc" }] }),
-    db.clanWarHistory.findMany({ orderBy: [{ syncNumber: "asc" }, { warId: "asc" }, { clanTag: "asc" }] }),
-    db.clanWarParticipation.findMany({ where: { matchType: "FWA" }, orderBy: [{ guildId: "asc" }, { warId: "asc" }, { playerTag: "asc" }] }),
-    db.warLookup.findMany({ orderBy: [{ startTime: "asc" }, { warId: "asc" }] }),
+  const [cycles, rawSnapshots, rawSchedules, rawPoints, rawHistories, rawEvaluations] = await Promise.all([
+    db.syncCycle.findMany({
+      orderBy: [{ guildId: "asc" }, { syncNumber: "asc" }],
+      select: { guildId: true, syncNumber: true, syncTime: true },
+    }),
+    db.syncClanMemberSnapshot.findMany({
+      orderBy: [{ guildId: "asc" }, { syncTime: "asc" }, { clanTag: "asc" }, { playerTag: "asc" }],
+      select: { guildId: true, syncTime: true, clanTag: true, playerTag: true },
+    }),
+    db.scheduledSyncPost.findMany({
+      orderBy: [{ guildId: "asc" }, { syncTime: "asc" }],
+      select: { id: true, guildId: true, syncTime: true, status: true },
+    }),
+    db.clanPointsSync.findMany({
+      orderBy: [{ guildId: "asc" }, { syncNum: "asc" }, { clanTag: "asc" }],
+      select: { guildId: true, syncNum: true, clanTag: true, warId: true, warStartTime: true, opponentTag: true, isFwa: true },
+    }),
+    db.clanWarHistory.findMany({
+      orderBy: [{ syncNumber: "asc" }, { warId: "asc" }, { clanTag: "asc" }],
+      select: { warId: true, syncNumber: true, matchType: true, clanTag: true, opponentTag: true, warStartTime: true, prepStartTime: true, warEndTime: true },
+    }),
     db.warPlanComplianceEvaluation.findMany({
       orderBy: [{ guildId: "asc" }, { warId: "asc" }],
-      select: { guildId: true, warId: true, warHistory: { select: { warId: true, syncNumber: true, matchType: true, clanTag: true, warStartTime: true, opponentTag: true } } },
+      select: { guildId: true, warId: true, warHistory: { select: { warId: true, syncNumber: true, matchType: true, clanTag: true, warStartTime: true, opponentTag: true, prepStartTime: true, warEndTime: true } } },
     }),
   ]);
   const normalizedHistories = normalizeHistories(rawHistories);
+  const normalizedPoints = [
+    ...normalizePoints(rawPoints),
+    ...normalizeComplianceIdentities(rawEvaluations, normalizedHistories),
+  ];
+  const normalizedSchedules = normalizeSchedules(rawSchedules);
+  const normalizedSnapshots = normalizeSnapshots(rawSnapshots);
+  const stageOneInputs = buildCycleInputs(
+    normalizedPoints,
+    normalizedHistories,
+    [],
+    normalizedSchedules,
+    normalizedSnapshots,
+    [],
+    cycles,
+  );
+  const canonicalWarIds = [...new Set(stageOneInputs.flatMap((input) => input.histories.map((history) => history.warId)))];
+  const [rawParticipation, rawLookups] = await Promise.all([
+    readCanonicalWarRows(canonicalWarIds, (warIds) => db.clanWarParticipation.findMany({
+      where: { matchType: "FWA", warId: { in: warIds } },
+      orderBy: [{ guildId: "asc" }, { warId: "asc" }, { playerTag: "asc" }],
+      select: { guildId: true, warId: true, clanTag: true, playerTag: true, matchType: true },
+    })),
+    readCanonicalWarRows(canonicalWarIds, (warIds) => db.warLookup.findMany({
+      where: { warId: { in: warIds } },
+      orderBy: [{ startTime: "asc" }, { warId: "asc" }],
+      select: { warId: true, clanTag: true, startTime: true, payload: true },
+    })),
+  ]);
   return buildCycleInputs(
-    [...normalizePoints(rawPoints), ...normalizeComplianceIdentities(rawEvaluations, normalizedHistories)],
+    normalizedPoints,
     normalizedHistories,
     normalizeParticipation(rawParticipation),
-    normalizeSchedules(rawSchedules),
-    normalizeSnapshots(rawSnapshots),
+    normalizedSchedules,
+    normalizedSnapshots,
     normalizeLookups(rawLookups),
     cycles,
   );

--- a/src/scripts/auditMembershipHistoryBackfill.ts
+++ b/src/scripts/auditMembershipHistoryBackfill.ts
@@ -766,6 +766,8 @@ export function buildCycleInputs(
   return [...identities.values()].sort((left, right) =>
     left.guildId.localeCompare(right.guildId) || left.syncNumber - right.syncNumber,
   ).map((identity) => {
+    const persistedSyncNumberDisagreement = identity.points.some((point) =>
+      hasPersistedSyncNumberDisagreement(point, histories));
     const matchingHistories = histories.filter((history) => identity.points.some((point) => historyMatchesPoint(history, point)));
     const cycleParticipation = participation.filter((row) => row.guildId === identity.guildId && matchingHistories.some((history) =>
       history.warId === row.warId && normalizeClanTag(history.clanTag) === normalizeClanTag(row.clanTag)));
@@ -795,6 +797,7 @@ export function buildCycleInputs(
       ...(lookupOwnerKeys.size > 1 ? ["warlookup_maps_to_multiple_guild_sync_owners"] : []),
       ...(relevantLookups.length !== matchingLookups.length ? ["warlookup_clan_identity_mismatch"] : []),
       ...(historyOwnerKeys.size > 1 ? ["history_maps_to_multiple_guild_sync_owners"] : []),
+      ...(persistedSyncNumberDisagreement ? ["persisted_sync_number_disagreement"] : []),
       ...(partialIdentityConflictOwners.has(`${identity.guildId}|${identity.syncNumber}`)
         ? ["conflicting_partial_war_identity_across_sync_buckets"]
         : []),

--- a/tests/auditMembershipHistoryBackfill.test.ts
+++ b/tests/auditMembershipHistoryBackfill.test.ts
@@ -304,6 +304,7 @@ describe("auditMembershipHistoryBackfill", () => {
     ));
     expect(report[0].classification).toBe("EXISTING_CYCLE_FALLBACK");
     expect(report[0].conflicts).not.toContain("warlookup_clan_identity_mismatch");
+    expect(report[0].conflicts).not.toContain("persisted_sync_number_disagreement");
     expect(report[0].playerClanFacts).toEqual([
       { playerTag: "#PLAYER1", clanTag: "#H0ME", source: "WarLookup.canonical.participants" },
       { playerTag: "#PLAYER2", clanTag: "#H0ME", source: "WarLookup.canonical.participants" },
@@ -323,6 +324,47 @@ describe("auditMembershipHistoryBackfill", () => {
     ));
     expect(report[0].classification).toBe("EXISTING_CYCLE_FALLBACK");
     expect(report[0].conflicts).not.toContain("warlookup_clan_identity_mismatch");
+    expect(report[0].conflicts).not.toContain("persisted_sync_number_disagreement");
+  });
+
+  it("preserves persisted sync disagreement before dropping the conflicting history", () => {
+    const conflictingHistory = history({
+      warId: 42,
+      syncNumber: 499,
+      prepStartTime: new Date("2026-01-01T10:00:00.000Z"),
+    });
+    const canonical = history({ warId: 100123, syncNumber: 500 });
+    const report = classifyAuditCycles(buildCycleInputs(
+      [point({ syncNumber: 500, warId: 42 })],
+      [conflictingHistory, canonical],
+      [],
+      [schedule()],
+      [],
+      [lookup({ warId: 100123 })],
+      [{ guildId: "guild-1", syncNumber: 500, syncTime: sync }],
+    ));
+    expect(report[0].classification).toBe("AMBIGUOUS");
+    expect(report[0].conflicts).toContain("persisted_sync_number_disagreement");
+    expect(report[0].canonicalHistoryCount).toBe(1);
+    expect(report[0].prepCluster.min?.getTime()).toBe(prep.getTime());
+    expect(report[0].prepCluster.max?.getTime()).toBe(prep.getTime());
+  });
+
+  it("does not treat a stale raw ID history owned by another clan as disagreement", () => {
+    const canonical = history({ warId: 100123, syncNumber: 500 });
+    const unrelatedClanHistory = history({ warId: 900001, syncNumber: 499, clanTag: "#OTHER" });
+    const report = classifyAuditCycles(buildCycleInputs(
+      [point({ syncNumber: 500, warId: 900001 })],
+      [canonical, unrelatedClanHistory],
+      [],
+      [schedule()],
+      [],
+      [lookup({ warId: 100123 })],
+      [{ guildId: "guild-1", syncNumber: 500, syncTime: sync }],
+    ));
+    expect(report[0].classification).toBe("EXISTING_CYCLE_FALLBACK");
+    expect(report[0].conflicts).not.toContain("persisted_sync_number_disagreement");
+    expect(report[0].canonicalHistoryCount).toBe(1);
   });
 
   it("fails closed when a canonical history lookup has the wrong clan", () => {

--- a/tests/auditMembershipHistoryBackfill.test.ts
+++ b/tests/auditMembershipHistoryBackfill.test.ts
@@ -290,6 +290,94 @@ describe("auditMembershipHistoryBackfill", () => {
     expect(twoNullOwners.map((report) => report.classification)).toEqual(["AMBIGUOUS", "AMBIGUOUS"]);
   });
 
+  it("recovers WarLookup through canonical history instead of raw point warId", () => {
+    const canonical = history({ warId: 100123, syncNumber: 500 });
+    const cycles = [{ guildId: "guild-1", syncNumber: 500, syncTime: sync }];
+    const report = classifyAuditCycles(buildCycleInputs(
+      [point({ syncNumber: 500, warId: 900001 })],
+      [canonical],
+      [],
+      [schedule()],
+      [],
+      [lookup({ warId: 100123 })],
+      cycles,
+    ));
+    expect(report[0].classification).toBe("EXISTING_CYCLE_FALLBACK");
+    expect(report[0].conflicts).not.toContain("warlookup_clan_identity_mismatch");
+    expect(report[0].playerClanFacts).toEqual([
+      { playerTag: "#PLAYER1", clanTag: "#H0ME", source: "WarLookup.canonical.participants" },
+      { playerTag: "#PLAYER2", clanTag: "#H0ME", source: "WarLookup.canonical.participants" },
+    ]);
+  });
+
+  it("ignores an unrelated lookup whose ID equals a stale raw point ID", () => {
+    const canonical = history({ warId: 100123, syncNumber: 500 });
+    const report = classifyAuditCycles(buildCycleInputs(
+      [point({ syncNumber: 500, warId: 900001 })],
+      [canonical],
+      [participation({ warId: 100123 })],
+      [schedule()],
+      [],
+      [lookup({ warId: 900001, clanTag: "#OTHER" })],
+      [{ guildId: "guild-1", syncNumber: 500, syncTime: sync }],
+    ));
+    expect(report[0].classification).toBe("EXISTING_CYCLE_FALLBACK");
+    expect(report[0].conflicts).not.toContain("warlookup_clan_identity_mismatch");
+  });
+
+  it("fails closed when a canonical history lookup has the wrong clan", () => {
+    const canonical = history({ warId: 100123, syncNumber: 500 });
+    const report = classifyAuditCycles(buildCycleInputs(
+      [point({ syncNumber: 500, warId: 900001 })],
+      [canonical],
+      [],
+      [schedule()],
+      [],
+      [lookup({ warId: 100123, clanTag: "#OTHER" })],
+      [{ guildId: "guild-1", syncNumber: 500, syncTime: sync }],
+    ));
+    expect(report[0].classification).toBe("AMBIGUOUS");
+    expect(report[0].conflicts).toContain("warlookup_clan_identity_mismatch");
+    expect(formatAuditSummary(report)).toContain("warlookup_clan_identity_mismatch: 1");
+  });
+
+  it("recovers a matching lookup from a tuple-resolved null raw point ID", () => {
+    const canonical = history({ warId: 100123, syncNumber: 500 });
+    const report = classifyAuditCycles(buildCycleInputs(
+      [point({ syncNumber: 500, warId: null })],
+      [canonical],
+      [],
+      [schedule()],
+      [],
+      [lookup({ warId: 100123 })],
+      [{ guildId: "guild-1", syncNumber: 500, syncTime: sync }],
+    ));
+    expect(report[0].classification).toBe("EXISTING_CYCLE_FALLBACK");
+    expect(report[0].conflicts).not.toContain("warlookup_clan_identity_mismatch");
+  });
+
+  it("preserves ambiguity when one canonical history maps to multiple owners", () => {
+    const canonical = history({ warId: 100123, syncNumber: 500 });
+    const report = classifyAuditCycles(buildCycleInputs(
+      [
+        point({ guildId: "guild-1", syncNumber: 500, warId: 900001 }),
+        point({ guildId: "guild-2", syncNumber: 500, warId: 900002 }),
+      ],
+      [canonical],
+      [],
+      [schedule()],
+      [],
+      [lookup({ warId: 100123 })],
+      [
+        { guildId: "guild-1", syncNumber: 500, syncTime: sync },
+        { guildId: "guild-2", syncNumber: 500, syncTime: sync },
+      ],
+    ));
+    expect(report).toHaveLength(2);
+    expect(report.every((row) => row.classification === "AMBIGUOUS")).toBe(true);
+    expect(report.every((row) => row.conflicts.includes("history_maps_to_multiple_guild_sync_owners"))).toBe(true);
+  });
+
   it("marks multiple schedules and excessive prep spread ambiguous", () => {
     expect(classifyAuditCycle(input({ schedules: [schedule(), schedule({ id: "schedule-2", syncTime: new Date("2026-01-01T04:00:00.000Z") })] })).classification)
       .toBe("AMBIGUOUS");
@@ -704,6 +792,56 @@ describe("auditMembershipHistoryBackfill", () => {
     expect((reads as unknown as Record<string, unknown>).update).toBeUndefined();
     expect((reads as unknown as Record<string, unknown>).delete).toBeUndefined();
     log.mockRestore();
+  });
+
+  it("stages participation and WarLookup reads by canonical history IDs", async () => {
+    const rawHistory = {
+      warId: 100123,
+      syncNumber: 77,
+      matchType: "FWA",
+      clanTag: "#HOME",
+      opponentTag: "#OPPONENT",
+      warStartTime: warStart,
+      prepStartTime: prep,
+      warEndTime: new Date("2026-01-01T05:00:00.000Z"),
+    };
+    const participationArgs: any[] = [];
+    const lookupArgs: any[] = [];
+    const reads = {
+      syncCycle: { findMany: vi.fn(async () => []), groupBy: vi.fn(async () => []) },
+      syncClanMemberSnapshot: { findMany: vi.fn(async () => []), groupBy: vi.fn(async () => []) },
+      scheduledSyncPost: { findMany: vi.fn(async () => [{ id: "schedule-1", guildId: "guild-1", syncTime: sync, status: "SCHEDULED" }]) },
+      clanPointsSync: { findMany: vi.fn(async () => [{ guildId: "guild-1", syncNum: 77, clanTag: "#HOME", warId: "900001", warStartTime: warStart, opponentTag: "#OPPONENT", isFwa: true }]) },
+      clanWarHistory: { findMany: vi.fn(async () => [rawHistory]) },
+      clanWarParticipation: { findMany: vi.fn(async (args) => {
+        participationArgs.push(args);
+        return [{ guildId: "guild-1", warId: "100123", clanTag: "#HOME", playerTag: "#PLAYER1", matchType: "FWA" }, { guildId: "guild-1", warId: "999999", clanTag: "#OTHER", playerTag: "#UNRELATED", matchType: "FWA" }];
+      }) },
+      warLookup: { findMany: vi.fn(async (args) => {
+        lookupArgs.push(args);
+        return [
+          { warId: "100123", clanTag: "#HOME", startTime: warStart, payload: { warMeta: { teamSize: 2, teamSizeSource: "war_event_snapshot" }, canonical: { participants: ["#PLAYER1", "#PLAYER2"] } } },
+          { warId: "999999", clanTag: "#OTHER", startTime: warStart, payload: { canonical: { participants: ["#UNRELATED"] } } },
+        ];
+      }) },
+      clanHomeMembershipPeriod: { findMany: vi.fn(async () => []) },
+      syncClanReadinessSnapshot: { groupBy: vi.fn(async () => []) },
+      allianceClanMembershipInterval: { findMany: vi.fn(async () => []) },
+      warPlanComplianceEvaluation: { findMany: vi.fn(async () => []) },
+    } satisfies ReadOnlyAuditDb;
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const reports = await runMembershipHistoryBackfillAudit(reads);
+    log.mockRestore();
+
+    expect(reports).toHaveLength(1);
+    expect(reports[0].classification).toBe("SCHEDULED_SYNC_CANDIDATE");
+    expect(participationArgs).toHaveLength(1);
+    expect(participationArgs[0].where.warId.in).toEqual(["100123"]);
+    expect(lookupArgs).toHaveLength(1);
+    expect(lookupArgs[0].where.warId.in).toEqual(["100123"]);
+    expect((reads as unknown as Record<string, unknown>).create).toBeUndefined();
+    expect((reads as unknown as Record<string, unknown>).update).toBeUndefined();
+    expect((reads as unknown as Record<string, unknown>).delete).toBeUndefined();
   });
 
   it("reports prep cluster spread in seconds and minutes", () => {


### PR DESCRIPTION
Keep the membership-history audit strictly read-only while resolving WarLookup ownership through canonical ClanWarHistory rows, staging bounded war-scoped reads, and running the documented diagnostic from compiled JavaScript.

Validation: focused audit and streak tests, full suite 322 files / 4508 tests, build, ESLint 0 errors with existing warnings, npx tsc --noEmit, npx prisma validate, and git diff --check.