### PR TITLE
feat: add conservative historical SyncCycle replay

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -60,6 +60,7 @@ Mirror sync also carries the finalized war-plan history tables (`WarPlanComplian
 - The replacement container may be running while it is still building, but that does not count as ready.
 - Promotion is gated on app-level `/healthz`, not Docker status.
 - The final handoff still includes a brief restart window when the old app is stopped and the canonical app is started.
+- Historical SyncCycle replay is a one-time compiled repair utility. Dry-run is the default and only exact persisted `ScheduledSyncPost` boundaries can be written; prep-derived times are never promoted, and no membership snapshots or Home rows are synthesized. After the normal build, inspect with `docker exec clashcookies-app node dist/scripts/backfillMembershipHistorySyncCycles.js --guild <guild-id> --syncs <range>` and apply explicitly with `docker exec clashcookies-app node dist/scripts/backfillMembershipHistorySyncCycles.js --guild <guild-id> --syncs <range> --apply`.
 
 ## Health Endpoints
 

--- a/src/scripts/auditMembershipHistoryBackfill.ts
+++ b/src/scripts/auditMembershipHistoryBackfill.ts
@@ -11,7 +11,9 @@ import {
   hasMembershipHistorySyncNumberDisagreement,
   hasMembershipHistoryPartialIdentityConflict,
   historicalHistoryMatchesPoint,
+  membershipHistoryConflictingPersistedOwnerKeys,
   membershipHistoryPointIdentityKey,
+  normalizeMembershipHistoryClanTag,
 } from "../services/membershipHistoryIdentity";
 
 export const SCHEDULE_CORRELATION_THRESHOLD_MS = 24 * 60 * 60 * 1000;
@@ -283,29 +285,6 @@ function findScheduleCandidates(
     .sort((left, right) => left.syncTime.getTime() - right.syncTime.getTime() || left.id.localeCompare(right.id));
 }
 
-/** Purpose: map canonical histories to a points identity without nearest-time guessing. */
-/** Purpose: detect conflicting persisted owners for one historical war and clan. */
-function hasConflictingPersistedOwners(points: readonly AuditPointEvidence[]): boolean {
-  const ownersByWarClan = new Map<string, Set<string>>();
-  for (const point of points) {
-    if (point.warId === null) continue;
-    const key = `${normalizeClanTag(point.clanTag)}|${point.warId}`;
-    const owners = ownersByWarClan.get(key) ?? new Set<string>();
-    owners.add(`${point.guildId}|${point.syncNumber}`);
-    ownersByWarClan.set(key, owners);
-  }
-  return [...ownersByWarClan.values()].some((owners) => owners.size > 1);
-}
-
-/** Purpose: apply persisted-owner conflict detection only to the current cycle identity. */
-function pointHasConflictingPersistedOwner(point: AuditPointEvidence, points: readonly AuditPointEvidence[]): boolean {
-  if (point.warId === null) return false;
-  const owners = new Set(points
-    .filter((candidate) => candidate.warId === point.warId && normalizeClanTag(candidate.clanTag) === normalizeClanTag(point.clanTag))
-    .map((candidate) => `${candidate.guildId}|${candidate.syncNumber}`));
-  return owners.size > 1;
-}
-
 /** Purpose: build one diagnostic report from already-normalized historical evidence. */
 export function classifyAuditCycle(input: AuditCycleInput): AuditCycleReport {
   const guildId = normalizeGuildId(input.guildId);
@@ -346,13 +325,16 @@ export function classifyAuditCycle(input: AuditCycleInput): AuditCycleReport {
     }
   }
   const conflicts = [...(input.explicitConflicts ?? [])];
+  const conflictingPersistedOwnerKeys = membershipHistoryConflictingPersistedOwnerKeys(points);
   const identityKeysByClan = new Map<string, Set<string>>();
   for (const point of points) {
     const identities = identityKeysByClan.get(normalizeClanTag(point.clanTag)) ?? new Set<string>();
     identities.add(reconciledWarIdentityKey(point, points));
     identityKeysByClan.set(normalizeClanTag(point.clanTag), identities);
     if (hasPersistedSyncNumberDisagreement(point, histories)) conflicts.push("persisted_sync_number_disagreement");
-    if (pointHasConflictingPersistedOwner(point, points)) conflicts.push("conflicting_persisted_identity_sources");
+    if (point.warId !== null && conflictingPersistedOwnerKeys.has(`${normalizeMembershipHistoryClanTag(point.clanTag)}|${point.warId}`)) {
+      conflicts.push("conflicting_persisted_identity_sources");
+    }
   }
   if ([...identityKeysByClan.values()].some((identities) => identities.size > 1)) {
     conflicts.push("conflicting_war_identities");
@@ -685,24 +667,7 @@ export function buildCycleInputs(
   cycles: any[],
 ): AuditCycleInput[] {
   const identities = new Map<string, { guildId: string; syncNumber: number; points: AuditPointEvidence[]; syncCycleTime: Date | null }>();
-  const conflictingWarClanKeys = new Set<string>();
-  const ownersByWarClan = new Map<string, Set<string>>();
-  for (const point of points) {
-    if (point.warId === null) continue;
-    const key = `${normalizeClanTag(point.clanTag)}|${point.warId}`;
-    const owners = ownersByWarClan.get(key) ?? new Set<string>();
-    owners.add(`${point.guildId}|${point.syncNumber}`);
-    ownersByWarClan.set(key, owners);
-  }
-  for (const [key, owners] of ownersByWarClan) {
-    if (owners.size > 1) conflictingWarClanKeys.add(key);
-  }
-  // Keep this helper in the normalization path so future callers cannot accidentally drop owner conflicts.
-  if (hasConflictingPersistedOwners(points)) {
-    for (const [key, owners] of ownersByWarClan) {
-      if (owners.size > 1) conflictingWarClanKeys.add(key);
-    }
-  }
+  const conflictingWarClanKeys = membershipHistoryConflictingPersistedOwnerKeys(points);
   const partialIdentityConflictOwners = new Set<string>();
   for (const point of points) {
     if (hasMembershipHistoryPartialIdentityConflict(point, points)) {

--- a/src/scripts/backfillMembershipHistorySyncCycles.ts
+++ b/src/scripts/backfillMembershipHistorySyncCycles.ts
@@ -12,6 +12,7 @@ export type BackfillMembershipHistorySyncCyclesArgs = {
   apply: boolean;
 };
 
+/** Purpose: parse and validate one positive historical sync number. */
 function parsePositiveSync(value: string): number {
   const syncNumber = Number(value.trim());
   if (!Number.isInteger(syncNumber) || syncNumber <= 0) {
@@ -20,6 +21,7 @@ function parsePositiveSync(value: string): number {
   return syncNumber;
 }
 
+/** Purpose: parse comma-separated sync numbers and inclusive ascending ranges. */
 export function parseSyncFilter(value: string): Set<number> {
   const syncNumbers = new Set<number>();
   for (const token of value.split(",")) {
@@ -40,6 +42,7 @@ export function parseSyncFilter(value: string): Set<number> {
   return syncNumbers;
 }
 
+/** Purpose: parse explicit guild, sync-filter, and apply-mode command-line arguments. */
 export function parseBackfillMembershipHistorySyncCyclesArgs(argv: string[]): BackfillMembershipHistorySyncCyclesArgs {
   let guildId = "";
   let syncFilter: Set<number> | null = null;
@@ -69,10 +72,12 @@ export function parseBackfillMembershipHistorySyncCyclesArgs(argv: string[]): Ba
   return { guildId, syncFilter, apply };
 }
 
+/** Purpose: format an optional plan timestamp deterministically for operator output. */
 function formatDate(value: Date | null): string {
   return value?.toISOString() ?? "-";
 }
 
+/** Purpose: render the complete deterministic dry-run or apply plan and summary. */
 export function formatBackfillPlan(plan: MembershipSyncCycleBackfillPlan, apply: boolean): string {
   const lines = [
     apply ? "APPLY MODE — only CREATE rows from this plan may be written" : "DRY RUN — no database mutations performed",
@@ -101,6 +106,7 @@ export function formatBackfillPlan(plan: MembershipSyncCycleBackfillPlan, apply:
   return lines.join("\n");
 }
 
+/** Purpose: plan the selected historical replay, print it, and apply only on explicit request. */
 export async function runBackfillMembershipHistorySyncCycles(
   args: BackfillMembershipHistorySyncCyclesArgs,
   db: MembershipHistorySyncCycleBackfillDb = prisma as unknown as MembershipHistorySyncCycleBackfillDb,
@@ -114,6 +120,7 @@ export async function runBackfillMembershipHistorySyncCycles(
   return plan;
 }
 
+/** Purpose: execute the compiled historical SyncCycle backfill command. */
 async function main(): Promise<void> {
   const args = parseBackfillMembershipHistorySyncCyclesArgs(process.argv.slice(2));
   await runBackfillMembershipHistorySyncCycles(args);

--- a/src/scripts/backfillMembershipHistorySyncCycles.ts
+++ b/src/scripts/backfillMembershipHistorySyncCycles.ts
@@ -1,0 +1,131 @@
+import { prisma } from "../prisma";
+import {
+  MembershipHistorySyncCycleBackfillService,
+  type MembershipHistorySyncCycleBackfillDb,
+  type MembershipSyncFilter,
+  type MembershipSyncCycleBackfillPlan,
+} from "../services/MembershipHistorySyncCycleBackfillService";
+
+export type BackfillMembershipHistorySyncCyclesArgs = {
+  guildId: string;
+  syncFilter: MembershipSyncFilter;
+  apply: boolean;
+};
+
+function parsePositiveSync(value: string): number {
+  const syncNumber = Number(value.trim());
+  if (!Number.isInteger(syncNumber) || syncNumber <= 0) {
+    throw new Error(`Invalid sync number: ${value}`);
+  }
+  return syncNumber;
+}
+
+export function parseSyncFilter(value: string): Set<number> {
+  const syncNumbers = new Set<number>();
+  for (const token of value.split(",")) {
+    const part = token.trim();
+    if (!part) continue;
+    const range = part.split("-").map((piece) => piece.trim());
+    if (range.length === 1) {
+      syncNumbers.add(parsePositiveSync(range[0]));
+      continue;
+    }
+    if (range.length !== 2) throw new Error(`Invalid sync range: ${part}`);
+    const start = parsePositiveSync(range[0]);
+    const end = parsePositiveSync(range[1]);
+    if (end < start) throw new Error(`Sync range must be ascending: ${part}`);
+    for (let syncNumber = start; syncNumber <= end; syncNumber += 1) syncNumbers.add(syncNumber);
+  }
+  if (syncNumbers.size === 0) throw new Error("Sync filter must contain at least one sync number.");
+  return syncNumbers;
+}
+
+export function parseBackfillMembershipHistorySyncCyclesArgs(argv: string[]): BackfillMembershipHistorySyncCyclesArgs {
+  let guildId = "";
+  let syncFilter: Set<number> | null = null;
+  let filterFlag: string | null = null;
+  let apply = false;
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === "--apply") {
+      apply = true;
+      continue;
+    }
+    if (token === "--guild" || token === "--sync" || token === "--syncs") {
+      const value = argv[index + 1];
+      if (!value || value.startsWith("--")) throw new Error(`${token} requires a value`);
+      index += 1;
+      if (token === "--guild") guildId = value.trim();
+      else {
+        if (filterFlag && filterFlag !== token) throw new Error("Use only one of --sync or --syncs.");
+        filterFlag = token;
+        syncFilter = token === "--sync" ? new Set([parsePositiveSync(value)]) : parseSyncFilter(value);
+      }
+      continue;
+    }
+    throw new Error(`Unknown argument: ${token}`);
+  }
+  if (!guildId) throw new Error("Usage: node dist/scripts/backfillMembershipHistorySyncCycles.js --guild <guild-id> [--sync <number>|--syncs <list/range>] [--apply]");
+  return { guildId, syncFilter, apply };
+}
+
+function formatDate(value: Date | null): string {
+  return value?.toISOString() ?? "-";
+}
+
+export function formatBackfillPlan(plan: MembershipSyncCycleBackfillPlan, apply: boolean): string {
+  const lines = [
+    apply ? "APPLY MODE — only CREATE rows from this plan may be written" : "DRY RUN — no database mutations performed",
+    `guild=${plan.guildId}`,
+    "",
+  ];
+  for (const row of plan.rows) {
+    lines.push([
+      `guild=${row.guildId}`,
+      `sync=${row.syncNumber}`,
+      `action=${row.action}`,
+      `candidate_sync_time=${formatDate(row.candidateSyncTime)}`,
+      `scheduled_sync_post_id=${row.scheduledSyncPostId ?? "-"}`,
+      `canonical_history_count=${row.canonicalHistoryCount}`,
+      `reasons=${row.reasons.join(",") || "-"}`,
+    ].join(" | "));
+  }
+  lines.push(
+    "",
+    `considered=${plan.considered}`,
+    `creatable=${plan.creatable}`,
+    `already_present=${plan.alreadyPresent}`,
+    `skipped=${plan.skipped}`,
+    `conflicts=${plan.conflicts}`,
+  );
+  return lines.join("\n");
+}
+
+export async function runBackfillMembershipHistorySyncCycles(
+  args: BackfillMembershipHistorySyncCyclesArgs,
+  db: MembershipHistorySyncCycleBackfillDb = prisma as unknown as MembershipHistorySyncCycleBackfillDb,
+): Promise<MembershipSyncCycleBackfillPlan> {
+  const service = new MembershipHistorySyncCycleBackfillService(db);
+  const plan = await service.plan(args.guildId, args.syncFilter);
+  console.log(formatBackfillPlan(plan, args.apply));
+  if (!args.apply) return plan;
+  if (plan.conflicts > 0) throw new Error("Apply aborted before writes because the selected plan contains conflicts.");
+  await service.apply(plan);
+  return plan;
+}
+
+async function main(): Promise<void> {
+  const args = parseBackfillMembershipHistorySyncCyclesArgs(process.argv.slice(2));
+  await runBackfillMembershipHistorySyncCycles(args);
+}
+
+if (require.main === module) {
+  main()
+    .catch((error) => {
+      console.error(error instanceof Error ? error.message : String(error));
+      process.exitCode = 1;
+    })
+    .finally(async () => {
+      await prisma.$disconnect();
+    });
+}

--- a/src/services/MembershipHistorySyncCycleBackfillService.ts
+++ b/src/services/MembershipHistorySyncCycleBackfillService.ts
@@ -62,23 +62,28 @@ type HistoryIdentity = MembershipCanonicalHistoryIdentity & {
 type ScheduleIdentity = { id: string; guildId: string; syncTime: Date; status: string };
 type CycleIdentity = { guildId: string; syncNumber: number; syncTime: Date };
 
+/** Purpose: normalize a persisted value to a positive integer identity. */
 function normalizePositiveInteger(value: unknown): number | null {
   const parsed = Number(value);
   return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
 }
 
+/** Purpose: normalize a persisted guild identifier for scoped ownership checks. */
 function normalizeGuildId(value: unknown): string {
   return String(value ?? "").trim();
 }
 
+/** Purpose: normalize persisted comparison text for case-insensitive decisions. */
 function normalizeComparable(value: unknown): string {
   return String(value ?? "").trim().toUpperCase();
 }
 
+/** Purpose: accept only finite persisted dates for historical identity and boundary calculations. */
 function normalizeDate(value: unknown): Date | null {
   return value instanceof Date && Number.isFinite(value.getTime()) ? value : null;
 }
 
+/** Purpose: normalize a persisted ClanPointsSync-style row into the shared point identity. */
 function normalizePoint(row: any): PointIdentity | null {
   const guildId = normalizeGuildId(row?.guildId);
   const syncNumber = normalizePositiveInteger(row?.syncNum);
@@ -97,6 +102,7 @@ function normalizePoint(row: any): PointIdentity | null {
   };
 }
 
+/** Purpose: normalize an ended FWA ClanWarHistory row into canonical historical identity. */
 function normalizeHistory(row: any): HistoryIdentity | null {
   const warId = normalizePositiveInteger(row?.warId);
   const clanTag = normalizeMembershipHistoryClanTag(row?.clanTag);
@@ -114,6 +120,7 @@ function normalizeHistory(row: any): HistoryIdentity | null {
   };
 }
 
+/** Purpose: normalize a persisted ScheduledSyncPost row for exact schedule matching. */
 function normalizeSchedule(row: any): ScheduleIdentity | null {
   const id = String(row?.id ?? "").trim();
   const guildId = normalizeGuildId(row?.guildId);
@@ -122,6 +129,7 @@ function normalizeSchedule(row: any): ScheduleIdentity | null {
   return { id, guildId, syncTime, status: normalizeComparable(row?.status) };
 }
 
+/** Purpose: normalize an existing SyncCycle row for uniqueness and idempotency checks. */
 function normalizeCycle(row: any): CycleIdentity | null {
   const guildId = normalizeGuildId(row?.guildId);
   const syncNumber = normalizePositiveInteger(row?.syncNumber);
@@ -130,6 +138,7 @@ function normalizeCycle(row: any): CycleIdentity | null {
   return { guildId, syncNumber, syncTime };
 }
 
+/** Purpose: remove duplicate persisted point identities before owner analysis. */
 function uniquePoints(points: PointIdentity[]): PointIdentity[] {
   const seen = new Set<string>();
   return points.filter((point) => {
@@ -140,6 +149,7 @@ function uniquePoints(points: PointIdentity[]): PointIdentity[] {
   });
 }
 
+/** Purpose: remove duplicate canonical history identities before schedule resolution. */
 function uniqueHistories(histories: HistoryIdentity[]): HistoryIdentity[] {
   const seen = new Set<string>();
   return histories.filter((history) => {
@@ -150,10 +160,12 @@ function uniqueHistories(histories: HistoryIdentity[]): HistoryIdentity[] {
   });
 }
 
+/** Purpose: derive the stable guild/sync owner key used throughout the planner. */
 function parseOwnerKey(point: PointIdentity): string {
   return `${point.guildId ?? ""}|${point.syncNumber}`;
 }
 
+/** Purpose: normalize a compliance evaluation and its persisted war history into a point identity. */
 function normalizeCompliancePoint(row: any): PointIdentity | null {
   const history = row?.warHistory;
   return normalizePoint({
@@ -167,6 +179,7 @@ function normalizeCompliancePoint(row: any): PointIdentity | null {
   });
 }
 
+/** Purpose: find eligible persisted schedules in the live SyncCycle lookback window. */
 function scheduleCandidates(guildId: string, history: HistoryIdentity, schedules: readonly ScheduleIdentity[]): ScheduleIdentity[] {
   if (!history.prepStartTime) return [];
   const lower = history.prepStartTime.getTime() - SCHEDULE_LOOKBACK_MS;
@@ -178,6 +191,7 @@ function scheduleCandidates(guildId: string, history: HistoryIdentity, schedules
     .sort((left, right) => left.syncTime.getTime() - right.syncTime.getTime() || left.id.localeCompare(right.id));
 }
 
+/** Purpose: collect fail-closed identity and ownership conflicts for each target guild/sync owner. */
 function historyOwnerConflictReasons(
   points: readonly PointIdentity[],
   allPoints: readonly PointIdentity[],
@@ -241,6 +255,7 @@ function historyOwnerConflictReasons(
   return reasonsByOwner;
 }
 
+/** Purpose: select canonical histories that match one target guild/sync owner. */
 function canonicalMatchesForOwner(
   points: readonly PointIdentity[],
   histories: readonly HistoryIdentity[],
@@ -250,6 +265,7 @@ function canonicalMatchesForOwner(
     parseOwnerKey(point) === owner && historicalHistoryMatchesPoint(history, point))));
 }
 
+/** Purpose: produce deterministic, de-duplicated conflict reason output. */
 function summarizeReasons(reasons: Iterable<string>): string[] {
   return [...new Set(reasons)].sort((left, right) => left.localeCompare(right));
 }
@@ -257,6 +273,7 @@ function summarizeReasons(reasons: Iterable<string>): string[] {
 export class MembershipHistorySyncCycleBackfillService {
   constructor(private readonly db: MembershipHistorySyncCycleBackfillDb) {}
 
+  /** Purpose: build a conservative dry-run plan from persisted historical ownership and schedules. */
   async plan(guildIdInput: string, syncFilter: MembershipSyncFilter = null): Promise<MembershipSyncCycleBackfillPlan> {
     const guildId = normalizeGuildId(guildIdInput);
     if (!guildId) throw new Error("guild ID is required");
@@ -424,6 +441,7 @@ export class MembershipHistorySyncCycleBackfillService {
     };
   }
 
+  /** Purpose: transactionally apply only CREATE rows from a previously validated plan. */
   async apply(plan: MembershipSyncCycleBackfillPlan): Promise<SyncCycleBindingResult[]> {
     if (plan.conflicts > 0) throw new Error("Apply aborted: the complete selected plan contains CONFLICT rows.");
     const createRows = plan.rows.filter((row) => row.action === "CREATE");

--- a/src/services/MembershipHistorySyncCycleBackfillService.ts
+++ b/src/services/MembershipHistorySyncCycleBackfillService.ts
@@ -4,6 +4,7 @@ import {
   hasMembershipHistorySyncNumberDisagreement,
   historicalHistoryMatchesPoint,
   membershipCanonicalHistoryKey,
+  membershipHistoryConflictingPersistedOwnerKeys,
   normalizeMembershipHistoryClanTag,
   type MembershipCanonicalHistoryIdentity,
   type MembershipHistoryPointIdentity,
@@ -153,6 +154,19 @@ function parseOwnerKey(point: PointIdentity): string {
   return `${point.guildId ?? ""}|${point.syncNumber}`;
 }
 
+function normalizeCompliancePoint(row: any): PointIdentity | null {
+  const history = row?.warHistory;
+  return normalizePoint({
+    guildId: row?.guildId,
+    syncNum: history?.syncNumber,
+    warId: row?.warId,
+    clanTag: history?.clanTag,
+    warStartTime: history?.warStartTime,
+    opponentTag: history?.opponentTag,
+    isFwa: normalizeComparable(row?.matchType ?? history?.matchType) === "FWA",
+  });
+}
+
 function scheduleCandidates(guildId: string, history: HistoryIdentity, schedules: readonly ScheduleIdentity[]): ScheduleIdentity[] {
   if (!history.prepStartTime) return [];
   const lower = history.prepStartTime.getTime() - SCHEDULE_LOOKBACK_MS;
@@ -177,6 +191,14 @@ function historyOwnerConflictReasons(
   };
   const matchedOwnersByHistory = new Map<string, Set<string>>();
   const matchedClansByWar = new Map<number, Set<string>>();
+  const conflictingPersistedOwnerKeys = membershipHistoryConflictingPersistedOwnerKeys(allPoints);
+
+  for (const point of allPoints) {
+    if (!point.isFwa || point.warId === null) continue;
+    if (conflictingPersistedOwnerKeys.has(`${normalizeMembershipHistoryClanTag(point.clanTag)}|${point.warId}`)) {
+      add(parseOwnerKey(point), "conflicting_persisted_identity_sources");
+    }
+  }
 
   for (const point of allPoints) {
     if (!point.isFwa) continue;
@@ -253,28 +275,27 @@ export class MembershipHistorySyncCycleBackfillService {
       },
     });
     const scopedPoints = uniquePoints(scopedPointRows.map(normalizePoint).filter((point): point is PointIdentity => Boolean(point)));
-    const evaluationPoints = scopedEvaluationRows.map((row) => normalizePoint({
-      guildId: row.guildId,
-      syncNum: row.warHistory?.syncNumber,
-      warId: row.warId,
-      clanTag: row.warHistory?.clanTag,
-      warStartTime: row.warHistory?.warStartTime,
-      opponentTag: row.warHistory?.opponentTag,
-      isFwa: normalizeComparable(row.matchType ?? row.warHistory?.matchType) === "FWA",
-    })).filter((point): point is PointIdentity => Boolean(point));
+    const evaluationPoints = scopedEvaluationRows
+      .map(normalizeCompliancePoint)
+      .filter((point): point is PointIdentity => Boolean(point));
     const targetPoints = uniquePoints([...scopedPoints, ...evaluationPoints]).filter((point) => syncFilter === null || syncFilter.has(point.syncNumber));
     const syncNumbers = new Set(targetPoints.map((point) => point.syncNumber));
+    const targetRawWarIds = [...new Set(targetPoints.map((point) => point.warId).filter((warId): warId is number => warId !== null))];
     const allPointRows = syncNumbers.size > 0
       ? await this.db.clanPointsSync.findMany({
-          where: { syncNum: { in: [...syncNumbers] } },
+          where: {
+            OR: [
+              { syncNum: { in: [...syncNumbers] } },
+              ...targetRawWarIds.map((warId) => ({ warId: String(warId) })),
+            ],
+          },
           select: { guildId: true, syncNum: true, warId: true, clanTag: true, warStartTime: true, opponentTag: true, isFwa: true },
         })
       : [];
-    const allPoints = uniquePoints([
-      ...allPointRows.map(normalizePoint).filter((point): point is PointIdentity => Boolean(point)),
-      ...targetPoints,
-    ]);
-    const rawWarIds = [...new Set(allPoints.map((point) => point.warId).filter((warId): warId is number => warId !== null))];
+    const normalizedAllPointRows = allPointRows.map(normalizePoint).filter((point): point is PointIdentity => Boolean(point));
+    const rawWarIds = [...new Set([...normalizedAllPointRows, ...targetPoints]
+      .map((point) => point.warId)
+      .filter((warId): warId is number => warId !== null))];
     const rawHistories = syncNumbers.size > 0
       ? await this.db.clanWarHistory.findMany({
           where: {
@@ -296,6 +317,25 @@ export class MembershipHistorySyncCycleBackfillService {
         })
       : [];
     const histories = uniqueHistories(rawHistories.map(normalizeHistory).filter((history): history is HistoryIdentity => Boolean(history)));
+    const crossOwnerEvaluationRows = histories.length > 0
+      ? await this.db.warPlanComplianceEvaluation.findMany({
+          where: { warId: { in: histories.map((history) => history.warId) } },
+          select: {
+            guildId: true,
+            warId: true,
+            matchType: true,
+            warHistory: { select: { warId: true, syncNumber: true, matchType: true, clanTag: true, warStartTime: true, opponentTag: true } },
+          },
+        })
+      : [];
+    const crossOwnerEvaluationPoints = crossOwnerEvaluationRows
+      .map(normalizeCompliancePoint)
+      .filter((point): point is PointIdentity => Boolean(point));
+    const allPoints = uniquePoints([
+      ...normalizedAllPointRows,
+      ...targetPoints,
+      ...crossOwnerEvaluationPoints,
+    ]);
     const schedules = (await this.db.scheduledSyncPost.findMany({
       where: { guildId },
       select: { id: true, guildId: true, syncTime: true, status: true },
@@ -329,6 +369,7 @@ export class MembershipHistorySyncCycleBackfillService {
       }
       if (resolvedSchedules.size > 1) reasons.add("histories_resolve_to_different_schedules");
       if (reasons.size > 0 && [...reasons].some((reason) => [
+        "conflicting_persisted_identity_sources",
         "persisted_sync_number_disagreement",
         "conflicting_war_identities",
         "conflicting_partial_war_identity_across_sync_buckets",

--- a/src/services/MembershipHistorySyncCycleBackfillService.ts
+++ b/src/services/MembershipHistorySyncCycleBackfillService.ts
@@ -1,0 +1,410 @@
+import {
+  hasMembershipHistoryIdentityConflict,
+  hasMembershipHistoryPartialIdentityConflict,
+  hasMembershipHistorySyncNumberDisagreement,
+  historicalHistoryMatchesPoint,
+  membershipCanonicalHistoryKey,
+  normalizeMembershipHistoryClanTag,
+  type MembershipCanonicalHistoryIdentity,
+  type MembershipHistoryPointIdentity,
+} from "./membershipHistoryIdentity";
+import {
+  persistResolvedSyncCycle,
+  type SyncCycleBindingResult,
+  type SyncCyclePersistenceDb,
+  type SyncCycleResolvedBindingInput,
+} from "./SyncCycleService";
+
+const SCHEDULE_LOOKBACK_MS = 24 * 60 * 60 * 1000;
+
+export type MembershipSyncFilter = Set<number> | null;
+
+export type MembershipHistorySyncCycleBackfillDb = SyncCyclePersistenceDb & {
+  clanPointsSync: { findMany: (args?: any) => Promise<any[]> };
+  warPlanComplianceEvaluation: { findMany: (args?: any) => Promise<any[]> };
+  clanWarHistory: { findMany: (args?: any) => Promise<any[]> };
+  scheduledSyncPost: { findMany: (args?: any) => Promise<any[]> };
+  syncCycle: SyncCyclePersistenceDb["syncCycle"] & {
+    findMany: (args?: any) => Promise<any[]>;
+  };
+  $transaction?: <T>(callback: (tx: MembershipHistorySyncCycleBackfillDb) => Promise<T>) => Promise<T>;
+};
+
+export type MembershipSyncCycleBackfillAction = "CREATE" | "ALREADY_PRESENT" | "SKIP" | "CONFLICT";
+
+export type MembershipSyncCycleBackfillPlanRow = {
+  guildId: string;
+  syncNumber: number;
+  action: MembershipSyncCycleBackfillAction;
+  candidateSyncTime: Date | null;
+  scheduledSyncPostId: string | null;
+  canonicalHistoryCount: number;
+  reasons: string[];
+};
+
+export type MembershipSyncCycleBackfillPlan = {
+  guildId: string;
+  rows: MembershipSyncCycleBackfillPlanRow[];
+  considered: number;
+  creatable: number;
+  alreadyPresent: number;
+  skipped: number;
+  conflicts: number;
+};
+
+type PointIdentity = MembershipHistoryPointIdentity & { isFwa: boolean };
+type HistoryIdentity = MembershipCanonicalHistoryIdentity & {
+  matchType: string | null;
+  prepStartTime: Date | null;
+  warEndTime: Date | null;
+};
+type ScheduleIdentity = { id: string; guildId: string; syncTime: Date; status: string };
+type CycleIdentity = { guildId: string; syncNumber: number; syncTime: Date };
+
+function normalizePositiveInteger(value: unknown): number | null {
+  const parsed = Number(value);
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+function normalizeGuildId(value: unknown): string {
+  return String(value ?? "").trim();
+}
+
+function normalizeComparable(value: unknown): string {
+  return String(value ?? "").trim().toUpperCase();
+}
+
+function normalizeDate(value: unknown): Date | null {
+  return value instanceof Date && Number.isFinite(value.getTime()) ? value : null;
+}
+
+function normalizePoint(row: any): PointIdentity | null {
+  const guildId = normalizeGuildId(row?.guildId);
+  const syncNumber = normalizePositiveInteger(row?.syncNum);
+  const clanTag = normalizeMembershipHistoryClanTag(row?.clanTag);
+  const warStartTime = normalizeDate(row?.warStartTime);
+  const opponentTag = normalizeMembershipHistoryClanTag(row?.opponentTag);
+  if (!guildId || !syncNumber || !clanTag || !warStartTime || !opponentTag) return null;
+  return {
+    guildId,
+    syncNumber,
+    warId: normalizePositiveInteger(row?.warId),
+    clanTag,
+    warStartTime,
+    opponentTag,
+    isFwa: row?.isFwa === true || normalizeComparable(row?.matchType) === "FWA",
+  };
+}
+
+function normalizeHistory(row: any): HistoryIdentity | null {
+  const warId = normalizePositiveInteger(row?.warId);
+  const clanTag = normalizeMembershipHistoryClanTag(row?.clanTag);
+  const warEndTime = normalizeDate(row?.warEndTime);
+  if (!warId || !clanTag || !warEndTime || normalizeComparable(row?.matchType) !== "FWA") return null;
+  return {
+    warId,
+    syncNumber: normalizePositiveInteger(row?.syncNumber),
+    clanTag,
+    warStartTime: normalizeDate(row?.warStartTime),
+    opponentTag: row?.opponentTag == null ? null : normalizeMembershipHistoryClanTag(row.opponentTag),
+    matchType: normalizeComparable(row?.matchType),
+    prepStartTime: normalizeDate(row?.prepStartTime),
+    warEndTime,
+  };
+}
+
+function normalizeSchedule(row: any): ScheduleIdentity | null {
+  const id = String(row?.id ?? "").trim();
+  const guildId = normalizeGuildId(row?.guildId);
+  const syncTime = normalizeDate(row?.syncTime);
+  if (!id || !guildId || !syncTime) return null;
+  return { id, guildId, syncTime, status: normalizeComparable(row?.status) };
+}
+
+function normalizeCycle(row: any): CycleIdentity | null {
+  const guildId = normalizeGuildId(row?.guildId);
+  const syncNumber = normalizePositiveInteger(row?.syncNumber);
+  const syncTime = normalizeDate(row?.syncTime);
+  if (!guildId || !syncNumber || !syncTime) return null;
+  return { guildId, syncNumber, syncTime };
+}
+
+function uniquePoints(points: PointIdentity[]): PointIdentity[] {
+  const seen = new Set<string>();
+  return points.filter((point) => {
+    const key = `${point.guildId}|${point.syncNumber}|${point.warId ?? "null"}|${point.clanTag}|${point.warStartTime.getTime()}|${point.opponentTag}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function uniqueHistories(histories: HistoryIdentity[]): HistoryIdentity[] {
+  const seen = new Set<string>();
+  return histories.filter((history) => {
+    const key = `${history.warId}|${history.syncNumber ?? "null"}|${history.clanTag}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+function parseOwnerKey(point: PointIdentity): string {
+  return `${point.guildId ?? ""}|${point.syncNumber}`;
+}
+
+function scheduleCandidates(guildId: string, history: HistoryIdentity, schedules: readonly ScheduleIdentity[]): ScheduleIdentity[] {
+  if (!history.prepStartTime) return [];
+  const lower = history.prepStartTime.getTime() - SCHEDULE_LOOKBACK_MS;
+  const upper = history.prepStartTime.getTime();
+  return schedules
+    .filter((schedule) => schedule.guildId === guildId &&
+      !["CANCELLED", "REPLACED"].includes(schedule.status) &&
+      schedule.syncTime.getTime() >= lower && schedule.syncTime.getTime() <= upper)
+    .sort((left, right) => left.syncTime.getTime() - right.syncTime.getTime() || left.id.localeCompare(right.id));
+}
+
+function historyOwnerConflictReasons(
+  points: readonly PointIdentity[],
+  allPoints: readonly PointIdentity[],
+  histories: readonly HistoryIdentity[],
+): Map<string, Set<string>> {
+  const reasonsByOwner = new Map<string, Set<string>>();
+  const add = (owner: string, reason: string) => {
+    const reasons = reasonsByOwner.get(owner) ?? new Set<string>();
+    reasons.add(reason);
+    reasonsByOwner.set(owner, reasons);
+  };
+  const matchedOwnersByHistory = new Map<string, Set<string>>();
+  const matchedClansByWar = new Map<number, Set<string>>();
+
+  for (const point of allPoints) {
+    if (!point.isFwa) continue;
+    const owner = parseOwnerKey(point);
+    const sameOwnerPoints = allPoints.filter((candidate) =>
+      candidate.guildId === point.guildId && candidate.syncNumber === point.syncNumber);
+    if (hasMembershipHistorySyncNumberDisagreement(point, histories)) add(owner, "persisted_sync_number_disagreement");
+    if (hasMembershipHistoryIdentityConflict(point, sameOwnerPoints)) add(owner, "conflicting_war_identities");
+    if (hasMembershipHistoryPartialIdentityConflict(point, allPoints)) add(owner, "conflicting_partial_war_identity_across_sync_buckets");
+    for (const history of histories) {
+      if (!historicalHistoryMatchesPoint(history, point)) continue;
+      const historyKey = membershipCanonicalHistoryKey(history);
+      const owners = matchedOwnersByHistory.get(historyKey) ?? new Set<string>();
+      owners.add(owner);
+      matchedOwnersByHistory.set(historyKey, owners);
+      const clans = matchedClansByWar.get(history.warId) ?? new Set<string>();
+      clans.add(normalizeMembershipHistoryClanTag(history.clanTag));
+      matchedClansByWar.set(history.warId, clans);
+    }
+  }
+
+  for (const [historyKey, owners] of matchedOwnersByHistory) {
+    if (owners.size <= 1) continue;
+    for (const owner of owners) add(owner, "history_maps_to_multiple_guild_sync_owners");
+    const [warIdText] = historyKey.split("|");
+    const warId = Number(warIdText);
+    for (const point of allPoints.filter((candidate) => owners.has(parseOwnerKey(candidate)))) {
+      if (point.warId === warId || point.warId === null) add(parseOwnerKey(point), "history_maps_to_multiple_guild_sync_owners");
+    }
+  }
+  for (const [warId, clans] of matchedClansByWar) {
+    if (clans.size <= 1) continue;
+    for (const point of allPoints.filter((candidate) => candidate.warId === warId)) {
+      add(parseOwnerKey(point), "contradictory_clan_ownership");
+    }
+  }
+  for (const point of points) {
+    if (!point.isFwa) add(parseOwnerKey(point), "non_fwa_cycle");
+  }
+  return reasonsByOwner;
+}
+
+function canonicalMatchesForOwner(
+  points: readonly PointIdentity[],
+  histories: readonly HistoryIdentity[],
+  owner: string,
+): HistoryIdentity[] {
+  return uniqueHistories(histories.filter((history) => points.some((point) =>
+    parseOwnerKey(point) === owner && historicalHistoryMatchesPoint(history, point))));
+}
+
+function summarizeReasons(reasons: Iterable<string>): string[] {
+  return [...new Set(reasons)].sort((left, right) => left.localeCompare(right));
+}
+
+export class MembershipHistorySyncCycleBackfillService {
+  constructor(private readonly db: MembershipHistorySyncCycleBackfillDb) {}
+
+  async plan(guildIdInput: string, syncFilter: MembershipSyncFilter = null): Promise<MembershipSyncCycleBackfillPlan> {
+    const guildId = normalizeGuildId(guildIdInput);
+    if (!guildId) throw new Error("guild ID is required");
+    const syncWhere = syncFilter ? { syncNum: { in: [...syncFilter] } } : {};
+    const scopedPointRows = await this.db.clanPointsSync.findMany({
+      where: { guildId, ...syncWhere },
+      select: { guildId: true, syncNum: true, warId: true, clanTag: true, warStartTime: true, opponentTag: true, isFwa: true },
+    });
+    const scopedEvaluationRows = await this.db.warPlanComplianceEvaluation.findMany({
+      where: { guildId },
+      select: {
+        guildId: true,
+        warId: true,
+        matchType: true,
+        warHistory: { select: { warId: true, syncNumber: true, matchType: true, clanTag: true, warStartTime: true, opponentTag: true } },
+      },
+    });
+    const scopedPoints = uniquePoints(scopedPointRows.map(normalizePoint).filter((point): point is PointIdentity => Boolean(point)));
+    const evaluationPoints = scopedEvaluationRows.map((row) => normalizePoint({
+      guildId: row.guildId,
+      syncNum: row.warHistory?.syncNumber,
+      warId: row.warId,
+      clanTag: row.warHistory?.clanTag,
+      warStartTime: row.warHistory?.warStartTime,
+      opponentTag: row.warHistory?.opponentTag,
+      isFwa: normalizeComparable(row.matchType ?? row.warHistory?.matchType) === "FWA",
+    })).filter((point): point is PointIdentity => Boolean(point));
+    const targetPoints = uniquePoints([...scopedPoints, ...evaluationPoints]).filter((point) => syncFilter === null || syncFilter.has(point.syncNumber));
+    const syncNumbers = new Set(targetPoints.map((point) => point.syncNumber));
+    const allPointRows = syncNumbers.size > 0
+      ? await this.db.clanPointsSync.findMany({
+          where: { syncNum: { in: [...syncNumbers] } },
+          select: { guildId: true, syncNum: true, warId: true, clanTag: true, warStartTime: true, opponentTag: true, isFwa: true },
+        })
+      : [];
+    const allPoints = uniquePoints([
+      ...allPointRows.map(normalizePoint).filter((point): point is PointIdentity => Boolean(point)),
+      ...targetPoints,
+    ]);
+    const rawWarIds = [...new Set(allPoints.map((point) => point.warId).filter((warId): warId is number => warId !== null))];
+    const rawHistories = syncNumbers.size > 0
+      ? await this.db.clanWarHistory.findMany({
+          where: {
+            OR: [
+              { syncNumber: { in: [...syncNumbers] } },
+              ...rawWarIds.map((warId) => ({ warId })),
+            ],
+          },
+          select: {
+            warId: true,
+            syncNumber: true,
+            matchType: true,
+            clanTag: true,
+            warStartTime: true,
+            opponentTag: true,
+            prepStartTime: true,
+            warEndTime: true,
+          },
+        })
+      : [];
+    const histories = uniqueHistories(rawHistories.map(normalizeHistory).filter((history): history is HistoryIdentity => Boolean(history)));
+    const schedules = (await this.db.scheduledSyncPost.findMany({
+      where: { guildId },
+      select: { id: true, guildId: true, syncTime: true, status: true },
+    })).map(normalizeSchedule).filter((schedule): schedule is ScheduleIdentity => Boolean(schedule));
+    const existingCycles = (await this.db.syncCycle.findMany({
+      where: { guildId },
+      select: { guildId: true, syncNumber: true, syncTime: true },
+    })).map(normalizeCycle).filter((cycle): cycle is CycleIdentity => Boolean(cycle));
+    const reasonsByOwner = historyOwnerConflictReasons(targetPoints, allPoints, histories);
+    const targetSyncNumbers = [...new Set(targetPoints.map((point) => point.syncNumber).concat(syncFilter ? [...syncFilter] : []))].sort((a, b) => a - b);
+    const rows = targetSyncNumbers.map((syncNumber): MembershipSyncCycleBackfillPlanRow => {
+      const owner = `${guildId}|${syncNumber}`;
+      const points = targetPoints.filter((point) => point.guildId === guildId && point.syncNumber === syncNumber && point.isFwa);
+      const canonicalHistories = canonicalMatchesForOwner(points, histories, owner);
+      const reasons = new Set(reasonsByOwner.get(owner) ?? []);
+      if (points.length === 0) reasons.add("no_guild_owned_historical_identity");
+      if (canonicalHistories.length === 0 && reasons.size === 0) reasons.add("no_canonical_history");
+      const resolvedSchedules = new Map<string, ScheduleIdentity>();
+      let scheduleResolutionFailed = false;
+      for (const history of canonicalHistories) {
+        const candidates = scheduleCandidates(guildId, history, schedules);
+        if (candidates.length === 0) {
+          scheduleResolutionFailed = true;
+          reasons.add(history.prepStartTime ? "no_eligible_schedule" : "missing_prep_start_time");
+        } else if (candidates.length > 1) {
+          scheduleResolutionFailed = true;
+          reasons.add("multiple_eligible_scheduled_posts");
+        } else {
+          resolvedSchedules.set(candidates[0].id, candidates[0]);
+        }
+      }
+      if (resolvedSchedules.size > 1) reasons.add("histories_resolve_to_different_schedules");
+      if (reasons.size > 0 && [...reasons].some((reason) => [
+        "persisted_sync_number_disagreement",
+        "conflicting_war_identities",
+        "conflicting_partial_war_identity_across_sync_buckets",
+        "history_maps_to_multiple_guild_sync_owners",
+        "contradictory_clan_ownership",
+        "multiple_eligible_scheduled_posts",
+        "histories_resolve_to_different_schedules",
+      ].includes(reason))) {
+        return {
+          guildId,
+          syncNumber,
+          action: "CONFLICT",
+          candidateSyncTime: null,
+          scheduledSyncPostId: null,
+          canonicalHistoryCount: canonicalHistories.length,
+          reasons: summarizeReasons(reasons),
+        };
+      }
+      if (canonicalHistories.length === 0 || scheduleResolutionFailed || resolvedSchedules.size !== 1) {
+        return {
+          guildId,
+          syncNumber,
+          action: "SKIP",
+          candidateSyncTime: !scheduleResolutionFailed && resolvedSchedules.size === 1 ? [...resolvedSchedules.values()][0].syncTime : null,
+          scheduledSyncPostId: !scheduleResolutionFailed && resolvedSchedules.size === 1 ? [...resolvedSchedules.values()][0].id : null,
+          canonicalHistoryCount: canonicalHistories.length,
+          reasons: summarizeReasons(reasons.size > 0 ? reasons : ["no_eligible_schedule"]),
+        };
+      }
+      const schedule = [...resolvedSchedules.values()][0];
+      const existingByNumber = existingCycles.find((cycle) => cycle.syncNumber === syncNumber);
+      const existingByTime = existingCycles.find((cycle) => cycle.syncTime.getTime() === schedule.syncTime.getTime());
+      if (existingByNumber && existingByNumber.syncTime.getTime() !== schedule.syncTime.getTime()) {
+        return { guildId, syncNumber, action: "CONFLICT", candidateSyncTime: schedule.syncTime, scheduledSyncPostId: schedule.id, canonicalHistoryCount: canonicalHistories.length, reasons: ["sync_number_already_mapped"] };
+      }
+      if (existingByTime && existingByTime.syncNumber !== syncNumber) {
+        return { guildId, syncNumber, action: "CONFLICT", candidateSyncTime: schedule.syncTime, scheduledSyncPostId: schedule.id, canonicalHistoryCount: canonicalHistories.length, reasons: ["sync_time_already_mapped"] };
+      }
+      if (existingByNumber || existingByTime) {
+        return { guildId, syncNumber, action: "ALREADY_PRESENT", candidateSyncTime: schedule.syncTime, scheduledSyncPostId: schedule.id, canonicalHistoryCount: canonicalHistories.length, reasons: ["exact_mapping_already_present"] };
+      }
+      return { guildId, syncNumber, action: "CREATE", candidateSyncTime: schedule.syncTime, scheduledSyncPostId: schedule.id, canonicalHistoryCount: canonicalHistories.length, reasons: [] };
+    });
+    return {
+      guildId,
+      rows,
+      considered: rows.length,
+      creatable: rows.filter((row) => row.action === "CREATE").length,
+      alreadyPresent: rows.filter((row) => row.action === "ALREADY_PRESENT").length,
+      skipped: rows.filter((row) => row.action === "SKIP").length,
+      conflicts: rows.filter((row) => row.action === "CONFLICT").length,
+    };
+  }
+
+  async apply(plan: MembershipSyncCycleBackfillPlan): Promise<SyncCycleBindingResult[]> {
+    if (plan.conflicts > 0) throw new Error("Apply aborted: the complete selected plan contains CONFLICT rows.");
+    const createRows = plan.rows.filter((row) => row.action === "CREATE");
+    if (createRows.length === 0) return [];
+    if (!this.db.$transaction) throw new Error("Apply requires a transactional database delegate.");
+    return this.db.$transaction(async (tx) => {
+      const results: SyncCycleBindingResult[] = [];
+      for (const row of createRows) {
+        if (!row.candidateSyncTime || !row.scheduledSyncPostId) throw new Error(`CREATE row missing schedule for sync ${row.syncNumber}`);
+        const input: SyncCycleResolvedBindingInput = {
+          guildId: row.guildId,
+          syncNumber: row.syncNumber,
+          syncTime: row.candidateSyncTime,
+          scheduledSyncPostId: row.scheduledSyncPostId,
+        };
+        const result = await persistResolvedSyncCycle(tx, input);
+        if (result.status === "conflict" || result.status === "failed") {
+          throw new Error(`Apply aborted for sync ${row.syncNumber}: ${result.status} ${"reason" in result ? result.reason : ""}`.trim());
+        }
+        results.push(result);
+      }
+      return results;
+    });
+  }
+}

--- a/src/services/SyncCycleService.ts
+++ b/src/services/SyncCycleService.ts
@@ -5,7 +5,7 @@ import { prisma } from "../prisma";
 
 export const SYNC_CYCLE_SCHEDULE_LOOKBACK_MS = 24 * 60 * 60 * 1000;
 
-type SyncCycleDb = {
+export type SyncCycleDb = {
   scheduledSyncPost?: {
     findFirst: (args: any) => Promise<{
       id: string;
@@ -13,6 +13,21 @@ type SyncCycleDb = {
     } | null>;
   };
   syncCycle?: {
+    findUnique: (args: any) => Promise<SyncCycle | null>;
+    create: (args: any) => Promise<SyncCycle>;
+  };
+};
+
+export type SyncCycleResolvedBindingInput = {
+  guildId: string;
+  syncNumber: number;
+  syncTime: Date;
+  scheduledSyncPostId: string;
+  resolvedAt?: Date;
+};
+
+export type SyncCyclePersistenceDb = {
+  syncCycle: {
     findUnique: (args: any) => Promise<SyncCycle | null>;
     create: (args: any) => Promise<SyncCycle>;
   };
@@ -59,9 +74,107 @@ function cycleIdentity(cycle: SyncCycle): string {
   return `guild_id=${cycle.guildId} sync_number=${cycle.syncNumber} sync_time=${cycle.syncTime.toISOString()}`;
 }
 
+/** Purpose: persist one already-resolved canonical schedule mapping with live-path uniqueness semantics. */
+export async function persistResolvedSyncCycle(
+  db: SyncCyclePersistenceDb,
+  input: SyncCycleResolvedBindingInput,
+): Promise<SyncCycleBindingResult> {
+  const { guildId, syncNumber, syncTime, scheduledSyncPostId } = input;
+  const resolvedAt = input.resolvedAt ?? new Date();
+  const byNumberWhere = { guildId_syncNumber: { guildId, syncNumber } };
+  const byTimeWhere = { guildId_syncTime: { guildId, syncTime } };
+  let existingByNumber: SyncCycle | null;
+  let existingByTime: SyncCycle | null;
+  try {
+    [existingByNumber, existingByTime] = await Promise.all([
+      db.syncCycle.findUnique({ where: byNumberWhere }),
+      db.syncCycle.findUnique({ where: byTimeWhere }),
+    ]);
+  } catch (error) {
+    dozzleLog.warn(
+      `[sync-cycle] event=read_existing outcome=failure guild_id=${guildId} sync_number=${syncNumber} sync_time=${syncTime.toISOString()} error=${formatError(error)}`,
+    );
+    return { status: "failed", reason: "sync_cycle_read_failed", error };
+  }
+
+  if (existingByNumber && existingByNumber.syncTime.getTime() !== syncTime.getTime()) {
+    const reason = `sync_number_already_mapped existing_sync_time=${existingByNumber.syncTime.toISOString()} candidate_sync_time=${syncTime.toISOString()}`;
+    dozzleLog.warn(`[sync-cycle] event=bind outcome=conflict guild_id=${guildId} sync_number=${syncNumber} ${reason}`);
+    return { status: "conflict", reason };
+  }
+  if (existingByTime && existingByTime.syncNumber !== syncNumber) {
+    const reason = `sync_time_already_mapped existing_sync_number=${existingByTime.syncNumber} candidate_sync_number=${syncNumber}`;
+    dozzleLog.warn(`[sync-cycle] event=bind outcome=conflict guild_id=${guildId} sync_time=${syncTime.toISOString()} ${reason}`);
+    return { status: "conflict", reason };
+  }
+  if (existingByNumber || existingByTime) {
+    dozzleLog.debug(`[sync-cycle] event=bind outcome=idempotent ${cycleIdentity(existingByNumber ?? existingByTime!)}`);
+    return { status: "existing", cycle: existingByNumber ?? existingByTime! };
+  }
+
+  try {
+    const cycle = await db.syncCycle.create({
+      data: {
+        guildId,
+        syncNumber,
+        syncTime,
+        scheduledSyncPostId,
+        resolvedAt,
+        resolutionSource: SyncCycleResolutionSource.ENDED_WAR_CANONICAL,
+      },
+    });
+    dozzleLog.info(
+      `[sync-cycle] event=bind outcome=created ${cycleIdentity(cycle)} scheduled_sync_post_id=${scheduledSyncPostId}`,
+    );
+    return { status: "created", cycle };
+  } catch (error) {
+    if (!isUniqueViolation(error)) {
+      dozzleLog.warn(
+        `[sync-cycle] event=bind outcome=failure guild_id=${guildId} sync_number=${syncNumber} sync_time=${syncTime.toISOString()} error=${formatError(error)}`,
+      );
+      return { status: "failed", reason: "sync_cycle_create_failed", error };
+    }
+
+    try {
+      const [racedByNumber, racedByTime] = await Promise.all([
+        db.syncCycle.findUnique({ where: byNumberWhere }),
+        db.syncCycle.findUnique({ where: byTimeWhere }),
+      ]);
+      if (racedByNumber && racedByNumber.syncTime.getTime() !== syncTime.getTime()) {
+        const reason = `sync_number_already_mapped existing_sync_time=${racedByNumber.syncTime.toISOString()} candidate_sync_time=${syncTime.toISOString()}`;
+        dozzleLog.warn(`[sync-cycle] event=bind outcome=conflict guild_id=${guildId} sync_number=${syncNumber} ${reason}`);
+        return { status: "conflict", reason };
+      }
+      if (racedByTime && racedByTime.syncNumber !== syncNumber) {
+        const reason = `sync_time_already_mapped existing_sync_number=${racedByTime.syncNumber} candidate_sync_number=${syncNumber}`;
+        dozzleLog.warn(`[sync-cycle] event=bind outcome=conflict guild_id=${guildId} sync_time=${syncTime.toISOString()} ${reason}`);
+        return { status: "conflict", reason };
+      }
+      const cycle = racedByNumber ?? racedByTime;
+      if (cycle) {
+        dozzleLog.debug(`[sync-cycle] event=bind outcome=idempotent_after_race ${cycleIdentity(cycle)}`);
+        return { status: "existing", cycle };
+      }
+    } catch (readError) {
+      dozzleLog.warn(
+        `[sync-cycle] event=bind outcome=failure guild_id=${guildId} sync_number=${syncNumber} sync_time=${syncTime.toISOString()} error=${formatError(readError)}`,
+      );
+      return { status: "failed", reason: "sync_cycle_race_read_failed", error: readError };
+    }
+    return { status: "failed", reason: "sync_cycle_unique_conflict_without_row", error };
+  }
+}
+
 /** Purpose: bind canonical ended-war sync identity to one exact scheduled sync boundary. */
 export class SyncCycleService {
   constructor(private readonly db: SyncCycleDb = prisma as unknown as SyncCycleDb) {}
+
+  async bindResolvedCanonical(input: SyncCycleResolvedBindingInput): Promise<SyncCycleBindingResult> {
+    if (!this.db.syncCycle?.findUnique || !this.db.syncCycle?.create) {
+      return { status: "failed", reason: "sync_cycle_database_unavailable", error: new Error("SyncCycle database delegates unavailable") };
+    }
+    return persistResolvedSyncCycle({ syncCycle: this.db.syncCycle }, input);
+  }
 
   async bindFromEndedWar(input: SyncCycleBindingInput): Promise<SyncCycleBindingResult> {
     const guildId = normalizeGuildId(input.guildId);
@@ -109,92 +222,11 @@ export class SyncCycleService {
       return { status: "unmapped", reason: "no_eligible_schedule" };
     }
 
-    const syncTime = schedule.syncTime;
-    const byNumberWhere = { guildId_syncNumber: { guildId, syncNumber } };
-    const byTimeWhere = { guildId_syncTime: { guildId, syncTime } };
-    let existingByNumber: SyncCycle | null;
-    let existingByTime: SyncCycle | null;
-    try {
-      [existingByNumber, existingByTime] = await Promise.all([
-        this.db.syncCycle.findUnique({ where: byNumberWhere }),
-        this.db.syncCycle.findUnique({ where: byTimeWhere }),
-      ]);
-    } catch (error) {
-      dozzleLog.warn(
-        `[sync-cycle] event=read_existing outcome=failure guild_id=${guildId} sync_number=${syncNumber} sync_time=${syncTime.toISOString()} error=${formatError(error)}`,
-      );
-      return { status: "failed", reason: "sync_cycle_read_failed", error };
-    }
-
-    if (existingByNumber && existingByNumber.syncTime.getTime() !== syncTime.getTime()) {
-      const reason = `sync_number_already_mapped existing_sync_time=${existingByNumber.syncTime.toISOString()} candidate_sync_time=${syncTime.toISOString()}`;
-      dozzleLog.warn(`[sync-cycle] event=bind outcome=conflict guild_id=${guildId} sync_number=${syncNumber} ${reason}`);
-      return { status: "conflict", reason };
-    }
-    if (existingByTime && existingByTime.syncNumber !== syncNumber) {
-      const reason = `sync_time_already_mapped existing_sync_number=${existingByTime.syncNumber} candidate_sync_number=${syncNumber}`;
-      dozzleLog.warn(`[sync-cycle] event=bind outcome=conflict guild_id=${guildId} sync_time=${syncTime.toISOString()} ${reason}`);
-      return { status: "conflict", reason };
-    }
-    if (existingByNumber || existingByTime) {
-      dozzleLog.debug(
-        `[sync-cycle] event=bind outcome=idempotent ${cycleIdentity(existingByNumber ?? existingByTime!)}`,
-      );
-      return { status: "existing", cycle: existingByNumber ?? existingByTime! };
-    }
-
-    try {
-      const cycle = await this.db.syncCycle.create({
-        data: {
-          guildId,
-          syncNumber,
-          syncTime,
-          scheduledSyncPostId: schedule.id,
-          resolvedAt: new Date(),
-          resolutionSource: SyncCycleResolutionSource.ENDED_WAR_CANONICAL,
-        },
-      });
-      dozzleLog.info(
-        `[sync-cycle] event=bind outcome=created ${cycleIdentity(cycle)} scheduled_sync_post_id=${schedule.id}`,
-      );
-      return { status: "created", cycle };
-    } catch (error) {
-      if (!isUniqueViolation(error)) {
-        dozzleLog.warn(
-          `[sync-cycle] event=bind outcome=failure guild_id=${guildId} sync_number=${syncNumber} sync_time=${syncTime.toISOString()} error=${formatError(error)}`,
-        );
-        return { status: "failed", reason: "sync_cycle_create_failed", error };
-      }
-
-      try {
-        const [racedByNumber, racedByTime] = await Promise.all([
-          this.db.syncCycle.findUnique({ where: byNumberWhere }),
-          this.db.syncCycle.findUnique({ where: byTimeWhere }),
-        ]);
-        if (racedByNumber && racedByNumber.syncTime.getTime() !== syncTime.getTime()) {
-          const reason = `sync_number_already_mapped existing_sync_time=${racedByNumber.syncTime.toISOString()} candidate_sync_time=${syncTime.toISOString()}`;
-          dozzleLog.warn(`[sync-cycle] event=bind outcome=conflict guild_id=${guildId} sync_number=${syncNumber} ${reason}`);
-          return { status: "conflict", reason };
-        }
-        if (racedByTime && racedByTime.syncNumber !== syncNumber) {
-          const reason = `sync_time_already_mapped existing_sync_number=${racedByTime.syncNumber} candidate_sync_number=${syncNumber}`;
-          dozzleLog.warn(`[sync-cycle] event=bind outcome=conflict guild_id=${guildId} sync_time=${syncTime.toISOString()} ${reason}`);
-          return { status: "conflict", reason };
-        }
-        const cycle = racedByNumber ?? racedByTime;
-        if (cycle) {
-          dozzleLog.debug(
-            `[sync-cycle] event=bind outcome=idempotent_after_race ${cycleIdentity(cycle)}`,
-          );
-          return { status: "existing", cycle };
-        }
-      } catch (readError) {
-        dozzleLog.warn(
-          `[sync-cycle] event=bind outcome=failure guild_id=${guildId} sync_number=${syncNumber} sync_time=${syncTime.toISOString()} error=${formatError(readError)}`,
-        );
-        return { status: "failed", reason: "sync_cycle_race_read_failed", error: readError };
-      }
-      return { status: "failed", reason: "sync_cycle_unique_conflict_without_row", error };
-    }
+    return this.bindResolvedCanonical({
+      guildId,
+      syncNumber,
+      syncTime: schedule.syncTime,
+      scheduledSyncPostId: schedule.id,
+    });
   }
 }

--- a/src/services/SyncCycleService.ts
+++ b/src/services/SyncCycleService.ts
@@ -169,6 +169,7 @@ export async function persistResolvedSyncCycle(
 export class SyncCycleService {
   constructor(private readonly db: SyncCycleDb = prisma as unknown as SyncCycleDb) {}
 
+  /** Purpose: persist a caller-resolved canonical boundary while preserving SyncCycle uniqueness semantics. */
   async bindResolvedCanonical(input: SyncCycleResolvedBindingInput): Promise<SyncCycleBindingResult> {
     if (!this.db.syncCycle?.findUnique || !this.db.syncCycle?.create) {
       return { status: "failed", reason: "sync_cycle_database_unavailable", error: new Error("SyncCycle database delegates unavailable") };

--- a/src/services/membershipHistoryIdentity.ts
+++ b/src/services/membershipHistoryIdentity.ts
@@ -100,3 +100,20 @@ export function hasMembershipHistoryPartialIdentityConflict(
 export function membershipCanonicalHistoryKey(history: MembershipCanonicalHistoryIdentity): string {
   return `${history.warId}|${normalizeMembershipHistoryClanTag(history.clanTag)}`;
 }
+
+/** Purpose: return raw non-null clan/war identities claimed by more than one persisted guild/sync owner. */
+export function membershipHistoryConflictingPersistedOwnerKeys(
+  points: readonly MembershipHistoryPointIdentity[],
+): Set<string> {
+  const ownersByIdentity = new Map<string, Set<string>>();
+  for (const point of points) {
+    if (point.warId === null) continue;
+    const identityKey = `${normalizeMembershipHistoryClanTag(point.clanTag)}|${point.warId}`;
+    const owners = ownersByIdentity.get(identityKey) ?? new Set<string>();
+    owners.add(`${point.guildId ?? ""}|${point.syncNumber}`);
+    ownersByIdentity.set(identityKey, owners);
+  }
+  return new Set([...ownersByIdentity.entries()]
+    .filter(([, owners]) => owners.size > 1)
+    .map(([identityKey]) => identityKey));
+}

--- a/tests/backfillMembershipHistorySyncCycles.test.ts
+++ b/tests/backfillMembershipHistorySyncCycles.test.ts
@@ -37,6 +37,16 @@ function history(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function complianceEvaluation(overrides: Record<string, unknown> = {}) {
+  return {
+    guildId: otherGuildId,
+    warId: 100,
+    matchType: "FWA",
+    warHistory: history(),
+    ...overrides,
+  };
+}
+
 function schedule(overrides: Record<string, unknown> = {}) {
   return { id: "schedule-520", guildId, syncTime, status: "PENDING", ...overrides };
 }
@@ -53,8 +63,24 @@ function makeDb(options: {
   const histories = [...(options.histories ?? [history()])];
   const schedules = [...(options.schedules ?? [schedule()])];
   const cycles = [...(options.cycles ?? [])];
+  const matchesPointWhere = (row: any, where: any) => {
+    if (where?.guildId && row.guildId !== where.guildId) return false;
+    if (where?.syncNum?.in && !where.syncNum.in.includes(row.syncNum)) return false;
+    if (where?.OR) {
+      return where.OR.some((condition: any) =>
+        (condition.syncNum?.in && condition.syncNum.in.includes(row.syncNum)) ||
+        (condition.warId !== undefined && String(row.warId) === String(condition.warId)));
+    }
+    return true;
+  };
+  const matchesHistoryWhere = (row: any, where: any) => {
+    if (!where?.OR) return true;
+    return where.OR.some((condition: any) =>
+      (condition.syncNumber?.in && condition.syncNumber.in.includes(row.syncNumber)) ||
+      (condition.warId !== undefined && row.warId === condition.warId));
+  };
   const syncCycle = {
-    findMany: vi.fn(async () => cycles),
+    findMany: vi.fn(async ({ where }: any = {}) => cycles.filter((row) => !where?.guildId || row.guildId === where.guildId)),
     findUnique: vi.fn(async ({ where }: any) => {
       if (where.guildId_syncNumber) {
         return cycles.find((row) => row.guildId === where.guildId_syncNumber.guildId && row.syncNumber === where.guildId_syncNumber.syncNumber) ?? null;
@@ -74,11 +100,15 @@ function makeDb(options: {
   };
   const db: any = {
     clanPointsSync: {
-      findMany: vi.fn(async ({ where }: any) => where?.guildId ? points.filter((row) => row.guildId === where.guildId) : points),
+      findMany: vi.fn(async ({ where }: any = {}) => points.filter((row) => matchesPointWhere(row, where))),
     },
-    warPlanComplianceEvaluation: { findMany: vi.fn(async () => evaluations) },
-    clanWarHistory: { findMany: vi.fn(async () => histories) },
-    scheduledSyncPost: { findMany: vi.fn(async () => schedules) },
+    warPlanComplianceEvaluation: {
+      findMany: vi.fn(async ({ where }: any = {}) => evaluations.filter((row) =>
+        (!where?.guildId || row.guildId === where.guildId) &&
+        (!where?.warId?.in || where.warId.in.includes(row.warId)))),
+    },
+    clanWarHistory: { findMany: vi.fn(async ({ where }: any = {}) => histories.filter((row) => matchesHistoryWhere(row, where))) },
+    scheduledSyncPost: { findMany: vi.fn(async ({ where }: any = {}) => schedules.filter((row) => !where?.guildId || row.guildId === where.guildId)) },
     syncCycle,
   };
   db.$transaction = vi.fn(async (callback: (tx: any) => Promise<unknown>) => callback(db));
@@ -139,6 +169,62 @@ describe("MembershipHistorySyncCycleBackfillService", () => {
     });
     const plan = await new MembershipHistorySyncCycleBackfillService(db).plan(guildId, new Set([520]));
     expect(plan.rows[0].action).toBe("CREATE");
+  });
+
+  it("rejects a raw clan/war owner collision from another sync before canonical matching", async () => {
+    const db = makeDb({
+      points: [point(), point({ guildId: otherGuildId, syncNum: 519 })],
+      histories: [history()],
+    });
+    const plan = await new MembershipHistorySyncCycleBackfillService(db).plan(guildId, new Set([520]));
+    expect(plan.rows[0].action).toBe("CONFLICT");
+    expect(plan.rows[0].reasons).toContain("conflicting_persisted_identity_sources");
+  });
+
+  it("rejects a raw clan/war owner collision from another guild in the same sync", async () => {
+    const db = makeDb({
+      points: [point(), point({ guildId: otherGuildId })],
+      histories: [history()],
+    });
+    const plan = await new MembershipHistorySyncCycleBackfillService(db).plan(guildId, new Set([520]));
+    expect(plan.rows[0].action).toBe("CONFLICT");
+    expect(plan.rows[0].reasons).toContain("conflicting_persisted_identity_sources");
+  });
+
+  it("does not collide raw numeric war IDs when the persisted clans differ", async () => {
+    const db = makeDb({
+      points: [
+        point({ warId: 100 }),
+        point({ guildId: otherGuildId, syncNum: 519, clanTag: "#OTHER", warId: 100 }),
+      ],
+      histories: [history()],
+    });
+    const plan = await new MembershipHistorySyncCycleBackfillService(db).plan(guildId, new Set([520]));
+    expect(plan.rows[0].action).toBe("CREATE");
+    expect(plan.rows[0].reasons).not.toContain("conflicting_persisted_identity_sources");
+  });
+
+  it("includes bounded cross-guild compliance owners in ambiguity checks", async () => {
+    const db = makeDb({ evaluations: [complianceEvaluation()] });
+    const plan = await new MembershipHistorySyncCycleBackfillService(db).plan(guildId, new Set([520]));
+    expect(plan.rows[0].action).toBe("CONFLICT");
+    expect(plan.rows[0].reasons).toContain("conflicting_persisted_identity_sources");
+    expect(db.warPlanComplianceEvaluation.findMany).toHaveBeenCalledWith(expect.objectContaining({
+      where: { warId: { in: [100] } },
+    }));
+  });
+
+  it("preserves stale raw-ID recovery when an unrelated clan owns that raw ID", async () => {
+    const db = makeDb({
+      points: [
+        point({ warId: 900001 }),
+        point({ guildId: otherGuildId, syncNum: 519, clanTag: "#OTHER", warId: 900001 }),
+      ],
+      histories: [history({ warId: 100123 })],
+    });
+    const plan = await new MembershipHistorySyncCycleBackfillService(db).plan(guildId, new Set([520]));
+    expect(plan.rows[0].action).toBe("CREATE");
+    expect(plan.rows[0].reasons).not.toContain("conflicting_persisted_identity_sources");
   });
 
   it("rejects persisted same-clan sync disagreement", async () => {

--- a/tests/backfillMembershipHistorySyncCycles.test.ts
+++ b/tests/backfillMembershipHistorySyncCycles.test.ts
@@ -1,0 +1,268 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  formatBackfillPlan,
+  parseBackfillMembershipHistorySyncCyclesArgs,
+} from "../src/scripts/backfillMembershipHistorySyncCycles";
+import { MembershipHistorySyncCycleBackfillService } from "../src/services/MembershipHistorySyncCycleBackfillService";
+
+const guildId = "guild-1";
+const otherGuildId = "guild-2";
+const prep = new Date("2026-08-15T12:00:00.000Z");
+const syncTime = new Date("2026-08-15T11:00:00.000Z");
+
+function point(overrides: Record<string, unknown> = {}) {
+  return {
+    guildId,
+    syncNum: 520,
+    warId: 100,
+    clanTag: "#HOME",
+    warStartTime: new Date("2026-08-15T13:00:00.000Z"),
+    opponentTag: "#OPPONENT",
+    isFwa: true,
+    ...overrides,
+  };
+}
+
+function history(overrides: Record<string, unknown> = {}) {
+  return {
+    warId: 100,
+    syncNumber: 520,
+    matchType: "FWA",
+    clanTag: "#HOME",
+    warStartTime: new Date("2026-08-15T13:00:00.000Z"),
+    opponentTag: "#OPPONENT",
+    prepStartTime: prep,
+    warEndTime: new Date("2026-08-15T14:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+function schedule(overrides: Record<string, unknown> = {}) {
+  return { id: "schedule-520", guildId, syncTime, status: "PENDING", ...overrides };
+}
+
+function makeDb(options: {
+  points?: any[];
+  evaluations?: any[];
+  histories?: any[];
+  schedules?: any[];
+  cycles?: any[];
+} = {}) {
+  const points = [...(options.points ?? [point()])];
+  const evaluations = [...(options.evaluations ?? [])];
+  const histories = [...(options.histories ?? [history()])];
+  const schedules = [...(options.schedules ?? [schedule()])];
+  const cycles = [...(options.cycles ?? [])];
+  const syncCycle = {
+    findMany: vi.fn(async () => cycles),
+    findUnique: vi.fn(async ({ where }: any) => {
+      if (where.guildId_syncNumber) {
+        return cycles.find((row) => row.guildId === where.guildId_syncNumber.guildId && row.syncNumber === where.guildId_syncNumber.syncNumber) ?? null;
+      }
+      return cycles.find((row) => row.guildId === where.guildId_syncTime.guildId && row.syncTime.getTime() === where.guildId_syncTime.syncTime.getTime()) ?? null;
+    }),
+    create: vi.fn(async ({ data }: any) => {
+      const created = {
+        id: `cycle-${data.syncNumber}`,
+        createdAt: data.resolvedAt,
+        updatedAt: data.resolvedAt,
+        ...data,
+      };
+      cycles.push(created);
+      return created;
+    }),
+  };
+  const db: any = {
+    clanPointsSync: {
+      findMany: vi.fn(async ({ where }: any) => where?.guildId ? points.filter((row) => row.guildId === where.guildId) : points),
+    },
+    warPlanComplianceEvaluation: { findMany: vi.fn(async () => evaluations) },
+    clanWarHistory: { findMany: vi.fn(async () => histories) },
+    scheduledSyncPost: { findMany: vi.fn(async () => schedules) },
+    syncCycle,
+  };
+  db.$transaction = vi.fn(async (callback: (tx: any) => Promise<unknown>) => callback(db));
+  return db;
+}
+
+describe("MembershipHistorySyncCycleBackfillService", () => {
+  it("plans one canonical history and exact schedule as CREATE", async () => {
+    const db = makeDb();
+    const plan = await new MembershipHistorySyncCycleBackfillService(db).plan(guildId, new Set([520]));
+    expect(plan.rows).toEqual([expect.objectContaining({
+      syncNumber: 520,
+      action: "CREATE",
+      candidateSyncTime: syncTime,
+      scheduledSyncPostId: "schedule-520",
+      canonicalHistoryCount: 1,
+    })]);
+  });
+
+  it("creates one plan row when multiple canonical histories converge on one schedule", async () => {
+    const db = makeDb({
+      points: [point(), point({ warId: 101, clanTag: "#OTHER", opponentTag: "#OPPONENT2" })],
+      histories: [history(), history({ warId: 101, clanTag: "#OTHER", opponentTag: "#OPPONENT2" })],
+    });
+    const plan = await new MembershipHistorySyncCycleBackfillService(db).plan(guildId, new Set([520]));
+    expect(plan.rows[0]).toMatchObject({ action: "CREATE", canonicalHistoryCount: 2 });
+  });
+
+  it("reports an exact existing mapping as ALREADY_PRESENT", async () => {
+    const db = makeDb({ cycles: [{ guildId, syncNumber: 520, syncTime }] });
+    const plan = await new MembershipHistorySyncCycleBackfillService(db).plan(guildId, new Set([520]));
+    expect(plan.rows[0]).toMatchObject({ action: "ALREADY_PRESENT" });
+    expect(db.syncCycle.create).not.toHaveBeenCalled();
+  });
+
+  it("rejects a sync-number conflict without overwriting it", async () => {
+    const db = makeDb({ cycles: [{ guildId, syncNumber: 520, syncTime: new Date("2026-08-15T10:00:00.000Z") }] });
+    const plan = await new MembershipHistorySyncCycleBackfillService(db).plan(guildId, new Set([520]));
+    expect(plan.rows[0]).toMatchObject({ action: "CONFLICT", reasons: ["sync_number_already_mapped"] });
+  });
+
+  it("rejects a sync-time conflict without overwriting it", async () => {
+    const db = makeDb({ cycles: [{ guildId, syncNumber: 519, syncTime }] });
+    const plan = await new MembershipHistorySyncCycleBackfillService(db).plan(guildId, new Set([520]));
+    expect(plan.rows[0]).toMatchObject({ action: "CONFLICT", reasons: ["sync_time_already_mapped"] });
+  });
+
+  it("does not require participation evidence for a valid boundary", async () => {
+    const db = makeDb({ histories: [history()] });
+    const plan = await new MembershipHistorySyncCycleBackfillService(db).plan(guildId, new Set([520]));
+    expect(plan.creatable).toBe(1);
+  });
+
+  it("recovers a stale raw point war ID through the canonical tuple", async () => {
+    const db = makeDb({
+      points: [point({ warId: 900001 })],
+      histories: [history({ warId: 100123 })],
+    });
+    const plan = await new MembershipHistorySyncCycleBackfillService(db).plan(guildId, new Set([520]));
+    expect(plan.rows[0].action).toBe("CREATE");
+  });
+
+  it("rejects persisted same-clan sync disagreement", async () => {
+    const db = makeDb({
+      points: [point({ warId: 900001 })],
+      histories: [history({ warId: 900001, syncNumber: 519 }), history({ warId: 100123 })],
+    });
+    const plan = await new MembershipHistorySyncCycleBackfillService(db).plan(guildId, new Set([520]));
+    expect(plan.rows[0]).toMatchObject({ action: "CONFLICT", reasons: ["persisted_sync_number_disagreement"] });
+  });
+
+  it("rejects incompatible persisted identities within one guild/sync/clan", async () => {
+    const db = makeDb({
+      points: [point({ warId: 100 }), point({ warId: 101 })],
+      histories: [history({ warId: 100 }), history({ warId: 101 })],
+    });
+    const plan = await new MembershipHistorySyncCycleBackfillService(db).plan(guildId, new Set([520]));
+    expect(plan.rows[0].action).toBe("CONFLICT");
+    expect(plan.rows[0].reasons).toContain("conflicting_war_identities");
+  });
+
+  it("rejects one canonical history mapped to multiple guild/sync owners", async () => {
+    const db = makeDb({
+      points: [point(), point({ guildId: otherGuildId })],
+      histories: [history()],
+    });
+    const plan = await new MembershipHistorySyncCycleBackfillService(db).plan(guildId, new Set([520]));
+    expect(plan.rows[0]).toMatchObject({ action: "CONFLICT" });
+    expect(plan.rows[0].reasons).toContain("history_maps_to_multiple_guild_sync_owners");
+  });
+
+  it("rejects histories that resolve to different schedules", async () => {
+    const db = makeDb({
+      points: [point(), point({ warId: 101, clanTag: "#OTHER", opponentTag: "#OPPONENT2" })],
+      histories: [
+        history(),
+        history({ warId: 101, clanTag: "#OTHER", opponentTag: "#OPPONENT2", prepStartTime: new Date("2026-08-17T12:00:00.000Z") }),
+      ],
+      schedules: [schedule(), schedule({ id: "schedule-other", syncTime: new Date("2026-08-17T11:00:00.000Z") })],
+    });
+    const plan = await new MembershipHistorySyncCycleBackfillService(db).plan(guildId, new Set([520]));
+    expect(plan.rows[0]).toMatchObject({ action: "CONFLICT" });
+    expect(plan.rows[0].reasons).toContain("histories_resolve_to_different_schedules");
+  });
+
+  it("ignores cancelled and replaced schedules", async () => {
+    const db = makeDb({ schedules: [
+      schedule({ id: "cancelled", status: "CANCELLED" }),
+      schedule({ id: "replaced", status: "REPLACED" }),
+      schedule(),
+    ] });
+    const plan = await new MembershipHistorySyncCycleBackfillService(db).plan(guildId, new Set([520]));
+    expect(plan.rows[0].action).toBe("CREATE");
+  });
+
+  it("skips when no exact persisted schedule is eligible", async () => {
+    const db = makeDb({ schedules: [schedule({ syncTime: new Date("2026-08-17T00:00:00.000Z") })] });
+    const plan = await new MembershipHistorySyncCycleBackfillService(db).plan(guildId, new Set([520]));
+    expect(plan.rows[0]).toMatchObject({ action: "SKIP", reasons: ["no_eligible_schedule"] });
+  });
+
+  it("never promotes a prep-cluster timestamp without a schedule", async () => {
+    const db = makeDb({ schedules: [] });
+    const plan = await new MembershipHistorySyncCycleBackfillService(db).plan(guildId, new Set([520]));
+    expect(plan.rows[0].action).toBe("SKIP");
+    expect(plan.rows[0].candidateSyncTime).toBeNull();
+  });
+
+  it("performs no writes during dry-run planning", async () => {
+    const db = makeDb();
+    await new MembershipHistorySyncCycleBackfillService(db).plan(guildId, new Set([520]));
+    expect(db.syncCycle.create).not.toHaveBeenCalled();
+    expect(db.$transaction).not.toHaveBeenCalled();
+  });
+
+  it("applies the exact scheduled mapping and is idempotent on rerun", async () => {
+    const db = makeDb();
+    const service = new MembershipHistorySyncCycleBackfillService(db);
+    const plan = await service.plan(guildId, new Set([520]));
+    const first = await service.apply(plan);
+    expect(first[0]).toMatchObject({ status: "created" });
+    expect(db.syncCycle.create).toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({
+        guildId,
+        syncNumber: 520,
+        syncTime,
+        scheduledSyncPostId: "schedule-520",
+        resolutionSource: "ENDED_WAR_CANONICAL",
+      }),
+    }));
+    const rerun = await service.plan(guildId, new Set([520]));
+    expect(rerun.rows[0].action).toBe("ALREADY_PRESENT");
+    expect((await service.apply(rerun)).length).toBe(0);
+    expect(db.syncCycle.create).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not partially apply a selected set containing a conflict", async () => {
+    const db = makeDb({
+      points: [point(), point({ syncNum: 521, warId: 101 })],
+      histories: [history(), history({ syncNumber: 521, warId: 101 })],
+      schedules: [schedule(), schedule({ id: "schedule-521", syncTime: new Date("2026-08-16T11:00:00.000Z") })],
+      cycles: [{ guildId, syncNumber: 521, syncTime: new Date("2026-08-16T10:00:00.000Z") }],
+    });
+    const service = new MembershipHistorySyncCycleBackfillService(db);
+    const plan = await service.plan(guildId, new Set([520, 521]));
+    expect(plan.rows.map((row) => row.action)).toEqual(["CREATE", "CONFLICT"]);
+    await expect(service.apply(plan)).rejects.toThrow(/conflict/i);
+    expect(db.syncCycle.create).not.toHaveBeenCalled();
+    expect(db.$transaction).not.toHaveBeenCalled();
+  });
+
+  it("parses guild and sync range arguments with dry-run as the default", () => {
+    expect(parseBackfillMembershipHistorySyncCyclesArgs(["--guild", guildId, "--syncs", "520,522-526"])).toEqual({
+      guildId,
+      syncFilter: new Set([520, 522, 523, 524, 525, 526]),
+      apply: false,
+    });
+    expect(parseBackfillMembershipHistorySyncCyclesArgs(["--guild", guildId, "--sync", "520", "--apply"]).apply).toBe(true);
+  });
+
+  it("prints deterministic dry-run output", async () => {
+    const db = makeDb();
+    const plan = await new MembershipHistorySyncCycleBackfillService(db).plan(guildId, new Set([520]));
+    expect(formatBackfillPlan(plan, false)).toContain("DRY RUN — no database mutations performed");
+    expect(formatBackfillPlan(plan, false)).toContain("action=CREATE");
+  });
+});


### PR DESCRIPTION
Add a dry-run-by-default, explicit-guild historical SyncCycle planner and apply utility. It reuses the ENDED_WAR_CANONICAL persistence path, requires canonical ended FWA history plus an exact persisted ScheduledSyncPost, and fails closed on ambiguous identity, schedule, or existing-cycle state without synthesizing membership or Home data.

Validation: focused backfill/SyncCycle/MembershipStreak/audit/Home/analytics/link/mirror tests (254 passed), full suite 323 files / 4536 tests, build, ESLint 0 errors with 68 existing warnings, npx tsc --noEmit, npx prisma validate, and git diff --check.